### PR TITLE
DX: Move CI to Swift 6.3.3 (Xcode 26.6) — 6.3 fixes the WMO memory blowup, retiring the debug-build workaround

### DIFF
--- a/.github/workflows/recipe-check.yml
+++ b/.github/workflows/recipe-check.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 
@@ -33,7 +33,7 @@ jobs:
         run: scripts/check-no-committed-plans.sh
 
   test:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,16 +50,16 @@ jobs:
         uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2
 
       - name: Install tmux
-        # macos-15 runners don't ship tmux. The reconcile reboot-recovery
+        # macos-26 runners don't ship tmux. The reconcile reboot-recovery
         # regression test (WorktreeLifecycleTests.testRecreateAfterRebootBootstrapKillOrdering)
         # drives TmuxManager against a real tmux server on a unique socket.
         run: brew install tmux
 
-      # macos-15 runner defaults to Xcode 16.4 (Swift 6.1.2). Pinning to
-      # 26.3 (Swift 6.2.4) matches the local toolchain — keeps CI and local
+      # macos-26 arm64 runner defaults to Xcode 26.5 (Swift 6.2.x). Pinning to
+      # 26.6 (Swift 6.3.3) matches the local toolchain — keeps CI and local
       # behavior consistent.
-      - name: Select Xcode 26.3 (Swift 6.2.4)
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+      - name: Select Xcode 26.6 (Swift 6.3.3)
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
 
       - name: Capture Swift toolchain version
         run: echo "SWIFT_VERSION=$(xcrun swift --version | head -1)" >> $GITHUB_ENV
@@ -104,8 +104,8 @@ jobs:
             ls -la .build/*/debug/Modules/"$module".swiftmodule 2>/dev/null || echo "(absent)"
           done
 
-      # `-j 2` caps parallel swift-frontend processes. The macos-15 runner
-      # has limited RAM (~7-14 GB) and Swift 6.2.4 frontends each consume
+      # `-j 2` caps parallel swift-frontend processes. The macos-26 runner
+      # has limited RAM (~7-14 GB) and Swift frontends each consume
       # 1-2 GB on heavy SwiftUI / NIO code. With the default parallelism,
       # the build OOMs late (~file 1260+/1356) and emits a bare
       # `error: fatalError` with no diagnostic — different file every run.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,10 @@ jobs:
         # drives TmuxManager against a real tmux server on a unique socket.
         run: brew install tmux
 
-      # macos-26 arm64 runner defaults to Xcode 26.5 (Swift 6.2.x). Pinning to
-      # 26.6 (Swift 6.3.3) matches the local toolchain — keeps CI and local
-      # behavior consistent.
+      # macos-26 arm64 runner defaults to Xcode 26.5 (Swift 6.3.2). Pin 26.6
+      # (Swift 6.3.3) so the toolchain is deterministic rather than drifting
+      # with the image default, and matches the swift.org 6.3.3 toolchain
+      # used for local validation.
       - name: Select Xcode 26.6 (Swift 6.3.3)
         run: sudo xcode-select -s /Applications/Xcode_26.6.app
 
@@ -104,12 +105,12 @@ jobs:
             ls -la .build/*/debug/Modules/"$module".swiftmodule 2>/dev/null || echo "(absent)"
           done
 
-      # `-j 2` caps parallel swift-frontend processes. The macos-26 runner
-      # has limited RAM (~7-14 GB) and Swift frontends each consume
-      # 1-2 GB on heavy SwiftUI / NIO code. With the default parallelism,
-      # the build OOMs late (~file 1260+/1356) and emits a bare
-      # `error: fatalError` with no diagnostic — different file every run.
-      # Capping parallelism trades wall-clock for stability.
+      # `-j 2` caps parallel swift-frontend processes on the ~7 GB runner.
+      # Historically (Swift 6.2, all-per-file builds) default parallelism
+      # OOMed late in the build with a bare `error: fatalError`. Under
+      # Swift 6.3 the two big modules build WMO in debug (~1.35 GB peak
+      # frontend RSS each, measured), so the cap is likely over-conservative
+      # now — kept as safety margin; candidate for re-validation.
       - name: Test
         run: swift test --parallel -j 2
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,20 @@
 // swift-tools-version: 6.0
 import PackageDescription
 
