### PR TITLE
feat: auto-continue after transient API errors (connection closed, 5xx, transient 429)

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -38,6 +38,9 @@ extension AppState {
             if result.autoResumeOnLimitReset != autoResumeOnLimitReset {
                 autoResumeOnLimitReset = result.autoResumeOnLimitReset
             }
+            if result.autoResumeOnApiError != autoResumeOnApiError {
+                autoResumeOnApiError = result.autoResumeOnApiError
+            }
         } catch {
             logger.error("Failed to list model profiles: \(error, privacy: .public)")
             handleConnectionError(error)
@@ -182,6 +185,17 @@ extension AppState {
             autoResumeOnLimitReset = enabled
         } catch {
             logger.error("Failed to set auto-resume gate: \(error, privacy: .public)")
+            showAlert("Failed to set auto-resume: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set the global transient-API-error auto-continue gate.
+    func setAutoResumeOnApiError(_ enabled: Bool) async {
+        do {
+            try await daemonClient.setAutoResumeOnApiError(enabled)
+            autoResumeOnApiError = enabled
+        } catch {
+            logger.error("Failed to set auto-resume-on-API-error gate: \(error, privacy: .public)")
             showAlert("Failed to set auto-resume: \(error.localizedDescription)", isError: true)
         }
     }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -424,6 +424,10 @@ final class AppState: ObservableObject {
     /// Daemon-side (not @AppStorage) because the daemon must act while the
     /// app is closed.
     @Published var autoResumeOnLimitReset: Bool = false
+    /// Daemon-persisted gate for transient-API-error auto-continue (default
+    /// OFF). Daemon-side (not @AppStorage) because the daemon must act while
+    /// the app is closed.
+    @Published var autoResumeOnApiError: Bool = false
     /// Terminals where the user has dismissed the proxy-unreachable banner.
     /// Cleared on app relaunch (in-memory only — banners are advisory).
     @Published var dismissedProxyWarnings: Set<UUID> = []

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -778,6 +778,14 @@ actor DaemonClient {
         )
     }
 
+    /// Set the global transient-API-error auto-continue gate.
+    func setAutoResumeOnApiError(_ enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetAutoResumeOnApiError,
+            params: ConfigSetAutoResumeOnApiErrorParams(enabled: enabled)
+        )
+    }
+
     /// Set the global scratch-space system-prompt override. Nil or blank resets to the built-in default.
     func setScratchInstructions(_ instructions: String?) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -149,6 +149,12 @@ struct GeneralSettingsTab: View {
                     set: { newValue in Task { await appState.setAutoResumeOnLimitReset(newValue) } }
                 ))
                 .help("When a session hits the usage limit, TBD schedules a resume for the reset time and types \"continue\" into the pane. Off by default; detection and notifications run regardless.")
+                Toggle("Auto-continue after transient API errors",
+                       isOn: Binding(
+                    get: { appState.autoResumeOnApiError },
+                    set: { newValue in Task { await appState.setAutoResumeOnApiError(newValue) } }
+                ))
+                .help("When a turn dies on a transient API error (connection drop, server error, overload), TBD types \"continue\" after a backoff (60s, 2m, 5m, 10m) and gives up after 4 straight failures. Off by default. Auth and billing errors are never retried.")
                 Toggle("Show usage tooltip on Claude tabs", isOn: $showClaudeTabUsageTooltip)
                     .help("Show a hover card on Claude tabs with the session's account, profile, 5h/weekly usage, and spawn time.")
             }

