### PR TITLE
Feat: Make manual Hibernate stick and put it back on the tab

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -134,8 +134,17 @@ extension AppState {
     /// terminal when it is itself parked; (2) otherwise the first parked
     /// terminal; (3) nil when none are parked. Extracted as a pure function so
     /// the fan-out choice is unit-tested without a live `DaemonClient`.
+    ///
+    /// Manually-parked sessions (`hibernateReason == .manual`) are excluded
+    /// UP FRONT — before the focused-match and the `.first` fallback — so an
+    /// explicit "Hibernate now" is never silently undone by navigating back to
+    /// the worktree. They wake only via the explicit affordances (parked-pane
+    /// click, Wake menu). nil-reason (legacy), auto, and recovery parks still
+    /// focus-wake.
     func terminalIDToWakeOnFocus(worktreeID: UUID) -> UUID? {
-        let parked = (terminals[worktreeID] ?? []).filter { $0.isParked }
+        let parked = (terminals[worktreeID] ?? []).filter {
+            $0.isParked && $0.hibernateReason != .manual
+        }
         guard !parked.isEmpty else { return nil }
         if let focusedID = terminalIDForAutofocus(worktreeID: worktreeID),
            parked.contains(where: { $0.id == focusedID }) {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1082,9 +1082,19 @@ final class AppState: ObservableObject {
         terminals[delta.worktreeID]?[idx].profileID = delta.newProfileID
     }
 
-    /// Hibernate / wake / keep-warm change: update `hibernatedAt` + `keepWarm`
-    /// on the row in place so the whisper indicator and action menu re-render
-    /// without a full terminal refetch.
+    /// Hibernate / wake / keep-warm change: update `hibernatedAt`, `keepWarm`,
+    /// `suspendedSnapshot`, and `hibernateReason` on the row in place so the
+    /// whisper indicator and action menu re-render without a full terminal
+    /// refetch. Snapshot and reason must land WITH the `hibernated` flip: the
+    /// parked TerminalPanelView materializes the instant `isParked` flips
+    /// (identity `id-tmuxWindowID-isParked`) and reads `initialSnapshot` from
+    /// this cached row once at creation — a snapshot arriving only in the
+    /// later refetch shows a blank parked pane — and wake-on-focus filters on
+    /// the cached `hibernateReason`, so a focus event in the delta-to-refetch
+    /// gap must not auto-wake a just-manually-parked session. On wake the
+    /// reason is cleared but the snapshot is KEPT, matching the daemon's
+    /// `clearHibernated` (the woken view shows the frozen pane while the live
+    /// tmux client reconnects).
     private func applyTerminalHibernationDelta(_ delta: TerminalHibernationDelta) {
         guard let idx = terminals[delta.worktreeID]?.firstIndex(where: { $0.id == delta.terminalID }) else {
             return
@@ -1102,6 +1112,16 @@ final class AppState: ObservableObject {
         }
         terminals[delta.worktreeID]?[idx].hibernatedAt = delta.hibernated ? Date() : nil
         terminals[delta.worktreeID]?[idx].keepWarm = delta.keepWarm
+        if delta.hibernated {
+            // Parked: the delta carries the just-captured snapshot + reason
+            // (nil from an older daemon — same blank-pane behavior as before).
+            terminals[delta.worktreeID]?[idx].suspendedSnapshot = delta.suspendedSnapshot
+            terminals[delta.worktreeID]?[idx].hibernateReason = delta.hibernateReason
+        } else {
+            // Woken: clear the reason, keep the snapshot (clearHibernated
+            // semantics — reconnect backdrop, overwritten on the next park).
+            terminals[delta.worktreeID]?[idx].hibernateReason = nil
+        }
     }
 
     /// Update the in-place usage entry for a single profile. If no match,

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -479,6 +479,32 @@ enum SwapProfileMenu {
     }
 }
 
+// MARK: - TabParkMenuModel
+
+/// Pure decision behind the tab context menu's per-terminal park affordance:
+/// which of Hibernate / Wake (if either) the menu should offer for a tab's
+/// terminal. The two states are mutually exclusive by definition —
+/// `isManuallyHibernatable` requires the terminal NOT be parked — so at most
+/// one item ever shows. Extracted from the view so each branch is
+/// unit-testable without SwiftUI (same pattern as `RowActionMenu`).
+enum TabParkMenuModel {
+    enum ParkAction: Equatable {
+        /// Terminal is live and manually hibernatable → offer "Hibernate".
+        case hibernate
+        /// Terminal is parked (hibernated or legacy-suspended) → offer "Wake".
+        case wake
+    }
+
+    /// nil = show neither item (no terminal, non-Claude terminal, or a Claude
+    /// session that is mid-turn / waiting on a permission prompt).
+    static func action(for terminal: Terminal?) -> ParkAction? {
+        guard let terminal else { return nil }
+        if terminal.isManuallyHibernatable { return .hibernate }
+        if terminal.isParked { return .wake }
+        return nil
+    }
+}
+
 // MARK: - TabBarItem
 
 private struct TabBarItem: View {
@@ -818,10 +844,39 @@ private struct TabBarItem: View {
                 Label("Fork Session", systemImage: "arrow.triangle.branch")
             }
 
-            // Park (formerly the Suspend/Resume play/pause button) is a
-            // row-level action now (WorktreeRowView). A scheduled auto-resume
-            // can still be pending on a live session that hit its limit, so
-            // keep the cancel affordance here (#341).
+            // Park (formerly the Suspend/Resume play/pause button) lives here
+            // as per-terminal Hibernate/Wake items — THIS tab's session only,
+            // unlike the worktree row's action which sweeps every session in
+            // the worktree. A scheduled auto-resume can still be pending on a
+            // live session that hit its limit, so keep the cancel affordance
+            // here too (#341).
+            switch TabParkMenuModel.action(for: terminal) {
+            case .hibernate:
+                Button {
+                    guard let terminalID = terminal?.id else { return }
+                    Task { await appState.hibernateTerminal(terminalID: terminalID, worktreeID: worktreeID) }
+                } label: {
+                    Label("Hibernate", systemImage: "moon.zzz")
+                }
+            case .wake:
+                Button {
+                    guard let terminalID = terminal?.id else { return }
+                    Task {
+                        // Explicit user action → surface the failure (single
+                        // wake, so the coalescer yields the bare message).
+                        if let failure = await appState.wakeTerminal(
+                            terminalID: terminalID, worktreeID: worktreeID, userInitiated: true
+                        ), let message = AppState.coalescedWakeFailureMessage(failures: [failure]) {
+                            appState.showAlert(message, isError: true)
+                        }
+                    }
+                } label: {
+                    Label("Wake", systemImage: "sun.max")
+                }
+            case nil:
+                EmptyView()
+            }
+
             if terminal?.pendingResumeAt != nil {
                 Button {
                     guard let terminalID = terminal?.id else { return }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -804,6 +804,18 @@ public final class TBDDatabase: Sendable {
                 type: .boolean, defaults: false)
         }
 
+        // WHO parked a session (`auto` idle sweep / `manual` "Hibernate now" /
+        // `recovery` crash-recovery reconcile — see `HibernateReason`), so an
+        // explicit user park is not silently undone by wake-on-focus. Nullable
+        // TEXT: legacy parked rows stay NULL and keep the old behavior (focus
+        // still wakes them). (Authored as v46 on the feature branch; renumbered
+        // on rebase as upstream took v46 first — never shipped to a live
+        // database under the old name, so renaming is safe.)
+        migrator.registerMigration("v47_hibernate_reason") { db in
+            try db.addColumnIfMissing(
+                table: "terminal", column: "hibernateReason", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -24,6 +24,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var kind: String?
     var activityState: String?
     var hibernatedAt: Date?
+    var hibernateReason: String?
     var keepWarm: Bool?
     var pendingResumeAt: Date?
 
@@ -43,6 +44,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.kind = terminal.kind?.rawValue
         self.activityState = terminal.activityState.rawValue
         self.hibernatedAt = terminal.hibernatedAt
+        self.hibernateReason = terminal.hibernateReason?.rawValue
         self.keepWarm = terminal.keepWarm
         self.pendingResumeAt = terminal.pendingResumeAt
     }
@@ -75,6 +77,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             kind: kind.flatMap(TerminalKind.init(rawValue:)),
             activityState: activityState.flatMap(TerminalActivityState.init(rawValue:)) ?? .unknown,
             hibernatedAt: hibernatedAt,
+            hibernateReason: hibernateReason.flatMap(HibernateReason.init(rawValue:)),
             keepWarm: keepWarm ?? false,
             pendingResumeAt: pendingResumeAt
         )
@@ -258,6 +261,7 @@ public struct TerminalStore: Sendable {
             record.suspendedAt = nil
             record.suspendedSnapshot = nil
             record.hibernatedAt = nil
+            record.hibernateReason = nil
             record.label = TerminalLabel.shell
             record.kind = TerminalKind.shell.rawValue
             record.activityState = TerminalActivityState.unknown.rawValue
@@ -308,13 +312,19 @@ public struct TerminalStore: Sendable {
     /// orthogonal to which timestamp wins) so the app can show the frozen pane as
     /// the backdrop while the session is parked / waking. Pass `nil` to leave any
     /// existing snapshot untouched.
-    public func setHibernated(id: UUID, sessionID: String, snapshot: String? = nil, at date: Date = Date()) async throws {
+    ///
+    /// `reason` records WHO parked the session (idle sweep / manual action /
+    /// crash-recovery reconcile) — see `HibernateReason`. It is stamped
+    /// unconditionally (a re-park overwrites any stale reason); `nil` keeps
+    /// legacy semantics (the row is still eligible for wake-on-focus).
+    public func setHibernated(id: UUID, sessionID: String, snapshot: String? = nil, reason: HibernateReason? = nil, at date: Date = Date()) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Terminal not found")
             }
             record.claudeSessionID = sessionID
             record.hibernatedAt = date
+            record.hibernateReason = reason?.rawValue
             if let snapshot {
                 record.suspendedSnapshot = snapshot
             }
@@ -337,6 +347,7 @@ public struct TerminalStore: Sendable {
             }
             record.hibernatedAt = nil
             record.suspendedAt = nil
+            record.hibernateReason = nil
             try record.update(db)
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -183,7 +183,7 @@ public actor HibernationCoordinator {
         guard terminal.isManuallyHibernatable else {
             return .notEligible(reason: manualBlockReason(terminal))
         }
-        return await performHibernate(terminal: terminal)
+        return await performHibernate(terminal: terminal, reason: .manual)
     }
 
     /// The reason a manual hibernate was refused, for the RPC error string.
@@ -204,7 +204,11 @@ public actor HibernationCoordinator {
     /// (typed-but-unsent input, transcript-tail validity) that the DB row can't
     /// express. After the kill it verifies the claude process is gone and the
     /// pane's shell survived, and logs any orphaned claude children.
-    private func performHibernate(terminal: Terminal) async -> HibernateResult {
+    ///
+    /// `reason` records WHO parked the session (`.manual` from the explicit
+    /// "Hibernate now" entry points, `.auto` from the idle sweep) — persisted
+    /// so the app's wake-on-focus can skip manual parks.
+    private func performHibernate(terminal: Terminal, reason: HibernateReason) async -> HibernateResult {
         guard !hibernatesInFlight.contains(terminal.id) else {
             return .alreadyHibernated
         }
@@ -286,7 +290,8 @@ public actor HibernationCoordinator {
 
         do {
             try await db.terminals.setHibernated(
-                id: terminal.id, sessionID: sessionID, snapshot: capturedSnapshot, at: now()
+                id: terminal.id, sessionID: sessionID, snapshot: capturedSnapshot,
+                reason: reason, at: now()
             )
         } catch {
             logger.warning("hibernate: failed to mark hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -705,7 +710,7 @@ public actor HibernationCoordinator {
                 }
                 if let pending = pendingKillSince[terminal.id] {
                     if reference.timeIntervalSince(pending) >= Self.killDebounce {
-                        _ = await performHibernate(terminal: terminal)
+                        _ = await performHibernate(terminal: terminal, reason: .auto)
                     }
                 } else {
                     pendingKillSince[terminal.id] = reference

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -167,7 +167,13 @@ public actor HibernationCoordinator {
     public func setKeepWarm(terminalID: UUID, keepWarm: Bool) async -> Bool {
         guard let terminal = try? await db.terminals.get(id: terminalID) else { return false }
         try? await db.terminals.setKeepWarm(id: terminalID, keepWarm: keepWarm)
-        broadcastHibernation(terminal: terminal, hibernated: terminal.isHibernated, keepWarm: keepWarm)
+        // Carry the row's persisted snapshot/reason: on a parked row this
+        // re-broadcast has hibernated == true, and the app's in-place apply
+        // would otherwise wipe both from its cached row.
+        broadcastHibernation(
+            terminal: terminal, hibernated: terminal.isHibernated, keepWarm: keepWarm,
+            suspendedSnapshot: terminal.isHibernated ? terminal.suspendedSnapshot : nil,
+            hibernateReason: terminal.isHibernated ? terminal.hibernateReason : nil)
         return true
     }
 
@@ -302,7 +308,13 @@ public actor HibernationCoordinator {
         _ = try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)
         idleSince[terminal.id] = nil
         pendingKillSince[terminal.id] = nil
-        broadcastHibernation(terminal: terminal, hibernated: true, keepWarm: terminal.keepWarm)
+        // The delta must carry the just-captured snapshot and the park reason:
+        // the app's parked view materializes on this flip reading its cached
+        // row, and wake-on-focus filters on the cached reason — the refetch
+        // that would eventually bring both lands after the view is built.
+        broadcastHibernation(
+            terminal: terminal, hibernated: true, keepWarm: terminal.keepWarm,
+            suspendedSnapshot: capturedSnapshot, hibernateReason: reason)
         logger.info("hibernated terminal \(terminal.id, privacy: .public) (session \(sessionID, privacy: .public))")
         return .ok
     }
@@ -879,9 +891,16 @@ public actor HibernationCoordinator {
         }
     }
 
+    /// `suspendedSnapshot`/`hibernateReason` ride hibernate broadcasts (and
+    /// keep-warm re-broadcasts on a parked row) because the app applies this
+    /// delta to its cached row IN PLACE: the parked view materializes on the
+    /// `hibernated` flip and reads the row's snapshot once, and wake-on-focus
+    /// reads the row's reason — a later refetch is too late. Wake broadcasts
+    /// leave them nil.
     private func broadcastHibernation(
         terminal: Terminal, hibernated: Bool, keepWarm: Bool,
-        tmuxWindowID: String? = nil, tmuxPaneID: String? = nil
+        tmuxWindowID: String? = nil, tmuxPaneID: String? = nil,
+        suspendedSnapshot: String? = nil, hibernateReason: HibernateReason? = nil
     ) {
         subscriptions?.broadcast(delta: .terminalHibernationChanged(TerminalHibernationDelta(
             terminalID: terminal.id,
@@ -889,7 +908,9 @@ public actor HibernationCoordinator {
             hibernated: hibernated,
             keepWarm: keepWarm,
             tmuxWindowID: tmuxWindowID,
-            tmuxPaneID: tmuxPaneID
+            tmuxPaneID: tmuxPaneID,
+            suspendedSnapshot: suspendedSnapshot,
+            hibernateReason: hibernateReason
         )))
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -285,7 +285,7 @@ extension WorktreeLifecycle {
                     // Deleting here would orphan the transcript and the session
                     // would vanish from TBD. Write the authoritative `hibernatedAt`
                     // column so `wake()` (which un-parks any parked row) can resume it.
-                    try? await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID)
+                    try? await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID, reason: .recovery)
                     logger.info("reconcile: parked terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone, session \(sessionID, privacy: .public) preserved, wakeable via the unified resume path")
                 } else {
                     // Plain shell / Codex: nothing resumable to preserve, delete.

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -31,7 +31,8 @@ public struct TmuxManager: Sendable {
     /// Without it, dryRun reports every window as alive, which makes paths
     /// like the pre-session `.paneKilled` short-circuit untestable.
     public let dryRunWindowIsDead: (@Sendable (String) -> Bool)?
-    /// Optional test hook consulted by `capturePaneOutput` in dryRun mode:
+    /// Optional test hook consulted by `capturePaneOutput` and
+    /// `capturePaneWithAnsi` in dryRun mode:
     /// (server, paneID) → pane text. Without it, dryRun captures return "",
     /// which reads as "pane not ready" to the auto-login pump.
     public let dryRunCapturePane: (@Sendable (String, String) -> String)?
@@ -484,7 +485,9 @@ public struct TmuxManager: Sendable {
 
     /// Capture pane content with ANSI escape sequences preserved for snapshot display.
     public func capturePaneWithAnsi(server: String, paneID: String) async throws -> String {
-        if dryRun { return "" }
+        // dryRun consults the same capture hook as `capturePaneOutput` so tests
+        // can exercise the park path's snapshot capture end-to-end.
+        if dryRun { return dryRunCapturePane?(server, paneID) ?? "" }
         let args = Self.capturePaneWithAnsiCommand(server: server, paneID: paneID)
         return try await runTmux(args)
     }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -226,6 +226,19 @@ public enum TerminalActivityState: String, Codable, Sendable {
     case idle
     case waitingForUser = "waiting_for_user"
 }
+
+/// WHO parked a session — persisted alongside `hibernatedAt` so an explicit
+/// user park can be distinguished from an automatic one (and survive the
+/// wake-on-focus sweep, which must not silently undo a manual park).
+public enum HibernateReason: String, Codable, Sendable {
+    /// Idle-sweep auto-hibernation.
+    case auto
+    /// Explicit user "Hibernate now" (terminal.hibernate RPC or the legacy
+    /// terminal.suspend shim). Excluded from wake-on-focus.
+    case manual
+    /// Crash-recovery / reconcile parking (window or server gone).
+    case recovery
+}
 public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var worktreeID: UUID
@@ -253,6 +266,11 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// from `suspendedAt` (which kills the tmux window's program entirely and
     /// snapshots the pane); a hibernated terminal keeps its live window.
     public var hibernatedAt: Date?
+    /// WHO parked this session (see `HibernateReason`). Stamped together with
+    /// `hibernatedAt` at park time and cleared with it on wake. `nil` on
+    /// legacy rows parked before the column existed (pre-v46) — treated like
+    /// `.auto`, i.e. still eligible for wake-on-focus.
+    public var hibernateReason: HibernateReason?
     /// User pin that exempts this terminal from auto-hibernation. `false` =
     /// eligible for the idle timer; `true` = the daemon never auto-hibernates
     /// it (manual "Hibernate now" still works). Persisted per-terminal.
@@ -272,6 +290,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 kind: TerminalKind? = nil,
                 activityState: TerminalActivityState = .unknown,
                 hibernatedAt: Date? = nil,
+                hibernateReason: HibernateReason? = nil,
                 keepWarm: Bool = false,
                 pendingResumeAt: Date? = nil) {
         self.id = id
@@ -289,6 +308,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.kind = kind
         self.activityState = activityState
         self.hibernatedAt = hibernatedAt
+        self.hibernateReason = hibernateReason
         self.keepWarm = keepWarm
         self.pendingResumeAt = pendingResumeAt
     }
@@ -297,7 +317,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
         case activityState
-        case hibernatedAt, keepWarm, pendingResumeAt
+        case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -317,6 +337,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         kind = try c.decodeIfPresent(TerminalKind.self, forKey: .kind)
         activityState = try c.decodeIfPresent(TerminalActivityState.self, forKey: .activityState) ?? .unknown
         hibernatedAt = try c.decodeIfPresent(Date.self, forKey: .hibernatedAt)
+        hibernateReason = try c.decodeIfPresent(HibernateReason.self, forKey: .hibernateReason)
         keepWarm = try c.decodeIfPresent(Bool.self, forKey: .keepWarm) ?? false
         pendingResumeAt = try c.decodeIfPresent(Date.self, forKey: .pendingResumeAt)
     }

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -50,9 +50,29 @@ public struct TerminalHibernationDelta: Codable, Sendable {
     /// nil default so payloads from older daemons still decode.
     public let tmuxWindowID: String?
     public let tmuxPaneID: String?
+    /// The ANSI pane snapshot captured just before the park's kill, carried on
+    /// hibernate so the app updates its cached row together with the
+    /// `hibernated` flip. Without it, the parked TerminalPanelView — which
+    /// materializes the instant `isParked` flips and reads `initialSnapshot`
+    /// from the cached row ONCE at creation — sees a still-nil
+    /// `suspendedSnapshot` and shows a blank pane; the snapshot arriving in
+    /// the later `refreshTerminals` refetch never reaches the already-built
+    /// view. Nil on wake deltas (the daemon's `clearHibernated` keeps the DB
+    /// snapshot, so the app keeps its cached one too). Optional with a nil
+    /// default so payloads from older daemons still decode.
+    public let suspendedSnapshot: String?
+    /// WHO parked the session (`.manual` / `.auto` / `.recovery`), carried on
+    /// hibernate so the cached row has it between the delta and the next
+    /// refetch. Wake-on-focus filters on this reason; without it a focus
+    /// event landing in that gap could wrongly auto-wake a just-manually-
+    /// parked session. Nil on wake deltas (the apply clears it, matching
+    /// `clearHibernated`). Optional with a nil default so payloads from older
+    /// daemons still decode.
+    public let hibernateReason: HibernateReason?
     public init(
         terminalID: UUID, worktreeID: UUID, hibernated: Bool, keepWarm: Bool,
-        tmuxWindowID: String? = nil, tmuxPaneID: String? = nil
+        tmuxWindowID: String? = nil, tmuxPaneID: String? = nil,
+        suspendedSnapshot: String? = nil, hibernateReason: HibernateReason? = nil
     ) {
         self.terminalID = terminalID
         self.worktreeID = worktreeID
@@ -60,6 +80,8 @@ public struct TerminalHibernationDelta: Codable, Sendable {
         self.keepWarm = keepWarm
         self.tmuxWindowID = tmuxWindowID
         self.tmuxPaneID = tmuxPaneID
+        self.suspendedSnapshot = suspendedSnapshot
+        self.hibernateReason = hibernateReason
     }
 }
 

--- a/Tests/TBDAppTests/TabParkMenuModelTests.swift
+++ b/Tests/TBDAppTests/TabParkMenuModelTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// The per-tab Hibernate/Wake context-menu affordance (the park control that
+/// returned to the tab after PR #362 retired the play/pause Suspend button).
+/// Tests the pure decision `TabParkMenuModel.action(for:)` across every
+/// branch without SwiftUI: hibernate for a live manually-hibernatable Claude
+/// session, wake for a parked one (authoritative `hibernatedAt` AND legacy
+/// `suspendedAt`), and neither for busy/nil/non-Claude terminals.
+@Suite("Tab park menu decision (per-tab Hibernate/Wake)")
+struct TabParkMenuModelTests {
+    /// A live, resumable Claude terminal — the shape `isManuallyHibernatable`
+    /// requires (session id present, Claude kind, not parked, not busy).
+    private func claudeTerminal(
+        activityState: TerminalActivityState = .idle,
+        suspendedAt: Date? = nil,
+        hibernatedAt: Date? = nil
+    ) -> Terminal {
+        Terminal(id: UUID(), worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+                 claudeSessionID: "session-1", suspendedAt: suspendedAt,
+                 kind: .claude, activityState: activityState,
+                 hibernatedAt: hibernatedAt)
+    }
+
+    /// Branch 1: a live, idle, resumable Claude session is manually
+    /// hibernatable → offer Hibernate.
+    @Test func manuallyHibernatableTerminalOffersHibernate() {
+        let terminal = claudeTerminal()
+        #expect(terminal.isManuallyHibernatable)
+        #expect(TabParkMenuModel.action(for: terminal) == .hibernate)
+    }
+
+    /// Branch 2: a parked session (authoritative `hibernatedAt`) → offer Wake.
+    @Test func parkedTerminalOffersWake() {
+        let terminal = claudeTerminal(hibernatedAt: Date())
+        #expect(TabParkMenuModel.action(for: terminal) == .wake)
+    }
+
+    /// Branch 2 (legacy): a row parked by the pre-merge Suspend feature has
+    /// ONLY `suspendedAt` set — it must still read as parked and offer Wake.
+    @Test func legacySuspendedOnlyTerminalOffersWake() {
+        let terminal = claudeTerminal(suspendedAt: Date())
+        #expect(terminal.hibernatedAt == nil)
+        #expect(TabParkMenuModel.action(for: terminal) == .wake)
+    }
+
+    /// Branch 3: a Claude session mid-turn (`.working`) is neither parked nor
+    /// manually hibernatable → no item.
+    @Test func workingTerminalOffersNothing() {
+        let terminal = claudeTerminal(activityState: .working)
+        #expect(TabParkMenuModel.action(for: terminal) == nil)
+    }
+
+    /// Branch 3: a Claude session waiting on a permission prompt — hibernating
+    /// would eat the raised hand → no item.
+    @Test func waitingForUserTerminalOffersNothing() {
+        let terminal = claudeTerminal(activityState: .waitingForUser)
+        #expect(TabParkMenuModel.action(for: terminal) == nil)
+    }
+
+    /// Branch 3: no terminal backing the tab → no item.
+    @Test func nilTerminalOffersNothing() {
+        #expect(TabParkMenuModel.action(for: nil) == nil)
+    }
+
+    /// Branch 3: non-Claude terminals (plain shell, Codex) are never
+    /// hibernatable → no item.
+    @Test func nonClaudeTerminalOffersNothing() {
+        let shell = Terminal(id: UUID(), worktreeID: UUID(), tmuxWindowID: "@1",
+                             tmuxPaneID: "%1", kind: .shell, activityState: .idle)
+        let codex = Terminal(id: UUID(), worktreeID: UUID(), tmuxWindowID: "@2",
+                             tmuxPaneID: "%2", kind: .codex, activityState: .idle)
+        #expect(TabParkMenuModel.action(for: shell) == nil)
+        #expect(TabParkMenuModel.action(for: codex) == nil)
+    }
+}

--- a/Tests/TBDAppTests/TerminalHibernationDeltaAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalHibernationDeltaAppStateTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// `terminalHibernationChanged` delta application to the cached terminal row.
+///
+/// The parked `TerminalPanelView` materializes the instant `isParked` flips
+/// (identity `id-tmuxWindowID-isParked`) and reads `initialSnapshot` from the
+/// cached row ONCE at creation, and wake-on-focus filters on the cached row's
+/// `hibernateReason` — so BOTH must land on the row together with the
+/// `hibernated` flip, not in the later `refreshTerminals` refetch.
+@MainActor
+@Suite("Hibernation delta handling")
+struct TerminalHibernationDeltaAppStateTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.HibernationDelta.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    @Test func hibernateDelta_populatesSnapshotAndReasonOnCachedRow() {
+        withState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            state.terminals = [worktreeID: [
+                Terminal(id: terminalID, worktreeID: worktreeID,
+                         tmuxWindowID: "@1", tmuxPaneID: "%1", kind: .claude)
+            ]]
+
+            state.handleDelta(.terminalHibernationChanged(TerminalHibernationDelta(
+                terminalID: terminalID, worktreeID: worktreeID,
+                hibernated: true, keepWarm: false,
+                suspendedSnapshot: "FROZEN PANE", hibernateReason: .manual
+            )))
+
+            let row = state.terminals[worktreeID]?[0]
+            #expect(row?.hibernatedAt != nil)
+            #expect(row?.suspendedSnapshot == "FROZEN PANE",
+                    "the parked view reads the cached row's snapshot at creation — it must arrive with the flip")
+            #expect(row?.hibernateReason == .manual,
+                    "wake-on-focus filters on the cached reason — it must arrive with the flip")
+        }
+    }
+
+    @Test func wakeDelta_clearsReasonAndParkFlag_keepsSnapshot() {
+        withState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            state.terminals = [worktreeID: [
+                Terminal(id: terminalID, worktreeID: worktreeID,
+                         tmuxWindowID: "@1", tmuxPaneID: "%1",
+                         suspendedSnapshot: "FROZEN PANE", kind: .claude,
+                         hibernatedAt: Date(), hibernateReason: .manual)
+            ]]
+
+            state.handleDelta(.terminalHibernationChanged(TerminalHibernationDelta(
+                terminalID: terminalID, worktreeID: worktreeID,
+                hibernated: false, keepWarm: false
+            )))
+
+            let row = state.terminals[worktreeID]?[0]
+            #expect(row?.hibernatedAt == nil)
+            #expect(row?.hibernateReason == nil,
+                    "wake clears the reason, matching the daemon's clearHibernated")
+            // clearHibernated deliberately KEEPS suspendedSnapshot in the DB so
+            // the woken view can show the frozen pane while the live tmux
+            // client reconnects — the cached row must match.
+            #expect(row?.suspendedSnapshot == "FROZEN PANE")
+        }
+    }
+}

--- a/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
+++ b/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
@@ -15,6 +15,17 @@ struct WakeOnFocusDecisionTests {
                  hibernatedAt: parked ? Date() : nil)
     }
 
+    private func parkedTerminal(_ id: UUID, reason: HibernateReason?) -> Terminal {
+        Terminal(id: id, worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+                 hibernatedAt: Date(), hibernateReason: reason)
+    }
+
+    /// Focus `terminalID`'s tab in `wt` so `terminalIDForAutofocus` resolves it.
+    private func focus(_ state: AppState, worktreeID wt: UUID, terminalID: UUID) {
+        state.tabs[wt] = [Tab(id: UUID(), content: .terminal(terminalID: terminalID), label: nil)]
+        state.activeTabIndices[wt] = 0
+    }
+
     /// Branch 1: the focused terminal is itself parked → wake exactly it (not
     /// merely the first parked row).
     @Test func wakesTheFocusedParkedTerminal() {
@@ -54,6 +65,78 @@ struct WakeOnFocusDecisionTests {
         state.terminals[wt] = [terminal(UUID(), parked: false), terminal(UUID(), parked: false)]
 
         #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == nil)
+    }
+
+    // MARK: - Manual-park exclusion (hibernateReason)
+    //
+    // An explicit "Hibernate now" (`hibernateReason == .manual`) must NOT be
+    // silently undone by navigating back to the worktree: focus-wake skips it
+    // at BOTH decision points (the focused-terminal match and the `.first`
+    // fallback). Auto, recovery, and legacy nil-reason parks keep the old
+    // behavior and still wake on focus.
+
+    /// A manually-parked session is skipped even when it is the FOCUSED
+    /// terminal — and with nothing else parked, nothing is woken at all.
+    @Test func skipsManuallyParkedTerminalEvenWhenFocused() {
+        let state = AppState()
+        let wt = UUID()
+        let manual = UUID()
+        state.terminals[wt] = [parkedTerminal(manual, reason: .manual)]
+        focus(state, worktreeID: wt, terminalID: manual)
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == nil)
+    }
+
+    /// An auto-parked (idle-sweep) session still wakes on focus.
+    @Test func wakesAutoParkedTerminalOnFocus() {
+        let state = AppState()
+        let wt = UUID()
+        let auto = UUID()
+        state.terminals[wt] = [parkedTerminal(auto, reason: .auto)]
+        focus(state, worktreeID: wt, terminalID: auto)
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == auto)
+    }
+
+    /// A recovery-parked (crash-recovery reconcile) session still wakes on focus.
+    @Test func wakesRecoveryParkedTerminalOnFocus() {
+        let state = AppState()
+        let wt = UUID()
+        let recovery = UUID()
+        state.terminals[wt] = [parkedTerminal(recovery, reason: .recovery)]
+        focus(state, worktreeID: wt, terminalID: recovery)
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == recovery)
+    }
+
+    /// A legacy parked row with NO reason (pre-v46) still wakes on focus —
+    /// the old behavior is preserved for rows the migration can't attribute.
+    @Test func wakesLegacyNilReasonParkedTerminalOnFocus() {
+        let state = AppState()
+        let wt = UUID()
+        let legacy = UUID()
+        state.terminals[wt] = [parkedTerminal(legacy, reason: nil)]
+        focus(state, worktreeID: wt, terminalID: legacy)
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == legacy)
+    }
+
+    /// Mixed worktree: a manual park and an auto park coexist. The manual one
+    /// is FIRST in the list (a naive `.first` fallback would pick it) and also
+    /// FOCUSED (a naive focused-match would pick it) — the auto one must be
+    /// chosen anyway, proving the exclusion applies at both decision points.
+    @Test func mixedManualAndAutoParkedChoosesTheAutoOne() {
+        let state = AppState()
+        let wt = UUID()
+        let manual = UUID()
+        let auto = UUID()
+        state.terminals[wt] = [
+            parkedTerminal(manual, reason: .manual),
+            parkedTerminal(auto, reason: .auto),
+        ]
+        focus(state, worktreeID: wt, terminalID: manual)
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == auto)
     }
 
     // MARK: - Wake-failure alert coalescing (modal-spam fix)

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -176,18 +176,17 @@ struct HibernationCoordinatorTests {
     @Test func parkPersistsPaneSnapshot() async throws {
         let (db, _, terminalID) = try await setup(activityState: .idle)
         // Inject a non-empty ANSI capture via the capturePane dryRun hook; the
-        // park path reads it through `capturePaneWithAnsi`.
+        // park path reads it through `capturePaneWithAnsi` (which consults the
+        // same hook in dryRun) and must persist it into `suspendedSnapshot`.
         let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in "FROZEN PANE" })
-        // capturePaneWithAnsi returns "" in dryRun regardless of the hook, so
-        // this test asserts the write PATH is exercised (snapshot param wired)
-        // by checking setHibernated persists whatever capture returns. Since
-        // dryRun capturePaneWithAnsi is "", the snapshot ends up nil — so we
-        // instead assert the DB path directly with an explicit snapshot.
-        _ = tmux
-        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1", snapshot: "FROZEN PANE")
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+
+        let result = await coord.manualHibernate(terminalID: terminalID)
+        #expect(result == .ok)
         let after = try await db.terminals.get(id: terminalID)
         #expect(after?.suspendedSnapshot == "FROZEN PANE",
-                "the snapshot param must persist into suspendedSnapshot")
+                "the captured pane must persist into suspendedSnapshot")
         #expect(after?.hibernatedAt != nil)
     }
 
