### PR TITLE
fix(terminal): submit large messages via bracketed paste, not send-keys -l

### DIFF
--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1333,11 +1333,24 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
 
-        try await tmux.sendKeys(
-            server: worktree.tmuxServer,
-            paneID: terminal.tmuxPaneID,
-            text: params.text
-        )
+        // Deliver the body as an EXPLICIT bracketed paste (load-buffer +
+        // paste-buffer -d -p) rather than raw `send-keys -l`. For payloads
+        // larger than the pty buffer (~1 KB) the pty splits `send-keys -l` into
+        // multiple rapid reads, which a TUI's non-bracketed paste-burst
+        // detection mistakes for a paste and coalesces — absorbing the trailing
+        // Enter so nothing submits. The explicit `ESC[201~` terminator puts the
+        // Enter provably outside the paste. tmux emits the wrappers iff the pane
+        // has bracketed-paste mode on — agent TUIs and modern interactive shells
+        // both enable it at the prompt; cooked-mode consumers get bare bytes and
+        // behave as before. Skip an empty body entirely (don't paste an empty
+        // buffer) but still press Enter below if requested.
+        if !params.text.isEmpty {
+            try await tmux.pasteText(
+                server: worktree.tmuxServer,
+                paneID: terminal.tmuxPaneID,
+                bytes: Data(params.text.utf8)
+            )
+        }
 
         if params.submit == true {
             try await tmux.sendKey(

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -252,6 +252,32 @@ public struct TmuxManager: Sendable {
         ["-L", server, "send-keys", "-t", paneID, key]
     }
 
+    /// Load a temp file's bytes into a uniquely named tmux paste buffer. The
+    /// path is passed as a distinct argv element (no shell), so spaces are safe.
+    public static func loadBufferCommand(server: String, bufferName: String, path: String) -> [String] {
+        ["-L", server, "load-buffer", "-b", bufferName, path]
+    }
+
+    /// Paste a named buffer into a pane WITH `-p` (bracketed-paste authority
+    /// handed to tmux) and `-d` (delete the buffer after pasting). tmux wraps
+    /// the payload in `ESC[200~`/`ESC[201~` iff the pane has bracketed-paste
+    /// mode enabled — which agent TUIs (Claude Code, Codex) AND modern
+    /// interactive shells (zsh, bash ≥4.4, fish) all do at their prompt — and
+    /// emits bare bytes otherwise (a cooked-mode consumer, e.g. a program
+    /// reading stdin). Note `-d`/no-`-r`: like the GUI `PasteExecutor` path,
+    /// tmux replaces interior LF with CR in the pasted body; this is the proven
+    /// paste behavior we deliberately match, and is inside the brackets so it
+    /// does not affect the separate trailing Enter.
+    public static func pasteBufferCommand(server: String, bufferName: String, paneID: String) -> [String] {
+        ["-L", server, "paste-buffer", "-d", "-p", "-b", bufferName, "-t", paneID]
+    }
+
+    /// Delete a named paste buffer (best-effort cleanup when `paste-buffer -d`
+    /// never ran because the paste itself failed).
+    public static func deleteBufferCommand(server: String, bufferName: String) -> [String] {
+        ["-L", server, "delete-buffer", "-b", bufferName]
+    }
+
     public static func listWindowsCommand(server: String, session: String) -> [String] {
         ["-L", server, "list-windows", "-t", session, "-F", "#{window_id} #{pane_id}"]
     }
@@ -474,6 +500,67 @@ public struct TmuxManager: Sendable {
             return
         }
         try await runTmux(args)
+    }
+
+    /// Deliver `bytes` to a pane as an EXPLICIT bracketed paste over the plain
+    /// `tmux -L` subprocess path: write to a temp file, `load-buffer` it into a
+    /// uniquely named buffer, then `paste-buffer -d -p` into the pane. tmux
+    /// surrounds the payload with `ESC[200~`/`ESC[201~` iff the pane enabled
+    /// bracketed-paste mode (agent TUIs), and emits bare bytes for plain shells
+    /// — so a subsequent separate `Enter` keystroke lands provably OUTSIDE the
+    /// paste and can't be absorbed by a TUI's paste-burst coalescing window
+    /// (the root cause of `--submit` silently dropping large messages).
+    ///
+    /// Mirrors `PasteExecutor.paste` (the GUI paste path) but over `runTmux`
+    /// rather than the `-CC` control command client, so it stays consistent with
+    /// `handleTerminalSend`'s existing plain-subprocess tmux usage and adds no
+    /// coupling to control mode. The temp file is removed in all paths; a paste
+    /// failure best-effort deletes the orphaned buffer before rethrowing so the
+    /// caller surfaces the error.
+    public func pasteText(server: String, paneID: String, bytes: Data) async throws {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-paste-\(UUID().uuidString)")
+        let path = tempURL.path
+        // Note: no quote/newline guard is needed here (unlike PasteExecutor,
+        // which single-quotes the path INTO a tmux command string). `runTmux`
+        // passes `path` as a distinct argv element with no shell, so any bytes
+        // in a FileManager temp path are safe.
+        // Unique buffer per call so concurrent pastes never clobber each other.
+        let bufferName = "tbd-paste-\(UUID().uuidString.prefix(8))"
+        let loadArgs = Self.loadBufferCommand(server: server, bufferName: bufferName, path: path)
+        let pasteArgs = Self.pasteBufferCommand(server: server, bufferName: bufferName, paneID: paneID)
+
+        if dryRun {
+            // Record the intended argv without touching the filesystem.
+            dryRunRecorder?(loadArgs)
+            dryRunRecorder?(pasteArgs)
+            return
+        }
+
+        // Register cleanup BEFORE the write so a mid-write throw still removes
+        // any partial temp file (PasteExecutor's "removed in all paths").
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+        try bytes.write(to: tempURL)
+
+        try await runTmux(loadArgs)
+        do {
+            try await runTmux(pasteArgs)
+        } catch {
+            // load-buffer succeeded but paste-buffer threw (e.g. the pane died
+            // between the two awaits). `-d` would have deleted the buffer on
+            // success; since it didn't run, best-effort delete before rethrowing
+            // so the uniquely named buffer doesn't linger on the server.
+            do {
+                try await runTmux(Self.deleteBufferCommand(server: server, bufferName: bufferName))
+            } catch let cleanupError {
+                logger.debug("""
+                    delete-buffer cleanup failed for \(bufferName, privacy: .public): \
+                    \(String(describing: cleanupError), privacy: .public) — the buffer may \
+                    linger on the tmux server (original paste error is rethrown)
+                    """)
+            }
+            throw error
+        }
     }
 
     public func capturePaneOutput(server: String, paneID: String) async throws -> String {

--- a/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
@@ -52,6 +52,124 @@ extension RPCRouterTests {
         #expect(terminals.count == 1)
     }
 
+    /// Thread-safe collector for tmux argv lists invoked during dryRun.
+    private final class SendRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _calls: [[String]] = []
+        var calls: [[String]] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+        func record(_ args: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            _calls.append(args)
+        }
+    }
+
+    /// A router whose tmux records every dryRun argv, plus a seeded terminal to
+    /// send to. Used by the bracketed-paste ordering tests below.
+    private func makeRecorderFixture() async throws -> (RPCRouter, SendRecorder, Terminal) {
+        let recorder = SendRecorder()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorder.record($0) })
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date()
+        )
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+        return (router, recorder, terminal)
+    }
+
+    @Test("terminal.send with submit brackets the paste then presses Enter, in order")
+    func terminalSendBracketedPasteThenEnter() async throws {
+        let (router, recorder, terminal) = try await makeRecorderFixture()
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id,
+                text: "line one\nline two\nline three",
+                submit: true
+            )
+        )
+        #expect(await router.handle(request).success)
+
+        let calls = recorder.calls
+        let loadIdx = try #require(calls.firstIndex { $0.contains("load-buffer") })
+        let pasteIdx = try #require(calls.firstIndex { $0.contains("paste-buffer") })
+        let enterIdx = try #require(
+            calls.firstIndex { $0.contains("send-keys") && $0.contains("Enter") })
+
+        // Ordering: load the buffer, paste it, THEN press Enter.
+        #expect(loadIdx < pasteIdx)
+        #expect(pasteIdx < enterIdx)
+
+        // The paste must use -p (bracketed-paste authority to tmux) and target
+        // the pane; the Enter must NOT be part of the paste.
+        let pasteArgs = calls[pasteIdx]
+        #expect(pasteArgs.contains("-p"))
+        #expect(pasteArgs.contains("-t"))
+        #expect(pasteArgs.contains("%mock-0"))
+    }
+
+    @Test("terminal.send without submit does not press Enter")
+    func terminalSendNoSubmitNoEnter() async throws {
+        let (router, recorder, terminal) = try await makeRecorderFixture()
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id,
+                text: "line one\nline two",
+                submit: false
+            )
+        )
+        #expect(await router.handle(request).success)
+
+        let calls = recorder.calls
+        // Body still pasted...
+        #expect(calls.contains { $0.contains("paste-buffer") })
+        // ...but no Enter keystroke.
+        #expect(!calls.contains { $0.contains("send-keys") && $0.contains("Enter") })
+    }
+
+    @Test("terminal.send with empty text and submit presses Enter but skips the paste")
+    func terminalSendEmptyTextSubmitEnterOnly() async throws {
+        let (router, recorder, terminal) = try await makeRecorderFixture()
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminal.id, text: "", submit: true)
+        )
+        #expect(await router.handle(request).success)
+
+        let calls = recorder.calls
+        // Empty body → never load or paste an empty buffer...
+        #expect(!calls.contains { $0.contains("load-buffer") })
+        #expect(!calls.contains { $0.contains("paste-buffer") })
+        // ...but a bare --submit still presses Enter.
+        #expect(calls.contains { $0.contains("send-keys") && $0.contains("Enter") })
+    }
+
     @Test("terminal.send dispatches to tmux")
     func terminalSend() async throws {
         let repo = try await db.repos.create(

--- a/Tests/TBDDaemonTests/TerminalSendBracketedPasteLiveTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendBracketedPasteLiveTests.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Live-tmux proof of the `--submit` bracketed-paste delivery fix
+/// (`handleTerminalSend` → `TmuxManager.pasteText` + separate Enter).
+///
+/// The daemon delivers a message body via `load-buffer` + `paste-buffer -d -p`
+/// then presses Enter as a SEPARATE keystroke. The regression this guards:
+/// large/multi-line bodies sent with raw `send-keys -l` were split by the pty
+/// into multiple rapid reads, which a TUI's non-bracketed paste-burst detection
+/// mistook for a paste and coalesced — absorbing the trailing Enter so nothing
+/// submitted. With an explicit bracketed paste the `ESC[201~` terminator puts
+/// the Enter provably OUTSIDE the paste.
+///
+/// Two cases prove the wire bytes at the pty:
+///  - bracketed-paste mode ON (agent TUI): body arrives wrapped in
+///    `ESC[200~`…`ESC[201~`, and the Enter (`\r`) follows OUTSIDE the wrapper.
+///  - bracketed-paste mode OFF (plain shell): body arrives bare + `\r`, with no
+///    `ESC[200~` — proving no shell regression.
+///
+/// The pane captures its own input under a raw tty via `head -c N > file`
+/// (rc-free bootstrap: the pane command IS the capture). Body is >1 KB and
+/// multi-line to exercise the original failure size. 15s deadlines throughout.
+@Suite("terminal.send bracketed paste (live tmux)", .serialized)
+struct TerminalSendBracketedPasteLiveTests {
+
+    /// ESC[200~ / ESC[201~ bracketed-paste wrappers.
+    private static let bracketStart = Data([0x1b, 0x5b, 0x32, 0x30, 0x30, 0x7e])
+    private static let bracketEnd = Data([0x1b, 0x5b, 0x32, 0x30, 0x31, 0x7e])
+    /// Enter → carriage return.
+    private static let enter = Data([0x0d])
+
+    /// A multi-line, >1 KB printable-ASCII body (the original failure size).
+    private static func makeBody() -> Data {
+        var text = ""
+        for i in 1...40 {
+            text += "Item \(i): the quick brown fox jumps over the lazy dog 0123456789\n"
+        }
+        text += "When finished reply with exactly: ACK"
+        let data = Data(text.utf8)
+        precondition(data.count > 1024, "body must exceed the ~1 KB pty split boundary")
+        return data
+    }
+
+    /// The body AS IT ARRIVES on the wire: tmux `paste-buffer` (without `-r`)
+    /// translates every LF (0x0a) to CR (0x0d) — the same behavior as the proven
+    /// GUI paste path (`PasteExecutor`, also no `-r`). The TUI treats each CR
+    /// inside the bracketed block as a line break in the pasted text (not a
+    /// submit), so multi-line messages land intact. Length is preserved.
+    private static func pastedForm(_ body: Data) -> Data {
+        Data(body.map { $0 == 0x0a ? 0x0d : $0 })
+    }
+
+    @discardableResult
+    private func tmux(_ args: [String]) -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tmux"] + args
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }
+
+    private func tmuxCapture(_ args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tmux"] + args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            return String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Poll `#{pane_current_command}` until it equals `command`, or time out.
+    private func awaitPaneCommand(server: String, paneID: String, command: String) async throws {
+        let deadline = ContinuousClock.now + .seconds(15)
+        while ContinuousClock.now < deadline {
+            if tmuxCapture(["-L", server, "display-message", "-t", paneID,
+                            "-p", "#{pane_current_command}"]) == command { return }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        Issue.record("head never became the pane's foreground command")
+    }
+
+    /// Bootstrap a raw-capture pane sized to `count` bytes. When `bracketed` is
+    /// true, the pane first enables DECSET 2004 (bracketed-paste mode) so tmux
+    /// wraps a later `paste-buffer -p`. Returns the pane id once `head` owns the
+    /// tty.
+    private func startRawCapture(server: String, count: Int, outputPath: String,
+                                 bracketed: Bool) async throws -> String {
+        let prefix = bracketed ? "printf '\\033[?2004h' > /dev/tty; " : ""
+        try #require(tmux(["-L", server, "new-session", "-d", "-s", "main", "-x", "200", "-y", "50",
+                           "/bin/sh", "-c",
+                           "\(prefix)stty raw -echo; exec head -c \(count) > \(outputPath)"]),
+                     "failed to bootstrap raw-capture tmux session")
+        let paneID = try #require(
+            tmuxCapture(["-L", server, "display-message", "-t", "main", "-p", "#{pane_id}"]),
+            "could not resolve pane id")
+        try await awaitPaneCommand(server: server, paneID: paneID, command: "head")
+        return paneID
+    }
+
+    private func awaitFileBytes(path: String, expected: Data) async throws {
+        let deadline = ContinuousClock.now + .seconds(15)
+        while ContinuousClock.now < deadline {
+            if let data = FileManager.default.contents(atPath: path), data == expected { return }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        let actual = FileManager.default.contents(atPath: path) ?? Data()
+        let expectedBytes = Array(expected)
+        let actualBytes = Array(actual)
+        var diffHint = ""
+        for i in 0..<min(expectedBytes.count, actualBytes.count) where expectedBytes[i] != actualBytes[i] {
+            diffHint = "; first diff at byte \(i): expected 0x\(String(expectedBytes[i], radix: 16)), got 0x\(String(actualBytes[i], radix: 16))"
+            break
+        }
+        Issue.record("capture mismatch: expected \(expected.count) bytes, got \(actual.count)\(diffHint)")
+    }
+
+    /// Mirror `handleTerminalSend`: bracketed paste of the body, then a separate
+    /// Enter keystroke.
+    private func sendWithSubmit(server: String, paneID: String, body: Data) async throws {
+        let manager = TmuxManager()
+        try await manager.pasteText(server: server, paneID: paneID, bytes: body)
+        try await manager.sendKey(server: server, paneID: paneID, key: "Enter")
+    }
+
+    @Test("bracketed pane: body wrapped in ESC[200~/201~ with Enter OUTSIDE the paste")
+    func bracketedPaneEnterOutsidePaste() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-brk-\(UUID().uuidString.prefix(8))"
+        let outputPath = NSTemporaryDirectory() + "tbd-send-brk-\(UUID().uuidString).bin"
+        defer {
+            tmux(["-L", server, "kill-server"])
+            try? FileManager.default.removeItem(atPath: outputPath)
+        }
+
+        let body = Self.makeBody()
+        let expected = Self.bracketStart + Self.pastedForm(body) + Self.bracketEnd + Self.enter
+        let paneID = try await startRawCapture(
+            server: server, count: expected.count, outputPath: outputPath, bracketed: true)
+
+        try await sendWithSubmit(server: server, paneID: paneID, body: body)
+        try await awaitFileBytes(path: outputPath, expected: expected)
+    }
+
+    @Test("plain pane: body arrives bare + Enter, no bracketed markers")
+    func plainPaneNoBrackets() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-plain-\(UUID().uuidString.prefix(8))"
+        let outputPath = NSTemporaryDirectory() + "tbd-send-plain-\(UUID().uuidString).bin"
+        defer {
+            tmux(["-L", server, "kill-server"])
+            try? FileManager.default.removeItem(atPath: outputPath)
+        }
+
+        let body = Self.makeBody()
+        let expected = Self.pastedForm(body) + Self.enter
+        let paneID = try await startRawCapture(
+            server: server, count: expected.count, outputPath: outputPath, bracketed: false)
+
+        try await sendWithSubmit(server: server, paneID: paneID, body: body)
+        try await awaitFileBytes(path: outputPath, expected: expected)
+    }
+}