--- a/Sources/TBDCLI/Commands/FakeRateLimitCommand.swift
+++ b/Sources/TBDCLI/Commands/FakeRateLimitCommand.swift
@@ -21,6 +21,11 @@ struct FakeRateLimitCommand: AsyncParsableCommand {
     @Option(name: .long, help: "Terminal ID (defaults to TBD_TERMINAL_ID)")
     var terminal: String?
 
+    @Flag(
+        name: .long,
+        help: "Fabricate a transient API error instead of a usage limit (--resets-in is ignored — the daemon owns the retry delay)")
+    var apiError = false
+
     mutating func run() async throws {
         let idString = terminal
             ?? ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"]
@@ -33,6 +38,19 @@ struct FakeRateLimitCommand: AsyncParsableCommand {
             print("fake-rate-limit: daemon is not running")
             return
         }
+
+        if apiError {
+            let result = try client.call(
+                method: RPCMethod.claudeTransientApiErrorDetected,
+                params: TransientApiErrorDetectedParams(
+                    terminalID: terminalID,
+                    errorClass: "debug",
+                    rawMessage: "debug: fake transient API error"),
+                resultType: TransientApiErrorDetectedResult.self)
+            print("fake-rate-limit: transient API error reported; handled=\(result.handled)")
+            return
+        }
+
         let resetsAt = Date().addingTimeInterval(TimeInterval(resetsIn))
         try client.callVoid(
             method: RPCMethod.claudeRateLimitDetected,

--- a/Sources/TBDCLI/Commands/StopFailureCommand.swift
+++ b/Sources/TBDCLI/Commands/StopFailureCommand.swift
@@ -29,6 +29,9 @@ struct StopFailureCommand: AsyncParsableCommand {
         if let detected = outcome.detectedLimit, reportToDaemon(detected) {
             return  // daemon owns the limit_reached notification
         }
+        if let transient = outcome.detectedTransient, reportTransientToDaemon(transient) {
+            return  // daemon owns messaging (scheduled / gave-up / latch)
+        }
         if let message = outcome.message {
             print(message)
         }
@@ -56,6 +59,33 @@ struct StopFailureCommand: AsyncParsableCommand {
             return false
         }
     }
+
+    /// Fire the transientApiErrorDetected RPC. Returns the daemon's
+    /// `handled` flag: `true` means the daemon owns user messaging (scheduled
+    /// a retry / gave up / latch-silenced) so the CLI prints nothing; `false`
+    /// (toggle off or unknown terminal) falls through to the legacy print.
+    /// Mirrors `reportToDaemon`: silent on every failure — the hook must never
+    /// wedge Claude.
+    private func reportTransientToDaemon(_ detected: DetectedTransientError) -> Bool {
+        guard let terminalIDString = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+              let terminalID = UUID(uuidString: terminalIDString) else {
+            return false
+        }
+        let client = SocketClient()
+        guard client.isDaemonRunning else { return false }
+        do {
+            let result = try client.call(
+                method: RPCMethod.claudeTransientApiErrorDetected,
+                params: TransientApiErrorDetectedParams(
+                    terminalID: terminalID,
+                    errorClass: detected.errorClass,
+                    rawMessage: detected.rawMessage),
+                resultType: TransientApiErrorDetectedResult.self)
+            return result.handled
+        } catch {
+            return false
+        }
+    }
 }
 
 // MARK: - Pure core (testable)
@@ -67,6 +97,21 @@ enum StopFailureMessage {
         let message: String?
         /// Non-nil when the transcript's last API error is a schedulable hard limit.
         let detectedLimit: DetectedRateLimit?
+        /// Non-nil when the last API error is an allowlisted transient (5xx /
+        /// overloaded / network blip) the daemon may auto-retry. Mutually
+        /// exclusive with `detectedLimit` (hard limits always win). Defaulted so
+        /// existing construction sites (and their tests) stay untouched.
+        let detectedTransient: DetectedTransientError?
+
+        init(
+            message: String?,
+            detectedLimit: DetectedRateLimit?,
+            detectedTransient: DetectedTransientError? = nil
+        ) {
+            self.message = message
+            self.detectedLimit = detectedLimit
+            self.detectedTransient = detectedTransient
+        }
     }
 
     /// Pure detection + message construction; every branch unit-testable.
@@ -124,7 +169,10 @@ enum StopFailureMessage {
         let errorType = (payload["error"] as? String) ?? (payload["error_type"] as? String) ?? "unknown"
         let fallback = "Claude stopped: API error (\(errorType))"
 
-        // Payload-first: race-free, never touches the transcript file.
+        // Payload-first hard-limit: race-free, never touches the transcript
+        // file. Hard limits ALWAYS take precedence over transient errors, so
+        // this loop runs to completion over both keys before the transient
+        // loop below even starts.
         for key in ["last_assistant_message", "error_details"] {
             if let candidate = payload[key] as? String,
                let detected = RateLimitDetection.detect(messageText: candidate, now: now, timeZone: timeZone) {
@@ -132,8 +180,29 @@ enum StopFailureMessage {
             }
         }
 
-        guard let transcriptPath = payload["transcript_path"] as? String else {
+        // Payload-first transient: same keys, still race-free. Only reached when
+        // no key was a hard limit.
+        for key in ["last_assistant_message", "error_details"] {
+            if let candidate = payload[key] as? String,
+               let transient = TransientErrorDetection.detect(messageText: candidate, errorField: errorType) {
+                return Outcome(message: transient.rawMessage, detectedLimit: nil, detectedTransient: transient)
+            }
+        }
+
+        // Shared errorField-only transient backstop: when no usable text is
+        // available (no transcript path, or the transcript never yields a
+        // recent record), a `server_error` error field alone still counts as a
+        // transient — Claude Code sometimes omits display text for that class.
+        // Miss → the unchanged legacy fallback outcome.
+        func transientFallbackOutcome() -> Outcome {
+            if let transient = TransientErrorDetection.detect(messageText: nil, errorField: errorType) {
+                return Outcome(message: fallback, detectedLimit: nil, detectedTransient: transient)
+            }
             return Outcome(message: fallback, detectedLimit: nil)
+        }
+
+        guard let transcriptPath = payload["transcript_path"] as? String else {
+            return transientFallbackOutcome()
         }
 
         // Recency floor for the transcript-append race: the StopFailure hook
@@ -156,18 +225,31 @@ enum StopFailureMessage {
         }
 
         guard let data else {
-            return Outcome(message: fallback, detectedLimit: nil)
+            return transientFallbackOutcome()
         }
 
-        // Single scan: derive both the detected limit and the display
-        // message from the SAME floor-gated record — one parse of `data`
-        // instead of two independent full-file scans for the same result.
+        // Single scan: derive the detected limit, the display message, AND the
+        // record's `error` field from the SAME floor-gated record — one parse
+        // of `data` instead of independent full-file scans for the same result.
         guard let scan = RateLimitDetection.detectWithText(
             transcriptData: data, now: now, timeZone: timeZone, newerThan: recencyFloor
         ) else {
-            return Outcome(message: fallback, detectedLimit: nil)
+            return transientFallbackOutcome()
         }
-        return Outcome(message: scan.text ?? fallback, detectedLimit: scan.detectedLimit)
+
+        // Hard limit always wins.
+        if let detectedLimit = scan.detectedLimit {
+            return Outcome(message: scan.text ?? fallback, detectedLimit: detectedLimit)
+        }
+        // Else classify the scanned record as a transient, keying off the
+        // record's own `error` field (falling back to the payload `errorType`).
+        if let transient = TransientErrorDetection.detect(
+            messageText: scan.text, errorField: scan.errorClass ?? errorType
+        ) {
+            return Outcome(message: scan.text ?? fallback, detectedLimit: nil, detectedTransient: transient)
+        }
+        // Neither limit nor transient — today's plain notify-only shape.
+        return Outcome(message: scan.text ?? fallback, detectedLimit: nil)
     }
 
     /// Legacy entry point — existing tests exercise this shape.

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -159,18 +159,20 @@ public struct LimitResumeActuator: LimitResumeActuating {
     /// alive → user-already-continued → Claude foreground → copy-mode.
     /// Foreground is checked before copy-mode so a dead/backgrounded shell
     /// classifies `.failed` rather than endlessly rescheduling on a stale
-    /// copy-mode flag. Two additional checks (0a global toggle, 1b row
+    /// copy-mode flag. Two additional checks (0a the row's own limitType-aware toggle, 1b row
     /// status) run on every pass too — they aren't in the spec's numbered
     /// list but close the same "state changed during a prior attempt's ~20s
     /// verify window" gap the spec's steps 1-4 already cover for the other
     /// cancellation reasons.
     private func checkEligibility(_ resume: ScheduledResume) async -> EligibilityCheckResult {
-        // 0a. Toggle-off-mid-flight: the global gate can be switched off
-        //     while a prior attempt's ~20s verify window is running. This
-        //     check runs on EVERY call to `checkEligibility` (the initial
-        //     pass and every attempt>1 re-check in `actuate`), so attempt 2
-        //     never fires after the user turns auto-resume off mid-flight.
-        guard (try? await db.config.get())?.autoResumeOnLimitReset ?? false else {
+        // 0a. Toggle-off-mid-flight: the row's own gate — autoResumeOnApiError
+        //     for api_error rows, autoResumeOnLimitReset for everything else
+        //     (spec 2026-07-08 §Gating) — can be switched off while a prior
+        //     attempt's ~20s verify window is running. This check runs on
+        //     EVERY call to `checkEligibility` (the initial pass and every
+        //     attempt>1 re-check in `actuate`), so attempt 2 never fires
+        //     after the user turns the row's gate off mid-flight.
+        guard ((try? await db.config.get())?.autoResumeEnabled(forLimitType: resume.limitType)) ?? false else {
             return .notEligible(.cancelledExternally)
         }
 

--- a/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
@@ -159,6 +159,37 @@ public actor LimitResumeScheduler {
         return inserted
     }
 
+    /// Insert a pending api_error row firing at now + delay. NO slack/jitter
+    /// — `slack`/`jitterProvider` above defend against N panes independently
+    /// waking at the SAME shared reset second (a hard usage-limit reset is a
+    /// clock-time coincidence across terminals); a transient API error has
+    /// no such shared instant — each terminal's failures are already
+    /// scattered in time — and `TransientResumeBackoff`'s ladder already
+    /// diverges repeat offenders from one-off blips, so adding jitter on top
+    /// would only blur the backoff steps without buying anything (spec
+    /// 2026-07-08 §Backoff). Same double-send latch as `schedule` via
+    /// `store.insertPending`.
+    public func scheduleTransient(
+        terminalID: UUID, worktreeID: UUID, claudeSessionID: String?,
+        delay: TimeInterval, rawMessage: String
+    ) async -> ScheduledResume? {
+        let now = clock.now()
+        let fireAt = now.addingTimeInterval(delay)
+        let row = ScheduledResume(
+            terminalID: terminalID, worktreeID: worktreeID,
+            claudeSessionID: claudeSessionID,
+            resetsAt: fireAt, fireAt: fireAt,
+            limitType: ScheduledResume.apiErrorLimitType, rawMessage: rawMessage,
+            createdAt: now)
+        guard let inserted = try? await store.insertPending(row) else {
+            logger.info("scheduleTransient: no pending row created for terminal \(terminalID.uuidString, privacy: .public) (latch or store error)")
+            return nil
+        }
+        logger.info("scheduleTransient: resume for terminal \(terminalID.uuidString, privacy: .public) at \(fireAt.description, privacy: .public) (delay \(delay, privacy: .public)s)")
+        wake()
+        return inserted
+    }
+
     // MARK: - Loop
 
     private func runLoop() async {
@@ -220,7 +251,10 @@ public actor LimitResumeScheduler {
 
         // Belt-and-braces gate check: toggle-off should already have
         // cancelled pending rows; if one slipped through, cancel silently.
-        let enabled = (try? await config.get())?.autoResumeOnLimitReset ?? false
+        // The row's own limitType picks which toggle governs it — api_error
+        // rows follow autoResumeOnApiError, everything else follows
+        // autoResumeOnLimitReset (spec 2026-07-08 §Gating).
+        let enabled = ((try? await config.get())?.autoResumeEnabled(forLimitType: row.limitType)) ?? false
         guard enabled else {
             if await setStatusWithRetry(id: row.id, status: .cancelled, terminalID: row.terminalID, context: "toggle-off") {
                 inFlightOrFired.remove(row.id)

--- a/Sources/TBDDaemon/Claude/TransientResumeBackoff.swift
+++ b/Sources/TBDDaemon/Claude/TransientResumeBackoff.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// Backoff ladder for transient API-error auto-continue (spec
+/// 2026-07-08 §Backoff). A transient API error (5xx, overloaded, network
+/// blip) is not a hard usage limit — Claude can often just be re-poked —
+/// but repeatedly failing the same way within a short window signals
+/// something more persistent, so each consecutive failure widens the delay
+/// until the ladder gives up and leaves the row for a human.
+public enum TransientResumeBackoff {
+
+    /// Delay (seconds) for the 1st, 2nd, 3rd, 4th consecutive attempt.
+    public static let steps: [TimeInterval] = [60, 120, 300, 600]
+
+    /// Once this many consecutive attempts have landed within `lookback`,
+    /// stop retrying — `delay(consecutiveAttempts:)` returns nil.
+    public static let maxAttempts = 4
+
+    /// Window `countRecentApiErrorAttempts` looks back over to count
+    /// "consecutive" attempts — resets the ladder once a terminal has gone
+    /// this long without a transient error.
+    public static let lookback: TimeInterval = 30 * 60
+
+    /// Delay for the NEXT attempt given how many consecutive attempts the
+    /// lookback window already holds. nil == give up (cap reached).
+    public static func delay(consecutiveAttempts: Int) -> TimeInterval? {
+        guard consecutiveAttempts >= 0, consecutiveAttempts < maxAttempts else { return nil }
+        return steps[consecutiveAttempts]
+    }
+
+    /// Notification copy: 60 -> "60s", 120 -> "2m", 300 -> "5m", 600 -> "10m".
+    public static func copy(forDelay delay: TimeInterval) -> String {
+        if delay < 120 {
+            return "\(Int(delay))s"
+        }
+        return "\(Int(delay / 60))m"
+    }
+}

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -616,9 +616,13 @@ public final class Daemon: Sendable {
                             (type, message) = (.limitReached, "Auto-resumed Claude after the limit reset")
                         }
                     case .failed(let reason):
-                        let noun = resume.limitType == ScheduledResume.apiErrorLimitType ? "Auto-continue" : "Auto-resume"
-                        (type, message) = (.attentionNeeded,
-                            "\(noun) failed — \(reason). Claude may still be parked.")
+                        if resume.limitType == ScheduledResume.apiErrorLimitType {
+                            (type, message) = (.attentionNeeded,
+                                "Auto-continue failed — \(reason). Claude may still be stopped on an API error.")
+                        } else {
+                            (type, message) = (.attentionNeeded,
+                                "Auto-resume failed — \(reason). Claude may still be parked at the limit screen.")
+                        }
                     }
                     guard let notification = try? await database.notifications.create(
                         worktreeID: resume.worktreeID, type: type,

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -610,10 +610,15 @@ public final class Daemon: Sendable {
                     let (type, message): (NotificationType, String)
                     switch outcome {
                     case .sent:
-                        (type, message) = (.limitReached, "Auto-resumed Claude after the limit reset")
+                        if resume.limitType == ScheduledResume.apiErrorLimitType {
+                            (type, message) = (.limitReached, "Auto-continued Claude after a transient API error")
+                        } else {
+                            (type, message) = (.limitReached, "Auto-resumed Claude after the limit reset")
+                        }
                     case .failed(let reason):
+                        let noun = resume.limitType == ScheduledResume.apiErrorLimitType ? "Auto-continue" : "Auto-resume"
                         (type, message) = (.attentionNeeded,
-                            "Auto-resume failed — \(reason). Claude may still be parked at the limit screen.")
+                            "\(noun) failed — \(reason). Claude may still be parked.")
                     }
                     guard let notification = try? await database.notifications.create(
                         worktreeID: resume.worktreeID, type: type,

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -26,6 +26,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var auto_hibernate_enabled: Bool?
     var hibernate_idle_minutes: Int?
     var control_mode_enabled: Bool?
+    var auto_resume_on_api_error: Bool?
 
     func toModel() -> Config {
         Config(
@@ -43,7 +44,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
                 .flatMap(NightwatchMode.init(rawValue:)) ?? .off,
             autoHibernateEnabled: auto_hibernate_enabled ?? true,
             hibernateIdleMinutes: hibernate_idle_minutes ?? Config.defaultHibernateIdleMinutes,
-            controlModeEnabled: control_mode_enabled ?? false
+            controlModeEnabled: control_mode_enabled ?? false,
+            autoResumeOnApiError: auto_resume_on_api_error ?? false
         )
     }
 }
@@ -137,6 +139,16 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET auto_resume_on_limit_reset = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the transient API-error auto-resume gate (default OFF).
+    public func setAutoResumeOnApiError(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_resume_on_api_error = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -796,6 +796,14 @@ public final class TBDDatabase: Sendable {
                 type: .boolean, defaults: false)
         }
 
+        // `config.auto_resume_on_api_error` gates transient API-error auto-continue
+        // (spec 2026-07-08, default OFF) — sibling of auto_resume_on_limit_reset.
+        migrator.registerMigration("v46_auto_resume_api_error") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "auto_resume_on_api_error",
+                type: .boolean, defaults: false)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
+++ b/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
@@ -49,6 +49,13 @@ struct ScheduledResumeRecord: Codable, FetchableRecord, PersistableRecord, Senda
     }
 }
 
+/// Which pending rows a bulk cancel targets (toggle-off scoping, spec §Cancellation).
+public enum ResumeCancelScope: Sendable {
+    case all
+    case apiErrorOnly     // limitType == ScheduledResume.apiErrorLimitType
+    case limitOnly        // limitType != ScheduledResume.apiErrorLimitType
+}
+
 /// CRUD for scheduled session-limit resumes. The single `pending` row per
 /// terminal is the double-send latch (spec §State); every transition that
 /// creates/moves/ends a pending row also syncs `terminal.pendingResumeAt`
@@ -191,13 +198,21 @@ public struct ScheduledResumeStore: Sendable {
         }
     }
 
-    /// Cancel every pending row (global toggle switched off). Returns count.
+    /// Cancel pending rows matching `scope` (global toggle switched off). Returns count.
     @discardableResult
-    public func cancelAllPending() async throws -> Int {
+    public func cancelAllPending(scope: ResumeCancelScope = .all) async throws -> Int {
         try await writer.write { db in
-            let records = try ScheduledResumeRecord
+            var query = ScheduledResumeRecord
                 .filter(Column("status") == ScheduledResumeStatus.pending.rawValue)
-                .fetchAll(db)
+            switch scope {
+            case .all:
+                break
+            case .apiErrorOnly:
+                query = query.filter(Column("limitType") == ScheduledResume.apiErrorLimitType)
+            case .limitOnly:
+                query = query.filter(Column("limitType") != ScheduledResume.apiErrorLimitType)
+            }
+            let records = try query.fetchAll(db)
             for var record in records {
                 record.status = ScheduledResumeStatus.cancelled.rawValue
                 try record.update(db)
@@ -206,6 +221,22 @@ public struct ScheduledResumeStore: Sendable {
                     arguments: [record.terminalID])
             }
             return records.count
+        }
+    }
+
+    /// Count `sent`/`failed` attempts for a terminal's api-error-classified
+    /// resumes since a cutoff — the consecutive-attempt gate (spec
+    /// §Backoff). Pending/cancelled rows are never attempts: a still-armed
+    /// or user-cancelled row hasn't fired yet.
+    public func countRecentApiErrorAttempts(terminalID: UUID, since: Date) async throws -> Int {
+        try await writer.read { db in
+            try ScheduledResumeRecord
+                .filter(Column("terminalID") == terminalID.uuidString)
+                .filter(Column("limitType") == ScheduledResume.apiErrorLimitType)
+                .filter([ScheduledResumeStatus.sent.rawValue, ScheduledResumeStatus.failed.rawValue]
+                    .contains(Column("status")))
+                .filter(Column("createdAt") > since)
+                .fetchCount(db)
         }
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -15,17 +15,36 @@ extension RPCRouter {
         return .ok()
     }
 
-    /// Persist the session-limit auto-resume gate. Turning it OFF cancels
-    /// every pending scheduled resume (spec §Cancellation) and wakes the
-    /// scheduler so its in-flight sleep re-evaluates.
+    /// Persist the session-limit auto-resume gate. Turning it OFF cancels only
+    /// the session-limit pending resumes (`.limitOnly` scope) — the transient
+    /// API-error toggle owns its own rows (spec: each toggle cancels only its
+    /// own scope) — and wakes the scheduler so its in-flight sleep re-evaluates.
     func handleConfigSetAutoResumeOnLimitReset(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ConfigSetAutoResumeOnLimitResetParams.self, from: paramsData)
         if !params.enabled {
             // Cancel before persisting the off-state so a cancel failure can never
             // leave the gate off with live pending rows, violating the feature invariant.
-            _ = try await db.scheduledResumes.cancelAllPending()
+            _ = try await db.scheduledResumes.cancelAllPending(scope: .limitOnly)
         }
         try await db.config.setAutoResumeOnLimitReset(params.enabled)
+        await limitResumeScheduler?.wake()
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
+    /// Persist the transient-API-error auto-continue gate. Turning it OFF
+    /// cancels only the `api_error`-scoped pending resumes (`.apiErrorOnly`) —
+    /// session-limit rows are left to their own toggle (spec: each toggle
+    /// cancels only its own scope) — and wakes the scheduler.
+    func handleConfigSetAutoResumeOnApiError(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetAutoResumeOnApiErrorParams.self, from: paramsData)
+        if !params.enabled {
+            // Cancel before persisting the off-state so a cancel failure can never
+            // leave the gate off with live pending rows, violating the feature invariant.
+            _ = try await db.scheduledResumes.cancelAllPending(scope: .apiErrorOnly)
+        }
+        try await db.config.setAutoResumeOnApiError(params.enabled)
         await limitResumeScheduler?.wake()
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -58,7 +58,8 @@ extension RPCRouter {
             globalEnvOverrides: config.envOverrides,
             autoArchiveOnMergeDefault: config.autoArchiveOnMergeDefault,
             nightwatchMode: config.nightwatchMode,
-            autoResumeOnLimitReset: config.autoResumeOnLimitReset
+            autoResumeOnLimitReset: config.autoResumeOnLimitReset,
+            autoResumeOnApiError: config.autoResumeOnApiError
         ))
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+RateLimitHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RateLimitHandlers.swift
@@ -52,14 +52,56 @@ extension RPCRouter {
             message = "Session limit hit — resets \(ResumeTimeFormatter.string(from: params.resetsAt))"
         }
 
+        try await notify(terminal: terminal, type: .limitReached, message: message)
+        return .ok()
+    }
+
+    /// A transient API error killed a turn (spec 2026-07-08). Gate OFF → not
+    /// handled: the CLI keeps its legacy error print, behavior unchanged.
+    /// Gate ON → schedule an auto-continue with backoff, or give up past the
+    /// cap. `handled` tells the CLI whether the daemon owns user messaging.
+    func handleTransientApiErrorDetected(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TransientApiErrorDetectedParams.self, from: paramsData)
+        guard let terminal = try await db.terminals.get(id: params.terminalID) else {
+            logger.debug("transientApiErrorDetected: unknown terminal \(params.terminalID.uuidString, privacy: .public) — ignoring")
+            return try RPCResponse(result: TransientApiErrorDetectedResult(handled: false))
+        }
+        let enabled = (try? await db.config.get())?.autoResumeOnApiError ?? false
+        guard enabled, let scheduler = limitResumeScheduler else {
+            return try RPCResponse(result: TransientApiErrorDetectedResult(handled: false))
+        }
+
+        let attempts = (try? await db.scheduledResumes.countRecentApiErrorAttempts(
+            terminalID: terminal.id,
+            since: Date().addingTimeInterval(-TransientResumeBackoff.lookback))) ?? 0
+
+        guard let delay = TransientResumeBackoff.delay(consecutiveAttempts: attempts) else {
+            try await notify(terminal: terminal, type: .attentionNeeded,
+                message: "Auto-continue gave up after \(TransientResumeBackoff.maxAttempts) attempts — \(params.rawMessage)")
+            return try RPCResponse(result: TransientApiErrorDetectedResult(handled: true))
+        }
+        guard let _ = await scheduler.scheduleTransient(
+            terminalID: terminal.id, worktreeID: terminal.worktreeID,
+            claudeSessionID: terminal.claudeSessionID,
+            delay: delay, rawMessage: params.rawMessage)
+        else {
+            return try RPCResponse(result: TransientApiErrorDetectedResult(handled: true)) // latch: no duplicate notification
+        }
+        try await notify(terminal: terminal, type: .error,
+            message: "\(params.rawMessage) — auto-continue in \(TransientResumeBackoff.copy(forDelay: delay)) (attempt \(attempts + 1)/\(TransientResumeBackoff.maxAttempts))")
+        return try RPCResponse(result: TransientApiErrorDetectedResult(handled: true))
+    }
+
+    /// Create a notification and broadcast its delta — the create+broadcast
+    /// block shared by the rate-limit and transient-API-error handlers.
+    private func notify(terminal: Terminal, type: NotificationType, message: String) async throws {
         let notification = try await db.notifications.create(
-            worktreeID: terminal.worktreeID, type: .limitReached,
+            worktreeID: terminal.worktreeID, type: type,
             message: message, terminalID: terminal.id)
         subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
             notificationID: notification.id, worktreeID: notification.worktreeID,
             type: notification.type, message: notification.message,
             terminalID: notification.terminalID)))
-        return .ok()
     }
 
     /// Explicit user cancel ("Cancel scheduled resume" context-menu item).

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -212,6 +212,8 @@ public final class RPCRouter: Sendable {
                 return try await handleSetClaudeSpawnPreferences(request.paramsData)
             case RPCMethod.claudeRateLimitDetected:
                 return try await handleRateLimitDetected(request.paramsData)
+            case RPCMethod.claudeTransientApiErrorDetected:
+                return try await handleTransientApiErrorDetected(request.paramsData)
             case RPCMethod.terminalCancelScheduledResume:
                 return try await handleCancelScheduledResume(request.paramsData)
             case RPCMethod.attachRequest:
@@ -323,6 +325,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetAutoArchiveDefault(request.paramsData)
             case RPCMethod.configSetAutoResumeOnLimitReset:
                 return try await handleConfigSetAutoResumeOnLimitReset(request.paramsData)
+            case RPCMethod.configSetAutoResumeOnApiError:
+                return try await handleConfigSetAutoResumeOnApiError(request.paramsData)
             case RPCMethod.configSetScratchInstructions:
                 return try await handleConfigSetScratchInstructions(request.paramsData)
             case RPCMethod.configSetScratchRenamePrompt:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -692,6 +692,11 @@ public struct Config: Codable, Sendable, Equatable {
     /// gate is `env || flag` (a truthy `TBD_TMUX_CONTROL_MODE` is the
     /// developer override) AND tmux >= 3.2; applies to newly created panes.
     public var controlModeEnabled: Bool
+    /// Global gate for transient-API-error auto-resume (spec 2026-07-08).
+    /// Sibling of `autoResumeOnLimitReset` but governs `ScheduledResume` rows
+    /// classified as `ScheduledResume.apiErrorLimitType` rather than a hard
+    /// usage-limit hit. Default OFF.
+    public var autoResumeOnApiError: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -708,7 +713,8 @@ public struct Config: Codable, Sendable, Equatable {
                 nightwatchMode: NightwatchMode = .off,
                 autoHibernateEnabled: Bool = true,
                 hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes,
-                controlModeEnabled: Bool = false) {
+                controlModeEnabled: Bool = false,
+                autoResumeOnApiError: Bool = false) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -722,6 +728,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.autoHibernateEnabled = autoHibernateEnabled
         self.hibernateIdleMinutes = hibernateIdleMinutes
         self.controlModeEnabled = controlModeEnabled
+        self.autoResumeOnApiError = autoResumeOnApiError
     }
 
     public init(from decoder: Decoder) throws {
@@ -749,6 +756,17 @@ public struct Config: Codable, Sendable, Equatable {
             ?? Config.defaultHibernateIdleMinutes
         controlModeEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .controlModeEnabled) ?? false
+        autoResumeOnApiError = try c.decodeIfPresent(
+            Bool.self, forKey: .autoResumeOnApiError) ?? false
+    }
+}
+
+public extension Config {
+    /// Which auto-resume gate governs a `scheduled_resumes` row: the
+    /// transient-API-error gate for `ScheduledResume.apiErrorLimitType` rows,
+    /// or the hard usage-limit gate for everything else (session/debug/weekly).
+    func autoResumeEnabled(forLimitType limitType: String) -> Bool {
+        limitType == ScheduledResume.apiErrorLimitType ? autoResumeOnApiError : autoResumeOnLimitReset
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -796,6 +796,13 @@ public struct ScheduledResume: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
+extension ScheduledResume {
+    /// `limitType` sentinel for rows scheduled from a transient API-error
+    /// classification (as opposed to a hard usage-limit hit) — distinguishes
+    /// the two in the scheduler/actuator's gating logic.
+    public static let apiErrorLimitType = "api_error"
+}
+
 public struct Note: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var worktreeID: UUID

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -105,6 +105,7 @@ public enum RPCMethod {
     public static let cleanup = "cleanup"
     public static let claudeSetSpawnPreferences = "claude.setSpawnPreferences"
     public static let claudeRateLimitDetected = "claude.rateLimitDetected"
+    public static let claudeTransientApiErrorDetected = "claude.transientApiErrorDetected"
     public static let terminalSuspend = "terminal.suspend"
     public static let terminalResume = "terminal.resume"
     public static let worktreeSuspend = "worktree.suspend"
@@ -166,6 +167,7 @@ public enum RPCMethod {
     public static let configGet = "config.get"
     public static let configSetAutoArchiveOnMergeDefault = "config.setAutoArchiveOnMergeDefault"
     public static let configSetAutoResumeOnLimitReset = "config.setAutoResumeOnLimitReset"
+    public static let configSetAutoResumeOnApiError = "config.setAutoResumeOnApiError"
     public static let configSetScratchInstructions = "config.setScratchInstructions"
     public static let configSetScratchRenamePrompt = "config.setScratchRenamePrompt"
     public static let configSetScratchProfileOverride = "config.setScratchProfileOverride"
@@ -500,6 +502,7 @@ public struct ModelProfileListResult: Codable, Sendable {
     public let autoArchiveOnMergeDefault: Bool
     public let nightwatchMode: NightwatchMode
     public let autoResumeOnLimitReset: Bool
+    public let autoResumeOnApiError: Bool
     public init(
         profiles: [ModelProfileWithUsage],
         defaultID: UUID? = nil,
@@ -507,7 +510,8 @@ public struct ModelProfileListResult: Codable, Sendable {
         globalEnvOverrides: [String: String] = [:],
         autoArchiveOnMergeDefault: Bool = false,
         nightwatchMode: NightwatchMode = .off,
-        autoResumeOnLimitReset: Bool = false
+        autoResumeOnLimitReset: Bool = false,
+        autoResumeOnApiError: Bool = false
     ) {
         self.profiles = profiles
         self.defaultID = defaultID
@@ -516,6 +520,7 @@ public struct ModelProfileListResult: Codable, Sendable {
         self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
         self.nightwatchMode = nightwatchMode
         self.autoResumeOnLimitReset = autoResumeOnLimitReset
+        self.autoResumeOnApiError = autoResumeOnApiError
     }
 
     public init(from decoder: Decoder) throws {
@@ -536,6 +541,8 @@ public struct ModelProfileListResult: Codable, Sendable {
             NightwatchMode.self, forKey: .nightwatchMode) ?? .off
         autoResumeOnLimitReset = try c.decodeIfPresent(
             Bool.self, forKey: .autoResumeOnLimitReset) ?? false
+        autoResumeOnApiError = try c.decodeIfPresent(
+            Bool.self, forKey: .autoResumeOnApiError) ?? false
     }
 }
 
@@ -1035,6 +1042,14 @@ public struct ConfigSetAutoResumeOnLimitResetParams: Codable, Sendable {
     public init(enabled: Bool) { self.enabled = enabled }
 }
 
+/// Params for `config.setAutoResumeOnApiError` — the transient-API-error
+/// auto-continue gate (default OFF). Disabling cancels only pending
+/// `api_error`-scoped resumes (session-limit rows are untouched).
+public struct ConfigSetAutoResumeOnApiErrorParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
 /// Params for `config.setScratchInstructions` — the global scratch-space
 /// system-prompt override. `nil` (or blank) resets to the built-in default.
 public struct ConfigSetScratchInstructionsParams: Codable, Sendable {
@@ -1505,6 +1520,29 @@ public struct RateLimitDetectedParams: Codable, Sendable {
         self.limitType = limitType
         self.rawMessage = rawMessage
     }
+}
+
+/// Params for `claude.transientApiErrorDetected` — sent by `tbd hooks
+/// stop-failure` when the turn died on an allowlisted transient API error
+/// (5xx / overloaded / network blip) rather than a hard usage limit.
+public struct TransientApiErrorDetectedParams: Codable, Sendable {
+    public let terminalID: UUID
+    public let errorClass: String
+    public let rawMessage: String
+    public init(terminalID: UUID, errorClass: String, rawMessage: String) {
+        self.terminalID = terminalID
+        self.errorClass = errorClass
+        self.rawMessage = rawMessage
+    }
+}
+
+/// Result for `claude.transientApiErrorDetected`.
+/// `handled == true` → the daemon owns user messaging (scheduled / gave-up /
+/// latch-silenced); the CLI prints nothing. `handled == false` → toggle off
+/// or unknown terminal; the CLI falls back to the legacy error print.
+public struct TransientApiErrorDetectedResult: Codable, Sendable {
+    public let handled: Bool
+    public init(handled: Bool) { self.handled = handled }
 }
 
 /// Params for `terminal.cancelScheduledResume` — explicit user cancel from

--- a/Sources/TBDShared/RateLimitDetection.swift
+++ b/Sources/TBDShared/RateLimitDetection.swift
@@ -44,25 +44,31 @@ public enum RateLimitDetection {
     }
 
     /// Single-scan variant of `detect(transcriptData:)` that also returns the
-    /// matched record's verbatim text, so a caller needing both the detected
-    /// limit AND the display message (e.g. the CLI's StopFailure hook) parses
-    /// the transcript exactly once instead of running two independent
-    /// full-file scans for the same record.
+    /// matched record's verbatim text and top-level `error` field, so a
+    /// caller needing the detected limit, the display message, AND the error
+    /// class (e.g. the CLI's StopFailure hook, feeding both rate-limit
+    /// scheduling and transient-error classification) parses the transcript
+    /// exactly once instead of running independent full-file scans for the
+    /// same record.
     public static func detectWithText(
         transcriptData: Data,
         now: Date = Date(),
         timeZone: TimeZone = .current,
         newerThan floor: Date? = nil
-    ) -> (text: String?, detectedLimit: DetectedRateLimit?)? {
+    ) -> (text: String?, errorClass: String?, detectedLimit: DetectedRateLimit?)? {
         guard let entry = lastApiErrorEntry(in: transcriptData, newerThan: floor) else { return nil }
-        return (text: entry.text, detectedLimit: detect(entry: entry, now: now, timeZone: timeZone))
+        return (
+            text: entry.text,
+            errorClass: entry.errorClass,
+            detectedLimit: detect(entry: entry, now: now, timeZone: timeZone)
+        )
     }
 
     /// Shared entry→DetectedRateLimit derivation used by both `detect(transcriptData:)`
     /// (via `detectWithText`) so there is exactly one implementation of the
     /// structured/text-fallback decision.
     private static func detect(
-        entry: (text: String?, rateLimitInfo: [String: Any]?),
+        entry: (text: String?, errorClass: String?, rateLimitInfo: [String: Any]?),
         now: Date,
         timeZone: TimeZone
     ) -> DetectedRateLimit? {
@@ -251,7 +257,7 @@ public enum RateLimitDetection {
     static func lastApiErrorEntry(
         in data: Data,
         newerThan floor: Date? = nil
-    ) -> (text: String?, rateLimitInfo: [String: Any]?)? {
+    ) -> (text: String?, errorClass: String?, rateLimitInfo: [String: Any]?)? {
         guard let contents = String(data: data, encoding: .utf8) else { return nil }
         for line in contents.split(separator: "\n", omittingEmptySubsequences: true).reversed() {
             guard let lineData = line.data(using: .utf8),
@@ -277,7 +283,11 @@ public enum RateLimitDetection {
                     }
                 }
             }
-            return (text: text, rateLimitInfo: obj["rate_limit_info"] as? [String: Any])
+            return (
+                text: text,
+                errorClass: obj["error"] as? String,
+                rateLimitInfo: obj["rate_limit_info"] as? [String: Any]
+            )
         }
         return nil
     }

--- a/Sources/TBDShared/TransientErrorDetection.swift
+++ b/Sources/TBDShared/TransientErrorDetection.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// A transient (retryable) API error extracted from a Claude Code transcript
+/// or hook payload — distinct from a hard usage-limit hit (`DetectedRateLimit`).
+public struct DetectedTransientError: Equatable, Sendable {
+    /// Coarse category driving backoff policy in later tasks: `connection_closed`,
+    /// `transient_429`, `server_5xx`, `timeout`, or `server_error`.
+    public let errorClass: String
+    /// Verbatim display text when available, else a synthesized fallback.
+    public let rawMessage: String
+
+    public init(errorClass: String, rawMessage: String) {
+        self.errorClass = errorClass
+        self.rawMessage = rawMessage
+    }
+}
+
+/// Pure detection logic for transient (auto-retryable) API errors — the
+/// counterpart to `RateLimitDetection` for hard usage limits.
+///
+/// Spec: docs/specs/2026-07-08-transient-api-error-auto-continue-design.md §Detection.
+public enum TransientErrorDetection {
+
+    /// Classify a candidate error message + the transcript record's
+    /// top-level `error` field into a `DetectedTransientError`, or `nil` if
+    /// this is not something to auto-retry.
+    ///
+    /// Order (spec):
+    /// 1. Permanent-exclusion wordings (auth/billing) always win — never
+    ///    auto-retry those, even if the caller passes a transient-looking
+    ///    `errorField` alongside them.
+    /// 2. Hard usage-limit wordings defer to `RateLimitDetection` — that
+    ///    pipeline schedules its own resume; this classifier must not
+    ///    double-schedule the same record (defensive: callers are expected
+    ///    to have already checked `RateLimitDetection` first, but this
+    ///    guards the contract even if they forgot).
+    /// 3. Known transient text wordings, first match wins.
+    /// 4. No usable text but a `server_error` error field still counts —
+    ///    Claude Code sometimes omits display text on this class.
+    /// 5. Otherwise, not a transient error we know how to retry.
+    public static func detect(messageText: String?, errorField: String?) -> DetectedTransientError? {
+        if let messageText, !messageText.isEmpty {
+            if isPermanentExclusion(messageText) { return nil }
+            if RateLimitDetection.isHardLimitMessage(messageText) { return nil }
+            if let errorClass = classifyText(messageText) {
+                return DetectedTransientError(errorClass: errorClass, rawMessage: messageText)
+            }
+        }
+
+        // No matching text wording — fall back to the structured error field.
+        guard errorField == "server_error" else { return nil }
+        let rawMessage = (messageText?.isEmpty == false ? messageText! : nil) ?? "API error (server_error)"
+        return DetectedTransientError(errorClass: "server_error", rawMessage: rawMessage)
+    }
+
+    /// Wordings that indicate an auth/billing failure, never auto-retryable
+    /// regardless of any accompanying error field — retrying would just spin
+    /// against the same permanent failure.
+    private static func isPermanentExclusion(_ text: String) -> Bool {
+        let lower = text.lowercased()
+        if lower.contains("oauth") { return true }
+        if lower.contains("authentication") { return true }
+        if lower.contains("invalid api key") { return true }
+        if lower.contains("credit balance") { return true }
+        if lower.range(of: #"\b40[13]\b"#, options: .regularExpression) != nil { return true }
+        return false
+    }
+
+    /// Known transient wordings, first match wins (spec: ordered allowlist).
+    private static func classifyText(_ text: String) -> String? {
+        let lower = text.lowercased()
+        if lower.contains("connection closed mid-response") { return "connection_closed" }
+        if lower.contains("temporarily limiting requests") || lower.contains("not your usage limit") {
+            return "transient_429"
+        }
+        if lower.range(of: #"api error:?\s*5\d\d"#, options: .regularExpression) != nil
+            || lower.contains("overloaded") {
+            return "server_5xx"
+        }
+        if lower.range(of: #"api error:?\s*429"#, options: .regularExpression) != nil {
+            return "transient_429"
+        }
+        if lower.contains("timed out") || lower.contains("timeout") { return "timeout" }
+        return nil
+    }
+}

--- a/Tests/TBDCLITests/StopFailureMessageTests.swift
+++ b/Tests/TBDCLITests/StopFailureMessageTests.swift
@@ -21,9 +21,9 @@ struct StopFailureMessageTests {
     /// a fixed instant must pass a matching `timestamp` explicitly, since the
     /// retry/detection path is recency-gated (records must be newer than
     /// `now - 10s`).
-    private static func transcript(text: String, timestamp: Date = Date()) -> Data {
+    private static func transcript(text: String, timestamp: Date = Date(), error: String = "rate_limit") -> Data {
         let line = """
-        {"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"rate_limit","timestamp":"\(Self.iso(timestamp))","message":{"role":"assistant","content":[{"type":"text","text":"\(text)"}]}}
+        {"type":"assistant","isApiErrorMessage":true,"apiErrorStatus":429,"error":"\(error)","timestamp":"\(Self.iso(timestamp))","message":{"role":"assistant","content":[{"type":"text","text":"\(text)"}]}}
         """
         return Data((line + "\n").utf8)
     }
@@ -321,5 +321,109 @@ struct StopFailureMessageTests {
             now: Date(), timeZone: TimeZone(identifier: "UTC")!)
         #expect(outcome.message == "Claude stopped: API error (rate_limit)")
         #expect(outcome.detectedLimit == nil)
+    }
+
+    // MARK: - Transient API-error detection (Task 6)
+
+    /// Payload-first transient: a connection-closed `last_assistant_message`
+    /// classifies as `connection_closed`, keeps the verbatim text, and never
+    /// touches the transcript file.
+    @Test func payloadFirstTransientViaLastAssistantMessageSkipsTranscriptRead() {
+        let text = "API Error: Connection closed mid-response"
+        let counter = CallCounter()
+        let outcome = StopFailureMessage.computeOutcomeWithRetry(
+            stdinData: Self.stdinWithExtras(
+                error: "server_error",
+                transcriptPath: "/irrelevant.jsonl",
+                lastAssistantMessage: text),
+            readFile: { (_: String) -> Data? in counter.count += 1; return nil },
+            now: Date(timeIntervalSince1970: 1_783_173_600),
+            timeZone: TimeZone(identifier: "UTC")!)
+        #expect(counter.count == 0)
+        #expect(outcome.message == text)
+        #expect(outcome.detectedLimit == nil)
+        #expect(outcome.detectedTransient?.errorClass == "connection_closed")
+        #expect(outcome.detectedTransient?.rawMessage == text)
+    }
+
+    /// Hard-limit precedence: a session-limit `last_assistant_message` with a
+    /// parseable reset must be a detected LIMIT, never a transient — the
+    /// payload-first hard-limit loop runs before the transient loop.
+    @Test func hardLimitPayloadPrecedesTransient() {
+        let text = "You've hit your session limit · resets 3pm (UTC)"
+        let outcome = StopFailureMessage.computeOutcomeWithRetry(
+            stdinData: Self.stdinWithExtras(
+                error: "rate_limit",
+                transcriptPath: "/irrelevant.jsonl",
+                lastAssistantMessage: text),
+            readFile: { (_: String) -> Data? in nil },
+            now: Date(timeIntervalSince1970: 1_783_173_600),
+            timeZone: TimeZone(identifier: "UTC")!)
+        #expect(outcome.detectedLimit != nil)
+        #expect(outcome.detectedTransient == nil)
+    }
+
+    /// Transcript transient: no payload text keys, but the recent transcript
+    /// record carries connection-closed text + `"error":"server_error"` — the
+    /// transient is detected after passing the recency retry gate.
+    @Test func transcriptTransientDetectedAfterRetryGate() {
+        let text = "API Error: Connection closed mid-response"
+        let now = Date(timeIntervalSince1970: 1_783_173_600)
+        let outcome = StopFailureMessage.computeOutcome(
+            stdinData: Self.stdinWithExtras(error: "server_error", transcriptPath: "/x.jsonl"),
+            readFile: { _ in Self.transcript(text: text, timestamp: now, error: "server_error") },
+            now: now,
+            timeZone: TimeZone(identifier: "UTC")!)
+        #expect(outcome.detectedLimit == nil)
+        #expect(outcome.detectedTransient?.errorClass == "connection_closed")
+        #expect(outcome.message == text)
+    }
+
+    /// ErrorField-only on exhaustion: payload `error: "server_error"`, no text
+    /// keys, and the transcript never gains a recent record before retries
+    /// exhaust — the `server_error` field alone still counts as transient, and
+    /// the message is the synthesized fallback.
+    @Test func errorFieldOnlyTransientOnRetryExhaustion() {
+        let counter = CallCounter()
+        let outcome = StopFailureMessage.computeOutcomeWithRetry(
+            stdinData: Self.stdinWithExtras(error: "server_error", transcriptPath: "/x.jsonl"),
+            readFile: { _ in counter.count += 1; return nil },
+            now: Date(timeIntervalSince1970: 1_783_173_600),
+            timeZone: TimeZone(identifier: "UTC")!,
+            waiter: { _ in },
+            maxRetries: 2,
+            retryInterval: 0.001)
+        #expect(outcome.detectedLimit == nil)
+        #expect(outcome.detectedTransient?.errorClass == "server_error")
+        #expect(outcome.message == "Claude stopped: API error (server_error)")
+    }
+
+    /// Negative: an unknown error field with no text is neither a limit nor a
+    /// transient — the legacy fallback message is byte-identical.
+    @Test func unknownErrorNoTextIsNotTransient() {
+        let outcome = StopFailureMessage.computeOutcome(
+            stdinData: Self.stdinWithExtras(error: "unknown"),
+            readFile: { _ in nil },
+            now: Date(timeIntervalSince1970: 1_783_173_600),
+            timeZone: TimeZone(identifier: "UTC")!)
+        #expect(outcome.detectedLimit == nil)
+        #expect(outcome.detectedTransient == nil)
+        #expect(outcome.message == "Claude stopped: API error (unknown)")
+    }
+
+    /// Negative: an OAuth/401 wording in `last_assistant_message` is a
+    /// permanent auth failure — the exclusion guard wins even though the text
+    /// also contains a connection-closed phrase, so both detections are nil and
+    /// the message falls through to the legacy fallback.
+    @Test func oauthTextIsExcludedFromTransient() {
+        let text = "OAuth token expired · connection closed mid-response"
+        let outcome = StopFailureMessage.computeOutcome(
+            stdinData: Self.stdinWithExtras(error: "authentication_error", lastAssistantMessage: text),
+            readFile: { _ in nil },
+            now: Date(timeIntervalSince1970: 1_783_173_600),
+            timeZone: TimeZone(identifier: "UTC")!)
+        #expect(outcome.detectedLimit == nil)
+        #expect(outcome.detectedTransient == nil)
+        #expect(outcome.message == "Claude stopped: API error (authentication_error)")
     }
 }

--- a/Tests/TBDCLITests/StopFailureMessageTests.swift
+++ b/Tests/TBDCLITests/StopFailureMessageTests.swift
@@ -366,7 +366,7 @@ struct StopFailureMessageTests {
     /// Transcript transient: no payload text keys, but the recent transcript
     /// record carries connection-closed text + `"error":"server_error"` — the
     /// transient is detected after passing the recency retry gate.
-    @Test func transcriptTransientDetectedAfterRetryGate() {
+    @Test func transcriptTransientDetectedViaScan() {
         let text = "API Error: Connection closed mid-response"
         let now = Date(timeIntervalSince1970: 1_783_173_600)
         let outcome = StopFailureMessage.computeOutcome(

--- a/Tests/TBDDaemonTests/AutoResumeConfigRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoResumeConfigRPCTests.swift
@@ -65,5 +65,68 @@ import Testing
         let json = #"{"profiles":[],"globalEnvOverrides":{},"autoArchiveOnMergeDefault":false}"#
         let result = try JSONDecoder().decode(ModelProfileListResult.self, from: Data(json.utf8))
         #expect(result.autoResumeOnLimitReset == false)
+        #expect(result.autoResumeOnApiError == false)
+    }
+
+    @Test func apiErrorListResultCarriesFlag() async throws {
+        try await db.config.setAutoResumeOnApiError(true)
+        let response = await router.handle(RPCRequest(method: RPCMethod.modelProfileList))
+        #expect(response.success)
+        let result = try response.decodeResult(ModelProfileListResult.self)
+        #expect(result.autoResumeOnApiError == true)
+    }
+
+    // Seed one pending `session` row and one pending `api_error` row on two
+    // separate terminals, then assert each toggle's off-path cancels only its
+    // own scope (spec: per-toggle scoped cancel).
+    private func seedTwoPendingRows() async throws -> (session: UUID, apiError: UUID) {
+        let repo = try await db.repos.create(
+            path: "/tmp/arc2-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/arc2-wt-\(UUID().uuidString)", tmuxServer: "tbd-arc2")
+        let sessionTerminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        let apiErrorTerminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2")
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: sessionTerminal.id, worktreeID: wt.id,
+            resetsAt: Date(), fireAt: Date().addingTimeInterval(60),
+            limitType: "session", rawMessage: "m"))
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: apiErrorTerminal.id, worktreeID: wt.id,
+            resetsAt: Date(), fireAt: Date().addingTimeInterval(60),
+            limitType: ScheduledResume.apiErrorLimitType, rawMessage: "m"))
+        return (sessionTerminal.id, apiErrorTerminal.id)
+    }
+
+    @Test func disableApiErrorCancelsApiErrorRowNotSession() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        try await db.config.setAutoResumeOnApiError(true)
+        let (session, apiError) = try await seedTwoPendingRows()
+
+        let request = try RPCRequest(
+            method: RPCMethod.configSetAutoResumeOnApiError,
+            params: ConfigSetAutoResumeOnApiErrorParams(enabled: false))
+        let response = await router.handle(request)
+        #expect(response.success)
+        #expect(try await db.config.get().autoResumeOnApiError == false)
+        #expect(try await db.scheduledResumes.pending(terminalID: apiError) == nil)
+        #expect(try await db.scheduledResumes.pending(terminalID: session) != nil)
+    }
+
+    @Test func disableLimitResetCancelsSessionRowNotApiError() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        try await db.config.setAutoResumeOnApiError(true)
+        let (session, apiError) = try await seedTwoPendingRows()
+
+        let request = try RPCRequest(
+            method: RPCMethod.configSetAutoResumeOnLimitReset,
+            params: ConfigSetAutoResumeOnLimitResetParams(enabled: false))
+        let response = await router.handle(request)
+        #expect(response.success)
+        #expect(try await db.config.get().autoResumeOnLimitReset == false)
+        #expect(try await db.scheduledResumes.pending(terminalID: session) == nil)
+        #expect(try await db.scheduledResumes.pending(terminalID: apiError) != nil)
     }
 }

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -255,6 +255,62 @@ struct FakeInspector: PaneProcessInspecting {
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
     }
 
+    // MARK: - Eligibility 0a: limitType-aware gate (spec 2026-07-08 §Gating)
+
+    /// `row` (limitType "session") occupies the terminal's latch, so these
+    /// api_error-row tests clear it first and insert their own pending row
+    /// for the same terminal — mirrors how `scheduler.scheduleTransient`
+    /// always inserts before `actuate` ever sees a row.
+    private func insertApiErrorRow() async throws -> ScheduledResume {
+        _ = try await db.scheduledResumes.cancelPending(terminalID: terminalID)
+        let apiErrorRow = ScheduledResume(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: "sess",
+            resetsAt: row.resetsAt, fireAt: row.fireAt,
+            limitType: ScheduledResume.apiErrorLimitType, rawMessage: "m", createdAt: row.createdAt)
+        guard let inserted = try await db.scheduledResumes.insertPending(apiErrorRow) else {
+            Issue.record("expected latch to accept row after cancelPending")
+            return apiErrorRow
+        }
+        return inserted
+    }
+
+    @Test func apiErrorRowCancelledExternallyWhenApiErrorToggleOffEvenIfLimitResetOn() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        try await db.config.setAutoResumeOnApiError(false)
+        let apiErrorRow = try await insertApiErrorRow()
+        let outcome = await makeActuator().actuate(apiErrorRow)
+        #expect(outcome == .cancelledExternally)
+        #expect(tmux.sends.isEmpty)
+    }
+
+    @Test func apiErrorRowProceedsPastEligibility0aWhenApiErrorToggleOnEvenIfLimitResetOff() async throws {
+        try await db.config.setAutoResumeOnLimitReset(false)
+        try await db.config.setAutoResumeOnApiError(true)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        let apiErrorRow = try await insertApiErrorRow()
+        let outcome = await makeActuator().actuate(apiErrorRow)
+        // Falls through past 0a and runs the full send sequence (happy path).
+        #expect(outcome == .sent)
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func sessionRowUnaffectedByApiErrorToggle() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        try await db.config.setAutoResumeOnApiError(false)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .sent)
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func sessionRowCancelledExternallyWhenLimitResetOffEvenIfApiErrorOn() async throws {
+        try await db.config.setAutoResumeOnLimitReset(false)
+        try await db.config.setAutoResumeOnApiError(true)
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .cancelledExternally)
+        #expect(tmux.sends.isEmpty)
+    }
+
     @Test func rowCancelledBetweenAttemptsCancelsAfterOneSend() async throws {
         // Same timeout setup as above, but instead of the global toggle,
         // the ROW is cancelled between attempts (mirrors

--- a/Tests/TBDDaemonTests/LimitResumeSchedulerTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSchedulerTests.swift
@@ -263,4 +263,107 @@ final class OutcomeCollector: @unchecked Sendable {
         #expect(collector.events.isEmpty)
         await scheduler.stop()
     }
+
+    // MARK: - scheduleTransient (spec 2026-07-08 §Backoff)
+
+    @Test func scheduleTransientFireAtIsExactNoSlackNoJitter() async throws {
+        // Non-zero jitter provider proves scheduleTransient never consults it.
+        let scheduler = makeScheduler(actuator: FakeActuator(), jitter: 999)
+        let now = clock.now()
+        let row = await scheduler.scheduleTransient(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            delay: 60, rawMessage: "m")
+        #expect(row != nil)
+        #expect(row!.limitType == ScheduledResume.apiErrorLimitType)
+        #expect(row!.fireAt == now.addingTimeInterval(60))
+        #expect(row!.resetsAt == row!.fireAt)
+    }
+
+    @Test func scheduleTransientLatchSecondCallReturnsNil() async throws {
+        let scheduler = makeScheduler(actuator: FakeActuator())
+        _ = await scheduler.scheduleTransient(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            delay: 60, rawMessage: "m")
+        let second = await scheduler.scheduleTransient(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            delay: 60, rawMessage: "m")
+        #expect(second == nil)
+    }
+
+    /// Api-error row fires purely off `autoResumeOnApiError`, independent of
+    /// `autoResumeOnLimitReset` — mirror-image of
+    /// `sessionRowGatedOnlyByLimitResetToggle` below (spec 2026-07-08 §Gating).
+    @Test func apiErrorRowGatedOnlyByApiErrorToggle() async throws {
+        try await db.config.setAutoResumeOnLimitReset(false)
+        try await db.config.setAutoResumeOnApiError(true)
+        let actuator = FakeActuator([.sent])
+        let scheduler = makeScheduler(actuator: actuator)
+        await scheduler.start()
+        let scheduled = await scheduler.scheduleTransient(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            delay: 60, rawMessage: "m")
+        #expect(scheduled != nil)
+        await clock.advance(by: 65)
+        await pump()
+        #expect(actuator.calls.count == 1)
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .sent)
+        await scheduler.stop()
+    }
+
+    @Test func apiErrorRowCancelledWhenApiErrorToggleOffEvenIfLimitResetOn() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        try await db.config.setAutoResumeOnApiError(false)
+        let actuator = FakeActuator([.sent])
+        let scheduler = makeScheduler(actuator: actuator)
+        await scheduler.start()
+        let scheduled = await scheduler.scheduleTransient(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            delay: 60, rawMessage: "m")
+        #expect(scheduled != nil)
+        await clock.advance(by: 65)
+        await pump()
+        #expect(actuator.calls.isEmpty)
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .cancelled)
+        await scheduler.stop()
+    }
+
+    /// Session row fires purely off `autoResumeOnLimitReset`, independent of
+    /// `autoResumeOnApiError` — mirror-image of the api_error pair above.
+    @Test func sessionRowGatedOnlyByLimitResetToggle() async throws {
+        try await db.config.setAutoResumeOnLimitReset(true)
+        try await db.config.setAutoResumeOnApiError(false)
+        let actuator = FakeActuator([.sent])
+        let scheduler = makeScheduler(actuator: actuator)
+        await scheduler.start()
+        let scheduled = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(60), limitType: "session", rawMessage: "m")
+        #expect(scheduled != nil)
+        await clock.advance(by: 130)
+        await pump()
+        #expect(actuator.calls.count == 1)
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .sent)
+        await scheduler.stop()
+    }
+
+    @Test func sessionRowCancelledWhenLimitResetToggleOffEvenIfApiErrorOn() async throws {
+        try await db.config.setAutoResumeOnLimitReset(false)
+        try await db.config.setAutoResumeOnApiError(true)
+        let actuator = FakeActuator([.sent])
+        let scheduler = makeScheduler(actuator: actuator)
+        await scheduler.start()
+        let scheduled = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(60), limitType: "session", rawMessage: "m")
+        #expect(scheduled != nil)
+        await clock.advance(by: 130)
+        await pump()
+        #expect(actuator.calls.isEmpty)
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .cancelled)
+        await scheduler.stop()
+    }
 }