@@ -709,6 +708,102 @@ struct HibernationCoordinatorTests {
         #expect(try await db.terminals.get(id: terminalID)?.keepWarm == false)
     }
 
+    // MARK: - Broadcast delta contents (snapshot + reason ride the delta)
+    //
+    // The app applies `terminalHibernationChanged` to its cached row IN PLACE;
+    // the parked view materializes on that flip and reads the row's
+    // `suspendedSnapshot` once, and wake-on-focus reads `hibernateReason` — so
+    // the hibernate delta must CARRY both (a later refetch is too late).
+
+    /// Manual park: the published delta carries the just-captured ANSI
+    /// snapshot and the `.manual` reason alongside `hibernated: true`.
+    @Test func manualHibernatePublishesSnapshotAndReasonOnDelta() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let recorder = RecordedHibernationDeltas()
+        let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in "FROZEN PANE" })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux,
+            subscriptions: recorder.subscriptions(),
+            configDirManager: isolatedConfigDirManager())
+
+        let result = await coord.manualHibernate(terminalID: terminalID)
+        #expect(result == .ok)
+
+        let delta = recorder.snapshot().last
+        #expect(delta?.hibernated == true)
+        #expect(delta?.suspendedSnapshot == "FROZEN PANE",
+                "the hibernate delta must carry the captured snapshot — the parked view reads the cached row at the flip")
+        #expect(delta?.hibernateReason == .manual,
+                "the hibernate delta must carry the park reason — wake-on-focus filters on it before the refetch")
+    }
+
+    /// Wake: the un-park delta publishes nil snapshot/reason (the app clears
+    /// its cached reason; the DB keeps the snapshot per `clearHibernated`).
+    @Test func wakePublishesNilSnapshotAndReasonOnDelta() async throws {
+        let (db, _, terminalID) = try await setup()
+        let recorder = RecordedHibernationDeltas()
+        let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in "FROZEN PANE" })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux,
+            subscriptions: recorder.subscriptions(),
+            configDirManager: isolatedConfigDirManager())
+
+        _ = await coord.manualHibernate(terminalID: terminalID)
+        let wake = await coord.wake(terminalID: terminalID)
+        #expect(wake == .ok)
+
+        let delta = recorder.snapshot().last
+        #expect(delta?.hibernated == false)
+        #expect(delta?.suspendedSnapshot == nil)
+        #expect(delta?.hibernateReason == nil)
+    }
+
+    /// Keep-warm toggle on an ALREADY PARKED row re-broadcasts
+    /// `hibernated: true` — it must carry the row's persisted snapshot and
+    /// reason, or the in-place apply would wipe them from the cached row.
+    @Test func keepWarmOnParkedRowRebroadcastsRowSnapshotAndReason() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(
+            id: terminalID, sessionID: "sess-1",
+            snapshot: "FROZEN PANE", reason: .manual)
+        let recorder = RecordedHibernationDeltas()
+        let coord = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            subscriptions: recorder.subscriptions(),
+            configDirManager: isolatedConfigDirManager())
+
+        let ok = await coord.setKeepWarm(terminalID: terminalID, keepWarm: true)
+        #expect(ok)
+
+        let delta = recorder.snapshot().last
+        #expect(delta?.hibernated == true)
+        #expect(delta?.keepWarm == true)
+        #expect(delta?.suspendedSnapshot == "FROZEN PANE",
+                "a keep-warm re-broadcast on a parked row must not wipe the cached snapshot")
+        #expect(delta?.hibernateReason == .manual,
+                "a keep-warm re-broadcast on a parked row must not wipe the cached reason")
+    }
+
+    /// Keep-warm toggle on a LIVE (non-parked) row: `hibernated: false` with
+    /// nil snapshot/reason — nothing parked, nothing to carry.
+    @Test func keepWarmOnLiveRowPublishesNilSnapshotAndReason() async throws {
+        let (db, _, terminalID) = try await setup()
+        let recorder = RecordedHibernationDeltas()
+        let coord = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            subscriptions: recorder.subscriptions(),
+            configDirManager: isolatedConfigDirManager())
+
+        let ok = await coord.setKeepWarm(terminalID: terminalID, keepWarm: true)
+        #expect(ok)
+
+        let delta = recorder.snapshot().last
+        #expect(delta?.hibernated == false)
+        #expect(delta?.keepWarm == true)
+        #expect(delta?.suspendedSnapshot == nil)
+        #expect(delta?.hibernateReason == nil)
+    }
+
     // MARK: - Idle sweep gating
 
     @Test func sweepDoesNotHibernateWhenFeatureDisabled() async throws {
@@ -788,6 +883,38 @@ struct RPCRouterWakeErrorMappingTests {
                 "the RPC error must name the gone window; got: \(resp.error ?? "nil")")
         #expect(try await db.terminals.get(id: terminal.id)?.isParked == true,
                 "the row must stay parked so a retry can wake it")
