### PR TITLE
Feat: Stop the 'Do you trust this folder?' prompt on every scratch-space Claude launch

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
@@ -1,0 +1,124 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust")
+
+/// Pre-accepts Claude Code's "Do you trust the files in this folder?" dialog for
+/// TBD-owned scratch spaces.
+///
+/// Claude Code persists the folder-trust decision per-directory in
+/// `<CLAUDE_CONFIG_DIR>/.claude.json` under
+/// `projects["<absolute-cwd-path>"].hasTrustDialogAccepted = true`. Scratch dirs
+/// are brand new, TBD-created, empty directories each time, so that key is always
+/// absent and Claude prompts on every launch. Since TBD owns the directory, the
+/// trust gate has no security value there — this seeder pre-writes the accepted
+/// flag so the prompt never appears.
+///
+/// This is a separate gate from `--dangerously-skip-permissions`, which does NOT
+/// suppress the trust dialog. There is no CLI flag or env var for it; pre-seeding
+/// the JSON key is the only mechanism.
+///
+/// Known limitation (degrades gracefully to the status quo): when a user sets
+/// `CLAUDE_CONFIG_DIR` only in their interactive shell rc (e.g. `.zshrc`) and uses
+/// no TBD model profile, the daemon can't observe that value — it isn't in the
+/// daemon's own environment. The seed then lands in `~/.claude.json` while the
+/// spawned pane reads config from the shell-rc dir, so the trust prompt still
+/// appears. This is no worse than the pre-seeder behavior and is unresolvable from
+/// the daemon side, so we accept it.
+enum ClaudeTrustSeeder {
+    /// Pre-accept Claude Code's folder-trust dialog for a scratch worktree by
+    /// writing `projects["<path>"].hasTrustDialogAccepted = true` into the
+    /// effective config dir's `.claude.json`. No-op for non-scratch worktrees.
+    ///
+    /// Best-effort: never throws (logs on failure). Idempotent. Preserves all
+    /// existing top-level keys and all existing keys inside the target project
+    /// entry via read-merge-write. Leaves a malformed `.claude.json` untouched.
+    static func ensureTrustedForScratch(
+        worktree: Worktree,
+        profileConfigDir: String?,
+        homeDirectory: String = NSHomeDirectory(),
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        // THE gate: only scratch spaces get pre-seeded. Non-scratch worktrees
+        // live in real repos where the user may legitimately want the trust
+        // prompt, so we never touch their config.
+        guard worktree.isScratch else { return }
+
+        // Resolve the effective config dir the same way Claude Code does:
+        // an explicit profile config dir wins, then CLAUDE_CONFIG_DIR, then the
+        // home directory (where Claude reads `~/.claude.json` by default).
+        // Mirror `claudeProjectsRoot`'s empty-string guard so a blank profile
+        // path falls through to the env/home fallback.
+        let effectiveConfigDir: String
+        if let profileConfigDir, !profileConfigDir.isEmpty {
+            effectiveConfigDir = profileConfigDir
+        } else if let envConfigDir = environment["CLAUDE_CONFIG_DIR"], !envConfigDir.isEmpty {
+            effectiveConfigDir = envConfigDir
+        } else {
+            effectiveConfigDir = homeDirectory
+        }
+
+        let configDirURL = URL(fileURLWithPath: effectiveConfigDir, isDirectory: true)
+        let claudeJSONPath = configDirURL.appendingPathComponent(".claude.json")
+
+        // Project keys to seed. `worktree.path` is the cwd tmux launches the pane
+        // in. If the symlink-resolved form differs, seed both — harmless, and it
+        // defends against a cwd/symlink mismatch between what TBD stores and what
+        // Claude derives at runtime.
+        var projectKeys = [worktree.path]
+        let resolvedPath = URL(fileURLWithPath: worktree.path).resolvingSymlinksInPath().path
+        if resolvedPath != worktree.path {
+            projectKeys.append(resolvedPath)
+        }
+
+        let fm = FileManager.default
+
+        // Read-merge-write, preserving every existing key. If the file exists but
+        // is malformed JSON, do NOT clobber it — log and return (best-effort).
+        var topLevel: [String: Any] = [:]
+        if fm.fileExists(atPath: claudeJSONPath.path) {
+            guard let existing = try? Data(contentsOf: claudeJSONPath) else {
+                logger.warning("could not read \(claudeJSONPath.path, privacy: .public); skipping trust seed")
+                return
+            }
+            guard let parsed = try? JSONSerialization.jsonObject(with: existing) as? [String: Any] else {
+                logger.warning("malformed .claude.json at \(claudeJSONPath.path, privacy: .public); leaving untouched")
+                return
+            }
+            topLevel = parsed
+        }
+
+        // Skip the write entirely when every target key is already trusted. The
+        // early return avoids clobbering a concurrently-running ambient Claude's
+        // write to this SHARED file: our atomic rename from a slightly-stale read
+        // would drop whatever that process wrote (history, numStartups, project
+        // state) between our read and our write. Returning here collapses writes
+        // to at most once per new scratch path instead of once per spawn, keeping
+        // us within the same infrequent-writer envelope Claude's own multi-instance
+        // writes already tolerate.
+        let existingProjects = (topLevel["projects"] as? [String: Any]) ?? [:]
+        let allAlreadyTrusted = projectKeys.allSatisfy { key in
+            (existingProjects[key] as? [String: Any])?["hasTrustDialogAccepted"] as? Bool == true
+        }
+        if allAlreadyTrusted { return }
+
+        var projects = existingProjects
+        for key in projectKeys {
+            var entry = (projects[key] as? [String: Any]) ?? [:]
+            entry["hasTrustDialogAccepted"] = true
+            projects[key] = entry
+        }
+        topLevel["projects"] = projects
+
+        do {
+            try fm.createDirectory(at: configDirURL, withIntermediateDirectories: true)
+            let data = try JSONSerialization.data(
+                withJSONObject: topLevel, options: [.prettyPrinted, .sortedKeys])
+            try data.write(to: claudeJSONPath, options: [.atomic])
+            logger.debug("seeded folder-trust for scratch worktree at \(claudeJSONPath.path, privacy: .public)")
+        } catch {
+            logger.warning("failed to seed folder-trust at \(claudeJSONPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -425,6 +425,11 @@ public actor HibernationCoordinator {
             sessionKey: terminal.id.uuidString
         )
         let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
+        // Pre-accept Claude's folder-trust dialog for scratch spaces so a wake
+        // onto a fresh isolated profile dir (never seeded before) doesn't re-prompt.
+        // Self-gates on isScratch; a cheap no-op once already trusted.
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: worktree, profileConfigDir: profileConfigDir)
         // Pre-resume freshness: if the worktree was moved/promoted while this
         // session was parked, its transcript still lives under the OLD munged
         // project dir; the cwd-scoped `claude --resume` below only checks the

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -517,6 +517,11 @@ extension WorktreeLifecycle {
                     scratchInstructions: config.scratchInstructions,
                     scratchRenamePrompt: config.scratchRenamePrompt)
             let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
+            // Pre-accept Claude Code's folder-trust dialog for scratch spaces so
+            // fresh, TBD-owned scratch dirs don't prompt on every launch.
+            // Self-gates on isScratch; best-effort, never throws.
+            ClaudeTrustSeeder.ensureTrustedForScratch(
+                worktree: worktree, profileConfigDir: profileConfigDir)
             if isResume {
                 // Pre-resume freshness: `claude --resume` only looks in the
                 // project dir derived from the current cwd. If the archived
@@ -653,6 +658,10 @@ extension WorktreeLifecycle {
                 let plannedID = UUID()
                 createdTerminalIDs.append(plannedID)
                 let restoreProfileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
+                // Pre-accept the folder-trust dialog for scratch spaces so restoring
+                // an extra archived session onto a fresh profile dir doesn't re-prompt.
+                ClaudeTrustSeeder.ensureTrustedForScratch(
+                    worktree: worktree, profileConfigDir: restoreProfileConfigDir)
                 // Same pre-resume freshness sync as the primary terminal above.
                 await TranscriptProjectDirSync.ensureSessionResumableDetached(
                     sessionID: sessionID,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -277,6 +277,15 @@ extension RPCRouter {
             ? ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
             : nil
 
+        // Pre-accept Claude Code's folder-trust dialog for scratch spaces so
+        // fresh, TBD-owned scratch dirs don't prompt on every launch. Only the
+        // claude path can trigger the dialog; self-gates on isScratch and is
+        // best-effort (never throws), so seeding on both fresh and resume is safe.
+        if isClaudeType {
+            ClaudeTrustSeeder.ensureTrustedForScratch(
+                worktree: worktree, profileConfigDir: profileConfigDir)
+        }
+
         // Pre-resume freshness: `claude --resume` only looks in the project
         // dir derived from the CURRENT cwd. If this session's transcript lives
         // elsewhere (worktree moved/promoted since it was written), mirror it
@@ -1034,6 +1043,15 @@ extension RPCRouter {
             repo: repo?.envOverrides,
             profile: resolved?.envOverrides
         )
+        // Pre-accept the folder-trust dialog for scratch spaces before either
+        // swap spawn (resume or fresh) — a swap onto a new profile's isolated
+        // config dir would otherwise re-prompt. Both build calls below resolve
+        // the same `resolveConfigDir(for: resolved)`; seed it once here. This is
+        // a claude-only handler; the method self-gates on isScratch.
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: worktree,
+            profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolved))
+
         let spawn: ClaudeSpawnCommandBuilder.Result
         let storedSessionID: String
         let scheduleRecapture: Bool

--- a/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("ClaudeTrustSeeder")
+struct ClaudeTrustSeederTests {
+
+    /// A temp config dir passed as `profileConfigDir` so tests never touch the
+    /// developer's real `~/.claude.json`.
+    private func tempConfigDir() -> URL {
+        URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-trust-seed-test-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    private func makeWorktree(isScratch: Bool, path: String) -> Worktree {
+        Worktree(
+            repoID: isScratch ? nil : UUID(),
+            name: "wt",
+            displayName: "wt",
+            branch: "main",
+            path: path,
+            tmuxServer: "srv"
+        )
+    }
+
+    private func readClaudeJSON(_ configDir: URL) -> [String: Any]? {
+        let file = configDir.appendingPathComponent(".claude.json")
+        guard let data = try? Data(contentsOf: file),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return json
+    }
+
+    // MARK: - Gate ON
+
+    @Test("scratch worktree seeds hasTrustDialogAccepted=true")
+    func gateOnSeedsTrust() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: true, path: wtPath)
+
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt, profileConfigDir: configDir.path)
+
+        let json = readClaudeJSON(configDir)
+        let projects = json?["projects"] as? [String: Any]
+        let entry = projects?[wtPath] as? [String: Any]
+        #expect(entry?["hasTrustDialogAccepted"] as? Bool == true)
+    }
+
+    // MARK: - Gate OFF (required both-branches test)
+
+    @Test("non-scratch worktree writes nothing")
+    func gateOffWritesNothing() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-real-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: false, path: wtPath)
+
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt, profileConfigDir: configDir.path)
+
+        let file = configDir.appendingPathComponent(".claude.json")
+        #expect(FileManager.default.fileExists(atPath: file.path) == false)
+    }
+
+    // MARK: - Preserve top-level keys
+
+    @Test("preserves unrelated top-level keys and other project entries")
+    func preservesTopLevelKeys() throws {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let file = configDir.appendingPathComponent(".claude.json")
+
+        let existing: [String: Any] = [
+            "hasCompletedOnboarding": true,
+            "someUnrelatedKey": "keep-me",
+            "projects": [
+                "/other/project": ["hasTrustDialogAccepted": true],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: existing).write(to: file)
+
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: true, path: wtPath)
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt, profileConfigDir: configDir.path)
+
+        let json = readClaudeJSON(configDir)
+        #expect(json?["hasCompletedOnboarding"] as? Bool == true)
+        #expect(json?["someUnrelatedKey"] as? String == "keep-me")
+        let projects = json?["projects"] as? [String: Any]
+        let other = projects?["/other/project"] as? [String: Any]
+        #expect(other?["hasTrustDialogAccepted"] as? Bool == true)
+        let mine = projects?[wtPath] as? [String: Any]
+        #expect(mine?["hasTrustDialogAccepted"] as? Bool == true)
+    }
+
+    // MARK: - Preserve intra-project keys
+
+    @Test("preserves existing keys inside the target project entry")
+    func preservesIntraProjectKeys() throws {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let file = configDir.appendingPathComponent(".claude.json")
+
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let existing: [String: Any] = [
+            "projects": [
+                wtPath: ["existingKey": "survive"],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: existing).write(to: file)
+
+        let wt = makeWorktree(isScratch: true, path: wtPath)
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt, profileConfigDir: configDir.path)
+
+        let json = readClaudeJSON(configDir)
+        let projects = json?["projects"] as? [String: Any]
+        let entry = projects?[wtPath] as? [String: Any]
+        #expect(entry?["existingKey"] as? String == "survive")
+        #expect(entry?["hasTrustDialogAccepted"] as? Bool == true)
+    }
+
+    // MARK: - Idempotent
+
+    @Test("running twice produces identical valid JSON")
+    func idempotent() throws {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: true, path: wtPath)
+
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt, profileConfigDir: configDir.path)
+        let firstData = try Data(contentsOf: configDir.appendingPathComponent(".claude.json"))
+
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt, profileConfigDir: configDir.path)
+        let secondData = try Data(contentsOf: configDir.appendingPathComponent(".claude.json"))
+
+        #expect(firstData == secondData)
+        // And still valid + correct.
+        let json = readClaudeJSON(configDir)
+        let entry = (json?["projects"] as? [String: Any])?[wtPath] as? [String: Any]
+        #expect(entry?["hasTrustDialogAccepted"] as? Bool == true)
+    }
+
+    // MARK: - Malformed JSON
+
+    @Test("malformed .claude.json is left untouched and no throw")
+    func malformedJSONLeftUntouched() throws {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let file = configDir.appendingPathComponent(".claude.json")
+
+        let garbage = "{ this is not valid json ]["
+        try garbage.write(to: file, atomically: true, encoding: .utf8)
+
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: true, path: wtPath)
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt, profileConfigDir: configDir.path)
+
+        let after = try String(contentsOf: file, encoding: .utf8)
+        #expect(after == garbage)
+    }
+
+    // MARK: - Config-dir fallback branches
+
+    @Test("nil profileConfigDir falls back to environment CLAUDE_CONFIG_DIR")
+    func fallsBackToEnvConfigDir() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: true, path: wtPath)
+
+        // homeDirectory points somewhere else to prove CLAUDE_CONFIG_DIR wins.
+        let homeDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: homeDir) }
+
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt,
+            profileConfigDir: nil,
+            homeDirectory: homeDir.path,
+            environment: ["CLAUDE_CONFIG_DIR": configDir.path])
+
+        // Seeded into the env dir, NOT the home dir.
+        let entry = (readClaudeJSON(configDir)?["projects"] as? [String: Any])?[wtPath] as? [String: Any]
+        #expect(entry?["hasTrustDialogAccepted"] as? Bool == true)
+        #expect(FileManager.default.fileExists(atPath: homeDir.appendingPathComponent(".claude.json").path) == false)
+    }
+
+    @Test("nil profileConfigDir + no CLAUDE_CONFIG_DIR falls back to homeDirectory")
+    func fallsBackToHomeDirectory() {
+        // Use a temp dir as homeDirectory so the real ~/.claude.json is never touched.
+        let homeDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: homeDir) }
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: true, path: wtPath)
+
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt,
+            profileConfigDir: nil,
+            homeDirectory: homeDir.path,
+            environment: [:])
+
+        let entry = (readClaudeJSON(homeDir)?["projects"] as? [String: Any])?[wtPath] as? [String: Any]
+        #expect(entry?["hasTrustDialogAccepted"] as? Bool == true)
+    }
+
+    // MARK: - Skip-if-already-trusted (no clobbering a concurrent writer)
+
+    @Test("already-trusted key: file is not rewritten (byte-identical)")
+    func alreadyTrustedSkipsWrite() throws {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let file = configDir.appendingPathComponent(".claude.json")
+
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        // Pre-write with the trust key already true + an unrelated top-level key
+        // that a concurrent ambient Claude might own. If the seeder rewrote the
+        // file it would re-serialize (sorted keys, pretty-print), changing bytes.
+        let sentinel = "{\"concurrentWriterState\":\"do-not-clobber\","
+            + "\"projects\":{\"\(wtPath)\":{\"hasTrustDialogAccepted\":true}}}"
+        try sentinel.write(to: file, atomically: true, encoding: .utf8)
+
+        let wt = makeWorktree(isScratch: true, path: wtPath)
+        ClaudeTrustSeeder.ensureTrustedForScratch(
+            worktree: wt, profileConfigDir: configDir.path)
+
+        let after = try String(contentsOf: file, encoding: .utf8)
+        #expect(after == sentinel)
+    }
+}