--- a/Tests/TBDDaemonTests/ScheduledResumeStoreTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumeStoreTests.swift
@@ -22,13 +22,21 @@ import Testing
         terminalID = terminal.id
     }
 
-    private func makeResume(fireAt: Date = Date().addingTimeInterval(90)) -> ScheduledResume {
+    private func makeResume(
+        fireAt: Date = Date().addingTimeInterval(90),
+        limitType: String = "session",
+        createdAt: Date = Date(),
+        status: ScheduledResumeStatus = .pending,
+        terminalID overrideTerminalID: UUID? = nil
+    ) -> ScheduledResume {
         ScheduledResume(
-            terminalID: terminalID, worktreeID: worktreeID,
+            terminalID: overrideTerminalID ?? terminalID, worktreeID: worktreeID,
             claudeSessionID: "sess-1",
             resetsAt: Date().addingTimeInterval(60), fireAt: fireAt,
-            limitType: "session",
-            rawMessage: "You've hit your session limit · resets 3pm (UTC)")
+            limitType: limitType,
+            rawMessage: "You've hit your session limit · resets 3pm (UTC)",
+            createdAt: createdAt,
+            status: status)
     }
 
     @Test func insertPendingSetsTerminalBadgeAndRoundTrips() async throws {
@@ -145,6 +153,87 @@ import Testing
         #expect(count == 2)
         #expect(try await db.scheduledResumes.pending().isEmpty)
         #expect(try await db.terminals.get(id: terminal2.id)?.pendingResumeAt == nil)
+    }
+
+    @Test func countRecentApiErrorAttemptsFiltersTerminalTypeStatusAndWindow() async throws {
+        let now = Date()
+        let since = now.addingTimeInterval(-30 * 60)
+
+        // Right terminal, api_error, sent, within window -> counts.
+        try await db.scheduledResumes.insertAudit(makeResume(
+            limitType: ScheduledResume.apiErrorLimitType,
+            createdAt: now.addingTimeInterval(-5 * 60), status: .sent))
+        // Right terminal, api_error, failed, within window -> counts.
+        try await db.scheduledResumes.insertAudit(makeResume(
+            limitType: ScheduledResume.apiErrorLimitType,
+            createdAt: now.addingTimeInterval(-10 * 60), status: .failed))
+        // Right terminal, api_error, sent, but outside the window -> excluded.
+        try await db.scheduledResumes.insertAudit(makeResume(
+            limitType: ScheduledResume.apiErrorLimitType,
+            createdAt: now.addingTimeInterval(-45 * 60), status: .sent))
+        // Right terminal, api_error, cancelled, within window -> not a failed attempt, excluded.
+        try await db.scheduledResumes.insertAudit(makeResume(
+            limitType: ScheduledResume.apiErrorLimitType,
+            createdAt: now.addingTimeInterval(-2 * 60), status: .cancelled))
+        // Wrong terminal, api_error, pending -> excluded.
+        let terminal2 = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2")
+        _ = try await db.scheduledResumes.insertPending(makeResume(
+            limitType: ScheduledResume.apiErrorLimitType,
+            createdAt: now, terminalID: terminal2.id))
+        // Right terminal, sent, within window, but wrong limitType -> excluded.
+        try await db.scheduledResumes.insertAudit(makeResume(
+            limitType: "session",
+            createdAt: now.addingTimeInterval(-1 * 60), status: .sent))
+
+        let count = try await db.scheduledResumes.countRecentApiErrorAttempts(
+            terminalID: terminalID, since: since)
+        #expect(count == 2)
+    }
+
+    @Test func cancelAllPendingScopedToApiErrorOnly() async throws {
+        let resumeA = makeResume(limitType: ScheduledResume.apiErrorLimitType)
+        _ = try await db.scheduledResumes.insertPending(resumeA)
+        let terminalB = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2")
+        let resumeB = makeResume(limitType: "session", terminalID: terminalB.id)
+        _ = try await db.scheduledResumes.insertPending(resumeB)
+
+        let count = try await db.scheduledResumes.cancelAllPending(scope: .apiErrorOnly)
+        #expect(count == 1)
+        #expect(try await db.scheduledResumes.get(id: resumeA.id)?.status == .cancelled)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
+        #expect(try await db.scheduledResumes.get(id: resumeB.id)?.status == .pending)
+        #expect(try await db.terminals.get(id: terminalB.id)?.pendingResumeAt != nil)
+    }
+
+    @Test func cancelAllPendingScopedToLimitOnly() async throws {
+        let resumeA = makeResume(limitType: ScheduledResume.apiErrorLimitType)
+        _ = try await db.scheduledResumes.insertPending(resumeA)
+        let terminalB = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2")
+        let resumeB = makeResume(limitType: "session", terminalID: terminalB.id)
+        _ = try await db.scheduledResumes.insertPending(resumeB)
+
+        let count = try await db.scheduledResumes.cancelAllPending(scope: .limitOnly)
+        #expect(count == 1)
+        #expect(try await db.scheduledResumes.get(id: resumeB.id)?.status == .cancelled)
+        #expect(try await db.terminals.get(id: terminalB.id)?.pendingResumeAt == nil)
+        #expect(try await db.scheduledResumes.get(id: resumeA.id)?.status == .pending)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt != nil)
+    }
+
+    @Test func cancelAllPendingDefaultScopeCancelsBothScopes() async throws {
+        let resumeA = makeResume(limitType: ScheduledResume.apiErrorLimitType)
+        _ = try await db.scheduledResumes.insertPending(resumeA)
+        let terminalB = try await db.terminals.create(
+            worktreeID: worktreeID, tmuxWindowID: "@2", tmuxPaneID: "%2")
+        let resumeB = makeResume(limitType: "session", terminalID: terminalB.id)
+        _ = try await db.scheduledResumes.insertPending(resumeB)
+
+        let count = try await db.scheduledResumes.cancelAllPending(scope: .all)
+        #expect(count == 2)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
     }
 
     @Test func pendingOrderedByFireAt() async throws {

--- a/Tests/TBDDaemonTests/ScheduledResumesMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumesMigrationTests.swift
@@ -44,6 +44,45 @@ import GRDB
         #expect(config.autoResumeOnLimitReset == false)
     }
 