+    }
+}
+
+/// Thread-safe collector of `terminalHibernationChanged` deltas published
+/// through a real `StateSubscriptionManager` — the same wire the app's
+/// subscription receives, so these tests assert the actual encoded payload.
+private final class RecordedHibernationDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [TerminalHibernationDelta] = []
+
+    /// A subscription manager whose (kept-alive) subscriber records every
+    /// hibernation delta into this collector.
+    func subscriptions() -> StateSubscriptionManager {
+        let manager = StateSubscriptionManager()
+        manager.addSubscriber { [weak self] data in
+            if let decoded = try? JSONDecoder().decode(StateDelta.self, from: data),
+               case .terminalHibernationChanged(let delta) = decoded {
+                self?.record(delta)
+            }
+            return true
+        }
+        return manager
+    }
+
+    private func record(_ delta: TerminalHibernationDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [TerminalHibernationDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
     }
 }
 

--- a/Tests/TBDDaemonTests/MigrationV47HibernateReasonTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV47HibernateReasonTests.swift
@@ -1,0 +1,156 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// v47 adds the nullable TEXT `hibernateReason` column: WHO parked a session
+/// (idle sweep / manual "Hibernate now" / crash-recovery reconcile), so the
+/// app's wake-on-focus can skip manual parks. Modeled on
+/// `MigrationV39HibernationTests`.
+@Suite struct MigrationV47HibernateReasonTests {
+
+    /// repo + worktree + Claude terminal fixture for an in-memory DB.
+    private func makeClaudeTerminal(_ db: TBDDatabase) async throws -> Terminal {
+        let repo = try await db.repos.create(
+            path: "/tmp/v46-repo-\(UUID().uuidString)", displayName: "V46", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v46-wt-\(UUID().uuidString)", tmuxServer: "tbd-v46")
+        return try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude", claudeSessionID: "s-1", kind: .claude)
+    }
+
+    @Test func hibernateReasonColumnExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let terminalCols = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(terminal)")
+                .compactMap { $0["name"] as String? }
+            #expect(terminalCols.contains("hibernateReason"))
+        }
+    }
+
+    /// Each reason round-trips through setHibernated → fetch unchanged.
+    @Test(arguments: [HibernateReason.auto, .manual, .recovery])
+    func hibernateReasonRoundTrips(reason: HibernateReason) async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeClaudeTerminal(db)
+
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "s-1", reason: reason)
+        let parked = try await db.terminals.get(id: terminal.id)
+        #expect(parked?.hibernatedAt != nil)
+        #expect(parked?.hibernateReason == reason)
+    }
+
+    /// The defaulted `reason:` parameter (used by call sites that predate the
+    /// column, e.g. the recreate-window park) stores NULL — legacy semantics.
+    @Test func setHibernatedWithoutReasonStoresNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeClaudeTerminal(db)
+
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "s-1")
+        let parked = try await db.terminals.get(id: terminal.id)
+        #expect(parked?.hibernatedAt != nil)
+        #expect(parked?.hibernateReason == nil)
+    }
+
+    /// Waking (clearHibernated) clears the reason along with hibernatedAt —
+    /// the single un-park point nils all three parked columns.
+    @Test func clearHibernatedClearsReason() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeClaudeTerminal(db)
+
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "s-1", reason: .manual)
+        try await db.terminals.clearHibernated(id: terminal.id)
+        let woken = try await db.terminals.get(id: terminal.id)
+        #expect(woken?.hibernatedAt == nil)
+        #expect(woken?.hibernateReason == nil)
+    }
+
+    /// clearRecreated also un-parks (nils hibernatedAt), so it must clear the
+    /// reason too — a stale `.manual` on a recreated shell row would wrongly
+    /// shield a future park from focus-wake.
+    @Test func clearRecreatedClearsReason() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeClaudeTerminal(db)
+
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "s-1", reason: .manual)
+        try await db.terminals.clearRecreated(id: terminal.id)
+        let recreated = try await db.terminals.get(id: terminal.id)
+        #expect(recreated?.hibernatedAt == nil)
+        #expect(recreated?.hibernateReason == nil)
+    }
+
+    /// A re-park overwrites any prior reason (stamped unconditionally): a row
+    /// parked manually, woken, then auto-parked must read `.auto`.
+    @Test func reparkOverwritesPriorReason() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let terminal = try await makeClaudeTerminal(db)
+
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "s-1", reason: .manual)
+        try await db.terminals.clearHibernated(id: terminal.id)
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "s-1", reason: .auto)
+        let reparked = try await db.terminals.get(id: terminal.id)
+        #expect(reparked?.hibernateReason == .auto)
+    }
+
+    /// A pre-v47 parked row (inserted without any hibernateReason value, as an
+    /// old daemon binary would have written it) still loads, reads as parked,
+    /// and carries a nil reason.
+    @Test func preV46ParkedRowLoadsWithNilReason() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v46-legacy-repo-\(UUID().uuidString)", displayName: "V46", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v46-legacy-wt-\(UUID().uuidString)", tmuxServer: "tbd-v46")
+
+        let id = UUID()
+        try await db.writerForTests.write { dbConn in
+            try dbConn.execute(
+                sql: """
+                    INSERT INTO terminal (id, worktreeID, tmuxWindowID, tmuxPaneID, createdAt, claudeSessionID, hibernatedAt)
+                    VALUES (?, ?, '@9', '%9', ?, 's-legacy', ?)
+                    """,
+                arguments: [id.uuidString, wt.id.uuidString, Date(), Date()]
+            )
+        }
+
+        let legacy = try await db.terminals.get(id: id)
+        #expect(legacy != nil)
+        #expect(legacy?.isParked == true)
+        #expect(legacy?.hibernateReason == nil)
+    }
+
+    /// Legacy JSON without the `hibernateReason` field (emitted by an older
+    /// daemon/app over RPC) still decodes `Terminal`, with a nil reason — the
+    /// custom `init(from:)` must use decodeIfPresent for the new key.
+    @Test func legacyTerminalJSONWithoutReasonDecodes() throws {
+        let json = """
+            {
+                "id": "\(UUID().uuidString)",
+                "worktreeID": "\(UUID().uuidString)",
+                "tmuxWindowID": "@1",
+                "tmuxPaneID": "%1",
+                "createdAt": 0,
+                "hibernatedAt": 0
+            }
+            """
+        let terminal = try JSONDecoder().decode(Terminal.self, from: Data(json.utf8))
+        #expect(terminal.hibernateReason == nil)
+        #expect(terminal.isParked == true)
+    }
+
+    /// The reason survives a JSON encode/decode round-trip (the RPC path the
+    /// app reads terminals through), proving CodingKeys + encode + decode all
+    /// carry the new field.
+    @Test func hibernateReasonSurvivesJSONRoundTrip() throws {
+        let original = Terminal(
+            id: UUID(), worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+            hibernatedAt: Date(), hibernateReason: .manual)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Terminal.self, from: data)
+        #expect(decoded.hibernateReason == .manual)
+    }
+}