+// Swift 6.2's Sendable region analysis made WMO debug builds of the two big
+// modules reach 6-9 GB RSS per swift-frontend (NIO + GRDB + many @Sendable
+// closure captures), jetsam-killing CI's ~7 GB runner (surfaces as a bare
+// `error: fatalError`, swiftlang/swift-package-manager#7086). Swift 6.3 fixes
+// the blowup (measured peak: 1.35 GB), so the workaround only applies to
+// older compilers — drop this entirely once no 6.2 toolchain builds the repo.
+#if compiler(>=6.3)
+let noWMODebugWorkaround: [SwiftSetting] = []
+#else
+let noWMODebugWorkaround: [SwiftSetting] = [
+    .unsafeFlags(["-no-whole-module-optimization"], .when(configuration: .debug)),
+]
+#endif
+
 let package = Package(
     name: "TBD",
     platforms: [
@@ -54,18 +68,8 @@ let package = Package(
             ],
             path: "Sources/TBDDaemon",
             exclude: ["main.swift"],
-            // Disable whole-module optimization in debug builds. WMO compiles
-            // all files in the module as a single swift-frontend process,
-            // which on this module reaches 6-9 GB RSS during Swift 6.2's
-            // Sendable region analysis (NIO + GRDB + many @Sendable closure
-            // captures of ChannelHandlerContext). The macos-15 GHA runner
-            // caps at ~7 GB; jetsam SIGKILLs the frontend and SPM reports
-            // a bare `error: fatalError` (Diagnostics.fatalError sentinel —
-            // see swiftlang/swift-package-manager#7086). Per-file compilation
-            // keeps each frontend at ~150-300 MB. Release builds keep WMO.
-            swiftSettings: [
-                .unsafeFlags(["-no-whole-module-optimization"], .when(configuration: .debug)),
-            ]
+            // Swift 6.2 WMO-debug OOM workaround — see noWMODebugWorkaround above.
+            swiftSettings: noWMODebugWorkaround
         ),
         .executableTarget(
             name: "TBDDaemon",
@@ -103,12 +107,10 @@ let package = Package(
             ],
             path: "Sources/TBDApp",
             resources: [.copy("Resources/Icons")],
-            // See TBDDaemonLib above. TBDApp is the larger of the two
-            // memory-heavy modules (SwiftUI view bodies + MarkdownUI +
-            // SwiftTerm); same WMO-OOM symptom on the macos-15 runner.
-            swiftSettings: [
-                .unsafeFlags(["-no-whole-module-optimization"], .when(configuration: .debug)),
-            ]
+            // Swift 6.2 WMO-debug OOM workaround — see noWMODebugWorkaround
+            // above. TBDApp is the larger of the two memory-heavy modules
+            // (SwiftUI view bodies + MarkdownUI + SwiftTerm).
+            swiftSettings: noWMODebugWorkaround
         ),
         .target(
             name: "TestSupport",


### PR DESCRIPTION
## Summary
- Moves CI to `macos-26` runners pinned to Xcode 26.6 (Swift 6.3.3) — the old `macos-15` image tops out at Xcode 26.3 / Swift 6.2.4. `recipe-check.yml` moves to the same image for consistency.
- Gates the `-no-whole-module-optimization` debug workaround behind `#if compiler(<6.3)` in `Package.swift`. Swift 6.2's Sendable region analysis drove WMO debug builds of TBDDaemonLib/TBDApp to 6–9 GB RSS per swift-frontend (jetsam-killed the ~7 GB runner, SPM#7086's bare `error: fatalError`); measured under Swift 6.3.3 the same cold WMO builds peak at **1.35 GB / 1.10 GB** — the blowup is fixed. The guard keeps 6.2.x local builds (Xcode 26.3) on the safe path until dev machines update.
- Migration preflight found zero source breaks for 6.3: builds clean with 0 errors, all 3,100 tests pass under 6.3.3, and nothing in the repo string-matches the SE-0489-reformatted Codable error text. 32 new (non-blocking) 6.3 diagnostics — mostly unused-result and stricter Sendable-capture warnings — are left for a follow-up PR.

## Test plan
- [x] `swift build` under Swift 6.2.4 (default toolchain) — succeeds, `-no-whole-module-optimization` present in `-v` output
- [x] `swift build` under Swift 6.3.3 (swift.org toolchain) — succeeds, flag absent
- [x] `swift test --parallel -j 2` — 3,100 tests / 382 suites pass (both toolchains)
- [x] `swiftlint --strict` — 0 violations; workflow YAML parse-checked
- [x] CI green on this PR — first real exercise of the macos-26 + Xcode 26.6 + WMO-debug path (cache key rolls over via `$SWIFT_VERSION`)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=5FEEF6B8-242F-4CD1-9BEE-12BB0E19F7DA)