+    @Test func configAutoResumeOnApiErrorDefaultsFalseThenSettable() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let config = try await db.config.get()
+        #expect(config.autoResumeOnApiError == false)
+
+        try await db.config.setAutoResumeOnApiError(true)
+        let updated = try await db.config.get()
+        #expect(updated.autoResumeOnApiError == true)
+    }
+
+    @Test func configJSONWithoutAutoResumeOnApiErrorDecodesFalse() throws {
+        // decode-compat rule: pre-v46 payloads have no autoResumeOnApiError.
+        let json = """
+        {"primaryAgentPreference":"claude","envSettingOverrides":{},"envOverrides":{},
+         "autoArchiveOnMergeDefault":false,"autoResumeOnLimitReset":false,
+         "nightwatchMode":"off","autoHibernateEnabled":true,"hibernateIdleMinutes":30,
+         "controlModeEnabled":false}
+        """
+        let config = try JSONDecoder().decode(Config.self, from: Data(json.utf8))
+        #expect(config.autoResumeOnApiError == false)
+    }
+
+    @Test func autoResumeEnabledForLimitTypeFollowsCorrectGate() {
+        var config = Config()
+        config.autoResumeOnApiError = false
+        config.autoResumeOnLimitReset = true
+        #expect(config.autoResumeEnabled(forLimitType: ScheduledResume.apiErrorLimitType) == false)
+        #expect(config.autoResumeEnabled(forLimitType: "session") == true)
+        #expect(config.autoResumeEnabled(forLimitType: "debug") == true)
+        #expect(config.autoResumeEnabled(forLimitType: "weekly") == true)
+
+        config.autoResumeOnApiError = true
+        config.autoResumeOnLimitReset = false
+        #expect(config.autoResumeEnabled(forLimitType: ScheduledResume.apiErrorLimitType) == true)
+        #expect(config.autoResumeEnabled(forLimitType: "session") == false)
+        #expect(config.autoResumeEnabled(forLimitType: "debug") == false)
+        #expect(config.autoResumeEnabled(forLimitType: "weekly") == false)
+    }
+
     @Test func oldTerminalJSONStillDecodes() throws {
         // decode-compat rule: pre-v38 payloads have no pendingResumeAt.
         let json = """

--- a/Tests/TBDDaemonTests/TransientApiErrorRPCTests.swift
+++ b/Tests/TBDDaemonTests/TransientApiErrorRPCTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct TransientApiErrorRPCTests {
+    let db: TBDDatabase
+    let router: RPCRouter
+    let clock = TestPollerClock()
+    let terminalID: UUID
+    let worktreeID: UUID
+
+    init() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        self.db = db
+        self.router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(),
+                tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date())
+        let repo = try await db.repos.create(
+            path: "/tmp/tae-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/tae-wt-\(UUID().uuidString)", tmuxServer: "tbd-tae")
+        worktreeID = wt.id
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+        terminalID = terminal.id
+        // Router-held scheduler, not started (schedule() works without loop).
+        router.limitResumeScheduler = LimitResumeScheduler(
+            store: db.scheduledResumes, config: db.config,
+            actuator: FakeActuator(), clock: clock,
+            jitterProvider: { 0 }, onOutcome: { _, _ in })
+    }
+
+    private func detect(terminalID: UUID? = nil, rawMessage: String = "API Error: 500") async -> RPCResponse {
+        let request = try! RPCRequest(
+            method: RPCMethod.claudeTransientApiErrorDetected,
+            params: TransientApiErrorDetectedParams(
+                terminalID: terminalID ?? self.terminalID,
+                errorClass: "overloaded",
+                rawMessage: rawMessage))
+        return await router.handle(request)
+    }
+
+    /// Seed a `sent` api_error attempt row so the backoff ladder counts it.
+    private func seedSentApiErrorAttempts(_ count: Int) async throws {
+        for _ in 0..<count {
+            try await db.scheduledResumes.insertAudit(ScheduledResume(
+                terminalID: terminalID, worktreeID: worktreeID,
+                resetsAt: Date(), fireAt: Date(),
+                limitType: ScheduledResume.apiErrorLimitType, rawMessage: "m",
+                createdAt: Date(), status: .sent))
+        }
+    }
+
+    // GATE OFF: not handled, no row, no notification.
+    @Test func toggleOffIsNotHandled() async throws {
+        try await db.config.setAutoResumeOnApiError(false)
+        let response = await detect()
+        #expect(response.success)
+        #expect(try response.decodeResult(TransientApiErrorDetectedResult.self).handled == false)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        #expect(try await db.scheduledResumes.all(terminalID: terminalID).isEmpty)
+        #expect(try await db.notifications.unread(worktreeID: worktreeID).isEmpty)
+    }
+
+    // GATE ON, attempt 1: pending api_error row + "auto-continue in 60s (attempt 1/4)".
+    @Test func toggleOnAttempt1SchedulesAndNotifies() async throws {
+        try await db.config.setAutoResumeOnApiError(true)
+        let response = await detect(rawMessage: "API Error: 529 overloaded")
+        #expect(response.success)
+        #expect(try response.decodeResult(TransientApiErrorDetectedResult.self).handled == true)
+        let pending = try await db.scheduledResumes.pending(terminalID: terminalID)
+        #expect(pending != nil)
+        #expect(pending?.limitType == ScheduledResume.apiErrorLimitType)
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(unread.count == 1)
+        #expect(unread[0].type == .error)
+        #expect(unread[0].message?.contains("auto-continue in 60s (attempt 1/4)") == true)
+        #expect(unread[0].terminalID == terminalID)
+    }
+
+    // GATE ON, one prior attempt seeded → next fires at 2m (attempt 2/4).
+    @Test func seededOneAttemptSchedulesAt2m() async throws {
+        try await db.config.setAutoResumeOnApiError(true)
+        try await seedSentApiErrorAttempts(1)
+        let response = await detect()
+        #expect(try response.decodeResult(TransientApiErrorDetectedResult.self).handled == true)
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(unread.count == 1)
+        #expect(unread[0].message?.contains("auto-continue in 2m (attempt 2/4)") == true)
+    }
+
+    // GATE ON, cap reached (4 prior attempts) → handled, NO new row, gave-up notice.
+    @Test func seededFourAttemptsGivesUp() async throws {
+        try await db.config.setAutoResumeOnApiError(true)
+        try await seedSentApiErrorAttempts(4)
+        let response = await detect(rawMessage: "API Error: 500")
+        #expect(try response.decodeResult(TransientApiErrorDetectedResult.self).handled == true)
+        #expect(try await db.scheduledResumes.pending(terminalID: terminalID) == nil)
+        let unread = try await db.notifications.unread(worktreeID: worktreeID)
+        #expect(unread.count == 1)
+        #expect(unread[0].type == .attentionNeeded)
+        #expect(unread[0].message?.contains("gave up after 4 attempts") == true)
+    }
+
+    // Unknown terminal → not handled, nothing else.
+    @Test func unknownTerminalIsNotHandled() async throws {
+        try await db.config.setAutoResumeOnApiError(true)
+        let response = await detect(terminalID: UUID())
+        #expect(response.success)
+        #expect(try response.decodeResult(TransientApiErrorDetectedResult.self).handled == false)
+        #expect(try await db.scheduledResumes.pending().isEmpty)
+        #expect(try await db.notifications.unread(worktreeID: worktreeID).isEmpty)
+    }
+
+    // Pending limit row already present (limitType-agnostic latch) → handled,
+    // no duplicate notification.
+    @Test func pendingLimitRowLatchesSilently() async throws {
+        try await db.config.setAutoResumeOnApiError(true)
+        _ = try await db.scheduledResumes.insertPending(ScheduledResume(
+            terminalID: terminalID, worktreeID: worktreeID,
+            resetsAt: Date(), fireAt: Date().addingTimeInterval(3600),
+            limitType: "session", rawMessage: "limit"))
+        let response = await detect()
+        #expect(try response.decodeResult(TransientApiErrorDetectedResult.self).handled == true)
+        // No api_error row added; the pre-seeded session row is the only pending one.
+        let pending = try await db.scheduledResumes.pending()
+        #expect(pending.count == 1)
+        #expect(pending[0].limitType == "session")
+        #expect(try await db.notifications.unread(worktreeID: worktreeID).isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/TransientResumeBackoffTests.swift
+++ b/Tests/TBDDaemonTests/TransientResumeBackoffTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Spec 2026-07-08 §Backoff: fixed 4-step ladder (60s/2m/5m/10m), then give
+/// up. No jitter — see `LimitResumeScheduler.scheduleTransient` doc comment
+/// for why.
+@Suite struct TransientResumeBackoffTests {
+
+    @Test func delayReturnsLadderStepsInOrder() {
+        #expect(TransientResumeBackoff.delay(consecutiveAttempts: 0) == 60)
+        #expect(TransientResumeBackoff.delay(consecutiveAttempts: 1) == 120)
+        #expect(TransientResumeBackoff.delay(consecutiveAttempts: 2) == 300)
+        #expect(TransientResumeBackoff.delay(consecutiveAttempts: 3) == 600)
+    }
+
+    @Test func delayReturnsNilAtAndBeyondCap() {
+        #expect(TransientResumeBackoff.delay(consecutiveAttempts: 4) == nil)
+        #expect(TransientResumeBackoff.delay(consecutiveAttempts: 40) == nil)
+    }
+
+    @Test func copyForDelayMatchesNotificationStrings() {
+        #expect(TransientResumeBackoff.copy(forDelay: 60) == "60s")
+        #expect(TransientResumeBackoff.copy(forDelay: 120) == "2m")
+        #expect(TransientResumeBackoff.copy(forDelay: 300) == "5m")
+        #expect(TransientResumeBackoff.copy(forDelay: 600) == "10m")
+    }
+
+    @Test func constantsMatchBrief() {
+        #expect(TransientResumeBackoff.steps == [60, 120, 300, 600])
+        #expect(TransientResumeBackoff.maxAttempts == TransientResumeBackoff.steps.count)
+        #expect(TransientResumeBackoff.lookback == 30 * 60)
+    }
+}

--- a/Tests/TBDSharedTests/RateLimitDetectionTests.swift
+++ b/Tests/TBDSharedTests/RateLimitDetectionTests.swift
@@ -159,6 +159,24 @@ struct RateLimitDetectionTests {
             newerThan: Self.now.addingTimeInterval(600), in: data))
     }
 
+    // MARK: - errorClass surfacing
+
+    @Test func detectWithTextSurfacesErrorClassFromRecord() {
+        let obj: [String: Any] = [
+            "type": "assistant",
+            "isApiErrorMessage": true,
+            "timestamp": "2026-07-03T14:00:00.123Z",
+            "error": "server_error",
+            "message": ["role": "assistant",
+                        "content": [["type": "text", "text": "API Error: Connection closed mid-response."]]]
+        ]
+        let lineData = try! JSONSerialization.data(withJSONObject: obj)
+        let line = String(data: lineData, encoding: .utf8)!
+        let scan = RateLimitDetection.detectWithText(
+            transcriptData: Self.transcript([line]), now: Self.now, timeZone: Self.utc)
+        #expect(scan?.errorClass == "server_error")
+    }
+
     // MARK: - ResumeTimeFormatter
 
     @Test func formatterDropsZeroMinutes() {

--- a/Tests/TBDSharedTests/TransientErrorDetectionTests.swift
+++ b/Tests/TBDSharedTests/TransientErrorDetectionTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite struct TransientErrorDetectionTests {
+    private let connectionClosed =
+        "API Error: Connection closed mid-response. The response above may be incomplete."
+
+    @Test func connectionClosedIsTransient() {
+        let d = TransientErrorDetection.detect(messageText: connectionClosed, errorField: "server_error")
+        #expect(d == DetectedTransientError(errorClass: "connection_closed", rawMessage: connectionClosed))
+    }
+
+    @Test func textAbsentServerErrorClassIsTransient() {
+        let d = TransientErrorDetection.detect(messageText: nil, errorField: "server_error")
+        #expect(d == DetectedTransientError(errorClass: "server_error", rawMessage: "API error (server_error)"))
+    }
+
+    @Test func transient429TextIsTransient() {
+        let text = "API Error: 429 {\"error\":{\"message\":\"We're temporarily limiting requests (not your usage limit).\"}}"
+        #expect(TransientErrorDetection.detect(messageText: text, errorField: "rate_limit")?.errorClass == "transient_429")
+    }
+
+    @Test func serverFiveHundredTextIsTransient() {
+        #expect(TransientErrorDetection.detect(messageText: "API Error: 529 Overloaded", errorField: nil)?.errorClass == "server_5xx")
+    }
+
+    @Test func hardLimitTextIsNeverTransient() {
+        let text = "You've hit your session limit · resets 1pm (America/Toronto)"
+        #expect(TransientErrorDetection.detect(messageText: text, errorField: "rate_limit") == nil)
+    }
+
+    @Test func rateLimitClassWithoutTransientTextIsNotRetried() {
+        #expect(TransientErrorDetection.detect(messageText: nil, errorField: "rate_limit") == nil)
+        #expect(TransientErrorDetection.detect(messageText: "", errorField: "rate_limit") == nil)
+    }
+
+    @Test func oauthErrorIsExcludedEvenWithServerErrorClass() {
+        let text = "API Error: 401 OAuth token has expired. Please run /login."
+        #expect(TransientErrorDetection.detect(messageText: text, errorField: "server_error") == nil)
+    }
+
+    @Test func creditBalanceIsExcluded() {
+        #expect(TransientErrorDetection.detect(messageText: "Your credit balance is too low to access the API.", errorField: nil) == nil)
+    }
+
+    @Test func unknownErrorClassWithoutTextIsNotRetried() {
+        #expect(TransientErrorDetection.detect(messageText: nil, errorField: "unknown") == nil)
+        #expect(TransientErrorDetection.detect(messageText: nil, errorField: nil) == nil)
+    }
+
+    @Test func timeoutWordingIsTransient() {
+        #expect(TransientErrorDetection.detect(messageText: "API Error: Request timed out.", errorField: nil)?.errorClass == "timeout")
+    }
+}

--- a/Tests/TBDSharedTests/TransientErrorDetectionTests.swift
+++ b/Tests/TBDSharedTests/TransientErrorDetectionTests.swift
@@ -52,4 +52,10 @@ import Testing
     @Test func timeoutWordingIsTransient() {
         #expect(TransientErrorDetection.detect(messageText: "API Error: Request timed out.", errorField: nil)?.errorClass == "timeout")
     }
+
+    @Test func unmatchedTextWithServerErrorClassFallsBackToClassRetry() {
+        let text = "API Error: something novel went sideways"
+        let d = TransientErrorDetection.detect(messageText: text, errorField: "server_error")
+        #expect(d == DetectedTransientError(errorClass: "server_error", rawMessage: text))
+    }
 }

--- a/docs/specs/2026-07-08-transient-api-error-auto-continue-design.md
+++ b/docs/specs/2026-07-08-transient-api-error-auto-continue-design.md
@@ -1,0 +1,187 @@
+# Transient API-Error Auto-Continue — Design
+
+**Date:** 2026-07-08
+**Status:** Approved design, pre-implementation
+**Branch:** `transient-api-error-auto-continue`
+**Parent feature:** [Session-Limit Auto-Resume](2026-07-03-session-limit-auto-resume-design.md) (PR #341, race fix PR #375)
+
+## Problem
+
+Claude Code turns die intermittently on transient API errors —
+"API Error: Connection closed mid-response. The response above may be
+incomplete." — and the session parks until a human types `continue`.
+Fleet telemetry from the live TBD database shows this is a daily-plus
+occurrence: in one 24h window (2026-07-07/08) there were 4 connection-closed
+deaths, 1 bare `server_error`, and 2 transient-429 deaths across different
+worktrees. Each one stopped an agent project mid-flight.
+
+The session-limit auto-resume pipeline (detection → `scheduled_resumes` →
+`LimitResumeScheduler` → `LimitResumeActuator`) already does everything
+needed except classify these errors as retryable. This feature extends it:
+auto-type `continue` after a short backoff, behind a separate opt-in toggle.
+
+## Evidence (captured from the 2026-07-08 14:13 incident)
+
+Transcript record for a connection-closed death:
+
+- `isApiErrorMessage: true`
+- `error: "server_error"` (coarse class — same field the CLI already reads)
+- `rate_limit_info: null`
+- message text: `API Error: Connection closed mid-response. The response
+  above may be incomplete.`
+- Single error record; the turn died immediately (no internal-retry records
+  after it).
+
+A same-day counterexample (2026-07-07 20:57) produced the fallback
+notification "Claude stopped: API error (server_error)" — i.e. **no message
+text was recoverable**. The classifier must handle the text-absent case.
+
+Non-retryable counterexample from the same window: two agent runs died on an
+**expired OAuth token**. Auto-continuing those is useless — every attempt
+fails identically. This motivates the allowlist.
+
+## Classification
+
+New shared classifier in `TBDShared` alongside `RateLimitDetection`,
+splitting StopFailures three ways, checked in order:
+
+1. **Hard limit** — existing `RateLimitDetection` path, byte-for-byte
+   unchanged, always checked first.
+2. **Transient** (new) — schedules an auto-continue when either:
+   - the message text matches the transient allowlist:
+     - `Connection closed mid-response`
+     - `temporarily limiting requests` (the "(not your usage limit)" 429)
+     - `API Error: 5xx` — 500 / 502 / 503 / 529 — and `Overloaded`
+     - request-timeout wordings (`timed out`, `timeout`)
+   - **or** the error class field is `server_error` (definitionally 5xx;
+     covers the text-absent case observed live).
+3. **Other** — notification only, behavior unchanged. Includes: auth errors
+   (OAuth / 401 / 403 / invalid API key), billing (`credit balance`),
+   `rate_limit` class without hard-limit text (could be a hard limit whose
+   text we failed to read — never blind-retry it), and anything
+   unrecognized. Unknown errors are excluded by construction (allowlist,
+   not denylist).
+
+Detection mechanics reuse the PR #375 shape exactly: payload text fields
+first (`last_assistant_message`, `error_details` — race-free), then the
+recency-floored, bounded-retry transcript read. The classifier gains
+outcomes; the read path does not change.
+
+**Why this doesn't conflict with the parent spec's transient exclusion.**
+The parent spec excluded transient errors because community tools raced
+Claude Code's *internal* retry loop. StopFailure fires only when the turn
+has already died (internal retries exhausted), and the actuator's
+user-already-continued and foreground checks catch any session that
+recovered during the backoff window. The parent's exclusion applied to
+*scheduling a limit-reset resume* off transient errors — that rule stands;
+this feature schedules a *short-delay continue* instead, which is what a
+human does today.
+
+## RPC and backoff
+
+New RPC `claude.transientApiErrorDetected` with
+`{terminalID, errorClass, rawMessage}`. **No `resetsAt` from the CLI** —
+the CLI is stateless and cannot know the attempt number. The daemon
+computes `fireAt = now + step`.
+
+Backoff steps: **60s → 2m → 5m → 10m**, then give up.
+
+- **Consecutive counting:** the attempt number = count of this terminal's
+  `api_error` rows with status `sent` or `failed` created within a 30-minute
+  lookback window. (A `sent` row followed by another transient StopFailure
+  inside the window = our continue was typed and the turn died again.)
+- **Give-up:** past the 4th consecutive attempt, no row is inserted;
+  instead an attention notification: "Auto-continue gave up after 4
+  attempts — <error text>".
+- **Reset:** a resume whose turn survives simply stops producing
+  StopFailures; once the lookback window slides past the old rows, the
+  chain restarts at 60s. No explicit reset bookkeeping.
+
+Existing `claude.rateLimitDetected` RPC is untouched.
+
+## State
+
+**No migration.** Rows reuse `scheduled_resumes` verbatim with
+`limitType = "api_error"`, `rawMessage` = the error text,
+`resetsAt` = computed fire time. Existing status lifecycle
+(`pending`/`sent`/`cancelled`/`failed`) and `attemptCount` apply.
+
+- **Shared one-pending-per-terminal latch** — deliberate: a pending
+  limit-reset resume blocks a redundant `api_error` row and vice versa
+  (whichever fires will revive the session; the other would double-send).
+- **Config:** `autoResumeOnApiError` (bool, default **false**), daemon-side
+  next to `autoResumeOnLimitReset`, set from the app via the existing
+  config RPC. Detection and notification always run; only scheduling is
+  gated (same convention as the parent).
+- `Terminal.pendingResumeAt` broadcast works unchanged.
+
+## Actuation
+
+Byte-identical to the limit path — same `LimitResumeActuator` code:
+
+1. Eligibility ladder unchanged: terminal alive → toggle on → row still
+   pending → user-already-continued (transcript newer than incident) →
+   Claude foreground (`ps -o stat=` `+`) → copy-mode reschedule.
+   The toggle check reads **`autoResumeOnApiError` for `api_error` rows**
+   and `autoResumeOnLimitReset` for the rest.
+2. Send sequence unchanged: `Escape` → 150ms → `send-keys -l "continue"` →
+   150ms → separate `Enter`. (Escape is harmless here — no
+   `/rate-limit-options` menu — and still protects against UI-transition
+   key drops.)
+3. Verify unchanged: ~20s for activity/transcript signal, one full
+   re-checked retry, then `failed` + attention notification.
+
+## Cancellation
+
+Same choke points as the parent, plus toggle scoping:
+
+- `UserPromptSubmit` for the terminal, terminal close/suspend, hibernation
+  parking, explicit "Cancel scheduled resume" — cancel any pending row
+  regardless of type (unchanged).
+- **`autoResumeOnApiError` switched off cancels pending `api_error` rows
+  only**; `autoResumeOnLimitReset` off cancels only limit rows.
+
+## UI
+
+- Settings toggle under the existing one: "Auto-continue after transient
+  API errors (connection drops, server errors)" — default off.
+- Notifications: toggle on → "API error — auto-continue in 60s
+  (attempt 2/4)"; toggle off → today's error notification, unchanged.
+- Terminal badge reuses the existing `pendingResumeAt` badge
+  ("⏳ resumes 2:34pm").
+
+## Testing
+
+- **Classifier fixtures from real captures:** connection-closed with
+  `error: server_error`; text-absent `server_error`; OAuth/401 and
+  credit-balance exclusions; transient-429 text vs hard-limit 429
+  (hard-limit precedence); unknown error class → excluded.
+- **Backoff:** consecutive counting across the lookback window; step
+  progression 60s→2m→5m→10m; give-up at cap emits notification and no row;
+  window-slide reset; latch interaction (pending limit row blocks
+  `api_error` insert).
+- **Toggle gates, both branches** (CLAUDE.md rule): off → notification
+  only, no row; on → row scheduled. For BOTH toggles independently —
+  api_error rows must not fire when only `autoResumeOnLimitReset` is on,
+  and vice versa.
+- **Debug seam:** `tbd hooks fake-rate-limit` grows an `--api-error` mode
+  (injects at the RPC seam, exercises schedule → actuate → verify).
+- **Real-hook E2E (PR #375 lesson):** at least one verification feeds a
+  synthetic StopFailure payload through `tbd hooks stop-failure` stdin —
+  the seam-injected test validates nothing upstream of the RPC.
+
+## Out of scope (v1)
+
+- Per-terminal/per-worktree enable overrides.
+- Retrying auth/billing errors, or any denylist-based broadening.
+- Codex terminals.
+- Draft-text protection (same accepted risk as parent).
+- Distinct badge wording for short retries ("⏳ retrying in 1m").
+
+## Sources
+
+- Live captures: TBD `state.db` notification log 2026-07-07/08; transcript
+  `8C72C1FC-…EE0C.jsonl` (worktree `20260708-crucial-porcupine`) record at
+  `2026-07-08T14:13:16.555Z`.
+- Parent design + mined community-tool gotchas:
+  [2026-07-03-session-limit-auto-resume-design.md](2026-07-03-session-limit-auto-resume-design.md).

--- a/docs/specs/2026-07-08-transient-api-error-auto-continue-design.md
+++ b/docs/specs/2026-07-08-transient-api-error-auto-continue-design.md
@@ -146,7 +146,11 @@ Same choke points as the parent, plus toggle scoping:
 - Settings toggle under the existing one: "Auto-continue after transient
   API errors (connection drops, server errors)" — default off.
 - Notifications: toggle on → "API error — auto-continue in 60s
-  (attempt 2/4)"; toggle off → today's error notification, unchanged.
+  (attempt 2/4)"; toggle off → an error notification carrying the verbatim
+  error text when the payload or transcript yields it (previously a
+  synthesized "Claude stopped: API error (…)" fallback could appear when the
+  transcript record was missing), otherwise the legacy fallback — behavior
+  otherwise unchanged.
 - Terminal badge reuses the existing `pendingResumeAt` badge
   ("⏳ resumes 2:34pm").
 


### PR DESCRIPTION
## Summary

Extends session-limit auto-resume (#341/#375) to transient API errors. When a turn dies on an allowlisted transient error — "Connection closed mid-response", 5xx/529/Overloaded, transient 429, timeouts, or error-class `server_error` — the daemon schedules an auto-typed `continue` with **60s → 2m → 5m → 10m backoff** (gives up + attention notification after 4 consecutive attempts in a 30-min window), behind a new **default-OFF** toggle "Auto-continue after transient API errors".

Motivation: fleet telemetry showed 4 connection-closed + 1 server_error + 2 transient-429 turn deaths in one 24h window, each parking an agent until manually poked.

Spec: `docs/specs/2026-07-08-transient-api-error-auto-continue-design.md` (first commit).

## Design highlights

- **Allowlist, never denylist** — auth (OAuth/401/403), billing, and unknown errors are never retried; hard-limit detection takes precedence at every stage. `rate_limit` class without transient text is never blind-retried.
- Rides the existing pipeline end to end: `scheduled_resumes` rows with `limitType = "api_error"`, same scheduler/actuator (Escape → continue → Enter, eligibility ladder, verify), shared one-pending-per-terminal latch. `fireAt = now + step` exactly — no slack/jitter (rationale in `scheduleTransient` doc comment).
- Backoff state is derived, not stored: attempt number = count of the terminal's `sent`/`failed` api_error rows in the last 30 min; cancelled rows don't count, success resets by window slide.
- New RPC `claude.transientApiErrorDetected` returns `{handled}`: false (toggle off / unknown terminal) → CLI falls back to the byte-identical legacy error print.
- Each toggle's OFF now cancels only its own rows (`cancelAllPending(scope:)`).
- Migration `v46_auto_resume_api_error` (additive, default false; the spec's "No migration" line refers to `scheduled_resumes` — the config column does need this).
- `.limitReached` reused as the resume-outcome notification channel (no new NotificationType case, zero decode churn).

## Testing

- 3059/3059 full suite, `swiftlint --strict` clean. 30+ new tests: classifier fixtures from real captured records, backoff ladder, both branches of BOTH toggles × both row types at every gate (RPC handler, scheduler fire, actuator eligibility), scoped cancels, decode-compat, CLI ordering incl. payload-first no-file-read and hard-limit precedence.
- **Live E2E through the real hook** (PR #375 lesson — the fake seam validates nothing upstream of the RPC): piped a real captured StopFailure payload into `tbd hooks stop-failure` on a live terminal. Toggle ON: error notification "…auto-continue in 60s (attempt 1/4)", ⏳ badge, fired at +60s, `continue` typed, row `sent`, badge cleared, "Auto-continued Claude after a transient API error". Toggle OFF: `handled=false`, CLI printed the verbatim error text, no row.
- Also: `tbd hooks fake-rate-limit --api-error` debug seam for RPC-downstream testing.

## Known deviations / follow-ups

- Toggle-off notification text now carries the verbatim error text in one narrow case where legacy synthesized "Claude stopped: API error (…)" (transcript record missing but payload text present) — strictly more informative; spec §UI updated to match.
- Pre-existing (affects #341 too, discovered during E2E): a stale terminal row can point at a tmux pane since reassigned to another terminal (pane-ID reuse on the shared per-repo server) — the actuator would type into the wrong session. Deserves its own issue: verify pane env `TBD_TERMINAL_ID` before sending, or GC stale terminal rows.

https://claude.ai/code/session_01Leu1sJPDm8YrELnTKvPuN3