### PR TITLE
Feat: Pick a model profile (with live usage bars) when creating a worktree from the repo + button

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -17,7 +17,10 @@ extension AppState {
     /// into a new worktree (no auto-generated `tbd/*` branch); the optimistic
     /// placeholder uses the branch's local name so the row looks right
     /// immediately.
-    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil) {
+    /// `profileID` is an optional explicit model-profile override chosen at
+    /// creation time (sidebar `+` profile picker). nil resolves the profile via
+    /// the daemon's normal repo/scratch/global precedence chain (today's behavior).
+    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil, profileID: UUID? = nil) {
         // Optimistic placeholder so the row appears instantly. When picking an
         // existing branch we use its local name so the placeholder name
         // doesn't briefly show a fake `tbd/*` value.
@@ -59,7 +62,8 @@ extension AppState {
                     displayName: placeholderName,
                     cols: size.cols, rows: size.rows,
                     parentWorktreeID: parentWorktreeID,
-                    useExistingBranch: existingBranch != nil
+                    useExistingBranch: existingBranch != nil,
+                    profileID: profileID
                 )
                 // Replace the placeholder with the real worktree, carrying
                 // over any rename the user typed while creation was in

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+import TBDShared
+
+/// A compact two-row usage meter for a Claude OAuth profile: the 5-hour session
+/// window and the weekly all-models window, each drawn as a thin bar with a
+/// severity-colored fill, a neutral "time marker" tick showing how far
+/// through the window we are, and a trailing percent.
+///
+/// Pure presentation over a `ProfileUsageSnapshot` (no picker/tab state), so it
+/// is reusable anywhere a snapshot is in hand. `now`/`timeZone` are injectable
+/// for previews and deterministic layout. A row is skipped entirely when its
+/// bucket is absent; the whole view collapses to nothing when there is no usage
+/// data at all.
+struct UsageBarsView: View {
+    let snapshot: ProfileUsageSnapshot?
+    let now: Date
+    let timeZone: TimeZone
+
+    init(snapshot: ProfileUsageSnapshot?,
+         now: Date = Date(),
+         timeZone: TimeZone = .current) {
+        self.snapshot = snapshot
+        self.now = now
+        self.timeZone = timeZone
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
+                UsageBarRow(bucket: session,
+                            label: "5h:",
+                            windowLabel: "5-hour window",
+                            windowDuration: ProfileUsagePresentation.sessionWindow,
+                            usesRelativeReset: false,
+                            now: now,
+                            timeZone: timeZone)
+            }
+            if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
+                UsageBarRow(bucket: weekly,
+                            label: "wk:",
+                            windowLabel: "Weekly window",
+                            windowDuration: ProfileUsagePresentation.weeklyWindow,
+                            usesRelativeReset: true,
+                            now: now,
+                            timeZone: timeZone)
+            }
+        }
+    }
+}
+
+// MARK: - One bar row
+
+/// A single window's row: a fixed-width label, the flexible bar (fill + time
+/// marker), and a fixed-width trailing percent — the three fixed columns keep
+/// bars vertically aligned across rows.
+private struct UsageBarRow: View {
+    let bucket: ClaudeUsageLimitBucket
+    /// Leading label ("5h:" / "wk:").
+    let label: String
+    /// Spelled-out window name for the `.help` tooltip ("5-hour window").
+    let windowLabel: String
+    /// Window length feeding the time marker's elapsed fraction.
+    let windowDuration: TimeInterval
+    /// The 5h window shows an absolute reset clock; the weekly window shows a
+    /// relative countdown ("resets in 2d 5h").
+    let usesRelativeReset: Bool
+    let now: Date
+    let timeZone: TimeZone
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Text(label)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .frame(width: 22, alignment: .leading)
+            bar
+            Text(ProfileUsagePresentation.percentText(bucket.percent))
+                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(fillColor)
+                .frame(width: 30, alignment: .trailing)
+        }
+        .help(helpText)
+    }
+
+    // MARK: Bar geometry
+
+    private var bar: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                // Track.
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(Color.primary.opacity(0.08))
+                // Usage fill.
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(fillColor)
+                    .frame(width: geo.size.width * min(bucket.percent / 100, 1))
+            }
+            .frame(height: 5)
+            // Time marker: a 9pt tick centered on the 5pt bar (overhangs 2pt
+            // each side) at the current position within the window. Drawn only
+            // when the window has a live elapsed fraction.
+            .overlay(alignment: .leading) {
+                if let fraction = elapsedFraction {
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(Color.primary)
+                        .frame(width: 2.5, height: 9)
+                        .offset(x: round(geo.size.width * fraction) - 0.75)
+                }
+            }
+        }
+        .frame(height: 5)
+    }
+
+    // MARK: Colors
+
+    /// Usage-severity fill: green (adaptive) when healthy, orange at warning,
+    /// red at critical.
+    private var fillColor: Color {
+        switch ProfileUsagePresentation.severityLevel(severity: bucket.severity,
+                                                      percent: bucket.percent) {
+        case .normal: return Self.adaptiveGreen(colorScheme)
+        case .warning: return .orange
+        case .critical: return .red
+        }
+    }
+
+    private var elapsedFraction: Double? {
+        ProfileUsagePresentation.elapsedFraction(resetsAt: bucket.resetsAt,
+                                                 windowDuration: windowDuration,
+                                                 now: now)
+    }
+
+    /// Green that reads on both appearances: a brighter mint in dark mode, a
+    /// deeper forest in light mode (the light default green washes out on a
+    /// pale bar track).
+    private static func adaptiveGreen(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(red: 60 / 255, green: 199 / 255, blue: 95 / 255)
+            : Color(red: 27 / 255, green: 107 / 255, blue: 52 / 255)
+    }
+
+    // MARK: Tooltip
+
+    /// The spelled-out reset info the compact form omits, kept as a `.help`
+    /// tooltip so nothing is lost: "5-hour window: 12% used · resets 23:10".
+    private var helpText: String {
+        var text = "\(windowLabel): \(ProfileUsagePresentation.percentText(bucket.percent)) used"
+        if let resets = bucket.resetsAt {
+            if usesRelativeReset {
+                if let relative = ProfileUsagePresentation.relativeResetText(resets, now: now) {
+                    text += " · resets in \(relative)"
+                }
+            } else {
+                text += " · resets \(ProfileUsagePresentation.resetTimeText(resets, timeZone: timeZone))"
+            }
+        }
+        return text
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Usage bars") {
+    // Fixed clock so the previewed markers land deterministically.
+    let now = Date(timeIntervalSince1970: 1_720_000_000)
+
+    func bucket(_ kind: String, _ percent: Double, severity: String? = nil,
+                resetsIn: TimeInterval? = nil) -> ClaudeUsageLimitBucket {
+        ClaudeUsageLimitBucket(kind: kind, percent: percent, severity: severity,
+                               resetsAt: resetsIn.map { now.addingTimeInterval($0) })
+    }
+    func snap(_ buckets: [ClaudeUsageLimitBucket]) -> ProfileUsageSnapshot {
+        ProfileUsageSnapshot(buckets: buckets, fetchedAt: now,
+                             lastAttemptAt: now, status: "ok", statusKind: .ok)
+    }
+
+    return VStack(alignment: .leading, spacing: 16) {
+        // Healthy, low usage, early in both windows.
+        UsageBarsView(snapshot: snap([
+            bucket("session", 6, severity: "normal", resetsIn: 4 * 3600),
+            bucket("weekly_all", 12, severity: "normal", resetsIn: 6 * 24 * 3600),
+        ]), now: now)
+
+        // Mid usage, over pace — the marker sits behind the fill (burning fast).
+        UsageBarsView(snapshot: snap([
+            bucket("session", 70, severity: "normal", resetsIn: 3.5 * 3600),
+            bucket("weekly_all", 55, severity: "warning", resetsIn: 5 * 24 * 3600),
+        ]), now: now)
+
+        // Near limit.
+        UsageBarsView(snapshot: snap([
+            bucket("session", 94, severity: "critical", resetsIn: 0.5 * 3600),
+            bucket("weekly_all", 88, severity: "warning", resetsIn: 24 * 3600),
+        ]), now: now)
+
+        // No reset date → no time marker.
+        UsageBarsView(snapshot: snap([
+            bucket("session", 40, severity: "normal"),
+            bucket("weekly_all", 30, severity: "normal"),
+        ]), now: now)
+    }
+    .frame(width: 220)
+    .padding()
+}

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -474,10 +474,10 @@ actor DaemonClient {
     /// When `useExistingBranch` is true, `branch` MUST be set to an existing
     /// ref name (local like `foo` or remote like `origin/foo`) — the daemon
     /// checks it out instead of creating a new `tbd/*` branch.
-    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false) async throws -> Worktree {
+    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false, profileID: UUID? = nil) async throws -> Worktree {
         return try await callAsync(
             method: RPCMethod.worktreeCreate,
-            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch),
+            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch, profileID: profileID),
             resultType: Worktree.self
         )
     }

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -56,6 +56,34 @@ enum ProfileUsagePresentation {
         }
     }
 
