### PR TITLE
feat(pr): render 🚌 with queue position for PRs in the merge queue

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -414,8 +414,13 @@ struct PRButtonLabel: View {
     static let iconSide: CGFloat = 12
     static let badgeGap: CGFloat = 3
 
+    /// A queued PR renders the full-color bus (with its position baked in)
+    /// instead of the status icon; the archivebox armed-badge is suppressed in
+    /// that mode, so the baked image stays a single square.
+    var isMergeQueued: Bool { prStatus.mergeQueuePosition != nil }
+
     var bakedWidth: CGFloat {
-        isAutoArchiveArmed ? Self.iconSide + Self.badgeGap + Self.iconSide : Self.iconSide
+        (isAutoArchiveArmed && !isMergeQueued) ? Self.iconSide + Self.badgeGap + Self.iconSide : Self.iconSide
     }
 
     /// The `.id` key for the PR split-button toolbar item. AppKit materializes
@@ -427,10 +432,13 @@ struct PRButtonLabel: View {
     /// before the row appears would otherwise stay permanently empty. The key
     /// contains exactly the `PRStatus` fields the label/menu/primaryAction
     /// consume: `number` (label text/help), `state` (icon via
-    /// `PRStatusPresentation`), and `url` (captured by `primaryAction`, so a
-    /// re-pointed PR must recreate the item too). `reason` is deliberately
-    /// excluded — the split button's presentation ignores it, and keying on it
-    /// would force spurious toolbar-item rebuilds for zero visual change.
+    /// `PRStatusPresentation`), `url` (captured by `primaryAction`, so a
+    /// re-pointed PR must recreate the item too), and `mergeQueuePosition`
+    /// (the bus glyph short-circuits on it and bakes the position into the
+    /// icon, so a 2→1 queue move with an unchanged `state` must still rebuild).
+    /// `reason` is deliberately excluded — the split button's presentation
+    /// ignores it, and keying on it would force spurious toolbar-item rebuilds
+    /// for zero visual change.
     ///
     /// This key MUST stay a String. The macOS 26 toolbar bridge only honors
     /// `.id` identity changes for String values here — a custom Hashable
@@ -447,6 +455,7 @@ struct PRButtonLabel: View {
     ) -> String {
         "pr-split-\(worktreeID)-\(worktreeFound)-\(armed)-\(blocked)"
             + "-\(prStatus.number)-\(prStatus.state.rawValue)-\(prStatus.url)"
+            + "-\(prStatus.mergeQueuePosition.map(String.init) ?? "nil")"
             + "-\(colorScheme)"
     }
 
@@ -491,8 +500,9 @@ struct PRButtonLabel: View {
         )
     }
 
-    /// Cache for baked icons, keyed by (iconName, colorSemantic, armed,
-    /// colorScheme). The bake does disk I/O (`Bundle.module.url` +
+    /// Cache for baked `.asset` icons, keyed by (asset name, colorSemantic,
+    /// armed, colorScheme). (The `.emoji` bus glyph is cached separately by
+    /// `PRStatusPresentation.busImage`.) The bake does disk I/O (`Bundle.module.url` +
     /// `NSImage(contentsOf:)`) plus symbol creation on every body evaluation,
     /// and — per the materialize-once behavior documented at the `.id` call
     /// site — those re-evaluations never reach AppKit anyway. MainActor
@@ -512,9 +522,16 @@ struct PRButtonLabel: View {
     /// must live inside it.
     @MainActor
     func coloredIcon(_ presentation: PRStatusPresentation, colorScheme: ColorScheme) -> NSImage? {
-        let cacheKey = "\(presentation.iconName)-\(presentation.colorSemantic)-\(isAutoArchiveArmed)-\(colorScheme)"
+        // Merge-queue bus: full-color glyph with its position baked in via the
+        // SAME shared helper the sidebar uses. It must NOT be tinted, so skip
+        // the color-baking fill path entirely (and the archivebox armed-badge —
+        // queue mode supersedes it, matching `bakedWidth`).
+        if case .emoji = presentation.glyph {
+            return PRStatusPresentation.busImage(position: presentation.badge, side: Self.iconSide)
+        }
+        guard case .asset(let name) = presentation.glyph else { return nil }
+        let cacheKey = "\(name)-\(presentation.colorSemantic)-\(isAutoArchiveArmed)-\(colorScheme)"
         if let cached = Self.bakedIconCache[cacheKey] { return cached }
-        let name = presentation.iconName
         let nsColor = presentation.nsColor
         guard let url = Bundle.module.url(forResource: name, withExtension: "svg", subdirectory: "Icons"),
               let base = NSImage(contentsOf: url) else { return nil }

--- a/Sources/TBDApp/PRStatusPresentation.swift
+++ b/Sources/TBDApp/PRStatusPresentation.swift
@@ -11,8 +11,23 @@ struct PRStatusPresentation: Equatable {
         case merged
     }
 
-    let iconName: String
+    /// What the leading icon draws. `.asset` is a bundled monochrome SVG that
+    /// gets tinted with `color`/`nsColor`; `.emoji` is a full-color glyph (the
+    /// merge-queue 🚌) that must NOT be tinted — both render sites branch on
+    /// this so the tint-vs-no-tint decision lives in one place.
+    enum Glyph: Equatable {
+        case asset(String)   // existing bundled SVGs, e.g. "git-pull-request"
+        case emoji(String)   // 🚌
+    }
+
+    let glyph: Glyph
     let colorSemantic: ColorSemantic
+    /// 1-indexed merge-queue position rendered as a small corner chip, or nil.
+    /// Only set on the bus presentation.
+    var badge: Int? = nil
+
+    /// The literal emoji rendered for a PR sitting in a merge queue.
+    static let mergeQueueEmoji = "🚌"
 
     var color: Color {
         switch colorSemantic {
@@ -61,23 +76,155 @@ struct PRStatusPresentation: Equatable {
 
     static func make(for prStatus: PRStatus?) -> PRStatusPresentation? {
         guard let prStatus else { return nil }
+        // A PR in a merge queue is in a distinct mode (no longer waiting on the
+        // author) that `mergeStateStatus` can't express — a queued PR reports
+        // UNKNOWN, which maps to the ordinary olive pending icon. Short-circuit
+        // to the bus regardless of `state`, gated on a non-nil position so the
+        // badge always carries a number. `colorSemantic` is unused for `.emoji`
+        // (it isn't tinted) but must still be provided.
+        if let position = prStatus.mergeQueuePosition {
+            return PRStatusPresentation(
+                glyph: .emoji(mergeQueueEmoji),
+                colorSemantic: .pending,
+                badge: position
+            )
+        }
         switch prStatus.state {
         case .pending:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .pending)
+            return PRStatusPresentation(glyph: .asset("git-pull-request"), colorSemantic: .pending)
         case .blocked:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .nonMergeable)
+            return PRStatusPresentation(glyph: .asset("git-pull-request"), colorSemantic: .nonMergeable)
         case .changesRequested:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .nonMergeable)
+            return PRStatusPresentation(glyph: .asset("git-pull-request"), colorSemantic: .nonMergeable)
         case .checksFailed:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .nonMergeable)
+            return PRStatusPresentation(glyph: .asset("git-pull-request"), colorSemantic: .nonMergeable)
         case .draft:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .draft)
+            return PRStatusPresentation(glyph: .asset("git-pull-request"), colorSemantic: .draft)
         case .mergeable:
-            return PRStatusPresentation(iconName: "git-pull-request", colorSemantic: .mergeable)
+            return PRStatusPresentation(glyph: .asset("git-pull-request"), colorSemantic: .mergeable)
         case .merged:
-            return PRStatusPresentation(iconName: "git-merge", colorSemantic: .merged)
+            return PRStatusPresentation(glyph: .asset("git-merge"), colorSemantic: .merged)
         case .closed:
-            return PRStatusPresentation(iconName: "git-pull-request-closed", colorSemantic: .nonMergeable)
+            return PRStatusPresentation(glyph: .asset("git-pull-request-closed"), colorSemantic: .nonMergeable)
         }
     }
+
+    /// Renders `emoji` to a full-color, non-template `NSImage` of `side`×`side`.
+    /// The ONE shared emoji→NSImage path used by both the sidebar row and the
+    /// toolbar split-button label so their glyphs can't drift. Full-color and
+    /// non-template: callers must render it with `.renderingMode(.original)` and
+    /// must NOT tint it.
+    @MainActor
+    static func emojiImage(_ emoji: String, side: CGFloat) -> NSImage {
+        if let cached = emojiImageCache[emoji] { return cached }
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            drawEmoji(emoji, in: rect)
+            return true
+        }
+        image.isTemplate = false
+        emojiImageCache[emoji] = image
+        return image
+    }
+
+    /// The full-color merge-queue bus glyph with its 1-indexed `position` baked
+    /// into a small rounded-rect corner chip. Shared by BOTH render sites (the
+    /// sidebar row and the flattened toolbar split-button label, which can only
+    /// carry one image), so the bus + badge never drift. `position == nil`
+    /// yields the bare bus. Non-template: render with `.renderingMode(.original)`
+    /// and do not tint.
+    @MainActor
+    static func busImage(position: Int?, side: CGFloat) -> NSImage {
+        let cacheKey = "bus-\(position.map(String.init) ?? "none")-\(side)"
+        if let cached = busImageCache[cacheKey] { return cached }
+        let image = NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            drawEmoji(mergeQueueEmoji, in: rect)
+            if let position { drawQueueBadge(position: position, in: rect) }
+            return true
+        }
+        image.isTemplate = false
+        busImageCache[cacheKey] = image
+        return image
+    }
+
+    /// Draws `emoji` centered within `rect` at a font size matching the square.
+    private static func drawEmoji(_ emoji: String, in rect: NSRect) {
+        let font = NSFont.systemFont(ofSize: rect.height)
+        let attrs: [NSAttributedString.Key: Any] = [.font: font]
+        let str = emoji as NSString
+        let textSize = str.size(withAttributes: attrs)
+        let origin = NSPoint(x: rect.midX - textSize.width / 2, y: rect.midY - textSize.height / 2)
+        str.draw(at: origin, withAttributes: attrs)
+    }
+
+    /// The largest queue position rendered literally; anything greater collapses
+    /// to `"99+"` so the chip never needs more than three glyphs.
+    static let maxQueueBadgeValue = 99
+
+    /// Geometry + text for the queue-position chip, computed so a 2- or 3-glyph
+    /// badge stays legible and never clips outside `rect`. Pulled out of
+    /// `drawQueueBadge` so tests can assert the chip stays within the icon bounds
+    /// for double- and triple-digit positions. Nonisolated so it runs inside the
+    /// nonisolated `NSImage` draw closure (like the rest of the draw path).
+    struct QueueBadgeLayout {
+        let text: String
+        let chipRect: NSRect
+        let attrs: [NSAttributedString.Key: Any]
+        let textSize: NSSize
+    }
+
+    /// Lays out the badge for `position` inside `rect`. The displayed value is
+    /// clamped to `"99+"` past `maxQueueBadgeValue`, and the font is shrunk until
+    /// the chip (text + horizontal padding) fits `rect.width`, so the chip is
+    /// always fully contained in the icon square — a double-digit position no
+    /// longer truncates the way a fixed square chip did.
+    static func queueBadgeLayout(position: Int, in rect: NSRect) -> QueueBadgeLayout {
+        let display = position > maxQueueBadgeValue ? "\(maxQueueBadgeValue)+" : "\(position)"
+        let text = display as NSString
+        let padH = rect.width * 0.12
+        let maxChipW = rect.width               // the chip may span the icon but never exceed it
+
+        // Shrink the font until text + padding fit the icon width. A single digit
+        // keeps the full size; wider values step down so they read without clipping.
+        var fontSize = rect.height * 0.5
+        var attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: fontSize, weight: .bold),
+            .foregroundColor: NSColor.white
+        ]
+        var textSize = text.size(withAttributes: attrs)
+        while textSize.width + padH * 2 > maxChipW && fontSize > 1 {
+            fontSize -= 0.5
+            attrs[.font] = NSFont.systemFont(ofSize: fontSize, weight: .bold)
+            textSize = text.size(withAttributes: attrs)
+        }
+
+        let chipW = min(maxChipW, textSize.width + padH * 2)
+        let chipH = min(rect.height, textSize.height + padH)
+        let chipRect = NSRect(x: rect.maxX - chipW, y: rect.minY, width: chipW, height: chipH)
+        return QueueBadgeLayout(text: display, chipRect: chipRect, attrs: attrs, textSize: textSize)
+    }
+
+    /// Draws the 1-indexed queue `position` as a rounded-rect chip in the
+    /// bottom-trailing corner of `rect`, using the control accent color with
+    /// white text so it reads over the bus in light and dark. The chip grows
+    /// horizontally (and the font shrinks) for multi-digit positions so 10–99
+    /// stay legible instead of clipping; positions past 99 render as `"99+"`.
+    private static func drawQueueBadge(position: Int, in rect: NSRect) {
+        let layout = queueBadgeLayout(position: position, in: rect)
+        let radius = layout.chipRect.height * 0.35
+        NSColor.controlAccentColor.setFill()
+        NSBezierPath(roundedRect: layout.chipRect, xRadius: radius, yRadius: radius).fill()
+        let textOrigin = NSPoint(
+            x: layout.chipRect.midX - layout.textSize.width / 2,
+            y: layout.chipRect.midY - layout.textSize.height / 2
+        )
+        (layout.text as NSString).draw(at: textOrigin, withAttributes: layout.attrs)
+    }
+
+    /// Identity-stable caches: `Image(nsImage:)` diffs by object identity, so a
+    /// fresh bitmap per body evaluation would rebuild the icon layer.
+    /// MainActor-confined (SwiftUI bodies run on main), so no lock is needed.
+    @MainActor
+    private static var emojiImageCache: [String: NSImage] = [:]
+    @MainActor
+    private static var busImageCache: [String: NSImage] = [:]
 }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -62,25 +62,22 @@ struct WorktreeRowView: View {
             hasPRStatus: prPresentation != nil
         ) {
         case .prStatus:
-            if let presentation = prPresentation,
-               let nsImage = Self.loadIcon(presentation.iconName),
-               let status = prStatus {
-                let reasonText = status.reason ?? status.state.displayReason
+            if let presentation = prPresentation, let status = prStatus {
+                // A queued PR describes itself by its queue position, not its
+                // underlying (UNKNOWN→pending) check reason.
+                let detail = presentation.badge.map { "in merge queue, position \($0)" }
+                    ?? (status.reason ?? status.state.displayReason)
                 Button(action: openPR) {
-                    Image(nsImage: nsImage)
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
+                    prGlyph(presentation)
                         .frame(width: 12, height: 12)
-                        .foregroundStyle(presentation.color)
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
                 .onHover { isPRIconHovered = $0 }
-                .accessibilityLabel("PR #\(status.number): \(reasonText)")
+                .accessibilityLabel("PR #\(status.number): \(detail)")
                 .anchorPreference(key: RowTooltipPreferenceKey.self, value: .bounds) { anchor in
                     isPRIconHovered
-                        ? RowTooltipPreference(text: "PR #\(status.number) · \(reasonText)", anchor: anchor)
+                        ? RowTooltipPreference(text: "PR #\(status.number) · \(detail)", anchor: anchor)
                         : nil
                 }
             }
@@ -91,6 +88,29 @@ struct WorktreeRowView: View {
                 .frame(width: 12, height: 12)
         case nil:
             EmptyView()
+        }
+    }
+
+    /// The leading PR glyph. `.asset` is a bundled monochrome SVG tinted with
+    /// the status color; `.emoji` (the merge-queue bus) is full-color and must
+    /// NOT be tinted — so it drops `.renderingMode(.template)`/`.foregroundStyle`
+    /// and, when queued, bakes its position badge via the shared `busImage`.
+    @ViewBuilder
+    private func prGlyph(_ presentation: PRStatusPresentation) -> some View {
+        switch presentation.glyph {
+        case .asset(let name):
+            if let nsImage = Self.loadIcon(name) {
+                Image(nsImage: nsImage)
+                    .renderingMode(.template)
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(presentation.color)
+            }
+        case .emoji:
+            Image(nsImage: PRStatusPresentation.busImage(position: presentation.badge, side: 12))
+                .renderingMode(.original)
+                .resizable()
+                .scaledToFit()
         }
     }
 

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -190,7 +190,8 @@ public actor PRStatusManager {
                 requiredChecksFailing: signals.failing,
                 requiredChecksPending: signals.pending
             )
-            let status = PRStatus(number: match.node.number, url: match.node.url, state: state, reason: reason)
+            let status = PRStatus(number: match.node.number, url: match.node.url, state: state, reason: reason,
+                                  mergeQueuePosition: match.node.mergeQueuePosition)
             await apply(status, for: match.worktreeID)
             await onPRStatusComputed?(match.worktreeID, status, repoPath)
         }
@@ -204,15 +205,30 @@ public actor PRStatusManager {
         return state != "SUCCESS"
     }
 
-    /// Refresh a single worktree using `gh pr view`. Used for on-select refresh.
+    /// Refresh a single worktree via `gh api graphql`. Used for on-select refresh.
+    ///
+    /// Deliberately NOT `gh pr view --json`: that field set exposes neither
+    /// `isInMergeQueue` nor `mergeQueueEntry`, so a manual refresh through it
+    /// would clobber `mergeQueuePosition` back to nil and flicker the bus away
+    /// until the next batch poll. The GraphQL path requests the same
+    /// merge-queue field set the batch query does. `gh repo view` resolves the
+    /// checkout's `owner/name` so the query can scope to this repo+branch —
+    /// which, unlike the 100-PR viewer batch, always finds an old PR.
     public func refresh(worktreeID: UUID, branch: String, upstreamBranch: String?, repoPath: String) async -> PRStatus? {
+        guard let ownerRepo = await resolveNameWithOwner(repoPath: repoPath) else {
+            return cache[worktreeID]   // can't resolve owner/name → leave cache unchanged
+        }
         let candidates = Self.branchCandidates(localBranch: branch, upstreamBranch: upstreamBranch)
         for candidate in candidates {
-            let args = ["pr", "view", candidate,
-                        "--json", "number,url,state,mergeStateStatus,reviewDecision,isDraft"]
-            guard let output = await runGH(args: args, repoPath: repoPath),
-                  let data = output.data(using: .utf8),
-                  let obj = try? JSONDecoder().decode(GHPRViewResult.self, from: data) else {
+            let args = Self.prByBranchArgs(owner: ownerRepo.owner, name: ownerRepo.name, branch: candidate)
+            let result = await runGHResult(args: args, repoPath: repoPath)
+            guard let result,
+                  result.exitStatus == 0,
+                  let data = Self.graphQLOutputData(stdout: result.stdout),
+                  let obj = try? Self.parsePRByBranch(from: data) else {
+                let exit = result?.exitStatus ?? -1
+                let errSuffix = result?.stderr.trimmingCharacters(in: .whitespacesAndNewlines) ?? "gh not launched"
+                logger.debug("refresh: gh graphql failed or unparseable for branch \(candidate, privacy: .public) (exit \(exit, privacy: .public)): \(errSuffix, privacy: .public); trying next candidate")
                 continue
             }
 
@@ -235,7 +251,8 @@ public actor PRStatusManager {
                 requiredChecksFailing: signals.failing,
                 requiredChecksPending: signals.pending
             )
-            let status = PRStatus(number: obj.number, url: obj.url, state: state, reason: reason)
+            let status = PRStatus(number: obj.number, url: obj.url, state: state, reason: reason,
+                                  mergeQueuePosition: obj.mergeQueuePosition)
             await apply(status, for: worktreeID)
             lastDirectUpdate[worktreeID] = Date()
             await onPRStatusComputed?(worktreeID, status, repoPath)
@@ -243,6 +260,7 @@ public actor PRStatusManager {
         }
 
         // gh exited non-zero or parse failed for every candidate — leave cache unchanged.
+        logger.debug("refresh: no candidate branch yielded a PR for worktree \(worktreeID, privacy: .public); keeping cached status")
         return cache[worktreeID]
     }
 
@@ -482,6 +500,49 @@ public actor PRStatusManager {
         """
     }
 
+    /// Single-PR refresh query: the same per-PR field set as the batch query
+    /// (including `mergeQueueEntry { position }`), scoped to one repo + head
+    /// branch. Ordered newest-first so `parsePRByBranch` can pick the best node
+    /// without a separate `createdAt` tiebreak. `first: 10` covers a branch
+    /// reused across a closed+reopened PR pair.
+    ///
+    /// `owner`/`name`/`branch` are GraphQL **variables**, never interpolated
+    /// into the query text: a git ref may legally contain `"`, and interpolating
+    /// `headRefName: "\(branch)"` for a branch like `foo"bar` produced a
+    /// malformed query (a regression from the old `gh pr view <branch>` execve
+    /// arg). `prByBranchArgs` binds the values as raw-string fields.
+    static func prByBranchQuery() -> String {
+        """
+        query($owner: String!, $name: String!, $branch: String!) {
+          repository(owner: $owner, name: $name) {
+            pullRequests(headRefName: $branch, first: 10,
+                         orderBy: {field: CREATED_AT, direction: DESC}) {
+              nodes {
+                number url state mergeStateStatus reviewDecision isDraft
+                mergeQueueEntry { position }
+              }
+            }
+          }
+        }
+        """
+    }
+
+    /// The `gh api graphql` argument vector for the single-PR refresh, binding
+    /// `owner`/`name`/`branch` as GraphQL variables. Uses `-f` (raw string), not
+    /// `-F` (typed): the variables are declared `String!`, and `-F` would coerce
+    /// a branch that looks like a number or `true`/`false`/`null` into the wrong
+    /// JSON type and be rejected. Passing them as fields — not interpolated text
+    /// — also makes a `"` in any value harmless.
+    static func prByBranchArgs(owner: String, name: String, branch: String) -> [String] {
+        [
+            "api", "graphql",
+            "-f", "query=\(prByBranchQuery())",
+            "-f", "owner=\(owner)",
+            "-f", "name=\(name)",
+            "-f", "branch=\(branch)"
+        ]
+    }
+
     /// Compute human-readable reason string for the PR merge state.
     /// Delegates to mapStateAndReason() for the single source of truth.
     public static func computeReason(
@@ -532,6 +593,9 @@ public actor PRStatusManager {
         public let createdAt: String        // ISO 8601, e.g. "2026-03-24T15:58:27Z"
         public let isDraft: Bool
         public let statusCheckRollupState: String?
+        /// 1-indexed merge-queue position (`mergeQueueEntry.position`), or nil
+        /// when the PR is not queued or reports a null position.
+        public let mergeQueuePosition: Int?
     }
 
     public static func parsePRNodes(from data: Data) throws -> [PRNode] {
@@ -554,17 +618,75 @@ public actor PRStatusManager {
             let isDraft = node["isDraft"] as? Bool ?? false
             let statusCheckRollup = node["statusCheckRollup"] as? [String: Any]
             let statusCheckRollupState = statusCheckRollup?["state"] as? String
+            // A null/absent mergeQueueEntry (not queued) yields nil; only a real
+            // entry carrying an Int position gates the bus icon.
+            let mergeQueueEntry = node["mergeQueueEntry"] as? [String: Any]
+            let mergeQueuePosition = mergeQueueEntry?["position"] as? Int
             return PRNode(number: number, url: url, state: state,
                           mergeStateStatus: mergeStateStatus,
                           reviewDecision: reviewDecision,
                           headRefName: headRefName,
                           createdAt: createdAt,
                           isDraft: isDraft,
-                          statusCheckRollupState: statusCheckRollupState)
+                          statusCheckRollupState: statusCheckRollupState,
+                          mergeQueuePosition: mergeQueuePosition)
         }
     }
 
+    /// Parse the single-PR refresh response (`prByBranchQuery`).
+    ///
+    /// Walks `data.repository.pullRequests.nodes` and returns the best node —
+    /// highest state priority (OPEN > MERGED > CLOSED), and, because the query
+    /// orders newest-first, the first node seen at that priority. Returns nil
+    /// when the branch has no PR (empty nodes). Throws `PRStatusError.invalidJSON`
+    /// only when the outer shape can't be parsed at all.
+    static func parsePRByBranch(from data: Data) throws -> GHPRViewResult? {
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = root["data"] as? [String: Any],
+              let repository = dataObj["repository"] as? [String: Any],
+              let prs = repository["pullRequests"] as? [String: Any],
+              let nodes = prs["nodes"] as? [Any] else {
+            throw PRStatusError.invalidJSON
+        }
+
+        var best: GHPRViewResult?
+        var bestPriority = Int.min
+        for node in nodes.compactMap({ $0 as? [String: Any] }) {
+            guard let number = node["number"] as? Int,
+                  let url = node["url"] as? String,
+                  let state = node["state"] as? String,
+                  let mergeStateStatus = node["mergeStateStatus"] as? String else { continue }
+            let priority = Self.prPriority(state)
+            // Nodes are newest-first, so the first node seen at a priority is the
+            // newest; only a strictly higher priority displaces it.
+            guard priority > bestPriority else { continue }
+            let mergeQueueEntry = node["mergeQueueEntry"] as? [String: Any]
+            best = GHPRViewResult(
+                number: number,
+                url: url,
+                state: state,
+                mergeStateStatus: mergeStateStatus,
+                reviewDecision: node["reviewDecision"] as? String,
+                isDraft: node["isDraft"] as? Bool ?? false,
+                mergeQueuePosition: mergeQueueEntry?["position"] as? Int
+            )
+            bestPriority = priority
+        }
+        return best
+    }
+
     // MARK: - Shell helpers
+
+    /// Resolve the checkout's `owner/name` for repo-scoped GraphQL queries.
+    /// Uses `gh repo view` (git-remote resolution) so `refresh` need not already
+    /// hold a PR URL to parse.
+    private nonisolated func resolveNameWithOwner(repoPath: String) async -> (owner: String, name: String)? {
+        let args = ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
+        guard let output = await runGH(args: args, repoPath: repoPath) else { return nil }
+        let parts = output.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: "/")
+        guard parts.count == 2 else { return nil }
+        return (owner: String(parts[0]), name: String(parts[1]))
+    }
 
     private nonisolated func runGHGraphQL(repoPath: String) async -> Data? {
         let query = """
@@ -575,6 +697,7 @@ public actor PRStatusManager {
               nodes {
                 number url state mergeStateStatus reviewDecision headRefName createdAt isDraft
                 statusCheckRollup { state }
+                mergeQueueEntry { position }
               }
             }
           }
@@ -704,13 +827,19 @@ private struct GHCommandResult {
 
 // MARK: - Supporting types
 
-private struct GHPRViewResult: Codable {
+/// Result of the single-PR refresh query, populated by `parsePRByBranch`.
+/// (No longer `Codable`: the refresh path moved from `gh pr view --json` to
+/// `gh api graphql`, whose nested `mergeQueueEntry { position }` shape is hand
+/// parsed like the batch response.) Internal so tests can assert the decode.
+struct GHPRViewResult {
     let number: Int
     let url: String
     let state: String
     let mergeStateStatus: String
     let reviewDecision: String?
     let isDraft: Bool
+    /// 1-indexed merge-queue position, or nil when not queued.
+    let mergeQueuePosition: Int?
 }
 
 public enum PRStatusError: Error {

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -955,9 +955,18 @@ public struct PRStatus: Codable, Sendable, Equatable {
     public let commits: Int?
     /// UUID of the worktree that authored this PR, if known.
     public let authorWorktreeID: UUID?
+    /// 1-indexed position in GitHub's merge queue (front of queue == 1), or nil
+    /// when the PR is not in a merge queue. Sourced from
+    /// `PullRequest.mergeQueueEntry.position` — not expressible via
+    /// `mergeStateStatus` (there is no `QUEUED` value). Optional with a nil
+    /// default so JSON persisted before this field existed still decodes: it
+    /// rides in the existing `worktree.prStatus` TEXT column (migration v34),
+    /// so no new migration is required.
+    public let mergeQueuePosition: Int?
 
     public init(number: Int, url: String, state: PRMergeableState, reason: String? = nil,
-                files: [String]? = nil, commits: Int? = nil, authorWorktreeID: UUID? = nil) {
+                files: [String]? = nil, commits: Int? = nil, authorWorktreeID: UUID? = nil,
+                mergeQueuePosition: Int? = nil) {
         self.number = number
         self.url = url
         self.state = state
@@ -965,6 +974,7 @@ public struct PRStatus: Codable, Sendable, Equatable {
         self.files = files
         self.commits = commits
         self.authorWorktreeID = authorWorktreeID
+        self.mergeQueuePosition = mergeQueuePosition
     }
 }
 

--- a/Tests/TBDAppTests/PRButtonLabelTests.swift
+++ b/Tests/TBDAppTests/PRButtonLabelTests.swift
@@ -6,14 +6,17 @@ import Testing
 @testable import TBDShared
 
 @Suite("PRButtonLabel")
+@MainActor
 struct PRButtonLabelTests {
     private static func makeStatus(
         number: Int = 42,
         url: String? = nil,
         state: PRMergeableState = .mergeable,
-        reason: String? = nil
+        reason: String? = nil,
+        mergeQueuePosition: Int? = nil
     ) -> PRStatus {
-        PRStatus(number: number, url: url ?? "https://example.com/\(number)", state: state, reason: reason)
+        PRStatus(number: number, url: url ?? "https://example.com/\(number)", state: state,
+                 reason: reason, mergeQueuePosition: mergeQueuePosition)
     }
 
     private static func makeKey(
@@ -50,14 +53,38 @@ struct PRButtonLabelTests {
         #expect(label.bakedWidth > PRButtonLabel(prStatus: Self.makeStatus(), isAutoArchiveArmed: false).bakedWidth)
     }
 
+    @Test("bakedWidth stays a single square for a queued PR even when armed")
+    func bakedWidthQueuedSuppressesArchiveBadge() {
+        // Queue mode supersedes the archivebox armed-badge: the bus is one
+        // full-color square with its position baked in, so the label must not
+        // reserve the extra gap+badge width.
+        let queuedArmed = PRButtonLabel(
+            prStatus: Self.makeStatus(state: .pending, mergeQueuePosition: 2),
+            isAutoArchiveArmed: true
+        )
+        #expect(queuedArmed.isMergeQueued)
+        #expect(queuedArmed.bakedWidth == PRButtonLabel.iconSide)
+    }
+
+    @Test("coloredIcon bakes a single square for a queued PR (bus, untinted)")
+    func coloredIconQueuedIsSquare() throws {
+        let label = PRButtonLabel(
+            prStatus: Self.makeStatus(state: .pending, mergeQueuePosition: 3),
+            isAutoArchiveArmed: true
+        )
+        let presentation = try #require(PRStatusPresentation.make(for: label.prStatus))
+        let icon = try #require(label.coloredIcon(presentation, colorScheme: .light))
+        #expect(icon.size == NSSize(width: PRButtonLabel.iconSide, height: PRButtonLabel.iconSide))
+        #expect(icon.isTemplate == false)
+    }
+
     // MARK: - coloredIcon baked image size (armed gate, both branches)
 
-    @MainActor
     @Test("coloredIcon bakes a square image when not armed and a wide badge composite when armed")
     func coloredIconSizeMatchesArmedState() throws {
         let unarmed = PRButtonLabel(prStatus: Self.makeStatus(), isAutoArchiveArmed: false)
         let armed = PRButtonLabel(prStatus: Self.makeStatus(), isAutoArchiveArmed: true)
-        let presentation = PRStatusPresentation(iconName: "git-merge", colorSemantic: .merged)
+        let presentation = PRStatusPresentation(glyph: .asset("git-merge"), colorSemantic: .merged)
 
         let unarmedIcon = try #require(unarmed.coloredIcon(presentation, colorScheme: .light))
         let armedIcon = try #require(armed.coloredIcon(presentation, colorScheme: .light))
@@ -143,12 +170,27 @@ struct PRButtonLabelTests {
         // url — reason deliberately excluded), so a new field is otherwise
         // silently unkeyed: decide whether the split button renders it and
         // update prSplitButtonID (and this count) accordingly.
-        // 7 = number, state, url, reason + the nightwatch gate metadata
+        // 8 = number, state, url, reason + the nightwatch gate metadata
         // (files, commits, authorWorktreeID), which the split button does NOT
         // render — deliberately excluded like reason, else every metadata
-        // fetch would force a spurious toolbar-item rebuild.
+        // fetch would force a spurious toolbar-item rebuild — plus
+        // mergeQueuePosition, which the split button DOES render (bus glyph +
+        // baked position badge) and which IS keyed.
         let status = Self.makeStatus()
-        #expect(Mirror(reflecting: status).children.count == 7)
+        #expect(Mirror(reflecting: status).children.count == 8)
+    }
+
+    @Test("id key differs by merge-queue position so a queue move rebuilds the item")
+    func idKeyDiffersByMergeQueuePosition() {
+        let worktreeID = UUID()
+        // A queued PR keeps state UNKNOWN→.pending as it advances, so state
+        // alone can't distinguish position 2 from 1; the baked position badge
+        // would go stale unless mergeQueuePosition is part of the key.
+        let notQueued = Self.makeKey(worktreeID: worktreeID, prStatus: Self.makeStatus(state: .pending))
+        let atTwo = Self.makeKey(worktreeID: worktreeID, prStatus: Self.makeStatus(state: .pending, mergeQueuePosition: 2))
+        let atOne = Self.makeKey(worktreeID: worktreeID, prStatus: Self.makeStatus(state: .pending, mergeQueuePosition: 1))
+        #expect(notQueued != atTwo)
+        #expect(atOne != atTwo)
     }
 
     @Test("id key differs between blocked states, color schemes, and worktrees")

--- a/Tests/TBDAppTests/PRStatusPresentationTests.swift
+++ b/Tests/TBDAppTests/PRStatusPresentationTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Testing
 @testable import TBDApp
 @testable import TBDShared
@@ -15,7 +16,7 @@ struct PRStatusPresentationTests {
     func mergedPresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 1, url: "https://example.com/1", state: .merged))
 
-        #expect(presentation?.iconName == "git-merge")
+        #expect(presentation?.glyph == .asset("git-merge"))
         #expect(presentation?.colorSemantic == .merged)
     }
 
@@ -23,7 +24,7 @@ struct PRStatusPresentationTests {
     func mergeablePresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 2, url: "https://example.com/2", state: .mergeable))
 
-        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.glyph == .asset("git-pull-request"))
         #expect(presentation?.colorSemantic == .mergeable)
     }
 
@@ -31,7 +32,7 @@ struct PRStatusPresentationTests {
     func draftPresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 3, url: "https://example.com/3", state: .draft))
 
-        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.glyph == .asset("git-pull-request"))
         #expect(presentation?.colorSemantic == .draft)
     }
 
@@ -39,7 +40,7 @@ struct PRStatusPresentationTests {
     func checksFailedPresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 4, url: "https://example.com/4", state: .checksFailed))
 
-        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.glyph == .asset("git-pull-request"))
         #expect(presentation?.colorSemantic == .nonMergeable)
     }
 
