### PR TITLE
fix(app): daemon auto-restart self-heals via source worktree path

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1396,14 +1396,15 @@ final class AppState: ObservableObject {
             try? FileManager.default.removeItem(atPath: TBDConstants.socketPath)
         }
 
-        // Find TBDDaemon binary next to this executable
-        let selfPath = ProcessInfo.processInfo.arguments.first ?? ""
-        let siblingPath = (selfPath as NSString).deletingLastPathComponent + "/TBDDaemon"
-
-        let candidates = [
-            siblingPath,
-            Bundle.main.executableURL?.deletingLastPathComponent().appendingPathComponent("TBDDaemon").path,
-        ].compactMap { $0 }
+        // Find TBDDaemon binary using sibling and source-worktree candidates
+        let sourceWorktreePath = SourceWorktreePathResolver.resolve(
+            bundleURL: Bundle.main.bundleURL,
+            executablePath: Bundle.main.executablePath
+        )
+        let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+            appExecutablePath: Bundle.main.executablePath,
+            sourceWorktreePath: sourceWorktreePath
+        )
 
         var tbddPath: String?
         for path in candidates {
@@ -1414,7 +1415,12 @@ final class AppState: ObservableObject {
         }
 
         guard let path = tbddPath else {
-            showAlert("Could not find TBDDaemon binary", isError: true)
+            let candidateList = candidates.isEmpty
+                ? "no candidates found"
+                : "tried: " + candidates.joined(separator: ", ")
+            let message = "Could not find TBDDaemon binary (\(candidateList)). "
+                + "Try running scripts/restart.sh from your worktree."
+            showAlert(message, isError: true)
             return
         }
 

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -163,6 +163,7 @@ private struct UsageBarRow: View {
 
 // MARK: - Preview
 
+#if XCODE_PREVIEWS
 #Preview("Usage bars") {
     // Fixed clock so the previewed markers land deterministically.
     let now = Date(timeIntervalSince1970: 1_720_000_000)
@@ -205,3 +206,4 @@ private struct UsageBarRow: View {
     .frame(width: 220)
     .padding()
 }
+#endif

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -146,43 +146,18 @@ actor DaemonClient {
         }
     }
 
-    /// Find the tbdd binary by checking several locations.
+    /// Find the TBDDaemon binary by checking sibling and source-worktree locations.
     private func findTbddBinary() -> String? {
-        // 1. Same directory as the running app binary
-        if let execURL = Bundle.main.executableURL {
-            let siblingURL = execURL.deletingLastPathComponent().appendingPathComponent("tbdd")
-            if FileManager.default.isExecutableFile(atPath: siblingURL.path) {
-                return siblingURL.path
-            }
-        }
+        let sourceWorktreePath = SourceWorktreePathResolver.resolve(
+            bundleURL: Bundle.main.bundleURL,
+            executablePath: Bundle.main.executablePath
+        )
+        let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+            appExecutablePath: Bundle.main.executablePath,
+            sourceWorktreePath: sourceWorktreePath
+        )
 
-        // 2. Try `which tbdd` via shell
-        let whichProcess = Process()
-        let pipe = Pipe()
-        whichProcess.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        whichProcess.arguments = ["which", "tbdd"]
-        whichProcess.standardOutput = pipe
-        whichProcess.standardError = FileHandle.nullDevice
-        do {
-            try whichProcess.run()
-            whichProcess.waitUntilExit()
-            if whichProcess.terminationStatus == 0 {
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let path = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
-                if let path, FileManager.default.isExecutableFile(atPath: path) {
-                    return path
-                }
-            }
-        } catch {
-            // Fall through
-        }
-
-        // 3. Common paths
-        let commonPaths = [
-            "/usr/local/bin/tbdd",
-            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".local/bin/tbdd").path,
-        ]
-        for path in commonPaths {
+        for path in candidates {
             if FileManager.default.isExecutableFile(atPath: path) {
                 return path
             }

--- a/Sources/TBDApp/Helpers/DaemonCandidateFinder.swift
+++ b/Sources/TBDApp/Helpers/DaemonCandidateFinder.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Resolves candidate paths for the TBDDaemon binary, supporting both app-sibling
+/// and source-worktree locations. Used by both the app's auto-spawn and the
+/// daemon client's fallback startup.
+enum DaemonCandidateFinder {
+    /// Build a list of candidate daemon binary paths to search in order.
+    ///
+    /// Candidates include:
+    /// 1. The app executable's sibling directory (the .app bundle's MacOS/)
+    /// 2. The source worktree's `.build/debug/TBDDaemon` (if known)
+    ///
+    /// Paths are returned as absolute strings for immediate filesystem checks;
+    /// they are NOT yet resolved for symlinks. The caller is responsible for
+    /// verifying executability via `FileManager.isExecutableFile(atPath:)`.
+    ///
+    /// - Parameters:
+    ///   - appExecutablePath: The path to the running app executable
+    ///     (e.g., `"/Applications/TBD.app/Contents/MacOS/TBDApp"`).
+    ///     Nil inputs return only worktree candidates.
+    ///   - sourceWorktreePath: The absolute path of the worktree that built
+    ///     this app, e.g. `"/Users/me/tbd/worktrees/mywork"`.
+    ///     Nil inputs skip worktree-derived candidates.
+    ///
+    /// - Returns: An array of candidate daemon paths, in search order. Empty
+    ///   if both inputs are nil.
+    static func daemonCandidatePaths(
+        appExecutablePath: String?,
+        sourceWorktreePath: String?
+    ) -> [String] {
+        var candidates: [String] = []
+
+        // First candidate: daemon next to the app executable
+        if let execPath = appExecutablePath {
+            let siblingPath = (execPath as NSString).deletingLastPathComponent + "/TBDDaemon"
+            candidates.append(siblingPath)
+        }
+
+        // Second candidate: daemon in the source worktree's build directory
+        if let worktreePath = sourceWorktreePath, !worktreePath.isEmpty {
+            let worktreeDaemonPath = worktreePath + "/.build/debug/TBDDaemon"
+            candidates.append(worktreeDaemonPath)
+        }
+
+        return candidates
+    }
+}

--- a/Sources/TBDApp/Helpers/SourceWorktreePathResolver.swift
+++ b/Sources/TBDApp/Helpers/SourceWorktreePathResolver.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Resolves the absolute path of the worktree that built this running app.
+///
+/// Primary source is a sidecar file written into the bundle by `scripts/restart.sh`;
+/// falls back to parsing the exec path for legacy in-place `.build/debug/TBD.app` launches.
+/// Extracted as a non-actor type so callers from different isolation contexts
+/// (main-actor views, background actors like DaemonClient) can use it without
+/// isolation violations.
+enum SourceWorktreePathResolver {
+    /// Resolve the source worktree path from the bundle or exec path.
+    ///
+    /// Tries the sidecar file (Contents/SourceWorktreePath.txt) written by
+    /// `scripts/restart.sh` first; falls back to parsing the executable path
+    /// for the legacy in-place `.build/debug/TBD.app` launch shape.
+    ///
+    /// - Parameters:
+    ///   - bundleURL: The URL of the app bundle (typically `Bundle.main.bundleURL`)
+    ///   - executablePath: The path to the running app executable
+    ///     (typically `Bundle.main.executablePath`)
+    ///   - sidecarReader: Injection seam for reading the sidecar file;
+    ///     defaults to filesystem read. Tests can provide a custom reader
+    ///     to avoid needing a real bundle structure.
+    ///
+    /// - Returns: The absolute path of the source worktree, or nil if neither
+    ///   source is available.
+    static func resolve(
+        bundleURL: URL,
+        executablePath: String?,
+        sidecarReader: (URL) -> String? = { try? String(contentsOf: $0, encoding: .utf8) }
+    ) -> String? {
+        let sidecarURL = bundleURL.appendingPathComponent("Contents/SourceWorktreePath.txt")
+        if let raw = sidecarReader(sidecarURL) {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        if let execPath = executablePath,
+           let buildRange = execPath.range(of: "/.build/", options: .backwards) {
+            return String(execPath[..<buildRange.lowerBound])
+        }
+        return nil
+    }
+}

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -27,21 +27,17 @@ struct StatusBarView: View {
 
     /// Pure helper extracted so tests can exercise it without a real bundle.
     /// Tries the sidecar file first, then the exec-path heuristic.
+    /// Delegates to SourceWorktreePathResolver for the actual resolution logic.
     static func resolveSourceWorktreePath(
         bundleURL: URL,
         executablePath: String?,
         sidecarReader: (URL) -> String? = { try? String(contentsOf: $0, encoding: .utf8) }
     ) -> String? {
-        let sidecarURL = bundleURL.appendingPathComponent("Contents/SourceWorktreePath.txt")
-        if let raw = sidecarReader(sidecarURL) {
-            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty { return trimmed }
-        }
-        if let execPath = executablePath,
-           let buildRange = execPath.range(of: "/.build/", options: .backwards) {
-            return String(execPath[..<buildRange.lowerBound])
-        }
-        return nil
+        SourceWorktreePathResolver.resolve(
+            bundleURL: bundleURL,
+            executablePath: executablePath,
+            sidecarReader: sidecarReader
+        )
     }
 
     private var footerLabel: (text: String, tooltip: String?) {

--- a/Tests/TBDAppTests/DaemonCandidateFinderTests.swift
+++ b/Tests/TBDAppTests/DaemonCandidateFinderTests.swift
@@ -1,0 +1,57 @@
+import Testing
+import Foundation
+@testable import TBDApp
+
+@Test func daemonCandidatePaths_withBothInputs_returnsBothCandidates() {
+    let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+        appExecutablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
+        sourceWorktreePath: "/Users/me/tbd/worktrees/mywork"
+    )
+    #expect(candidates == [
+        "/Applications/TBD.app/Contents/MacOS/TBDDaemon",
+        "/Users/me/tbd/worktrees/mywork/.build/debug/TBDDaemon"
+    ])
+}
+
+@Test func daemonCandidatePaths_withOnlyAppPath_returnsSiblingCandidate() {
+    let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+        appExecutablePath: "/some/path/TBDApp",
+        sourceWorktreePath: nil
+    )
+    #expect(candidates == ["/some/path/TBDDaemon"])
+}
+
+@Test func daemonCandidatePaths_withOnlyWorktreePath_returnsWorktreeCandidate() {
+    let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+        appExecutablePath: nil,
+        sourceWorktreePath: "/Users/me/tbd/worktrees/mywork"
+    )
+    #expect(candidates == ["/Users/me/tbd/worktrees/mywork/.build/debug/TBDDaemon"])
+}
+
+@Test func daemonCandidatePaths_withNeitherInput_returnsEmpty() {
+    let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+        appExecutablePath: nil,
+        sourceWorktreePath: nil
+    )
+    #expect(candidates == [])
+}
+
+@Test func daemonCandidatePaths_withEmptyWorktreePath_skipsIt() {
+    let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+        appExecutablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
+        sourceWorktreePath: ""
+    )
+    #expect(candidates == ["/Applications/TBD.app/Contents/MacOS/TBDDaemon"])
+}
+
+@Test func daemonCandidatePaths_returnsSiblingFirst() {
+    // Verify ordering: sibling should come before worktree
+    let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+        appExecutablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
+        sourceWorktreePath: "/Users/me/tbd/worktrees/mywork"
+    )
+    #expect(candidates.count == 2)
+    #expect(candidates[0].contains("Contents/MacOS/TBDDaemon"))
+    #expect(candidates[1].contains(".build/debug/TBDDaemon"))
+}

