### PR TITLE
fix(terminal): verify --submit landed and retry Enter if the paste is stuck

### DIFF
--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1358,9 +1358,71 @@ extension RPCRouter {
                 paneID: terminal.tmuxPaneID,
                 key: "Enter"
             )
+
+            // If text was non-empty, verify the submit and retry if the message
+            // got stuck as [Pasted text]. This is Option 3 from submit-reliability.md:
+            // bounded verify-and-retry scoped to the [Pasted text] signature.
+            // The transient race (pane not at prompt) is rare and mitigated by the
+            // retry loop; if the issue persists after 3 attempts, log and return
+            // success anyway (do not change RPC contract / exit code).
+            if !params.text.isEmpty {
+                await verifyAndRetrySubmit(
+                    server: worktree.tmuxServer,
+                    paneID: terminal.tmuxPaneID,
+                    textLength: params.text.count
+                )
+            }
         }
 
         return .ok()
+    }
+
+    /// Verify that a submit succeeded by checking the pane output. If the
+    /// composer still shows [Pasted text, retry Enter with bounded attempts.
+    /// Best-effort; never throws or fails the RPC.
+    private func verifyAndRetrySubmit(
+        server: String,
+        paneID: String,
+        textLength: Int
+    ) async {
+        var retryCount = 0
+        for delay in submitVerifyDelays {
+            try? await Task.sleep(for: delay)
+
+            // Capture pane output; failure is silent (best-effort verification).
+            guard let paneText = try? await tmux.capturePaneOutput(server: server, paneID: paneID) else {
+                return
+            }
+
+            // Find the last line starting with "❯" (Claude's composer prompt).
+            // Transcript echoes also use ❯ but the composer is always the bottom-most,
+            // so search from the end to scope correctly.
+            let lines = paneText.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            if let lastComposerIdx = lines.lastIndex(where: { $0.starts(with: "❯") }),
+               lines[lastComposerIdx].contains("[Pasted text") {
+                // The paste is stuck in the composer. Retry Enter.
+                retryCount += 1
+                logger.warning(
+                    "terminal.send submit verification: [Pasted text] detected in composer (attempt \(retryCount, privacy: .public)), retrying Enter (text length: \(textLength, privacy: .public) bytes)"
+                )
+                try? await tmux.sendKey(server: server, paneID: paneID, key: "Enter")
+            } else {
+                // The composer is clear (no [Pasted text] in the bottom ❯ line, or no ❯ line at all).
+                // The submit succeeded; stop retrying.
+                if retryCount > 0 {
+                    logger.debug(
+                        "terminal.send submit verification: composer clear after \(retryCount, privacy: .public) retries"
+                    )
+                }
+                return
+            }
+        }
+
+        // All retries exhausted and [Pasted text] still there. Log a warning but return success
+        // (the RPC contract remains unchanged; Option 4 exit-code semantics are deferred).
+        logger.warning(
+            "terminal.send submit verification: [Pasted text] persisted after \(self.submitVerifyDelays.count, privacy: .public) retries (text length: \(textLength, privacy: .public) bytes); returning success anyway"
+        )
     }
 
     // MARK: - Main Area Size Broadcast

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1369,7 +1369,7 @@ extension RPCRouter {
                 await verifyAndRetrySubmit(
                     server: worktree.tmuxServer,
                     paneID: terminal.tmuxPaneID,
-                    textLength: params.text.count
+                    textLength: params.text.utf8.count
                 )
             }
         }