@@ -47,7 +48,7 @@ struct PRStatusPresentationTests {
     func changesRequestedPresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 5, url: "https://example.com/5", state: .changesRequested))
 
-        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.glyph == .asset("git-pull-request"))
         #expect(presentation?.colorSemantic == .nonMergeable)
     }
 
@@ -55,7 +56,7 @@ struct PRStatusPresentationTests {
     func pendingPresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 6, url: "https://example.com/6", state: .pending))
 
-        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.glyph == .asset("git-pull-request"))
         #expect(presentation?.colorSemantic == .pending)
     }
 
@@ -63,7 +64,7 @@ struct PRStatusPresentationTests {
     func blockedPresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 7, url: "https://example.com/7", state: .blocked))
 
-        #expect(presentation?.iconName == "git-pull-request")
+        #expect(presentation?.glyph == .asset("git-pull-request"))
         #expect(presentation?.colorSemantic == .nonMergeable)
     }
 
@@ -71,7 +72,94 @@ struct PRStatusPresentationTests {
     func closedPresentation() {
         let presentation = PRStatusPresentation.make(for: PRStatus(number: 8, url: "https://example.com/8", state: .closed))
 
-        #expect(presentation?.iconName == "git-pull-request-closed")
+        #expect(presentation?.glyph == .asset("git-pull-request-closed"))
         #expect(presentation?.colorSemantic == .nonMergeable)
+    }
+
+    // MARK: - Merge-queue bus (the mergeQueuePosition gate)
+
+    /// Branch OFF: with no queue position, every state keeps its ordinary asset
+    /// icon and carries no badge. Complements the per-state tests above by
+    /// asserting the bus short-circuit did NOT fire.
+    @Test("no merge-queue position keeps the ordinary asset icon and no badge", arguments: [
+        PRMergeableState.pending, .blocked, .changesRequested, .checksFailed,
+        .draft, .mergeable, .merged, .closed
+    ])
+    func noQueuePositionKeepsAssetIcon(state: PRMergeableState) {
+        let presentation = PRStatusPresentation.make(
+            for: PRStatus(number: 1, url: "https://github.com/acme/acme-prod/pull/1", state: state)
+        )
+        if case .asset = presentation?.glyph {} else {
+            Issue.record("expected an asset glyph for \(state) with no queue position")
+        }
+        #expect(presentation?.badge == nil)
+    }
+
+    /// Branch ON: any state with a queue position short-circuits to the bus
+    /// emoji, and the badge equals the 1-indexed position.
+    @Test("a merge-queue position renders the bus glyph with the position as its badge", arguments: [
+        (PRMergeableState.pending, 1),
+        (.mergeable, 2),
+        (.blocked, 3),
+        (.checksFailed, 7)
+    ])
+    func queuePositionRendersBus(state: PRMergeableState, position: Int) {
+        let presentation = PRStatusPresentation.make(
+            for: PRStatus(number: 1, url: "https://github.com/acme/acme-prod/pull/1",
+                          state: state, mergeQueuePosition: position)
+        )
+        #expect(presentation?.glyph == .emoji(PRStatusPresentation.mergeQueueEmoji))
+        #expect(presentation?.badge == position)
+    }
+
+    @Test("front-of-queue position is 1-indexed, not 0")
+    func frontOfQueueIsOne() {
+        let presentation = PRStatusPresentation.make(
+            for: PRStatus(number: 5, url: "https://github.com/acme/acme-prod/pull/5",
+                          state: .pending, mergeQueuePosition: 1)
+        )
+        #expect(presentation?.badge == 1)
+    }
+
+    // MARK: - Queue badge rendering (double-digit positions must not clip)
+
+    /// The badge chip must stay fully inside the icon square for 1-, 2-, and
+    /// 3-digit positions — the old fixed-square chip truncated anything past a
+    /// single digit, and a real merge queue routinely has 10+ entries.
+    @MainActor
+    @Test("queue badge chip stays within the icon bounds for 1-, 2-, and 3-digit positions",
+          arguments: [1, 10, 99, 100])
+    func queueBadgeStaysInBounds(position: Int) {
+        let iconRect = NSRect(x: 0, y: 0, width: 12, height: 12)
+        let layout = PRStatusPresentation.queueBadgeLayout(position: position, in: iconRect)
+        #expect(iconRect.contains(layout.chipRect),
+                "chip \(layout.chipRect) escaped icon \(iconRect) for position \(position)")
+        // The text also fits inside its own chip (no glyph clipping).
+        #expect(layout.textSize.width <= layout.chipRect.width + 0.01)
+    }
+
+    /// Clamp boundary: 99 renders literally, 100 collapses to "99+".
+    @MainActor
+    @Test("positions past 99 clamp to \"99+\"")
+    func queueBadgeClampsPast99() {
+        let iconRect = NSRect(x: 0, y: 0, width: 12, height: 12)
+        #expect(PRStatusPresentation.queueBadgeLayout(position: 99, in: iconRect).text == "99")
+        #expect(PRStatusPresentation.queueBadgeLayout(position: 100, in: iconRect).text == "99+")
+        #expect(PRStatusPresentation.queueBadgeLayout(position: 1234, in: iconRect).text == "99+")
+    }
+
+    /// The rendered bitmap must actually differ between positions, proving the
+    /// cache key varies and the badge is redrawn per position (single vs double
+    /// digit produce visibly different chips).
+    @MainActor
+    @Test("busImage differs between single- and double-digit positions")
+    func busImageDiffersByPosition() throws {
+        let side: CGFloat = 12
+        let one = try #require(PRStatusPresentation.busImage(position: 1, side: side).tiffRepresentation)
+        let ten = try #require(PRStatusPresentation.busImage(position: 10, side: side).tiffRepresentation)
+        let ninetyNine = try #require(PRStatusPresentation.busImage(position: 99, side: side).tiffRepresentation)
+        #expect(one != ten)
+        #expect(ten != ninetyNine)
+        #expect(one != ninetyNine)
     }
 }

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -370,6 +370,215 @@ struct PRStatusManagerTests {
         #expect(nodes[2].headRefName == "feature/not-tbd")
     }
 
