### PR TITLE
Fix: Stop heavy-streaming pane corruption in control mode (Phase B flow control)

### DIFF
--- a/Sources/TBDDaemon/Tmux/ControlMode/AttachReplayOrchestrator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/AttachReplayOrchestrator.swift
@@ -226,7 +226,7 @@ struct AttachReplayOrchestrator: Sendable {
         // sends: one dead pane must not tear down the whole server's
         // connection.
         let pause = "refresh-client -A '\(paneID):pause'"
-        let pauseResults = await sendBatch(client, texts: [pause])
+        let pauseResults = await client.sendBatch(texts: [pause])
 
         // A failed pause means the captures below run UNPAUSED: the pane may
         // emit between the capture replies and the gate opening, so the
@@ -279,41 +279,14 @@ struct AttachReplayOrchestrator: Sendable {
         // zero — the first post-continue byte (which flows into the armed
         // fence) is contiguous with the capture's tail.
         //
-        // All entries tolerate errors at the correlator level: a capture
-        // %error (pane died mid-attach) must fail THIS attach, not tear down
-        // the server's connection and every other pane on it. The orchestrator
-        // turns any capture failure into `AttachReplayError.captureFailed`.
-        // THREE capture legs (review H1): `-a` reaches only the saved primary
-        // VIEWPORT while the pane is on the alt screen — the primary
-        // SCROLLBACK is reachable only through the history portion of a
-        // no-`-a` capture (adding `-S` to the `-a` leg is a no-op; live-probed
-        // on tmux 3.6a). So the scrollback is captured on its own leg
-        // (`-E -1` = end before the visible screen), which works during alt
-        // mode too, and the assembler recombines the legs by `alternate_on`.
-        let captureCommands = [
-            // Pure primary scrollback, NO screen rows. QUIRK (live-probed):
-            // on a history-less pane this clamps and returns the first
-            // visible screen row — the assembler discards this leg when
-            // `history_size` == 0. -q guards %error.
-            "capture-pane -peqJN -S -\(historyDepth) -E -1 -q -t \(paneID)",
-            // Current screen only — the PRIMARY screen normally, the ALT
-            // screen while `alternate_on`.
-            "capture-pane -peqJN -t \(paneID)",
-            // -a: the SAVED primary viewport while `alternate_on`;
-            // -q: empty (not %error) when there is no saved screen.
-            "capture-pane -peqJN -a -q -t \(paneID)",
-            // COMBINED history+screen in ONE invocation (review R8-M3): `-J`
-            // joins soft wraps only WITHIN a capture, so the split legs above
-            // hard-break a logical line that wraps across the scrollback/
-            // screen seam. Non-alt replays use this leg verbatim (identical
-            // to the pre-split single capture); the split legs remain for the
-            // alt mapping, which has no combined-capture equivalent.
-            "capture-pane -peqJN -S -\(historyDepth) -t \(paneID)",
-            PaneStateCapture.listPanesCommand(target: paneID),
-            "capture-pane -p -P -C -t \(paneID)",
-        ]
+        // The capture list (and its leg semantics) is shared with the M3
+        // overflow-repair coordinator — see `PaneCaptureReplay`. A capture
+        // %error is tolerated at the correlator level and turned into
+        // `AttachReplayError.captureFailed` by the assembler.
+        let captureCommands = PaneCaptureReplay.captureCommands(
+            paneID: paneID, historyDepth: historyDepth)
         let continueCommand = "refresh-client -A '\(paneID):continue'"
-        let results = await sendBatch(client, texts: captureCommands + [continueCommand])
+        let results = await client.sendBatch(texts: captureCommands + [continueCommand])
 
         // A failed batched continue is log-only: a %error is tolerated (the
         // failure-path unpause below re-sends one when the captures failed
@@ -363,58 +336,15 @@ struct AttachReplayOrchestrator: Sendable {
         captureResults: [Result<[String], TmuxCommandError>],
         captureCommands: [String]
     ) async throws -> Outcome {
-        var captured: [[String]] = []
-        for (result, command) in zip(captureResults, captureCommands) {
-            switch result {
-            case .success(let lines):
-                captured.append(lines)
-            case .failure(let error):
-                Self.logger.error("""
-                    attach capture failed for \(server, privacy: .public)/\(paneID, privacy: .public) \
-                    (\(command, privacy: .public)): \(String(describing: error), privacy: .public)
-                    """)
-                throw AttachReplayError.captureFailed(command: command)
-            }
-        }
-        let (historyLeg, screenLeg, savedLeg, combinedLeg, stateLines, pending) =
-            (captured[0], captured[1], captured[2], captured[3], captured[4], captured[5])
-
-        // Truncation telemetry (plan M4.4 fold-in): at >= depth lines the
-        // scrollback capture almost certainly hit the history ceiling and
-        // older scrollback was lost to this replay.
-        if historyLeg.count >= historyDepth {
-            Self.logger.info("""
-                capture hit history ceiling for \(server, privacy: .public)/\(paneID, privacy: .public): \
-                \(historyLeg.count) lines >= depth \(self.historyDepth)
-                """)
-            onHistoryTruncation?(historyLeg.count)
-        }
-
-        guard let state = try PaneStateCapture.state(forPane: paneID, in: stateLines) else {
-            throw AttachReplayError.paneStateMissing
-        }
-        // Leg recombination (reviews H1 + R8-M3, verified live on tmux 3.6a):
-        // - NON-alt: use combinedLeg VERBATIM — one tmux invocation whose -J
-        //   joins soft wraps across the scrollback/screen seam, byte-identical
-        //   to the pre-split single capture (and immune to the history-less
-        //   clamp quirk: with no history it is exactly the screen).
-        // - ALT: the primary content must be stitched from historyLeg (pure
-        //   scrollback; reachable during alt, but CLAMPS to the first screen
-        //   row on a history-less pane, so discarded when history_size == 0)
-        //   + savedLeg (the -a saved primary viewport). ACCEPTED RESIDUAL: a
-        //   logical line soft-wrapping across THAT seam replays with a
-        //   spurious hard break — there is no combined capture that reaches
-        //   both regions while the pane is on the alt screen. Cosmetic,
-        //   narrow (exact seam alignment), no data loss.
-        //   screenLeg is the ALT content in this case.
-        let scrollback = state.historySize > 0 ? historyLeg : []
-        let replay = try ReplayWriter.assemble(
-            history: state.alternateOn ? scrollback + savedLeg : combinedLeg,
-            altScreen: state.alternateOn ? screenLeg : nil,
-            pending: pending,
-            state: state,
-            cols: state.width,
-            rows: state.height)
+        // Parse + truncation telemetry + leg recombination + byte assembly —
+        // shared with the M3 repair coordinator (`PaneCaptureReplay`).
+        let replay = try PaneCaptureReplay.assemble(
+            captureResults: captureResults,
+            captureCommands: captureCommands,
+            server: server,
+            paneID: paneID,
+            historyDepth: historyDepth,
+            onHistoryTruncation: onHistoryTruncation)
 
         do {
             // Pre-ready, generation-checked; blocks (bounded by its deadline)
@@ -457,67 +387,5 @@ struct AttachReplayOrchestrator: Sendable {
         await client.sendList([
             TmuxCommand(text: "refresh-client -A '\(paneID):continue'", tolerateErrors: true) { _ in }
         ])
-    }
-
-    /// Send `texts` as ONE atomic command list and await ALL their replies.
-    /// Sound because the correlator guarantees every completion eventually
-    /// fires: a reply block per command in FIFO order, or `.connectionClosed`
-    /// for the remainder when the stream ends. (A mute-but-alive tmux stalls
-    /// this like any other awaited command — stream teardown resolves it.)
-    private func sendBatch(
-        _ client: TmuxControlCommandClient, texts: [String]
-    ) async -> [Result<[String], TmuxCommandError>] {
-        let collector = BatchCollector(count: texts.count)
-        let commands = texts.enumerated().map { index, text in
-            TmuxCommand(text: text, tolerateErrors: true) { result in
-                collector.set(index, result)
-            }
-        }
-        await client.sendList(commands)
-        return await collector.wait()
-    }
-}
-
-/// Bridges the correlator's per-command completion callbacks to one awaited
-/// batch result. Lock-protected: completions arrive on the correlator actor,
-/// `wait` suspends the orchestrator's task.
-private final class BatchCollector: @unchecked Sendable {
-    private let lock = NSLock()
-    private var results: [Result<[String], TmuxCommandError>?]
-    private var continuation: CheckedContinuation<[Result<[String], TmuxCommandError>], Never>?
-
-    init(count: Int) {
-        results = Array(repeating: nil, count: count)
-    }
-
-    func set(_ index: Int, _ result: Result<[String], TmuxCommandError>) {
-        lock.lock()
-        results[index] = result
-        guard let done = completedResults(), let continuation else {
-            lock.unlock()
-            return
-        }
-        self.continuation = nil
-        lock.unlock()
-        continuation.resume(returning: done)
-    }
-
-    func wait() async -> [Result<[String], TmuxCommandError>] {
-        await withCheckedContinuation { continuation in
-            lock.lock()
-            if let done = completedResults() {
-                lock.unlock()
-                continuation.resume(returning: done)
-                return
-            }
-            self.continuation = continuation
-            lock.unlock()
-        }
-    }
-
-    /// All results, iff every slot is filled. Caller must hold `lock`.
-    private func completedResults() -> [Result<[String], TmuxCommandError>]? {
-        let filled = results.compactMap { $0 }
-        return filled.count == results.count ? filled : nil
     }
 }

--- a/Sources/TBDDaemon/Tmux/ControlMode/AttachReplayOrchestrator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/AttachReplayOrchestrator.swift
@@ -40,38 +40,70 @@ struct AttachReplayFailure: Error {
     let underlying: any Error
 }
 
-/// The attach orchestration v2 (M4.3, addendum §3): `attach.ready` triggers
-/// pause → capture → replay → gate → unpause, with pause as the serialization
-/// mechanism — the pane emits nothing between the pause and the unpause the
-/// orchestrator sends only after the replay bytes are in the pipe, so live
-/// output physically cannot race the replay. No interleave buffer.
+/// The attach orchestration v2 (M4.3, addendum §3) with the Phase B M2
+/// attach-boundary fence (issue #376): `attach.ready` triggers pause →
+/// fence → captures+continue → replay → gate+flush, with pause as the
+/// serialization mechanism and a generation-scoped fence queue closing the
+/// boundary gap — live output physically cannot precede, interleave, OR be
+/// lost around the replay.
 ///
 /// Sequence:
 ///  1. Acknowledge the attach and read its CURRENT generation atomically —
 ///     the whole sequence is tagged with it, and the ready-timeout stops
 ///     threatening the attach (its purpose is "app never acked").
-///  2. ONE atomic command list down the `-CC` stream: pause, then the
-///     5-command capture (pure scrollback, current screen, saved primary,
-///     pane state, pending).
-///  3. Assemble the replay (`ReplayWriter`) and write it into the pane's
-///     pipe behind the still-closed gate (`writeReplay`, generation-checked).
-///  4. Open the gate (`markReady`) — ONLY after the replay bytes landed.
-///  5. Unpause LAST, on every exit path after the pause was sent EXCEPT
-///     mid-sequence supersession: pause state is per PANE on the shared
-///     per-server correlator, so a superseded generation leaves the unpause
-///     to its successor's own FIFO-ordered sequence — a stale continue could
-///     otherwise land inside the successor's pause window and resume output
-///     into its still-closed gate. (A stale unpause on an unpaused pane
-///     no-ops via tolerate-errors.)
+///  2. Batch 1: the PAUSE alone, awaited. Command replies and `%output`
+///     reach the daemon on paths that do NOT preserve relative order
+///     end-to-end (`%output` is routed synchronously on the connection
+///     reader thread via `outputSink` → `PaneFanout.route`; replies hop
+///     AsyncStream → supervisor actor → correlator actor → completion), so
+///     the fence can only be armed at a moment the pane is PROVABLY silent
+///     — arming it any earlier could fence pre-pause output the capture
+///     already holds; any later could miss post-continue output racing
+///     ahead of a reply. The pause reply is that moment: everything the
+///     pane emitted before the pause has, by stream order, already been
+///     routed (and dropped by the closed gate — it is in the capture, no
+///     loss), and a PAUSED pane delivers NOTHING (live-probed, tmux 3.6a:
+///     zero bytes even with ~500k tokens emitted while paused; the content
+///     lands in pane history/screen, reachable via capture).
+///  3. Arm the fence (generation-checked): output routed for the pane while
+///     the gate stays closed now QUEUES (the M1 machinery, drain unarmed)
+///     instead of dropping.
+///  4. Batch 2: the 6-command capture + the continue, ONE atomic command
+///     list with the continue LAST — live-probed (tmux 3.6a, 6/6 trials
+///     under throttled AND firehose load): the first live token delivered
+///     after an atomic [captures…, continue] is contiguous with the
+///     capture's last token, a seam gap of exactly ZERO. Post-continue
+///     output flows into the armed fence.
+///  5. Assemble the replay (`ReplayWriter`) and write it into the pane's
+///     pipe behind the still-closed gate (`writeReplay`, generation-checked)
+///     — safe against the fence queue because the drain is never armed
+///     while fenced.
+///  6. Open the gate (`markReady`) — ONLY after the replay bytes landed. It
+///     clears the fence and arms the drain, so the fenced bytes follow the
+///     replay in order and live output folds in behind them (`route()`'s
+///     queue-nonempty ordering). ZERO output loss at the attach seam.
+///  7. No trailing unpause on success — batch 2's continue already ran.
+///     Failure paths after the pause still send a generation-checked
+///     unpause: it covers "the pause executed but batch 2's continue may
+///     not have" (e.g. the send raced a connection close); a redundant
+///     continue on an unpaused pane no-ops via tolerate-errors. Mid-sequence
+///     supersession NEVER unpauses (R11): pause state is per PANE on the
+///     shared per-server correlator, so a superseded generation leaves it
+///     to its successor's own FIFO-ordered sequence — a stale continue
+///     could otherwise land inside the successor's pause window and resume
+///     output into its still-closed gate.
 ///
-/// Measured residual (tmux 3.6a, M4 live matrix): pause → continue DISCARDS
+/// HISTORY (pre-M2 residual, M4 live matrix): pause → continue DISCARDS
 /// pane output emitted while paused — tmux resumes delivery from the pane's
 /// CURRENT position, draining nothing (with or without the `pause-after`
-/// client flag; iTerm2 handles `%pause` by re-capturing for the same reason).
-/// So output the pane emits between the capture and the unpause is lost to
-/// the viewer: a boundary-only, strictly-forward gap. Live output still
-/// cannot precede or interleave the replay; closing the gap needs an
-/// interleave buffer (capture fence → gate open), a design follow-up.
+/// client flag; iTerm2 handles `%pause` by re-capturing for the same
+/// reason). Before the fence, output the pane emitted between the capture
+/// and the trailing unpause was therefore lost to the viewer: a measured
+/// boundary-only forward gap (3–25 tokens under load). The fence + atomic
+/// captures+continue batch eliminate it. Remaining residual: fence-queue
+/// OVERFLOW during replay assembly (a blast pane exceeding the 128 KB cap)
+/// still drops whole chunks with telemetry — M3's pause+repair cycle owns
+/// healing that.
 struct AttachReplayOrchestrator: Sendable {
     /// How the sequence ended without error.
     enum Outcome: Equatable {
@@ -185,10 +217,67 @@ struct AttachReplayOrchestrator: Sendable {
             return .superseded
         }
 
-        // ONE atomic sendList: pause FIRST, then the capture batch — atomicity
-        // in the FIFO guarantees nothing (not even our own commands) slips
-        // between the pause and the captures, and everything the pane emitted
-        // before the pause is already ordered ahead of the capture replies.
+        // Batch 1 — the PAUSE alone, awaited (M2). The fence below can only
+        // be armed while the pane is provably silent, and the pause reply is
+        // the earliest such moment (see the sequence doc: replies and
+        // %output travel order-skewed paths, so no reply-relative moment
+        // earlier than "paused and confirmed" is race-free). Tolerates
+        // errors at the correlator level like every command this sequence
+        // sends: one dead pane must not tear down the whole server's
+        // connection.
+        let pause = "refresh-client -A '\(paneID):pause'"
+        let pauseResults = await sendBatch(client, texts: [pause])
+
+        // A failed pause means the captures below run UNPAUSED: the pane may
+        // emit between the capture replies and the gate opening, so the
+        // replay can be slightly torn (cursor vs content mismatch). Surface
+        // it and PROCEED rather than fail the attach: fullscreen apps
+        // repaint differentially and self-heal, and a genuinely dead pane
+        // %errors the captures right below, which fails the attach on its
+        // own (review M4). The fence still arms — whatever the pane emits
+        // after the arm is queued, not lost.
+        if case .failure(let pauseError) = pauseResults.first {
+            Self.logger.error("""
+                attach pause failed for \(server, privacy: .public)/\(paneID, privacy: .public) \
+                (\(pause, privacy: .public)): \(String(describing: pauseError), privacy: .public) \
+                — proceeding with an unpaused capture (replay may be slightly torn; self-heals)
+                """)
+            onPauseFailure?(String(describing: pauseError))
+        }
+
+        // Post-pause supersession re-check (M2): splitting the batch adds an
+        // await between the acknowledge and the capture send — a stale task
+        // resumed here must not send its captures+continue after a
+        // successor's completed sequence (same rationale as the R10-3
+        // post-hop re-check above). R11 scoping: superseded → send NOTHING
+        // more and do NOT unpause — the successor's own FIFO-ordered
+        // sequence owns the pane's pause state.
+        guard await supervisor.currentGeneration(server: server, paneID: paneID) == generation else {
+            Self.logger.debug("""
+                attach.ready superseded after the pause for \
+                \(server, privacy: .public)/\(paneID, privacy: .public) gen=\(generation) — sending nothing
+                """)
+            return .superseded
+        }
+
+        // Arm the fence — the pane is silent (pause reply in hand), so no
+        // output can race the arming. Generation-checked: refusal means a
+        // newer attach owns the pane, the same benign race as above (R11:
+        // no unpause; the successor owns the pause state).
+        guard await supervisor.armFence(server: server, paneID: paneID, generation: generation) else {
+            Self.logger.debug("""
+                attach.ready superseded at the fence for \
+                \(server, privacy: .public)/\(paneID, privacy: .public) gen=\(generation) — sending nothing
+                """)
+            return .superseded
+        }
+
+        // Batch 2 — the capture list + the CONTINUE, one atomic command list
+        // with the continue LAST (M2): atomicity in the FIFO guarantees
+        // nothing slips between the captures and the continue, and the
+        // live-probed seam of an atomic [captures…, continue] is exactly
+        // zero — the first post-continue byte (which flows into the armed
+        // fence) is contiguous with the capture's tail.
         //
         // All entries tolerate errors at the correlator level: a capture
         // %error (pane died mid-attach) must fail THIS attach, not tear down
@@ -201,7 +290,6 @@ struct AttachReplayOrchestrator: Sendable {
         // on tmux 3.6a). So the scrollback is captured on its own leg
         // (`-E -1` = end before the visible screen), which works during alt
         // mode too, and the assembler recombines the legs by `alternate_on`.
-        let pause = "refresh-client -A '\(paneID):pause'"
         let captureCommands = [
             // Pure primary scrollback, NO screen rows. QUIRK (live-probed):
             // on a history-less pane this clamps and returns the first
@@ -224,54 +312,43 @@ struct AttachReplayOrchestrator: Sendable {
             PaneStateCapture.listPanesCommand(target: paneID),
             "capture-pane -p -P -C -t \(paneID)",
         ]
-        let results = await sendBatch(client, texts: [pause] + captureCommands)
+        let continueCommand = "refresh-client -A '\(paneID):continue'"
+        let results = await sendBatch(client, texts: captureCommands + [continueCommand])
 
-        // A failed pause means the captures below ran UNPAUSED: the pane may
-        // have emitted between the capture replies and the gate opening, so
-        // the replay can be slightly torn (cursor vs content mismatch).
-        // Surface it and PROCEED rather than fail the attach: the tear is the
-        // same class as the accepted pause-discard boundary gap — fullscreen
-        // apps repaint differentially and self-heal, and a genuinely dead
-        // pane %errors the captures right below, which fails the attach on
-        // its own (review M4).
-        if case .failure(let pauseError) = results.first {
+        // A failed batched continue is log-only: a %error is tolerated (the
+        // failure-path unpause below re-sends one when the captures failed
+        // too), and a connection close fails the captures as well — which
+        // fails the attach on its own. Pause state is per control CLIENT,
+        // so it cannot outlive a closed connection either way.
+        if case .failure(let continueError) = results.last {
             Self.logger.error("""
-                attach pause failed for \(server, privacy: .public)/\(paneID, privacy: .public) \
-                (\(pause, privacy: .public)): \(String(describing: pauseError), privacy: .public) \
-                — proceeding with an unpaused capture (replay may be slightly torn; self-heals)
+                attach batched continue failed for \(server, privacy: .public)/\(paneID, privacy: .public): \
+                \(String(describing: continueError), privacy: .public)
                 """)
-            onPauseFailure?(String(describing: pauseError))
         }
 
-        // The pause has been sent — from here, unpause runs on every exit
-        // path EXCEPT mid-sequence supersession (defer-equivalent; `defer`
-        // can't await the actor call).
+        // The pause has been sent — from here, every FAILURE exit unpauses
+        // unless superseded (defer-equivalent; `defer` can't await the actor
+        // call). The SUCCESS path sends nothing more: batch 2's continue
+        // already ran.
         do {
-            let outcome = try await replayAndOpenGate(
+            // `.superseded` (writeReplay/markReady saw a newer generation)
+            // sends nothing further either — batch 2 (with its continue) was
+            // already on the stream BEFORE the successor's own sequence, so
+            // FIFO keeps it clear of the successor's pause window (R11).
+            return try await replayAndOpenGate(
                 server: server, paneID: paneID, generation: generation,
-                captureResults: Array(results.dropFirst()),
+                captureResults: Array(results.dropLast()),
                 captureCommands: captureCommands)
-            // `.superseded` (writeReplay/markReady saw a newer generation) SKIPS the
-            // unpause: pause state is per PANE on the shared correlator, and
-            // FIFO ordering puts the successor's own pause → captures →
-            // replay → unpause sequence AFTER ours — a stale continue here
-            // could land while the successor is mid-capture with its gate
-            // still closed, resuming live output into a closed gate (dropped;
-            // widens the boundary gap). Accepted residual: if the successor's
-            // ready never arrives, the pane stays paused until the NEXT
-            // attach's sequence unpauses it — benign (no viewer is watching;
-            // tmux buffers server-side).
-            if outcome == .ready {
-                await sendUnpause(client, paneID: paneID)
-            }
-            return outcome
         } catch {
-            // Same generation scoping as the success path's `.superseded`
-            // skip (R11): a failing STALE sequence must not unpause either —
-            // its continue could land between a live successor's pause and
-            // captures, tearing the successor's capture. When we still own
-            // the pane, unpause as always; when superseded, the successor's
-            // own sequence (unpause on every exit path) owns the pause state.
+            // Generation-checked unpause-on-failure: it covers "the pause
+            // executed but batch 2's continue may not have" (e.g. the send
+            // raced a connection close); a redundant continue on an unpaused
+            // pane no-ops via tolerate-errors. R11 scoping unchanged: a
+            // failing STALE sequence must not unpause — its continue could
+            // land between a live successor's pause and captures, tearing
+            // the successor's capture. The successor's own sequence owns the
+            // pane's pause state.
             if await supervisor.currentGeneration(server: server, paneID: paneID) == generation {
                 await sendUnpause(client, paneID: paneID)
             }
@@ -354,7 +431,10 @@ struct AttachReplayOrchestrator: Sendable {
             return .superseded
         }
         // Gate opens ONLY after the replay bytes are in the pipe: live output
-        // routed from here lands strictly after the replay. Generation-checked
+        // routed from here lands strictly after the replay. markReady also
+        // clears the M2 fence and arms the drain, flushing the fenced bytes
+        // (everything the pane emitted since batch 2's continue) in behind
+        // the replay — the zero-seam flush. Generation-checked
         // (R6-H1): a re-attach can swap the sink between the writeReplay above
         // and this call, and a stale markReady must not open the successor's
         // gate before ITS replay landed. Refusal is the same benign race as a
@@ -369,8 +449,9 @@ struct AttachReplayOrchestrator: Sendable {
         return .ready
     }
 
-    /// Unpause, tolerate-errors: must no-op when the pane wasn't paused or a
-    /// newer attach already unpaused it. Fire-and-forget — the reply is not
+    /// Failure-path unpause (M2: the success path's continue rides batch 2),
+    /// tolerate-errors: must no-op when the pane wasn't paused or a newer
+    /// attach already unpaused it. Fire-and-forget — the reply is not
     /// awaited (nothing left to order behind it for THIS attach).
     private func sendUnpause(_ client: TmuxControlCommandClient, paneID: String) async {
         await client.sendList([

--- a/Sources/TBDDaemon/Tmux/ControlMode/AttachReplayOrchestrator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/AttachReplayOrchestrator.swift
@@ -264,6 +264,13 @@ struct AttachReplayOrchestrator: Sendable {
         // output can race the arming. Generation-checked: refusal means a
         // newer attach owns the pane, the same benign race as above (R11:
         // no unpause; the successor owns the pause state).
+        //
+        // TOCTOU residual (accepted): this generation check and the batch
+        // send below are not atomic — a successor can interpose between
+        // them, so batch 2 can land inside the successor's pause window in
+        // a vanishingly narrow race. Consequence: a torn capture that
+        // differentially self-heals, same class as the accepted
+        // pause-failure tear above.
         guard await supervisor.armFence(server: server, paneID: paneID, generation: generation) else {
             Self.logger.debug("""
                 attach.ready superseded at the fence for \
@@ -288,16 +295,20 @@ struct AttachReplayOrchestrator: Sendable {
         let continueCommand = "refresh-client -A '\(paneID):continue'"
         let results = await client.sendBatch(texts: captureCommands + [continueCommand])
 
-        // A failed batched continue is log-only: a %error is tolerated (the
-        // failure-path unpause below re-sends one when the captures failed
-        // too), and a connection close fails the captures as well — which
-        // fails the attach on its own. Pause state is per control CLIENT,
-        // so it cannot outlive a closed connection either way.
+        // A failed batched continue is tolerated: a connection close fails
+        // the captures as well — which fails the attach on its own (and
+        // pause state is per control CLIENT, so it cannot outlive a closed
+        // connection) — and the failure-path unpause below covers the error
+        // exits. But a plain %error with healthy captures would otherwise
+        // leave a live-looking attach on a still-PAUSED pane, so the success
+        // path retries the continue once (review round 2, M3).
+        var continueErrored = false
         if case .failure(let continueError) = results.last {
             Self.logger.error("""
                 attach batched continue failed for \(server, privacy: .public)/\(paneID, privacy: .public): \
                 \(String(describing: continueError), privacy: .public)
                 """)
+            if case .commandFailed = continueError { continueErrored = true }
         }
 
         // The pause has been sent — from here, every FAILURE exit unpauses
@@ -309,10 +320,20 @@ struct AttachReplayOrchestrator: Sendable {
             // sends nothing further either — batch 2 (with its continue) was
             // already on the stream BEFORE the successor's own sequence, so
             // FIFO keeps it clear of the successor's pause window (R11).
-            return try await replayAndOpenGate(
+            let outcome = try await replayAndOpenGate(
                 server: server, paneID: paneID, generation: generation,
                 captureResults: Array(results.dropLast()),
                 captureCommands: captureCommands)
+            // An %error'd batched continue (NOT a connection close — that
+            // fails the captures too) leaves a live-looking attach on a
+            // still-PAUSED pane. Retry ONE generation-checked,
+            // tolerate-errors, fire-and-forget continue (review round 2,
+            // M3) — same still-owner scoping as the failure path below.
+            if outcome == .ready, continueErrored,
+               await supervisor.currentGeneration(server: server, paneID: paneID) == generation {
+                await sendUnpause(client, paneID: paneID)
+            }
+            return outcome
         } catch {
             // Generation-checked unpause-on-failure: it covers "the pause
             // executed but batch 2's continue may not have" (e.g. the send
@@ -322,6 +343,13 @@ struct AttachReplayOrchestrator: Sendable {
             // land between a live successor's pause and captures, tearing
             // the successor's capture. The successor's own sequence owns the
             // pane's pause state.
+            //
+            // TOCTOU residual (accepted): the generation check and the
+            // continue send are not atomic — a successor can interpose
+            // between them, so this continue can land inside the successor's
+            // pause window in a vanishingly narrow race. Consequence: a torn
+            // capture that differentially self-heals, same class as the
+            // accepted pause-failure tear.
             if await supervisor.currentGeneration(server: server, paneID: paneID) == generation {
                 await sendUnpause(client, paneID: paneID)
             }

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneCaptureReplay.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneCaptureReplay.swift
@@ -1,0 +1,186 @@
+import Foundation
+import os
+
+/// Shared capture-list + replay-assembly for the two sequences that rebuild a
+/// pane's terminal state from tmux captures:
+///
+///  - the ATTACH orchestrator (M4.3 + Phase B M2): attach.ready → pause →
+///    fence → captures+continue → replay behind the closed gate;
+///  - the overflow REPAIR coordinator (Phase B M3): queue overflow → pause →
+///    wait for the reader → recapture + atomic continue → replay → fence
+///    flush.
+///
+/// Both send the SAME 6-command capture list and assemble the SAME replay
+/// bytes; extracting them here keeps the two sequences byte-identical (the
+/// M3 repair is exactly "the attach's capture half, re-run mid-session").
+enum PaneCaptureReplay {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "tmuxControlMode")
+
+    /// The capture half of the atomic captures+continue batch — all entries
+    /// tolerate errors at the correlator level: a capture %error (pane died
+    /// mid-sequence) must fail THIS sequence, not tear down the server's
+    /// connection and every other pane on it. The caller turns any capture
+    /// failure into `AttachReplayError.captureFailed`.
+    /// THREE capture legs (review H1): `-a` reaches only the saved primary
+    /// VIEWPORT while the pane is on the alt screen — the primary
+    /// SCROLLBACK is reachable only through the history portion of a
+    /// no-`-a` capture (adding `-S` to the `-a` leg is a no-op; live-probed
+    /// on tmux 3.6a). So the scrollback is captured on its own leg
+    /// (`-E -1` = end before the visible screen), which works during alt
+    /// mode too, and the assembler recombines the legs by `alternate_on`.
+    static func captureCommands(paneID: String, historyDepth: Int) -> [String] {
+        [
+            // Pure primary scrollback, NO screen rows. QUIRK (live-probed):
+            // on a history-less pane this clamps and returns the first
+            // visible screen row — the assembler discards this leg when
+            // `history_size` == 0. -q guards %error.
+            "capture-pane -peqJN -S -\(historyDepth) -E -1 -q -t \(paneID)",
+            // Current screen only — the PRIMARY screen normally, the ALT
+            // screen while `alternate_on`.
+            "capture-pane -peqJN -t \(paneID)",
+            // -a: the SAVED primary viewport while `alternate_on`;
+            // -q: empty (not %error) when there is no saved screen.
+            "capture-pane -peqJN -a -q -t \(paneID)",
+            // COMBINED history+screen in ONE invocation (review R8-M3): `-J`
+            // joins soft wraps only WITHIN a capture, so the split legs above
+            // hard-break a logical line that wraps across the scrollback/
+            // screen seam. Non-alt replays use this leg verbatim (identical
+            // to the pre-split single capture); the split legs remain for the
+            // alt mapping, which has no combined-capture equivalent.
+            "capture-pane -peqJN -S -\(historyDepth) -t \(paneID)",
+            PaneStateCapture.listPanesCommand(target: paneID),
+            "capture-pane -p -P -C -t \(paneID)",
+        ]
+    }
+
+    /// Parse the capture batch's results and assemble the replay bytes —
+    /// everything between "all reply blocks are in hand" and "write the
+    /// replay into the pipe". Throws `AttachReplayError.captureFailed` /
+    /// `.paneStateMissing`, `PaneStateCaptureError`, or `ReplayWriterError`;
+    /// the caller owns the write, the gate/fence, and failure cleanup.
+    static func assemble(
+        captureResults: [Result<[String], TmuxCommandError>],
+        captureCommands: [String],
+        server: String,
+        paneID: String,
+        historyDepth: Int,
+        onHistoryTruncation: (@Sendable (Int) -> Void)?
+    ) throws -> Data {
+        var captured: [[String]] = []
+        for (result, command) in zip(captureResults, captureCommands) {
+            switch result {
+            case .success(let lines):
+                captured.append(lines)
+            case .failure(let error):
+                logger.error("""
+                    capture failed for \(server, privacy: .public)/\(paneID, privacy: .public) \
+                    (\(command, privacy: .public)): \(String(describing: error), privacy: .public)
+                    """)
+                throw AttachReplayError.captureFailed(command: command)
+            }
+        }
+        let (historyLeg, screenLeg, savedLeg, combinedLeg, stateLines, pending) =
+            (captured[0], captured[1], captured[2], captured[3], captured[4], captured[5])
+
+        // Truncation telemetry (plan M4.4 fold-in): at >= depth lines the
+        // scrollback capture almost certainly hit the history ceiling and
+        // older scrollback was lost to this replay.
+        if historyLeg.count >= historyDepth {
+            logger.info("""
+                capture hit history ceiling for \(server, privacy: .public)/\(paneID, privacy: .public): \
+                \(historyLeg.count) lines >= depth \(historyDepth)
+                """)
+            onHistoryTruncation?(historyLeg.count)
+        }
+
+        guard let state = try PaneStateCapture.state(forPane: paneID, in: stateLines) else {
+            throw AttachReplayError.paneStateMissing
+        }
+        // Leg recombination (reviews H1 + R8-M3, verified live on tmux 3.6a):
+        // - NON-alt: use combinedLeg VERBATIM — one tmux invocation whose -J
+        //   joins soft wraps across the scrollback/screen seam, byte-identical
+        //   to the pre-split single capture (and immune to the history-less
+        //   clamp quirk: with no history it is exactly the screen).
+        // - ALT: the primary content must be stitched from historyLeg (pure
+        //   scrollback; reachable during alt, but CLAMPS to the first screen
+        //   row on a history-less pane, so discarded when history_size == 0)
+        //   + savedLeg (the -a saved primary viewport). ACCEPTED RESIDUAL: a
+        //   logical line soft-wrapping across THAT seam replays with a
+        //   spurious hard break — there is no combined capture that reaches
+        //   both regions while the pane is on the alt screen. Cosmetic,
+        //   narrow (exact seam alignment), no data loss.
+        //   screenLeg is the ALT content in this case.
+        let scrollback = state.historySize > 0 ? historyLeg : []
+        return try ReplayWriter.assemble(
+            history: state.alternateOn ? scrollback + savedLeg : combinedLeg,
+            altScreen: state.alternateOn ? screenLeg : nil,
+            pending: pending,
+            state: state,
+            cols: state.width,
+            rows: state.height)
+    }
+}
+
+extension TmuxControlCommandClient {
+    /// Send `texts` as ONE atomic command list and await ALL their replies.
+    /// Sound because the correlator guarantees every completion eventually
+    /// fires: a reply block per command in FIFO order, or `.connectionClosed`
+    /// for the remainder when the stream ends. (A mute-but-alive tmux stalls
+    /// this like any other awaited command — stream teardown resolves it.)
+    /// Every entry tolerates errors at the correlator level — one dead pane's
+    /// %error must not tear down the whole server's connection.
+    func sendBatch(texts: [String]) async -> [Result<[String], TmuxCommandError>] {
+        let collector = TmuxCommandBatchCollector(count: texts.count)
+        let commands = texts.enumerated().map { index, text in
+            TmuxCommand(text: text, tolerateErrors: true) { result in
+                collector.set(index, result)
+            }
+        }
+        sendList(commands)
+        return await collector.wait()
+    }
+}
+
+/// Bridges the correlator's per-command completion callbacks to one awaited
+/// batch result. Lock-protected: completions arrive on the correlator actor,
+/// `wait` suspends the sender's task.
+final class TmuxCommandBatchCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var results: [Result<[String], TmuxCommandError>?]
+    private var continuation: CheckedContinuation<[Result<[String], TmuxCommandError>], Never>?
+
+    init(count: Int) {
+        results = Array(repeating: nil, count: count)
+    }
+
+    func set(_ index: Int, _ result: Result<[String], TmuxCommandError>) {
+        lock.lock()
+        results[index] = result
+        guard let done = completedResults(), let continuation else {
+            lock.unlock()
+            return
+        }
+        self.continuation = nil
+        lock.unlock()
+        continuation.resume(returning: done)
+    }
+
+    func wait() async -> [Result<[String], TmuxCommandError>] {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if let done = completedResults() {
+                lock.unlock()
+                continuation.resume(returning: done)
+                return
+            }
+            self.continuation = continuation
+            lock.unlock()
+        }
+    }
+
+    /// All results, iff every slot is filled. Caller must hold `lock`.
+    private func completedResults() -> [Result<[String], TmuxCommandError>]? {
+        let filled = results.compactMap { $0 }
+        return filled.count == results.count ? filled : nil
+    }
+}

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
@@ -80,8 +80,17 @@ final class PaneFanout: @unchecked Sendable {
         /// The attach handshake's write gate: false between `attach` (fd
         /// vended) and the end of the attach.ready replay sequence (M4.3):
         /// the orchestrator opens the gate only AFTER the replay bytes are in
-        /// the pipe. Output routed while not ready is dropped.
+        /// the pipe. Output routed while not ready is dropped — unless the
+        /// M2 attach fence (`fenced`) is armed, which queues it instead for
+        /// the post-replay flush.
         var ready = false
+        /// Attach-boundary fence (Phase B M2, issue #376): armed by the
+        /// attach orchestrator once the pane is provably silent (the pause
+        /// reply completed). While set — the gate is necessarily still
+        /// closed — routed output QUEUES (M1 machinery, drain deliberately
+        /// unarmed) instead of dropping; `markReady` clears it and arms the
+        /// drain, flushing the parked bytes strictly after the replay.
+        var fenced = false
         /// The app's `attach.ready` ack arrived (M4.3). Since M4.3, `ready`
         /// flips only after the replay lands — so the ready-timeout (whose
         /// purpose is "app never acked") keys off THIS flag instead: a slow
@@ -169,17 +178,48 @@ final class PaneFanout: @unchecked Sendable {
     @discardableResult
     func markReady(key: PaneKey, generation: UInt64) -> Bool {
         lock.lock()
-        guard let sink = sinks[key], sink.generation == generation else {
+        guard var sink = sinks[key], sink.generation == generation else {
             lock.unlock()
             logger.info(
                 "fanout stale ready refused \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation)")
             return false
         }
-        sinks[key]?.ready = true
-        sinks[key]?.acknowledged = true
+        sink.ready = true
+        sink.acknowledged = true
+        // Clear the M2 attach fence and flush what it parked: the replay
+        // bytes are already in the pipe (`writeReplay` precedes markReady),
+        // so arming the drain NOW delivers the fenced bytes strictly after
+        // the replay — and `route()`'s queue-nonempty ordering folds live
+        // output in behind them. Zero loss at the attach seam.
+        sink.fenced = false
+        armDrainIfNeededLocked(&sink, key: key)
+        sinks[key] = sink
         lock.unlock()
         logger.info(
             "fanout ready \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation)")
+        return true
+    }
+
+    /// Arm the attach-boundary fence for `key` (Phase B M2) — generation-
+    /// checked like every other sink mutation: mismatch or missing sink →
+    /// `false`, nothing touched (the caller treats it like a superseded
+    /// attach). Call ONLY at a moment the pane is provably silent (the
+    /// orchestrator's pause reply): `%output` is routed synchronously on the
+    /// reader thread while command replies hop actors, so arming at any
+    /// noisier moment could fence pre-pause output the capture already holds.
+    @discardableResult
+    func armFence(key: PaneKey, generation: UInt64) -> Bool {
+        lock.lock()
+        guard let sink = sinks[key], sink.generation == generation else {
+            lock.unlock()
+            logger.info(
+                "fanout stale fence refused \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation)")
+            return false
+        }
+        sinks[key]?.fenced = true
+        lock.unlock()
+        logger.debug(
+            "fanout fence armed \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation)")
         return true
     }
 
@@ -292,9 +332,11 @@ final class PaneFanout: @unchecked Sendable {
 
     /// Write the attach replay into `key`'s pipe. Callable while the sink is
     /// NOT ready — that's the point: the replay lands behind the closed gate
-    /// (live output routed meanwhile is still dropped), and the orchestrator
-    /// acks `attach.ready` only after this returns, so live bytes follow the
-    /// replay in order (addendum §3).
+    /// (live output routed meanwhile is dropped, or PARKED in the fence
+    /// queue once the M2 fence is armed — the drain is never live while
+    /// fenced, so this direct write cannot be interleaved), and the
+    /// orchestrator opens the gate only after this returns, so live bytes
+    /// follow the replay in order (addendum §3).
     ///
     /// Unlike `route()` (hot path — queues on EAGAIN and drains
     /// asynchronously), a replay must arrive
@@ -411,13 +453,27 @@ final class PaneFanout: @unchecked Sendable {
 
         lock.lock()
         defer { lock.unlock() }
-        guard var sink = sinks[key], sink.ready else {
-            // Not-ready / unattached drops are unchanged in M1 — the attach
-            // fence (M2) owns that window.
-            if sinks[key] != nil {
-                sinks[key]!.droppedEvents += 1
+        guard var sink = sinks[key] else {
+            unattachedDrops += 1
+            return
+        }
+        guard sink.ready else {
+            if sink.fenced {
+                // Attach-fence window (M2): the pane's attach sequence owns
+                // the seam from the pause reply to markReady — queue (M1 cap
+                // + overflow telemetry apply unchanged) WITHOUT arming the
+                // drain. The queue must stay parked behind the closed gate
+                // until the replay lands: `writeReplay` writes the pipe
+                // directly, and a live drain would interleave fenced bytes
+                // into the replay. `markReady` clears the fence and arms it.
+                enqueueLocked(bytes, into: &sink, key: key)
+                sinks[key] = sink
             } else {
-                unattachedDrops += 1
+                // Pre-fence not-ready window (attach → pause reply): dropped
+                // — those bytes are in the attach's capture, not lost;
+                // delivering them too would duplicate them.
+                sink.droppedEvents += 1
+                sinks[key] = sink
             }
             return
         }
@@ -459,7 +515,11 @@ final class PaneFanout: @unchecked Sendable {
     /// continuation is lost, corrupting escape sequences; dropping the entire
     /// incoming chunk keeps everything delivered + queued an intact prefix.
     /// The overflow drop here is the M3 hook point — the pause+repair cycle
-    /// (tmux flow control + recapture) replaces it later.
+    /// (tmux flow control + recapture) replaces it later. That includes the
+    /// FENCED window's residual (M2): a blast pane can exceed the cap while
+    /// the replay is still being assembled, and the chunks dropped here are
+    /// then missing between the replay and the flushed queue — M3's repair
+    /// cycle owns healing that; M2 adds no extra behavior for it.
     private func enqueueLocked(_ data: Data, into sink: inout Sink, key: PaneKey) {
         guard !data.isEmpty else { return }
         if sink.queuedBytes + data.count > Self.queueCap {

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
@@ -121,6 +121,10 @@ final class PaneFanout: @unchecked Sendable {
         var droppedEvents = 0
         var droppedBytes = 0
         var lastDropLog = Date.distantPast
+        /// Rate limiter for `route()`'s hard-write-error log, separate from
+        /// `lastDropLog` so a blast of overflow drops can't suppress the
+        /// hard-error diagnostic (or vice versa).
+        var lastWriteErrorLog = Date.distantPast
         /// Backpressure queue (Phase B M1): bytes the pipe could not accept
         /// yet, delivered IN ORDER by the async drain task. Bounded by
         /// `PaneFanout.queueCap`; scoped to this (key, generation) — a
@@ -678,8 +682,8 @@ final class PaneFanout: @unchecked Sendable {
                             let remainder = buf.count - offset
                             sink.droppedEvents += 1
                             sink.droppedBytes += remainder
-                            if Date().timeIntervalSince(sink.lastDropLog) > 1 {
-                                sink.lastDropLog = Date()
+                            if Date().timeIntervalSince(sink.lastWriteErrorLog) > 1 {
+                                sink.lastWriteErrorLog = Date()
                                 logger.error(
                                     "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) write errno=\(err) — dropped \(remainder) bytes")
                             }

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
@@ -31,6 +31,17 @@ enum PaneReplayWriteError: Error, Equatable {
     case writeFailed(errno: Int32)
 }
 
+/// Locked snapshot of one pane's flow-control counters (Phase B M1) — test
+/// visibility plus diagnostics. `droppedEvents`/`droppedBytes` count ONLY
+/// overflow and not-ready drops; plain EAGAIN no longer drops (it queues).
+struct PaneFlowStats: Equatable {
+    let queuedBytes: Int
+    let droppedBytes: Int
+    let droppedEvents: Int
+    let overflowEvents: Int
+    let queuedHighWater: Int
+}
+
 /// Outcome of the generation-checked `PaneFanout.acknowledge`.
 enum PaneAcknowledgeResult: Equatable {
     /// The ack landed: a sink exists and (when a generation was echoed) it
@@ -76,10 +87,35 @@ final class PaneFanout: @unchecked Sendable {
         /// purpose is "app never acked") keys off THIS flag instead: a slow
         /// capture must not let the stale timer kill a live, acked attach.
         var acknowledged = false
+        /// Overflow + not-ready drops only (Phase B M1): plain EAGAIN no
+        /// longer drops — the unwritten remainder is queued instead.
         var droppedEvents = 0
         var droppedBytes = 0
         var lastDropLog = Date.distantPast
+        /// Backpressure queue (Phase B M1): bytes the pipe could not accept
+        /// yet, delivered IN ORDER by the async drain task. Bounded by
+        /// `PaneFanout.queueCap`; scoped to this (key, generation) — a
+        /// superseded sink's queued bytes die with it.
+        var queue: [Data] = []
+        var queuedBytes = 0
+        /// A drain task is live for this (key, generation).
+        var drainArmed = false
+        /// Chunks dropped whole because the queue was at its cap.
+        var overflowEvents = 0
+        /// Highest `queuedBytes` ever observed on this sink.
+        var queuedHighWater = 0
+        /// Cumulative bytes that were queued and later delivered by the
+        /// drain (telemetry for the recovery log only).
+        var queuedDeliveredBytes = 0
+        /// Rate limiter for the backpressure-enter / drain-recovery logs
+        /// (`lastDropLog` covers the drop logs).
+        var lastFlowLog = Date.distantPast
     }
+
+    /// Per-pane backpressure queue cap. Beyond this, incoming chunks are
+    /// dropped whole (see `enqueueLocked`) — the M3 pause+repair cycle
+    /// replaces that drop later.
+    static let queueCap = 128 * 1024
 
     private let logger = Logger(subsystem: "com.tbd.daemon", category: "tmuxControlMode")
     private let lock = NSLock()
@@ -98,7 +134,9 @@ final class PaneFanout: @unchecked Sendable {
         if !ok { throw PaneFanoutError.pipeAllocationFailed(errno) }
         let (readFD, writeFD) = (fds[0], fds[1])
         // Nonblocking write end: a slow app-side reader must never stall the
-        // reader thread. EAGAIN → drop-and-count (Phase 6 adds flow control).
+        // reader thread. EAGAIN → queue-and-drain (Phase B M1): the unwritten
+        // remainder is queued per pane (cap `queueCap`) and an async drain
+        // task delivers it as the reader catches up.
         let flags = fcntl(writeFD, F_GETFL)
         _ = fcntl(writeFD, F_SETFL, flags | O_NONBLOCK)
 
@@ -258,7 +296,8 @@ final class PaneFanout: @unchecked Sendable {
     /// acks `attach.ready` only after this returns, so live bytes follow the
     /// replay in order (addendum §3).
     ///
-    /// Unlike `route()` (hot path — drops on EAGAIN), a replay must arrive
+    /// Unlike `route()` (hot path — queues on EAGAIN and drains
+    /// asynchronously), a replay must arrive
     /// INTACT: a truncated escape sequence corrupts the terminal. On EAGAIN
     /// this waits for pipe writability in short poll slices under `deadline`,
     /// re-validating the sink between slices. It can therefore block up to
@@ -333,7 +372,28 @@ final class PaneFanout: @unchecked Sendable {
             "replay write \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation) \(total) bytes delivered")
     }
 
+    /// Locked snapshot of `key`'s flow-control counters. `nil` when no sink
+    /// exists (never attached, detached, or superseded-and-gone).
+    func flowStats(key: PaneKey) -> PaneFlowStats? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let sink = sinks[key] else { return nil }
+        return PaneFlowStats(
+            queuedBytes: sink.queuedBytes,
+            droppedBytes: sink.droppedBytes,
+            droppedEvents: sink.droppedEvents,
+            overflowEvents: sink.overflowEvents,
+            queuedHighWater: sink.queuedHighWater)
+    }
+
     /// Hot path — called on the reader thread for every output event.
+    ///
+    /// Phase B M1 backpressure: a chunk the pipe cannot accept whole is no
+    /// longer truncated (issue #376 — every dropped byte leaves permanently
+    /// wrong cells on a differential renderer). The unwritten remainder is
+    /// queued (bounded by `queueCap`) and an async drain task delivers it in
+    /// order; while ANY bytes are queued, new chunks go straight to the queue
+    /// so live bytes can never overtake queued ones.
     func route(server: String, event: TmuxControlEvent) {
         let paneID: String
         let bytes: Data
@@ -352,6 +412,8 @@ final class PaneFanout: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         guard var sink = sinks[key], sink.ready else {
+            // Not-ready / unattached drops are unchanged in M1 — the attach
+            // fence (M2) owns that window.
             if sinks[key] != nil {
                 sinks[key]!.droppedEvents += 1
             } else {
@@ -360,32 +422,187 @@ final class PaneFanout: @unchecked Sendable {
             return
         }
 
-        // Partial-write loop: nonblocking write() may legally return a short
-        // count. Stopping mid-chunk and dropping the REMAINDER keeps the
-        // delivered prefix intact; skipping bytes in the middle would corrupt
-        // the escape-sequence stream.
-        let buf = [UInt8](bytes)
-        var offset = 0
-        while offset < buf.count {
-            let written = buf[offset...].withUnsafeBytes { Darwin.write(sink.writeFD, $0.baseAddress, $0.count) }
-            if written > 0 {
-                offset += written
-                continue
-            }
-            if written < 0 && errno == EAGAIN {
-                sink.droppedEvents += 1
-                sink.droppedBytes += buf.count - offset
-                if Date().timeIntervalSince(sink.lastDropLog) > 1 {
-                    sink.lastDropLog = Date()
-                    logger.debug(
-                        "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) EAGAIN — dropped \(sink.droppedBytes) bytes total (\(sink.droppedEvents) events)")
+        if sink.queuedBytes > 0 {
+            // Order preservation: bytes must NEVER overtake queued bytes —
+            // while the queue is non-empty, everything goes through it.
+            enqueueLocked(bytes, into: &sink, key: key)
+        } else {
+            // Partial-write loop: nonblocking write() may legally return a
+            // short count. On EAGAIN (or a short write) the UNWRITTEN
+            // remainder is queued — the delivered prefix stays intact and
+            // the queued continuation follows it in order.
+            let buf = [UInt8](bytes)
+            var offset = 0
+            while offset < buf.count {
+                let written = buf[offset...].withUnsafeBytes { Darwin.write(sink.writeFD, $0.baseAddress, $0.count) }
+                if written > 0 {
+                    offset += written
+                    continue
                 }
-            } else {
-                logger.error(
-                    "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) write errno=\(errno)")
+                if written < 0 && errno == EINTR { continue }
+                if written < 0 && errno == EAGAIN {
+                    enqueueLocked(Data(buf[offset...]), into: &sink, key: key)
+                } else {
+                    logger.error(
+                        "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) write errno=\(errno)")
+                }
+                break
             }
-            break
+        }
+        armDrainIfNeededLocked(&sink, key: key)
+        sinks[key] = sink
+    }
+
+    /// Append `data` to the sink's backpressure queue — MUST be called with
+    /// `lock` held. Chunks are enqueued (and, on overflow, dropped) WHOLE:
+    /// splitting what we enqueue would put a fragment mid-queue whose
+    /// continuation is lost, corrupting escape sequences; dropping the entire
+    /// incoming chunk keeps everything delivered + queued an intact prefix.
+    /// The overflow drop here is the M3 hook point — the pause+repair cycle
+    /// (tmux flow control + recapture) replaces it later.
+    private func enqueueLocked(_ data: Data, into sink: inout Sink, key: PaneKey) {
+        guard !data.isEmpty else { return }
+        if sink.queuedBytes + data.count > Self.queueCap {
+            sink.overflowEvents += 1
+            sink.droppedEvents += 1
+            sink.droppedBytes += data.count
+            if Date().timeIntervalSince(sink.lastDropLog) > 1 {
+                sink.lastDropLog = Date()
+                let (dropped, events, overflows) = (sink.droppedBytes, sink.droppedEvents, sink.overflowEvents)
+                logger.info(
+                    "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) queue overflow — dropped \(dropped) bytes total (\(events) events, \(overflows) overflows)")
+            }
+            return
+        }
+        let wasEmpty = sink.queuedBytes == 0
+        sink.queue.append(data)
+        sink.queuedBytes += data.count
+        sink.queuedHighWater = max(sink.queuedHighWater, sink.queuedBytes)
+        if wasEmpty, Date().timeIntervalSince(sink.lastFlowLog) > 1 {
+            sink.lastFlowLog = Date()
+            let queued = sink.queuedBytes
+            logger.info(
+                "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) backpressure — pipe full, queued \(queued) bytes")
+        }
+    }
+
+    /// Spawn the drain task for `sink` if its queue is non-empty and no drain
+    /// is live yet — MUST be called with `lock` held. The task captures only
+    /// (key, generation): it re-validates the sink on every pass, so a
+    /// superseded or detached sink's queue simply dies with it.
+    private func armDrainIfNeededLocked(_ sink: inout Sink, key: PaneKey) {
+        guard sink.queuedBytes > 0, !sink.drainArmed else { return }
+        sink.drainArmed = true
+        let generation = sink.generation
+        Task.detached { [weak self] in
+            await self?.drainQueue(key: key, generation: generation)
+        }
+    }
+
+    /// Async drain for one (key, generation)'s backpressure queue. Writes
+    /// with the same nonblocking write-under-lock discipline as `route()` /
+    /// `writeReplay` (every fd use re-validates the sink under the lock, so
+    /// a write into a closed-and-recycled fd cannot happen). On EAGAIN it
+    /// sleeps OFF the lock (10 ms — the sleep IS the pacing) and retries.
+    ///
+    /// Generation-scoped, the invariant everything here protects: a
+    /// superseded attach's queued bytes must NEVER flush into a successor's
+    /// pipe. On generation mismatch or missing sink this exits touching
+    /// NOTHING — the successor manages its own `drainArmed`.
+    private func drainQueue(key: PaneKey, generation: UInt64) async {
+        while true {
+            // The pass itself is synchronous (NSLock is `noasync`); this
+            // loop only paces between passes, never holding the lock across
+            // a suspension.
+            if drainPass(key: key, generation: generation) == .finished { return }
+            // Pipe still full: pace OFF the lock, then re-validate and retry.
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    private enum DrainPassResult {
+        /// The drain task is done: queue emptied, sink gone/superseded, or a
+        /// hard write error abandoned the queue.
+        case finished
+        /// EAGAIN — the pipe is still full; sleep and run another pass.
+        case pipeFull
+    }
+
+    /// One locked drain pass — the synchronous half of `drainQueue`.
+    private func drainPass(key: PaneKey, generation: UInt64) -> DrainPassResult {
+        lock.lock()
+        guard var sink = sinks[key], sink.generation == generation, sink.ready else {
+            // Only a still-live sink at OUR generation gets its flag
+            // cleared (`ready` never reverts once set — that arm is
+            // defensive only).
+            if let current = sinks[key], current.generation == generation {
+                sinks[key]!.drainArmed = false
+            }
+            lock.unlock()
+            return .finished
+        }
+
+        var sawHardError = false
+        var pipeFull = false
+        while let head = sink.queue.first, !pipeFull, !sawHardError {
+            let buf = [UInt8](head)
+            var offset = 0
+            while offset < buf.count {
+                let written = buf[offset...].withUnsafeBytes {
+                    Darwin.write(sink.writeFD, $0.baseAddress, $0.count)
+                }
+                if written > 0 {
+                    offset += written
+                    continue
+                }
+                if written < 0 && errno == EINTR { continue }
+                if written < 0 && errno == EAGAIN {
+                    pipeFull = true
+                } else {
+                    sawHardError = true
+                }
+                break
+            }
+            if offset > 0 {
+                sink.queuedBytes -= offset
+                sink.queuedDeliveredBytes += offset
+                if offset >= buf.count {
+                    sink.queue.removeFirst()
+                } else {
+                    // Partial write: keep the remainder at the head.
+                    sink.queue[0] = Data(buf[offset...])
+                }
+            }
+        }
+
+        if sawHardError {
+            // e.g. EPIPE after the app closed the read end — the queue can
+            // never deliver; count it dropped and stand down (the detach
+            // path closes the fd).
+            logger.error(
+                "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) drain write errno=\(errno) — abandoning \(sink.queuedBytes) queued bytes")
+            sink.droppedEvents += sink.queue.count
+            sink.droppedBytes += sink.queuedBytes
+            sink.queue.removeAll()
+            sink.queuedBytes = 0
+            sink.drainArmed = false
+            sinks[key] = sink
+            lock.unlock()
+            return .finished
+        }
+        if sink.queue.isEmpty {
+            sink.drainArmed = false
+            if Date().timeIntervalSince(sink.lastFlowLog) > 1 {
+                sink.lastFlowLog = Date()
+                logger.info(
+                    "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) drained — high water \(sink.queuedHighWater) bytes, \(sink.queuedDeliveredBytes) bytes queued-then-delivered total")
+            }
+            sinks[key] = sink
+            lock.unlock()
+            return .finished
         }
         sinks[key] = sink
+        lock.unlock()
+        return .pipeFull
     }
 }

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
@@ -48,6 +48,19 @@ struct PaneFlowStats: Equatable {
     let repairs: Int
 }
 
+/// Tri-state result of `PaneFanout.isPipeWritable` — the repair
+/// coordinator's reader-catch-up gate.
+enum PipeWritability {
+    /// `POLLOUT`: the pipe has room; the repair may proceed.
+    case writable
+    /// `poll` timed out with no events: the pipe is full but healthy — the
+    /// reader just hasn't caught up yet; keep waiting.
+    case full
+    /// `POLLERR`/`POLLHUP`/`POLLNVAL`: the read end is closed or the fd is
+    /// invalid — the pipe can NEVER drain, so waiting is pointless.
+    case broken
+}
+
 /// Outcome of the generation-checked `PaneFanout.acknowledge`.
 enum PaneAcknowledgeResult: Equatable {
     /// The ack landed: a sink exists and (when a generation was echoed) it
@@ -533,13 +546,20 @@ final class PaneFanout: @unchecked Sendable {
     /// or the repair replay would just re-overflow it. Held under the lock
     /// (same fd-close safety discipline as every write path). `nil` when the
     /// sink is gone or superseded — the repair must abort silently.
-    func isPipeWritable(key: PaneKey, generation: UInt64) -> Bool? {
+    /// `.broken` when `poll` flags `POLLERR`/`POLLHUP`/`POLLNVAL` (read end
+    /// closed / fd invalid): the pipe can never drain, so the coordinator
+    /// unpauses and aborts instead of waiting forever; `.full` on a quiet
+    /// poll — keep waiting for the reader.
+    func isPipeWritable(key: PaneKey, generation: UInt64) -> PipeWritability? {
         lock.lock()
         defer { lock.unlock() }
         guard let sink = sinks[key], sink.generation == generation else { return nil }
         var pollFD = pollfd(fd: sink.writeFD, events: Int16(POLLOUT), revents: 0)
         let result = Darwin.poll(&pollFD, 1, 0)
-        return result > 0 && (pollFD.revents & Int16(POLLOUT)) != 0
+        guard result > 0 else { return .full }
+        let brokenFlags = Int16(POLLERR) | Int16(POLLHUP) | Int16(POLLNVAL)
+        if pollFD.revents & brokenFlags != 0 { return .broken }
+        return (pollFD.revents & Int16(POLLOUT)) != 0 ? .writable : .full
     }
 
     /// Hot path — called on the reader thread for every output event.
@@ -764,14 +784,21 @@ final class PaneFanout: @unchecked Sendable {
     /// One locked drain pass — the synchronous half of `drainQueue`.
     private func drainPass(key: PaneKey, generation: UInt64) -> DrainPassResult {
         lock.lock()
-        guard var sink = sinks[key], sink.generation == generation, sink.ready, !sink.fenced else {
+        guard var sink = sinks[key], sink.generation == generation, sink.ready, !sink.fenced,
+              !sink.repairing else {
             // Only a still-live sink at OUR generation gets its flag cleared
             // (`ready` never reverts once set — that arm is defensive only).
             // FENCED stands the drain down too (M3): the repair fence arms on
             // a READY sink, and a straggler drain task from pre-overflow
             // backpressure would otherwise flush fence-parked bytes into the
-            // pipe AHEAD of the repair replay. `endRepair`/`markReady` clears
-            // the fence and re-arms the drain for the ordered flush.
+            // pipe AHEAD of the repair replay. REPAIRING stands it down as
+            // well — structurally, not by cross-function invariant: today the
+            // repairing-unfenced window provably has an empty queue (overflow
+            // entry clears it; routed output drops), but a drain live there
+            // would race the repair's `writeReplay`, so the guard refuses it
+            // outright. Every resume path re-arms: `markReady`, `endRepair`,
+            // and `abortRepair` all clear their flags and call
+            // `armDrainIfNeededLocked` for the ordered flush.
             if let current = sinks[key], current.generation == generation {
                 sinks[key]!.drainArmed = false
             }

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
@@ -126,12 +126,12 @@ final class PaneFanout: @unchecked Sendable {
         /// hard-error diagnostic (or vice versa).
         var lastWriteErrorLog = Date.distantPast
         /// Backpressure queue (Phase B M1): bytes the pipe could not accept
-        /// yet, delivered IN ORDER by the async drain task. Bounded by
+        /// yet, delivered IN ORDER by the GCD drain worker. Bounded by
         /// `PaneFanout.queueCap`; scoped to this (key, generation) — a
         /// superseded sink's queued bytes die with it.
         var queue: [Data] = []
         var queuedBytes = 0
-        /// A drain task is live for this (key, generation).
+        /// A drain worker is live for this (key, generation).
         var drainArmed = false
         /// Chunks dropped whole because the queue was at its cap.
         var overflowEvents = 0
@@ -188,8 +188,8 @@ final class PaneFanout: @unchecked Sendable {
         let (readFD, writeFD) = (fds[0], fds[1])
         // Nonblocking write end: a slow app-side reader must never stall the
         // reader thread. EAGAIN → queue-and-drain (Phase B M1): the unwritten
-        // remainder is queued per pane (cap `queueCap`) and an async drain
-        // task delivers it as the reader catches up.
+        // remainder is queued per pane (cap `queueCap`) and a GCD drain
+        // worker delivers it as the reader catches up.
         let flags = fcntl(writeFD, F_GETFL)
         _ = fcntl(writeFD, F_SETFL, flags | O_NONBLOCK)
 
@@ -572,7 +572,7 @@ final class PaneFanout: @unchecked Sendable {
     /// Phase B M1 backpressure: a chunk the pipe cannot accept whole is no
     /// longer truncated (issue #376 — every dropped byte leaves permanently
     /// wrong cells on a differential renderer). The unwritten remainder is
-    /// queued (bounded by `queueCap`) and an async drain task delivers it in
+    /// queued (bounded by `queueCap`) and a GCD drain worker delivers it in
     /// order; while ANY bytes are queued, new chunks go straight to the queue
     /// so live bytes can never overtake queued ones.
     ///
@@ -760,49 +760,60 @@ final class PaneFanout: @unchecked Sendable {
         return false
     }
 
-    /// Spawn the drain task for `sink` if its queue is non-empty and no drain
-    /// is live yet — MUST be called with `lock` held. The task captures only
-    /// (key, generation): it re-validates the sink on every pass, so a
-    /// superseded or detached sink's queue simply dies with it.
+    /// Spawn the drain worker for `sink` if its queue is non-empty and no
+    /// drain is live yet — MUST be called with `lock` held. The worker
+    /// captures only (key, generation): it re-validates the sink on every
+    /// pass, so a superseded or detached sink's queue simply dies with it.
+    ///
+    /// The drain deliberately runs on GCD, NOT the Swift Concurrency
+    /// cooperative pool: one GCD worker per backpressured pane, blocked at
+    /// most in 10 ms `usleep` slices, and GCD grows its pool to absorb
+    /// blocking — the same discipline as `stopOffPool`/`stopAll` in
+    /// `TmuxControlSupervisor` (R8-M2). A `Task.detached` drain rides the
+    /// fixed-width (CPU-core-count) cooperative executor, so a saturated
+    /// pool — e.g. synchronous consumers busy-waiting on cooperative
+    /// threads — starves the render-path delivery entirely. Observed as a
+    /// real starvation-deadlock on CI's narrow-vCPU runners (PR #379):
+    /// blocking test functions occupied every cooperative thread while
+    /// polling for bytes only the detached drain task could deliver.
     private func armDrainIfNeededLocked(_ sink: inout Sink, key: PaneKey) {
         guard sink.queuedBytes > 0, !sink.drainArmed else { return }
         sink.drainArmed = true
         let generation = sink.generation
-        Task.detached { [weak self] in
-            await self?.drainQueue(key: key, generation: generation)
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.drainLoop(key: key, generation: generation)
         }
     }
 
-    /// Async drain for one (key, generation)'s backpressure queue. Writes
-    /// with the same nonblocking write-under-lock discipline as `route()` /
-    /// `writeReplay` (every fd use re-validates the sink under the lock, so
-    /// a write into a closed-and-recycled fd cannot happen). On EAGAIN it
-    /// sleeps OFF the lock (10 ms — the sleep IS the pacing) and retries.
+    /// Drain loop for one (key, generation)'s backpressure queue — runs on a
+    /// GCD worker (see `armDrainIfNeededLocked` for why it must stay off the
+    /// cooperative pool). Writes with the same nonblocking write-under-lock
+    /// discipline as `route()` / `writeReplay` (every fd use re-validates the
+    /// sink under the lock, so a write into a closed-and-recycled fd cannot
+    /// happen). On EAGAIN it sleeps OFF the lock (10 ms — the sleep IS the
+    /// pacing) and retries.
     ///
     /// Generation-scoped, the invariant everything here protects: a
     /// superseded attach's queued bytes must NEVER flush into a successor's
     /// pipe. On generation mismatch or missing sink this exits touching
     /// NOTHING — the successor manages its own `drainArmed`.
-    private func drainQueue(key: PaneKey, generation: UInt64) async {
-        while true {
-            // The pass itself is synchronous (NSLock is `noasync`); this
-            // loop only paces between passes, never holding the lock across
-            // a suspension.
-            if drainPass(key: key, generation: generation) == .finished { return }
-            // Pipe still full: pace OFF the lock, then re-validate and retry.
-            try? await Task.sleep(for: .milliseconds(10))
+    private func drainLoop(key: PaneKey, generation: UInt64) {
+        // Each pass runs and releases the lock; the sleep between passes
+        // (pipe still full) never holds it.
+        while drainPass(key: key, generation: generation) == .pipeFull {
+            usleep(10_000)
         }
     }
 
     private enum DrainPassResult {
-        /// The drain task is done: queue emptied, sink gone/superseded, or a
-        /// hard write error abandoned the queue.
+        /// The drain worker is done: queue emptied, sink gone/superseded, or
+        /// a hard write error abandoned the queue.
         case finished
         /// EAGAIN — the pipe is still full; sleep and run another pass.
         case pipeFull
     }
 
-    /// One locked drain pass — the synchronous half of `drainQueue`.
+    /// One locked drain pass — the body of `drainLoop`'s retry cycle.
     private func drainPass(key: PaneKey, generation: UInt64) -> DrainPassResult {
         lock.lock()
         guard var sink = sinks[key], sink.generation == generation, sink.ready, !sink.fenced,
@@ -810,7 +821,7 @@ final class PaneFanout: @unchecked Sendable {
             // Only a still-live sink at OUR generation gets its flag cleared
             // (`ready` never reverts once set — that arm is defensive only).
             // FENCED stands the drain down too (M3): the repair fence arms on
-            // a READY sink, and a straggler drain task from pre-overflow
+            // a READY sink, and a straggler drain worker from pre-overflow
             // backpressure would otherwise flush fence-parked bytes into the
             // pipe AHEAD of the repair replay. REPAIRING stands it down as
             // well — structurally, not by cross-function invariant: today the

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
@@ -33,9 +33,9 @@ enum PaneReplayWriteError: Error, Equatable {
 
 /// Locked snapshot of one pane's flow-control counters (Phase B M1/M3) —
 /// test visibility plus diagnostics. `droppedEvents`/`droppedBytes` count
-/// ONLY fenced-overflow, not-ready, and mid-repair drops; plain EAGAIN no
-/// longer drops (it queues), and a steady-state overflow enters the repair
-/// cycle instead of dropping.
+/// ONLY fenced-overflow, not-ready, mid-repair, and hard-write-error drops;
+/// plain EAGAIN no longer drops (it queues), and a steady-state overflow
+/// enters the repair cycle instead of dropping.
 struct PaneFlowStats: Equatable {
     let queuedBytes: Int
     let droppedBytes: Int
@@ -115,8 +115,9 @@ final class PaneFanout: @unchecked Sendable {
         /// purpose is "app never acked") keys off THIS flag instead: a slow
         /// capture must not let the stale timer kill a live, acked attach.
         var acknowledged = false
-        /// Overflow + not-ready drops only (Phase B M1): plain EAGAIN no
-        /// longer drops — the unwritten remainder is queued instead.
+        /// Overflow, not-ready, mid-repair, and hard-write-error drops only
+        /// (Phase B M1): plain EAGAIN no longer drops — the unwritten
+        /// remainder is queued instead.
         var droppedEvents = 0
         var droppedBytes = 0
         var lastDropLog = Date.distantPast
@@ -625,6 +626,7 @@ final class PaneFanout: @unchecked Sendable {
                 // — those bytes are in the attach's capture, not lost;
                 // delivering them too would duplicate them.
                 sink.droppedEvents += 1
+                sink.droppedBytes += bytes.count
                 sinks[key] = sink
             } else if sink.repairing {
                 // Repair window before the repair fence arms (overflow →
@@ -658,14 +660,29 @@ final class PaneFanout: @unchecked Sendable {
                             offset += written
                             continue
                         }
-                        if written < 0 && errno == EINTR { continue }
-                        if written < 0 && errno == EAGAIN {
+                        // Capture errno at the failing write, before any
+                        // intervening call can clobber it.
+                        let err = errno
+                        if written < 0 && err == EINTR { continue }
+                        if written < 0 && err == EAGAIN {
                             if enqueueLocked(Data(buf[offset...]), into: &sink, key: key) {
                                 repairSignal = sink.generation
                             }
                         } else {
-                            logger.error(
-                                "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) write errno=\(errno)")
+                            // Hard error (e.g. EPIPE after the app closed
+                            // the read end): the unwritten remainder is
+                            // discarded — count it like the drain's
+                            // hard-error path, and rate-limit the log (a
+                            // blast pane with a closed read end would
+                            // otherwise log per chunk).
+                            let remainder = buf.count - offset
+                            sink.droppedEvents += 1
+                            sink.droppedBytes += remainder
+                            if Date().timeIntervalSince(sink.lastDropLog) > 1 {
+                                sink.lastDropLog = Date()
+                                logger.error(
+                                    "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) write errno=\(err) — dropped \(remainder) bytes")
+                            }
                         }
                         break
                     }
@@ -807,6 +824,7 @@ final class PaneFanout: @unchecked Sendable {
         }
 
         var sawHardError = false
+        var hardErrno: Int32 = 0
         var pipeFull = false
         while let head = sink.queue.first, !pipeFull, !sawHardError {
             let buf = [UInt8](head)
@@ -819,11 +837,15 @@ final class PaneFanout: @unchecked Sendable {
                     offset += written
                     continue
                 }
-                if written < 0 && errno == EINTR { continue }
-                if written < 0 && errno == EAGAIN {
+                // Capture errno at the failing write, before any intervening
+                // call can clobber it.
+                let err = errno
+                if written < 0 && err == EINTR { continue }
+                if written < 0 && err == EAGAIN {
                     pipeFull = true
                 } else {
                     sawHardError = true
+                    hardErrno = err
                 }
                 break
             }
@@ -844,7 +866,7 @@ final class PaneFanout: @unchecked Sendable {
             // never deliver; count it dropped and stand down (the detach
             // path closes the fd).
             logger.error(
-                "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) drain write errno=\(errno) — abandoning \(sink.queuedBytes) queued bytes")
+                "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) drain write errno=\(hardErrno) — abandoning \(sink.queuedBytes) queued bytes")
             sink.droppedEvents += sink.queue.count
             sink.droppedBytes += sink.queuedBytes
             sink.queue.removeAll()

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneFanout.swift
@@ -31,15 +31,21 @@ enum PaneReplayWriteError: Error, Equatable {
     case writeFailed(errno: Int32)
 }
 
-/// Locked snapshot of one pane's flow-control counters (Phase B M1) — test
-/// visibility plus diagnostics. `droppedEvents`/`droppedBytes` count ONLY
-/// overflow and not-ready drops; plain EAGAIN no longer drops (it queues).
+/// Locked snapshot of one pane's flow-control counters (Phase B M1/M3) —
+/// test visibility plus diagnostics. `droppedEvents`/`droppedBytes` count
+/// ONLY fenced-overflow, not-ready, and mid-repair drops; plain EAGAIN no
+/// longer drops (it queues), and a steady-state overflow enters the repair
+/// cycle instead of dropping.
 struct PaneFlowStats: Equatable {
     let queuedBytes: Int
     let droppedBytes: Int
     let droppedEvents: Int
     let overflowEvents: Int
     let queuedHighWater: Int
+    /// An M3 overflow-repair cycle is underway for this sink.
+    let repairing: Bool
+    /// Completed (endRepair'd) repair cycles on this sink.
+    let repairs: Int
 }
 
 /// Outcome of the generation-checked `PaneFanout.acknowledge`.
@@ -119,11 +125,20 @@ final class PaneFanout: @unchecked Sendable {
         /// Rate limiter for the backpressure-enter / drain-recovery logs
         /// (`lastDropLog` covers the drop logs).
         var lastFlowLog = Date.distantPast
+        /// An M3 overflow-repair cycle is underway (Phase B M3, issue #376):
+        /// the queue was cleared at overflow (its content is already in pane
+        /// history; the repair's capture supersedes it) and the repair
+        /// coordinator owns the pane's pause state until `endRepair` /
+        /// `abortRepair`. While set (and not fenced), routed output is
+        /// dropped with counters — pre-pause bytes the capture will include.
+        var repairing = false
+        /// Completed repair cycles (telemetry + the live heal test).
+        var repairs = 0
     }
 
-    /// Per-pane backpressure queue cap. Beyond this, incoming chunks are
-    /// dropped whole (see `enqueueLocked`) — the M3 pause+repair cycle
-    /// replaces that drop later.
+    /// Per-pane backpressure queue cap. Beyond this, a steady-state sink
+    /// enters the M3 pause+repair cycle (see `enqueueLocked`); a fenced or
+    /// already-repairing sink still drops incoming chunks whole.
     static let queueCap = 128 * 1024
 
     private let logger = Logger(subsystem: "com.tbd.daemon", category: "tmuxControlMode")
@@ -132,6 +147,17 @@ final class PaneFanout: @unchecked Sendable {
     private var nextGeneration: UInt64 = 0
     /// %output events dropped because no attach was registered for their pane.
     private var unattachedDrops = 0
+    private var _onOverflowRepair: (@Sendable (PaneKey, UInt64) -> Void)?
+
+    /// M3 overflow-repair signal — fired (strictly OUTSIDE the lock, from
+    /// `route()`'s tail) when a steady-state queue overflow flips a sink into
+    /// `repairing`. Installed ONCE at bridge init, BEFORE any connection
+    /// starts (the same guarantee the supervisor's layout filter relies on);
+    /// lock-protected like the filter's box so the reader threads see it.
+    var onOverflowRepair: (@Sendable (PaneKey, UInt64) -> Void)? {
+        get { lock.lock(); defer { lock.unlock() }; return _onOverflowRepair }
+        set { lock.lock(); _onOverflowRepair = newValue; lock.unlock() }
+    }
 
     /// Allocate a pipe for `key`, remember the (nonblocking) write end, and
     /// return the read end (plus this attach's generation) for the caller to
@@ -425,7 +451,95 @@ final class PaneFanout: @unchecked Sendable {
             droppedBytes: sink.droppedBytes,
             droppedEvents: sink.droppedEvents,
             overflowEvents: sink.overflowEvents,
-            queuedHighWater: sink.queuedHighWater)
+            queuedHighWater: sink.queuedHighWater,
+            repairing: sink.repairing,
+            repairs: sink.repairs)
+    }
+
+    // MARK: - M3 repair cycle (Phase B)
+
+    /// Arm the REPAIR fence — the repair cycle's twin of `armFence`:
+    /// generation-checked, and additionally requires the sink to be
+    /// mid-repair (`repairing`): the fence parks post-continue output behind
+    /// the repair replay exactly like the attach fence, and arming it on a
+    /// non-repairing sink would freeze a healthy stream behind a flush that
+    /// never comes. Call ONLY at a provably-silent moment — the repair's
+    /// pause reply is in hand and the pane delivers nothing while paused.
+    /// Mismatch / missing / not-repairing → `false`, nothing touched.
+    @discardableResult
+    func beginRepairFence(key: PaneKey, generation: UInt64) -> Bool {
+        lock.lock()
+        guard let sink = sinks[key], sink.generation == generation, sink.repairing else {
+            lock.unlock()
+            logger.info(
+                "fanout repair fence refused \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation)")
+            return false
+        }
+        sinks[key]?.fenced = true
+        lock.unlock()
+        logger.debug(
+            "fanout repair fence armed \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation)")
+        return true
+    }
+
+    /// Complete a repair cycle: clear the fence and `repairing`, count the
+    /// repair, and arm the drain so the fenced bytes (everything the pane
+    /// emitted since the atomic batch's continue) flush strictly after the
+    /// repair replay `writeReplay` already put in the pipe — the same
+    /// zero-seam flush as `markReady`'s. Generation-checked: mismatch or
+    /// missing sink → `false`, nothing touched (the successor owns itself).
+    @discardableResult
+    func endRepair(key: PaneKey, generation: UInt64) -> Bool {
+        lock.lock()
+        guard var sink = sinks[key], sink.generation == generation else {
+            lock.unlock()
+            return false
+        }
+        sink.fenced = false
+        sink.repairing = false
+        sink.repairs += 1
+        armDrainIfNeededLocked(&sink, key: key)
+        sinks[key] = sink
+        lock.unlock()
+        logger.debug(
+            "fanout repair complete \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation)")
+        return true
+    }
+
+    /// Failure-path exit from a repair cycle the caller still owns: clear
+    /// `repairing` (and the fence if armed), keep whatever is queued (likely
+    /// nothing — the overflow cleared it) and arm the drain for it. The
+    /// stream resumes with a possible hole; a pane frozen forever behind a
+    /// fence that never flushes is worse than a hole. Generation-checked
+    /// no-op on mismatch/missing.
+    func abortRepair(key: PaneKey, generation: UInt64) {
+        lock.lock()
+        guard var sink = sinks[key], sink.generation == generation else {
+            lock.unlock()
+            return
+        }
+        sink.fenced = false
+        sink.repairing = false
+        armDrainIfNeededLocked(&sink, key: key)
+        sinks[key] = sink
+        lock.unlock()
+        logger.info(
+            "fanout repair aborted \(key.server, privacy: .public)/\(key.paneID, privacy: .public) gen=\(generation)")
+    }
+
+    /// Nonblocking writability probe of `key`'s pipe (`poll` POLLOUT,
+    /// timeout 0) — the repair coordinator's reader-catch-up gate: the
+    /// recapture+continue must not run until the app has drained the pipe,
+    /// or the repair replay would just re-overflow it. Held under the lock
+    /// (same fd-close safety discipline as every write path). `nil` when the
+    /// sink is gone or superseded — the repair must abort silently.
+    func isPipeWritable(key: PaneKey, generation: UInt64) -> Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let sink = sinks[key], sink.generation == generation else { return nil }
+        var pollFD = pollfd(fd: sink.writeFD, events: Int16(POLLOUT), revents: 0)
+        let result = Darwin.poll(&pollFD, 1, 0)
+        return result > 0 && (pollFD.revents & Int16(POLLOUT)) != 0
     }
 
     /// Hot path — called on the reader thread for every output event.
@@ -436,6 +550,25 @@ final class PaneFanout: @unchecked Sendable {
     /// queued (bounded by `queueCap`) and an async drain task delivers it in
     /// order; while ANY bytes are queued, new chunks go straight to the queue
     /// so live bytes can never overtake queued ones.
+    ///
+    /// Behavior table (M1 queue + M2 fence + M3 repair):
+    ///  - no sink → count an unattached drop.
+    ///  - fenced (ANY ready state) → enqueue, NEVER arm the drain: a fence
+    ///    (attach M2, or repair M3) parks bytes behind a replay-in-flight;
+    ///    `markReady` / `endRepair` clears it and arms the flush.
+    ///  - !ready && !fenced → drop (pre-fence attach window: the bytes are
+    ///    in the attach's capture; delivering them too would duplicate).
+    ///  - ready && repairing && !fenced → drop with counters, no per-chunk
+    ///    log: pre-pause bytes of the repair cycle — the repair's capture
+    ///    includes them, so nothing is lost.
+    ///  - ready && queue non-empty → enqueue + arm drain (M1 ordering).
+    ///  - ready && queue empty → direct write; EAGAIN remainder → enqueue +
+    ///    arm drain (M1).
+    /// A steady-state queue overflow (ready, unfenced, not repairing) enters
+    /// the M3 repair cycle instead of dropping — see `enqueueLocked`; the
+    /// `onOverflowRepair` signal fires AFTER the lock is released (the
+    /// handler hops onto the repair coordinator, and callbacks under a hot
+    /// lock are a deadlock invitation).
     func route(server: String, event: TmuxControlEvent) {
         let paneID: String
         let bytes: Data
@@ -451,78 +584,117 @@ final class PaneFanout: @unchecked Sendable {
         }
         let key = PaneKey(server: server, paneID: paneID)
 
+        // Generation to fire `onOverflowRepair` for, collected under the
+        // lock and fired at function end OUTSIDE it.
+        var repairSignal: UInt64?
         lock.lock()
-        defer { lock.unlock() }
-        guard var sink = sinks[key] else {
-            unattachedDrops += 1
-            return
-        }
-        guard sink.ready else {
+        if var sink = sinks[key] {
             if sink.fenced {
-                // Attach-fence window (M2): the pane's attach sequence owns
-                // the seam from the pause reply to markReady — queue (M1 cap
-                // + overflow telemetry apply unchanged) WITHOUT arming the
-                // drain. The queue must stay parked behind the closed gate
-                // until the replay lands: `writeReplay` writes the pipe
-                // directly, and a live drain would interleave fenced bytes
-                // into the replay. `markReady` clears the fence and arms it.
-                enqueueLocked(bytes, into: &sink, key: key)
+                // Fence window (attach M2 or repair M3): the pane's sequence
+                // owns the seam up to markReady/endRepair — queue (M1 cap +
+                // overflow telemetry apply unchanged) WITHOUT arming the
+                // drain. The queue must stay parked behind the replay:
+                // `writeReplay` writes the pipe directly, and a live drain
+                // would interleave fenced bytes into the replay.
+                // (`enqueueLocked` can never enter repair here — its repair
+                // branch requires an UNFENCED sink.)
+                _ = enqueueLocked(bytes, into: &sink, key: key)
                 sinks[key] = sink
-            } else {
+            } else if !sink.ready {
                 // Pre-fence not-ready window (attach → pause reply): dropped
                 // — those bytes are in the attach's capture, not lost;
                 // delivering them too would duplicate them.
                 sink.droppedEvents += 1
                 sinks[key] = sink
-            }
-            return
-        }
-
-        if sink.queuedBytes > 0 {
-            // Order preservation: bytes must NEVER overtake queued bytes —
-            // while the queue is non-empty, everything goes through it.
-            enqueueLocked(bytes, into: &sink, key: key)
-        } else {
-            // Partial-write loop: nonblocking write() may legally return a
-            // short count. On EAGAIN (or a short write) the UNWRITTEN
-            // remainder is queued — the delivered prefix stays intact and
-            // the queued continuation follows it in order.
-            let buf = [UInt8](bytes)
-            var offset = 0
-            while offset < buf.count {
-                let written = buf[offset...].withUnsafeBytes { Darwin.write(sink.writeFD, $0.baseAddress, $0.count) }
-                if written > 0 {
-                    offset += written
-                    continue
-                }
-                if written < 0 && errno == EINTR { continue }
-                if written < 0 && errno == EAGAIN {
-                    enqueueLocked(Data(buf[offset...]), into: &sink, key: key)
+            } else if sink.repairing {
+                // Repair window before the repair fence arms (overflow →
+                // pause reply): these bytes are pre-pause — already in the
+                // pane's history, so the repair's capture includes them.
+                // Counted, never logged per-chunk, never re-signaled.
+                sink.droppedEvents += 1
+                sink.droppedBytes += bytes.count
+                sinks[key] = sink
+            } else {
+                if sink.queuedBytes > 0 {
+                    // Order preservation: bytes must NEVER overtake queued
+                    // bytes — while the queue is non-empty, everything goes
+                    // through it.
+                    if enqueueLocked(bytes, into: &sink, key: key) {
+                        repairSignal = sink.generation
+                    }
                 } else {
-                    logger.error(
-                        "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) write errno=\(errno)")
+                    // Partial-write loop: nonblocking write() may legally
+                    // return a short count. On EAGAIN (or a short write) the
+                    // UNWRITTEN remainder is queued — the delivered prefix
+                    // stays intact and the queued continuation follows it in
+                    // order.
+                    let buf = [UInt8](bytes)
+                    var offset = 0
+                    while offset < buf.count {
+                        let written = buf[offset...].withUnsafeBytes {
+                            Darwin.write(sink.writeFD, $0.baseAddress, $0.count)
+                        }
+                        if written > 0 {
+                            offset += written
+                            continue
+                        }
+                        if written < 0 && errno == EINTR { continue }
+                        if written < 0 && errno == EAGAIN {
+                            if enqueueLocked(Data(buf[offset...]), into: &sink, key: key) {
+                                repairSignal = sink.generation
+                            }
+                        } else {
+                            logger.error(
+                                "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) write errno=\(errno)")
+                        }
+                        break
+                    }
                 }
-                break
+                armDrainIfNeededLocked(&sink, key: key)
+                sinks[key] = sink
             }
+        } else {
+            unattachedDrops += 1
         }
-        armDrainIfNeededLocked(&sink, key: key)
-        sinks[key] = sink
+        lock.unlock()
+        if let generation = repairSignal {
+            // Property getter re-takes the lock briefly; the callback itself
+            // runs with NO fanout lock held.
+            onOverflowRepair?(key, generation)
+        }
     }
 
     /// Append `data` to the sink's backpressure queue — MUST be called with
     /// `lock` held. Chunks are enqueued (and, on overflow, dropped) WHOLE:
     /// splitting what we enqueue would put a fragment mid-queue whose
-    /// continuation is lost, corrupting escape sequences; dropping the entire
-    /// incoming chunk keeps everything delivered + queued an intact prefix.
-    /// The overflow drop here is the M3 hook point — the pause+repair cycle
-    /// (tmux flow control + recapture) replaces it later. That includes the
-    /// FENCED window's residual (M2): a blast pane can exceed the cap while
-    /// the replay is still being assembled, and the chunks dropped here are
-    /// then missing between the replay and the flushed queue — M3's repair
-    /// cycle owns healing that; M2 adds no extra behavior for it.
-    private func enqueueLocked(_ data: Data, into sink: inout Sink, key: PaneKey) {
-        guard !data.isEmpty else { return }
+    /// continuation is lost, corrupting escape sequences.
+    ///
+    /// Overflow (Phase B M3, issue #376):
+    ///  - STEADY STATE (ready, unfenced, not repairing): enter the repair
+    ///    cycle instead of dropping — clear the queue (everything queued is
+    ///    already in the pane's history; the repair's capture supersedes it,
+    ///    so NOTHING counts as dropped), flip `repairing`, and return `true`
+    ///    so `route()` fires `onOverflowRepair` once the lock is released.
+    ///  - FENCED or already REPAIRING: keep the M1 whole-chunk drop +
+    ///    telemetry — a bounded residual: a repair started during a fence
+    ///    would race the in-flight attach/repair sequence on the same pane's
+    ///    pause state, so the fenced window accepts the (rare) hole instead.
+    ///
+    /// Returns whether the sink just ENTERED the repair cycle.
+    private func enqueueLocked(_ data: Data, into sink: inout Sink, key: PaneKey) -> Bool {
+        guard !data.isEmpty else { return false }
         if sink.queuedBytes + data.count > Self.queueCap {
+            if sink.ready && !sink.fenced && !sink.repairing {
+                sink.repairing = true
+                sink.queue.removeAll()
+                sink.queuedBytes = 0
+                if Date().timeIntervalSince(sink.lastFlowLog) > 1 {
+                    sink.lastFlowLog = Date()
+                    logger.info(
+                        "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) queue overflow — entering repair")
+                }
+                return true
+            }
             sink.overflowEvents += 1
             sink.droppedEvents += 1
             sink.droppedBytes += data.count
@@ -532,7 +704,7 @@ final class PaneFanout: @unchecked Sendable {
                 logger.info(
                     "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) queue overflow — dropped \(dropped) bytes total (\(events) events, \(overflows) overflows)")
             }
-            return
+            return false
         }
         let wasEmpty = sink.queuedBytes == 0
         sink.queue.append(data)
@@ -544,6 +716,7 @@ final class PaneFanout: @unchecked Sendable {
             logger.info(
                 "fanout \(key.server, privacy: .public)/\(key.paneID, privacy: .public) backpressure — pipe full, queued \(queued) bytes")
         }
+        return false
     }
 
     /// Spawn the drain task for `sink` if its queue is non-empty and no drain
@@ -591,10 +764,14 @@ final class PaneFanout: @unchecked Sendable {
     /// One locked drain pass — the synchronous half of `drainQueue`.
     private func drainPass(key: PaneKey, generation: UInt64) -> DrainPassResult {
         lock.lock()
-        guard var sink = sinks[key], sink.generation == generation, sink.ready else {
-            // Only a still-live sink at OUR generation gets its flag
-            // cleared (`ready` never reverts once set — that arm is
-            // defensive only).
+        guard var sink = sinks[key], sink.generation == generation, sink.ready, !sink.fenced else {
+            // Only a still-live sink at OUR generation gets its flag cleared
+            // (`ready` never reverts once set — that arm is defensive only).
+            // FENCED stands the drain down too (M3): the repair fence arms on
+            // a READY sink, and a straggler drain task from pre-overflow
+            // backpressure would otherwise flush fence-parked bytes into the
+            // pipe AHEAD of the repair replay. `endRepair`/`markReady` clears
+            // the fence and re-arms the drain for the ordered flush.
             if let current = sinks[key], current.generation == generation {
                 sinks[key]!.drainArmed = false
             }

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
@@ -1,0 +1,225 @@
+import Foundation
+import os
+
+/// Phase B M3 — heals a pane whose backpressure queue overflowed (the
+/// flow-control state machine's "Draining" state, Policy B, issue #376).
+///
+/// When a ready, unfenced sink's queue overflows, `PaneFanout` clears the
+/// queue, flips the sink to `repairing`, and fires `onOverflowRepair`, which
+/// lands here. The repair cycle:
+///
+///  1. PAUSE the pane server-side. Probe-verified (tmux 3.6a, 6/6 trials,
+///     throttled + full-blast): a paused pane delivers NOTHING — zero bytes
+///     even with ~500k tokens emitted while paused; the content lands in
+///     pane history/screen, reachable via capture.
+///  2. Wait for the app reader to catch up (pipe writability): a recapture
+///     replayed into a still-full pipe would just re-overflow.
+///  3. Arm the repair fence, then send the 6-command capture + continue as
+///     ONE atomic command list (`PaneCaptureReplay`, shared with the attach
+///     orchestrator). Probe-verified: an atomic [captures…, continue] has a
+///     seam gap of exactly ZERO — the first live token after the continue is
+///     contiguous with the capture's tail, and it flows into the armed fence.
+///  4. Write the recapture replay behind the fence (`writeReplay`), then
+///     `endRepair` — the fence flush delivers the post-continue bytes
+///     strictly after the replay. Zero-loss heal of the overflow hole.
+///
+/// The spec's original design — drain buffered `%extended-output` while
+/// paused — was REFUTED live: pause DISCARDS (tmux resumes delivery from the
+/// pane's CURRENT position, draining nothing). The repair therefore
+/// re-captures instead, the addendum §3 reserved "re-capture on pause"
+/// (iTerm2's shape for `%pause`), which the M2 fence machinery makes cheap.
+///
+/// The repair replay resets the terminal (reset prelude + full history)
+/// MID-SESSION — accepted and intentional: iTerm2 re-captures on %pause for
+/// the same reason, and a one-frame repaint beats permanently corrupt cells
+/// on a differential renderer.
+///
+/// Generation discipline (R10-3 / R11, mirroring the attach orchestrator):
+/// every await is followed by a generation re-validation; on ANY supersession
+/// the repair aborts silently — it sends NOTHING further and never unpauses
+/// (pause state is per PANE on the shared per-server correlator; the
+/// successor's own FIFO-ordered sequence owns it), and the superseded sink's
+/// state died with it, so there is nothing to clean.
+actor PaneRepairCoordinator {
+    private static let logger = Logger(subsystem: "com.tbd.daemon", category: "tmuxControlMode")
+
+    private let supervisor: TmuxControlSupervisor
+    /// Command seam (`TmuxControlModeBridge.commandProvider`): resolves the
+    /// server's FIFO correlator; tests substitute a fake-backed client.
+    private let commandProvider: @Sendable (String) async -> TmuxControlCommandClient?
+    /// Recapture depth — matches the attach orchestrator's (see its note on
+    /// the server-side `history-limit 50000`).
+    private let historyDepth: Int
+    /// Reader-catch-up poll pacing and deadline (step 2) — injectable so
+    /// tests can wedge the reader without waiting 30 s.
+    private let writableCheckInterval: Duration
+    private let writableDeadline: Duration
+    /// One in-flight repair per pane. Belt-and-suspenders: the sink's
+    /// `repairing` flag already gates re-signaling at the fanout, but a
+    /// duplicate signal for a key mid-repair must still be a no-op here.
+    private var inFlight: Set<PaneKey> = []
+
+    init(supervisor: TmuxControlSupervisor,
+         commandProvider: @escaping @Sendable (String) async -> TmuxControlCommandClient?,
+         historyDepth: Int = 50_000,
+         writableCheckInterval: Duration = .milliseconds(50),
+         writableDeadline: Duration = .seconds(30)) {
+        self.supervisor = supervisor
+        self.commandProvider = commandProvider
+        self.historyDepth = historyDepth
+        self.writableCheckInterval = writableCheckInterval
+        self.writableDeadline = writableDeadline
+    }
+
+    /// Test seam: whether a repair for `key` is currently running.
+    func isInFlight(_ key: PaneKey) -> Bool {
+        inFlight.contains(key)
+    }
+
+    /// Run the repair cycle for `key` unless one is already in flight for it.
+    func repairIfNeeded(key: PaneKey, generation: UInt64) async {
+        guard !inFlight.contains(key) else { return }
+        inFlight.insert(key)
+        defer { inFlight.remove(key) }
+        await repair(key: key, generation: generation)
+    }
+
+    private func repair(key: PaneKey, generation: UInt64) async {
+        let (server, paneID) = (key.server, key.paneID)
+        guard let client = await commandProvider(server) else {
+            // No correlator (connection torn down): nothing to pause, nothing
+            // paused — just unfreeze the sink if we still own it
+            // (`abortRepair` is generation-checked, a stale call no-ops).
+            Self.logger.error("""
+                repair: no command client for \(server, privacy: .public)/\(paneID, privacy: .public) \
+                — aborting repair
+                """)
+            supervisor.fanout.abortRepair(key: key, generation: generation)
+            return
+        }
+        // Ownership re-check after the provider hop (R10-3): a stale repair
+        // resumed here must send NOTHING on the shared correlator (R11).
+        guard await stillOwner(key, generation) else { return }
+
+        // Step 1 — the PAUSE alone, awaited. A failed pause means the
+        // captures below run UNPAUSED: the replay may be slightly torn
+        // (cursor vs content mismatch) — surface it and PROCEED, same
+        // reasoning as the attach: fullscreen apps repaint differentially
+        // and self-heal, and a genuinely dead pane %errors the captures
+        // below, which aborts the repair on its own.
+        let continueCommand = "refresh-client -A '\(paneID):continue'"
+        let pauseResults = await client.sendBatch(texts: ["refresh-client -A '\(paneID):pause'"])
+        if case .failure(let pauseError) = pauseResults.first {
+            Self.logger.error("""
+                repair pause failed for \(server, privacy: .public)/\(paneID, privacy: .public): \
+                \(String(describing: pauseError), privacy: .public) — proceeding with an unpaused capture
+                """)
+        }
+        guard await stillOwner(key, generation) else { return }
+
+        // Step 2 — wait for the app reader to catch up. `isPipeWritable` is
+        // generation-checked: `nil` means the sink is gone or superseded and
+        // the repair aborts silently (R11: no unpause — a successor attach's
+        // own sequence owns the pane's pause state, and a plain detach
+        // %errors nothing worse than a paused, viewerless pane).
+        let deadline = ContinuousClock.now + writableDeadline
+        waitLoop: while true {
+            switch supervisor.fanout.isPipeWritable(key: key, generation: generation) {
+            case nil:
+                return
+            case true?:
+                break waitLoop
+            case false?:
+                if ContinuousClock.now >= deadline {
+                    // The reader is wedged. Deliberately do NOT abortRepair:
+                    // a continue now would just re-overflow the queue, so
+                    // the pane stays PAUSED (tmux buffers it server-side in
+                    // pane history/screen — nothing is being lost) and the
+                    // sink stays `repairing` (which keeps re-signaling
+                    // gated). A later attach replaces the sink and re-runs
+                    // the full pause→capture→replay sequence, which heals
+                    // everything this repair could not.
+                    Self.logger.error("""
+                        repair reader wedged for \(server, privacy: .public)/\(paneID, privacy: .public) \
+                        gen=\(generation) — leaving the pane paused; a later attach re-runs the sequence
+                        """)
+                    return
+                }
+                try? await Task.sleep(for: writableCheckInterval)
+            }
+        }
+
+        // Step 3 — arm the repair fence (generation-checked; requires the
+        // sink to still be `repairing`). The pane is provably silent — the
+        // pause reply is in hand and a paused pane delivers nothing — so no
+        // output can race the arming. Refusal → superseded; send nothing.
+        guard supervisor.fanout.beginRepairFence(key: key, generation: generation) else { return }
+
+        // Step 4 — captures + continue, ONE atomic list with the continue
+        // LAST: identical shape (and shared construction) with the attach's
+        // batch 2; the zero-seam probe fact carries the heal.
+        let captureCommands = PaneCaptureReplay.captureCommands(
+            paneID: paneID, historyDepth: historyDepth)
+        let results = await client.sendBatch(texts: captureCommands + [continueCommand])
+        // A failed batched continue is log-only, as in the attach: a %error
+        // is tolerated, and a connection close fails the captures too, which
+        // aborts the repair below with its own unpause.
+        if case .failure(let continueError) = results.last {
+            Self.logger.error("""
+                repair batched continue failed for \(server, privacy: .public)/\(paneID, privacy: .public): \
+                \(String(describing: continueError), privacy: .public)
+                """)
+        }
+
+        do {
+            // Step 5 — assemble the recapture replay and write it behind the
+            // armed fence (the drain is never live while fenced, so the
+            // direct pipe write cannot be interleaved).
+            let replay = try PaneCaptureReplay.assemble(
+                captureResults: Array(results.dropLast()),
+                captureCommands: captureCommands,
+                server: server,
+                paneID: paneID,
+                historyDepth: historyDepth,
+                onHistoryTruncation: nil)
+            try supervisor.writeReplay(
+                server: server, paneID: paneID, generation: generation, bytes: replay)
+            // Step 6 — the flush: clear fence + repairing, arm the drain so
+            // the fenced (post-continue) bytes follow the replay in order.
+            let fencedBytes = supervisor.fanout.flowStats(key: key)?.queuedBytes ?? 0
+            guard supervisor.fanout.endRepair(key: key, generation: generation) else { return }
+            Self.logger.info("""
+                pane repaired \(server, privacy: .public)/\(paneID, privacy: .public) gen=\(generation) \
+                — replay \(replay.count) bytes, \(fencedBytes) fenced bytes flushed
+                """)
+        } catch PaneReplayWriteError.superseded {
+            // A newer attach owns the pane: its own sequence manages the
+            // gate, the fence, and the pause state (R11). Send nothing.
+            Self.logger.debug("""
+                repair superseded at writeReplay for \(server, privacy: .public)/\(paneID, privacy: .public) \
+                gen=\(generation)
+                """)
+        } catch {
+            // Still-owner cleanup (capture %error, malformed state, replay
+            // write failure): unpause (tolerate-errors, fire-and-forget — it
+            // covers "the pause ran but batch 2's continue may not have")
+            // and abort the repair so the stream resumes. A pane frozen
+            // forever behind a fence is worse than a hole. A STALE failure
+            // sends nothing — the successor owns the pane's pause state.
+            Self.logger.error("""
+                repair failed for \(server, privacy: .public)/\(paneID, privacy: .public) \
+                gen=\(generation): \(String(describing: error), privacy: .public)
+                """)
+            if await stillOwner(key, generation) {
+                await client.sendList([
+                    TmuxCommand(text: continueCommand, tolerateErrors: true) { _ in }
+                ])
+                supervisor.fanout.abortRepair(key: key, generation: generation)
+            }
+        }
+    }
+
+    private func stillOwner(_ key: PaneKey, _ generation: UInt64) async -> Bool {
+        await supervisor.currentGeneration(server: key.server, paneID: key.paneID) == generation
+    }
+}

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
@@ -195,6 +195,12 @@ actor PaneRepairCoordinator {
                     repair pipe broken (read end closed) for \(server, privacy: .public)/\(paneID, privacy: .public) \
                     gen=\(generation) — unpausing and aborting; the app-death detach path finishes the job
                     """)
+                // TOCTOU residual (accepted): the still-owner check and the
+                // continue send are not atomic — a successor can interpose
+                // between them, so this continue can land inside the
+                // successor's pause window in a vanishingly narrow race.
+                // Consequence: a torn capture that differentially self-heals,
+                // same class as the accepted pause-failure tear.
                 if await stillOwner(key, generation) {
                     await client.sendList([
                         TmuxCommand(text: continueCommand, tolerateErrors: true) { _ in }
@@ -213,7 +219,17 @@ actor PaneRepairCoordinator {
                 }
                 let interval = waited >= writableEscalationThreshold
                     ? writableSlowInterval : writableCheckInterval
-                try? await Task.sleep(for: interval)
+                // Cancellation bail (latent — the bridge's dispatch Tasks are
+                // never cancelled today): in a cancelled task `Task.sleep`
+                // throws immediately, which would turn this deadline-free
+                // wait into an unbounded busy-spin. Exit silently, like the
+                // superseded `nil` case above: send nothing — the sink stays
+                // `repairing`, and a later overflow signal or attach heals it.
+                do {
+                    try await Task.sleep(for: interval)
+                } catch {
+                    return
+                }
             }
         }
 

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
@@ -86,15 +86,52 @@ actor PaneRepairCoordinator {
     }
 
     /// Run the repair cycle for `key` unless one is already in flight for it.
+    ///
+    /// One repair per pane stays deliberately serialized — two concurrent
+    /// repairs would both drive the same PANE's pause state on the shared
+    /// correlator. The cost of that serialization is that an overflow signal
+    /// arriving for a key mid-repair is discarded by the guard below — fine
+    /// for a duplicate signal on the SAME sink (the `repairing` flag gates
+    /// re-signaling), but a SUCCESSOR sink's signal (re-attach while gen-N's
+    /// repair was parked on an await, then the gen-M > N sink overflowed)
+    /// used to be swallowed too, leaving the successor `repairing` forever:
+    /// route() drops all its output and `enqueueLocked` never re-signals — a
+    /// permanently blank pane (review round 2, S1).
+    ///
+    /// The exit re-dispatch below heals every such swallow: after each pass,
+    /// if the pane's CURRENT sink is still stuck mid-repair (`repairing` is
+    /// set only by an overflow entry and cleared only by this coordinator),
+    /// run the repair again for the CURRENT generation. Structurally bounded:
+    /// each pass services one distinct overflow entry (one `repairing`
+    /// false→true flip) and either completes it, aborts it, or is superseded
+    /// by a strictly newer generation — never a busy spin, every iteration
+    /// awaits a full repair cycle.
     func repairIfNeeded(key: PaneKey, generation: UInt64) async {
         guard !inFlight.contains(key) else { return }
         inFlight.insert(key)
         defer { inFlight.remove(key) }
-        await repair(key: key, generation: generation)
+        var target = generation
+        while true {
+            await repair(key: key, generation: target)
+            guard supervisor.fanout.flowStats(key: key)?.repairing == true,
+                  let current = supervisor.fanout.currentGeneration(key: key) else { return }
+            target = current
+        }
     }
 
     private func repair(key: PaneKey, generation: UInt64) async {
         let (server, paneID) = (key.server, key.paneID)
+        // Entry guard (review round 2, S1): the exit re-dispatch above can
+        // race a not-yet-run overflow signal Task for the same overflow —
+        // whichever lands second must find the sink already healed (no
+        // longer `repairing`, or replaced by a newer generation) and send
+        // NOTHING: a pause sent for a sink that is not mid-repair would
+        // freeze a healthy pane (`beginRepairFence` refuses non-repairing
+        // sinks, and no later path would unpause). Stale signals from a
+        // superseded generation exit here too, before touching the
+        // correlator.
+        guard supervisor.fanout.currentGeneration(key: key) == generation,
+              supervisor.fanout.flowStats(key: key)?.repairing == true else { return }
         guard let client = await commandProvider(server) else {
             // No correlator (connection torn down): nothing to pause, nothing
             // paused — just unfreeze the sink if we still own it
@@ -184,6 +221,13 @@ actor PaneRepairCoordinator {
         // sink to still be `repairing`). The pane is provably silent — the
         // pause reply is in hand and a paused pane delivers nothing — so no
         // output can race the arming. Refusal → superseded; send nothing.
+        //
+        // TOCTOU residual (accepted): this generation check and the batch
+        // send below are not atomic — a successor can interpose between
+        // them, so this batch can land inside the successor's pause window
+        // in a vanishingly narrow race. Consequence: a torn capture that
+        // differentially self-heals, same class as the accepted
+        // pause-failure tear above.
         guard supervisor.fanout.beginRepairFence(key: key, generation: generation) else { return }
 
         // Step 4 — captures + continue, ONE atomic list with the continue
@@ -192,14 +236,18 @@ actor PaneRepairCoordinator {
         let captureCommands = PaneCaptureReplay.captureCommands(
             paneID: paneID, historyDepth: historyDepth)
         let results = await client.sendBatch(texts: captureCommands + [continueCommand])
-        // A failed batched continue is log-only, as in the attach: a %error
-        // is tolerated, and a connection close fails the captures too, which
-        // aborts the repair below with its own unpause.
+        // A failed batched continue is tolerated here, as in the attach: a
+        // connection close fails the captures too, which aborts the repair
+        // below with its own unpause — but a plain %error leaves the
+        // captures healthy and the pane PAUSED, so the success path below
+        // retries the continue once (review round 2, M3).
+        var continueErrored = false
         if case .failure(let continueError) = results.last {
             Self.logger.error("""
                 repair batched continue failed for \(server, privacy: .public)/\(paneID, privacy: .public): \
                 \(String(describing: continueError), privacy: .public)
                 """)
+            if case .commandFailed = continueError { continueErrored = true }
         }
 
         do {
@@ -223,6 +271,17 @@ actor PaneRepairCoordinator {
                 pane repaired \(server, privacy: .public)/\(paneID, privacy: .public) gen=\(generation) \
                 — replay \(replay.count) bytes, \(fencedBytes) fenced bytes flushed
                 """)
+            // An %error'd batched continue (NOT a connection close — that
+            // fails the captures too) leaves a healthy-looking completed
+            // repair with the pane still PAUSED server-side. Retry ONE
+            // generation-checked, tolerate-errors, fire-and-forget continue
+            // (review round 2, M3) — same still-owner scoping as the error
+            // path below (R11: a successor owns the pane's pause state).
+            if continueErrored, await stillOwner(key, generation) {
+                await client.sendList([
+                    TmuxCommand(text: continueCommand, tolerateErrors: true) { _ in }
+                ])
+            }
         } catch PaneReplayWriteError.superseded {
             // A newer attach owns the pane: its own sequence manages the
             // gate, the fence, and the pause state (R11). Send nothing.
@@ -237,6 +296,13 @@ actor PaneRepairCoordinator {
             // and abort the repair so the stream resumes. A pane frozen
             // forever behind a fence is worse than a hole. A STALE failure
             // sends nothing — the successor owns the pane's pause state.
+            //
+            // TOCTOU residual (accepted): the still-owner check and the
+            // continue send are not atomic — a successor can interpose
+            // between them, so this continue can land inside the successor's
+            // pause window in a vanishingly narrow race. Consequence: a torn
+            // capture that differentially self-heals, same class as the
+            // accepted pause-failure tear.
             Self.logger.error("""
                 repair failed for \(server, privacy: .public)/\(paneID, privacy: .public) \
                 gen=\(generation): \(String(describing: error), privacy: .public)

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
@@ -50,10 +50,17 @@ actor PaneRepairCoordinator {
     /// Recapture depth — matches the attach orchestrator's (see its note on
     /// the server-side `history-limit 50000`).
     private let historyDepth: Int
-    /// Reader-catch-up poll pacing and deadline (step 2) — injectable so
-    /// tests can wedge the reader without waiting 30 s.
+    /// Reader-catch-up poll pacing (step 2) — injectable so tests can wedge
+    /// the reader on tiny intervals. The wait has NO deadline: pacing starts
+    /// at `writableCheckInterval` and relaxes to `writableSlowInterval` once
+    /// the wait exceeds `writableEscalationThreshold`.
     private let writableCheckInterval: Duration
-    private let writableDeadline: Duration
+    private let writableSlowInterval: Duration
+    private let writableEscalationThreshold: Duration
+    /// One `.error` line when the wait crosses this mark — the pane is still
+    /// healthy (paused, buffering server-side) but the app reader has been
+    /// stalled suspiciously long.
+    private static let readerStallLogThreshold: Duration = .seconds(30)
     /// One in-flight repair per pane. Belt-and-suspenders: the sink's
     /// `repairing` flag already gates re-signaling at the fanout, but a
     /// duplicate signal for a key mid-repair must still be a no-op here.
@@ -63,12 +70,14 @@ actor PaneRepairCoordinator {
          commandProvider: @escaping @Sendable (String) async -> TmuxControlCommandClient?,
          historyDepth: Int = 50_000,
          writableCheckInterval: Duration = .milliseconds(50),
-         writableDeadline: Duration = .seconds(30)) {
+         writableSlowInterval: Duration = .milliseconds(500),
+         writableEscalationThreshold: Duration = .seconds(5)) {
         self.supervisor = supervisor
         self.commandProvider = commandProvider
         self.historyDepth = historyDepth
         self.writableCheckInterval = writableCheckInterval
-        self.writableDeadline = writableDeadline
+        self.writableSlowInterval = writableSlowInterval
+        self.writableEscalationThreshold = writableEscalationThreshold
     }
 
     /// Test seam: whether a repair for `key` is currently running.
@@ -122,30 +131,52 @@ actor PaneRepairCoordinator {
         // the repair aborts silently (R11: no unpause — a successor attach's
         // own sequence owns the pane's pause state, and a plain detach
         // %errors nothing worse than a paused, viewerless pane).
-        let deadline = ContinuousClock.now + writableDeadline
+        //
+        // The wait has NO deadline: a TRANSIENTLY wedged reader (e.g. a long
+        // app main-thread hitch) must not turn into a permanently frozen
+        // pane — nothing in the daemon ever re-triggers a given generation's
+        // repair, so giving up here would leave the sink `repairing` and the
+        // pane paused forever. Instead the loop waits it out: the pane stays
+        // paused (tmux buffers server-side — nothing is lost) and THIS repair
+        // completes whenever the reader drains. Pacing escalates from
+        // `writableCheckInterval` to `writableSlowInterval` past the
+        // escalation threshold, with ONE `.error` line at the 30 s mark.
+        // A BROKEN pipe (read end closed) can never drain: unpause + abort —
+        // the viewer is gone or dying, the app-death detach path finishes the
+        // job, and leaving the pane unpaused keeps it healthy for the next
+        // attach.
+        let waitStart = ContinuousClock.now
+        var loggedStall = false
         waitLoop: while true {
             switch supervisor.fanout.isPipeWritable(key: key, generation: generation) {
             case nil:
                 return
-            case true?:
+            case .writable?:
                 break waitLoop
-            case false?:
-                if ContinuousClock.now >= deadline {
-                    // The reader is wedged. Deliberately do NOT abortRepair:
-                    // a continue now would just re-overflow the queue, so
-                    // the pane stays PAUSED (tmux buffers it server-side in
-                    // pane history/screen — nothing is being lost) and the
-                    // sink stays `repairing` (which keeps re-signaling
-                    // gated). A later attach replaces the sink and re-runs
-                    // the full pause→capture→replay sequence, which heals
-                    // everything this repair could not.
-                    Self.logger.error("""
-                        repair reader wedged for \(server, privacy: .public)/\(paneID, privacy: .public) \
-                        gen=\(generation) — leaving the pane paused; a later attach re-runs the sequence
-                        """)
-                    return
+            case .broken?:
+                Self.logger.error("""
+                    repair pipe broken (read end closed) for \(server, privacy: .public)/\(paneID, privacy: .public) \
+                    gen=\(generation) — unpausing and aborting; the app-death detach path finishes the job
+                    """)
+                if await stillOwner(key, generation) {
+                    await client.sendList([
+                        TmuxCommand(text: continueCommand, tolerateErrors: true) { _ in }
+                    ])
+                    supervisor.fanout.abortRepair(key: key, generation: generation)
                 }
-                try? await Task.sleep(for: writableCheckInterval)
+                return
+            case .full?:
+                let waited = ContinuousClock.now - waitStart
+                if !loggedStall, waited >= Self.readerStallLogThreshold {
+                    loggedStall = true
+                    Self.logger.error("""
+                        repair reader stalled >30s for \(server, privacy: .public)/\(paneID, privacy: .public) \
+                        gen=\(generation) — waiting; the pane stays paused, tmux buffers server-side
+                        """)
+                }
+                let interval = waited >= writableEscalationThreshold
+                    ? writableSlowInterval : writableCheckInterval
+                try? await Task.sleep(for: interval)
             }
         }
 

--- a/Sources/TBDDaemon/Tmux/ControlMode/TmuxControlModeBridge.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/TmuxControlModeBridge.swift
@@ -44,6 +44,11 @@ struct TmuxControlModeBridge: Sendable {
     /// clients; injectable so orchestration tests can substitute a fake-backed
     /// client (same seam shape as the input router / resize coordinator).
     let commandProvider: @Sendable (String) async -> TmuxControlCommandClient?
+    /// Heals steady-state queue overflows with the Phase B M3 pause+recapture
+    /// repair cycle. A reference type (actor) shared across every copy of
+    /// this value struct, wired to `PaneFanout.onOverflowRepair` in this
+    /// init; injectable seam like `inputRouter`/`resizeCoordinator`.
+    let repairCoordinator: PaneRepairCoordinator
 
     init(supervisor: TmuxControlSupervisor,
          tmuxVersion: TmuxVersion?,
@@ -53,7 +58,8 @@ struct TmuxControlModeBridge: Sendable {
          inputRouter: ControlModeInputRouter? = nil,
          resizeCoordinator: ControlModeResizeCoordinator? = nil,
          persistedFlagProvider: @escaping @Sendable () async -> Bool = { false },
-         commandProvider: (@Sendable (String) async -> TmuxControlCommandClient?)? = nil) {
+         commandProvider: (@Sendable (String) async -> TmuxControlCommandClient?)? = nil,
+         repairCoordinator: PaneRepairCoordinator? = nil) {
         self.supervisor = supervisor
         self.tmuxVersion = tmuxVersion
         self.environment = environment
@@ -80,6 +86,15 @@ struct TmuxControlModeBridge: Sendable {
         let coordinator = self.resizeCoordinator
         supervisor.setLayoutChangeFilter { server, windowID in
             coordinator.shouldApplyLayoutChange(server: server, windowID: windowID)
+        }
+        // Wire the M3 overflow-repair signal, also BEFORE any connection
+        // starts (same startup guarantee as the layout filter): the very
+        // first routed byte can already overflow a wedged pipe.
+        self.repairCoordinator = repairCoordinator
+            ?? PaneRepairCoordinator(supervisor: supervisor, commandProvider: self.commandProvider)
+        let repair = self.repairCoordinator
+        supervisor.fanout.onOverflowRepair = { key, generation in
+            Task { await repair.repairIfNeeded(key: key, generation: generation) }
         }
     }
 

--- a/Sources/TBDDaemon/Tmux/ControlMode/TmuxControlSupervisor.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/TmuxControlSupervisor.swift
@@ -274,6 +274,14 @@ actor TmuxControlSupervisor {
         fanout.markReady(key: PaneKey(server: server, paneID: paneID), generation: generation)
     }
 
+    /// Arm the attach-boundary fence (Phase B M2), generation-checked — see
+    /// `PaneFanout.armFence`. Returns whether the fence armed (`false` → the
+    /// caller's attach was superseded; send nothing more).
+    @discardableResult
+    func armFence(server: String, paneID: String, generation: UInt64) -> Bool {
+        fanout.armFence(key: PaneKey(server: server, paneID: paneID), generation: generation)
+    }
+
     /// Record the app's `attach.ready` ack and return the attach's CURRENT
     /// generation (M4.3) — the whole replay sequence is tagged with it.
     /// Generation-checked when the app echoed one (`expectedGeneration`): a

--- a/Tests/TBDDaemonTests/AttachRPCTests.swift
+++ b/Tests/TBDDaemonTests/AttachRPCTests.swift
@@ -168,14 +168,23 @@ struct AttachRPCOrchestrationTests {
         "\(paneID) 0 0 0 4294967295 4294967295 0 23 1 0 0 0 1 0 0 0 0 0 0 80 24 1"
     }
 
-    /// Feed the full happy-path reply set: pause, scrollback, screen, saved,
-    /// combined, state, pending. The non-alt assembly uses the COMBINED leg
-    /// verbatim (R8-M3), so it carries the history content these tests
-    /// assert on (screen leg empty → combined == history).
+    /// Feed the full happy-path reply set for the M2 two-batch sequence:
+    /// complete the pause (batch 1), await the captures+continue batch being
+    /// written (`recorder` reaching `captureBatchWrites`), then feed
+    /// scrollback, screen, saved, combined, state, pending and the batched
+    /// continue's reply. The non-alt assembly uses the COMBINED leg verbatim
+    /// (R8-M3), so it carries the history content these tests assert on
+    /// (screen leg empty → combined == history).
     private func feedCaptureReplies(
-        _ client: TmuxControlCommandClient, paneID: String, history: [String]
-    ) async {
-        for lines in [[], history, [], [], history, [stateLine(paneID: paneID)], [] as [String]] {
+        _ client: TmuxControlCommandClient, recorder: Recorder, paneID: String,
+        history: [String], captureBatchWrites: Int = 2,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async throws {
+        await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))  // pause
+        try await waitFor("capture batch write", sourceLocation: sourceLocation) {
+            recorder.writes.count >= captureBatchWrites
+        }
+        for lines in [history, [], [], history, [stateLine(paneID: paneID)], [], [] as [String]] {
             await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: lines))
         }
     }
@@ -329,21 +338,24 @@ struct AttachRPCOrchestrationTests {
             params: AttachReadyParams(worktreeID: worktreeID, paneID: "%7"))
         let readyTask = Task { await router.handle(ready) }
 
-        // The ack triggers ONE atomic stream write: pause then the captures.
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
-        let batch = try #require(recorder.writes.first)
-        #expect(batch.hasPrefix("refresh-client -A '%7:pause'\ncapture-pane -peqJN -S -50000 -E -1 -q -t %7\n"))
-        // The gate stays CLOSED while the capture is in flight.
+        // The ack triggers batch 1 — the pause ALONE (M2); the captures +
+        // continue follow as a second atomic write once the pause completes.
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        #expect(recorder.writes.first == "refresh-client -A '%7:pause'")
+        // The gate stays CLOSED while the sequence is in flight.
         #expect(await supervisor.isReady(server: "tbd-gate-test", paneID: "%7") == false)
 
-        await feedCaptureReplies(client, paneID: "%7", history: ["replayed-history"])
+        try await feedCaptureReplies(client, recorder: recorder, paneID: "%7",
+                                     history: ["replayed-history"])
         let response = await readyTask.value
         #expect(response.success)
         #expect(await supervisor.isReady(server: "tbd-gate-test", paneID: "%7") == true)
 
-        // Unpause is the last command, after the gate opened.
-        try await waitFor("unpause write") { recorder.writes.count >= 2 }
-        #expect(recorder.writes.last == "refresh-client -A '%7:continue'")
+        // The continue rides batch 2 as its LAST command; no separate unpause.
+        #expect(recorder.writes.count == 2)
+        let batch = try #require(recorder.writes.last)
+        #expect(batch.hasPrefix("capture-pane -peqJN -S -50000 -E -1 -q -t %7\n"))
+        #expect(batch.hasSuffix("\nrefresh-client -A '%7:continue'"))
 
         // The vended fd carries the replay (which ends with a CUP).
         let text = (String(bytes: drain(rxFD), encoding: .utf8) ?? "")
@@ -378,7 +390,7 @@ struct AttachRPCOrchestrationTests {
             method: RPCMethod.attachReady,
             params: AttachReadyParams(worktreeID: worktreeID, paneID: "%6"))
         let readyTask = Task { await router.handle(ready) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
 
         // Let the 100 ms ready-timeout fire while the replay is in flight:
         // the acked attach must NOT be torn down (no EOF on the vended fd).
@@ -390,7 +402,8 @@ struct AttachRPCOrchestrationTests {
         #expect(n < 0 && errno == EAGAIN, "acked attach must survive the timer (no EOF, no data yet)")
 
         // The stalled replies arrive; the sequence completes normally.
-        await feedCaptureReplies(client, paneID: "%6", history: ["late-history"])
+        try await feedCaptureReplies(client, recorder: recorder, paneID: "%6",
+                                     history: ["late-history"])
         let response = await readyTask.value
         #expect(response.success)
         #expect(await supervisor.isReady(server: "tbd-timeout-test", paneID: "%6") == true)
@@ -424,22 +437,25 @@ struct AttachRPCOrchestrationTests {
             method: RPCMethod.attachReady,
             params: AttachReadyParams(worktreeID: worktreeID, paneID: "%8"))
         let readyTask = Task { await router.handle(ready) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
 
-        // A newer attach replaces the sink mid-sequence.
+        // A newer attach replaces the sink mid-sequence — while batch 1's
+        // pause reply is still in flight.
         _ = await router.handle(try attachRequest())
         let (rxFD2, _) = try SidecarTestSupport.receiveVend(from: clientSide)
         defer { Darwin.close(rxFD2) }
 
-        await feedCaptureReplies(client, paneID: "%8", history: ["stale-history"])
+        // The pause reply lands: the post-pause re-check (M2) sees the newer
+        // generation and stands down.
+        await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))
         // Benign race: RPC SUCCESS, but the successor's gate stays closed
         // (its own attach.ready opens it) and its pipe got no stale replay.
         let response = await readyTask.value
         #expect(response.success)
         #expect(await supervisor.isReady(server: "tbd-supersede-test", paneID: "%8") == false)
-        // No unpause from the superseded sequence (M2 review fix): the
-        // successor's own FIFO-ordered sequence unpauses the pane. The RPC
-        // returned, so the write log is final — batch only, no continue.
+        // Nothing after the pause from the superseded sequence: no captures,
+        // no continue — the successor's own FIFO-ordered sequence owns the
+        // pane's pause state (R11). The RPC returned, so the log is final.
         #expect(recorder.writes.count == 1)
         #expect(!recorder.writes.contains { $0.contains(":continue'") })
         #expect(drain(rxFD2).isEmpty, "successor's pipe must not receive the stale replay")
@@ -493,12 +509,13 @@ struct AttachRPCOrchestrationTests {
             method: RPCMethod.attachReady,
             params: AttachReadyParams(worktreeID: worktreeID, paneID: "%12", generation: gen2))
         let readyTask = Task { await router.handle(freshReady) }
-        try await waitFor("successor capture batch") { recorder.writes.count >= 1 }
-        await feedCaptureReplies(client, paneID: "%12", history: ["fresh"])
+        try await waitFor("successor pause batch") { recorder.writes.count >= 1 }
+        try await feedCaptureReplies(client, recorder: recorder, paneID: "%12", history: ["fresh"])
         #expect((await readyTask.value).success)
         #expect(await supervisor.isReady(server: "tbd-staleready-test", paneID: "%12") == true)
-        try await waitFor("successor unpause") { recorder.writes.count >= 2 }
-        #expect(recorder.writes.last == "refresh-client -A '%12:continue'")
+        // The successor's continue rode its capture batch (LAST command).
+        #expect(recorder.writes.count == 2)
+        #expect(recorder.writes.last?.hasSuffix("\nrefresh-client -A '%12:continue'") == true)
     }
 
     @Test("mid-sequence supersession on ONE shared correlator: stale generation sends no continue; the successor's sequence ends with its own")
@@ -531,35 +548,38 @@ struct AttachRPCOrchestrationTests {
             method: RPCMethod.attachReady,
             params: AttachReadyParams(worktreeID: worktreeID, paneID: "%13", generation: gen1))
         let ready1Task = Task { await router.handle(ready1) }
-        try await waitFor("gen 1 capture batch") { recorder.writes.count >= 1 }
+        try await waitFor("gen 1 pause batch") { recorder.writes.count >= 1 }
 
-        // Attach #2 replaces the sink MID-sequence; gen 1's replies then land.
+        // Attach #2 replaces the sink MID-sequence (while gen 1's pause reply
+        // is in flight); the pause reply then lands and the post-pause
+        // re-check (M2) stands gen 1 down before its capture batch.
         let gen2 = try await attach()
         let (fd2, _) = try SidecarTestSupport.receiveVend(from: clientSide)
         defer { Darwin.close(fd2) }
-        await feedCaptureReplies(client, paneID: "%13", history: ["stale"])
+        await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))
         #expect((await ready1Task.value).success)
-        // The superseded sequence sent its batch and NOTHING else — its
-        // unpause is skipped so it cannot land inside the successor's own
-        // pause window (FIFO puts the successor's sequence after this one).
+        // The superseded sequence sent its pause and NOTHING else — no
+        // captures, and no continue that could land inside the successor's
+        // own pause window (FIFO puts the successor's sequence after this
+        // one).
         #expect(recorder.writes.count == 1)
         #expect(!recorder.writes.contains { $0.contains(":continue'") })
 
-        // The successor's sequence runs on the SAME correlator and ends with
-        // its own continue — the pane ends unpaused, exactly once.
+        // The successor's sequence runs on the SAME correlator and its
+        // capture batch ends with its own continue — the pane ends unpaused,
+        // exactly once.
         let ready2 = try RPCRequest(
             method: RPCMethod.attachReady,
             params: AttachReadyParams(worktreeID: worktreeID, paneID: "%13", generation: gen2))
         let ready2Task = Task { await router.handle(ready2) }
-        try await waitFor("gen 2 capture batch") { recorder.writes.count >= 2 }
-        await feedCaptureReplies(client, paneID: "%13", history: ["fresh"])
+        try await waitFor("gen 2 pause batch") { recorder.writes.count >= 2 }
+        try await feedCaptureReplies(client, recorder: recorder, paneID: "%13",
+                                     history: ["fresh"], captureBatchWrites: 3)
         #expect((await ready2Task.value).success)
         #expect(await supervisor.isReady(server: "tbd-sharedsup-test", paneID: "%13") == true)
-        try await waitFor("gen 2 unpause") { recorder.writes.count >= 3 }
         let continues = recorder.writes.filter { $0.contains(":continue'") }
-        #expect(continues == ["refresh-client -A '%13:continue'"],
-                "exactly ONE continue, the successor's own")
-        #expect(recorder.writes.last == "refresh-client -A '%13:continue'")
+        #expect(continues.count == 1, "exactly ONE continue, the successor's own")
+        #expect(recorder.writes.last?.hasSuffix("\nrefresh-client -A '%13:continue'") == true)
     }
 
     @Test("a stale attach's late failure must not kill a healthy successor's sink")
@@ -594,12 +614,16 @@ struct AttachRPCOrchestrationTests {
             method: RPCMethod.attachReady,
             params: AttachReadyParams(worktreeID: worktreeID, paneID: "%5"))
 
-        // Attach #1 (gen 1); its ready sequence starts and stalls on replies.
+        // Attach #1 (gen 1); its ready sequence starts, gets PAST its pause
+        // (still the owner, so its capture batch goes out) and then stalls on
+        // the capture replies.
         _ = await router.handle(try attachRequest())
         let (fd1, _) = try SidecarTestSupport.receiveVend(from: clientSide)
         defer { Darwin.close(fd1) }
         let ready1 = Task { await router.handle(ready) }
-        try await waitFor("gen 1 capture batch") { recorderA.writes.count >= 1 }
+        try await waitFor("gen 1 pause batch") { recorderA.writes.count >= 1 }
+        await clientA.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))  // gen 1 pause
+        try await waitFor("gen 1 capture batch") { recorderA.writes.count >= 2 }
 
         // Attach #2 (fast tab-switch re-attach, gen 2) replaces the sink and
         // completes its OWN sequence: replay written, gate open. Healthy.
@@ -607,18 +631,18 @@ struct AttachRPCOrchestrationTests {
         let (fd2, _) = try SidecarTestSupport.receiveVend(from: clientSide)
         defer { Darwin.close(fd2) }
         let ready2 = Task { await router.handle(ready) }
-        try await waitFor("gen 2 capture batch") { recorderB.writes.count >= 1 }
-        await feedCaptureReplies(clientB, paneID: "%5", history: ["fresh-history"])
+        try await waitFor("gen 2 pause batch") { recorderB.writes.count >= 1 }
+        try await feedCaptureReplies(clientB, recorder: recorderB, paneID: "%5",
+                                     history: ["fresh-history"])
         let response2 = await ready2.value
         #expect(response2.success)
         #expect(await supervisor.isReady(server: "tbd-stalefail-test", paneID: "%5") == true)
         #expect((String(bytes: drain(fd2), encoding: .utf8) ?? "").contains("fresh-history"))
 
         // Gen 1's DELAYED capture reply is a %error → its sequence fails.
-        // (pause OK, scrollback %error, remaining five OK.)
-        await clientA.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))
+        // (scrollback %error, remaining five + batched continue OK.)
         await clientA.handle(.commandFailed(number: 0, fromClient: true, lines: ["no such pane"]))
-        for _ in 0..<5 {
+        for _ in 0..<6 {
             await clientA.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))
         }
         let response1 = await ready1.value
@@ -755,13 +779,14 @@ struct AttachRPCOrchestrationTests {
             method: RPCMethod.attachReady,
             params: AttachReadyParams(worktreeID: worktreeID, paneID: "%9"))
         let readyTask = Task { await router.handle(ready) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))  // pause OK
+        try await waitFor("capture batch write") { recorder.writes.count >= 2 }
 
-        // pause OK, then the scrollback capture %errors (dead pane);
-        // remaining five (screen, saved, combined, state, pending) OK.
-        await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))
+        // The scrollback capture %errors (dead pane); remaining five
+        // (screen, saved, combined, state, pending) + batched continue OK.
         await client.handle(.commandFailed(number: 0, fromClient: true, lines: ["no such pane"]))
-        for _ in 0..<5 {
+        for _ in 0..<6 {
             await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))
         }
 
@@ -771,8 +796,8 @@ struct AttachRPCOrchestrationTests {
         var buffer = [UInt8](repeating: 0, count: 8)
         let n = buffer.withUnsafeMutableBytes { Darwin.read(rxFD, $0.baseAddress, $0.count) }
         #expect(n == 0, "failed attach must be detached (EOF on the vended fd)")
-        // Unpause still ran despite the failure.
-        try await waitFor("unpause write") { recorder.writes.count >= 2 }
+        // The failure-path unpause still ran despite the failure.
+        try await waitFor("unpause write") { recorder.writes.count >= 3 }
         #expect(recorder.writes.last == "refresh-client -A '%9:continue'")
     }
 }

--- a/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
+++ b/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
@@ -4,6 +4,11 @@ import Testing
 
 @testable import TBDDaemonLib
 
+/// Positive-wait deadline sized for starved CI runners (PR #379: cooperative-pool
+/// starvation stretched sub-second async-drain deliveries past a 5 s poll).
+/// Passing runs still complete in milliseconds — only failures wait this long.
+private let ciSafeDeadline: Duration = .seconds(30)
+
 /// Phase B M2 — the attach-boundary fence (issue #376, second bullet).
 ///
 /// Before M2, output a pane emitted between the attach's capture and the
@@ -56,7 +61,7 @@ struct AttachReplayFenceTests {
     /// Poll until `condition`, failing after `deadline` (async work — the
     /// orchestrator's batch writes — lands on other tasks).
     private func waitFor(
-        _ what: String, deadline: Duration = .seconds(15),
+        _ what: String, deadline: Duration = ciSafeDeadline,
         sourceLocation: SourceLocation = #_sourceLocation,
         _ condition: @Sendable () async -> Bool
     ) async throws {
@@ -108,7 +113,7 @@ struct AttachReplayFenceTests {
     /// accumulated text or the deadline passes — the fence flush arrives via
     /// the async drain task, so a one-shot read snapshot could race it.
     private func readUntil(
-        fd: Int32, deadline: Duration = .seconds(15),
+        fd: Int32, deadline: Duration = ciSafeDeadline,
         _ condition: @Sendable (String) -> Bool
     ) async -> String {
         let flags = fcntl(fd, F_GETFL)

--- a/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
+++ b/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
@@ -1,0 +1,340 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// Phase B M2 — the attach-boundary fence (issue #376, second bullet).
+///
+/// Before M2, output a pane emitted between the attach's capture and the
+/// trailing unpause (~0.2–0.5 s under load) was dropped by the closed gate
+/// and lost to the viewer. M2 closes that seam with two probe-verified tmux
+/// facts (3.6a): a PAUSED pane delivers nothing (its output lands in pane
+/// history, reachable via capture), and an atomic `[captures…, continue]`
+/// command list has a seam gap of exactly zero. The orchestrator therefore
+/// runs TWO batches — pause alone (await: the pane is provably silent), then
+/// captures + continue as one atomic list — arming a generation-scoped fence
+/// between them; fenced output queues behind the closed gate and `markReady`
+/// flushes it right after the replay. Zero loss at the attach seam.
+///
+/// Same seam as `AttachReplayOrchestratorTests`: a real
+/// `TmuxControlCommandClient` with recorded stream writes, reply blocks fed
+/// by hand, and a real supervisor + fanout so the gate/generation/fence
+/// semantics under test are the production ones.
+@Suite("AttachReplayFence")
+struct AttachReplayFenceTests {
+    private let server = "tbd-fence-unit"
+
+    /// Thread-safe, synchronous recorder of stream writes in call order.
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _writes: [String] = []
+        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
+        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
+    }
+
+    private func makeHarness() -> (
+        TmuxControlSupervisor, AttachReplayOrchestrator, Recorder, TmuxControlCommandClient
+    ) {
+        let recorder = Recorder()
+        let client = TmuxControlCommandClient(
+            writeLine: { recorder.record($0) },
+            onFatalError: {})
+        let supervisor = TmuxControlSupervisor()
+        let orchestrator = AttachReplayOrchestrator(
+            supervisor: supervisor,
+            commandProvider: { [server] in $0 == server ? client : nil })
+        return (supervisor, orchestrator, recorder, client)
+    }
+
+    /// A 22-field primary-screen state line for `paneID` at 80x24 with the
+    /// cursor at (x=2, y=1) — the replay's final CUP must be `ESC[2;3H`.
+    private func stateLine(paneID: String) -> String {
+        "\(paneID) 2 1 0 4294967295 4294967295 0 23 1 0 0 0 1 0 0 0 0 0 0 80 24 1"
+    }
+
+    /// Poll until `condition`, failing after `deadline` (async work — the
+    /// orchestrator's batch writes — lands on other tasks).
+    private func waitFor(
+        _ what: String, deadline: Duration = .seconds(15),
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let end = ContinuousClock.now + deadline
+        while ContinuousClock.now < end {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
+    }
+
+    /// Complete the next `lines.count` pending commands with `%end`.
+    private func succeed(_ client: TmuxControlCommandClient, _ lines: [[String]]) async {
+        for reply in lines {
+            await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: reply))
+        }
+    }
+
+    /// The happy-path capture replies (scrollback, screen, saved, combined,
+    /// state, pending) + the batched continue's reply.
+    private func captureAndContinueReplies(paneID: String) -> [[String]] {
+        [["hist-one"], ["hist-two"], [], ["hist-one", "hist-two"],
+         [stateLine(paneID: paneID)], [], []]
+    }
+
+    /// Await `body` expecting an `AttachReplayFailure` tagged `generation`;
+    /// returns its underlying error for case matching.
+    private func expectFailure(
+        generation: UInt64,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ body: () async throws -> AttachReplayOrchestrator.Outcome
+    ) async -> (any Error)? {
+        do {
+            _ = try await body()
+            Issue.record("expected AttachReplayFailure, got success", sourceLocation: sourceLocation)
+        } catch let failure as AttachReplayFailure {
+            #expect(failure.generation == generation,
+                    "failure must carry the sequence's own generation",
+                    sourceLocation: sourceLocation)
+            return failure.underlying
+        } catch {
+            Issue.record(
+                "expected AttachReplayFailure, got \(error)", sourceLocation: sourceLocation)
+        }
+        return nil
+    }
+
+    /// Poll-read `fd` (made nonblocking) until `condition` holds on the
+    /// accumulated text or the deadline passes — the fence flush arrives via
+    /// the async drain task, so a one-shot read snapshot could race it.
+    private func readUntil(
+        fd: Int32, deadline: Duration = .seconds(15),
+        _ condition: @Sendable (String) -> Bool
+    ) async -> String {
+        let flags = fcntl(fd, F_GETFL)
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+        var out = Data()
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        let end = ContinuousClock.now + deadline
+        while ContinuousClock.now < end {
+            let n = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            if n > 0 {
+                out.append(contentsOf: buffer[0..<n])
+                if condition(String(decoding: out, as: UTF8.self)) { break }
+                continue
+            }
+            if n == 0 { break }  // EOF
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return String(decoding: out, as: UTF8.self)
+    }
+
+    // MARK: - The headline: seam closure
+
+    @Test("seam closure: output routed while fenced lands after the replay, before later live bytes — nothing lost")
+    func fencedBytesFlushAfterReplayInOrder() async throws {
+        let (supervisor, orchestrator, recorder, client) = makeHarness()
+        let paneID = "%1"
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+
+        let task = Task {
+            try await orchestrator.performAttachReady(
+                server: server, paneID: paneID, expectedGeneration: generation)
+        }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        try #require(recorder.writes.first == "refresh-client -A '%1:pause'",
+                     "M2: batch 1 must be the pause ALONE")
+
+        // The pause reply lands: the pane is provably silent, the fence arms,
+        // and the captures+continue batch goes out.
+        await succeed(client, [[]])
+        try await waitFor("capture+continue batch write") { recorder.writes.count >= 2 }
+        try #require(recorder.writes.count >= 2, "captures+continue batch never sent")
+
+        // X: what the pane emits after the batched continue — routed while
+        // the gate is still closed but the fence is armed. Must be QUEUED,
+        // not dropped.
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("FENCED-X".utf8)))
+
+        // Captures + the batched continue complete; the replay assembles and
+        // lands behind the closed gate, then markReady flushes the fence.
+        await succeed(client, captureAndContinueReplies(paneID: paneID))
+        #expect(try await task.value == .ready)
+
+        // Y: live output after the sequence returned.
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("LIVE-Y".utf8)))
+
+        // Pipe order, byte-exact: replay (ends with the CUP for cursor
+        // x=2,y=1), then X, then Y — the seam is ZERO.
+        let text = await readUntil(fd: readFD) { $0.hasSuffix("LIVE-Y") }
+        #expect(text.hasPrefix(ReplayWriter.resetPrelude))
+        #expect(text.hasSuffix("\u{1b}[2;3HFENCED-XLIVE-Y"),
+                "expected replay ⊕ fenced ⊕ live, contiguous; tail \(text.suffix(40).debugDescription)")
+
+        // Nothing was dropped anywhere along the way.
+        let stats = try #require(supervisor.fanout.flowStats(
+            key: PaneKey(server: server, paneID: paneID)))
+        #expect(stats.droppedBytes == 0)
+        #expect(stats.droppedEvents == 0)
+    }
+
+    @Test("pre-pause output is still dropped (it is in the capture, not lost) and never reaches the pipe")
+    func prePauseBytesStillDropped() async throws {
+        let (supervisor, orchestrator, recorder, client) = makeHarness()
+        let paneID = "%2"
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+
+        let task = Task {
+            try await orchestrator.performAttachReady(
+                server: server, paneID: paneID, expectedGeneration: generation)
+        }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        try #require(recorder.writes.first == "refresh-client -A '%2:pause'",
+                     "M2: batch 1 must be the pause ALONE")
+
+        // Routed BEFORE the pause reply completes: the fence is not armed
+        // yet, so this is the pre-M2 drop window — the bytes are part of the
+        // capture, and delivering them too would duplicate them.
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("PRE-FENCE-DROPPED".utf8)))
+
+        await succeed(client, [[]])
+        try await waitFor("capture+continue batch write") { recorder.writes.count >= 2 }
+        try #require(recorder.writes.count >= 2, "captures+continue batch never sent")
+        await succeed(client, captureAndContinueReplies(paneID: paneID))
+        #expect(try await task.value == .ready)
+
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("LIVE-Z".utf8)))
+        let text = await readUntil(fd: readFD) { $0.hasSuffix("LIVE-Z") }
+        #expect(text.hasSuffix("\u{1b}[2;3HLIVE-Z"),
+                "live bytes must directly follow the replay; tail \(text.suffix(40).debugDescription)")
+        #expect(!text.contains("PRE-FENCE-DROPPED"),
+                "pre-pause output is in the capture — routing it too would duplicate it")
+    }
+
+    @Test("two sendLists: batch 1 is the pause alone, batch 2 is the captures with the continue LAST, no separate unpause")
+    func twoBatchesContinueLast() async throws {
+        let (supervisor, orchestrator, recorder, client) = makeHarness()
+        let paneID = "%3"
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+
+        let task = Task {
+            try await orchestrator.performAttachReady(
+                server: server, paneID: paneID, expectedGeneration: generation)
+        }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        try #require(recorder.writes.first == "refresh-client -A '%3:pause'",
+                     "M2: batch 1 must be the pause ALONE")
+
+        await succeed(client, [[]])
+        try await waitFor("capture+continue batch write") { recorder.writes.count >= 2 }
+        try #require(recorder.writes.count >= 2, "captures+continue batch never sent")
+        #expect(recorder.writes[1] == """
+            capture-pane -peqJN -S -50000 -E -1 -q -t %3
+            capture-pane -peqJN -t %3
+            capture-pane -peqJN -a -q -t %3
+            capture-pane -peqJN -S -50000 -t %3
+            list-panes -t %3 -F '\(PaneStateCapture.format)'
+            capture-pane -p -P -C -t %3
+            refresh-client -A '%3:continue'
+            """,
+            "batch 2 must be ONE atomic list: 6 captures with the continue LAST")
+
+        await succeed(client, captureAndContinueReplies(paneID: paneID))
+        #expect(try await task.value == .ready)
+
+        // SUCCESS path sends no trailing unpause — the batched continue
+        // already ran (bounded negative check; the sequence has returned).
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(recorder.writes.count == 2,
+                "no separate post-replay unpause may be sent on success")
+        _ = await readUntil(fd: readFD) { $0.hasSuffix("H") }
+    }
+
+    @Test("superseded between batch 1 and batch 2: captures+continue never sent, no unpause, successor untouched")
+    func supersededBetweenBatches() async throws {
+        let (supervisor, orchestrator, recorder, client) = makeHarness()
+        let paneID = "%4"
+        let (read1, gen1) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read1) }
+
+        let task = Task {
+            try await orchestrator.performAttachReady(
+                server: server, paneID: paneID, expectedGeneration: gen1)
+        }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        try #require(recorder.writes.first == "refresh-client -A '%4:pause'",
+                     "M2: batch 1 must be the pause ALONE")
+
+        // A successor attaches while batch 1 is in flight (its reply held).
+        let (read2, gen2) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read2) }
+
+        // The pause reply lands: the post-pause re-check must see gen2 and
+        // stand down — sending NOTHING more (R11: the successor owns the
+        // pane's pause state; a stale continue could land inside its pause
+        // window).
+        await succeed(client, [[]])
+        #expect(try await task.value == .superseded)
+
+        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
+        #expect(recorder.writes.count == 1, "batch 2 must never be sent by a superseded sequence")
+        #expect(!recorder.writes.contains { $0.contains("capture-pane") })
+        #expect(!recorder.writes.contains { $0.contains(":continue'") })
+
+        // Successor's sink untouched: gate closed, un-acked (its own ready
+        // still owns the sequence), no fence armed (a routed chunk drops
+        // rather than queues).
+        #expect(await supervisor.isReady(server: server, paneID: paneID) == false)
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("STALE-PROBE".utf8)))
+        let stats = try #require(supervisor.fanout.flowStats(
+            key: PaneKey(server: server, paneID: paneID)))
+        #expect(stats.queuedBytes == 0, "the stale sequence must not have fenced the successor's sink")
+        #expect(await supervisor.acknowledgeAttach(
+            server: server, paneID: paneID, expectedGeneration: gen2)
+            == .acknowledged(generation: gen2),
+            "successor must still be acknowledgeable — the stale sequence touched nothing")
+    }
+
+    @Test("error path still unpauses: a capture %error in batch 2 sends a trailing generation-checked continue")
+    func errorPathUnpauses() async throws {
+        let (supervisor, orchestrator, recorder, client) = makeHarness()
+        let paneID = "%5"
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+
+        let task = Task {
+            try await orchestrator.performAttachReady(
+                server: server, paneID: paneID, expectedGeneration: generation)
+        }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        try #require(recorder.writes.first == "refresh-client -A '%5:pause'",
+                     "M2: batch 1 must be the pause ALONE")
+        await succeed(client, [[]])
+        try await waitFor("capture+continue batch write") { recorder.writes.count >= 2 }
+        try #require(recorder.writes.count >= 2, "captures+continue batch never sent")
+
+        // Scrollback capture %errors (tolerated at the correlator level);
+        // the remaining captures and the batched continue succeed.
+        await client.handle(.commandFailed(number: 0, fromClient: true, lines: ["no such pane"]))
+        await succeed(client, [[], [], [], [stateLine(paneID: paneID)], [], []])
+
+        let underlying = await expectFailure(generation: generation) { try await task.value }
+        #expect(underlying as? AttachReplayError == .captureFailed(
+            command: "capture-pane -peqJN -S -50000 -E -1 -q -t %5"))
+
+        // The failure path must still send its own generation-checked
+        // continue: it covers "the pause ran but batch 2's continue may not
+        // have" (e.g. a connection close mid-batch). Redundant here — a
+        // continue on an unpaused pane no-ops via tolerate-errors.
+        try await waitFor("trailing unpause write") { recorder.writes.count >= 3 }
+        #expect(recorder.writes.last == "refresh-client -A '%5:continue'")
+    }
+}

--- a/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
+++ b/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
@@ -337,4 +337,38 @@ struct AttachReplayFenceTests {
         try await waitFor("trailing unpause write") { recorder.writes.count >= 3 }
         #expect(recorder.writes.last == "refresh-client -A '%5:continue'")
     }
+
+    @Test("%error'd batched continue on success: one generation-checked retry continue after the gate opens")
+    func erroredBatchedContinueRetriesAfterReady() async throws {
+        let (supervisor, orchestrator, recorder, client) = makeHarness()
+        let paneID = "%6"
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+
+        let task = Task {
+            try await orchestrator.performAttachReady(
+                server: server, paneID: paneID, expectedGeneration: generation)
+        }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])
+        try await waitFor("capture+continue batch write") { recorder.writes.count >= 2 }
+
+        // All six captures succeed; the batched continue %errors (tolerated
+        // at the correlator level — NOT a connection close, which would fail
+        // the captures too and fail the attach on its own).
+        await succeed(client, [["hist-one"], ["hist-two"], [], ["hist-one", "hist-two"],
+                               [stateLine(paneID: paneID)], []])
+        await client.handle(.commandFailed(number: 0, fromClient: true, lines: ["unknown flag"]))
+
+        // The attach still succeeds (replay landed, gate open)…
+        #expect(try await task.value == .ready)
+
+        // …and a retry continue goes out: without it the attach LOOKS live
+        // but the pane stays PAUSED server-side — a healthy-looking frozen
+        // pane.
+        try await waitFor("retry continue write") { recorder.writes.count >= 3 }
+        #expect(recorder.writes.last == "refresh-client -A '%6:continue'",
+                "an %error'd batched continue must be retried once, tolerate-errors")
+        _ = await readUntil(fd: readFD) { $0.hasSuffix("H") }
+    }
 }

--- a/Tests/TBDDaemonTests/AttachReplayOrchestratorTests.swift
+++ b/Tests/TBDDaemonTests/AttachReplayOrchestratorTests.swift
@@ -4,12 +4,15 @@ import Testing
 
 @testable import TBDDaemonLib
 
-/// Unit tests for the attach orchestration v2 (M4.3): pause → capture →
-/// replay → gate → unpause. No tmux — same seam as the resize-coordinator
-/// tests: a real `TmuxControlCommandClient` whose `writeLine` records stream
-/// writes synchronously, with reply blocks fed by hand through
-/// `client.handle(...)`. The supervisor (and its fanout) are real, so the
-/// gate/generation semantics under test are the production ones.
+/// Unit tests for the attach orchestration v2 (M4.3) with the Phase B M2
+/// fence: pause (batch 1, awaited) → arm fence → captures+continue (batch 2,
+/// continue LAST) → replay → gate+flush. No tmux — same seam as the
+/// resize-coordinator tests: a real `TmuxControlCommandClient` whose
+/// `writeLine` records stream writes synchronously, with reply blocks fed by
+/// hand through `client.handle(...)`. The supervisor (and its fanout) are
+/// real, so the gate/generation/fence semantics under test are the
+/// production ones. The fence-specific scenarios live in
+/// `AttachReplayFenceTests`.
 @Suite("AttachReplayOrchestrator")
 struct AttachReplayOrchestratorTests {
     private let server = "tbd-orch-unit"
@@ -141,6 +144,21 @@ struct AttachReplayOrchestratorTests {
         }
     }
 
+    /// M2 two-phase feed: complete batch 1 (the pause), await batch 2 (the
+    /// captures + continue) being written, then feed the 6 capture replies
+    /// and the batched continue's reply.
+    private func feedSequence(
+        _ client: TmuxControlCommandClient, recorder: Recorder,
+        captures: [[String]],
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) async throws {
+        await succeed(client, [[]])  // pause (batch 1)
+        try await waitFor("capture batch write", sourceLocation: sourceLocation) {
+            recorder.writes.count >= 2
+        }
+        await succeed(client, captures + [[]])  // 6 captures + continue (batch 2)
+    }
+
     /// Await `body` expecting an `AttachReplayFailure` whose generation is
     /// `generation`; returns its underlying error for case matching. Records
     /// an issue (and returns nil) on success or a bare/unwrapped error.
@@ -178,7 +196,7 @@ struct AttachReplayOrchestratorTests {
         return out
     }
 
-    @Test("happy path: pause+captures in ONE write, gate opens only after replay, unpause last")
+    @Test("happy path: pause alone, then captures+continue in ONE write, gate opens only after replay, NO separate unpause")
     func happyPathOrder() async throws {
         let (supervisor, orchestrator, recorder, client) = makeHarness()
         let paneID = "%1"
@@ -191,43 +209,50 @@ struct AttachReplayOrchestratorTests {
             try await orchestrator.performAttachReady(
                 server: server, paneID: paneID, expectedGeneration: generation)
         }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
 
-        // ONE atomic stream write: pause FIRST, then the 6-command capture
-        // (four legs: pure scrollback / current screen / saved primary /
-        // combined history+screen — R8-M3).
+        // Batch 1 (Phase B M2): the pause ALONE — its reply is the moment
+        // the pane is provably silent and the fence can arm.
         #expect(recorder.writes.count == 1)
-        let batch = try #require(recorder.writes.first)
-        #expect(batch == """
-            refresh-client -A '%1:pause'
+        #expect(recorder.writes.first == "refresh-client -A '%1:pause'")
+
+        // Gate still closed during the pre-fence window: a fabricated
+        // %output routed before the pause reply must be dropped (it is in
+        // the capture), not delivered before the replay.
+        #expect(await supervisor.isReady(server: server, paneID: paneID) == false)
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("MID-SEQUENCE".utf8)))
+
+        // The pause reply lands; batch 2 goes out: the 6-command capture
+        // (four legs: pure scrollback / current screen / saved primary /
+        // combined history+screen — R8-M3) + the continue LAST, one atomic
+        // stream write.
+        await succeed(client, [[]])
+        try await waitFor("capture batch write") { recorder.writes.count >= 2 }
+        #expect(recorder.writes.count == 2)
+        #expect(recorder.writes.last == """
             capture-pane -peqJN -S -50000 -E -1 -q -t %1
             capture-pane -peqJN -t %1
             capture-pane -peqJN -a -q -t %1
             capture-pane -peqJN -S -50000 -t %1
             list-panes -t %1 -F '\(PaneStateCapture.format)'
             capture-pane -p -P -C -t %1
