### PR TITLE
Fix: Preserve single newlines in transcript messages (they were vanishing entirely)

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/Renderer/MarkdownAttributedRenderer.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/MarkdownAttributedRenderer.swift
@@ -130,6 +130,21 @@ extension AttributedStringVisitor: @preconcurrency MarkupVisitor {
         NSAttributedString(string: text.string)
     }
 
+    // SoftBreak (a single newline inside a paragraph) and LineBreak (an explicit
+    // hard break) are leaf nodes with no children. Without these methods they fall
+    // through to `defaultVisit`, which iterates zero children and returns an EMPTY
+    // string — silently dropping the user's line breaks (e.g. "then?\nor" → "then?or").
+    // We emit "\n" to preserve the typed line breaks, matching GitHub-comment / chat
+    // rendering. (trimTrailingNewlines still strips a trailing run at block end, so a
+    // break at a paragraph's end never doubles into a blank line.)
+    mutating func visitSoftBreak(_ softBreak: Markdown.SoftBreak) -> NSAttributedString {
+        NSAttributedString(string: "\n")
+    }
+
+    mutating func visitLineBreak(_ lineBreak: Markdown.LineBreak) -> NSAttributedString {
+        NSAttributedString(string: "\n")
+    }
+
     mutating func visitStrong(_ s: Strong) -> NSAttributedString { traited(s, .bold) }
 
     mutating func visitEmphasis(_ e: Emphasis) -> NSAttributedString { traited(e, .italic) }

--- a/Tests/TBDAppTests/MarkdownAttributedRendererTests.swift
+++ b/Tests/TBDAppTests/MarkdownAttributedRendererTests.swift
@@ -208,6 +208,51 @@ struct MarkdownAttributedRendererTests {
         #expect(foundTableAttachment)
     }
 
+    // MARK: - Soft / hard line breaks
+
+    @Test("a single newline inside a paragraph is preserved, not dropped or turned into a space")
+    func softBreakPreservesNewline() {
+        // swift-markdown parses a lone newline within a paragraph as a SoftBreak
+        // leaf node; without visitSoftBreak it fell through to defaultVisit and
+        // vanished entirely ("line one\nline two" -> "line oneline two"). (#129)
+        let joined = MarkdownAttributedRenderer.renderBlocks("line one\nline two")
+            .compactMap { block -> String? in
+                if case .prose(let s) = block { return s.string }
+                return nil
+            }
+            .joined()
+        #expect(joined.contains("line one\nline two"))
+    }
+
+    @Test("an explicit hard line break renders a newline")
+    func hardLineBreakRendersNewline() {
+        // Two trailing spaces before the newline make a Markdown hard break
+        // (LineBreak leaf node). It must also emit "\n".
+        let joined = MarkdownAttributedRenderer.renderBlocks("line one  \nline two")
+            .compactMap { block -> String? in
+                if case .prose(let s) = block { return s.string }
+                return nil
+            }
+            .joined()
+        #expect(joined.contains("line one\nline two"))
+    }
+
+    @Test("blank-line-separated paragraphs still render as separate paragraphs")
+    func doubleNewlineStillSeparatesParagraphs() {
+        // Regression guard: adding SoftBreak/LineBreak handling must not disturb
+        // the existing paragraph-terminator behavior. A blank line still yields two
+        // paragraphs, present and separated by a newline.
+        let joined = MarkdownAttributedRenderer.renderBlocks("para one\n\npara two")
+            .compactMap { block -> String? in
+                if case .prose(let s) = block { return s.string }
+                return nil
+            }
+            .joined()
+        #expect(joined.contains("para one"))
+        #expect(joined.contains("para two"))
+        #expect(joined.contains("para one\npara two"))
+    }
+
     // MARK: - Block splitting (renderBlocks)
 
     @Test("renderBlocks: prose-only markdown is one prose block, no table block")


### PR DESCRIPTION
## Summary
- User (and assistant) messages in the NSTableView transcript renderer were dropping newlines **entirely** — e.g. a message typed as `does SSID names affect airplay then?` / `or does it affect printers too?` rendered as the run-on `...then?or does it affect printers too?...` with no break and not even a space.
- **Root cause:** `AttributedStringVisitor` in `MarkdownAttributedRenderer` had no `visitSoftBreak` / `visitLineBreak`. swift-markdown parses a single newline inside a paragraph as a `SoftBreak` leaf node (and an explicit hard break as `LineBreak`). Both are childless leaves, so they fell through to `defaultVisit`, which iterates zero children and returns an **empty** string — silently deleting the newline.
- **Fix:** add both visitors, emitting `"\n"` so the user's typed line breaks are preserved. This matches GitHub-comment / chat rendering, which is what this transcript viewer is. `trimTrailingNewlines` already strips a trailing run at block end, so a break at a paragraph's end never doubles into a blank line. Double-newline paragraph separation is unchanged.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --filter MarkdownAttributedRenderer` — all pass, incl. 3 new tests:
  - single newline within a paragraph is preserved (`line one\nline two`)
  - explicit hard line break renders a newline
  - regression guard: `para one\n\npara two` still renders as separate paragraphs
- [ ] Live: in the transcript viewer, a multi-line user message (worktree "📶 Home WiFi Tuning") now shows each line on its own line

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=82B7BC00-B218-4984-B2B4-25B1BFB5B8E7)