+    @Test("parsePRNodes decodes mergeQueueEntry.position and tolerates a null entry")
+    func parsesMergeQueuePosition() throws {
+        let json = """
+        {
+          "data": {
+            "viewer": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 12,
+                    "url": "https://github.com/acme/acme-prod/pull/12",
+                    "state": "OPEN",
+                    "mergeStateStatus": "UNKNOWN",
+                    "reviewDecision": null,
+                    "headRefName": "acme/queued-feature",
+                    "createdAt": "2026-03-24T10:00:00Z",
+                    "mergeQueueEntry": { "position": 3 }
+                  },
+                  {
+                    "number": 34,
+                    "url": "https://github.com/acme/acme-prod/pull/34",
+                    "state": "OPEN",
+                    "mergeStateStatus": "CLEAN",
+                    "reviewDecision": null,
+                    "headRefName": "acme/not-queued",
+                    "createdAt": "2026-03-24T11:00:00Z",
+                    "mergeQueueEntry": null
+                  },
+                  {
+                    "number": 56,
+                    "url": "https://github.com/acme/acme-prod/pull/56",
+                    "state": "OPEN",
+                    "mergeStateStatus": "CLEAN",
+                    "reviewDecision": null,
+                    "headRefName": "acme/no-entry-key",
+                    "createdAt": "2026-03-24T12:00:00Z"
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let nodes = try PRStatusManager.parsePRNodes(from: json)
+        #expect(nodes.count == 3)
+        #expect(nodes[0].mergeQueuePosition == 3)      // front-of-queue is 1-indexed; this PR is 3rd
+        #expect(nodes[1].mergeQueuePosition == nil)    // explicit null entry
+        #expect(nodes[2].mergeQueuePosition == nil)    // absent key entirely
+    }
+
+    // MARK: - parsePRByBranch (rewritten refresh() decoder)
+
+    @Test("parsePRByBranch decodes the same field set, including mergeQueuePosition")
+    func parsePRByBranchDecodesFields() throws {
+        let json = """
+        {
+          "data": {
+            "repository": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 77,
+                    "url": "https://github.com/acme/acme-prod/pull/77",
+                    "state": "OPEN",
+                    "mergeStateStatus": "UNKNOWN",
+                    "reviewDecision": "APPROVED",
+                    "isDraft": false,
+                    "mergeQueueEntry": { "position": 1 }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let result = try #require(try PRStatusManager.parsePRByBranch(from: json))
+        #expect(result.number == 77)
+        #expect(result.url == "https://github.com/acme/acme-prod/pull/77")
+        #expect(result.state == "OPEN")
+        #expect(result.mergeStateStatus == "UNKNOWN")
+        #expect(result.reviewDecision == "APPROVED")
+        #expect(result.isDraft == false)
+        #expect(result.mergeQueuePosition == 1)
+    }
+
+    @Test("parsePRByBranch yields nil position for a null mergeQueueEntry")
+    func parsePRByBranchNullQueueEntry() throws {
+        let json = """
+        {
+          "data": {
+            "repository": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 88,
+                    "url": "https://github.com/acme/acme-prod/pull/88",
+                    "state": "OPEN",
+                    "mergeStateStatus": "CLEAN",
+                    "reviewDecision": null,
+                    "isDraft": false,
+                    "mergeQueueEntry": null
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let result = try #require(try PRStatusManager.parsePRByBranch(from: json))
+        #expect(result.mergeQueuePosition == nil)
+        #expect(result.reviewDecision == nil)
+    }
+
+    @Test("parsePRByBranch picks the highest-priority PR (OPEN over CLOSED) for a reused branch")
+    func parsePRByBranchPicksBestNode() throws {
+        // Query orders newest-first; a branch reused across a closed then
+        // reopened PR must resolve to the OPEN one regardless of node order.
+        let json = """
+        {
+          "data": {
+            "repository": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 91,
+                    "url": "https://github.com/acme/acme-prod/pull/91",
+                    "state": "CLOSED",
+                    "mergeStateStatus": "UNKNOWN",
+                    "reviewDecision": null,
+                    "isDraft": false,
+                    "mergeQueueEntry": null
+                  },
+                  {
+                    "number": 90,
+                    "url": "https://github.com/acme/acme-prod/pull/90",
+                    "state": "OPEN",
+                    "mergeStateStatus": "UNKNOWN",
+                    "reviewDecision": null,
+                    "isDraft": false,
+                    "mergeQueueEntry": { "position": 2 }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let result = try #require(try PRStatusManager.parsePRByBranch(from: json))
+        #expect(result.number == 90)
+        #expect(result.state == "OPEN")
+        #expect(result.mergeQueuePosition == 2)
+    }
+
+    @Test("parsePRByBranch returns nil when the branch has no PR")
+    func parsePRByBranchEmpty() throws {
+        let json = """
+        { "data": { "repository": { "pullRequests": { "nodes": [] } } } }
+        """.data(using: .utf8)!
+        #expect(try PRStatusManager.parsePRByBranch(from: json) == nil)
+    }
+
+    @Test("parsePRByBranch throws on a malformed outer shape")
+    func parsePRByBranchThrows() {
+        let json = "{ \"data\": { \"repository\": null } }".data(using: .utf8)!
+        #expect(throws: PRStatusError.self) {
+            _ = try PRStatusManager.parsePRByBranch(from: json)
+        }
+    }
+
+    // MARK: - prByBranchArgs (branch passed as a GraphQL variable, never interpolated)
+
+    @Test("prByBranchArgs passes owner/name/branch as fields, not interpolated into the query")
+    func prByBranchArgsUsesVariables() {
+        let args = PRStatusManager.prByBranchArgs(owner: "acme", name: "acme-prod", branch: "feature/x")
+
+        // The query itself must reference GraphQL variables, never the literal values.
+        let queryArg = args.first { $0.hasPrefix("query=") }
+        #expect(queryArg?.contains("$branch") == true)
+        #expect(queryArg?.contains("$owner") == true)
+        #expect(queryArg?.contains("acme-prod") == false)
+        #expect(queryArg?.contains("feature/x") == false)
+
+        // Values are bound as raw-string (`-f`) fields so String! typing survives.
+        #expect(args.contains("owner=acme"))
+        #expect(args.contains("name=acme-prod"))
+        #expect(args.contains("branch=feature/x"))
+        #expect(!args.contains("-F"))   // -F would coerce a numeric/bool-looking branch
+    }
+
+    @Test("prByBranchArgs handles a branch containing a double-quote without corrupting the query")
+    func prByBranchArgsHandlesQuoteInBranch() {
+        // A git ref may legally contain `"`. Interpolating it into the query text
+        // (the old `headRefName: "\(branch)"`) produced malformed GraphQL; as a
+        // variable field the quote is inert and round-trips verbatim.
+        let branch = "foo\"bar"
+        let args = PRStatusManager.prByBranchArgs(owner: "acme", name: "acme-prod", branch: branch)
+
+        let queryArg = args.first { $0.hasPrefix("query=") }
+        #expect(queryArg?.contains(branch) == false)   // the quote never reaches the query text
+        #expect(queryArg?.contains("$branch") == true)
+
+        // The branch survives intact as its own field value (execve arg), quote and all.
+        #expect(args.contains("branch=\(branch)"))
+    }
+
     @Test("graphQLOutputData keeps non-empty stdout")
     func graphQLOutputDataUsesNonEmptyStdout() {
         let stdout = """

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -527,3 +527,27 @@ import Testing
     #expect(s.contains("\"worktreeSlot\":\"r\""))
     #expect(s.contains("\"status\":\"missing\""))
 }
+
+// MARK: - PRStatus persisted-JSON compatibility
+
+/// PRStatus rides in the single `worktree.prStatus` TEXT column (migration
+/// v34) as JSON. `mergeQueuePosition` was added as an OPTIONAL field with no
+/// new migration, so a blob written before the field existed (no
+/// `mergeQueuePosition` key) must still decode — yielding nil.
+@Test func prStatusDecodesLegacyJSONWithoutMergeQueuePosition() throws {
+    let legacy = """
+    {"number":123,"url":"https://github.com/acme/acme-prod/pull/123","state":"pending","reason":"Checks pending"}
+    """
+    let decoded = try JSONDecoder().decode(PRStatus.self, from: Data(legacy.utf8))
+    #expect(decoded.number == 123)
+    #expect(decoded.state == .pending)
+    #expect(decoded.mergeQueuePosition == nil)
+}
+
+@Test func prStatusRoundTripsMergeQueuePosition() throws {
+    let status = PRStatus(number: 7, url: "https://github.com/acme/acme-prod/pull/7",
+                          state: .pending, reason: "Checks pending", mergeQueuePosition: 2)
+    let data = try JSONEncoder().encode(status)
+    let decoded = try JSONDecoder().decode(PRStatus.self, from: data)
+    #expect(decoded.mergeQueuePosition == 2)
+}

--- a/docs/superpowers/specs/2026-07-08-merge-queue-bus-icon-design.md
+++ b/docs/superpowers/specs/2026-07-08-merge-queue-bus-icon-design.md
@@ -1,0 +1,121 @@
+# Merge-queue bus icon
+
+Render a 🚌 in place of the PR icon when a pull request is sitting in GitHub's
+merge queue, with a small badge showing its position in that queue.
+
+## Motivation
+
+A PR in a merge queue is in a different mode from every other PR state: it is no
+longer waiting on the author. TBD currently gives no signal that this has
+happened. A queued PR reports `mergeStateStatus: UNKNOWN`, which
+`PRStatusManager.mapStateAndReason` maps to `(.pending, "Checks pending")` — the
+ordinary olive PR icon. That is not wrong, but it is indistinguishable from a PR
+whose CI is still running on the branch.
+
+## What GitHub exposes
+
+Verified against a live merge queue via the GraphQL API:
+
+- `MergeStateStatus` has seven values — `DIRTY`, `UNKNOWN`, `BLOCKED`, `BEHIND`,
+  `UNSTABLE`, `HAS_HOOKS`, `CLEAN`. **There is no `QUEUED`.** Merge-queue
+  membership is not expressible through `mergeStateStatus`.
+- `PullRequest.isInMergeQueue: Boolean!` and `PullRequest.mergeQueueEntry` are
+  the real signals. `mergeQueueEntry` carries `position`, `state`
+  (`QUEUED | AWAITING_CHECKS | MERGEABLE | UNMERGEABLE | LOCKED`),
+  and `estimatedTimeToMerge` (seconds).
+- **`position` is 1-indexed.** The PR at the front of the queue reports `1`.
+- A queued PR's `mergeStateStatus` is `UNKNOWN`.
+- The `gh pr view --json` field set exposes neither `isInMergeQueue` nor
+  `mergeQueueEntry`. Only `autoMergeRequest` and `mergeStateStatus` are
+  available there.
+
+## Design
+
+### Data layer — `Sources/TBDDaemon/PR/PRStatusManager.swift`
+
+Add `mergeQueueEntry { position }` to the batch GraphQL query's per-PR node
+selection.
+
+Convert the single-PR `refresh()` path from `gh pr view --json ...` to a
+`gh api graphql` call requesting the same field set. This is required, not
+cosmetic: `gh pr view --json` cannot see merge-queue state at all, so leaving it
+in place would make a manual refresh clobber the position back to `nil` and
+flicker the bus away until the next batch poll.
+
+`PRNode` and the refresh result type each gain `mergeQueuePosition: Int?`.
+
+### Shared model — `Sources/TBDShared/Models.swift`
+
+`PRStatus` gains one field:
+
+```swift
+public let mergeQueuePosition: Int?
+```
+
+It must be optional with a `nil` default. `PRStatus` is persisted as JSON inside
+the single `worktree.prStatus` TEXT column (migration `v34`), so an optional
+field decodes against existing rows and **no new migration is required**.
+
+`PRMergeableState` gains **no new case.** Queue membership is orthogonal to
+mergeability — a queued PR still has a meaningful underlying check state, and
+collapsing the two would discard it and force edits into `mapStateAndReason`.
+Keeping a separate field leaves that switch untouched.
+
+### Presentation — `Sources/TBDApp/PRStatusPresentation.swift`
+
+`PRStatusPresentation.make(for:)` short-circuits: when `mergeQueuePosition` is
+non-nil, it returns the bus presentation regardless of `state`.
+
+The struct's `iconName: String` becomes a glyph enum so the two render sites can
+branch without duplicating the decision:
+
+```swift
+enum Glyph {
+    case asset(String)   // existing bundled SVGs
+    case emoji(String)   // 🚌
+}
+```
+
+and gains `badge: Int?`, carrying the queue position.
+
+### Rendering
+
+Two call sites consume the presentation and must not drift:
+
+- `Sources/TBDApp/Sidebar/WorktreeRowView.swift` — `leadingIcon()`
+- `Sources/TBDApp/ContentView.swift` — `PRButtonLabel.coloredIcon(_:colorScheme:)`
+
+Introduce one shared `emoji → NSImage` helper used by both.
+
+The emoji is full-color and must **not** be tinted: the sidebar drops
+`.renderingMode(.template)` for the `.emoji` case, and the toolbar skips its
+color-baking fill. The toolbar already composites an `archivebox` overlay onto
+the PR image when auto-archive is armed; the position badge reuses that
+compositing path.
+
+The badge is a small rounded-rect chip in the icon's corner containing the
+1-indexed position.
+
+## Deliberate trade-offs
+
+`mergeQueueEntry.position` is typed `Int` (nullable) in the GraphQL schema. The
+bus is gated on `position != nil`, so an entry that somehow reports a null
+position renders the ordinary PR icon rather than a bus with an empty badge.
+This is chosen so the badge always carries a number. It was not observed in
+practice against a live queue.
+
+## Testing
+
+Per CLAUDE.md, a branching conditional that gates behavior needs a test per
+branch:
+
+- `mergeQueuePosition == nil` → existing icon and color for each `PRMergeableState`.
+- `mergeQueuePosition != nil` → bus glyph plus badge, and the badge value equals
+  the position.
+- The batch GraphQL decoder parses `position`, and tolerates a null
+  `mergeQueueEntry` by yielding `nil`.
+- The rewritten `refresh()` decoder parses the same fields.
+- Round-trip: a `PRStatus` JSON blob written before this change (no
+  `mergeQueuePosition` key) still decodes, yielding `nil`.
+
+Test fixtures use `acme` / `acme-prod` placeholder repo names.


### PR DESCRIPTION
## What

A PR sitting in GitHub's merge queue is in a different mode from every other PR state — it's no longer waiting on the author. TBD gave no signal that this had happened.

A queued PR shows up as the ordinary olive "Checks pending" icon, indistinguishable from CI running on the branch. This renders a full-color 🚌 in its place, badged with its 1-indexed position in the queue.

## Why `mergeQueueEntry` and not `mergeStateStatus`

Checked against a live merge queue rather than assumed, and two things fell out:

- **`MergeStateStatus` has no `QUEUED` value.** It is exactly `DIRTY UNKNOWN BLOCKED BEHIND UNSTABLE HAS_HOOKS CLEAN`.
- **A queued PR's `mergeStateStatus` is inconsistent** — observed as both `UNKNOWN` and `CLEAN` on PRs sitting in the same queue.

So merge state cannot be used to infer queue membership; the bus would flicker. Detection keys off `PullRequest.mergeQueueEntry { position }`, and `position` is 1-indexed (verified live).

## Design

- **`PRStatus` gains an optional `mergeQueuePosition`.** It rides the existing `v34` `worktree.prStatus` JSON column, so **no migration** is required and legacy rows decode to `nil`.
- **`PRMergeableState` gains no case.** Queue membership is orthogonal to mergeability — a queued PR still has a real check state underneath — so `mapStateAndReason` is untouched.
- **`refresh()` moves from `gh pr view --json` to `gh api graphql`.** The CLI's field set cannot see merge-queue state at all, so leaving it would clobber the position to `nil` on every manual refresh and flicker the bus away until the next poll. Inputs bind as GraphQL **variables**, so a branch name containing `"` (which git permits) can't malform the query.
- **The badge chip grows horizontally and shrinks its font to fit, clamping to `99+`.** Queues of 10+ are routine; a square-capped chip truncated them.
- **Failure paths in `refresh()` now log at `.debug`** instead of falling through to the cache silently.

Both render sites (sidebar row + toolbar split-button) share one `emoji → NSImage` path so the glyph and badge can't drift. The emoji is deliberately **not** tinted. `busImage` caches by position, and `prSplitButtonID` folds `mergeQueuePosition` into the toolbar `.id`, so a 2→1 queue move repaints rather than showing a stale badge.

### Deliberate trade-off

`mergeQueueEntry.position` is nullable in the schema. The bus is gated on `position != nil`, so an entry reporting a null position renders the ordinary icon rather than a bus with an empty badge. Not observed against a live queue.

## Verification

- `swift build` — clean.
- `swift test` — **3119 tests in 382 suites passed** (3114 before; +5 tests, none removed or weakened).
- `swiftlint --strict` — 0 violations across 497 files.
- Actor-isolation warnings in `PRButtonLabelTests.swift` taken **7 → 0** (they pre-dated this change).
- **End-to-end against a live merge queue**: the query the daemon builds returns `position: 1` for a real queued PR, and a branch containing a `"` binds as a variable without corrupting the query.

## Not covered

This repo's `main` has no merge queue enabled, so the bus cannot be eyeballed here. Live visual verification needs a repo with a queue.

[merge-queue bus icon](https://cheapsteak.github.io/tbd/open/?worktree=9B009F6C-F446-46B3-A864-1122D8AA8523)