@@ -1386,11 +1386,14 @@ extension RPCRouter {
         textLength: Int
     ) async {
         var retryCount = 0
-        for delay in submitVerifyDelays {
+        for (attemptIndex, delay) in submitVerifyDelays.enumerated() {
             try? await Task.sleep(for: delay)
 
-            // Capture pane output; failure is silent (best-effort verification).
-            guard let paneText = try? await tmux.capturePaneOutput(server: server, paneID: paneID) else {
+            // Capture pane output with wrapped lines joined. Failure is best-effort.
+            guard let paneText = try? await tmux.capturePaneOutputJoined(server: server, paneID: paneID) else {
+                logger.debug(
+                    "terminal.send submit verification: capture failed on attempt \(attemptIndex + 1, privacy: .public), stopping verification"
+                )
                 return
             }
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -71,6 +71,9 @@ public final class RPCRouter: Sendable {
 
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
+    /// Delays between attempts to verify a terminal send's submit. Default schedule
+    /// for production; tests inject shorter delays to avoid multi-second test runs.
+    let submitVerifyDelays: [Duration]
 
     public init(
         db: TBDDatabase,
@@ -86,7 +89,8 @@ public final class RPCRouter: Sendable {
         repoSerializer: RepoSerializer = RepoSerializer(),
         configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager(),
         claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
-        loginSessions: LoginSessionCoordinator = LoginSessionCoordinator()
+        loginSessions: LoginSessionCoordinator = LoginSessionCoordinator(),
+        submitVerifyDelays: [Duration] = [.milliseconds(300), .milliseconds(500), .milliseconds(800)]
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -95,6 +99,7 @@ public final class RPCRouter: Sendable {
         self.startTime = startTime
         self.subscriptions = subscriptions
         self.prManager = prManager
+        self.submitVerifyDelays = submitVerifyDelays
         let resolvedModelProfileResolver = modelProfileResolver ?? ModelProfileResolver(
             profiles: db.modelProfiles,
             repos: db.repos,

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -298,6 +298,13 @@ public struct TmuxManager: Sendable {
         ["-L", server, "capture-pane", "-p", "-t", paneID]
     }
 
+    /// Capture pane content with wrapped lines joined (but no ANSI escape sequences).
+    /// Used by verify-and-retry so wrapped composer lines are not split; the plain text
+    /// avoids prefixing ANSI escapes before `❯` which would break the starts-with check.
+    public static func capturePaneJoinedCommand(server: String, paneID: String) -> [String] {
+        ["-L", server, "capture-pane", "-p", "-J", "-t", paneID]
+    }
+
     /// Capture pane content with ANSI escape sequences and joined wrapped lines preserved.
     public static func capturePaneWithAnsiCommand(server: String, paneID: String) -> [String] {
         ["-L", server, "capture-pane", "-p", "-e", "-J", "-t", paneID]
@@ -587,6 +594,19 @@ public struct TmuxManager: Sendable {
         // can exercise the park path's snapshot capture end-to-end.
         if dryRun { return dryRunCapturePane?(server, paneID) ?? "" }
         let args = Self.capturePaneWithAnsiCommand(server: server, paneID: paneID)
+        return try await runTmux(args)
+    }
+
+    /// Capture pane content with wrapped lines joined but no ANSI escape sequences.
+    /// Used for text pattern matching (e.g. detecting `[Pasted text`) where line wraps
+    /// can split patterns across physical lines.
+    public func capturePaneOutputJoined(server: String, paneID: String) async throws -> String {
+        if dryRun {
+            let args = Self.capturePaneJoinedCommand(server: server, paneID: paneID)
+            dryRunRecorder?(args)
+            return dryRunCapturePane?(server, paneID) ?? ""
+        }
+        let args = Self.capturePaneJoinedCommand(server: server, paneID: paneID)
         return try await runTmux(args)
     }
 

--- a/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
@@ -200,6 +200,377 @@ extension RPCRouterTests {
         #expect(response.success)
     }
 
+    // MARK: - Verify-and-Retry Tests (Option 3)
+
+    /// Thread-safe counter for tracking capturePaneOutput calls.
+    private final class CaptureCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _count = 0
+        private var _responses: [String] = []
+
+        var count: Int {
+            lock.lock(); defer { lock.unlock() }
+            return _count
+        }
+
+        func nextResponse() -> String {
+            lock.lock(); defer { lock.unlock() }
+            defer { _count += 1 }
+            guard _count < _responses.count else { return "" }
+            return _responses[_count]
+        }
+
+        func setUp(responses: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            _responses = responses
+            _count = 0
+        }
+    }
+
+    @Test("terminal.send with submit and text: stuck-then-cleared scenario retries and succeeds")
+    func terminalSendSubmitStuckThenCleared() async throws {
+        let recorder = SendRecorder()
+        let captureCounter = CaptureCounter()
+        let stuckComposer = "some transcript\n❯ [Pasted text #1 +25 lines]\n──\n  footer"
+        let clearedComposer = "some transcript\n❯ \n──\n  footer"
+        captureCounter.setUp(responses: [stuckComposer, clearedComposer])
+
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunCapturePane: { _, _ in captureCounter.nextResponse() }
+        )
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            submitVerifyDelays: [.milliseconds(1), .milliseconds(1), .milliseconds(1)]
+        )
+
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id,
+                text: "long message here",
+                submit: true
+            )
+        )
+        #expect(await router.handle(request).success)
+
+        // Exactly 2 Enter keystrokes: initial submit + 1 retry (stuck then cleared)
+        let enterCalls = recorder.calls.filter { $0.contains("send-keys") && $0.contains("Enter") }
+        #expect(enterCalls.count == 2)
+
+        // The first Enter comes after paste-buffer (initial submit, no retry yet)
+        let pasteIdx = try #require(recorder.calls.firstIndex { $0.contains("paste-buffer") })
+        let firstEnterIdx = try #require(recorder.calls.firstIndex { $0.contains("send-keys") && $0.contains("Enter") })
+        #expect(pasteIdx < firstEnterIdx)
+
+        // Two capture calls: first returns stuck, second returns cleared
+        #expect(captureCounter.count == 2)
+    }
+
+    @Test("terminal.send with submit and text: clean first verify (no retry needed)")
+    func terminalSendSubmitCleanFirstVerify() async throws {
+        let captureCounter = CaptureCounter()
+        let clearedComposer = "some transcript\n❯ \n──\n  footer"
+        captureCounter.setUp(responses: [clearedComposer])
+
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunCapturePane: { _, _ in captureCounter.nextResponse() }
+        )
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            submitVerifyDelays: [.milliseconds(1), .milliseconds(1), .milliseconds(1)]
+        )
+
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id,
+                text: "long message here",
+                submit: true
+            )
+        )
+        #expect(await router.handle(request).success)
+        // Only one capture call: composer was clear on first check
+        #expect(captureCounter.count == 1)
+    }
+
+    @Test("terminal.send with submit and text: never clears (bounded retries)")
+    func terminalSendSubmitNeverClears() async throws {
+        let recorder = SendRecorder()
+        let captureCounter = CaptureCounter()
+        let stuckComposer = "some transcript\n❯ [Pasted text #1 +25 lines]\n──\n  footer"
+        // Setup stuck responses — more than the retry schedule to ensure they stay stuck
+        // even if the test is modified later. With 3-delay schedule, provide at least 3.
+        captureCounter.setUp(responses: [stuckComposer, stuckComposer, stuckComposer, stuckComposer, stuckComposer])
+
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunCapturePane: { _, _ in captureCounter.nextResponse() }
+        )
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            submitVerifyDelays: [.milliseconds(1), .milliseconds(1), .milliseconds(1)]
+        )
+
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id,
+                text: "long message here",
+                submit: true
+            )
+        )
+        // Still returns success even if stuck (Option 3 design: try but don't fail)
+        #expect(await router.handle(request).success)
+
+        // Exactly 4 Enter keystrokes: initial submit + 3 retries (all attempts fail)
+        let enterCalls = recorder.calls.filter { $0.contains("send-keys") && $0.contains("Enter") }
+        #expect(enterCalls.count == 4)
+
+        // All 3 retries attempted
+        #expect(captureCounter.count == 3)
+    }
+
+    @Test("terminal.send with submit=false and text: no retries, no Enter, just paste")
+    func terminalSendNoSubmitNoVerify() async throws {
+        let recorder = SendRecorder()
+        let captureCounter = CaptureCounter()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunCapturePane: { _, _ in captureCounter.nextResponse() }
+        )
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            submitVerifyDelays: [.milliseconds(1)]
+        )
+
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id,
+                text: "long message here",
+                submit: false
+            )
+        )
+        #expect(await router.handle(request).success)
+        // Paste happens...
+        #expect(recorder.calls.contains { $0.contains("paste-buffer") })
+        // ...but no Enter keypress
+        #expect(!recorder.calls.contains { $0.contains("send-keys") && $0.contains("Enter") })
+        // ...and no captures (verification only on submit=true)
+        #expect(captureCounter.count == 0)
+    }
+
+    @Test("terminal.send with empty text and submit: only Enter, no paste, no verify")
+    func terminalSendEmptyTextSubmitNoVerify() async throws {
+        let recorder = SendRecorder()
+        let captureCounter = CaptureCounter()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunCapturePane: { _, _ in captureCounter.nextResponse() }
+        )
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            submitVerifyDelays: [.milliseconds(1)]
+        )
+
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id,
+                text: "",
+                submit: true
+            )
+        )
+        #expect(await router.handle(request).success)
+        // Empty text: no paste
+        #expect(!recorder.calls.contains { $0.contains("load-buffer") })
+        #expect(!recorder.calls.contains { $0.contains("paste-buffer") })
+        // But Enter is sent (the manual flush escape hatch)
+        #expect(recorder.calls.contains { $0.contains("send-keys") && $0.contains("Enter") })
+        // And no verification (empty text case skips verify-and-retry)
+        #expect(captureCounter.count == 0)
+    }
+
+    @Test("terminal.send verify-and-retry: false-positive guard (earlier ❯ with [Pasted text], last ❯ clear)")
+    func terminalSendVerifyComposerScoping() async throws {
+        let captureCounter = CaptureCounter()
+        // Earlier line contains ❯ [Pasted text (a transcript echo of a previous submit),
+        // but the LAST ❯ line (the composer prompt) is clear.
+        let paneText = """
+        User message:
+        ❯ [Pasted text #1 +10 lines]
+        ——
+        ❯
+        ──
+          footer
+        """
+        captureCounter.setUp(responses: [paneText])
+
+        let recorder = SendRecorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunCapturePane: { _, _ in captureCounter.nextResponse() }
+        )
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            submitVerifyDelays: [.milliseconds(1)]
+        )
+
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "test-wt",
+            branch: "tbd/test-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)",
+            tmuxServer: "tbd-test"
+        )
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@mock-0",
+            tmuxPaneID: "%mock-0"
+        )
+
+        let request = try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: terminal.id,
+                text: "message",
+                submit: true
+            )
+        )
+        #expect(await router.handle(request).success)
+        // Only one Enter sent (the initial Enter), no retry
+        let enterCalls = recorder.calls.filter { $0.contains("send-keys") && $0.contains("Enter") }
+        #expect(enterCalls.count == 1)
+        // One capture, and it was clear (no false positive on the earlier echo)
+        #expect(captureCounter.count == 1)
+    }
+
     // MARK: - Claude Terminal Creation
 
     @Test("terminal.create with type claude sets label and sessionID")