+            refresh-client -A '%1:continue'
             """)
 
-        // Gate still closed during the capture window: a fabricated %output
-        // routed mid-sequence must be dropped, not delivered before the replay.
-        #expect(await supervisor.isReady(server: server, paneID: paneID) == false)
-        supervisor.fanout.route(
-            server: server, event: .output(paneID: paneID, bytes: Data("MID-SEQUENCE".utf8)))
-
-        // Reply blocks in FIFO order: pause, scrollback, screen, saved,
-        // combined, state, pending. Non-alt uses the combined leg verbatim.
-        await succeed(client, [[], ["hist-one"], ["hist-two"], [],
+        // Reply blocks in FIFO order: scrollback, screen, saved, combined,
+        // state, pending, continue. Non-alt uses the combined leg verbatim.
+        await succeed(client, [["hist-one"], ["hist-two"], [],
                                ["hist-one", "hist-two"],
-                               [stateLine(paneID: paneID)], []])
+                               [stateLine(paneID: paneID)], [], []])
 
         let outcome = try await task.value
         #expect(outcome == .ready)
         #expect(await supervisor.isReady(server: server, paneID: paneID) == true)
 
-        // Unpause is the LAST command, sent after markReady.
-        try await waitFor("unpause write") { recorder.writes.count >= 2 }
+        // NO separate unpause on success — batch 2's continue already ran.
+        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
         #expect(recorder.writes.count == 2)
-        #expect(recorder.writes.last == "refresh-client -A '%1:continue'")
 
         // The pipe holds the replay: prelude first, history present, final
         // bytes are the CUP for cursor (x=2, y=1) — and no mid-sequence leak.
@@ -244,7 +269,7 @@ struct AttachReplayOrchestratorTests {
         #expect((String(bytes: drain(readFD), encoding: .utf8) ?? "") == "live-after")
     }
 
-    @Test("superseded mid-sequence: outcome success-shaped, successor's gate untouched, NO unpause")
+    @Test("superseded mid-sequence (after batch 2): outcome success-shaped, successor's gate untouched, NO extra unpause")
     func supersededMidSequence() async throws {
         let (supervisor, orchestrator, recorder, client) = makeHarness()
         let paneID = "%2"
@@ -252,28 +277,57 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(read1) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause — this sequence still owns the pane
+        try await waitFor("capture batch write") { recorder.writes.count >= 2 }
 
-        // A newer attach replaces the sink before the replies arrive.
+        // A newer attach replaces the sink before the capture replies arrive:
+        // writeReplay/markReady will see the newer generation.
         let (read2, _) = try await supervisor.attach(server: server, paneID: paneID)
         defer { Darwin.close(read2) }
 
-        await succeed(client, [[], ["hist"], [], [], ["hist"],
-                               [stateLine(paneID: paneID)], []])
+        await succeed(client, [["hist"], [], [], ["hist"],
+                               [stateLine(paneID: paneID)], [], []])
         let outcome = try await task.value
         #expect(outcome == .superseded)
 
         // This task must NOT open the successor's gate — its own sequence does.
         #expect(await supervisor.isReady(server: server, paneID: paneID) == false)
 
-        // And it must NOT unpause either (M2 review fix): pause state is per
-        // PANE on the shared correlator, and the successor's own sequence —
-        // FIFO-behind ours — pauses and unpauses it. A stale `continue` here
-        // could land while the successor is mid-capture with its gate still
-        // closed, resuming live output into a closed gate. The sequence ended
-        // (task.value returned), so the write log is final: batch only.
+        // And it must send NOTHING after batch 2 (R11): batch 2's continue
+        // was already on the stream BEFORE the successor attached (FIFO keeps
+        // it clear of the successor's pause window), but a post-supersession
+        // EXTRA continue could land while the successor is mid-capture with
+        // its gate still closed. The sequence ended (task.value returned), so
+        // the write log is final: pause + captures+continue, nothing more.
+        #expect(recorder.writes.count == 2)
+    }
+
+    @Test("superseded between batch 1 and batch 2: captures+continue never sent (post-pause re-check)")
+    func supersededBetweenBatchesSendsNoCaptures() async throws {
+        let (supervisor, orchestrator, recorder, client) = makeHarness()
+        let paneID = "%20"
+        let (read1, _) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read1) }
+
+        let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+
+        // The successor attaches while batch 1's reply is still in flight.
+        let (read2, _) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read2) }
+
+        await succeed(client, [[]])  // pause reply → post-pause re-check fires
+        let outcome = try await task.value
+        #expect(outcome == .superseded)
+
+        // Nothing after the pause: no captures, no continue (R11 — the
+        // successor's own sequence owns the pane's pause state).
+        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
         #expect(recorder.writes.count == 1)
+        #expect(!recorder.writes.contains { $0.contains("capture-pane") })
         #expect(!recorder.writes.contains { $0.contains(":continue'") })
+        #expect(await supervisor.isReady(server: server, paneID: paneID) == false)
     }
 
     @Test("stale ready (echoed generation != current attach) sends ZERO commands, successor stays un-acked")
@@ -332,20 +386,23 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause OK (batch 1)
+        try await waitFor("capture batch write") { recorder.writes.count >= 2 }
 
-        // pause OK, scrollback capture returns %error (tolerated at the
-        // correlator level so the connection survives), rest succeed
-        // (screen, saved, combined, state, pending).
-        await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))
+        // Scrollback capture returns %error (tolerated at the correlator
+        // level so the connection survives), rest succeed (screen, saved,
+        // combined, state, pending) — as does the batched continue.
         await client.handle(.commandFailed(number: 0, fromClient: true, lines: ["no such pane"]))
-        await succeed(client, [[], [], [], [stateLine(paneID: paneID)], []])
+        await succeed(client, [[], [], [], [stateLine(paneID: paneID)], [], []])
 
         let underlying = await expectFailure(generation: generation) { try await task.value }
         #expect(underlying as? AttachReplayError == .captureFailed(
             command: "capture-pane -peqJN -S -50000 -E -1 -q -t %3"))
         #expect(await supervisor.isReady(server: server, paneID: paneID) == false)
-        try await waitFor("unpause write") { recorder.writes.count >= 2 }
+        // The failure path sends its own generation-checked continue (it
+        // covers "pause ran but batch 2's continue may not have").
+        try await waitFor("unpause write") { recorder.writes.count >= 3 }
         #expect(recorder.writes.last == "refresh-client -A '%3:continue'")
     }
 
@@ -357,24 +414,28 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause — gen 1 still owns the pane
+        try await waitFor("capture batch write") { recorder.writes.count >= 2 }
 
-        // While gen-1's batch is in flight, a fast re-attach replaces the
-        // sink (gen 2). Gen-1's batch then fails with a real capture %error.
+        // While gen-1's capture batch is in flight, a fast re-attach replaces
+        // the sink (gen 2). Gen-1's batch then fails with a real capture
+        // %error. (Batch 2's own continue was already on the stream BEFORE
+        // gen 2 attached — FIFO keeps it clear of gen 2's pause window.)
         let (successorFD, _) = try await supervisor.attach(server: server, paneID: paneID)
         defer { Darwin.close(successorFD) }
-        await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))   // pause
         await client.handle(.commandFailed(number: 0, fromClient: true, lines: ["gone"]))
-        await succeed(client, [[], [], [], [stateLine(paneID: paneID)], []])
+        await succeed(client, [[], [], [], [stateLine(paneID: paneID)], [], []])
 
         let underlying = await expectFailure(generation: generation) { try await task.value }
         #expect(underlying is AttachReplayError)
-        // The stale catch path must NOT unpause: its continue could land
-        // between the successor's pause and captures, tearing the successor's
-        // capture. The successor's own sequence owns the pane's pause state.
+        // The stale catch path must NOT send an EXTRA unpause: its continue
+        // could land between the successor's pause and captures, tearing the
+        // successor's capture. The successor's own sequence owns the pane's
+        // pause state. Write log stays: pause + captures+continue only.
         try await Task.sleep(for: .milliseconds(200))   // bounded negative check
-        #expect(!recorder.writes.contains { $0.hasSuffix(":continue'") },
-                "stale sequence unpaused a pane a successor now owns")
+        #expect(recorder.writes.count == 2,
+                "stale sequence sent an extra command after supersession")
     }
 
     @Test("a malformed pending-output escape fails the attach; unpause still sent")
@@ -385,16 +446,17 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
 
         // Pending line with `\` not followed by three octal digits.
-        await succeed(client, [[], ["hist"], [], [], ["hist"],
-                               [stateLine(paneID: paneID)], ["bad\\9x"]])
+        try await feedSequence(client, recorder: recorder,
+                               captures: [["hist"], [], [], ["hist"],
+                                          [stateLine(paneID: paneID)], ["bad\\9x"]])
 
         let underlying = await expectFailure(generation: generation) { try await task.value }
         #expect(underlying is ReplayWriterError)
         #expect(await supervisor.isReady(server: server, paneID: paneID) == false)
-        try await waitFor("unpause write") { recorder.writes.count >= 2 }
+        try await waitFor("unpause write") { recorder.writes.count >= 3 }
         #expect(recorder.writes.last == "refresh-client -A '%4:continue'")
     }
 
@@ -434,16 +496,19 @@ struct AttachReplayOrchestratorTests {
             defer { Darwin.close(readFD) }
 
             let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-            try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+            try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+            await succeed(client, [[]])  // pause
+            try await waitFor("capture batch write") { recorder.writes.count >= 2 }
             // The injected depth reaches the scrollback capture command too.
-            #expect(recorder.writes.first?.contains("capture-pane -peqJN -S -3 -E -1 -q -t %9") == true)
+            #expect(recorder.writes.last?.contains("capture-pane -peqJN -S -3 -E -1 -q -t %9") == true)
 
             let history = (0..<lineCount).map { "line-\($0)" }
-            // Telemetry keys on the PURE-scrollback leg (index 1), not the
-            // combined one — the combined leg always carries screen rows too.
-            await succeed(client, [[], history, ["screen"], [],
+            // Telemetry keys on the PURE-scrollback leg (the batch's first
+            // capture), not the combined one — the combined leg always
+            // carries screen rows too.
+            await succeed(client, [history, ["screen"], [],
                                    history + ["screen"],
-                                   [stateLine(paneID: paneID, historySize: lineCount)], []])
+                                   [stateLine(paneID: paneID, historySize: lineCount)], [], []])
             let outcome = try await task.value
             #expect(outcome == .ready)
             #expect(truncations.counts == (expectFire ? [lineCount] : []),
@@ -460,16 +525,17 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
         // QUIRK (live-probed, tmux 3.6a): on a pane with history_size == 0
         // the `-S -N -E -1` leg does NOT return empty — it clamps and returns
         // the first visible screen row. Feeding that duplicate here must NOT
         // reach the replay when the state says the scrollback is empty. The
         // COMBINED leg has no such quirk: with no history it is exactly the
         // screen, and the non-alt path uses it verbatim (R8-M3).
-        await succeed(client, [[], ["screen-row-one"], ["screen-row-one", "screen-row-two"], [],
-                               ["screen-row-one", "screen-row-two"],
-                               [stateLine(paneID: paneID, historySize: 0)], []])
+        try await feedSequence(client, recorder: recorder, captures: [
+            ["screen-row-one"], ["screen-row-one", "screen-row-two"], [],
+            ["screen-row-one", "screen-row-two"],
+            [stateLine(paneID: paneID, historySize: 0)], []])
 
         let outcome = try await task.value
         #expect(outcome == .ready)
@@ -488,15 +554,15 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
         let scrollback = ["h1", "h2"]
         let screen = ["s1", "s2"]
         // The combined leg is what one tmux invocation would return for this
         // pane: the scrollback rows followed by the screen rows — the exact
         // legacy single-capture content.
-        await succeed(client, [[], scrollback, screen, [],
-                               scrollback + screen,
-                               [stateLine(paneID: paneID, historySize: 2)], []])
+        try await feedSequence(client, recorder: recorder, captures: [
+            scrollback, screen, [], scrollback + screen,
+            [stateLine(paneID: paneID, historySize: 2)], []])
         let outcome = try await task.value
         #expect(outcome == .ready)
 
@@ -520,10 +586,12 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
-        // The batch carries a COMBINED history+screen capture (one tmux
-        // invocation, `-J` joins the seam) as its fourth capture leg.
-        let batch = try #require(recorder.writes.first)
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause
+        try await waitFor("capture batch write") { recorder.writes.count >= 2 }
+        // The capture batch carries a COMBINED history+screen capture (one
+        // tmux invocation, `-J` joins the seam) as its fourth capture leg.
+        let batch = try #require(recorder.writes.last)
         #expect(batch.contains("capture-pane -peqJN -S -50000 -t %17"))
 
         // A logical line soft-wraps across the scrollback/screen seam: the
@@ -531,13 +599,13 @@ struct AttachReplayOrchestratorTests {
         // them with \r\n would insert a spurious hard break. The combined
         // leg — joined by tmux itself — carries the whole line.
         await succeed(client, [
-            [],                              // pause
             ["above", "WRAP-HEAD"],          // pure scrollback (seam-cut)
             ["WRAP-TAIL", "below"],          // current screen (seam-cut)
             [],                              // saved primary (not alt)
             ["above", "WRAP-HEADWRAP-TAIL", "below"],  // combined, tmux-joined
             [stateLine(paneID: paneID, historySize: 2)],
             [],                              // pending
+            [],                              // batched continue
         ])
         let outcome = try await task.value
         #expect(outcome == .ready)
@@ -557,15 +625,16 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
         // While alternate_on: historyLeg reaches the PRIMARY scrollback,
         // screenLeg returns the ALT content, savedLeg the saved primary
         // viewport (the H1 regression: historyLeg used to be dropped). The
         // combined leg is fed a marker line to prove the ALT branch ignores
         // it — it only reaches non-alt replays (R8-M3).
-        await succeed(client, [[], ["OLD-SCROLLBACK"], ["ALT-NOW"], ["SAVED-VIEWPORT"],
-                               ["COMBINED-UNUSED"],
-                               [altStateLine(paneID: paneID)], []])
+        try await feedSequence(client, recorder: recorder, captures: [
+            ["OLD-SCROLLBACK"], ["ALT-NOW"], ["SAVED-VIEWPORT"],
+            ["COMBINED-UNUSED"],
+            [altStateLine(paneID: paneID)], []])
         let outcome = try await task.value
         #expect(outcome == .ready)
 
@@ -596,14 +665,16 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
 
-        // The PAUSE fails; every capture succeeds. The captures therefore ran
+        // The PAUSE fails; every capture succeeds. The captures therefore run
         // UNPAUSED — a possibly-torn replay that self-heals — so the sequence
-        // must proceed to a ready gate, and the failure must be surfaced.
+        // must proceed (fence, batch 2, ready gate), and the failure must be
+        // surfaced.
         await client.handle(.commandFailed(number: 0, fromClient: true, lines: ["bad refresh-client"]))
+        try await waitFor("capture batch write") { recorder.writes.count >= 2 }
         await succeed(client, [["hist"], ["screen"], [], ["hist", "screen"],
-                               [stateLine(paneID: paneID)], []])
+                               [stateLine(paneID: paneID)], [], []])
 
         let outcome = try await task.value
         #expect(outcome == .ready)
@@ -624,9 +695,10 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
-        await succeed(client, [[], ["hist"], ["screen"], [], ["hist", "screen"],
-                               [stateLine(paneID: paneID)], []])
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
+        try await feedSequence(client, recorder: recorder, captures: [
+            ["hist"], ["screen"], [], ["hist", "screen"],
+            [stateLine(paneID: paneID)], []])
         let outcome = try await task.value
         #expect(outcome == .ready)
         #expect(failures.writes.isEmpty)
@@ -662,39 +734,43 @@ struct AttachReplayOrchestratorTests {
         }
         try await waitFor("stale task parked at the provider hop") { gate.hasParkedCaller }
 
-        // A successor attaches and runs its ENTIRE pause → captures → replay
-        // → unpause sequence to completion while the stale task is parked.
+        // A successor attaches and runs its ENTIRE pause → fence → captures+
+        // continue → replay sequence to completion while the stale task is
+        // parked.
         let (read2, gen2) = try await supervisor.attach(server: server, paneID: paneID)
         defer { Darwin.close(read2) }
         let successorTask = Task {
             try await orchestrator.performAttachReady(
                 server: server, paneID: paneID, expectedGeneration: gen2)
         }
-        try await waitFor("successor batch write") { recorder.writes.count >= 1 }
-        await succeed(client, [[], ["hist"], ["screen"], [], ["hist", "screen"],
-                               [stateLine(paneID: paneID)], []])
+        try await waitFor("successor pause write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // successor's pause
+        try await waitFor("successor capture batch write") { recorder.writes.count >= 2 }
+        await succeed(client, [["hist"], ["screen"], [], ["hist", "screen"],
+                               [stateLine(paneID: paneID)], [], []])
         #expect(try await successorTask.value == .ready)
-        try await waitFor("successor unpause write") { recorder.writes.count >= 2 }
         #expect(await supervisor.isReady(server: server, paneID: paneID) == true)
 
         // Release the stale task. Its pause landing NOW would re-freeze the
         // live pane with nothing left to unpause it (the supersession rule
-        // skips ITS unpause, and the successor's already ran) — the post-hop
-        // re-check must return .superseded having sent NOTHING.
+        // skips ITS unpause, and the successor's batched continue already
+        // ran) — the post-hop re-check must return .superseded having sent
+        // NOTHING.
         gate.release()
         try await waitFor("stale sequence resolution") {
             staleDone.writes.count == 1 || recorder.writes.count > 2
         }
         if recorder.writes.count > 2 {
-            // Regression path only: the stale batch WAS sent — feed its
-            // replies so the test fails on the assertions below instead of
-            // hanging on `staleTask.value`.
-            await succeed(client, [[], [], [], [], [],
-                                   [stateLine(paneID: paneID)], []])
+            // Regression path only: the stale PAUSE was sent — feed its
+            // reply so the test fails on the assertions below instead of
+            // hanging on `staleTask.value` (the post-pause re-check then
+            // supersedes it before any capture batch).
+            await succeed(client, [[]])
         }
         #expect(try await staleTask.value == .superseded)
-        // Exactly the successor's writes: one batch + one unpause. The stale
-        // task contributed ZERO commands — in particular no second pause.
+        // Exactly the successor's writes: pause + captures+continue. The
+        // stale task contributed ZERO commands — in particular no second
+        // pause.
         #expect(recorder.writes.count == 2)
         #expect(recorder.writes.filter { $0.contains(":pause'") }.count == 1)
         #expect(await supervisor.isReady(server: server, paneID: paneID) == true)
@@ -709,14 +785,15 @@ struct AttachReplayOrchestratorTests {
         defer { Darwin.close(readFD) }
 
         let task = Task { try await orchestrator.performAttachReady(server: server, paneID: paneID) }
-        try await waitFor("capture batch write") { recorder.writes.count >= 1 }
+        try await waitFor("pause batch write") { recorder.writes.count >= 1 }
         // The state reply describes a DIFFERENT pane.
-        await succeed(client, [[], ["hist"], [], [], ["hist"],
-                               [stateLine(paneID: "%99")], []])
+        try await feedSequence(client, recorder: recorder,
+                               captures: [["hist"], [], [], ["hist"],
+                                          [stateLine(paneID: "%99")], []])
 
         let underlying = await expectFailure(generation: generation) { try await task.value }
         #expect(underlying as? AttachReplayError == .paneStateMissing)
-        try await waitFor("unpause write") { recorder.writes.count >= 2 }
+        try await waitFor("unpause write") { recorder.writes.count >= 3 }
         #expect(recorder.writes.last == "refresh-client -A '%10:continue'")
     }
 }

--- a/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
+++ b/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
@@ -241,6 +241,102 @@ struct PaneFanoutFlowControlTests {
         #expect(fanout.flowStats(key: key) == nil)
     }
 
+    @Test("fence: routed-while-fenced bytes stay parked (nothing on the pipe) until markReady flushes them")
+    func fenceQueueParkedUntilMarkReadyFlushes() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%7")
+        let (readFD, gen) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+
+        #expect(fanout.armFence(key: key, generation: gen),
+                "arming the fence at the live generation must succeed")
+
+        // Routed while fenced (gate still closed): queued whole, not dropped.
+        let fenced = Data("FENCED-ATTACH-WINDOW-BYTES".utf8)
+        fanout.route(server: server, event: .output(paneID: "%7", bytes: fenced))
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.queuedBytes == fenced.count)
+        #expect(stats.droppedBytes == 0)
+        #expect(stats.droppedEvents == 0)
+
+        // The drain must NOT be armed while fenced: the queue stays parked
+        // behind the closed gate so writeReplay's direct pipe write cannot
+        // be interleaved. Nothing may appear on the pipe yet.
+        usleep(100_000)
+        var probe = [UInt8](repeating: 0, count: 64)
+        let n = probe.withUnsafeMutableBytes { Darwin.read(readFD, $0.baseAddress, $0.count) }
+        #expect(n < 0 && errno == EAGAIN, "fenced bytes must stay parked until markReady")
+        #expect(try #require(fanout.flowStats(key: key)).queuedBytes == fenced.count)
+
+        // markReady clears the fence and arms the drain: the parked bytes
+        // flush.
+        #expect(fanout.markReady(key: key, generation: gen))
+        let received = readAll(fd: readFD, expected: fenced.count)
+        #expect(received == fenced, "markReady must flush the fence queue intact and in order")
+
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, (fanout.flowStats(key: key)?.queuedBytes ?? 0) > 0 {
+            usleep(5_000)
+        }
+        #expect(fanout.flowStats(key: key)?.queuedBytes == 0)
+    }
+
+    @Test("armFence is generation-checked: stale generation or missing sink → false, sink untouched")
+    func armFenceGenerationChecked() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%8")
+        let (read1, gen1) = try fanout.attach(key: key)
+        defer { Darwin.close(read1) }
+        setNonblocking(read1)
+
+        // Wrong generation → refused, and the sink stays UNFENCED: a routed
+        // chunk drops (not-ready bookkeeping) instead of queueing.
+        #expect(fanout.armFence(key: key, generation: gen1 + 1) == false)
+        fanout.route(server: server, event: .output(paneID: "%8", bytes: Data("early".utf8)))
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.droppedEvents == 1, "an unfenced not-ready chunk must still drop")
+        #expect(stats.queuedBytes == 0, "a refused armFence must not have fenced the sink")
+
+        // Missing sink → refused.
+        #expect(fanout.armFence(
+            key: PaneKey(server: server, paneID: "%none"), generation: 1) == false)
+
+        // A re-attach supersedes: the old generation is refused, the new one
+        // arms.
+        let (read2, gen2) = try fanout.attach(key: key)
+        defer { Darwin.close(read2) }
+        #expect(fanout.armFence(key: key, generation: gen1) == false)
+        #expect(fanout.armFence(key: key, generation: gen2))
+    }
+
+    @Test("fence overflow: chunks past the queue cap drop whole with overflow telemetry (M1 semantics; M3 heals the residual)")
+    func fenceOverflowDropsWholeChunks() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%9")
+        let (readFD, gen) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        #expect(fanout.armFence(key: key, generation: gen))
+
+        // While fenced NOTHING reaches the pipe, so 5 x 32 KB fills the
+        // 128 KB queue exactly; the fifth chunk must overflow-drop whole.
+        let total = patterned(count: 160 * 1024)
+        routeChunks(fanout, paneID: "%9", data: total)
+
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.queuedBytes == PaneFanout.queueCap, "queue must fill to its cap, never past it")
+        #expect(stats.overflowEvents == 1)
+        #expect(stats.droppedBytes == 32 * 1024, "the overflowing chunk drops WHOLE")
+
+        // markReady flushes the intact prefix; the overflow residual is the
+        // M3 repair cycle's to heal.
+        #expect(fanout.markReady(key: key, generation: gen))
+        let received = readAll(fd: readFD, expected: PaneFanout.queueCap)
+        #expect(received == total.prefix(PaneFanout.queueCap),
+                "delivered bytes must be an intact prefix — no mid-stream holes")
+    }
+
     @Test("not-ready drop bookkeeping is unchanged: counted, nothing queued")
     func notReadyDropUnchanged() throws {
         let fanout = PaneFanout()

--- a/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
+++ b/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
@@ -479,7 +479,7 @@ struct PaneFanoutFlowControlTests {
                 "delivered bytes must be an intact prefix — no mid-stream holes")
     }
 
-    @Test("not-ready drop bookkeeping is unchanged: counted, nothing queued")
+    @Test("not-ready drop bookkeeping: events AND bytes counted, nothing queued")
     func notReadyDropUnchanged() throws {
         let fanout = PaneFanout()
         let key = PaneKey(server: server, paneID: "%6")
@@ -493,11 +493,42 @@ struct PaneFanoutFlowControlTests {
 
         let stats = try #require(fanout.flowStats(key: key))
         #expect(stats.droppedEvents == 1)
+        #expect(stats.droppedBytes == 5, "the not-ready drop must count its bytes too")
         #expect(stats.queuedBytes == 0)
         #expect(stats.overflowEvents == 0)
 
         var buffer = [UInt8](repeating: 0, count: 32)
         let n = buffer.withUnsafeMutableBytes { Darwin.read(readFD, $0.baseAddress, $0.count) }
         #expect(n < 0 && errno == EAGAIN, "nothing may reach the pipe before ready")
+    }
+
+    @Test("route hard error (EPIPE): the unwritten remainder is counted dropped, mirroring the drain's accounting")
+    func routeHardErrorCountsDroppedRemainder() throws {
+        // Mirror the daemon's process-wide SIGPIPE stance (main.swift): a
+        // write into a pipe whose read end is closed must return EPIPE, not
+        // kill the test process.
+        signal(SIGPIPE, SIG_IGN)
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%14")
+        let (readFD, gen) = try fanout.attach(key: key)
+        setNonblocking(readFD)
+        #expect(fanout.markReady(key: key, generation: gen))
+        // The viewer dies: the read end closes while the sink stays attached.
+        Darwin.close(readFD)
+
+        let chunk = patterned(count: 1024)
+        fanout.route(server: server, event: .output(paneID: "%14", bytes: chunk))
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.droppedEvents == 1, "a hard write error must count a dropped event")
+        #expect(stats.droppedBytes == 1024, "the discarded unwritten remainder must be counted")
+        #expect(stats.queuedBytes == 0, "a hard error must not queue the remainder")
+
+        // Counters keep accumulating on further chunks (the log is
+        // rate-limited; the accounting never is).
+        fanout.route(server: server, event: .output(paneID: "%14", bytes: chunk))
+        let after = try #require(fanout.flowStats(key: key))
+        #expect(after.droppedEvents == 2)
+        #expect(after.droppedBytes == 2048)
+        fanout.detach(key: key)
     }
 }

--- a/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
+++ b/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
@@ -1,0 +1,265 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// Phase B M1 — `PaneFanout.route` backpressure: instead of dropping the
+/// unwritten remainder on EAGAIN (issue #376's corruption source), the
+/// remainder is queued per (key, generation) and an async drain task delivers
+/// it in order as the reader catches up. Pure pipe mechanics — no tmux, no
+/// ~/tbd.
+@Suite("PaneFanout flow control")
+struct PaneFanoutFlowControlTests {
+    private let server = "tbd-test-server"
+
+    /// Darwin pipes buffer at most 64 KB; chunks are routed in 32 KB slices.
+    private static let chunkSize = 32 * 1024
+
+    private func setNonblocking(_ fd: Int32) {
+        let flags = fcntl(fd, F_GETFL)
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+    }
+
+    /// Position-dependent bytes so a dropped, duplicated, or reordered chunk
+    /// cannot go unnoticed.
+    private func patterned(count: Int, seed: UInt8 = 0) -> Data {
+        var data = Data(capacity: count)
+        var counter = seed
+        for _ in 0..<count {
+            data.append(counter)
+            counter &+= 1
+        }
+        return data
+    }
+
+    private func routeChunks(_ fanout: PaneFanout, paneID: String, data: Data) {
+        var offset = 0
+        while offset < data.count {
+            let end = min(offset + Self.chunkSize, data.count)
+            fanout.route(
+                server: server,
+                event: .output(paneID: paneID, bytes: data.subdata(in: offset..<end)))
+            offset = end
+        }
+    }
+
+    /// Poll-read a nonblocking fd until `expected` bytes arrived or the
+    /// deadline passes. Never a fixed sleep alone — the drain is async.
+    private func readAll(fd: Int32, expected: Int, deadline: TimeInterval = 5) -> Data {
+        let start = Date()
+        var received = Data()
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while received.count < expected && Date().timeIntervalSince(start) < deadline {
+            let n = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            if n > 0 {
+                received.append(contentsOf: buffer[0..<n])
+            } else if n == 0 {
+                break  // EOF
+            } else {
+                usleep(5_000)
+            }
+        }
+        return received
+    }
+
+    /// Poll-read a nonblocking fd until the pane's queue is empty AND the
+    /// pipe stops yielding data (quiescence), or the deadline passes. For
+    /// tests where the delivered byte count is not known up front.
+    private func readUntilQuiescent(
+        _ fanout: PaneFanout, key: PaneKey, fd: Int32, deadline: TimeInterval = 5
+    ) -> Data {
+        let start = Date()
+        var received = Data()
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while Date().timeIntervalSince(start) < deadline {
+            let n = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            if n > 0 {
+                received.append(contentsOf: buffer[0..<n])
+                continue
+            }
+            if n == 0 { break }  // EOF
+            // Pipe momentarily empty: done only once the queue is drained too.
+            if let stats = fanout.flowStats(key: key), stats.queuedBytes == 0 {
+                // One more grace poll in case the drain just wrote.
+                usleep(20_000)
+                let m = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+                if m > 0 {
+                    received.append(contentsOf: buffer[0..<m])
+                    continue
+                }
+                break
+            }
+            usleep(5_000)
+        }
+        return received
+    }
+
+    @Test("EAGAIN remainder is queued, not dropped — full stream arrives intact and in order")
+    func eagainRemainderQueuedNotDropped() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%1")
+        let (readFD, gen) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        fanout.markReady(key: key, generation: gen)
+
+        // 160 KB into a ~64 KB pipe with no reader yet: the writes past the
+        // pipe buffer must hit EAGAIN and queue, never drop.
+        let total = patterned(count: 160 * 1024)
+        routeChunks(fanout, paneID: "%1", data: total)
+
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.droppedBytes == 0, "no byte may be dropped below the queue cap")
+        #expect(stats.droppedEvents == 0)
+        #expect(stats.overflowEvents == 0)
+        #expect(stats.queuedBytes > 0, "the pipe cannot hold 160 KB — the remainder must be queued")
+        #expect(stats.queuedHighWater >= stats.queuedBytes)
+
+        // Now read everything: the drain task must deliver the queued
+        // remainder, byte-for-byte in order.
+        let received = readAll(fd: readFD, expected: total.count)
+        #expect(received.count == total.count)
+        #expect(received == total, "stream must arrive intact and in order across backpressure")
+
+        // Queue must eventually report empty.
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline, (fanout.flowStats(key: key)?.queuedBytes ?? 0) > 0 {
+            usleep(5_000)
+        }
+        #expect(fanout.flowStats(key: key)?.queuedBytes == 0)
+    }
+
+    @Test("order preservation: a chunk routed while bytes are queued must not overtake them")
+    func orderPreservedAcrossBackpressure() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%2")
+        let (readFD, gen) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        fanout.markReady(key: key, generation: gen)
+
+        // Chunk A overfills the pipe (remainder queues); B is small and would
+        // fit in the pipe directly — it must still land AFTER A's queued tail.
+        let chunkA = patterned(count: 100 * 1024, seed: 7)
+        routeChunks(fanout, paneID: "%2", data: chunkA)
+        let statsAfterA = try #require(fanout.flowStats(key: key))
+        #expect(statsAfterA.queuedBytes > 0, "A's tail must be queued for B to have anything to overtake")
+        let chunkB = Data("TAIL-MARKER-B".utf8)
+        fanout.route(server: server, event: .output(paneID: "%2", bytes: chunkB))
+
+        let expected = chunkA + chunkB
+        let received = readAll(fd: readFD, expected: expected.count)
+        #expect(received == expected, "B must arrive strictly after every byte of A")
+        #expect(fanout.flowStats(key: key)?.droppedBytes == 0)
+    }
+
+    @Test("queue cap overflow drops whole incoming chunks; delivered stream is an intact prefix")
+    func capOverflowDropsWholeChunksPrefixIntact() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%3")
+        let (readFD, gen) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        fanout.markReady(key: key, generation: gen)
+
+        // 320 KB with no reader: ~64 KB lands in the pipe, 128 KB fills the
+        // queue to its cap, the rest must overflow-drop (whole chunks only).
+        let total = patterned(count: 320 * 1024)
+        routeChunks(fanout, paneID: "%3", data: total)
+
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.overflowEvents > 0, "routing past the cap must record overflow")
+        #expect(stats.droppedEvents >= stats.overflowEvents)
+        #expect(stats.droppedBytes > 0)
+        #expect(stats.queuedBytes <= PaneFanout.queueCap, "queue must never exceed its cap")
+
+        let received = readUntilQuiescent(fanout, key: key, fd: readFD)
+        #expect(!received.isEmpty)
+        #expect(received.count < total.count, "overflow means not everything was delivered")
+        #expect(received == total.prefix(received.count),
+                "delivered bytes must be an intact prefix of the routed stream — no mid-stream holes")
+    }
+
+    @Test("generation scoping: a superseded sink's queued bytes die with it")
+    func supersededQueueDiesWithSink() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%4")
+
+        // Build a backpressured queue on generation 1.
+        let (read1, gen1) = try fanout.attach(key: key)
+        defer { Darwin.close(read1) }
+        setNonblocking(read1)
+        fanout.markReady(key: key, generation: gen1)
+        routeChunks(fanout, paneID: "%4", data: patterned(count: 160 * 1024, seed: 1))
+        #expect((fanout.flowStats(key: key)?.queuedBytes ?? 0) > 0)
+
+        // Re-attach replaces the sink; the old queue must NEVER flush into
+        // the successor's pipe.
+        let (read2, gen2) = try fanout.attach(key: key)
+        defer { Darwin.close(read2) }
+        setNonblocking(read2)
+        fanout.markReady(key: key, generation: gen2)
+
+        // Fresh sink starts with clean counters and an empty queue.
+        let freshStats = try #require(fanout.flowStats(key: key))
+        #expect(freshStats.queuedBytes == 0)
+        #expect(freshStats.droppedBytes == 0)
+
+        let newBytes = Data("ONLY-THE-NEW-GENERATION".utf8)
+        fanout.route(server: server, event: .output(paneID: "%4", bytes: newBytes))
+        let received = readAll(fd: read2, expected: newBytes.count)
+        #expect(received == newBytes, "successor pipe must carry ONLY the new generation's bytes")
+
+        // Give the old drain task time to observe the mismatch: whatever it
+        // does, nothing further may appear on the successor pipe.
+        usleep(100_000)
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        let n = buffer.withUnsafeMutableBytes { Darwin.read(read2, $0.baseAddress, $0.count) }
+        #expect(n < 0 && errno == EAGAIN, "no stale queued bytes may leak into the successor")
+    }
+
+    @Test("detach mid-drain does not crash; flowStats returns nil after detach")
+    func detachMidDrainIsSafe() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%5")
+        let (readFD, gen) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        fanout.markReady(key: key, generation: gen)
+
+        // Backpressure the queue so a drain task is live, then detach.
+        routeChunks(fanout, paneID: "%5", data: patterned(count: 160 * 1024))
+        #expect((fanout.flowStats(key: key)?.queuedBytes ?? 0) > 0)
+        fanout.detach(key: key)
+
+        #expect(fanout.flowStats(key: key) == nil)
+        // Drain the pipe to EOF — the write end is closed; the drain task
+        // must exit quietly without writing into a recycled fd.
+        _ = readUntilQuiescent(fanout, key: key, fd: readFD, deadline: 2)
+        usleep(100_000)
+        #expect(fanout.flowStats(key: key) == nil)
+    }
+
+    @Test("not-ready drop bookkeeping is unchanged: counted, nothing queued")
+    func notReadyDropUnchanged() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%6")
+        let (readFD, _) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+
+        // Routed before markReady: dropped (the M2 attach fence owns this
+        // window), never queued.
+        fanout.route(server: server, event: .output(paneID: "%6", bytes: Data("early".utf8)))
+
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.droppedEvents == 1)
+        #expect(stats.queuedBytes == 0)
+        #expect(stats.overflowEvents == 0)
+
+        var buffer = [UInt8](repeating: 0, count: 32)
+        let n = buffer.withUnsafeMutableBytes { Darwin.read(readFD, $0.baseAddress, $0.count) }
+        #expect(n < 0 && errno == EAGAIN, "nothing may reach the pipe before ready")
+    }
+}

--- a/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
+++ b/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
@@ -154,31 +154,158 @@ struct PaneFanoutFlowControlTests {
         #expect(fanout.flowStats(key: key)?.droppedBytes == 0)
     }
 
-    @Test("queue cap overflow drops whole incoming chunks; delivered stream is an intact prefix")
-    func capOverflowDropsWholeChunksPrefixIntact() throws {
+    /// Thread-safe recorder of overflow-repair signals.
+    private final class SignalRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _signals: [(PaneKey, UInt64)] = []
+        func record(_ key: PaneKey, _ generation: UInt64) {
+            lock.lock(); _signals.append((key, generation)); lock.unlock()
+        }
+        var signals: [(PaneKey, UInt64)] { lock.lock(); defer { lock.unlock() }; return _signals }
+    }
+
+    @Test("steady-state queue overflow enters repair: queue cleared, nothing counted dropped, signal fired exactly once")
+    func steadyStateOverflowEntersRepair() throws {
         let fanout = PaneFanout()
+        let signals = SignalRecorder()
+        fanout.onOverflowRepair = { key, generation in signals.record(key, generation) }
         let key = PaneKey(server: server, paneID: "%3")
         let (readFD, gen) = try fanout.attach(key: key)
         defer { Darwin.close(readFD) }
         setNonblocking(readFD)
         fanout.markReady(key: key, generation: gen)
 
-        // 320 KB with no reader: ~64 KB lands in the pipe, 128 KB fills the
-        // queue to its cap, the rest must overflow-drop (whole chunks only).
-        let total = patterned(count: 320 * 1024)
-        routeChunks(fanout, paneID: "%3", data: total)
+        // Route 32 KB chunks into the unread pipe until the cap overflows
+        // (~64 KB pipe + 128 KB queue → the 7th chunk): the M3 hook must NOT
+        // drop — it clears the queue (everything queued is already in pane
+        // history; the repair's capture supersedes it), flips `repairing`,
+        // and signals the repair coordinator exactly once.
+        let chunk = patterned(count: Self.chunkSize)
+        var entered = false
+        for _ in 0..<32 {
+            fanout.route(server: server, event: .output(paneID: "%3", bytes: chunk))
+            if fanout.flowStats(key: key)?.repairing == true {
+                entered = true
+                break
+            }
+        }
+        #expect(entered, "overflow on a ready, unfenced sink must enter repairing")
 
         let stats = try #require(fanout.flowStats(key: key))
-        #expect(stats.overflowEvents > 0, "routing past the cap must record overflow")
-        #expect(stats.droppedEvents >= stats.overflowEvents)
-        #expect(stats.droppedBytes > 0)
-        #expect(stats.queuedBytes <= PaneFanout.queueCap, "queue must never exceed its cap")
+        #expect(stats.queuedBytes == 0, "the queue must be CLEARED at repair entry — the capture supersedes it")
+        #expect(stats.droppedBytes == 0, "nothing counts as dropped at repair entry")
+        #expect(stats.droppedEvents == 0)
+        #expect(signals.signals.count == 1, "exactly one overflow-repair signal")
+        #expect(signals.signals.first?.0 == key)
+        #expect(signals.signals.first?.1 == gen)
 
-        let received = readUntilQuiescent(fanout, key: key, fd: readFD)
-        #expect(!received.isEmpty)
-        #expect(received.count < total.count, "overflow means not everything was delivered")
-        #expect(received == total.prefix(received.count),
-                "delivered bytes must be an intact prefix of the routed stream — no mid-stream holes")
+        // While repairing (pre-pause window of the repair cycle): routed
+        // bytes are dropped WITH counters — they are in the pane's history,
+        // the repair's capture will include them — and never re-signal.
+        let probe = Data("WHILE-REPAIRING".utf8)
+        fanout.route(server: server, event: .output(paneID: "%3", bytes: probe))
+        let after = try #require(fanout.flowStats(key: key))
+        #expect(after.droppedEvents == 1)
+        #expect(after.droppedBytes == probe.count)
+        #expect(after.queuedBytes == 0, "repairing bytes must not queue — the drain is not fence-parked here")
+        #expect(signals.signals.count == 1, "a repairing sink must not re-signal")
+    }
+
+    @Test("repair fence lifecycle: beginRepairFence requires repairing, endRepair flushes and counts, abortRepair unfreezes")
+    func repairFenceLifecycle() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%10")
+        let (readFD, gen) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        fanout.markReady(key: key, generation: gen)
+
+        // Not repairing → beginRepairFence refused (arming it on a healthy
+        // stream would freeze it).
+        #expect(fanout.beginRepairFence(key: key, generation: gen) == false,
+                "beginRepairFence must require a repairing sink")
+
+        // Drive the sink into repairing via a steady-state overflow.
+        let chunk = patterned(count: Self.chunkSize)
+        for _ in 0..<32 where fanout.flowStats(key: key)?.repairing != true {
+            fanout.route(server: server, event: .output(paneID: "%10", bytes: chunk))
+        }
+        try #require(fanout.flowStats(key: key)?.repairing == true)
+
+        // Generation-checked: wrong generation refused, right one arms.
+        #expect(fanout.beginRepairFence(key: key, generation: gen + 1) == false)
+        #expect(fanout.endRepair(key: key, generation: gen + 1) == false)
+        #expect(fanout.beginRepairFence(key: key, generation: gen))
+
+        // Fenced-while-repairing: routed bytes queue (post-continue bytes of
+        // the repair), nothing reaches the pipe until endRepair.
+        drainPipe(readFD)
+        let fenced = Data("REPAIR-FENCED".utf8)
+        fanout.route(server: server, event: .output(paneID: "%10", bytes: fenced))
+        #expect(try #require(fanout.flowStats(key: key)).queuedBytes == fenced.count)
+        usleep(100_000)
+        var probe = [UInt8](repeating: 0, count: 64)
+        let n = probe.withUnsafeMutableBytes { Darwin.read(readFD, $0.baseAddress, $0.count) }
+        #expect(n < 0 && errno == EAGAIN, "repair-fenced bytes must stay parked until endRepair")
+
+        // endRepair: clears fence + repairing, counts the repair, flushes.
+        #expect(fanout.endRepair(key: key, generation: gen))
+        let received = readAll(fd: readFD, expected: fenced.count)
+        #expect(received == fenced, "endRepair must flush the fenced bytes intact")
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.repairing == false)
+        #expect(stats.repairs == 1)
+
+        // Second cycle → abortRepair: clears repairing (failure path), the
+        // stream resumes (direct writes work again), no repair counted.
+        for _ in 0..<32 where fanout.flowStats(key: key)?.repairing != true {
+            fanout.route(server: server, event: .output(paneID: "%10", bytes: chunk))
+        }
+        try #require(fanout.flowStats(key: key)?.repairing == true)
+        fanout.abortRepair(key: key, generation: gen + 1)  // wrong gen: no-op
+        #expect(fanout.flowStats(key: key)?.repairing == true)
+        fanout.abortRepair(key: key, generation: gen)
+        let aborted = try #require(fanout.flowStats(key: key))
+        #expect(aborted.repairing == false)
+        #expect(aborted.repairs == 1, "an aborted repair must not count as completed")
+        drainPipe(readFD)
+        fanout.route(server: server, event: .output(paneID: "%10", bytes: Data("POST-ABORT".utf8)))
+        let resumed = readAll(fd: readFD, expected: "POST-ABORT".utf8.count)
+        #expect(String(decoding: resumed, as: UTF8.self) == "POST-ABORT")
+    }
+
+    @Test("isPipeWritable: false while full, true after the reader drains, nil on stale generation or missing sink")
+    func pipeWritableProbe() throws {
+        let fanout = PaneFanout()
+        let key = PaneKey(server: server, paneID: "%11")
+        let (readFD, gen) = try fanout.attach(key: key)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        fanout.markReady(key: key, generation: gen)
+
+        #expect(fanout.isPipeWritable(key: key, generation: gen) == true,
+                "a fresh pipe must be writable")
+        // Fill the pipe (direct writes land until EAGAIN queues the rest).
+        routeChunks(fanout, paneID: "%11", data: patterned(count: 160 * 1024))
+        #expect(fanout.isPipeWritable(key: key, generation: gen) == false,
+                "a full pipe must probe unwritable")
+        // The reader catches up.
+        _ = readAll(fd: readFD, expected: 160 * 1024)
+        #expect(fanout.isPipeWritable(key: key, generation: gen) == true)
+
+        // Stale generation / missing sink → nil (repair must abort silently).
+        #expect(fanout.isPipeWritable(key: key, generation: gen + 1) == nil)
+        #expect(fanout.isPipeWritable(
+            key: PaneKey(server: server, paneID: "%none"), generation: 1) == nil)
+    }
+
+    /// Read `fd` until EAGAIN.
+    private func drainPipe(_ fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let n = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            if n <= 0 { break }
+        }
     }
 
     @Test("generation scoping: a superseded sink's queued bytes die with it")
@@ -310,9 +437,11 @@ struct PaneFanoutFlowControlTests {
         #expect(fanout.armFence(key: key, generation: gen2))
     }
 
-    @Test("fence overflow: chunks past the queue cap drop whole with overflow telemetry (M1 semantics; M3 heals the residual)")
+    @Test("fence overflow: chunks past the queue cap drop whole with overflow telemetry — and do NOT signal repair (M1 semantics)")
     func fenceOverflowDropsWholeChunks() throws {
         let fanout = PaneFanout()
+        let signals = SignalRecorder()
+        fanout.onOverflowRepair = { key, generation in signals.record(key, generation) }
         let key = PaneKey(server: server, paneID: "%9")
         let (readFD, gen) = try fanout.attach(key: key)
         defer { Darwin.close(readFD) }
@@ -328,6 +457,11 @@ struct PaneFanoutFlowControlTests {
         #expect(stats.queuedBytes == PaneFanout.queueCap, "queue must fill to its cap, never past it")
         #expect(stats.overflowEvents == 1)
         #expect(stats.droppedBytes == 32 * 1024, "the overflowing chunk drops WHOLE")
+        // A fenced overflow must NOT enter the repair cycle: a repair-during-
+        // fence would race the in-flight attach/repair sequence on the same
+        // pane's pause state. Bounded residual, M1 drop preserved.
+        #expect(signals.signals.isEmpty, "fenced overflow must not signal repair")
+        #expect(stats.repairing == false)
 
         // markReady flushes the intact prefix; the overflow residual is the
         // M3 repair cycle's to heal.

--- a/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
+++ b/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
@@ -274,29 +274,37 @@ struct PaneFanoutFlowControlTests {
         #expect(String(decoding: resumed, as: UTF8.self) == "POST-ABORT")
     }
 
-    @Test("isPipeWritable: false while full, true after the reader drains, nil on stale generation or missing sink")
+    @Test("isPipeWritable: .full while full, .writable after the reader drains, .broken when the read end closes, nil on stale generation or missing sink")
     func pipeWritableProbe() throws {
         let fanout = PaneFanout()
         let key = PaneKey(server: server, paneID: "%11")
         let (readFD, gen) = try fanout.attach(key: key)
-        defer { Darwin.close(readFD) }
+        var readClosed = false
+        defer { if !readClosed { Darwin.close(readFD) } }
         setNonblocking(readFD)
         fanout.markReady(key: key, generation: gen)
 
-        #expect(fanout.isPipeWritable(key: key, generation: gen) == true,
+        #expect(fanout.isPipeWritable(key: key, generation: gen) == .writable,
                 "a fresh pipe must be writable")
         // Fill the pipe (direct writes land until EAGAIN queues the rest).
         routeChunks(fanout, paneID: "%11", data: patterned(count: 160 * 1024))
-        #expect(fanout.isPipeWritable(key: key, generation: gen) == false,
-                "a full pipe must probe unwritable")
+        #expect(fanout.isPipeWritable(key: key, generation: gen) == .full,
+                "a full pipe must probe full — healthy, keep waiting")
         // The reader catches up.
         _ = readAll(fd: readFD, expected: 160 * 1024)
-        #expect(fanout.isPipeWritable(key: key, generation: gen) == true)
+        #expect(fanout.isPipeWritable(key: key, generation: gen) == .writable)
 
         // Stale generation / missing sink → nil (repair must abort silently).
         #expect(fanout.isPipeWritable(key: key, generation: gen + 1) == nil)
         #expect(fanout.isPipeWritable(
             key: PaneKey(server: server, paneID: "%none"), generation: 1) == nil)
+
+        // The reader dies: read end closed → .broken (the pipe can never
+        // drain; the repair must unpause + abort instead of waiting forever).
+        Darwin.close(readFD)
+        readClosed = true
+        #expect(fanout.isPipeWritable(key: key, generation: gen) == .broken,
+                "a read-end-closed pipe must probe broken")
     }
 
     /// Read `fd` until EAGAIN.

--- a/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
+++ b/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
@@ -4,6 +4,11 @@ import Testing
 
 @testable import TBDDaemonLib
 
+/// Positive-wait deadline sized for starved CI runners (PR #379: cooperative-pool
+/// starvation stretched sub-second async-drain deliveries past a 5 s poll).
+/// Passing runs still complete in milliseconds — only failures wait this long.
+private let ciSafeDeadline: TimeInterval = 30
+
 /// Phase B M1 — `PaneFanout.route` backpressure: instead of dropping the
 /// unwritten remainder on EAGAIN (issue #376's corruption source), the
 /// remainder is queued per (key, generation) and an async drain task delivers
@@ -46,7 +51,7 @@ struct PaneFanoutFlowControlTests {
 
     /// Poll-read a nonblocking fd until `expected` bytes arrived or the
     /// deadline passes. Never a fixed sleep alone — the drain is async.
-    private func readAll(fd: Int32, expected: Int, deadline: TimeInterval = 5) -> Data {
+    private func readAll(fd: Int32, expected: Int, deadline: TimeInterval = ciSafeDeadline) -> Data {
         let start = Date()
         var received = Data()
         var buffer = [UInt8](repeating: 0, count: 64 * 1024)
@@ -67,7 +72,7 @@ struct PaneFanoutFlowControlTests {
     /// pipe stops yielding data (quiescence), or the deadline passes. For
     /// tests where the delivered byte count is not known up front.
     private func readUntilQuiescent(
-        _ fanout: PaneFanout, key: PaneKey, fd: Int32, deadline: TimeInterval = 5
+        _ fanout: PaneFanout, key: PaneKey, fd: Int32, deadline: TimeInterval = ciSafeDeadline
     ) -> Data {
         let start = Date()
         var received = Data()
@@ -123,7 +128,7 @@ struct PaneFanoutFlowControlTests {
         #expect(received == total, "stream must arrive intact and in order across backpressure")
 
         // Queue must eventually report empty.
-        let deadline = Date().addingTimeInterval(5)
+        let deadline = Date().addingTimeInterval(ciSafeDeadline)
         while Date() < deadline, (fanout.flowStats(key: key)?.queuedBytes ?? 0) > 0 {
             usleep(5_000)
         }
@@ -371,7 +376,7 @@ struct PaneFanoutFlowControlTests {
         #expect(fanout.flowStats(key: key) == nil)
         // Drain the pipe to EOF — the write end is closed; the drain task
         // must exit quietly without writing into a recycled fd.
-        _ = readUntilQuiescent(fanout, key: key, fd: readFD, deadline: 2)
+        _ = readUntilQuiescent(fanout, key: key, fd: readFD)
         usleep(100_000)
         #expect(fanout.flowStats(key: key) == nil)
     }
@@ -410,7 +415,7 @@ struct PaneFanoutFlowControlTests {
         let received = readAll(fd: readFD, expected: fenced.count)
         #expect(received == fenced, "markReady must flush the fence queue intact and in order")
 
-        let deadline = Date().addingTimeInterval(5)
+        let deadline = Date().addingTimeInterval(ciSafeDeadline)
         while Date() < deadline, (fanout.flowStats(key: key)?.queuedBytes ?? 0) > 0 {
             usleep(5_000)
         }

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -418,4 +418,337 @@ struct PaneRepairCoordinatorTests {
             await coordinator.isInFlight(key) == false
         }
     }
+
+    // MARK: - No command client (review round 2, S2)
+
+    @Test("no command client: repair aborts — repairing cleared, stream resumes, nothing sent")
+    func noCommandClientAbortsRepair() async throws {
+        // Bespoke harness: the provider finds no correlator (connection torn
+        // down). There is nothing to pause and nothing paused — the repair
+        // must abort so the sink unfreezes.
+        let supervisor = TmuxControlSupervisor()
+        let coordinator = PaneRepairCoordinator(
+            supervisor: supervisor,
+            commandProvider: { _ in nil },
+            writableCheckInterval: .milliseconds(10),
+            writableSlowInterval: .milliseconds(25),
+            writableEscalationThreshold: .milliseconds(50))
+        supervisor.fanout.onOverflowRepair = { key, generation in
+            Task { await coordinator.repairIfNeeded(key: key, generation: generation) }
+        }
+        let paneID = "%8"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        supervisor.fanout.markReady(key: key, generation: generation)
+
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("repair aborted") {
+            supervisor.fanout.flowStats(key: key)?.repairing == false
+        }
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.repairs == 0, "a client-less abort must not count as a completed repair")
+        try await waitFor("repair exit (in-flight cleared)") {
+            await coordinator.isInFlight(key) == false
+        }
+
+        // Not frozen: live output streams again once the reader drains.
+        drainPipe(readFD)
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("LIVE-NO-CLIENT".utf8)))
+        let live = await readUntil(fd: readFD) { $0.hasSuffix("LIVE-NO-CLIENT") }
+        #expect(live.hasSuffix("LIVE-NO-CLIENT"), "the stream must resume after a client-less abort")
+    }
+
+    // MARK: - Supersession before/at repair start (review round 2, S2)
+
+    @Test("superseded before the repair starts: nothing sent — not even the pause — successor untouched")
+    func supersededBeforeRepairStartSendsNothing() async throws {
+        let (supervisor, coordinator, recorder, _, _) = makeHarness()
+        let paneID = "%9"
+        let key = PaneKey(server: server, paneID: paneID)
+        // Capture-only wiring: the test dispatches the stale signal BY HAND
+        // after superseding the generation, pinning the window between the
+        // overflow signal and the repair start.
+        supervisor.fanout.onOverflowRepair = { _, _ in }
+
+        let (read1, gen1) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read1) }
+        setNonblocking(read1)
+        supervisor.fanout.markReady(key: key, generation: gen1)
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+
+        // A successor replaces the sink before the (stale) signal's repair
+        // ever runs.
+        let (read2, gen2) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read2) }
+
+        await coordinator.repairIfNeeded(key: key, generation: gen1)
+        #expect(recorder.writes.isEmpty, "a stale repair must send NOTHING — not even the pause")
+        #expect(await coordinator.isInFlight(key) == false)
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.repairing == false, "the successor's sink must not inherit the repair state")
+        #expect(stats.queuedBytes == 0, "the stale repair must not have fenced the successor's sink")
+        #expect(await supervisor.acknowledgeAttach(
+            server: server, paneID: paneID, expectedGeneration: gen2)
+            == .acknowledged(generation: gen2),
+            "successor must still be acknowledgeable — the stale repair touched nothing")
+    }
+
+    /// Thread-safe fd box for the provider-hop test below.
+    private final class FDBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _fd: Int32 = -1
+        func set(_ fd: Int32) { lock.lock(); _fd = fd; lock.unlock() }
+        var fd: Int32 { lock.lock(); defer { lock.unlock() }; return _fd }
+    }
+
+    @Test("superseded across the provider hop: the post-hop checkpoint refuses — nothing sent")
+    func supersededAcrossProviderHopSendsNothing() async throws {
+        // Bespoke harness: the provider ITSELF re-attaches the pane before
+        // returning the client, superseding the repair generation exactly
+        // inside the provider hop — the entry guard has already passed, so
+        // this pins the post-hop ownership re-check (R10-3).
+        let recorder = Recorder()
+        let client = TmuxControlCommandClient(
+            writeLine: { recorder.record($0) },
+            onFatalError: {})
+        let supervisor = TmuxControlSupervisor()
+        let paneID = "%10"
+        let key = PaneKey(server: server, paneID: paneID)
+        let successorRead = FDBox()
+        let coordinator = PaneRepairCoordinator(
+            supervisor: supervisor,
+            commandProvider: { [server] requested in
+                guard requested == server else { return nil }
+                if let (fd, _) = try? await supervisor.attach(server: server, paneID: paneID) {
+                    successorRead.set(fd)
+                }
+                return client
+            },
+            writableCheckInterval: .milliseconds(10),
+            writableSlowInterval: .milliseconds(25),
+            writableEscalationThreshold: .milliseconds(50))
+        supervisor.fanout.onOverflowRepair = { _, _ in }
+        defer { if successorRead.fd >= 0 { Darwin.close(successorRead.fd) } }
+
+        let (read1, gen1) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read1) }
+        setNonblocking(read1)
+        supervisor.fanout.markReady(key: key, generation: gen1)
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+
+        await coordinator.repairIfNeeded(key: key, generation: gen1)
+        #expect(recorder.writes.isEmpty,
+                "a repair superseded across the provider hop must send NOTHING — not even the pause")
+        #expect(await coordinator.isInFlight(key) == false)
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.repairing == false, "the successor's sink must not inherit the repair state")
+        #expect(stats.queuedBytes == 0)
+    }
+
+    // MARK: - Supersession mid reader-wait (review round 2, S2)
+
+    @Test("superseded mid reader-wait: sink replaced while the pipe is full → silent exit, no continue, successor untouched")
+    func supersededMidReaderWaitExitsSilently() async throws {
+        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        let paneID = "%11"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (read1, gen1) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read1) }
+        setNonblocking(read1)
+        supervisor.fanout.markReady(key: key, generation: gen1)
+        _ = gen1
+
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("pause write") { recorder.writes.count >= 1 }
+        // The pause reply lands while gen-1 still owns the pane: the repair
+        // enters the reader-wait (the pipe is full — read1 is never drained).
+        await succeed(client, [[]])
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(recorder.writes.count == 1, "still waiting while the pipe is merely full")
+        #expect(await coordinator.isInFlight(key) == true, "the repair must be parked in the reader-wait")
+
+        // A successor replaces the sink mid-wait: isPipeWritable(gen-1) now
+        // returns nil and the repair must exit silently — NO continue (R11:
+        // the successor owns the pane's pause state) and no abortRepair on
+        // the successor.
+        let (read2, gen2) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read2) }
+        try await waitFor("repair exit") {
+            await coordinator.isInFlight(key) == false
+        }
+        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
+        #expect(recorder.writes.count == 1, "a mid-wait supersession must send NOTHING after the pause")
+        #expect(!recorder.writes.contains { $0.contains("capture-pane") })
+        #expect(!recorder.writes.contains { $0.contains(":continue'") })
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.repairing == false, "the successor's sink must not inherit the repair state")
+        #expect(stats.queuedBytes == 0, "the stale repair must not have fenced the successor's sink")
+        #expect(await supervisor.acknowledgeAttach(
+            server: server, paneID: paneID, expectedGeneration: gen2)
+            == .acknowledged(generation: gen2),
+            "successor must still be acknowledgeable — the stale repair touched nothing")
+    }
+
+    // MARK: - Bridge wiring (review round 2, S2)
+
+    @Test("bridge wiring: a route() overflow on a bridge-owned fanout drives the default coordinator end-to-end")
+    func bridgeWiredCoordinatorRunsRepair() async throws {
+        // A REAL TmuxControlModeBridge with its DEFAULT repair coordinator:
+        // only the command provider is faked. This drives the production
+        // `onOverflowRepair` closure installed in the bridge's init.
+        let recorder = Recorder()
+        let client = TmuxControlCommandClient(
+            writeLine: { recorder.record($0) },
+            onFatalError: {})
+        let supervisor = TmuxControlSupervisor()
+        let bridge = TmuxControlModeBridge(
+            supervisor: supervisor,
+            tmuxVersion: TmuxVersion(major: 3, minor: 6),
+            environment: [:],
+            fdVending: FDVendingServer(),
+            commandProvider: { [server] in $0 == server ? client : nil })
+        let paneID = "%12"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (readFD, generation) = try await bridge.supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        bridge.supervisor.fanout.markReady(key: key, generation: generation)
+
+        // Blast past the cap through route(): the bridge-wired signal must
+        // start the repair — the fake client sees the pause.
+        overflowIntoRepair(bridge.supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("bridge-wired pause write") { recorder.writes.count >= 1 }
+        #expect(recorder.writes.first == "refresh-client -A '%12:pause'",
+                "the bridge's default coordinator must run the repair")
+
+        // Complete the cycle so the repair task doesn't outlive the test.
+        await succeed(client, [[]])
+        drainPipe(readFD)
+        try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+        await succeed(client, captureAndContinueReplies(paneID: paneID))
+        try await waitFor("repair completion") {
+            let stats = bridge.supervisor.fanout.flowStats(key: key)
+            return stats?.repairing == false && stats?.repairs == 1
+        }
+    }
+
+    // MARK: - Swallowed successor overflow (review round 2, S1)
+
+    @Test("swallowed successor overflow: gen-2's signal deduped while gen-1 is parked → exit re-dispatch heals gen-2")
+    func swallowedSuccessorOverflowIsReDispatched() async throws {
+        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        let paneID = "%6"
+        let key = PaneKey(server: server, paneID: paneID)
+
+        // Custom wiring — the bridge's shape plus a completion counter: a
+        // SWALLOWED repairIfNeeded returns immediately (dedupe guard), so
+        // `returns` lets the test prove gen-2's signal really was deduped
+        // while gen-1's repair still held the in-flight slot.
+        let returns = SignalCounter()
+        supervisor.fanout.onOverflowRepair = { key, generation in
+            Task {
+                await coordinator.repairIfNeeded(key: key, generation: generation)
+                returns.increment()
+            }
+        }
+
+        // Gen-1 attaches, goes ready, overflows: its repair parks awaiting
+        // the pause reply (held by the test — stands in for ANY long await,
+        // e.g. the indefinite reader-wait).
+        let (read1, gen1) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read1) }
+        setNonblocking(read1)
+        supervisor.fanout.markReady(key: key, generation: gen1)
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("gen-1 pause write") { recorder.writes.count >= 1 }
+        try #require(recorder.writes.first == "refresh-client -A '%6:pause'")
+        _ = gen1
+
+        // The user re-attaches (gen-2 sink), the new sink goes ready and
+        // ALSO overflows: its onOverflowRepair signal lands while gen-1's
+        // repair is still in flight for the same key — deduped (swallowed).
+        let (read2, gen2) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read2) }
+        setNonblocking(read2)
+        supervisor.fanout.markReady(key: key, generation: gen2)
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("gen-2 signal swallowed") {
+            if returns.count != 1 { return false }
+            return await coordinator.isInFlight(key)
+        }
+        #expect(supervisor.fanout.flowStats(key: key)?.repairing == true)
+
+        // Release gen-1: its pause reply lands and the post-pause generation
+        // check supersedes it. WITHOUT the exit re-dispatch, gen-2's sink
+        // would stay `repairing` forever — route() drops all its output and
+        // enqueueLocked never re-signals: a permanently blank pane.
+        await succeed(client, [[]])
+
+        // The coordinator must re-dispatch for the CURRENT generation:
+        // gen-2's repair runs to completion.
+        try await waitFor("gen-2 pause write (re-dispatch)") { recorder.writes.count >= 2 }
+        try #require(recorder.writes.count >= 2, "the swallowed gen-2 repair was never re-dispatched")
+        #expect(recorder.writes[1] == "refresh-client -A '%6:pause'")
+        await succeed(client, [[]])  // gen-2 pause reply
+        drainPipe(read2)             // the reader catches up
+        try await waitFor("gen-2 captures+continue write") { recorder.writes.count >= 3 }
+        try #require(recorder.writes.count >= 3, "gen-2's captures+continue were never sent")
+        #expect(recorder.writes[2].hasSuffix("refresh-client -A '%6:continue'"))
+        await succeed(client, captureAndContinueReplies(paneID: paneID))
+
+        try await waitFor("gen-2 repair completion") {
+            let stats = supervisor.fanout.flowStats(key: key)
+            return stats?.repairing == false && stats?.repairs == 1
+        }
+        // The healed gen-2 sink got the replay and streams again.
+        let replay = await readUntil(fd: read2) { $0.hasSuffix("\u{1b}[2;3H") }
+        #expect(replay.hasPrefix(ReplayWriter.resetPrelude),
+                "gen-2's repair must have written the recapture replay")
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("LIVE-GEN2".utf8)))
+        let live = await readUntil(fd: read2) { $0.hasSuffix("LIVE-GEN2") }
+        #expect(live.hasSuffix("LIVE-GEN2"), "streaming must resume on the healed successor")
+        try await waitFor("gen-1 dispatch returns") { returns.count == 2 }
+    }
+
+    // MARK: - %error'd batched continue (review round 2, M3)
+
+    @Test("%error'd batched continue: the repair completes AND retries one tolerate-errors continue")
+    func erroredBatchedContinueRetriesAfterEndRepair() async throws {
+        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        _ = coordinator
+        let paneID = "%7"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        supervisor.fanout.markReady(key: key, generation: generation)
+
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("pause write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause reply
+        drainPipe(readFD)            // reader catches up
+        try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+
+        // All six captures succeed; the batched continue %errors (tolerated
+        // at the correlator level — NOT a connection close, which would fail
+        // the captures too and abort the repair on its own).
+        await succeed(client, [["hist-one"], ["hist-two"], [], ["hist-one", "hist-two"],
+                               [stateLine(paneID: paneID)], []])
+        await client.handle(.commandFailed(number: 0, fromClient: true, lines: ["unknown flag"]))
+
+        // The repair still completes (replay lands, fence flushes)…
+        try await waitFor("repair completion") {
+            let stats = supervisor.fanout.flowStats(key: key)
+            return stats?.repairing == false && stats?.repairs == 1
+        }
+        // …and a retry continue goes out: without it the pane LOOKS healthy
+        // (repair counted, stream resumed) but stays PAUSED server-side.
+        try await waitFor("retry continue write") { recorder.writes.count >= 3 }
+        #expect(recorder.writes.last == "refresh-client -A '%7:continue'",
+                "an %error'd batched continue must be retried once, tolerate-errors")
+    }
 }

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -1,0 +1,354 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// Phase B M3 — the overflow repair cycle (issue #376, the queue-overflow
+/// residual M1/M2 left behind). When a ready, unfenced pane's backpressure
+/// queue overflows, the fanout clears the queue, marks the sink `repairing`,
+/// and signals the `PaneRepairCoordinator`, which pauses the pane server-side
+/// (a paused pane delivers NOTHING — live-probed, tmux 3.6a), waits for the
+/// app reader to catch up (pipe writability), then recaptures + continues in
+/// ONE atomic list (seam gap exactly zero — live-probed) and replays behind
+/// the repair fence. Zero-loss heal of the overflow hole.
+///
+/// Same seam as `AttachReplayFenceTests`: a real `TmuxControlCommandClient`
+/// with recorded stream writes, reply blocks fed by hand, and a real
+/// supervisor + fanout so the gate/generation/fence/repair semantics under
+/// test are the production ones.
+@Suite("PaneRepairCoordinator")
+struct PaneRepairCoordinatorTests {
+    private let server = "tbd-repair-unit"
+
+    /// Thread-safe, synchronous recorder of stream writes in call order.
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _writes: [String] = []
+        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
+        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
+    }
+
+    /// Thread-safe overflow-signal counter.
+    private final class SignalCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _count = 0
+        func increment() { lock.lock(); _count += 1; lock.unlock() }
+        var count: Int { lock.lock(); defer { lock.unlock() }; return _count }
+    }
+
+    private func makeHarness(
+        writableCheckInterval: Duration = .milliseconds(10),
+        writableDeadline: Duration = .seconds(15)
+    ) -> (TmuxControlSupervisor, PaneRepairCoordinator, Recorder, TmuxControlCommandClient, SignalCounter) {
+        let recorder = Recorder()
+        let client = TmuxControlCommandClient(
+            writeLine: { recorder.record($0) },
+            onFatalError: {})
+        let supervisor = TmuxControlSupervisor()
+        let coordinator = PaneRepairCoordinator(
+            supervisor: supervisor,
+            commandProvider: { [server] in $0 == server ? client : nil },
+            writableCheckInterval: writableCheckInterval,
+            writableDeadline: writableDeadline)
+        // Wire the signal exactly as the bridge does, plus a call counter.
+        let signals = SignalCounter()
+        supervisor.fanout.onOverflowRepair = { key, generation in
+            signals.increment()
+            Task { await coordinator.repairIfNeeded(key: key, generation: generation) }
+        }
+        return (supervisor, coordinator, recorder, client, signals)
+    }
+
+    /// A 22-field primary-screen state line for `paneID` at 80x24 with the
+    /// cursor at (x=2, y=1) — the replay's final CUP must be `ESC[2;3H`.
+    private func stateLine(paneID: String) -> String {
+        "\(paneID) 2 1 0 4294967295 4294967295 0 23 1 0 0 0 1 0 0 0 0 0 0 80 24 1"
+    }
+
+    /// The happy-path capture replies (scrollback, screen, saved, combined,
+    /// state, pending) + the batched continue's reply.
+    private func captureAndContinueReplies(paneID: String) -> [[String]] {
+        [["hist-one"], ["hist-two"], [], ["hist-one", "hist-two"],
+         [stateLine(paneID: paneID)], [], []]
+    }
+
+    private func setNonblocking(_ fd: Int32) {
+        let flags = fcntl(fd, F_GETFL)
+        _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+    }
+
+    /// Route 32 KB chunks into an unread pipe until the sink flips into
+    /// `repairing` (64 KB pipe + 128 KB queue → the 7th chunk overflows).
+    private func overflowIntoRepair(
+        _ fanout: PaneFanout, paneID: String, key: PaneKey,
+        sourceLocation: SourceLocation = #_sourceLocation
+    ) {
+        let chunk = Data(repeating: 0x41, count: 32 * 1024)
+        for _ in 0..<32 {
+            fanout.route(server: server, event: .output(paneID: paneID, bytes: chunk))
+            if fanout.flowStats(key: key)?.repairing == true { return }
+        }
+        Issue.record("sink never entered repairing", sourceLocation: sourceLocation)
+    }
+
+    /// Read `fd` until EAGAIN — the "app reader caught up" simulation.
+    private func drainPipe(_ fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let n = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            if n <= 0 { break }
+        }
+    }
+
+    /// Poll until `condition`, failing after `deadline`.
+    private func waitFor(
+        _ what: String, deadline: Duration = .seconds(15),
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let end = ContinuousClock.now + deadline
+        while ContinuousClock.now < end {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
+    }
+
+    /// Complete the next `lines.count` pending commands with `%end`.
+    private func succeed(_ client: TmuxControlCommandClient, _ lines: [[String]]) async {
+        for reply in lines {
+            await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: reply))
+        }
+    }
+
+    /// Poll-read `fd` (nonblocking) until `condition` holds on the
+    /// accumulated text or the deadline passes.
+    private func readUntil(
+        fd: Int32, deadline: Duration = .seconds(15),
+        _ condition: @Sendable (String) -> Bool
+    ) async -> String {
+        var out = Data()
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        let end = ContinuousClock.now + deadline
+        while ContinuousClock.now < end {
+            let n = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+            if n > 0 {
+                out.append(contentsOf: buffer[0..<n])
+                if condition(String(decoding: out, as: UTF8.self)) { break }
+                continue
+            }
+            if n == 0 { break }  // EOF
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return String(decoding: out, as: UTF8.self)
+    }
+
+    // MARK: - The headline: full repair happy path
+
+    @Test("full repair: pause alone → wait for reader → captures+continue atomically → replay → fence flush → streaming resumes")
+    func fullRepairHappyPath() async throws {
+        let (supervisor, coordinator, recorder, client, signals) = makeHarness()
+        _ = coordinator
+        let paneID = "%1"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        supervisor.fanout.markReady(key: key, generation: generation)
+
+        // Steady-state overflow on the unread pipe: enters repairing and
+        // fires the signal, which starts the repair.
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        #expect(signals.count == 1)
+
+        // Batch 1 must be the pause ALONE.
+        try await waitFor("pause write") { recorder.writes.count >= 1 }
+        try #require(recorder.writes.first == "refresh-client -A '%1:pause'",
+                     "M3: batch 1 must be the pause ALONE")
+        await succeed(client, [[]])  // pause reply — the pane is now silent
+
+        // The reader has NOT caught up (pipe still full): batch 2 must wait.
+        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
+        #expect(recorder.writes.count == 1,
+                "captures+continue must not be sent while the reader is behind")
+
+        // The app catches up — the pipe becomes writable.
+        drainPipe(readFD)
+        try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+        #expect(recorder.writes[1] == """
+            capture-pane -peqJN -S -50000 -E -1 -q -t %1
+            capture-pane -peqJN -t %1
+            capture-pane -peqJN -a -q -t %1
+            capture-pane -peqJN -S -50000 -t %1
+            list-panes -t %1 -F '\(PaneStateCapture.format)'
+            capture-pane -p -P -C -t %1
+            refresh-client -A '%1:continue'
+            """,
+            "batch 2 must be ONE atomic list: 6 captures with the continue LAST")
+
+        // Post-continue output routed while the repair fence is armed: it
+        // must queue behind the replay-in-flight, not drop.
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("FENCED-X".utf8)))
+
+        // Captures + continue complete: replay assembles, lands, endRepair
+        // flushes the fence.
+        await succeed(client, captureAndContinueReplies(paneID: paneID))
+
+        // Pipe order, byte-exact: replay (ends with the CUP for cursor
+        // x=2,y=1), then the fenced bytes — the overflow hole is healed.
+        let text = await readUntil(fd: readFD) { $0.hasSuffix("FENCED-X") }
+        #expect(text.hasPrefix(ReplayWriter.resetPrelude),
+                "repair replay must start with the reset prelude")
+        #expect(text.hasSuffix("\u{1b}[2;3HFENCED-X"),
+                "expected replay ⊕ fenced, contiguous; tail \(text.suffix(40).debugDescription)")
+
+        // Sink back to steady streaming: repairing cleared, repair counted,
+        // direct writes resume.
+        try await waitFor("repair completion") {
+            let stats = supervisor.fanout.flowStats(key: key)
+            return stats?.repairing == false && stats?.queuedBytes == 0
+        }
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.repairs == 1)
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("LIVE-Y".utf8)))
+        let live = await readUntil(fd: readFD) { $0.hasSuffix("LIVE-Y") }
+        #expect(live == "LIVE-Y", "direct writes must resume after the repair")
+        #expect(signals.count == 1, "the whole cycle must ride ONE overflow signal")
+    }
+
+    // MARK: - Supersession
+
+    @Test("superseded between batch 1 and batch 2: nothing more sent, no unpause, successor untouched")
+    func supersededMidRepairAbortsSilently() async throws {
+        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        _ = coordinator
+        let paneID = "%2"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (read1, gen1) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read1) }
+        setNonblocking(read1)
+        supervisor.fanout.markReady(key: key, generation: gen1)
+
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("pause write") { recorder.writes.count >= 1 }
+        try #require(recorder.writes.first == "refresh-client -A '%2:pause'")
+
+        // A successor attaches while batch 1's reply is in flight: the repair
+        // is superseded and must send NOTHING more — in particular NO unpause
+        // (R11: the successor's own attach sequence owns the pane's pause
+        // state; a stale continue could land inside its pause window).
+        let (read2, gen2) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(read2) }
+        await succeed(client, [[]])  // pause reply → post-pause re-check fires
+
+        try await waitFor("repair exit") {
+            await coordinator.isInFlight(key) == false
+        }
+        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
+        #expect(recorder.writes.count == 1, "a superseded repair must send NOTHING after the pause")
+        #expect(!recorder.writes.contains { $0.contains("capture-pane") })
+        #expect(!recorder.writes.contains { $0.contains(":continue'") })
+
+        // Successor untouched: gate closed, nothing queued (a routed chunk
+        // drops via the not-ready path, it is not fenced), still ackable.
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("STALE-PROBE".utf8)))
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.queuedBytes == 0, "the stale repair must not have fenced the successor's sink")
+        #expect(stats.repairing == false, "the successor's sink must not inherit the repair state")
+        #expect(await supervisor.acknowledgeAttach(
+            server: server, paneID: paneID, expectedGeneration: gen2)
+            == .acknowledged(generation: gen2),
+            "successor must still be acknowledgeable — the stale repair touched nothing")
+    }
+
+    // MARK: - Capture failure
+
+    @Test("capture %error: unpause sent, repair aborted, pane not frozen")
+    func captureFailureUnpausesAndAborts() async throws {
+        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        _ = coordinator
+        let paneID = "%3"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        supervisor.fanout.markReady(key: key, generation: generation)
+
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("pause write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause reply
+        drainPipe(readFD)            // reader catches up
+        try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+
+        // Scrollback capture %errors (tolerated at the correlator level);
+        // the remaining captures and the batched continue succeed.
+        await client.handle(.commandFailed(number: 0, fromClient: true, lines: ["no such pane"]))
+        await succeed(client, [[], [], [], [stateLine(paneID: paneID)], [], []])
+
+        // The failure path must still unpause (covers "the pause ran but
+        // batch 2's continue may not have") and abort the repair — a pane
+        // frozen forever is worse than a hole.
+        try await waitFor("trailing unpause write") { recorder.writes.count >= 3 }
+        #expect(recorder.writes.last == "refresh-client -A '%3:continue'")
+        try await waitFor("repair aborted") {
+            supervisor.fanout.flowStats(key: key)?.repairing == false
+        }
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.repairs == 0, "a failed repair must not count as completed")
+
+        // Not frozen: live output streams again.
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("LIVE-AFTER-ABORT".utf8)))
+        let live = await readUntil(fd: readFD) { $0.hasSuffix("LIVE-AFTER-ABORT") }
+        #expect(live.hasSuffix("LIVE-AFTER-ABORT"), "the pane must stream again after an aborted repair")
+    }
+
+    // MARK: - Wedged reader
+
+    @Test("wedged reader: deadline exceeded → NO continue, pane stays paused+repairing, no re-signal while repairing")
+    func wedgedReaderLeavesPanePaused() async throws {
+        // Tiny injected deadline: the pipe is never drained.
+        let (supervisor, coordinator, recorder, client, signals) = makeHarness(
+            writableCheckInterval: .milliseconds(10),
+            writableDeadline: .milliseconds(150))
+        let paneID = "%4"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        supervisor.fanout.markReady(key: key, generation: generation)
+
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("pause write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause reply — reader never catches up
+
+        // The repair must exit past its deadline WITHOUT sending a continue:
+        // a continue would just re-overflow. The pane stays paused (tmux
+        // buffers it server-side in pane history) and the sink stays
+        // `repairing`; a later attach re-runs the full capture sequence.
+        try await waitFor("repair exit (in-flight cleared)") {
+            await coordinator.isInFlight(key) == false
+        }
+        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
+        #expect(recorder.writes.count == 1, "no captures and NO continue on a wedged reader")
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.repairing == true, "the sink must stay repairing — the pane is still paused")
+        #expect(stats.repairs == 0)
+
+        // Further overflow-scale routing while repairing: dropped with
+        // counters, and NO second overflow signal (the repairing flag gates
+        // re-signaling).
+        #expect(signals.count == 1)
+        let chunk = Data(repeating: 0x42, count: 32 * 1024)
+        for _ in 0..<8 {
+            supervisor.fanout.route(server: server, event: .output(paneID: paneID, bytes: chunk))
+        }
+        #expect(signals.count == 1, "a repairing sink must not re-signal")
+        let after = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(after.droppedEvents >= 8, "routed bytes while repairing are counted drops")
+    }
+}

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -4,6 +4,11 @@ import Testing
 
 @testable import TBDDaemonLib
 
+/// Positive-wait deadline sized for starved CI runners (PR #379: cooperative-pool
+/// starvation stretched sub-second async-drain deliveries past a 5 s poll).
+/// Passing runs still complete in milliseconds — only failures wait this long.
+private let ciSafeDeadline: Duration = .seconds(30)
+
 /// Phase B M3 — the overflow repair cycle (issue #376, the queue-overflow
 /// residual M1/M2 left behind). When a ready, unfenced pane's backpressure
 /// queue overflows, the fanout clears the queue, marks the sink `repairing`,
@@ -105,7 +110,7 @@ struct PaneRepairCoordinatorTests {
 
     /// Poll until `condition`, failing after `deadline`.
     private func waitFor(
-        _ what: String, deadline: Duration = .seconds(15),
+        _ what: String, deadline: Duration = ciSafeDeadline,
         sourceLocation: SourceLocation = #_sourceLocation,
         _ condition: @Sendable () async -> Bool
     ) async throws {
@@ -127,7 +132,7 @@ struct PaneRepairCoordinatorTests {
     /// Poll-read `fd` (nonblocking) until `condition` holds on the
     /// accumulated text or the deadline passes.
     private func readUntil(
-        fd: Int32, deadline: Duration = .seconds(15),
+        fd: Int32, deadline: Duration = ciSafeDeadline,
         _ condition: @Sendable (String) -> Bool
     ) async -> String {
         var out = Data()

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -39,7 +39,8 @@ struct PaneRepairCoordinatorTests {
 
     private func makeHarness(
         writableCheckInterval: Duration = .milliseconds(10),
-        writableDeadline: Duration = .seconds(15)
+        writableSlowInterval: Duration = .milliseconds(25),
+        writableEscalationThreshold: Duration = .milliseconds(50)
     ) -> (TmuxControlSupervisor, PaneRepairCoordinator, Recorder, TmuxControlCommandClient, SignalCounter) {
         let recorder = Recorder()
         let client = TmuxControlCommandClient(
@@ -50,7 +51,8 @@ struct PaneRepairCoordinatorTests {
             supervisor: supervisor,
             commandProvider: { [server] in $0 == server ? client : nil },
             writableCheckInterval: writableCheckInterval,
-            writableDeadline: writableDeadline)
+            writableSlowInterval: writableSlowInterval,
+            writableEscalationThreshold: writableEscalationThreshold)
         // Wire the signal exactly as the bridge does, plus a call counter.
         let signals = SignalCounter()
         supervisor.fanout.onOverflowRepair = { key, generation in
@@ -309,12 +311,11 @@ struct PaneRepairCoordinatorTests {
 
     // MARK: - Wedged reader
 
-    @Test("wedged reader: deadline exceeded → NO continue, pane stays paused+repairing, no re-signal while repairing")
-    func wedgedReaderLeavesPanePaused() async throws {
-        // Tiny injected deadline: the pipe is never drained.
-        let (supervisor, coordinator, recorder, client, signals) = makeHarness(
-            writableCheckInterval: .milliseconds(10),
-            writableDeadline: .milliseconds(150))
+    @Test("wedged reader: NO deadline — no continue, pane stays paused+repairing, and the SAME repair completes when the reader drains")
+    func wedgedReaderWaitsOutTheStallThenHeals() async throws {
+        // Tiny injected intervals: escalation to slow polling happens within
+        // ~50 ms, so the wedged window below spans many slow intervals.
+        let (supervisor, coordinator, recorder, client, signals) = makeHarness()
         let paneID = "%4"
         let key = PaneKey(server: server, paneID: paneID)
         let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
@@ -324,17 +325,17 @@ struct PaneRepairCoordinatorTests {
 
         overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
         try await waitFor("pause write") { recorder.writes.count >= 1 }
-        await succeed(client, [[]])  // pause reply — reader never catches up
+        await succeed(client, [[]])  // pause reply — reader stays wedged
 
-        // The repair must exit past its deadline WITHOUT sending a continue:
-        // a continue would just re-overflow. The pane stays paused (tmux
-        // buffers it server-side in pane history) and the sink stays
-        // `repairing`; a later attach re-runs the full capture sequence.
-        try await waitFor("repair exit (in-flight cleared)") {
-            await coordinator.isInFlight(key) == false
-        }
-        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
-        #expect(recorder.writes.count == 1, "no captures and NO continue on a wedged reader")
+        // A TRANSIENTLY wedged reader (e.g. a long app main-thread hitch)
+        // must not kill the repair: with the pipe still full well past the
+        // escalation threshold (many slow poll intervals), the repair must
+        // NOT abort and must NOT send a continue — a continue would just
+        // re-overflow. It stays in flight; the pane stays paused (tmux
+        // buffers it server-side) and the sink stays `repairing`.
+        try await Task.sleep(for: .milliseconds(400))
+        #expect(recorder.writes.count == 1, "no captures and NO continue while the reader is wedged")
+        #expect(await coordinator.isInFlight(key) == true, "the repair must keep waiting, not give up")
         let stats = try #require(supervisor.fanout.flowStats(key: key))
         #expect(stats.repairing == true, "the sink must stay repairing — the pane is still paused")
         #expect(stats.repairs == 0)
@@ -350,5 +351,71 @@ struct PaneRepairCoordinatorTests {
         #expect(signals.count == 1, "a repairing sink must not re-signal")
         let after = try #require(supervisor.fanout.flowStats(key: key))
         #expect(after.droppedEvents >= 8, "routed bytes while repairing are counted drops")
+
+        // The reader unwedges (drains the pipe): the SAME in-flight repair
+        // proceeds — batch 2 (captures + continue), replay behind the fence,
+        // endRepair, streaming resumed. No new attach needed.
+        drainPipe(readFD)
+        try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+        #expect(recorder.writes[1].hasSuffix("refresh-client -A '%4:continue'"),
+                "the same repair must send batch 2 once the reader drains")
+        await succeed(client, captureAndContinueReplies(paneID: paneID))
+
+        try await waitFor("repair completion") {
+            let stats = supervisor.fanout.flowStats(key: key)
+            return stats?.repairing == false && stats?.repairs == 1
+        }
+        let replay = await readUntil(fd: readFD) { $0.hasSuffix("\u{1b}[2;3H") }
+        #expect(replay.hasPrefix(ReplayWriter.resetPrelude),
+                "the recovered repair must have written the recapture replay")
+        supervisor.fanout.route(
+            server: server, event: .output(paneID: paneID, bytes: Data("LIVE-AFTER-WEDGE".utf8)))
+        let live = await readUntil(fd: readFD) { $0.hasSuffix("LIVE-AFTER-WEDGE") }
+        #expect(live.hasSuffix("LIVE-AFTER-WEDGE"), "streaming must resume after the recovered repair")
+    }
+
+    // MARK: - Broken pipe
+
+    @Test("broken pipe mid-wait: read end closed → continue sent, abortRepair, repairing cleared")
+    func brokenPipeMidWaitUnpausesAndAborts() async throws {
+        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        _ = coordinator
+        let paneID = "%5"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        var readClosed = false
+        defer { if !readClosed { Darwin.close(readFD) } }
+        setNonblocking(readFD)
+        supervisor.fanout.markReady(key: key, generation: generation)
+
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("pause write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause reply — the reader wait begins
+
+        // A merely-full pipe keeps the repair waiting…
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(recorder.writes.count == 1, "still waiting while the pipe is merely full")
+
+        // …then the viewer dies: the READ end closes mid-wait. The pipe can
+        // never drain — instead of waiting forever, the repair must unpause
+        // (tolerate-errors continue) and abort: the app-death detach path
+        // finishes the job, and an unpaused pane stays healthy for the next
+        // attach.
+        Darwin.close(readFD)
+        readClosed = true
+
+        try await waitFor("trailing continue write") { recorder.writes.count >= 2 }
+        #expect(recorder.writes.last == "refresh-client -A '%5:continue'",
+                "a broken pipe must unpause the pane")
+        #expect(!recorder.writes.contains { $0.contains("capture-pane") },
+                "a broken-pipe abort must not run the captures")
+        try await waitFor("repair aborted") {
+            supervisor.fanout.flowStats(key: key)?.repairing == false
+        }
+        let stats = try #require(supervisor.fanout.flowStats(key: key))
+        #expect(stats.repairs == 0, "a broken-pipe abort must not count as a completed repair")
+        try await waitFor("repair exit (in-flight cleared)") {
+            await coordinator.isInFlight(key) == false
+        }
     }
 }

--- a/Tests/TBDDaemonTests/ReplayLiveIntegrationMatrixTests.swift
+++ b/Tests/TBDDaemonTests/ReplayLiveIntegrationMatrixTests.swift
@@ -544,6 +544,107 @@ struct ReplayLiveIntegrationMatrixTests {
 
         await supervisor.stopAll()
     }
+
+    // MARK: - Scenario 5: firehose overflow → pause+recapture repair (Phase B M3)
+
+    /// Thread-safe done-flag for cross-task drain coordination.
+    private final class FlagBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+        func set() { lock.lock(); value = true; lock.unlock() }
+        func get() -> Bool { lock.lock(); defer { lock.unlock() }; return value }
+    }
+
+    @Test("firehose overflow heals via the repair cycle: SEQ gapless and monotonic after the last reset prelude")
+    func firehoseOverflowRepairHeals() async throws {
+        guard await controlModeTmuxAvailable() else { return }
+        let server = "tbd-repair-\(UUID().uuidString.prefix(8))"
+        defer { tmux(["-L", server, "kill-server"]) }
+
+        // FULL-BLAST monotonic counter — no throttle: during the deliberate
+        // 2 s reader stall below the pane out-emits the unread pipe by far,
+        // overflowing the ~64 KB pipe + 128 KB queue, which must enter the
+        // M3 repair cycle (pause → wait for the reader → recapture + atomic
+        // continue → replay → fence flush) instead of dropping.
+        let script = "i=0; while :; do printf 'SEQ %07d\\n' $i; i=$((i+1)); done"
+        let paneID = try bootstrap(
+            server: server, script: script,
+            extraServerArgs: ["set-option", "-g", "history-limit", "50000", ";"])
+        try await poll("counter emitting") {
+            // Full blast: the counter races past any fixed value before the
+            // first capture — any SEQ token proves the firehose is live.
+            tmuxCapture(["-L", server, "capture-pane", "-p", "-t", paneID])?
+                .contains("SEQ ") == true
+        }
+
+        let supervisor = TmuxControlSupervisor()
+        await supervisor.ensureConnection(serverName: server)
+        _ = try await awaitClient(supervisor, server: server)
+
+        let (readFD, _) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+        makeNonblocking(readFD)
+        let provider: @Sendable (String) async -> TmuxControlCommandClient? =
+            { [supervisor] in await supervisor.command(server: $0) }
+        let orchestrator = AttachReplayOrchestrator(supervisor: supervisor, commandProvider: provider)
+        // A REAL repair coordinator wired through onOverflowRepair exactly as
+        // the bridge wires it at daemon startup.
+        let coordinator = PaneRepairCoordinator(supervisor: supervisor, commandProvider: provider)
+        supervisor.fanout.onOverflowRepair = { key, generation in
+            Task { await coordinator.repairIfNeeded(key: key, generation: generation) }
+        }
+
+        // Phase 1: read concurrently while the attach runs (its replay write
+        // needs the reader), until the attach outcome lands.
+        let attachDone = FlagBox()
+        async let phase1 = drain(fd: readFD, deadline: .seconds(30)) { _ in attachDone.get() }
+        let outcome = try await orchestrator.performAttachReady(server: server, paneID: paneID)
+        #expect(outcome == .ready)
+        attachDone.set()
+        var accumulated = await phase1
+
+        // Phase 2: deliberately do NOT read for ~2 s — the overflow window.
+        // The repair fires, pauses the pane, and parks in its reader-catch-up
+        // wait until phase 3 starts reading.
+        try await Task.sleep(for: .seconds(2))
+
+        // Phase 3: read continuously until at least one repair completed and
+        // the healed stream carries enough post-repair tokens to judge.
+        let key = PaneKey(server: server, paneID: paneID)
+        let fanout = supervisor.fanout
+        let phase1Prefix = accumulated
+        accumulated += await drain(fd: readFD, deadline: .seconds(45)) { [self] data in
+            guard (fanout.flowStats(key: key)?.repairs ?? 0) >= 1 else { return false }
+            let text = String(decoding: phase1Prefix + data, as: UTF8.self)
+            guard let last = text.range(of: ReplayWriter.resetPrelude, options: .backwards)
+            else { return false }
+            let healed = strippingEscapes(String(text[last.upperBound...]))
+            return tokens(in: healed, label: "SEQ").count >= 30
+        }
+        let text = String(decoding: accumulated, as: UTF8.self)
+
+        // (a) At least one repair completed — both in the counters and as a
+        // second reset prelude in the byte stream (attach replay + repair
+        // replay each begin with one).
+        let stats = try #require(fanout.flowStats(key: key), "sink vanished mid-test")
+        #expect(stats.repairs >= 1, "the overflow never triggered a completed repair")
+        let preludeCount = text.components(separatedBy: ReplayWriter.resetPrelude).count - 1
+        #expect(preludeCount >= 2,
+                "expected the repair's reset prelude in the stream (found \(preludeCount))")
+
+        // (b) The heal proof: after the LAST reset prelude — the final repair
+        // replay — SEQ tokens are gapless and monotonic through the end of
+        // the accumulated stream: recapture tail ⊕ fence flush ⊕ live, with
+        // no hole where the overflow used to drop.
+        let last = try #require(text.range(of: ReplayWriter.resetPrelude, options: .backwards))
+        let healed = tokens(in: strippingEscapes(String(text[last.upperBound...])), label: "SEQ")
+        #expect(healed.count >= 30, "healed stream too short to prove anything (\(healed.count) tokens)")
+        let violations = sequenceViolations(healed).joined(separator: "; ")
+        #expect(violations.isEmpty,
+                "LOSS/DUP after the repair replay — the overflow hole was not healed: \(violations)")
+
+        await supervisor.stopAll()
+    }
 }
 
 private enum MatrixError: Error {

--- a/Tests/TBDDaemonTests/ReplayLiveIntegrationMatrixTests.swift
+++ b/Tests/TBDDaemonTests/ReplayLiveIntegrationMatrixTests.swift
@@ -17,11 +17,11 @@ import Testing
 ///     snapshot shows a coherent frame and live output continues from a
 ///     counter >= the replayed one (replay/live boundary coherence).
 ///  4. Pending-output race: a monotonic SEQ counter emitting across the
-///     attach; history capture + pending + live must yield every token AT
-///     MOST ONCE, in order, with any loss confined to the replay/live seam —
-///     the pause-serialization claim, adjusted for the measured tmux-3.6a
-///     residual that pause → continue discards paused-window output (see the
-///     scenario's FINDING comment).
+///     attach; history capture + fence flush + live must yield every token
+///     EXACTLY ONCE, in order, with a seam gap of ZERO — the Phase B M2
+///     fence (pause → arm fence → atomic captures+continue → replay →
+///     markReady flush) closes the boundary gap the M4-era matrix had to
+///     accept (see the scenario's comment for the probe facts).
 ///
 /// Boundary detection: the replay's final cursor escape is always a
 /// PARAMETERIZED CUP (`ESC[<row>;<col>H`, digits — `ReplayWriter.cup`), while
@@ -462,7 +462,7 @@ struct ReplayLiveIntegrationMatrixTests {
 
     // MARK: - Scenario 4: pending-output race — no loss, no duplication
 
-    @Test("sequenced tokens: no dup/disorder anywhere; loss only at the replay/live seam")
+    @Test("sequenced tokens: no dup/disorder/loss anywhere — the replay/live seam is exactly zero")
     func pendingOutputRace() async throws {
         guard await controlModeTmuxAvailable() else { return }
         let server = "tbd-replay-\(UUID().uuidString.prefix(8))"
@@ -508,20 +508,22 @@ struct ReplayLiveIntegrationMatrixTests {
                                     "replay never produced its final digit-CUP")
         let boundaryBytes = context(text, around: boundary)
 
-        // MEASURED FINDING (tmux 3.6a, probed live during M4): pause →
-        // continue DISCARDS pane output emitted while paused — delivery
-        // resumes from the pane's CURRENT position and nothing is drained as
-        // backlog (with or without the `pause-after` client flag). Tokens the
-        // pane emits between the capture and the unpause are therefore lost:
-        // a boundary-only, strictly-forward gap whose width scales with the
-        // replay-assembly window (observed 3 -> 25 under full-suite load).
-        // Closing it needs an interleave buffer (capture fence → gate open),
-        // a design follow-up tracked with the M4 findings.
+        // M2 FENCE (Phase B): the boundary gap the M4-era matrix accepted
+        // (3 -> 25 tokens lost under load) is CLOSED. Two probe-verified
+        // facts (tmux 3.6a, 6/6 trials under throttle and firehose) carry
+        // the design: (1) a paused pane delivers NOTHING — its output lands
+        // in pane history, reachable via capture; (2) an atomic
+        // [captures…, continue] command list has a seam gap of exactly
+        // zero — the first live token delivered after the continue is
+        // contiguous with the capture's last token. The orchestrator pauses
+        // (awaited alone), arms a generation-scoped fence while the pane is
+        // provably silent, sends captures + continue as ONE list, and
+        // markReady flushes the fenced bytes right after the replay.
         //
-        // This test pins every guarantee that DOES hold at the boundary:
-        // nothing duplicated, nothing reordered, no rewind, gapless within
-        // the replay, gapless within the live stream — i.e. any loss is
-        // confined to the single replay/live seam.
+        // This test therefore pins the STRICT zero-seam contract: nothing
+        // duplicated, nothing reordered, no rewind, gapless within the
+        // replay, gapless within the live stream, and the first live token
+        // is EXACTLY lastReplayed + 1.
         let replayTokens = tokens(
             in: strippingEscapes(String(text[..<boundary.upperBound])), label: "SEQ")
         let liveTokens = tokens(
@@ -536,8 +538,8 @@ struct ReplayLiveIntegrationMatrixTests {
         #expect(liveViolations.isEmpty,
                 "LOSS/DUP inside the live stream: \(liveViolations) — boundary bytes \(boundaryBytes)")
         if let lastReplayed = replayTokens.last, let firstLive = liveTokens.first {
-            #expect(firstLive > lastReplayed,
-                    "DUPLICATION/REWIND at the replay/live boundary: replay ended at \(lastReplayed), live began at \(firstLive) — bytes \(boundaryBytes)")
+            #expect(firstLive == lastReplayed + 1,
+                    "SEAM violation at the replay/live boundary: replay ended at \(lastReplayed), live began at \(firstLive) — expected exactly \(lastReplayed + 1) (zero-loss fence, Phase B M2) — bytes \(boundaryBytes)")
         }
 
         await supervisor.stopAll()

--- a/Tests/TBDDaemonTests/TmuxControlSupervisorAttachTests.swift
+++ b/Tests/TBDDaemonTests/TmuxControlSupervisorAttachTests.swift
@@ -285,7 +285,7 @@ struct PaneFanoutTests {
         #expect(fanout.markReady(key: PaneKey(server: server, paneID: "%404"), generation: 1) == false)
     }
 
-    @Test("a chunk larger than the pipe buffer delivers an intact prefix and drops the rest")
+    @Test("a chunk larger than the pipe buffer delivers an intact prefix and enters repair for the rest")
     func partialWriteDropsTailNotMiddle() throws {
         let fanout = PaneFanout()
         let key = PaneKey(server: server, paneID: "%7")
@@ -294,10 +294,22 @@ struct PaneFanoutTests {
         fanout.markReady(key: key, generation: gen)
 
         // 256 KB into a ~64 KB pipe with no reader: the EAGAIN remainder
-        // (~192 KB) exceeds the 128 KB backpressure queue cap, so it is
-        // dropped WHOLE (Phase B M1 overflow) — never skipped in the middle.
+        // (~192 KB) exceeds the 128 KB backpressure queue cap. On a ready,
+        // unfenced, non-repairing sink that overflow takes the REPAIR-ENTRY
+        // branch (Phase B M3): the queue is cleared, the sink flips to
+        // `repairing`, and NOTHING counts as dropped — the repair's recapture
+        // supersedes the tail. Either way the delivered prefix stays intact:
+        // the pipe is never skipped in the middle. (The M1 whole-chunk-drop
+        // path is covered by the fenced-overflow test in
+        // PaneFanoutFlowControlTests, where repair entry is barred.)
         let big = Data(repeating: UInt8(ascii: "z"), count: 256 * 1024)
         fanout.route(server: server, event: .output(paneID: "%7", bytes: big))
+
+        let stats = try #require(fanout.flowStats(key: key))
+        #expect(stats.repairing == true,
+                "an oversized steady-state chunk must route into the repair cycle, not a drop")
+        #expect(stats.droppedBytes == 0,
+                "repair entry supersedes the tail — nothing counts as dropped")
 
         var received = Data()
         var buffer = [UInt8](repeating: 0, count: 16 * 1024)

--- a/Tests/TBDDaemonTests/TmuxControlSupervisorAttachTests.swift
+++ b/Tests/TBDDaemonTests/TmuxControlSupervisorAttachTests.swift
@@ -293,8 +293,9 @@ struct PaneFanoutTests {
         defer { Darwin.close(readFD) }
         fanout.markReady(key: key, generation: gen)
 
-        // 256 KB into a ~64 KB pipe with no reader: the write must stop at
-        // EAGAIN and drop the tail — never skip bytes in the middle.
+        // 256 KB into a ~64 KB pipe with no reader: the EAGAIN remainder
+        // (~192 KB) exceeds the 128 KB backpressure queue cap, so it is
+        // dropped WHOLE (Phase B M1 overflow) — never skipped in the middle.
         let big = Data(repeating: UInt8(ascii: "z"), count: 256 * 1024)
         fanout.route(server: server, event: .output(paneID: "%7", bytes: big))
 

--- a/docs/specs/2026-07-07-tmux-control-mode-phase-b-flow-control-addendum.md
+++ b/docs/specs/2026-07-07-tmux-control-mode-phase-b-flow-control-addendum.md
@@ -1,0 +1,94 @@
+# tmux control mode — Phase B addendum (flow control)
+
+**Date:** 2026-07-07
+**Status:** Implemented (M1–M3 of Phase B). Extends [`2026-05-17-tmux-control-mode-design.md`](./2026-05-17-tmux-control-mode-design.md) §"Flow control — Policy B" and [`2026-07-02-tmux-control-mode-phase-a-addendum.md`](./2026-07-02-tmux-control-mode-phase-a-addendum.md) §3. Tracking: #318 · dogfood evidence that pulled this forward: #376 · Phase A: #364.
+
+## 1. What changed versus the base spec — and why
+
+The base spec's Policy B state machine assumed tmux **buffers server-side while paused** and drains the backlog as `%extended-output` after `%continue` (`Streaming → Backpressured → Paused → Draining → Streaming`). Phase A's live matrix already refuted the premise, and this phase re-probed it directly:
+
+**Probe findings (tmux 3.6a, 6/6 trials, throttled ~100 tokens/s AND unthrottled full-blast):**
+
+1. **Pause discards.** A paused pane (`refresh-client -A '%X:pause'`) delivers **nothing** — zero bytes even with ~500k tokens emitted while paused. `continue` resumes delivery from the pane's *current* position; the paused-window output is never delivered to this client. It does land in the pane's history/screen, reachable via `capture-pane`.
+2. **An atomic command list `[captures…, continue]` has a seam gap of exactly zero.** The first live token delivered after the batched continue is contiguous with the capture's last token (`firstLive == capturedLast + 1` in every trial, under both load profiles). tmux executes the batched commands back-to-back with no pane-output interleave.
+
+Finding 1 kills the spec's `Draining` state: there is no backlog to drain. The replacement is the Phase A addendum §3 reserved design — **re-capture on pause** (iTerm2's shape for `%pause`) — which finding 2 upgrades from "converges eventually" to **provably gapless**: capture and continue in one atomic batch, with the post-continue output parked behind a fence until the recapture replay is in the pipe.
+
+The 32 KB resume-hysteresis knob from the base spec's defaults table is gone with the `Draining` state: the resume gate is now *pipe writability* (the app reader caught up), because the local queue is **cleared** at overflow — its content is already in pane history and the recapture supersedes it.
+
+## 2. The unified queue/fence machinery (`PaneFanout`)
+
+One per-sink byte queue (cap **128 KB**, chunk-granular, generation-scoped) serves three roles:
+
+- **M1 — backpressure queue.** `route()` no longer drops on `EAGAIN` (the #376 corruption source): the unwritten remainder queues, an async drain task (10 ms pacing, write-under-lock with sink+generation re-validation per pass) flushes as the reader catches up, and while *anything* is queued, new chunks enqueue behind it — live bytes can never overtake queued bytes.
+- **M2 — attach fence.** During the attach sequence, output routed for the pane queues behind the closed gate instead of dropping; `markReady` clears the fence and arms the drain, so fenced bytes follow the replay in order. This closes Phase A's accepted 0.2–0.5 s attach boundary gap (measured 3–25 lost tokens under load; now **zero**, pinned by the live matrix's strict `firstLive == lastReplayed + 1` assertion).
+- **M3 — repair fence.** The same fence parks post-continue output behind a mid-session recapture replay (below).
+
+`route()`'s behavior table (documented in-source) is the state machine's concrete form:
+
+| Sink state | `route()` behavior |
+|---|---|
+| no sink | count unattached drop |
+| fenced (any ready state) | enqueue; **never** arm the drain (the flush belongs to `markReady`/`endRepair`) |
+| !ready, !fenced | drop — pre-fence attach window; the bytes are in the attach's capture |
+| ready, repairing, !fenced | drop with counters — pre-pause repair window; the recapture includes them |
+| ready, queue non-empty | enqueue + arm drain |
+| ready, queue empty | direct write; `EAGAIN` remainder → enqueue + arm drain |
+
+Everything is **generation-scoped**, the invariant carried from Phase A's eleven review rounds: a superseded attach's queued/fenced bytes die with its sink; the drain, the fence, and every repair step re-validate `(key, generation)` and abort silently on mismatch.
+
+Telemetry (issue #376's explicit ask — the old `.debug` drop counters weren't persisted and we flew blind): backpressure entry, overflow, drain recovery, and repair completion log at rate-limited `.info`; `PaneFlowStats` exposes the counters.
+
+## 3. Why the attach/repair sequences batch in two phases
+
+Command replies and `%output` reach the daemon on paths that do **not** preserve relative order end-to-end: output events are routed synchronously on the connection reader thread (`outputSink` → `PaneFanout.route`), while command replies hop `AsyncStream` → supervisor actor → correlator actor → completion. So "arm the fence when the pause reply completes" cannot, by itself, split pre-pause from post-continue output — a post-continue chunk could race ahead of the reply's actor hops and hit a not-yet-armed fence.
+
+The fence is therefore armed only at a **provably silent** moment:
+
+1. **Batch 1: the pause alone, awaited.** By stream order, everything pre-pause has already been routed (and dropped — it is in the capture; no loss). From the pause reply onward the pane delivers nothing (probe finding 1). No race window exists.
+2. Arm the fence.
+3. **Batch 2: captures + continue, one atomic list, continue last.** Zero seam (probe finding 2); post-continue output flows into the armed fence.
+4. Write the replay behind the fence (the drain never runs while fenced), then clear the fence and arm the flush.
+
+The batch split adds one supersession window (between batches), guarded by the same generation re-check discipline as Phase A's R10-3, with R11's rule intact: a superseded sequence sends nothing further and never unpauses — the successor's own FIFO-ordered sequence owns the pane's pause state.
+
+## 4. The M3 repair cycle (`PaneRepairCoordinator`)
+
+Steady-state queue overflow (ready, unfenced, not repairing) no longer drops. Instead:
+
+1. The fanout **clears the queue** (its content is in pane history; the recapture supersedes it — nothing counts as dropped), flips the sink to `repairing` (routed output now drops-with-counters: pre-pause bytes the capture will include), and signals the coordinator outside the lock.
+2. The coordinator pauses the pane (batch 1), then **waits for the app reader to catch up** (nonblocking `POLLOUT` probe, 50 ms pacing, 30 s deadline) — a recapture replayed into a still-full pipe would just re-overflow.
+3. Repair fence → atomic captures+continue (shared `PaneCaptureReplay` construction, byte-identical to the attach's batch 2) → recapture replay via `writeReplay` → `endRepair` flushes the fenced bytes in order.
+
+The repair replay resets the terminal (reset prelude + full history) mid-session — accepted and intentional: iTerm2 re-captures on `%pause` for the same reason, and a one-frame repaint beats permanently corrupt cells on a differential renderer.
+
+**Deliberate policies:**
+
+- **Wedged reader (30 s deadline exceeded):** leave the pane *paused* and the sink `repairing`. A continue would just re-overflow; tmux holds the content server-side, and a later attach replaces the sink and re-runs the full sequence, healing everything. (Wedged-*tmux* detection is separate, still-open Phase B scope.)
+- **Repair failure while still owner** (capture `%error`, replay write failure): unpause + `abortRepair` — the stream resumes with a possible hole; a pane frozen behind a fence that never flushes is worse than a hole.
+- **Overflow while fenced or already repairing:** keeps the M1 whole-chunk drop + telemetry. A repair launched during a fence would race the in-flight attach/repair sequence on the same pane's pause state. Bounded residual, rare (requires a blast pane overflowing 128 KB *during* replay assembly).
+
+## 5. Defaults (updated from the base spec's table)
+
+| Knob | Value | Notes |
+|---|---|---|
+| Per-pane local-queue cap | 128 KB | overflow enters the repair cycle (was: drop) |
+| Resume gate | pipe writable | replaces the 32 KB drain hysteresis — the queue is cleared at overflow, so there is nothing to drain below a threshold |
+| Drain pacing | 10 ms | async task; nonblocking writes under the fanout lock |
+| Repair reader-wait | 50 ms poll / 30 s deadline | deadline → pane stays paused; later attach heals |
+| Repair recapture depth | 50 000 | matches the attach's `history-limit` |
+| `pause-after` safety nets | **not yet set** | remaining Phase B scope, below |
+
+## 6. Remaining Phase B scope (not in this change)
+
+- **`pause-after` safety nets + `%pause`-triggered repair** (base spec: 5 s visible / 250 ms non-visible, per window). Note: once `pause-after` is set, tmux can pause a pane *unprompted*, so `%pause` must trigger the repair cycle (the coordinator is built for it — `repairIfNeeded` is the entry point) or a pane freezes until the next attach. Do not set the option before wiring that trigger. Also revisit the fence-arm silence argument: under `pause-after`, a small `%extended-output` trickle can precede `%pause`; the probes above ran without the flag.
+- **Non-visible pane sampling** for notification heuristics (periodic continue → sample → re-pause).
+- **Wedged-tmux detection** (mute-but-alive `-CC`, the write-block thread pinning) — crash recovery scope (#364 known gaps).
+- **Router epochs vs server death; per-server input consumers** (#364 known gaps).
+- **Grouped-sessions fallback removal** — the "default-on" cleanup (Phase A addendum §5).
+
+## References
+
+- Base: [`2026-05-17-tmux-control-mode-design.md`](./2026-05-17-tmux-control-mode-design.md) · Phase A: [`2026-07-02-tmux-control-mode-phase-a-addendum.md`](./2026-07-02-tmux-control-mode-phase-a-addendum.md)
+- Issues: #318 (tracking), #376 (dogfood corruption evidence), #364 (Phase A PR, known-gaps list)
+- iTerm2 (local checkout `~/projects/iTerm2/sources/`): `PTYSession.m` `handleTmuxData:` backpressure rationale; `TmuxController.m` re-capture-on-`%pause`

--- a/docs/specs/2026-07-07-tmux-control-mode-phase-b-flow-control-addendum.md
+++ b/docs/specs/2026-07-07-tmux-control-mode-phase-b-flow-control-addendum.md
@@ -20,7 +20,7 @@ The 32 KB resume-hysteresis knob from the base spec's defaults table is gone wit
 
 One per-sink byte queue (cap **128 KB**, chunk-granular, generation-scoped) serves three roles:
 
-- **M1 — backpressure queue.** `route()` no longer drops on `EAGAIN` (the #376 corruption source): the unwritten remainder queues, an async drain task (10 ms pacing, write-under-lock with sink+generation re-validation per pass) flushes as the reader catches up, and while *anything* is queued, new chunks enqueue behind it — live bytes can never overtake queued bytes.
+- **M1 — backpressure queue.** `route()` no longer drops on `EAGAIN` (the #376 corruption source): the unwritten remainder queues, a GCD drain worker (10 ms pacing, write-under-lock with sink+generation re-validation per pass; deliberately **not** a cooperative-pool task — a saturated pool must never starve render-path delivery, the R8-M2 discipline, observed as a real starvation-deadlock on narrow-vCPU CI) flushes as the reader catches up, and while *anything* is queued, new chunks enqueue behind it — live bytes can never overtake queued bytes.
 - **M2 — attach fence.** During the attach sequence, output routed for the pane queues behind the closed gate instead of dropping; `markReady` clears the fence and arms the drain, so fenced bytes follow the replay in order. This closes Phase A's accepted 0.2–0.5 s attach boundary gap (measured 3–25 lost tokens under load; now **zero**, pinned by the live matrix's strict `firstLive == lastReplayed + 1` assertion).
 - **M3 — repair fence.** The same fence parks post-continue output behind a mid-session recapture replay (below).
 
@@ -74,7 +74,7 @@ The repair replay resets the terminal (reset prelude + full history) mid-session
 |---|---|---|
 | Per-pane local-queue cap | 128 KB | overflow enters the repair cycle (was: drop) |
 | Resume gate | pipe writable | replaces the 32 KB drain hysteresis — the queue is cleared at overflow, so there is nothing to drain below a threshold |
-| Drain pacing | 10 ms | async task; nonblocking writes under the fanout lock |
+| Drain pacing | 10 ms | GCD worker (off the cooperative pool); nonblocking writes under the fanout lock |
 | Repair reader-wait | 50 ms → 500 ms escalating poll, no deadline | one `.error` escalation log at 30 s; pane stays paused, tmux buffers server-side; broken pipe → unpause + abort |
 | Repair recapture depth | 50 000 | matches the attach's `history-limit` |
 | `pause-after` safety nets | **not yet set** | remaining Phase B scope, below |

--- a/docs/specs/2026-07-07-tmux-control-mode-phase-b-flow-control-addendum.md
+++ b/docs/specs/2026-07-07-tmux-control-mode-phase-b-flow-control-addendum.md
@@ -37,7 +37,7 @@ One per-sink byte queue (cap **128 KB**, chunk-granular, generation-scoped) serv
 
 Everything is **generation-scoped**, the invariant carried from Phase A's eleven review rounds: a superseded attach's queued/fenced bytes die with its sink; the drain, the fence, and every repair step re-validate `(key, generation)` and abort silently on mismatch.
 
-Telemetry (issue #376's explicit ask — the old `.debug` drop counters weren't persisted and we flew blind): backpressure entry, overflow, drain recovery, and repair completion log at rate-limited `.info`; `PaneFlowStats` exposes the counters.
+Telemetry (issue #376's explicit ask — the old `.debug` drop counters weren't persisted and we flew blind): backpressure entry, overflow, and drain recovery log at rate-limited `.info`; repair completion logs an unconditional `.info` (repairs are rare); `PaneFlowStats` exposes the counters.
 
 ## 3. Why the attach/repair sequences batch in two phases
 
@@ -57,14 +57,14 @@ The batch split adds one supersession window (between batches), guarded by the s
 Steady-state queue overflow (ready, unfenced, not repairing) no longer drops. Instead:
 
 1. The fanout **clears the queue** (its content is in pane history; the recapture supersedes it — nothing counts as dropped), flips the sink to `repairing` (routed output now drops-with-counters: pre-pause bytes the capture will include), and signals the coordinator outside the lock.
-2. The coordinator pauses the pane (batch 1), then **waits for the app reader to catch up** (nonblocking `POLLOUT` probe, 50 ms pacing, 30 s deadline) — a recapture replayed into a still-full pipe would just re-overflow.
+2. The coordinator pauses the pane (batch 1), then **waits for the app reader to catch up** (nonblocking `POLLOUT` probe, 50 ms pacing escalating to 500 ms after ~5 s, **no deadline**) — a recapture replayed into a still-full pipe would just re-overflow.
 3. Repair fence → atomic captures+continue (shared `PaneCaptureReplay` construction, byte-identical to the attach's batch 2) → recapture replay via `writeReplay` → `endRepair` flushes the fenced bytes in order.
 
 The repair replay resets the terminal (reset prelude + full history) mid-session — accepted and intentional: iTerm2 re-captures on `%pause` for the same reason, and a one-frame repaint beats permanently corrupt cells on a differential renderer.
 
 **Deliberate policies:**
 
-- **Wedged reader (30 s deadline exceeded):** leave the pane *paused* and the sink `repairing`. A continue would just re-overflow; tmux holds the content server-side, and a later attach replaces the sink and re-runs the full sequence, healing everything. (Wedged-*tmux* detection is separate, still-open Phase B scope.)
+- **Wedged reader:** wait indefinitely — the pane stays *paused* and the sink `repairing` while the repair polls for pipe writability (50 ms, then 500 ms past ~5 s; one `.error` escalation line at 30 s). A continue would just re-overflow, and giving up would freeze the pane forever (nothing re-triggers a generation's repair), so a *transiently* wedged reader — e.g. a long app main-thread hitch — heals the moment it drains: the **same in-flight repair** completes. tmux holds the content server-side meanwhile; a re-attach still supersedes the wait via the generation check. A **broken** pipe (read end closed — the viewer is gone or dying) can never drain: unpause + `abortRepair`; the app-death detach path finishes the job, and an unpaused pane stays healthy for the next attach. (Wedged-*tmux* detection is separate, still-open Phase B scope.)
 - **Repair failure while still owner** (capture `%error`, replay write failure): unpause + `abortRepair` — the stream resumes with a possible hole; a pane frozen behind a fence that never flushes is worse than a hole.
 - **Overflow while fenced or already repairing:** keeps the M1 whole-chunk drop + telemetry. A repair launched during a fence would race the in-flight attach/repair sequence on the same pane's pause state. Bounded residual, rare (requires a blast pane overflowing 128 KB *during* replay assembly).
 
@@ -75,7 +75,7 @@ The repair replay resets the terminal (reset prelude + full history) mid-session
 | Per-pane local-queue cap | 128 KB | overflow enters the repair cycle (was: drop) |
 | Resume gate | pipe writable | replaces the 32 KB drain hysteresis — the queue is cleared at overflow, so there is nothing to drain below a threshold |
 | Drain pacing | 10 ms | async task; nonblocking writes under the fanout lock |
-| Repair reader-wait | 50 ms poll / 30 s deadline | deadline → pane stays paused; later attach heals |
+| Repair reader-wait | 50 ms → 500 ms escalating poll, no deadline | one `.error` escalation log at 30 s; pane stays paused, tmux buffers server-side; broken pipe → unpause + abort |
 | Repair recapture depth | 50 000 | matches the attach's `history-limit` |
 | `pause-after` safety nets | **not yet set** | remaining Phase B scope, below |
 


### PR DESCRIPTION
## Summary

Dogfooding the control-mode toggle (#376) hit pervasive character-level corruption on heavy-streaming fullscreen Claude panes within minutes. Two documented Phase A gaps compounded on the differential-renderer workload:

1. **EAGAIN drop-and-count**: `PaneFanout.route` dropped overflow bytes whenever the 64KB pane pipe filled — every dropped chunk leaves permanently wrong cells until a full repaint.
2. **Attach-boundary discard gap**: each attach lost ~0.2–0.5s of output (measured 3–25 tokens under load), three attaches in two minutes = three sets of holes.

This PR is Phase B flow control (Policy B), built on two live-probed facts (tmux 3.6a, 6/6 trials, throttled + full-blast firehose):

- **Pause discards** — a paused pane delivers *nothing* (zero bytes even with ~500k tokens emitted while paused); content lands in pane history, reachable via capture. This refutes the base spec's drain-via-`%extended-output` Draining state.
- **An atomic `[captures…, continue]` command list has a seam gap of exactly zero** — the first live token after the continue is contiguous with the capture's tail.

What ships, one commit per milestone:

- **M1 — backpressure queue** (`db99d9b4`): EAGAIN never drops; the unwritten remainder queues per pane (128KB cap, generation-scoped, async drain), and drop/queue/repair telemetry is promoted to rate-limited persisted `.info` (#376's explicit ask — the old `.debug` counters weren't persisted and we flew blind).
- **M2 — zero-seam attach** (`74312667`): a fence queue + two-phase batching (pause alone, awaited → arm fence at provable silence → atomic captures+continue) closes the attach gap entirely. The live matrix now pins the strict contract `firstLive == lastReplayed + 1`, replacing the old "boundary-only gap accepted" finding.
- **M3 — overflow heals instead of dropping** (`6936bc25`, `fc4014d5`): queue overflow → pause → wait for the reader → recapture + atomic continue → replay repair → fence flush. This is the addendum §3 reserved "re-capture on pause" (iTerm2's shape), which the fence machinery makes cheap. Live-proven: an unthrottled firehose with a deliberately stalled reader overflows, repairs, and the stream is gapless and monotonic after the repair replay.
- **Docs** (`15673334`): Phase B addendum in `docs/specs/` recording the probe findings, the design divergence from the base spec, and remaining Phase B scope.

## Review hardening (multi-round, 2 significant findings fixed)

- `ff2b2498`: a wedged app reader no longer freezes the pane forever — the repair waits indefinitely (50ms→500ms escalating poll, generation-scoped, 30s escalation log) and heals the moment the reader recovers; a broken pipe (read end closed) unpauses + aborts. Also makes the drain's fence stand-down structural (`!repairing` guard) rather than an incidental cross-function invariant.
- `a55b3664`: a successor generation's overflow signal arriving while a stale repair held the per-pane dedupe slot was silently swallowed → permanently blank pane. Fixed with an exit re-dispatch loop + duplicate-safe entry guard; five new tests cover the previously untested failure/supersession branches and drive the production bridge wiring end-to-end.
- `ec9bf01a`: final nits (cancellation bail in the deadline-less wait, TOCTOU-residual comment, split rate-limiter timestamps).

A final adversarial verification pass traced the fix commits interleaving-by-interleaving (hot-spin, swallow-regression, deadlock hypotheses) and came back clean; the timing-sensitive re-dispatch test passed 5/5 consecutive runs.

## Test plan

- [x] Full suite: 2951 tests / 364 suites green; `swiftlint --strict` clean
- [x] Live tmux integration matrix (real `-CC` attach → fd vend → orchestrator → pipe): all 5 scenarios including the strict zero-seam assertion and the firehose overflow-repair heal
- [x] Unit coverage for every new gate branch (fenced/repairing/ready × generation match/mismatch, overflow both branches, repair failure paths)
- [ ] Post-merge dogfood: re-enable the control-mode toggle (Settings → Experimental) and watch `log show --predicate 'subsystem == "com.tbd.daemon"' | grep fanout` for backpressure/overflow/repair telemetry under real agent workloads

Remaining Phase B scope (tracked in #318, spelled out in the addendum §6): `pause-after` safety nets + `%pause`-triggered repair (the coordinator is built for it — do not set `pause-after` before wiring that trigger), non-visible pane sampling, wedged-tmux detection, router epochs, per-server input consumers, and the #376 log-trail's failure-path detach cycles.

Closes #376.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=21C2F3AE-119C-4627-82EE-C7929F52F787)