### PR TITLE
Tab bar: clearer active-tab state

### DIFF
--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -102,13 +102,6 @@ struct TabBar: View {
     var body: some View {
         HStack(spacing: 0) {
             ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
-                if index > 0 {
-                    // Subtle vertical divider between tabs (iTerm2-style)
-                    Rectangle()
-                        .fill(Color.primary.opacity(0.08))
-                        .frame(width: 1, height: 18)
-                }
-
                 TabBarItem(
                     tab: tab,
                     index: index,
@@ -119,11 +112,6 @@ struct TabBar: View {
                     onClose: { onCloseTab(index) }
                 )
             }
-
-            // Divider before + button
-            Rectangle()
-                .fill(Color.primary.opacity(0.08))
-                .frame(width: 1, height: 18)
 
             AddTabButton(
                 profiles: appState.modelProfiles,
@@ -633,6 +621,15 @@ private struct TabBarItem: View {
                 Color.clear.preference(key: TabWidthPreference.self, value: geo.size.width)
             }
         )
+        // Active-tab indicator: a bottom lip drawn as an overlay so it never
+        // participates in layout — the tab content must not shift on selection.
+        .overlay(alignment: .bottom) {
+            if isSelected {
+                Rectangle()
+                    .fill(Color.accentColor)
+                    .frame(height: 2)
+            }
+        }
         .onPreferenceChange(TabWidthPreference.self) { measuredWidth = $0 }
         .animation(.easeInOut(duration: 0.1), value: isHovering)
         // nil = no card (non-Claude tabs).

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -610,7 +610,12 @@ private struct TabBarItem: View {
             .opacity(showClose ? 1 : 0)
             .animation(.easeInOut(duration: 0.12), value: showClose)
         }
-        .frame(minHeight: 28)
+        // Stretch to the tab bar's full height (30px) so the bottom-aligned
+        // active indicator seats flush against the divider below the strip.
+        // Without maxHeight the 28px item center-aligns in the 30px bar,
+        // leaving a ~1px sliver under the indicator. Content stays centered,
+        // so the label doesn't shift on select/deselect.
+        .frame(minHeight: 28, maxHeight: .infinity)
         .background(
             isSelected
                 ? Color(nsColor: .controlBackgroundColor)

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -626,7 +626,7 @@ private struct TabBarItem: View {
         .overlay(alignment: .bottom) {
             if isSelected {
                 Rectangle()
-                    .fill(Color.accentColor)
+                    .fill(Color(nsColor: .separatorColor))
                     .frame(height: 2)
             }
         }


### PR DESCRIPTION
## What

Reworks the tab bar's visual language so the selected tab is easier to identify.

- **Removed the vertical separators** between tabs (and the one before the `+` button) for a cleaner strip.
- **Added a bottom-border active indicator** on the selected tab: a 2px bar seated flush against the divider under the tab strip.
- Uses the standard **separator color** (not accent) so it reads as a slightly thicker continuation of the border line rather than an eye-catching highlight.

## Implementation notes

- The indicator is an `.overlay(alignment: .bottom)`, so it takes no layout space — the tab's icon and label do **not** shift on select/deselect. Only the border appears/disappears.
- Fixed a ~1px sliver between the indicator and the divider: tab items were `minHeight: 28` inside a `height: 30` bar and center-aligned, floating the bottom overlay ~1px above the bar's true bottom edge. Stretching the item to full height (`maxHeight: .infinity`) seats it flush; content stays vertically centered so there's still no jump.

All changes are confined to `Sources/TBDApp/TabBar.swift`. `swift build` passes.