+    // MARK: - Pace projection
+
+    /// The 5-hour rolling session window, in seconds — the denominator for the
+    /// 5h bar's time marker.
+    static let sessionWindow: TimeInterval = 5 * 60 * 60
+    /// The 7-day weekly window, in seconds — the denominator for the wk bar's
+    /// time marker.
+    static let weeklyWindow: TimeInterval = 7 * 24 * 60 * 60
+
+    /// How far through a usage window we are right now, as a `0...1` fraction —
+    /// the position of the "time marker" tick on a usage bar. Derived from the
+    /// window's reset instant: `elapsed = duration - timeRemaining`.
+    ///
+    /// Returns nil (draw no marker) when there is no reset date, the duration
+    /// is non-positive, or the reset is already at/behind `now` — the latter
+    /// means the period is over and the daemon simply hasn't refreshed a new
+    /// window yet, so there is no meaningful "now" position to draw. `now` is
+    /// injectable for deterministic tests/previews.
+    static func elapsedFraction(resetsAt: Date?,
+                                windowDuration: TimeInterval,
+                                now: Date = Date()) -> Double? {
+        guard let resetsAt, windowDuration > 0 else { return nil }
+        let remaining = resetsAt.timeIntervalSince(now)
+        guard remaining > 0 else { return nil }
+        let elapsed = windowDuration - remaining
+        return min(max(elapsed / windowDuration, 0), 1)
+    }
+
     // MARK: - Formatting fragments
 
     /// "76%" — usage percents render as whole numbers everywhere.

--- a/Sources/TBDApp/Sidebar/BranchPickerView.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerView.swift
@@ -1,11 +1,27 @@
 import SwiftUI
 import TBDShared
 