--- a/Tests/TBDAppTests/SourceWorktreePathResolverTests.swift
+++ b/Tests/TBDAppTests/SourceWorktreePathResolverTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import TBDApp
+
+@Test func sourceWorktreePathResolver_sidecarPresent_returnsTrimmedContents() {
+    let bundleURL = URL(fileURLWithPath: "/Applications/TBD.app")
+    let resolved = SourceWorktreePathResolver.resolve(
+        bundleURL: bundleURL,
+        executablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
+        sidecarReader: { url in
+            #expect(url.path == "/Applications/TBD.app/Contents/SourceWorktreePath.txt")
+            return "  /Users/me/tbd/worktrees/foo  \n"
+        }
+    )
+    #expect(resolved == "/Users/me/tbd/worktrees/foo")
+}
+
+@Test func sourceWorktreePathResolver_sidecarAbsent_fallsBackToExecPath() {
+    let bundleURL = URL(fileURLWithPath: "/some/worktree/.build/debug/TBD.app")
+    let resolved = SourceWorktreePathResolver.resolve(
+        bundleURL: bundleURL,
+        executablePath: "/some/worktree/.build/debug/TBDApp",
+        sidecarReader: { _ in nil }
+    )
+    #expect(resolved == "/some/worktree")
+}
+
+@Test func sourceWorktreePathResolver_sidecarEmpty_fallsBackToExecPath() {
+    let bundleURL = URL(fileURLWithPath: "/some/worktree/.build/debug/TBD.app")
+    let resolved = SourceWorktreePathResolver.resolve(
+        bundleURL: bundleURL,
+        executablePath: "/some/worktree/.build/debug/TBDApp",
+        sidecarReader: { _ in "   \n  " }
+    )
+    #expect(resolved == "/some/worktree")
+}
+
+@Test func sourceWorktreePathResolver_neitherAvailable_returnsNil() {
+    let bundleURL = URL(fileURLWithPath: "/Applications/TBD.app")
+    let resolved = SourceWorktreePathResolver.resolve(
+        bundleURL: bundleURL,
+        executablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
+        sidecarReader: { _ in nil }
+    )
+    #expect(resolved == nil)
+}
+
+@Test func sourceWorktreePathResolver_nilExecPathAndNoSidecar_returnsNil() {
+    let bundleURL = URL(fileURLWithPath: "/Applications/TBD.app")
+    let resolved = SourceWorktreePathResolver.resolve(
+        bundleURL: bundleURL,
+        executablePath: nil,
+        sidecarReader: { _ in nil }
+    )
+    #expect(resolved == nil)
+}
+
+@Test func sourceWorktreePathResolver_sidecarPrefersOverExecPath() {
+    // When both sidecar and exec path are available, sidecar should win
+    let bundleURL = URL(fileURLWithPath: "/Applications/TBD.app")
+    let resolved = SourceWorktreePathResolver.resolve(
+        bundleURL: bundleURL,
+        executablePath: "/fallback/worktree/.build/debug/TBDApp",
+        sidecarReader: { _ in "/preferred/worktree" }
+    )
+    #expect(resolved == "/preferred/worktree")
+}


