### PR TITLE
fix(restart): copy TBD_TBDApp.bundle from real path (symlinked .build/debug broke the copy)

### DIFF
--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -88,11 +88,15 @@ fi
 # Copy the TBD_TBDApp.bundle (resource bundle with localized strings and assets).
 # SPM produces it in .build/arm64-apple-macosx/debug; it must be in the .app bundle
 # or app launch fails with "could not load resource bundle".
-SOURCE_RESOURCE_BUNDLE="$BUILD_DIR/../arm64-apple-macosx/debug/TBD_TBDApp.bundle"
+# NOTE: $BUILD_DIR is a symlink to arm64-apple-macosx/debug, so we reach the bundle
+# via $BUILD_DIR/TBD_TBDApp.bundle, not by composing a path with ../arm64-apple-macosx/debug.
+SOURCE_RESOURCE_BUNDLE="$BUILD_DIR/TBD_TBDApp.bundle"
 BUNDLE_RESOURCE_BUNDLE="$BUNDLE_RESOURCES/TBD_TBDApp.bundle"
 if [ -d "$SOURCE_RESOURCE_BUNDLE" ]; then
     rm -rf "$BUNDLE_RESOURCE_BUNDLE"
     cp -R "$SOURCE_RESOURCE_BUNDLE" "$BUNDLE_RESOURCE_BUNDLE"
+else
+    echo "warning: TBD_TBDApp.bundle not found at $SOURCE_RESOURCE_BUNDLE" >&2
 fi
 
 # Stash the source worktree path inside the bundle so the running app can

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -85,6 +85,16 @@ if [ ! -f "$BUNDLE_ICON" ] || [ "$SOURCE_ICON" -nt "$BUNDLE_ICON" ]; then
     cp "$SOURCE_ICON" "$BUNDLE_ICON"
 fi
 
+# Copy the TBD_TBDApp.bundle (resource bundle with localized strings and assets).
+# SPM produces it in .build/arm64-apple-macosx/debug; it must be in the .app bundle
+# or app launch fails with "could not load resource bundle".
+SOURCE_RESOURCE_BUNDLE="$BUILD_DIR/../arm64-apple-macosx/debug/TBD_TBDApp.bundle"
+BUNDLE_RESOURCE_BUNDLE="$BUNDLE_RESOURCES/TBD_TBDApp.bundle"
+if [ -d "$SOURCE_RESOURCE_BUNDLE" ]; then
+    rm -rf "$BUNDLE_RESOURCE_BUNDLE"
+    cp -R "$SOURCE_RESOURCE_BUNDLE" "$BUNDLE_RESOURCE_BUNDLE"
+fi
+
 # Stash the source worktree path inside the bundle so the running app can
 # show it in the status bar — it can no longer infer this from its own
 # exec path now that it runs from /Applications instead of .build/.


### PR DESCRIPTION
## The bug

`5744bef` added the `TBD_TBDApp.bundle` copy to `restart.sh`, but its source path is broken: `.build/debug` is a **symlink** to `arm64-apple-macosx/debug`, so `$BUILD_DIR/../arm64-apple-macosx/debug/TBD_TBDApp.bundle` resolves through the symlink to `.build/arm64-apple-macosx/arm64-apple-macosx/debug/...` — a double-nested path that doesn't exist. The `[ -d ... ]` guard is false and the copy is **silently skipped**, so the installed `/Applications/TBD.app` ships without its resource bundle and SwiftPM's `Bundle.module` accessor `fatalError`s at launch ("unable to find bundle named TBD_TBDApp").

Observed live on 2026-07-08: three TBDApp crash reports in one minute (SIGTRAP in `Bundle.module` one-time init, then a window-restoration crash loop). **Any `restart.sh` run from current main reproduces this.**

## The fix

- Source the bundle from `$BUILD_DIR/TBD_TBDApp.bundle` (resolves correctly through the symlink).
- Warn loudly on stderr if the bundle is ever missing instead of silently continuing, so this class of failure can't hide again.

## Verification

After the fix, `restart.sh` was run end-to-end: bundle present in both `.build/debug/TBD.app/Contents/Resources/` and `/Applications/TBD.app/Contents/Resources/`, app stayed alive past the previous crash window, zero new crash reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)