--- a/docs/submit-reliability.md
+++ b/docs/submit-reliability.md
@@ -1,0 +1,210 @@
+# `tbd terminal send --submit` silent non-submit — design brief
+
+**Status:** research + design, awaiting sign-off (no code changed yet)
+**Branch:** `tbd/submit-reliability-brainstorm`
+**Author:** investigation session, 2026-07-08
+
+## TL;DR
+
+`--submit` frequently fails to submit **large / multi-line** messages: the text
+lands in the target TUI's input box but is never sent, sitting unsent at the `❯`
+prompt as `[Pasted text #N]`. Short messages submit fine.
+
+Root cause (reproduced at the byte level): the daemon delivers the message body
+with `tmux send-keys -l` and then sends Enter with a second `tmux send-keys
+Enter`. For payloads larger than the pty buffer (~1 KB) the body is split by the
+pty into **multiple rapid reads**. Claude Code (and Codex) treat that multi-read
+burst as a *non-bracketed paste* and open a short coalescing window; the Enter
+(`\r`) that follows a few milliseconds later lands **inside that window** and is
+absorbed as pasted content instead of being processed as a submit key. Small
+payloads arrive in a single read, are not detected as a paste, and their Enter
+submits normally.
+
+**Recommendation:** deliver the body as an *explicit bracketed paste*
+(`load-buffer` + `paste-buffer -p`, the same mechanism the GUI paste path already
+uses) and send Enter as a separate keystroke. The explicit `ESC[201~` terminator
+makes the Enter unambiguously outside the paste, so it can never be absorbed.
+This is a root-cause fix, TUI-agnostic, and empirically verified to submit large
+multi-line messages. Optionally layer a verify-and-retry step so the unattended
+(nightwatch) path can *detect* a non-submit rather than trust it blindly.
+
+## The mechanism (current code)
+
+`Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift:1324` —
+`handleTerminalSend`:
+
+```swift
+try await tmux.sendKeys(server: …, paneID: …, text: params.text)   // send-keys -l  <text>
+if params.submit == true {
+    try await tmux.sendKey(server: …, paneID: …, key: "Enter")     // send-keys      Enter
+}
+```
+
+`sendKeys` → `send-keys -l -t <pane> <text>` (literal), `sendKey` →
+`send-keys -t <pane> Enter` (key name → `\r`). Two separate `tmux` subprocess
+invocations, sequential. This is the **only** send path that pushes
+arbitrary-size text through raw `send-keys -l`. It is unconditional — no
+control-mode branch, no size threshold. (`LimitResumeActuator` and any other
+daemon-originated sends go through the same two `TmuxManager` methods, so they
+share the bug.)
+
+Note the contrast with the **GUI paste path**, which already does the right
+thing: app-level paste interception → `.paste` sidecar frame →
+`ControlModeInputRouter.deliverPaste` → `PasteExecutor.paste` →
+`load-buffer` + `paste-buffer -d -p` (bracketed), and the user's Enter arrives
+later as a separate `.input` keystroke frame. That path is robust; the CLI path
+is not.
+
+## Evidence (reproductions)
+
+All runs used tmux 3.6a and real Claude Code v2.1.205, in isolated `tmux -L`
+servers (the live fleet was never touched).
+
+**1. The pty splits a large `send-keys -l` into multiple reads.**
+A 2000-byte `send-keys -l` observed by a raw pty reader arrived as:
+
+```
+read len=1022   (body)
+read len= 978   (body)
+read len=   1   b'\r'   ← the Enter, a separate read right after
+```
+
+The ~1 KB split is the pty buffer boundary. The Enter follows within
+milliseconds.
+
+**2. Small payload → submits (no paste UI).**
+596-byte multi-line body via `send-keys -l` + Enter → Claude submitted
+immediately; body shown inline, *not* collapsed to `[Pasted text]`.
+
+**3. Large payload → the reported failure, exactly.**
+1609-byte multi-line body via `send-keys -l` + Enter (the exact daemon path):
+
+```
+❯ [Pasted text #1]e.Item 14: … Item 20: … When finished reply with exactly: ACKF
+```
+
+Input box **non-empty**, message **unsent**, no "Brewing/Baked" — Enter absorbed.
+This is the reported `[Pasted text #N]` symptom. The first pty chunk collapsed to
+`[Pasted text #1]`; the second chunk appended as raw text; the trailing `\r` was
+swallowed into the paste.
+
+**4. Bracketed paste + separate Enter → submits, even large.**
+Same ~1.2–1.6 KB multi-line body delivered via `load-buffer` + `paste-buffer -d
+-p` then `send-keys Enter` → Claude submitted and replied `ACKG`; input box
+cleared. The explicit `ESC[201~` terminator ends the paste before the Enter
+arrives.
+
+**5. No regression for plain shells.**
+`paste-buffer -p` into a pane with bracketed-paste mode **off** (a plain shell)
+sends **bare** bytes — `hello from paste\nsecond line\n` — no `ESC[200~/201~`.
+tmux wraps *iff* the pane enabled the mode (`CSI ?2004h`), so shells behave
+exactly as today and only TUIs that opt in get bracketed.
+
+**6. Fixed-delay-before-Enter is flaky.**
+Inserting sleeps (50/150/300/600 ms) between the raw `send-keys -l` and the Enter
+gave inconsistent submit/non-submit results across runs — the coalescing window
+is not a clean fixed value and stretches under load. Confirms the "just wait then
+press Enter" hypothesis is fragile.
+
+## Why short works and long doesn't (the crux)
+
+- **Short (≤ ~1 KB):** one pty read → not a burst → not detected as a paste → the
+  following `\r` is a distinct keypress → **submits**.
+- **Long (> ~1 KB or enough to look pasted):** multi-read burst → detected as a
+  non-bracketed paste → coalescing window open → the `\r` lands inside it →
+  **absorbed**, message sits unsent.
+- **The "later short append flushed everything":** the short send wasn't a burst,
+  so *its* Enter was processed as submit and flushed the accumulated buffer —
+  consistent with the report.
+
+The failure is not tmux adding brackets (it doesn't, for `send-keys -l`) and not
+a trailing `\r` being *literally pasted by design*. It is the TUI's
+**non-bracketed paste-burst detection** mistaking a chunked `send-keys` for a
+paste and eating the Enter.
+
+## Options weighed
+
+### Option 1 — Delay before Enter *(rejected)*
+Sleep between the text and the Enter. Trivial, but the coalescing window is
+undocumented, version-dependent, and load-dependent (evidence #6). Under load the
+chunks themselves spread, so a "safe" delay can still fall inside the window; adds
+latency to every submit; does nothing for detectability. **Reject.**
+
+### Option 2 — Bracketed-paste delivery + separate Enter *(recommended, primary)*
+Deliver `text` via `load-buffer` + `paste-buffer -d -p` (mode-aware bracketing),
+then `send-keys Enter`.
+- **Pros:** root-cause fix — the explicit `ESC[201~` terminator puts the Enter
+  provably outside the paste, so it can't be absorbed (no timing dependence).
+  TUI-agnostic (standard bracketed-paste protocol; both Claude Code and Codex
+  enable `?2004h` — see `SwiftTermModeEscapeSmokeTests`). Mirrors the
+  already-working GUI paste path (`PasteExecutor`). Mode-aware → no shell
+  regression (evidence #5). Verified to submit large messages (evidence #4). Low
+  complexity; implementable over the plain `tmux -L` subprocess path already used
+  by `handleTerminalSend`, so **no new coupling to the `-CC` control connection.**
+- **Cons:** slightly changes `--text` semantics for embedded escape/control
+  bytes (they'd be literal pasted text) — but `send-keys -l` already treats
+  `--text` as literal, so this is near-equivalent in practice. Does not by itself
+  make a non-submit *detectable*. Rare transient edge: if the TUI is momentarily
+  not at its prompt (mode off), the paste falls back to bare bytes and the burst
+  risk returns — orthogonal to this fix and mitigated by Option 3.
+
+### Option 3 — Verify-and-retry + trustworthy result *(recommended, follow-up)*
+After submitting, capture the pane and check whether the input was actually
+consumed (input box cleared / no residual `[Pasted text]`); on a detected
+non-submit, retry Enter with bounded attempts, and return a real
+success/failure so the CLI exit code / RPC result can be trusted.
+- **Pros:** makes the silent non-submit **detectable and self-healing** — the
+  thing the unattended nightwatch path most needs (today `dispatch()` in
+  `NightwatchSkillContent.swift:405` fires `--submit` and returns `True`
+  unconditionally, so a drop is invisible). Defense-in-depth on top of Option 2.
+- **Cons:** TUI-coupled — "did it submit?" needs per-TUI heuristics (Claude vs
+  Codex render differently); capture is async so it races the render (needs
+  bounded polling, cf. condition-based waiting); a wrong "not submitted" verdict
+  could double-send Enter (usually harmless, but could confirm an unrelated
+  dialog). Best scoped to the agent TUIs, not shells.
+
+### Option 4 — Make `--submit` return submit-success
+Only meaningful *with* Option 3's verification (the daemon otherwise has no way to
+know). Folds into Option 3.
+
+## Recommendation
+
+1. **Ship Option 2 now.** It removes the root cause with low risk, reuses a
+   proven in-repo mechanism, and is TUI-agnostic. Add tests for both branches
+   (bracketed TUI submit; bare shell submit) per the repo's branch-coverage rule.
+2. **Then add Option 3 for the unattended path**, scoped to the agent TUIs, with
+   bounded retry and a trustworthy exit code that `nightwatch dispatch()` checks —
+   so a genuine drop pages/logs instead of silently reporting success.
+
+The task's stated hypothesis ("send a separate Enter after the paste settles") is
+half right: the Enter **must** be a separate keystroke — but the robustness comes
+from *explicitly bracketing the paste so it has a terminator*, **not** from
+waiting for it to "settle." Bracketing removes the race; waiting only narrows it.
+
+## Open questions for Chang
+
+1. **Always bracket, or only above a size threshold?** I lean always (uniform;
+   mode-aware bracketing already no-ops for shells). Do any callers send raw
+   escape/control sequences through `--text` that bracketing would neutralize? (I
+   believe not — `send-keys -l` is already literal-only.)
+2. **Include the verify-and-retry layer (Option 3) now, or ship Option 2 and
+   observe first?** For nightwatch, detectability is the higher-value half.
+3. **Should `--submit`'s exit code become meaningful** (non-zero on a confirmed
+   non-submit)? That's a CLI-contract change nightwatch could then trust.
+4. **Codex live confirmation:** I confirmed Claude Code end-to-end. The mechanism
+   is protocol-level (both TUIs enable `?2004h`), but want me to spin up a Codex
+   pane to confirm identical behavior before implementing?
+
+## Implementation sketch (if Option 2 approved)
+
+- Add a `TmuxManager.pasteBuffer(server:paneID:bytes:)` helper mirroring
+  `PasteExecutor`'s temp-file → `load-buffer` → `paste-buffer -d -p` →
+  best-effort `delete-buffer` dance, but over the plain `runTmux` subprocess path
+  (not the `-CC` command client), consistent with how `handleTerminalSend`
+  already talks to tmux.
+- In `handleTerminalSend`, replace `tmux.sendKeys(text:)` with the new paste
+  helper; keep the `if submit { sendKey("Enter") }` exactly as is (now safe).
+- Tests: (a) TUI pane with `?2004h` on → body arrives bracketed and a large
+  multi-line message submits; (b) shell pane → body arrives bare and submits;
+  (c) `submit == false` → no Enter. Follow the daemon test discipline in
+  `CLAUDE.md` (no `~/tbd`, live-tmux deadlines, rc-free bootstraps).


### PR DESCRIPTION
## Problem

`tbd terminal send --submit` frequently **fails to submit** large / multi-line messages. The text lands in the target TUI's input box but is never sent — it sits unsent as `[Pasted text #N]` at the `❯` prompt. Short messages submit fine. This is load-bearing for orchestration and especially bad for nightwatch (unattended: a silent non-submit = dropped work + a false "it's working" signal).

## Root cause (reproduced at the byte level against real Claude Code v2.1.205)

`handleTerminalSend` delivered the body with `tmux send-keys -l <text>` then a separate `tmux send-keys Enter`. A raw pty reader shows a large `send-keys -l` is split by the pty into **multiple rapid reads** (~1 KB each), with the Enter arriving as its own read right after:

```
read len=1022   (body)
read len= 978   (body)
read len=   1   b'\r'   ← the Enter
```

The TUI's **non-bracketed paste-burst heuristic** mistakes that multi-read burst for a paste and opens a coalescing window; the trailing `\r` lands inside it and is **absorbed as pasted content** instead of submitting. Small messages arrive in a single read, aren't detected as a paste, and their Enter submits — which is exactly why "short works, long doesn't."

The reported `[Pasted text #N]` symptom was reproduced precisely with the exact daemon path.

## Fix

Deliver the body as an **explicit bracketed paste** (`load-buffer` + `paste-buffer -d -p` — the same mechanism the GUI `PasteExecutor` path already uses), then send Enter as a separate keystroke. The explicit `ESC[201~` terminator puts the Enter provably **outside** the paste, so it can't be absorbed — no timing dependence. Verified empirically: the same large multi-line message delivered this way submits reliably.

tmux only emits the `ESC[200~/201~` wrappers when the pane has bracketed-paste mode on, so cooked-mode consumers get bare bytes and behave as before (no shell regression).

The naive "delay then Enter" alternative was tested and is flaky (the coalescing window isn't a clean constant); bracketing removes the race rather than narrowing it.

## Changes

- `TmuxManager.pasteText` + static `load/paste/delete-buffer` command builders (over the plain `runTmux` subprocess path, no `-CC` coupling).
- `handleTerminalSend` pastes the body (skips empty text) then presses Enter.
- Tests: dryRun command ordering + submit/no-submit/empty-text branches; live-tmux wire-byte proof that a >1 KB multi-line body arrives bracketed with the Enter **outside** the brackets, and bare on a plain pane.

## Scope

Daemon send path + tests only. No nightwatch files touched (to minimize merge conflicts with nightwatch lanes). No RPC-contract / exit-code changes; a verify-and-retry detectability layer for the unattended path is deferred as a follow-up.

Full root-cause analysis, options weighed, and rationale: `docs/submit-reliability.md`.

## Verification

- `swift build` clean; `swiftlint --strict` 0 violations on changed files.
- Affected suites pass (RPCRouterTerminal, TmuxManager, PasteExecutor, new TerminalSendBracketedPaste live suite).

[20260708-extensive-chickadee](https://cheapsteak.github.io/tbd/open/?worktree=1419C456-947C-440E-A832-16D8DFC02D75)