### PR DESCRIPTION
## Summary

The installed `/Applications/TBD.app` cannot restart a dead daemon, stranding the app with "Could not find TBDDaemon binary". Two broken discovery paths are now fixed:

1. **`AppState.startDaemonAndConnect()`** searched only the app bundle's sibling directory for TBDDaemon. The installed bundle contains ONLY TBDApp (scripts/restart.sh never copies the daemon into it), so this always failed.

2. **`DaemonClient.findTbddBinary()`** hunted a legacy `tbdd` binary (lowercase, old name) via `which`, common paths, and exec-sibling. No `tbdd` binary exists anymore (verified) — the real daemon is `TBDDaemon`. This path was dead code that also spawned via a non-standard `launchDaemon()` with no pid-file/logging conventions.

## Solution

Both code paths now resolve the daemon using a unified candidate list:
- **First candidate:** TBDDaemon next to the app executable (correct for `.build/debug/TBD.app` dev launches)
- **Second candidate:** TBDDaemon in the source worktree's `.build/debug` (the installed app's paired daemon from `scripts/restart.sh`)

The source worktree path is already known: `scripts/restart.sh` stamps it into the bundle at `Contents/SourceWorktreePath.txt`, and existing code (`StatusBarView.resolveSourceWorktreePath`, `DaemonBuildSkew`) already reads it.

