### PR TITLE
feat: spawn a default Claude/Codex terminal for scratch spaces

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -410,7 +410,7 @@ extension WorktreeLifecycle {
     /// broadcast `.terminalCreated` for each.
     @discardableResult
     func spawnPrimaryTerminals(
-        worktree: Worktree, repo: Repo,
+        worktree: Worktree, repo: Repo?,
         worktreePath: String? = nil, skipClaude: Bool,
         archivedClaudeSessions: [String]? = nil,
         initialPrompt: String? = nil,
@@ -453,7 +453,7 @@ extension WorktreeLifecycle {
         var resolvedProfile: ResolvedModelProfile? = nil
         if needsResolvedClaudeProfile, let resolver = modelProfileResolver {
             do {
-                resolvedProfile = try await resolver.resolve(repoID: repo.id)
+                resolvedProfile = try await resolver.resolve(repoID: repo?.id)
             } catch {
                 logger.warning("model profile resolution failed; falling back to keychain login")
                 resolvedProfile = nil
@@ -465,7 +465,7 @@ extension WorktreeLifecycle {
         // on top (below), so it can't be clobbered. See docs/env-overrides.md.
         let mergedEnvOverrides = EnvOverrideResolver.merge(
             global: config.envOverrides,
-            repo: repo.envOverrides,
+            repo: repo?.envOverrides,
             profile: resolvedProfile?.envOverrides
         )
 
@@ -590,52 +590,56 @@ extension WorktreeLifecycle {
             (id: plannedTerminalID1, label: primaryLabel)
         ]
 
-        // Create terminal 2: setup hook
-        let plannedTerminalID2 = UUID()
-        createdTerminalIDs.append(plannedTerminalID2)
-        let setupHookPath = hooks.resolve(
-            event: .setup,
-            repoPath: worktreePath,
-            appHookPath: worktree.repoID.map {
-                TBDConstants.hookPath(repoID: $0, eventName: HookEvent.setup.rawValue)
-            }
-        )
-        let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
-        // Suppress the omz update prompt only when a setup hook actually
-        // resolves — a hook-less "Setup" tab is just a regular shell and must
-        // keep oh-my-zsh update checks (see `hookPaneEnv`).
-        let setupSensitiveEnv = setupHookPath != nil ? Self.hookPaneEnv : [:]
-        // Full hook environment per docs/worktree-hooks.md (matches the
-        // preSession and archive hooks). TBD_WORKTREE_NAME uses
-        // `worktree.name` for consistency with the archive hook's env.
-        let setupEnv: [String: String] = [
-            "TBD_WORKTREE_ID": worktreeID.uuidString,
-            "TBD_TERMINAL_ID": plannedTerminalID2.uuidString,
-            "TBD_EVENT": HookEvent.setup.rawValue,
-            "TBD_WORKTREE_NAME": worktree.name,
-            "TBD_WORKTREE_PATH": worktreePath,
-            "TBD_REPO_PATH": repo.path,
-            "TBD_BRANCH": worktree.branch,
-        ]
-        let window2 = try await tmux.createWindow(
-            server: tmuxServer,
-            session: "main",
-            cwd: worktreePath,
-            shellCommand: setupCommand,
-            env: setupEnv,
-            sensitiveEnv: setupSensitiveEnv,
-            cols: resolvedCols,
-            rows: resolvedRows
-        )
-        _ = try await db.terminals.create(
-            id: plannedTerminalID2,
-            worktreeID: worktreeID,
-            tmuxWindowID: window2.windowID,
-            tmuxPaneID: window2.paneID,
-            label: TerminalLabel.setup,
-            kind: .shell
-        )
-        createdTerminals.append((id: plannedTerminalID2, label: TerminalLabel.setup))
+        // Create terminal 2: setup hook. Repo-backed worktrees only — scratch
+        // spaces (repo == nil) have no repo path/setup hook and get just the
+        // primary terminal, so the tab order stays `[primary]`.
+        if let repo {
+            let plannedTerminalID2 = UUID()
+            createdTerminalIDs.append(plannedTerminalID2)
+            let setupHookPath = hooks.resolve(
+                event: .setup,
+                repoPath: worktreePath,
+                appHookPath: worktree.repoID.map {
+                    TBDConstants.hookPath(repoID: $0, eventName: HookEvent.setup.rawValue)
+                }
+            )
+            let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
+            // Suppress the omz update prompt only when a setup hook actually
+            // resolves — a hook-less "Setup" tab is just a regular shell and must
+            // keep oh-my-zsh update checks (see `hookPaneEnv`).
+            let setupSensitiveEnv = setupHookPath != nil ? Self.hookPaneEnv : [:]
+            // Full hook environment per docs/worktree-hooks.md (matches the
+            // preSession and archive hooks). TBD_WORKTREE_NAME uses
+            // `worktree.name` for consistency with the archive hook's env.
+            let setupEnv: [String: String] = [
+                "TBD_WORKTREE_ID": worktreeID.uuidString,
+                "TBD_TERMINAL_ID": plannedTerminalID2.uuidString,
+                "TBD_EVENT": HookEvent.setup.rawValue,
+                "TBD_WORKTREE_NAME": worktree.name,
+                "TBD_WORKTREE_PATH": worktreePath,
+                "TBD_REPO_PATH": repo.path,
+                "TBD_BRANCH": worktree.branch,
+            ]
+            let window2 = try await tmux.createWindow(
+                server: tmuxServer,
+                session: "main",
+                cwd: worktreePath,
+                shellCommand: setupCommand,
+                env: setupEnv,
+                sensitiveEnv: setupSensitiveEnv,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+            _ = try await db.terminals.create(
+                id: plannedTerminalID2,
+                worktreeID: worktreeID,
+                tmuxWindowID: window2.windowID,
+                tmuxPaneID: window2.paneID,
+                label: TerminalLabel.setup,
+                kind: .shell
+            )
+            createdTerminals.append((id: plannedTerminalID2, label: TerminalLabel.setup))
+        }
 
         // Restore any archived Claude sessions that were not consumed by the
         // primary terminal.

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -48,8 +48,24 @@ extension RPCRouter {
             throw error
         }
 
+        // Spawn the default primary agent terminal (Claude/Codex/shell per the
+        // global primary-agent preference), mirroring what repo worktrees get on
+        // creation. Best-effort: a spawn failure must not fail scratch creation —
+        // the row + folder already exist and the user can add a terminal manually.
+        var createdTerminals: [(id: UUID, label: String)] = []
+        do {
+            createdTerminals = try await lifecycle.spawnPrimaryTerminals(
+                worktree: wt, repo: nil, skipClaude: false, preSessionTerminalID: nil)
+        } catch {
+            scratchLogger.warning("scratch.create: primary terminal spawn failed for \(wt.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+
         subscriptions.broadcast(delta: .worktreeCreated(WorktreeDelta(
             worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path, status: wt.status)))
+        for terminal in createdTerminals {
+            subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
+                terminalID: terminal.id, worktreeID: wt.id, label: terminal.label)))
+        }
         scratchLogger.info("scratch.create: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
         return try RPCResponse(result: wt)
     }

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -63,6 +63,9 @@ struct ScratchArchiveReviveRPCTests {
         let (router, _) = makeRouter(db: db)
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-terminal")))
         let wt = try created.decodeResult(Worktree.self)
+        // The scratch.create RPC now auto-spawns a default primary agent terminal;
+        // clear it so this test controls its own terminal fixture.
+        try await db.terminals.deleteForWorktree(worktreeID: wt.id)
 
         let terminal = try await db.terminals.create(
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")

--- a/Tests/TBDDaemonTests/ScratchCreateRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchCreateRPCTests.swift
@@ -35,6 +35,71 @@ struct ScratchCreateRPCTests {
         #expect(all.count == 1)
     }
 
+    /// Scratch create now spawns exactly ONE default primary agent terminal —
+    /// no "Setup" tab (that's the repo-only `if let repo` branch in
+    /// spawnPrimaryTerminals). With the default primaryAgentPreference the
+    /// primary is a Claude terminal, and it is the single tab / active tab.
+    @Test func spawnsSingleDefaultClaudePrimaryTerminal() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        let response = await router.handle(
+            try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        #expect(response.success)
+        let wt = try response.decodeResult(Worktree.self)
+
+        // Exactly one terminal: the primary. No "Setup" tab for scratch.
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.count == 1)
+        let primary = try #require(terminals.first)
+        #expect(primary.kind == .claude)          // default primaryAgentPreference
+        #expect(primary.label == TerminalLabel.claudeCode)
+        #expect(!terminals.contains { $0.label == TerminalLabel.setup })
+
+        // Tab order + active tab are that single terminal.
+        let tabOrder = try await db.worktrees.getTabOrder(worktreeID: wt.id)
+        #expect(tabOrder == [primary.id])
+        let activeTab = try await db.worktrees.getActiveTabID(worktreeID: wt.id)
+        #expect(activeTab == primary.id)
+    }
+
+    /// With the global primaryAgentPreference set to `.codex`, the single
+    /// spawned scratch terminal is a Codex terminal.
+    @Test func spawnsCodexPrimaryWhenPreferenceIsCodex() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        // Codex spawn resolves CODEX_HOME via CodexHomeManager; point it at a
+        // sandbox temp dir so it never touches the developer's real config.
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-scratch-codex-\(UUID().uuidString)")
+        setenv("TBD_TEST_CODEX_HOME", codexHome.path, 1)
+        defer {
+            unsetenv("TBD_TEST_CODEX_HOME")
+            try? FileManager.default.removeItem(at: codexHome)
+        }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPrimaryAgentPreference(.codex)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        let response = await router.handle(
+            try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+        #expect(response.success)
+        let wt = try response.decodeResult(Worktree.self)
+
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.count == 1)
+        let primary = try #require(terminals.first)
+        #expect(primary.kind == .codex)
+        #expect(primary.label == TerminalLabel.codex)
+    }
+
     @Test func honorsExplicitNameAndRegeneratesOnCollision() async throws {
         let iso = isolateTBDHome(); defer { iso.cleanup() }
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
@@ -39,6 +39,9 @@ struct ScratchDeleteRPCTests {
             tmux: TmuxManager(dryRun: true), startTime: Date())
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-terminal")))
         let wt = try created.decodeResult(Worktree.self)
+        // The scratch.create RPC now auto-spawns a default primary agent terminal;
+        // clear it so this test controls its own terminal fixture.
+        try await db.terminals.deleteForWorktree(worktreeID: wt.id)
 
         let terminal = try await db.terminals.create(
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")

--- a/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
@@ -68,6 +68,9 @@ struct ScratchPromoteMigrationTests {
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
         try gitInitCommit(at: wt.path)
+        // The scratch.create RPC now auto-spawns a default primary agent terminal;
+        // clear it so this test controls its own terminal fixture.
+        try await db.terminals.deleteForWorktree(worktreeID: wt.id)
 
         // Two live-ish terminals, a labeled tab, an order, and a selection.
         let t1 = try await db.terminals.create(
@@ -125,6 +128,9 @@ struct ScratchPromoteMigrationTests {
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
         try gitInitCommit(at: wt.path)
+        // The scratch.create RPC now auto-spawns a default primary agent terminal;
+        // clear it so this test controls its own terminal fixture.
+        try await db.terminals.deleteForWorktree(worktreeID: wt.id)
 
         // One ambient terminal and one profile-pinned terminal.
         let profileID = UUID()

--- a/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
@@ -215,6 +215,9 @@ struct ScratchPromoteRPCTests {
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
         try gitInitCommit(at: wt.path)
+        // The scratch.create RPC now auto-spawns a default primary agent terminal;
+        // clear it so this test controls its own terminal fixture.
+        try await db.terminals.deleteForWorktree(worktreeID: wt.id)
         let claude = try await db.terminals.create(
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
             label: "claude", claudeSessionID: "sess-1", kind: .claude)

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -61,6 +61,9 @@ struct ScratchPromoteReconcileTests {
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
         try gitInitCommit(at: wt.path)
+        // The scratch.create RPC now auto-spawns a default primary agent terminal;
+        // clear it so this test controls its own terminal fixture.
+        try await db.terminals.deleteForWorktree(worktreeID: wt.id)
 
         let claude = try await db.terminals.create(
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
@@ -178,6 +181,9 @@ struct ScratchPromoteReconcileTests {
         let created = await router.handle(try RPCRequest(
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let otherScratch = try created.decodeResult(Worktree.self)
+        // The scratch.create RPC now auto-spawns a default primary agent terminal;
+        // clear it so this test controls its own terminal fixture.
+        try await db.terminals.deleteForWorktree(worktreeID: otherScratch.id)
         #expect(otherScratch.tmuxServer == promoted.scratch.tmuxServer,
                 "sanity: scratch spaces share one tmux server")
         let liveTerminal = try await db.terminals.create(


### PR DESCRIPTION
## Problem

Scratch spaces were created with **no terminals**, while repo-backed worktrees come up with a default primary agent (Claude/Codex) terminal. Users had to manually add a terminal to every new scratch space.

## Root cause

Repo worktrees spawn their default LLM terminal via `WorktreeLifecycle.spawnPrimaryTerminals(...)` during the phase-2 create pipeline. `handleScratchCreate` is a separate, minimal path that only created a directory + DB row + broadcast — it never called `spawnPrimaryTerminals`.

The codebase already anticipated repo-less spawns: `ModelProfileResolver.resolve(repoID:)` has a `repoID == nil` scratch branch, `SystemPromptBuilder.build(repo:)` takes an optional repo with scratch-aware prompt layers, and there are `scratchInstructions`/`scratchRenamePrompt`/`scratchProfileOverrideID` config fields. The only missing piece was actually invoking the spawn.

## Change

- Generalize `spawnPrimaryTerminals` to accept `repo: Repo?`. When `repo == nil` (scratch), the repo-only **Setup hook** terminal is skipped, so a scratch space gets exactly one tab: the primary agent. The repo-worktree path is unchanged (`repo` is always non-nil there, so the three edits — `repo?.id`, `repo?.envOverrides`, and the `if let repo` around the Setup terminal — evaluate identically to before).
- Call it from `handleScratchCreate` with `repo: nil`, best-effort (a spawn failure logs a warning and leaves the scratch row/folder intact), then broadcast `.terminalCreated` so the app shows the tab immediately.

The default agent kind follows the existing global **primary-agent preference** (Claude by default, Codex if configured).

## Tests

Added two tests in `ScratchCreateRPCTests` (both branches of the new gate):
- Default preference → exactly one `.claude` terminal, no Setup tab, correct tab order / active tab.
- `primaryAgentPreference = .codex` → the single terminal is `.codex`.

Existing `ModelProfileSpawnTests` (25) confirm the repo-backed spawn path — including the Setup terminal — is unchanged.

`swift build` clean; `ScratchCreateRPCTests` 4/4 pass.

[🌱 Scratch Default LLM Terminal](https://cheapsteak.github.io/tbd/open/?worktree=1AB6400D-0CFE-4E3F-9EAC-756B14BD9E57)