-/// Popover content rendered when the user option-clicks the `+` button next
-/// to a repo in the sidebar. Lists local + `origin/*` branches with a
-/// text-field filter; selecting one creates a worktree from that existing
-/// branch instead of auto-generating a `tbd/*` name.
+/// Standalone popover wrapper around `BranchListView`. Retained as a named
+/// view type for any future call site that wants the branch list as its own
+/// popover; branch selection itself lives in `BranchListView` so there is a
+/// single source of truth (also embedded as page 2 of
+/// `WorktreeProfilePickerView`).
 struct BranchPickerView: View {
+    let repoID: UUID
+
+    var body: some View {
+        BranchListView(repoID: repoID)
+            .frame(width: 300, height: 400)
+    }
+}
+
+/// Searchable local + `origin/*` branch list. Selecting a branch creates a
+/// worktree from that existing branch (default model resolution — no profile
+/// override) and dismisses the enclosing popover. Frameless on purpose so
+/// hosts control sizing: `BranchPickerView` gives it a fixed popover frame,
+/// while `WorktreeProfilePickerView`'s branch page lets it fill the space left
+/// under the back bar.
+struct BranchListView: View {
     let repoID: UUID
     @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) private var dismiss
@@ -59,8 +75,8 @@ struct BranchPickerView: View {
                     }
                 }
             }
+            Spacer(minLength: 0)
         }