### PR DESCRIPTION
## Summary
- Scratch spaces are fresh, TBD-owned, empty directories, so Claude Code's per-directory **"Do you trust the files in this folder?"** dialog fires on every launch — with no security value, since TBD created the directory.
- The existing `--dangerously-skip-permissions` flag (already passed at spawn) does **not** suppress this dialog — it's a separate gate. There is no CLI flag or env var for it; the only mechanism is pre-seeding `projects["<path>"].hasTrustDialogAccepted = true` in `<CLAUDE_CONFIG_DIR>/.claude.json`.
- Adds `ClaudeTrustSeeder` — a best-effort, self-gating (`isScratch`), idempotent read-merge-write that preserves all existing keys — and wires it into **all six** claude spawn sites (fresh create, terminal create, restore, profile-swap resume/fresh, wake).

## Details
- **Config-dir resolution** mirrors Claude Code: explicit profile `CLAUDE_CONFIG_DIR` wins, then `CLAUDE_CONFIG_DIR` from env, then `~/.claude.json`.
- **Skip-if-already-trusted early return** collapses writes to at most once per new scratch path (not once per spawn), avoiding clobbering a concurrently-running ambient Claude's write to the shared `~/.claude.json`.
- **Preserves** all existing top-level and intra-project keys; leaves a malformed `.claude.json` untouched (best-effort, never throws, `os.Logger` only).
- **Known limitation (graceful):** if a user sets `CLAUDE_CONFIG_DIR` *only* in their interactive shell rc and uses no TBD profile, the daemon can't observe that value, so the seed lands in `~/.claude.json` while the pane reads elsewhere and the prompt still appears — no worse than today. Documented in the seeder.

## Test plan
- [x] `swift build` clean
- [x] `ClaudeTrustSeeder` unit tests (9): gate on/off, preserve top-level keys, preserve intra-project keys, idempotent, malformed-JSON-untouched, `CLAUDE_CONFIG_DIR`-env fallback, home-dir fallback, already-trusted byte-identical skip
- [x] Spawn-path regression suites pass (`ModelProfileSpawn`, `RPCRouterConfigScratch`, `Hibernation`/`Wake`/`WorktreeLifecycle`)
- [x] `swiftlint --strict` on changed files — no `print()`, no violations
- [ ] Manual: create a scratch space, open a Claude tab — no trust prompt; open a second tab and a promoted/profile-swapped session — still no prompt

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=BBA25E08-3CCD-439A-8555-9652150EABE2)