--- a/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
@@ -292,12 +292,14 @@ extension RPCRouterTests {
 
     @Test("terminal.send with submit and text: clean first verify (no retry needed)")
     func terminalSendSubmitCleanFirstVerify() async throws {
+        let recorder = SendRecorder()
         let captureCounter = CaptureCounter()
         let clearedComposer = "some transcript\n❯ \n──\n  footer"
         captureCounter.setUp(responses: [clearedComposer])
 
         let tmux = TmuxManager(
             dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
             dryRunCapturePane: { _, _ in captureCounter.nextResponse() }
         )
         let db = try TBDDatabase(inMemory: true)
@@ -336,6 +338,10 @@ extension RPCRouterTests {
             )
         )
         #expect(await router.handle(request).success)
+
+        // Verify the capture command used -J for joined wrapped lines
+        #expect(recorder.calls.contains { $0.contains("capture-pane") && $0.contains("-J") })
+
         // Only one capture call: composer was clear on first check
         #expect(captureCounter.count == 1)
     }

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -198,6 +198,11 @@ import Testing
     #expect(args == ["-L", "tbd-test", "capture-pane", "-p", "-t", "%42"])
 }
 
+@Test func capturePaneJoinedCommand() {
+    let args = TmuxManager.capturePaneJoinedCommand(server: "tbd-test", paneID: "%42")
+    #expect(args == ["-L", "tbd-test", "capture-pane", "-p", "-J", "-t", "%42"])
+}
+
 @Test func paneCurrentCommandQuery() {
     let args = TmuxManager.paneCurrentCommandQuery(server: "tbd-test", paneID: "%42")
     #expect(args == ["-L", "tbd-test", "list-panes", "-t", "%42", "-F", "#{pane_current_command}"])

--- a/docs/submit-reliability.md
+++ b/docs/submit-reliability.md
@@ -1,6 +1,6 @@
 # `tbd terminal send --submit` silent non-submit — design brief
 
-**Status:** research + design, awaiting sign-off (no code changed yet)
+**Status:** Option 2 shipped (PR #389); Option 3 implemented — see "Implementation Status" below
 **Branch:** `tbd/submit-reliability-brainstorm`
 **Author:** investigation session, 2026-07-08
 
@@ -208,3 +208,40 @@ waiting for it to "settle." Bracketing removes the race; waiting only narrows it
   multi-line message submits; (b) shell pane → body arrives bare and submits;
   (c) `submit == false` → no Enter. Follow the daemon test discipline in
   `CLAUDE.md` (no `~/tbd`, live-tmux deadlines, rc-free bootstraps).
+
+## Implementation Status (2026-07-08)
+
+**Option 2 shipped in PR #389** (commit 4885f89): bracketed-paste delivery + separate Enter
+is now the default for all `terminal.send --submit --text` calls. Two same-day failure reports
+(busy mid-turn Claude session, paste landed but Enter never submitted) almost certainly hit a stale
+daemon still running pre-#389 code: the fix was committed 14:37 local and the first daemon carrying it
+started 16:00; the reports predate that restart. 16 live trials against the #389 byte sequence —
+including the reported waiting-on-background-agent state and SIGSTOP-forced input coalescing — all
+submitted.
+
+**Option 3 implemented (this change):** verify-and-retry scoped to the `[Pasted text`
+composer signature. After the initial Enter, if both:
+- `params.submit == true` (a real submit, not a manual flush)
+- `!params.text.isEmpty` (non-empty text was sent, not the empty-text escape hatch)
+
+then the handler spawns a bounded retry loop (3 delays: 300/500/800 ms) that:
+1. Sleeps for each delay
+2. Captures the pane output (best-effort; failure is silent)
+3. Finds the LAST line starting with `❯` (the composer prompt, not transcript echoes)
+4. If that line contains `[Pasted text`, logs a warning and retries Enter
+5. If the composer is clear or capture failed, stops (success)
+
+If all retries exhaust and `[Pasted text` persists, logs a warning but returns `.ok()` (the
+RPC and CLI exit code remain unchanged — Option 4 semantics are still deferred). This
+bounds the latency hit to unattended paths (nightwatch) while providing a self-healing
+defense in depth on top of Option 2.
+
+**Test coverage:** six new tests cover:
+- Stuck-then-cleared: retry succeeds after 1 attempt
+- Clean first verify: no retry needed
+- Never clears: bounded by retry schedule (success anyway)
+- No-submit case: zero retries, zero captures
+- Empty-text submit: manual flush, zero retries, zero captures
+- Composer scoping: earlier transcript `❯ [Pasted text` does not trigger false-positive retry
+
+**Exit-code semantics (Option 4)** remain deferred (documented as open question in this doc).

--- a/docs/submit-reliability.md
+++ b/docs/submit-reliability.md
@@ -232,9 +232,10 @@ then the handler spawns a bounded retry loop (3 delays: 300/500/800 ms) that:
 5. If the composer is clear or capture failed, stops (success)
 
 If all retries exhaust and `[Pasted text` persists, logs a warning but returns `.ok()` (the
-RPC and CLI exit code remain unchanged — Option 4 semantics are still deferred). This
-bounds the latency hit to unattended paths (nightwatch) while providing a self-healing
-defense in depth on top of Option 2.
+RPC and CLI exit code remain unchanged — Option 4 semantics are still deferred). The clean
+path costs one ~300 ms verification pass on every submit-with-text call (bounded ~2.4 s
+worst case when stuck); the empty-text flush and text-only sends are unaffected. This
+provides a self-healing defense in depth on top of Option 2.
 
 **Test coverage:** six new tests cover:
 - Stuck-then-cleared: retry succeeds after 1 attempt


### PR DESCRIPTION
## Problem

Two 2026-07-08 reports: `tbd terminal send --terminal <id> --text <long> --submit` delivered the text into a busy (mid-turn) Claude Code session's composer, but it sat unsent as `[Pasted text #N]` until a second empty `--submit` flushed it.

## Investigation

The reports almost certainly never exercised #389's bracketed-paste fix: the fix was committed 14:37 local and the first daemon carrying it started 16:00 — the reports predate that restart, and the symptom is byte-identical to the pre-#389 `send-keys -l` bug. 16 live trials against the #389 byte sequence with real Claude Code 2.1.205 in an isolated `tmux -L` server — including the reported waiting-on-background-agent state and SIGSTOP-forced input coalescing (paste + `\r` in one stdin read) — **all submitted**.

But `docs/submit-reliability.md` documents a residual race Option 2 can't cover: if the pane momentarily has bracketed-paste mode off, the paste falls back to bare bytes and the TUI's paste-burst heuristic can absorb the Enter again. The brief recommends Option 3 (verify-and-retry) as the follow-up for unattended sends — that's what this PR lands.

## Change

After the Enter, `handleTerminalSend` captures the pane on a bounded schedule (300/500/800 ms); if the bottom-most composer line (last line starting with `❯`) still contains `[Pasted text`, it re-sends Enter and re-verifies.

- Scoped to submit-with-text only: the empty-text manual flush stays a single instant Enter (~20 ms measured), text-only sends never capture.
- The `[Pasted text` signature only appears in agent-TUI composers, so shells/REPLs can never receive a spurious extra Enter.
- Best-effort: capture failures and exhausted retries log a warning and never fail the RPC. Exit-code semantics (Option 4) stay deferred per the brief's open questions.
- `RPCRouter` gains an injectable `submitVerifyDelays` schedule so tests don't sleep.

## Tests

- 6 new dry-run tests: stuck-then-cleared (exactly 2 Enters, ordered after `paste-buffer`), clean first verify, never-clears (bounded at 4 Enters), no-submit, empty-text flush, and a transcript-echo false-positive guard (earlier `❯ [Pasted text` line must not trigger a retry).
- All 71 RPCRouter + live bracketed-paste tests pass; `swiftlint --strict` clean.
- E2E-verified through an isolated `TBD_HOME` daemon driving `tbd terminal send --submit` with a 2.2 KB payload into a real mid-stream Claude session (queued correctly; one verification pass, no spurious retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)