-        .frame(width: 300, height: 400)
         .task {
             isLoading = true
             loadError = false
@@ -85,6 +101,7 @@ struct BranchPickerView: View {
 
     private func pick(_ branch: BranchInfo) {
         dismiss()
+        // Branch selection always uses the default model (no profile override).
         appState.createWorktree(repoID: repoID, existingBranch: branch)
     }
 
@@ -95,7 +112,7 @@ struct BranchPickerView: View {
     }
 }
 
-private struct BranchPickerRow: View {
+struct BranchPickerRow: View {
     let branch: BranchInfo
     let onSelect: () -> Void
 

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -33,7 +33,8 @@ struct RepoSectionView: View {
     @State private var isChevronHovered = false
     @State private var hoverDebounceTask: Task<Void, Error>?
     @State private var showRemoveConfirm = false
-    // PROTOTYPE: model-profile picker on the `+` button (long-press + Option-click).
+    // Long-press or Option-click the `+` opens the model-profile picker; a plain
+    // click creates a worktree with the default profile.
     @State private var showProfilePicker = false
     // Set when a long-press opens the profile picker, so the Button's own tap
     // action (which fires on finger-up, after the long-press's onEnded) doesn't

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -33,7 +33,12 @@ struct RepoSectionView: View {
     @State private var isChevronHovered = false
     @State private var hoverDebounceTask: Task<Void, Error>?
     @State private var showRemoveConfirm = false
-    @State private var showBranchPicker = false
+    // PROTOTYPE: model-profile picker on the `+` button (long-press + Option-click).
+    @State private var showProfilePicker = false
+    // Set when a long-press opens the profile picker, so the Button's own tap
+    // action (which fires on finger-up, after the long-press's onEnded) doesn't
+    // ALSO create a default worktree. Reset on the next plain click.
+    @State private var longPressTriggered = false
 
     private func onSectionHoverChange(_ hovering: Bool) {
         if hovering {
@@ -134,15 +139,38 @@ struct RepoSectionView: View {
             Spacer()
 
             Group {
-                if isSectionHovered || showBranchPicker {
+                if isSectionHovered || showProfilePicker {
                     SectionHeaderPlusButton(
-                        help: "New worktree (\u{2325}-click to pick existing branch)",
+                        // Long-press or Option-click opens the unified profile
+                        // picker; its "Choose a branch…" row drills into the
+                        // (former standalone) branch picker.
+                        help: "New worktree (long-press or \u{2325}-click to pick a model profile)",
                         action: handlePlusButton
                     )
                     .disabled(repo.status == .missing)
-                    .popover(isPresented: $showBranchPicker, arrowEdge: .trailing) {
-                        BranchPickerView(repoID: repo.id)
+                    // Long-press (~0.3s) opens the profile picker. `.simultaneousGesture`
+                    // runs ALONGSIDE the Button's tap recognizer, so a plain click still
+                    // fires `handlePlusButton` (create-with-default) and long-press doesn't
+                    // swallow it — the guard flag prevents a create on the long-press release.
+                    .simultaneousGesture(
+                        LongPressGesture(minimumDuration: 0.3)
+                            .onEnded { _ in
+                                guard repo.status != .missing else { return }
+                                longPressTriggered = true
+                                showProfilePicker = true
+                            }
+                    )
+                    .popover(isPresented: $showProfilePicker, arrowEdge: .trailing) {
+                        WorktreeProfilePickerView(repoID: repo.id)
                             .environmentObject(appState)
+                    }
+                    // Safety net for the orphaned-flag cases: if the long-press
+                    // opened the picker but no follow-up tap on `+` ever cleared
+                    // the flag (press released off-button, or picker dismissed /
+                    // a profile chosen), clear it when the popover closes so the
+                    // next plain click isn't swallowed by the guard.
+                    .onChange(of: showProfilePicker) { _, isShown in
+                        if !isShown { longPressTriggered = false }
                     }
                 } else {
                     Color.clear
@@ -219,10 +247,17 @@ struct RepoSectionView: View {
     }
 
     private func handlePlusButton() {
-        // Option-click opens the existing-branch picker; plain click creates
-        // a fresh `tbd/*` worktree (existing behavior).
+        // A long-press already handled this interaction (it opened the profile
+        // picker and set the flag); the Button's tap fires on finger-up right
+        // after, so consume it here instead of creating a default worktree.
+        if longPressTriggered {
+            longPressTriggered = false
+            return
+        }
+        // Option-click (like long-press) opens the unified model-profile
+        // picker; branch selection now lives inside it under "Choose a branch…".
         if NSEvent.modifierFlags.contains(.option) {
-            showBranchPicker = true
+            showProfilePicker = true
         } else {
             createWorktree()
         }

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import TBDShared
 
-/// Popover content rendered when the user long-presses (or, for this
-/// prototype, Option-clicks) the `+` button next to a repo in the sidebar.
+/// Popover content rendered when the user long-presses or Option-clicks the
+/// `+` button next to a repo in the sidebar.
 ///
 /// Two in-place pages (NOT nested popovers — those are fragile on macOS):
 ///  - `.profiles` (default): a fixed "Choose a branch…" drill-in row at the
@@ -94,34 +94,43 @@ struct WorktreeProfilePickerView: View {
                     }
 
                     ForEach(appState.modelProfiles, id: \.profile.id) { entry in
-                        if showsUsageBars(for: entry) {
-                            // OAuth profile with a usage snapshot that has
-                            // buckets: render the two-bar meter instead of the
-                            // single-line usage text.
-                            UsageBarsProfileRow(
-                                entry: entry,
-                                isDefault: entry.profile.id == appState.defaultProfileID
-                            ) {
-                                pick(profileID: entry.profile.id)
-                            }
-                        } else {
-                            let line = ProfileUsagePresentation.menuLine(for: entry)
-                            let subtitle = profileSubtitle(for: entry, usageNote: line.secondary)
-                            ProfilePickerRow(
-                                title: line.primary,
-                                subtitle: subtitle.text,
-                                systemImage: "person.crop.circle",
-                                isDefault: entry.profile.id == appState.defaultProfileID,
-                                // Always reserve subtitle height so the row never
-                                // shifts, whichever state it resolves to.
-                                reservesSubtitle: true,
-                                // Skeleton is reserved for the ONE genuine loading
-                                // case (logged-in OAuth awaiting its first poll).
-                                showsSubtitleSkeleton: subtitle.showsSkeleton
-                            ) {
-                                pick(profileID: entry.profile.id)
+                        // A not-logged-in OAuth profile is not selectable: dim it
+                        // and disable its Button so its tap can't create a
+                        // worktree pinned to an account that can't run. apiKey /
+                        // bedrock rows report selectable and stay actionable.
+                        let isSelectable = ProfileUsagePresentation.isSelectable(entry)
+                        Group {
+                            if showsUsageBars(for: entry) {
+                                // OAuth profile with a usage snapshot that has
+                                // buckets: render the two-bar meter instead of the
+                                // single-line usage text.
+                                UsageBarsProfileRow(
+                                    entry: entry,
+                                    isDefault: entry.profile.id == appState.defaultProfileID
+                                ) {
+                                    pick(profileID: entry.profile.id)
+                                }
+                            } else {
+                                let line = ProfileUsagePresentation.menuLine(for: entry)
+                                let subtitle = profileSubtitle(for: entry, usageNote: line.secondary)
+                                ProfilePickerRow(
+                                    title: line.primary,
+                                    subtitle: subtitle.text,
+                                    systemImage: "person.crop.circle",
+                                    isDefault: entry.profile.id == appState.defaultProfileID,
+                                    // Always reserve subtitle height so the row never
+                                    // shifts, whichever state it resolves to.
+                                    reservesSubtitle: true,
+                                    // Skeleton is reserved for the ONE genuine loading
+                                    // case (logged-in OAuth awaiting its first poll).
+                                    showsSubtitleSkeleton: subtitle.showsSkeleton
+                                ) {
+                                    pick(profileID: entry.profile.id)
+                                }
                             }
                         }
+                        .disabled(!isSelectable)
+                        .opacity(isSelectable ? 1 : 0.5)
                     }
                 }
             }
@@ -167,7 +176,7 @@ struct WorktreeProfilePickerView: View {
     /// the session / weekly buckets the meter draws. Every other case (logged-in
     /// awaiting first poll, logged out, apiKey/bedrock) keeps its text subtitle.
     private func showsUsageBars(for entry: ModelProfileWithUsage) -> Bool {
-        guard entry.profile.kind == .oauth else { return false }
+        guard entry.profile.kind == .oauth, ProfileUsagePresentation.isSelectable(entry) else { return false }
         return ProfileUsagePresentation.sessionBucket(entry.usageSnapshot) != nil
             || ProfileUsagePresentation.weeklyAllBucket(entry.usageSnapshot) != nil
     }

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -1,0 +1,351 @@
+import SwiftUI
+import TBDShared
+
+/// Popover content rendered when the user long-presses (or, for this
+/// prototype, Option-clicks) the `+` button next to a repo in the sidebar.
+///
+/// Two in-place pages (NOT nested popovers — those are fragile on macOS):
+///  - `.profiles` (default): a fixed "Choose a branch…" drill-in row at the
+///    top, then "Resolve automatically" and one row per configured model
+///    profile. Selecting a profile row one-click-creates a worktree pinned to
+///    that profile; "Resolve automatically" creates one with no override
+///    (repo → scratch → global default precedence).
+///  - `.branches`: the reused searchable branch list (`BranchListView`) behind
+///    a back affordance. Selecting a branch creates a worktree on that existing
+///    branch using the DEFAULT model (accepted tradeoff).
+///
+/// Modeled on `BranchPickerView` for consistent popover sizing/styling.
+struct WorktreeProfilePickerView: View {
+    let repoID: UUID
+    @EnvironmentObject var appState: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    private enum Page {
+        case profiles
+        case branches
+    }
+
+    @State private var page: Page = .profiles
+
+    var body: some View {
+        Group {
+            switch page {
+            case .profiles:
+                profilesPage
+            case .branches:
+                branchesPage
+            }
+        }
+        .frame(width: 300, height: 400)
+        .task {
+            // Ensure the list (and usage suffixes) are populated even if the
+            // user hasn't opened Settings yet this session.
+            if appState.modelProfiles.isEmpty {
+                await appState.loadModelProfiles()
+            }
+        }
+    }
+
+    // MARK: - Page 1: profiles
+
+    private var profilesPage: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("New worktree with…")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            // Fixed at the top regardless of profile count: drill into the
+            // branch list. The trailing chevron signals in-place navigation.
+            ProfilePickerRow(
+                title: "Choose a branch…",
+                subtitle: "Create on an existing branch",
+                systemImage: "arrow.triangle.branch",
+                showsChevron: true
+            ) {
+                page = .branches
+            }
+            .padding(.top, 2)
+
+            Divider()
+                .padding(.vertical, 2)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    // Default / automatic resolution (no explicit override).
+                    ProfilePickerRow(
+                        title: "Resolve automatically",
+                        subtitle: "Use the repo / global default",
+                        systemImage: "wand.and.stars",
+                        isDefault: true
+                    ) {
+                        pick(profileID: nil)
+                    }
+
+                    if !appState.modelProfiles.isEmpty {
+                        Divider()
+                            .padding(.vertical, 2)
+                    }
+
+                    ForEach(appState.modelProfiles, id: \.profile.id) { entry in
+                        if showsUsageBars(for: entry) {
+                            // OAuth profile with a usage snapshot that has
+                            // buckets: render the two-bar meter instead of the
+                            // single-line usage text.
+                            UsageBarsProfileRow(
+                                entry: entry,
+                                isDefault: entry.profile.id == appState.defaultProfileID
+                            ) {
+                                pick(profileID: entry.profile.id)
+                            }
+                        } else {
+                            let line = ProfileUsagePresentation.menuLine(for: entry)
+                            let subtitle = profileSubtitle(for: entry, usageNote: line.secondary)
+                            ProfilePickerRow(
+                                title: line.primary,
+                                subtitle: subtitle.text,
+                                systemImage: "person.crop.circle",
+                                isDefault: entry.profile.id == appState.defaultProfileID,
+                                // Always reserve subtitle height so the row never
+                                // shifts, whichever state it resolves to.
+                                reservesSubtitle: true,
+                                // Skeleton is reserved for the ONE genuine loading
+                                // case (logged-in OAuth awaiting its first poll).
+                                showsSubtitleSkeleton: subtitle.showsSkeleton
+                            ) {
+                                pick(profileID: entry.profile.id)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Page 2: branches
+
+    private var branchesPage: some View {
+        VStack(spacing: 0) {
+            Button {
+                page = .profiles
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("Back")
+                        .font(.system(size: 12, weight: .semibold))
+                    Spacer()
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            Divider()
+
+            // Reused branch list: selecting a branch creates on that existing
+            // branch with the default model and dismisses the whole popover.
+            BranchListView(repoID: repoID)
+        }
+    }
+
+    private func pick(profileID: UUID?) {
+        dismiss()
+        appState.createWorktree(repoID: repoID, profileID: profileID)
+    }
+
+    /// Whether a profile row should render the two-bar usage meter (instead of
+    /// a text subtitle): an OAuth profile whose snapshot carries at least one of
+    /// the session / weekly buckets the meter draws. Every other case (logged-in
+    /// awaiting first poll, logged out, apiKey/bedrock) keeps its text subtitle.
+    private func showsUsageBars(for entry: ModelProfileWithUsage) -> Bool {
+        guard entry.profile.kind == .oauth else { return false }
+        return ProfileUsagePresentation.sessionBucket(entry.usageSnapshot) != nil
+            || ProfileUsagePresentation.weeklyAllBucket(entry.usageSnapshot) != nil
+    }
+
+    /// Resolve the fixed-height subtitle for a profile row. Precedence:
+    ///  1. A real usage / login note from `menuLine` (`usageNote`) — shown as-is.
+    ///  2. Logged-in OAuth awaiting its first usage poll → skeleton (the ONE
+    ///     genuine "loading" state).
+    ///  3. Logged-out OAuth → a plain "not logged in" note (no skeleton).
+    ///  4. API-key / Bedrock → the profile's own static kind descriptor.
+    private func profileSubtitle(
+        for entry: ModelProfileWithUsage,
+        usageNote: String?
+    ) -> (text: String?, showsSkeleton: Bool) {
+        if let usageNote {
+            return (usageNote, false)
+        }
+        switch entry.profile.kind {
+        case .oauth:
+            if ProfileUsagePresentation.isSelectable(entry) {
+                // Logged in; skeleton only until the first snapshot lands.
+                return (nil, entry.usageSnapshot == nil)
+            }
+            return ("Not logged in — run /login", false)
+        case .apiKey, .bedrock:
+            // Static descriptor from ModelProfile — never a loading state.
+            if let detail = entry.profile.detailCaption {
+                return ("\(entry.profile.kindLabel) · \(detail)", false)
+            }
+            return (entry.profile.kindLabel, false)
+        }
+    }
+}
+
+/// A profile row whose subtitle is the two-bar usage meter rather than a text
+/// line. Mirrors `ProfilePickerRow`'s chrome (icon, title, hover highlight,
+/// "default" chip) but hosts `UsageBarsView`, which sizes to its two bars — the
+/// fixed-single-line reservation only applies to the text rows.
+private struct UsageBarsProfileRow: View {
+    let entry: ModelProfileWithUsage
+    var isDefault: Bool = false
+    let onSelect: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 6) {
+                Image(systemName: "person.crop.circle")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(ProfileLoginPresentation.menuItemTitle(for: entry))
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    UsageBarsView(snapshot: entry.usageSnapshot)
+                }
+                Spacer(minLength: 4)
+                if isDefault {
+                    Text("default")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(Color.secondary.opacity(0.10))
+                        )
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isHovered ? Color.accentColor.opacity(0.15) : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}
+
+private struct ProfilePickerRow: View {
+    let title: String
+    let subtitle: String?
+    let systemImage: String
+    var isDefault: Bool = false
+    /// When true, a subtitle line is always rendered at full height — real text
+    /// when available, otherwise an invisible placeholder — so the row height
+    /// never changes across states (no pop-in).
+    var reservesSubtitle: Bool = false
+    /// When true (and there is no real `subtitle`), render a redacted skeleton
+    /// instead of empty space. Reserved for the one genuine loading case.
+    var showsSubtitleSkeleton: Bool = false
+    /// Trailing drill-in chevron (e.g. the "Choose a branch…" navigation row).
+    var showsChevron: Bool = false
+    let onSelect: () -> Void
+
+    @State private var isHovered = false
+
+    private var hasSubtitle: Bool {
+        if let subtitle, !subtitle.isEmpty { return true }
+        return false
+    }
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    subtitleLine
+                }
+                Spacer(minLength: 4)
+                if showsChevron {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                } else if isDefault {
+                    Text("default")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(Color.secondary.opacity(0.10))
+                        )
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isHovered ? Color.accentColor.opacity(0.15) : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+
+    @ViewBuilder
+    private var subtitleLine: some View {
+        if hasSubtitle {
+            subtitleText(subtitle ?? "")
+        } else if showsSubtitleSkeleton {
+            // Redacted → a subtle skeleton while the first usage poll is in
+            // flight (logged-in OAuth only).
+            subtitleText("resets 00:00 · week 00% used")
+                .redacted(reason: .placeholder)
+        } else if reservesSubtitle {
+            // No text and nothing loading: hold the line's height so the row
+            // stays identical to its usage / skeleton / descriptor siblings.
+            subtitleText(" ")
+                .hidden()
+        }
+    }
+
+    /// Shared styling so every subtitle state — usage text, skeleton, a
+    /// "not logged in" note, a kind descriptor, or the reserved blank — has an
+    /// identical font/size/line-limit and therefore an identical row height.
+    private func subtitleText(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -180,7 +180,7 @@ extension WorktreeLifecycle {
     /// When `existingBranchRef` is non-nil, the worktree is checked out from
     /// that existing ref (local or `origin/*`) — no fresh branch is created.
     @discardableResult
-    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil) async throws -> WorktreeCreateCompletion {
+    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, overrideProfileID: UUID? = nil) async throws -> WorktreeCreateCompletion {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -284,7 +284,8 @@ extension WorktreeLifecycle {
                         skipClaude: skipClaude,
                         initialPrompt: initialPrompt,
                         cols: cols, rows: rows,
-                        completionAction: .markActive
+                        completionAction: .markActive,
+                        overrideProfileID: overrideProfileID
                     )
                 }
                 return .preSessionPending(phase3: phase3)
@@ -299,7 +300,8 @@ extension WorktreeLifecycle {
                 initialPrompt: initialPrompt,
                 cols: cols,
                 rows: rows,
-                preSessionTerminalID: nil
+                preSessionTerminalID: nil,
+                overrideProfileID: overrideProfileID
             )
 
             // 6. Update status to active
@@ -416,7 +418,8 @@ extension WorktreeLifecycle {
         initialPrompt: String? = nil,
         cols: Int? = nil,
         rows: Int? = nil,
-        preSessionTerminalID: UUID?
+        preSessionTerminalID: UUID?,
+        overrideProfileID: UUID? = nil
     ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
@@ -445,7 +448,9 @@ extension WorktreeLifecycle {
         )
         await controlMode?.enableIfGated(serverName: tmuxServer)
 
-        // Resolve model profile (repo override → global default → none).
+        // Resolve model profile. An explicit per-creation `overrideProfileID`
+        // (chosen in the sidebar `+` profile picker) wins over the precedence
+        // chain (repo override → global default → none); nil preserves it.
         // Failures here must NOT break worktree creation — fall back to keychain login.
         let needsResolvedClaudeProfile = !skipClaude && (
             primaryTerminalKind == .claude || !archivedSessions.isEmpty
@@ -453,7 +458,7 @@ extension WorktreeLifecycle {
         var resolvedProfile: ResolvedModelProfile? = nil
         if needsResolvedClaudeProfile, let resolver = modelProfileResolver {
             do {
-                resolvedProfile = try await resolver.resolve(repoID: repo?.id)
+                resolvedProfile = try await resolver.resolve(repoID: repo?.id, override: overrideProfileID)
             } catch {
                 logger.warning("model profile resolution failed; falling back to keychain login")
                 resolvedProfile = nil

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -249,7 +249,8 @@ extension WorktreeLifecycle {
         archivedClaudeSessions: [String]? = nil,
         initialPrompt: String? = nil,
         cols: Int? = nil, rows: Int? = nil,
-        completionAction: PreSessionCompletionAction
+        completionAction: PreSessionCompletionAction,
+        overrideProfileID: UUID? = nil
     ) async {
         let outcome = await waitForPreSessionCompletion(
             preSession: preSession, tmuxServer: worktree.tmuxServer
@@ -311,7 +312,8 @@ extension WorktreeLifecycle {
                 archivedClaudeSessions: archivedClaudeSessions,
                 initialPrompt: initialPrompt,
                 cols: cols, rows: rows,
-                preSessionTerminalID: preSession.terminalID
+                preSessionTerminalID: preSession.terminalID,
+                overrideProfileID: overrideProfileID
             )
             for terminal in created {
                 subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(

--- a/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
+++ b/Sources/TBDDaemon/ModelProfile/ModelProfileResolver.swift
@@ -74,7 +74,24 @@ public struct ModelProfileResolver: Sendable {
         )
     }
 
-    public func resolve(repoID: UUID?) async throws -> ResolvedModelProfile? {
+    /// Resolve the model profile for a spawn.
+    ///
+    /// `override` is an explicit per-creation profile id (e.g. chosen in the
+    /// sidebar `+` profile picker). When non-nil AND it resolves, it wins over
+    /// EVERY tier of the precedence chain below. A nil `override` (the default)
+    /// preserves the exact pre-existing precedence: repo override → scratch
+    /// override → global default → none.
+    public func resolve(repoID: UUID?, override overrideID: UUID? = nil) async throws -> ResolvedModelProfile? {
+        // Step 0: explicit per-creation override — highest priority. If the
+        // row/keychain is missing we log and fall through to the normal chain
+        // rather than fail the spawn.
+        if let overrideID {
+            if let resolved = try await loadResolved(id: overrideID) {
+                return resolved
+            }
+            logger.warning("explicit profile override \(overrideID, privacy: .public) is missing; falling back to precedence chain")
+        }
+
         // Step 1: per-repo override.
         if let repoID, let repo = try await repos.get(id: repoID),
            let overrideID = repo.profileOverrideID {

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -37,12 +37,15 @@ extension RPCRouter {
         // Pass the raw branch ref (possibly `origin/...`) to phase 2 so it
         // can dispatch to the right git command.
         let existingBranchRef = useExistingBranch ? params.branch : nil
+        // Explicit per-creation model-profile override (sidebar `+` picker).
+        // nil preserves the repo/scratch/global precedence chain.
+        let overrideProfileID = params.profileID
         // handleWorktreeCreate is always repo-scoped (scratch creation uses a
         // separate RPC), so params.repoID is the reliable non-optional source
         // — pending.repoID mirrors it but is now UUID? on the shared model.
         await repoSerializer.submit(repoID: params.repoID) {
             do {
-                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
+                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, overrideProfileID: overrideProfileID)
                 switch completion {
                 case .ready:
                     subs.broadcast(delta: .worktreeCreated(WorktreeDelta(

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -774,7 +774,13 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// out into a new worktree — no fresh `tbd/*` branch is created.
     /// Optional/defaulted for backward compatibility with older clients.
     public let useExistingBranch: Bool?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil) {
+    /// Explicit per-creation model-profile override. When non-nil, the daemon
+    /// resolves THIS profile for the new worktree's primary Claude terminal,
+    /// bypassing the repo/scratch/global precedence chain. nil preserves the
+    /// existing precedence-based resolution. Not persisted — creation-time only.
+    /// Optional/defaulted for backward compatibility with older clients.
+    public let profileID: UUID?
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
         self.parentWorktreeID = parentWorktreeID
@@ -782,6 +788,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
         self.callerWorktreeID = callerWorktreeID
         self.suppressAutoParent = suppressAutoParent
         self.useExistingBranch = useExistingBranch
+        self.profileID = profileID
     }
 }
 

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -215,6 +215,70 @@ struct SeverityLevelTests {
     }
 }
 
+// MARK: - Pace projection: elapsed-time fraction
+
+@Suite("ProfileUsagePresentation — elapsedFraction")
+struct ElapsedFractionTests {
+    /// Fixed instant so no test touches the wall clock.
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test func windowConstantsAreFiveHoursAndSevenDays() {
+        #expect(ProfileUsagePresentation.sessionWindow == 5 * 60 * 60)
+        #expect(ProfileUsagePresentation.weeklyWindow == 7 * 24 * 60 * 60)
+    }
+
+    @Test func noResetDateYieldsNil() {
+        #expect(ProfileUsagePresentation.elapsedFraction(
+            resetsAt: nil,
+            windowDuration: ProfileUsagePresentation.sessionWindow,
+            now: now) == nil)
+    }
+
+    @Test func nonPositiveWindowDurationYieldsNil() {
+        // A zero/negative denominator has no meaningful fraction.
+        #expect(ProfileUsagePresentation.elapsedFraction(
+            resetsAt: now.addingTimeInterval(3600),
+            windowDuration: 0,
+            now: now) == nil)
+    }
+
+    @Test func resetBehindNowMeansPeriodOverYieldsNil() {
+        // reset already passed → the daemon just hasn't rolled a new window yet.
+        #expect(ProfileUsagePresentation.elapsedFraction(
+            resetsAt: now.addingTimeInterval(-100),
+            windowDuration: ProfileUsagePresentation.sessionWindow,
+            now: now) == nil)
+    }
+
+    @Test func resetExactlyNowIsPeriodOverYieldsNil() {
+        // Boundary: remaining == 0 fails the `remaining > 0` guard.
+        #expect(ProfileUsagePresentation.elapsedFraction(
+            resetsAt: now,
+            windowDuration: ProfileUsagePresentation.sessionWindow,
+            now: now) == nil)
+    }
+
+    @Test func midWindowIsHalfElapsed() throws {
+        // 2.5h remaining of a 5h window → half the window has elapsed.
+        let fraction = try #require(ProfileUsagePresentation.elapsedFraction(
+            resetsAt: now.addingTimeInterval(2.5 * 60 * 60),
+            windowDuration: ProfileUsagePresentation.sessionWindow,
+            now: now))
+        #expect(abs(fraction - 0.5) < 1e-9)
+    }
+
+    @Test func resetBeyondTheWindowClampsToZeroNotNegative() throws {
+        // reset 10h out on a 5h window → elapsed is negative; clamp to 0, stay in 0...1.
+        let fraction = try #require(ProfileUsagePresentation.elapsedFraction(
+            resetsAt: now.addingTimeInterval(10 * 60 * 60),
+            windowDuration: ProfileUsagePresentation.sessionWindow,
+            now: now))
+        #expect(fraction >= 0)
+        #expect(fraction <= 1)
+        #expect(abs(fraction - 0) < 1e-9)
+    }
+}
+
 // MARK: - Picker sort ordering
 
 @Suite("ProfileUsagePresentation — picker sort")

--- a/Tests/TBDDaemonTests/ModelProfileResolverTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileResolverTests.swift
@@ -315,6 +315,57 @@ struct ModelProfileResolverTests {
         #expect(result?.profileID == global.id)
     }
 
+    // MARK: - Explicit per-creation override (sidebar `+` profile picker)
+
+    @Test("explicit override wins over repo override, scratch override, and global default")
+    func resolve_explicitOverride_winsOverEverything() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let override = try await db.modelProfiles.create(name: "Chosen", kind: .apiKey)
+        let repoOverride = try await db.modelProfiles.create(name: "Repo", kind: .apiKey)
+        let global = try await db.modelProfiles.create(name: "Global", kind: .apiKey)
+        try await db.config.setDefaultProfileID(global.id)
+        let repo = try await makeRepo(db, override: repoOverride.id)
+        box.map[override.id.uuidString] = "secret-chosen"
+        box.map[repoOverride.id.uuidString] = "secret-repo"
+        box.map[global.id.uuidString] = "secret-global"
+
+        let result = try await resolver.resolve(repoID: repo.id, override: override.id)
+        #expect(result?.profileID == override.id)
+        #expect(result?.secret == "secret-chosen")
+    }
+
+    @Test("nil override falls through to the existing precedence chain unchanged")
+    func resolve_nilOverride_preservesPrecedence() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let repoOverride = try await db.modelProfiles.create(name: "Repo", kind: .apiKey)
+        let global = try await db.modelProfiles.create(name: "Global", kind: .apiKey)
+        try await db.config.setDefaultProfileID(global.id)
+        let repo = try await makeRepo(db, override: repoOverride.id)
+        box.map[repoOverride.id.uuidString] = "secret-repo"
+        box.map[global.id.uuidString] = "secret-global"
+
+        // Explicit-nil call must be byte-for-byte identical to the no-arg form:
+        // the repo override still wins.
+        let result = try await resolver.resolve(repoID: repo.id, override: nil)
+        #expect(result?.profileID == repoOverride.id)
+        #expect(result?.secret == "secret-repo")
+    }
+
+    @Test("explicit override missing/keychain-less falls back to the precedence chain")
+    func resolve_explicitOverride_missing_fallsBackToChain() async throws {
+        let (db, box, resolver) = try makeHarness()
+        let global = try await db.modelProfiles.create(name: "Global", kind: .apiKey)
+        try await db.config.setDefaultProfileID(global.id)
+        let repo = try await makeRepo(db)
+        box.map[global.id.uuidString] = "secret-global"
+
+        // Override points at a profile id that doesn't exist — must not fail the
+        // spawn; falls through to the global default.
+        let result = try await resolver.resolve(repoID: repo.id, override: UUID())
+        #expect(result?.profileID == global.id)
+        #expect(result?.secret == "secret-global")
+    }
+
     @Test("scratchProfileOverrideID does not leak into repo-scoped resolution")
     func resolve_repoScoped_ignoresScratchOverride() async throws {
         let (db, box, resolver) = try makeHarness()


### PR DESCRIPTION
## Summary
- **Long-press or Option-click** the repo-section **"+"** opens a model-profile picker for the new worktree. A plain click still creates with the default profile — the gesture split preserves the existing one-click behavior.
- The picker's first item is **"Choose a branch…"** (nested, in-place list; selecting a branch creates on it with the **default** model — an accepted tradeoff, since branch choice is the infrequent action). Every other row is a **model profile**: one click creates a new-branch worktree pinned to that account.
- Threads an optional `profileID` through `AppState.createWorktree → DaemonClient → RPC → daemon`, resolved by `ModelProfileResolver` as an **explicit override above** the existing repo/scratch/global precedence chain. `nil` preserves prior behavior exactly (covered by tests for both branches).
- New reusable **`UsageBarsView`**: compact `5h:` / `wk:` bars with severity-colored fill (green→orange→red) and a neutral elapsed-time **marker tick** (fill past the tick = ahead of pace). Pure, unit-tested pace/elapsed helpers (`elapsedFraction`, window constants) in `ProfileUsagePresentation`.
- Profile rows are **state-aware**: real usage bars for logged-in OAuth; a skeleton *only* while OAuth awaits its first poll; "Not logged in — run /login" for logged-out OAuth; and a `kind · config` descriptor (e.g. `Bedrock · us-west-2 · Opus`) for API-key/Bedrock profiles that never have usage — no more permanent fake skeleton.

## Notes
- **By-design fallback:** if an *explicitly picked* profile can't resolve (e.g. an API-key row whose keychain secret was cleared), the daemon logs a warning and falls back to the default account rather than failing the spawn. Flagged in review as a nit; kept for robustness. Could later surface the substitution to the client.
- Branch selection now lives entirely inside this picker; the old orphaned Option-click branch popover was removed (`BranchListView` extracted from `BranchPickerView` as the shared source).

## Test plan
- [ ] Plain-click a repo "+" → creates a worktree with the default profile (unchanged).
- [ ] Long-press and Option-click both open the profile picker; dismissing it and clicking "+" again still creates (no dead click — the `longPressTriggered` safety-net fix).
- [ ] Pick a profile → worktree spawns pinned to that account; "Choose a branch…" → pick a branch → spawns on that branch with the default model.
- [ ] Usage bars render for OAuth-with-usage; API-key/Bedrock show descriptors; logged-out shows "Not logged in".
- [ ] `swift build` + `swift test` (ModelProfileResolver, WorktreeLifecycle, ProfileUsagePresentation suites — 126 tests) pass.

[🎛 Long-Press Model Picker](https://cheapsteak.github.io/tbd/open/?worktree=B728A3F9-796D-4789-8671-46090C03FDC5)