--- a/Tests/TBDSharedTests/TerminalHibernationDeltaCodingTests.swift
+++ b/Tests/TBDSharedTests/TerminalHibernationDeltaCodingTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// Wire back-compat for the `suspendedSnapshot` / `hibernateReason` fields on
+/// `TerminalHibernationDelta` (added so the parked view and wake-on-focus see
+/// them together with the `hibernated` flip, not in the later refetch).
+@Suite("TerminalHibernationDelta coding")
+struct TerminalHibernationDeltaCodingTests {
+
+    /// A payload from an OLDER daemon that predates the snapshot/reason fields
+    /// must still decode — with both nil.
+    @Test func decodesPayloadWithoutSnapshotAndReasonFields() throws {
+        let json = """
+        {
+          "terminalHibernationChanged": {
+            "_0": {
+              "terminalID": "\(UUID().uuidString)",
+              "worktreeID": "\(UUID().uuidString)",
+              "hibernated": true,
+              "keepWarm": false
+            }
+          }
+        }
+        """
+        let decoded = try JSONDecoder().decode(StateDelta.self, from: Data(json.utf8))
+        guard case .terminalHibernationChanged(let delta) = decoded else {
+            Issue.record("expected terminalHibernationChanged, got \(decoded)")
+            return
+        }
+        #expect(delta.hibernated == true)
+        #expect(delta.suspendedSnapshot == nil)
+        #expect(delta.hibernateReason == nil)
+    }
+
+    /// Round-trip: a delta carrying snapshot + reason survives encode/decode.
+    @Test func roundTripsSnapshotAndReason() throws {
+        let original = TerminalHibernationDelta(
+            terminalID: UUID(), worktreeID: UUID(),
+            hibernated: true, keepWarm: false,
+            suspendedSnapshot: "FROZEN PANE", hibernateReason: .manual
+        )
+        let data = try JSONEncoder().encode(StateDelta.terminalHibernationChanged(original))
+        let decoded = try JSONDecoder().decode(StateDelta.self, from: data)
+        guard case .terminalHibernationChanged(let delta) = decoded else {
+            Issue.record("expected terminalHibernationChanged, got \(decoded)")
+            return
+        }
+        #expect(delta.suspendedSnapshot == "FROZEN PANE")
+        #expect(delta.hibernateReason == .manual)
+    }
+}