### New helpers

- **`DaemonCandidateFinder`**: Pure function to build the candidate list. Input: app executable path + source worktree path → output: ordered search list.
- **`SourceWorktreePathResolver`**: Extracted from `StatusBarView` as a non-actor type so `DaemonClient` (an actor) can call it without isolation violations. Tries sidecar file first, falls back to exec-path heuristic.

### Updated sites
- `AppState.startDaemonAndConnect()`: Now includes worktree candidate; error message names paths tried + suggests `scripts/restart.sh`
- `DaemonClient.findTbddBinary()`: Simplified; uses same helper + removed legacy `which tbdd` hunt

### Tests
- Unit tests for both helpers with injection seams (no real filesystem/bundle needed)
- Verify candidate ordering, nil/empty handling, sidecar vs. exec-path fallback
- All existing `StatusBarView.resolveSourceWorktreePath` tests still pass

### Build fix
- Wrapped `#Preview` macros in `#if XCODE_PREVIEWS` guard (bare toolchain lacks PreviewsMacros plugin) following the pattern from commit 12af147

## Test plan

- [x] `swift build` passes
- [x] Unit tests pass (6 + 6 = 12 new tests for both helpers)
- [x] Existing `StatusBarView.resolveSourceWorktreePath` tests still pass
- [x] Build guard allows bare-toolchain builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)