### PR TITLE
Fix: Stop subprocess-timeout tests flaking red under CI load (two independent starvation bugs)

### DIFF
--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -444,105 +444,28 @@ public struct GitManager: Sendable {
                      executable: String = "/usr/bin/git") async throws -> String {
         let timeout = subprocessTimeout
         let commandDescription = "git " + arguments.joined(separator: " ")
-        // Single-resume guard shared by the termination handler, the timeout
-        // timer, and the spawn-failure path (mirrors TmuxManager.runExternalCommand).
-        let state = ContinuationGuard()
-        let timeoutNanos = UInt64(max(0, timeout.components.seconds)) * 1_000_000_000
-            + UInt64(max(0, timeout.components.attoseconds / 1_000_000_000))
-
-        return try await withCheckedThrowingContinuation { continuation in
-            let process = Process()
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            let stdoutAccumulator = PipeDataAccumulator()
-            let stderrAccumulator = PipeDataAccumulator()
-
-            process.executableURL = URL(fileURLWithPath: executable)
-            process.arguments = arguments
-            process.currentDirectoryURL = URL(fileURLWithPath: directory)
-            process.standardOutput = stdoutPipe
-            process.standardError = stderrPipe
-
-            // Watchdog: a wedged git child (a `git fetch` was once stuck 95 min)
-            // is escalated SIGTERM → SIGKILL and the call throws GitTimeoutError.
-            let timer = DispatchSource.makeTimerSource(queue: .global())
-            timer.schedule(deadline: .now() + .nanoseconds(Int(min(timeoutNanos, UInt64(Int.max)))))
-            timer.setEventHandler {
-                guard state.claim() else { return }
-                timer.cancel()
-                // Stop draining and close the parent read ends NOW (mirrors
-                // TmuxManager.runExternalCommand). The kill below reaches only
-                // the DIRECT child; grandchildren it forked inherit the pipe
-                // write ends, so EOF may never come — waiting for it would
-                // leak the FDs and handler closures for their lifetime.
-                stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                stderrPipe.fileHandleForReading.readabilityHandler = nil
-                _ = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
-                _ = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
-                let pid = process.processIdentifier
-                if pid > 0 {
-                    kill(pid, SIGTERM)
-                    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(500)) {
-                        if process.isRunning { kill(pid, SIGKILL) }
-                    }
-                }
-                logger.warning("git subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
-                continuation.resume(throwing: GitTimeoutError(command: commandDescription, timeout: timeout))
+        // All the mechanism (starvation-proof watchdog thread, authoritative
+        // deadline, incremental pipe draining, no-EOF-wait, single-resume
+        // guard) lives in the shared `runBoundedProcess`; this only maps the
+        // outcome to GitError/GitTimeoutError. A wedged git child (a `git fetch`
+        // was once stuck 95 min) is escalated SIGTERM → SIGKILL there and
+        // surfaces here as GitTimeoutError.
+        switch try await runBoundedProcess(
+            executable: executable,
+            arguments: arguments,
+            currentDirectory: directory,
+            timeout: timeout
+        ) {
+        case .timedOut:
+            logger.warning("git subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
+            throw GitTimeoutError(command: commandDescription, timeout: timeout)
+        case let .completed(status, stdoutData, stderrData):
+            let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+            let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+            if status != 0 {
+                throw GitError(command: commandDescription, exitCode: status, stderr: stderr)
             }
-
-            // Drain pipes incrementally to prevent deadlock when output exceeds the
-            // OS pipe buffer (~64KB). Without this, the child process blocks on
-            // write and `terminationHandler` never fires.
-            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-                if !stdoutAccumulator.readAvailable(from: handle) {
-                    handle.readabilityHandler = nil
-                }
-            }
-            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-                if !stderrAccumulator.readAvailable(from: handle) {
-                    handle.readabilityHandler = nil
-                }
-            }
-
-            process.terminationHandler = { _ in
-                // Detach handlers; `finish` blocks on the same lock the readability
-                // handler holds, so any in-flight read+append completes before we snapshot.
-                stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                stderrPipe.fileHandleForReading.readabilityHandler = nil
-                let stdoutData = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
-                let stderrData = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
-
-                let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
-                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
-
-                guard state.claim() else { return }  // timer already won → timed out
-                timer.cancel()
-
-                if process.terminationStatus != 0 {
-                    continuation.resume(throwing: GitError(
-                        command: commandDescription,
-                        exitCode: process.terminationStatus,
-                        stderr: stderr
-                    ))
-                } else {
-                    continuation.resume(returning: stdout)
-                }
-            }
-
-            do {
-                try process.run()
-                timer.resume()
-            } catch {
-                // Spawn failed: no child will ever write — detach the drain
-                // handlers and close the read ends so nothing lingers.
-                stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                stderrPipe.fileHandleForReading.readabilityHandler = nil
-                _ = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
-                _ = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
-                guard state.claim() else { return }
-                timer.cancel()
-                continuation.resume(throwing: error)
-            }
+            return stdout
         }
     }
 

--- a/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
+++ b/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+/// A single dedicated OS thread that fires subprocess deadlines.
+///
+/// It replaces the `DispatchSource.makeTimerSource(queue: .global())` timer the
+/// bounded runner used to arm. That timer's event handler needed a free thread
+/// from the shared default-QoS GCD pool — and a dispatch queue of ANY QoS draws
+/// from that same pool, so a "dedicated queue" would not have helped. Under the
+/// full test suite (~3000 tests, every target in ONE process, suites running in
+/// parallel) the pool's ~64 worker threads all park on subprocesses/pipes/waits;
+/// with none free, the 100ms timer handler never ran, a `sleep 3` child ran to
+/// natural completion, and the call was reported as a clean success 30x past its
+/// deadline. This thread is created explicitly and blocks only in
+/// `NSCondition.wait`, so it is always available to run a deadline action on
+/// time regardless of pool saturation.
+///
+/// The thread owns a deadline-ordered set of pending entries; `schedule` appends
+/// one (waking the thread), `cancel` removes one. Actions run OFF the condition
+/// lock, so an action may re-enter `schedule`/`cancel` — the SIGTERM→SIGKILL
+/// escalation does exactly that.
+///
+/// Scheduling uses wall-clock `Date` (what `NSCondition` offers); a backward
+/// clock adjustment could delay a fire. That is a non-issue here: the bounded
+/// runner's completion path independently checks a *monotonic* `ContinuousClock`
+/// deadline (see `runBoundedProcess`), so a late watchdog can never turn a
+/// deadline breach into a false success.
+final class SubprocessWatchdog: @unchecked Sendable {
+    static let shared = SubprocessWatchdog()
+
+    private struct Entry {
+        let token: UInt64
+        let fireDate: Date
+        let action: () -> Void
+    }
+
+    private let condition = NSCondition()
+    private var entries: [Entry] = []
+    private var nextToken: UInt64 = 0
+    private var started = false
+
+    /// Schedules `action` to run on the watchdog thread after `delay`. Returns a
+    /// token for `cancel(_:)`. A `delay` far in the future converts to a `Date`
+    /// without overflow (the conversion is lossy-but-safe `Double` seconds), so
+    /// an arbitrarily large timeout can never trap — this subsumes the old
+    /// `min(timeoutNanos, Int.max)` clamp that guarded `DispatchTimeInterval`.
+    @discardableResult
+    func schedule(after delay: Duration, action: @escaping () -> Void) -> UInt64 {
+        condition.lock()
+        defer { condition.unlock() }
+        startIfNeededLocked()
+        let token = nextToken
+        nextToken &+= 1
+        entries.append(Entry(token: token, fireDate: Date(timeIntervalSinceNow: delay.seconds), action: action))
+        condition.signal()
+        return token
+    }
+
+    /// Removes a pending entry. A no-op if it already fired or never existed.
+    func cancel(_ token: UInt64) {
+        condition.lock()
+        defer { condition.unlock() }
+        entries.removeAll { $0.token == token }
+    }
+
+    private func startIfNeededLocked() {
+        guard !started else { return }
+        started = true
+        let thread = Thread { [self] in runLoop() }
+        thread.name = "com.tbd.daemon.subprocess-watchdog"
+        thread.stackSize = 512 * 1024
+        thread.start()
+    }
+
+    private func runLoop() {
+        condition.lock()
+        while true {
+            let now = Date()
+            if let index = entries.firstIndex(where: { $0.fireDate <= now }) {
+                let entry = entries.remove(at: index)
+                condition.unlock()
+                entry.action()
+                condition.lock()
+                continue
+            }
+            if let earliest = entries.map(\.fireDate).min() {
+                _ = condition.wait(until: earliest)
+            } else {
+                condition.wait()
+            }
+        }
+    }
+}
+
+/// Outcome of a bounded subprocess run.
+///
+/// `.timedOut` means the call exceeded its deadline — either the watchdog fired
+/// and killed the child, or the child's exit was only observed after the full
+/// deadline had already elapsed. Callers map it to their own timeout error type.
+enum BoundedProcessOutcome {
+    case completed(status: Int32, stdout: Data, stderr: Data)
+    case timedOut
+}
+
+/// Runs an external command with a hard timeout, draining stdout/stderr, and
+/// resolves to `.completed(status, stdout, stderr)` or `.timedOut` — or throws
+/// the spawn error if `Process.run()` fails. Shared by
+/// `TmuxManager.runExternalCommand` and `GitManager.run`, which map the outcome
+/// to their own error types (`TmuxError` / `GitError` / `GitTimeoutError`).
+///
+/// The deadline is immune to GCD-pool starvation via two independent guarantees:
+///
+/// 1. SCHEDULING — the deadline AND the SIGTERM→SIGKILL escalation fire on the
+///    dedicated `SubprocessWatchdog` thread, never on a GCD queue. The whole
+///    fire path (claim guard → detach readability handlers → finish accumulators
+///    → SIGTERM → resume) runs on that thread with no GCD hop before the
+///    continuation resumes.
+/// 2. AUTHORITY — the completion path records a monotonic start instant and, if
+///    the child's exit is observed only AFTER the full deadline elapsed, reports
+///    `.timedOut` regardless of exit status. The timeout bounds the CALL, not
+///    merely the child: a completion delayed past the deadline is a lie if
+///    reported as a clean success, so it is reported as a timeout. Production
+///    timeouts are >=5s, so this only ever triggers under the extreme starvation
+///    that made the report a lie in the first place.
+///
+/// Both pipes are drained incrementally via `readabilityHandler` while the child
+/// runs — a macOS pipe buffer is 64KB, so a child emitting more (e.g. `ps -Ao`
+/// on a busy machine, ~72KB) would otherwise block writing to the full pipe
+/// while we wait for it to exit — a mutual deadlock resolved only by the
+/// timeout. The drain never waits for pipe EOF: real call sites run
+/// `[shell, "-ic", cmd]`, and rc files can fork background grandchildren that
+/// inherit the write ends, so EOF may never arrive after the direct child dies.
+/// Termination, timeout, and spawn-failure all snapshot what has already arrived
+/// and close the parent read ends — no thread, FD, or closure outlives the call.
+///
+/// The continuation is guarded by a `ContinuationGuard` so exactly one of
+/// {termination, timeout, spawn-failure} resumes it, satisfying the single-resume
+/// contract even when the process exits concurrently with the watchdog.
+func runBoundedProcess(
+    executable: String,
+    arguments: [String],
+    currentDirectory: String?,
+    timeout: Duration
+) async throws -> BoundedProcessOutcome {
+    // Single-resume guard shared by the watchdog fire path, the termination
+    // handler, and the spawn-failure path. Whichever fires first wins; the
+    // losers are no-ops.
+    let state = ContinuationGuard()
+    // Monotonic start instant for the authoritative deadline decision below.
+    let start = ContinuousClock.now
+
+    return try await withCheckedThrowingContinuation { continuation in
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let stdoutAccumulator = PipeDataAccumulator()
+        let stderrAccumulator = PipeDataAccumulator()
+
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        if let currentDirectory {
+            process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory)
+        }
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        // Drain both pipes incrementally as chunks arrive: no thread parks for
+        // the subprocess's lifetime, and a child emitting more than the 64KB
+        // pipe buffer never deadlocks against an undrained pipe.
+        stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+            if !stdoutAccumulator.readAvailable(from: handle) { handle.readabilityHandler = nil }
+        }
+        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+            if !stderrAccumulator.readAvailable(from: handle) { handle.readabilityHandler = nil }
+        }
+
+        // Detach the drain handlers and snapshot both pipes WITHOUT waiting for
+        // EOF — EOF is NOT guaranteed (grandchildren may still hold the write
+        // ends) — then close the parent read ends. Idempotent and thread-safe;
+        // shared by every resume path.
+        @Sendable func snapshot() -> (Data, Data) {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            let out = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
+            let err = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
+            return (out, err)
+        }
+
+        // Watchdog deadline. On fire: stop draining, kill the DIRECT child
+        // (grandchildren keep their inherited write ends — see above), escalate
+        // to SIGKILL on the SAME watchdog thread after a brief grace (a GCD
+        // asyncAfter would starve alongside the timer it replaces), and resume
+        // `.timedOut`. Scheduled before `run()` — as with the old absolute-time
+        // DispatchSource, the deadline is measured from here; the escalation is
+        // only ever scheduled once the timeout has actually fired.
+        let deadlineToken = SubprocessWatchdog.shared.schedule(after: timeout) {
+            guard state.claim() else { return }
+            _ = snapshot()
+            let pid = process.processIdentifier
+            if pid > 0 {
+                kill(pid, SIGTERM)
+                SubprocessWatchdog.shared.schedule(after: .milliseconds(500)) {
+                    if process.isRunning { kill(pid, SIGKILL) }
+                }
+            }
+            continuation.resume(returning: .timedOut)
+        }
+
+        process.terminationHandler = { _ in
+            // The direct child exited; everything it wrote is already in the
+            // kernel pipe buffers. `snapshot` captures that without waiting for
+            // EOF and closes the parent read ends.
+            let (outData, errData) = snapshot()
+            guard state.claim() else { return }  // watchdog already won → timed out
+            SubprocessWatchdog.shared.cancel(deadlineToken)
+            // AUTHORITY: a child that outran its deadline — even with status 0 —
+            // must never be reported as a clean success, even if the watchdog
+            // itself was somehow late to fire.
+            if ContinuousClock.now - start >= timeout {
+                continuation.resume(returning: .timedOut)
+            } else {
+                continuation.resume(returning: .completed(
+                    status: process.terminationStatus,
+                    stdout: outData,
+                    stderr: errData
+                ))
+            }
+        }
+
+        do {
+            try process.run()
+        } catch {
+            // Spawn failed: no child will ever write — detach the drain handlers
+            // and close the read ends so nothing lingers. `run()` fails
+            // synchronously and immediately, long before the (>=100ms) watchdog
+            // could fire, so this path reliably wins the claim.
+            _ = snapshot()
+            guard state.claim() else { return }
+            SubprocessWatchdog.shared.cancel(deadlineToken)
+            continuation.resume(throwing: error)
+        }
+    }
+}
+
+extension Duration {
+    /// This `Duration` as seconds. Lossy for sub-attosecond precision (there is
+    /// none) and for `seconds` beyond `Double`'s 2^53 exact range, but never
+    /// traps — used for far-future watchdog deadlines.
+    fileprivate var seconds: TimeInterval {
+        let c = components
+        return TimeInterval(c.seconds) + TimeInterval(c.attoseconds) / 1_000_000_000_000_000_000
+    }
+}

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -609,22 +609,10 @@ public struct TmuxManager: Sendable {
 
     /// Runs an external command with a hard timeout, draining stdout/stderr.
     /// On timeout the child is signalled SIGTERM, then SIGKILL after a short
-    /// grace, and the call throws `TmuxError.timedOut` — never hangs. The
-    /// continuation is guarded by a lock so exactly one of {termination,
-    /// timeout, spawn-failure} resumes it, satisfying the single-resume
-    /// contract even when the process exits concurrently with the timer.
-    ///
-    /// Both pipes are drained incrementally via `readabilityHandler` while the
-    /// child runs: a macOS pipe buffer is 64KB, so a child emitting more (e.g.
-    /// `ps -Ao` on a busy machine, ~72KB) would otherwise block writing to the
-    /// full pipe while we wait for it to exit — a mutual deadlock resolved only
-    /// by the timeout, turning every large-output call into a spurious failure.
-    /// The drain never waits for pipe EOF: real call sites run
-    /// `[shell, "-ic", cmd]`, and rc files can fork background grandchildren
-    /// that inherit the write ends, so EOF may never arrive after the direct
-    /// child dies. Termination and timeout both snapshot what has already
-    /// arrived and close the parent read ends — no thread, FD, or closure
-    /// outlives the call.
+    /// grace, and the call throws `TmuxError.timedOut` — never hangs. All the
+    /// mechanism (starvation-proof watchdog thread, authoritative deadline,
+    /// incremental pipe draining, no-EOF-wait, single-resume guard) lives in
+    /// the shared `runBoundedProcess`; this only maps the outcome to `TmuxError`.
     ///
     /// Package-internal (not `private`) so timeout tests can drive it directly
     /// against a real slow binary (`/bin/sleep`) without a tmux server.
@@ -635,110 +623,24 @@ public struct TmuxManager: Sendable {
         label: String,
         timeout: Duration
     ) async throws -> String {
-        // Single-resume guard shared between the termination handler and the
-        // timeout timer. Whichever fires first wins; the loser is a no-op.
-        let state = ContinuationGuard()
         let commandDescription = "\(label) " + arguments.joined(separator: " ")
-        let timeoutNanos = UInt64(max(0, timeout.components.seconds)) * 1_000_000_000
-            + UInt64(max(0, timeout.components.attoseconds / 1_000_000_000))
-
-        return try await withCheckedThrowingContinuation { continuation in
-            let process = Process()
-            let stdoutPipe = Pipe()
-            let stderrPipe = Pipe()
-            let stdoutAccumulator = PipeDataAccumulator()
-            let stderrAccumulator = PipeDataAccumulator()
-
-            process.executableURL = URL(fileURLWithPath: executable)
-            process.arguments = arguments
-            process.standardOutput = stdoutPipe
-            process.standardError = stderrPipe
-
-            // Drain both pipes incrementally as chunks arrive (mirrors
-            // GitManager.run): no thread parks for the subprocess's lifetime,
-            // and a child emitting more than the 64KB pipe buffer never
-            // deadlocks against an undrained pipe.
-            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-                if !stdoutAccumulator.readAvailable(from: handle) {
-                    handle.readabilityHandler = nil
-                }
+        switch try await runBoundedProcess(
+            executable: executable,
+            arguments: arguments,
+            currentDirectory: nil,
+            timeout: timeout
+        ) {
+        case .timedOut:
+            logger.warning("subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
+            throw TmuxError.timedOut(command: commandDescription, timeout: timeout)
+        case let .completed(status, stdoutData, stderrData):
+            let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+            let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+            let output = stdout.isEmpty ? stderr : stdout
+            if status != 0 {
+                throw TmuxError.commandFailed(command: commandDescription, status: status, output: output)
             }
-            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-                if !stderrAccumulator.readAvailable(from: handle) {
-                    handle.readabilityHandler = nil
-                }
-            }
-
-            // Watchdog timer: on fire, escalate SIGTERM → SIGKILL and resume
-            // with a timeout error (if the process hasn't already exited).
-            let timer = DispatchSource.makeTimerSource(queue: .global())
-            timer.schedule(deadline: .now() + .nanoseconds(Int(min(timeoutNanos, UInt64(Int.max)))))
-            timer.setEventHandler {
-                guard state.claim() else { return }
-                timer.cancel()
-                // Stop draining and close the parent read ends NOW. The kill
-                // below reaches only the DIRECT child; grandchildren forked by
-                // the shell's rc files inherit the pipe write ends, so EOF may
-                // never come — waiting for it would leak the FDs and handler
-                // closures for the grandchildren's lifetime.
-                stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                stderrPipe.fileHandleForReading.readabilityHandler = nil
-                _ = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
-                _ = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
-                let pid = process.processIdentifier
-                if pid > 0 {
-                    kill(pid, SIGTERM)
-                    // Give it a brief grace to exit on SIGTERM, then SIGKILL.
-                    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(500)) {
-                        if process.isRunning { kill(pid, SIGKILL) }
-                    }
-                }
-                logger.warning("subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
-                continuation.resume(throwing: TmuxError.timedOut(command: commandDescription, timeout: timeout))
-            }
-
-            process.terminationHandler = { _ in
-                // The direct child exited; everything it wrote is already in
-                // the kernel pipe buffers. `finish` snapshots that WITHOUT
-                // waiting for EOF — EOF is NOT guaranteed here, because
-                // grandchildren may still hold the write ends open — and
-                // closes the parent read ends.
-                stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                stderrPipe.fileHandleForReading.readabilityHandler = nil
-                let stdoutData = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
-                let stderrData = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
-                let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
-                let stderr = String(data: stderrData, encoding: .utf8) ?? ""
-                let output = stdout.isEmpty ? stderr : stdout
-
-                guard state.claim() else { return }  // timer already won → timed out
-                timer.cancel()
-
-                if process.terminationStatus != 0 {
-                    continuation.resume(throwing: TmuxError.commandFailed(
-                        command: commandDescription,
-                        status: process.terminationStatus,
-                        output: output
-                    ))
-                } else {
-                    continuation.resume(returning: stdout)
-                }
-            }
-
-            do {
-                try process.run()
-                timer.resume()
-            } catch {
-                // Spawn failed: no child will ever write — detach the drain
-                // handlers and close the read ends so nothing lingers.
-                stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                stderrPipe.fileHandleForReading.readabilityHandler = nil
-                _ = stdoutAccumulator.finish(handle: stdoutPipe.fileHandleForReading)
-                _ = stderrAccumulator.finish(handle: stderrPipe.fileHandleForReading)
-                guard state.claim() else { return }
-                timer.cancel()
-                continuation.resume(throwing: error)
-            }
+            return stdout
         }
     }
 }

--- a/Tests/TBDDaemonTests/ReplayLiveIntegrationMatrixTests.swift
+++ b/Tests/TBDDaemonTests/ReplayLiveIntegrationMatrixTests.swift
@@ -126,23 +126,66 @@ struct ReplayLiveIntegrationMatrixTests {
 
     /// Read `fd` (nonblocking) until `condition` holds on the accumulated
     /// bytes, EOF, cancellation, or the deadline. Bursts drain without
-    /// sleeping; EAGAIN sleeps a poll slice.
+    /// waiting; when nothing is ready the read loop parks in `poll(2)`.
+    ///
+    /// The read loop runs on a DEDICATED `Thread`, not on the Swift
+    /// Concurrency cooperative pool, and that placement is load-bearing.
+    /// The pane's replay write (attach via `AttachReplayOrchestrator`,
+    /// repair via `PaneRepairCoordinator`) runs a synchronous, wall-clock
+    /// 5 s-deadlined `poll`/`write` against the ~64 KB vended pipe; if this
+    /// reader stalls the pipe stays full and the producer blows its
+    /// deadline with `PaneReplayWriteError.deadlineExceeded`. An earlier
+    /// version drained on the cooperative executor and yielded on EAGAIN
+    /// via `Task.sleep`; under CI CPU oversubscription the executor was
+    /// saturated, this reader Task wasn't scheduled promptly, the pipe
+    /// overflowed, and the producer's deadline fired — a pure test-harness
+    /// flake (the `firehoseOverflowRepairHeals` scenario went red with
+    /// `deadlineExceeded`). In production the reader is a real client, and
+    /// a genuinely stalled reader SHOULD surface as backpressure, so the
+    /// fix belongs here, not in the producer. A dedicated thread is immune
+    /// to executor starvation: the kernel schedules it independently of
+    /// the concurrency runtime. `withCheckedContinuation` bridges the
+    /// blocking loop back to this `async` signature so no caller changes.
+    /// Cancellation is honoured cooperatively (a stop flag flipped from the
+    /// task-cancellation handler) and, as a backstop, strictly bounded by
+    /// `deadline`.
     private func drain(fd: Int32, deadline: Duration = .seconds(15),
                        until condition: @escaping @Sendable (Data) -> Bool) async -> Data {
-        var accumulated = Data()
-        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
-        let end = ContinuousClock.now + deadline
-        while ContinuousClock.now < end && !Task.isCancelled {
-            let n = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
-            if n > 0 {
-                accumulated.append(contentsOf: buffer[0..<n])
-                if condition(accumulated) { break }
-                continue
+        let stop = FlagBox()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Data, Never>) in
+                let thread = Thread {
+                    var accumulated = Data()
+                    var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+                    let end = ContinuousClock.now + deadline
+                    while ContinuousClock.now < end && !stop.get() {
+                        // Park up to a 50 ms slice waiting for readable bytes
+                        // so the loop neither busy-spins nor oversleeps the
+                        // deadline. fd is already nonblocking (see caller).
+                        var pfd = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+                        _ = withUnsafeMutablePointer(to: &pfd) { Darwin.poll($0, 1, 50) }
+
+                        let n = buffer.withUnsafeMutableBytes {
+                            Darwin.read(fd, $0.baseAddress, $0.count)
+                        }
+                        if n > 0 {
+                            accumulated.append(contentsOf: buffer[0..<n])
+                            if condition(accumulated) { break }
+                        } else if n == 0 {
+                            break  // EOF — write end closed
+                        }
+                        // n < 0: EAGAIN — the poll above already waited; loop
+                        // and re-check the deadline.
+                    }
+                    continuation.resume(returning: accumulated)
+                }
+                thread.name = "replay-drain"
+                thread.stackSize = 512 * 1024
+                thread.start()
             }
-            if n == 0 { break }  // EOF — write end closed
-            try? await Task.sleep(for: .milliseconds(20))
+        } onCancel: {
+            stop.set()
         }
-        return accumulated
     }
 
     // MARK: - Byte-stream analysis helpers

--- a/Tests/TBDDaemonTests/SubprocessTimeoutStarvationTests.swift
+++ b/Tests/TBDDaemonTests/SubprocessTimeoutStarvationTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Regression coverage for the dispatch-pool-starvation flake behind three CI
+/// failures (SubprocessTimeoutTests, GitManagerTimeoutTests,
+/// HibernationOrphanDetectionTests).
+///
+/// The bug: the subprocess watchdog used to fire its deadline via
+/// `DispatchSource.makeTimerSource(queue: .global())`. That handler needs a
+/// free thread from the shared default-QoS GCD pool. Under the full suite
+/// (~3000 tests, every target in ONE process, suites run in parallel), many
+/// pool threads park on subprocesses/pipes/waits; a saturated pool means the
+/// 100ms timer handler never runs in time, the child (`/bin/sleep`) runs to
+/// natural completion, and `terminationHandler` reports a clean success for a
+/// call that blew its deadline by 300x.
+///
+/// These tests reproduce that deterministically by drowning the default-QoS
+/// global pool in blocking work items, then asserting the bounded runner STILL
+/// times out. On the pre-fix code they fail with "returned instead of timing
+/// out"; the fix (dedicated watchdog Thread + authoritative deadline decision)
+/// makes them pass.
+///
+/// BLAST RADIUS: all test targets compile into one process and Swift Testing
+/// runs suites in parallel across targets, so a saturated global pool stalls
+/// sibling suites for as long as the window is open. This suite is
+/// `.serialized`, keeps the saturation window as short as possible, and ALWAYS
+/// releases every parked work item in a path that runs regardless of the
+/// call's outcome. Never leave the pool parked past the end of a test.
+@Suite("Subprocess timeout under dispatch-pool starvation", .serialized)
+struct SubprocessTimeoutStarvationTests {
+
+    /// Number of blocking work items to flood the default-QoS pool with. The
+    /// default-QoS worker-thread ceiling is ~64/process; 128 comfortably
+    /// exhausts it on this 12-core box and on 2-core CI runners.
+    private static let floodCount = 128
+
+    /// Lock-guarded counter — `DispatchSemaphore.wait` is unavailable from an
+    /// async context, so we track flood-item progress with a counter polled via
+    /// `Task.sleep` (which runs on Swift's cooperative executor, a pool distinct
+    /// from the libdispatch global queue we are deliberately starving).
+    private final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+        func increment() { lock.lock(); value += 1; lock.unlock() }
+        var current: Int { lock.lock(); defer { lock.unlock() }; return value }
+    }
+
+    /// Saturates the default-QoS global pool with `floodCount` items each
+    /// blocked on `gate`, runs `body` while the pool is starved, then ALWAYS
+    /// releases every item (signals `gate` floodCount times) before returning —
+    /// on success, on thrown error, on assertion failure. Polls until the
+    /// flooded items observe the release so the pool is genuinely drained before
+    /// the next serialized test starts.
+    private func withSaturatedGlobalPool(_ body: () async -> Void) async {
+        let gate = DispatchSemaphore(value: 0)
+        let started = Counter()
+        let drained = Counter()
+        for _ in 0..<Self.floodCount {
+            DispatchQueue.global().async {
+                started.increment()
+                gate.wait()      // park a pool thread
+                drained.increment()
+            }
+        }
+        // Best-effort: wait until the pool has spun up workers and parked them.
+        // Once every item is parked no free default-QoS thread remains to
+        // service a `DispatchSource(queue: .global())` timer handler — the
+        // pre-fix watchdog's scheduling dependency.
+        let startDeadline = ContinuousClock.now + .seconds(5)
+        while started.current < Self.floodCount, ContinuousClock.now < startDeadline {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+
+        await body()
+
+        // ALWAYS release, on every exit path. `signal` (unlike `wait`) is
+        // allowed from async. Then poll until every item drains so the pool is
+        // fully free before the next serialized test (or sibling suite) runs.
+        // Keep signalling each pass rather than exactly `floodCount` times: a
+        // `DispatchSemaphore` hard-crashes on dealloc only when its value is
+        // BELOW its initial value (a waiter still parked), so over-signalling is
+        // harmless while under-signalling on a slow-drain deadline would crash.
+        for _ in 0..<Self.floodCount { gate.signal() }
+        let drainDeadline = ContinuousClock.now + .seconds(10)
+        while drained.current < Self.floodCount, ContinuousClock.now < drainDeadline {
+            gate.signal()
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    @Test func tmuxRunExternalCommandTimesOutEvenWhenPoolSaturated() async {
+        // `sleep 3` (not 30) so the pre-fix broken behavior — child runs to
+        // natural completion, terminationHandler resumes a clean success — is
+        // observed in bounded time. With the fix the 100ms deadline fires on
+        // the dedicated watchdog thread regardless of pool state.
+        await withSaturatedGlobalPool {
+            do {
+                _ = try await TmuxManager.runExternalCommand(
+                    executable: "/bin/sleep",
+                    arguments: ["3"],
+                    label: "starvation-test",
+                    timeout: .milliseconds(100)
+                )
+                Issue.record("expected runExternalCommand to time out under pool saturation, but it returned")
+            } catch let error as TmuxError {
+                guard case .timedOut = error else {
+                    Issue.record("expected TmuxError.timedOut, got \(error)")
+                    return
+                }
+            } catch {
+                Issue.record("expected TmuxError.timedOut, got \(error)")
+            }
+        }
+    }
+
+    @Test func gitRunTimesOutEvenWhenPoolSaturated() async {
+        let git = GitManager(subprocessTimeout: .milliseconds(100))
+        await withSaturatedGlobalPool {
+            do {
+                _ = try await git.runForTimeoutTesting(
+                    executable: "/bin/sleep",
+                    arguments: ["3"],
+                    at: FileManager.default.temporaryDirectory.path
+                )
+                Issue.record("expected runForTimeoutTesting to time out under pool saturation, but it returned")
+            } catch is GitTimeoutError {
+                // expected
+            } catch {
+                Issue.record("expected GitTimeoutError, got \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two of the four CI-flaky timeout tests were exposing a real production robustness bug; the third pair shares it; the fourth is a separate test-harness bug. This PR fixes both root causes. Neither test was loosened, disabled, or re-timed — the intermittent red was a genuine signal.

### Bug 1 — subprocess watchdog starves on the shared dispatch pool (production bug)

`TmuxManager.runExternalCommand` and `GitManager.run` armed their timeout with `DispatchSource.makeTimerSource(queue: .global())`. That handler needs a free thread from the shared default-QoS GCD pool. Under the full suite (~3000 tests, one process, parallel suites) the pool's ~64 workers all park on subprocesses/pipes/waits, so the 100ms timer never fired, the child (`sleep`) ran to natural completion, and `terminationHandler` reported a **clean success 30–300× past the deadline**. A genuinely wedged `git`/`ps` in a saturated daemon could blow its watchdog the same way.

Fixed with a shared `runBoundedProcess` (new `BoundedProcessRunner.swift`) used by both call sites:
- **Scheduling:** a single dedicated `SubprocessWatchdog` OS thread (`NSCondition` + deadline-ordered entries) fires the deadline and the SIGTERM→SIGKILL escalation. A dispatch queue of *any* QoS draws from the same starvable pool, so only an explicit `Thread` is immune. The whole fire path runs on that thread with no GCD hop before the continuation resumes.
- **Authority:** the completion path records a monotonic `ContinuousClock` start and reports `.timedOut` if the child's exit is observed only after the full deadline elapsed, regardless of exit status. The timeout bounds the *call*, not merely the child — a deadline-breaching child can never be reported as clean success even if the watchdog itself were late.

Covers `SubprocessTimeoutTests`, `GitManagerTimeoutTests`, and `HibernationOrphanDetectionTests` (which routes through `runExternalCommand`). All existing behaviors preserved: incremental pipe draining, no-EOF-wait when a grandchild holds the pipe, read-end closing on every path, spawn-failure path.

### Bug 2 — replay firehose test starves its own reader (test-harness bug)

`ReplayLiveIntegrationMatrixTests.firehoseOverflowRepairHeals` flaked with `PaneReplayWriteError.deadlineExceeded`. Different root cause: the producer's 5s replay-write deadline (a synchronous wall-clock `poll(2)` loop) fires *correctly*. The problem was the test's own `drain(fd:)` reader running on the Swift Concurrency cooperative executor and yielding on EAGAIN via `Task.sleep`. Under CI oversubscription the executor is saturated, the reader isn't scheduled, the ~64KB pipe stays full, and the producer blows its deadline. This is test-only — in production a stalled reader *should* surface as backpressure (the repair aborting is correct), so the fix is in the test, not `PaneFanout`.

Rewrote `drain` to run its read loop on a dedicated `Thread` (`poll` on POLLIN + bounded `read`), bridged back to the `async` signature via `withCheckedContinuation` so no caller changes.

## Test plan

- [x] New `SubprocessTimeoutStarvationTests` reproduces bug 1 deterministically: saturates the default-QoS global pool with 128 blocking items, then asserts the runner still times out. Confirmed **red pre-fix** ("returned instead of timing out"), green post-fix.
- [x] `swift test --filter "SubprocessTimeoutTests|GitManagerTimeoutTests|HibernationOrphanDetectionTests|SubprocessTimeoutStarvationTests"` — green.
- [x] Stress: timeout suites run **55× under 24 CPU burners, 0 failures**; firehose test **12× under load, 0 failures**.
- [x] Full `swift test` — 3034 tests, all passing.
- [x] Code review of the watchdog change: no blockers; the one nit (test semaphore over-signal on dealloc) applied.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=77A2BFFE-162A-413B-B6F4-43B16358CBBE)