### PR DESCRIPTION
## Summary

- **Manual parks now survive focus-wake.** Since the suspend/hibernate merge (#362), wake-on-focus filtered only on `isParked`, so an explicit "Hibernate now" was silently undone the next time the worktree was focused. Each park now records *who* parked it — `hibernateReason` (`auto` | `manual` | `recovery`, migration `v47`, stamped at every park site, cleared on wake) — and `terminalIDToWakeOnFocus` skips `manual` parks. Auto-parks, crash-recovery parks, and legacy nil-reason rows keep the transparent auto-wake (gating wake on the auto-hibernate *setting* was considered and rejected: it would leave every reboot-parked session dead until manually revived). No new settings.
- **Per-tab Hibernate/Wake** in the tab context menu, acting on that tab's session only (the row action sweeps the worktree). Availability is a pure `TabParkMenuModel` decision — hidden while the session is mid-turn or waiting on a permission prompt, same rails as the row.
- **Parked panes show their frozen screen again for interactive parks.** The hibernation delta flipped `isParked` before the refetch delivered `suspendedSnapshot`, and the parked view materializes on that flip reading the snapshot once — so manually parked panes rendered blank (recovery parks were immune: full refetch delivers the row atomically). The delta now carries `suspendedSnapshot` + `hibernateReason` (nil-defaulted; older-daemon payloads still decode — same pattern as the `tmuxWindowID` wake-flap fix), which also closes the race where a focus landing between delta and refetch could auto-wake a just-manually-parked session.

## Test plan

- [ ] Full suite green: 3124 tests / 385 suites (+29 new across the three commits: wake-on-focus branch coverage, migration round-trips incl. pre-v47 rows and legacy JSON, tab menu availability per branch, delta apply/publish/decode-compat)
- [ ] Live: right-click a Claude tab → Hibernate → parked pane shows the frozen screen; navigate away and back → stays parked; Wake revives it
- [ ] Live: idle-sweep or reboot-parked sessions still auto-wake on focus

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=DD23E916-C861-41EC-9930-2947FA9284B6)