### PR TITLE
DX: Zero out the 32 new Swift 6.3 warnings — all 16 concurrency diagnostics triaged as false positives before annotating

### DIFF
--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -526,9 +526,12 @@ final class HoverCardController {
             context.duration = timing.fadeOutDuration
             panel.animator().alphaValue = 0
         } completionHandler: { [weak self] in
-            guard let self, self.fadeGeneration == generation else { return }
-            panel.orderOut(nil)
-            panel.alphaValue = 1
+            // AppKit delivers this completion on the main thread.
+            MainActor.assumeIsolated {
+                guard let self, self.fadeGeneration == generation else { return }
+                panel.orderOut(nil)
+                panel.alphaValue = 1
+            }
         }
     }
 }

--- a/Sources/TBDApp/Helpers/DaemonLiveness.swift
+++ b/Sources/TBDApp/Helpers/DaemonLiveness.swift
@@ -47,6 +47,16 @@ enum DaemonLiveness {
         var buffer = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
         let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
         guard length > 0 else { return nil }
-        return String(cString: buffer)
+        // proc_pidpath NUL-terminates at `length`; truncate to the path's
+        // actual bytes before decoding so trailing zero-fill from the
+        // oversized buffer isn't folded into the string (String(cString:)
+        // stopped at the first NUL for free — String(decoding:as:) does not).
+        let pathBytes = buffer.prefix(Int(length)).map { UInt8(bitPattern: $0) }
+        // String(bytes:encoding:) is failable and would turn an invalid-UTF8
+        // path into `nil` ("not our daemon"); String(cString:) never failed
+        // that way (lossy U+FFFD repair), so String(decoding:as:) is the
+        // correct like-for-like replacement here, not Data.
+        // swiftlint:disable:next optional_data_string_conversion
+        return String(decoding: pathBytes, as: UTF8.self)
     }
 }

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -404,9 +404,10 @@ struct SessionTranscriptView: View {
                 }
                 .animation(.easeInOut(duration: 0.2), value: atBottom)
                 .onAppear {
+                    let count = messages.count
                     HangWatchdog.shared.recordContext { snap in
                         snap.focusedTerminalIDShort = nil
-                        snap.transcriptItemCount = messages.count
+                        snap.transcriptItemCount = count
                         snap.paneLabel = "history"
                     }
                 }
@@ -462,9 +463,10 @@ struct SessionTranscriptView: View {
                     }
                 }
                 .onAppear {
+                    let count = messages.count
                     HangWatchdog.shared.recordContext { snap in
                         snap.focusedTerminalIDShort = nil
-                        snap.transcriptItemCount = messages.count
+                        snap.transcriptItemCount = count
                         snap.paneLabel = "history"
                     }
                 }

--- a/Sources/TBDApp/Panes/Transcript/Renderer/CodeHighlightService.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/CodeHighlightService.swift
@@ -30,9 +30,11 @@ struct HighlightColorRun {
 /// safe even though the compiler cannot prove it statically.
 final class CodeHighlightService: @unchecked Sendable {
     /// Process singleton. The type is `@unchecked Sendable` (see above), so no
-    /// `nonisolated(unsafe)` is needed here — the same serial-queue confinement
-    /// pattern the sibling `DiffSyntaxHighlighter` uses for its shared
-    /// `Highlightr`s.
+    /// `nonisolated(unsafe)` is needed here — the safety argument is the same
+    /// serial-queue confinement the sibling `DiffSyntaxHighlighter` relies on for
+    /// its shared `Highlightr`s, though that class expresses it with
+    /// property-level `nonisolated(unsafe)` rather than class-level
+    /// `@unchecked Sendable`.
     static let shared = CodeHighlightService()
 
     /// Dedicated serial queue. The lazily-created `Highlightr` and EVERY call into

--- a/Sources/TBDApp/Panes/Transcript/Renderer/CodeHighlightService.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/CodeHighlightService.swift
@@ -23,12 +23,17 @@ struct HighlightColorRun {
 /// thread-confined). Code blocks render as plain monospaced text synchronously;
 /// the colors computed here are applied later, over the SAME fixed monospaced font,
 /// so they change only `.foregroundColor` and never the layout/height.
-final class CodeHighlightService {
-    /// Process singleton. `nonisolated(unsafe)` because the type's only mutable
-    /// state (the lazy `Highlightr`) is confined to `queue`, so access is
-    /// serialized at runtime rather than checked by the compiler — the same pattern
-    /// the sibling `DiffSyntaxHighlighter` uses for its shared `Highlightr`s.
-    nonisolated(unsafe) static let shared = CodeHighlightService()
+///
+/// `@unchecked Sendable` is justified by the same serial-queue confinement: the
+/// only mutable state (`highlightr`, `didCreateHighlightr`) is read/written
+/// exclusively on `queue`, so the `queue.async` closures capturing `self` are
+/// safe even though the compiler cannot prove it statically.
+final class CodeHighlightService: @unchecked Sendable {
+    /// Process singleton. The type is `@unchecked Sendable` (see above), so no
+    /// `nonisolated(unsafe)` is needed here — the same serial-queue confinement
+    /// pattern the sibling `DiffSyntaxHighlighter` uses for its shared
+    /// `Highlightr`s.
+    static let shared = CodeHighlightService()
 
     /// Dedicated serial queue. The lazily-created `Highlightr` and EVERY call into
     /// it happen only here — JSContext is thread-confined, so confining all access

--- a/Sources/TBDApp/Panes/Transcript/TextKit/TranscriptCardAttachment.swift
+++ b/Sources/TBDApp/Panes/Transcript/TextKit/TranscriptCardAttachment.swift
@@ -8,11 +8,19 @@ import SwiftUI
 @MainActor
 final class TranscriptCardAttachment: NSTextAttachment {
     let nodeID: String
-    let card: AnyView
+
+    /// The SwiftUI card, captured on the main actor at init and read by the
+    /// nonisolated `viewProvider` override below. Boxed in `_SendableBox`
+    /// because that override is nonisolated in the SDK even though TextKit
+    /// only calls it on the main thread — the box's runtime precondition
+    /// enforces the thread constraint the type system cannot express (the
+    /// same pattern `TranscriptCardViewProvider._card` uses). (#129)
+    private nonisolated let _card: _SendableBox<AnyView>
+    var card: AnyView { _card.mainThreadValue }
 
     init(nodeID: String, card: AnyView) {
         self.nodeID = nodeID
-        self.card = card
+        self._card = _SendableBox(card)
         super.init(data: nil, ofType: nil)
         allowsTextAttachmentView = true
     }
@@ -28,12 +36,14 @@ final class TranscriptCardAttachment: NSTextAttachment {
         // @MainActor state after construction (TextKit calls loadView on
         // the main thread, but Swift 6 can't verify that statically because
         // NSTextAttachmentViewProvider overrides are nonisolated in the SDK).
+        // The card comes out of `_card`, whose main-thread precondition
+        // enforces TextKit's main-thread delivery contract at runtime.
         let provider = TranscriptCardViewProvider(
             textAttachment: self,
             parentView: parentView,
             textLayoutManager: textContainer?.textLayoutManager,
             location: location,
-            card: card
+            card: _card.mainThreadValue
         )
         provider.tracksTextAttachmentViewBounds = true
         return provider

--- a/Sources/TBDApp/Panes/WebviewPaneView.swift
+++ b/Sources/TBDApp/Panes/WebviewPaneView.swift
@@ -64,8 +64,11 @@ struct WebviewPaneView: NSViewRepresentable {
         }
 
         func observe(_ webView: WKWebView) {
-            urlObservation = webView.observe(\.url, options: [.initial, .new]) { [weak state] webView, _ in
-                let newURL = webView.url
+            // Read the URL from the change object (populated because we request
+            // `.new`, and also on the `.initial` callback) instead of touching
+            // the main-actor `webView.url` from this nonisolated KVO closure.
+            urlObservation = webView.observe(\.url, options: [.initial, .new]) { [weak state] _, change in
+                let newURL = change.newValue ?? nil
                 Task { @MainActor in state?.currentURL = newURL }
             }
         }

--- a/Sources/TBDApp/Settings/ComboBoxField.swift
+++ b/Sources/TBDApp/Settings/ComboBoxField.swift
@@ -41,6 +41,7 @@ struct ComboBoxField: NSViewRepresentable {
         }
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSComboBoxDelegate {
         @Binding var text: String
         init(text: Binding<String>) { self._text = text }

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -375,8 +375,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
         // Close-on-exec so spawned children don't inherit the pipe ends.
-        fcntl(fds[0], F_SETFD, FD_CLOEXEC)
-        fcntl(fds[1], F_SETFD, FD_CLOEXEC)
+        _ = fcntl(fds[0], F_SETFD, FD_CLOEXEC)
+        _ = fcntl(fds[1], F_SETFD, FD_CLOEXEC)
         _relaunchPipeWriteEnd = fds[1]
 
         signal(SIGUSR1) { _ in

--- a/Sources/TBDApp/Terminal/FDSidecarClient.swift
+++ b/Sources/TBDApp/Terminal/FDSidecarClient.swift
@@ -38,7 +38,7 @@ final class FDSidecarClient: @unchecked Sendable {
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
         let sunPathSize = MemoryLayout.size(ofValue: addr.sun_path)
-        _ = path.withCString { src in
+        path.withCString { src in
             withUnsafeMutablePointer(to: &addr.sun_path) { dst in
                 dst.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { dstChars in
                     _ = strlcpy(dstChars, src, sunPathSize)

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -601,7 +601,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                     // Generation-scoped like the daemon-side detach below: a
                     // closing view's clear racing a new view's attach for the
                     // same pane must not drop the fresh attach's record.
-                    await appState.controlModePaneDetached(
+                    appState.controlModePaneDetached(
                         worktreeID: attach.worktreeID, paneID: attach.paneID,
                         generation: attach.generation)
                     // Order matters: detach first so the daemon closes the

--- a/Sources/TBDDaemon/Server/FDVendingServer.swift
+++ b/Sources/TBDDaemon/Server/FDVendingServer.swift
@@ -120,7 +120,7 @@ actor FDVendingServer {
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
         let sunPathSize = MemoryLayout.size(ofValue: addr.sun_path)
-        _ = path.withCString { src in
+        path.withCString { src in
             withUnsafeMutablePointer(to: &addr.sun_path) { dst in
                 dst.withMemoryRebound(to: CChar.self, capacity: sunPathSize) { dstChars in
                     _ = strlcpy(dstChars, src, sunPathSize)

--- a/Sources/TBDDaemon/Server/HTTPServer.swift
+++ b/Sources/TBDDaemon/Server/HTTPServer.swift
@@ -143,14 +143,16 @@ private final class HTTPRPCHandler: ChannelInboundHandler, @unchecked Sendable {
             let responseData = try JSONEncoder().encode(response)
             guard let responseString = String(data: responseData, encoding: .utf8) else { return }
 
-            let context = wrappedCtx.context
-            context.eventLoop.execute {
+            let eventLoop = wrappedCtx.context.eventLoop
+            eventLoop.execute {
+                let context = wrappedCtx.context
                 guard context.channel.isActive else { return }
                 Self.sendResponseOnLoop(context: context, status: .ok, body: responseString)
             }
         } catch {
-            let context = wrappedCtx.context
-            context.eventLoop.execute {
+            let eventLoop = wrappedCtx.context.eventLoop
+            eventLoop.execute {
+                let context = wrappedCtx.context
                 guard context.channel.isActive else { return }
                 Self.sendResponseOnLoop(context: context, status: .internalServerError,
                                         body: "{\"success\":false,\"error\":\"Failed to encode response\"}")

--- a/Sources/TBDDaemon/Server/SocketServer.swift
+++ b/Sources/TBDDaemon/Server/SocketServer.swift
@@ -202,8 +202,12 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
             // ChannelHandlerContext access must be dispatched to the event loop.
             // Accessing context.channel off the event loop hits a NIO precondition.
             let subID = router.registerSubscription { deltaData in
-                let context = sendableCtx.context
-                context.eventLoop.execute {
+                // EventLoop is Sendable; .eventLoop is the one property NIO
+                // permits off-loop. Unwrap the context INSIDE the closure so
+                // all channel access stays on the loop.
+                let eventLoop = sendableCtx.context.eventLoop
+                eventLoop.execute {
+                    let context = sendableCtx.context
                     guard context.channel.isActive else { return }
                     guard let deltaString = String(data: deltaData, encoding: .utf8) else { return }
                     var outBuffer = context.channel.allocator.buffer(capacity: deltaString.utf8.count + 1)
@@ -217,8 +221,9 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
 
             // Clean up subscription when the channel closes.
             // Must access context.channel on the event loop.
-            let context = sendableCtx.context
-            context.eventLoop.execute {
+            let eventLoop = sendableCtx.context.eventLoop
+            eventLoop.execute {
+                let context = sendableCtx.context
                 context.channel.closeFuture.whenComplete { _ in
                     router.removeSubscription(id: subID)
                 }
@@ -228,7 +233,8 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
             let ack = RPCResponse.ok()
             if let ackData = try? JSONEncoder().encode(ack),
                let ackString = String(data: ackData, encoding: .utf8) {
-                context.eventLoop.execute {
+                eventLoop.execute {
+                    let context = sendableCtx.context
                     guard context.channel.isActive else { return }
                     var outBuffer = context.channel.allocator.buffer(capacity: ackString.utf8.count + 1)
                     outBuffer.writeString(ackString)
@@ -268,8 +274,9 @@ private final class SocketRPCHandler: ChannelInboundHandler, @unchecked Sendable
             let responseData = try JSONEncoder().encode(response)
             guard let responseString = String(data: responseData, encoding: .utf8) else { return }
 
-            let context = wrappedCtx.context
-            context.eventLoop.execute {
+            let eventLoop = wrappedCtx.context.eventLoop
+            eventLoop.execute {
+                let context = wrappedCtx.context
                 guard context.channel.isActive else { return }
                 var outBuffer = context.channel.allocator.buffer(capacity: responseString.utf8.count + 1)
                 outBuffer.writeString(responseString)

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -366,19 +366,19 @@ public struct TmuxManager: Sendable {
             let output = try await runTmux(args)
             logger.info("ensureServer: created tmux server \(server, privacy: .public)")
             // Hide tmux chrome globally — TBD app provides its own UI
-            try? await runTmux(["-L", server, "set", "-g", "status", "off"])
-            try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
-            try? await runTmux(["-L", server, "set", "-g", "pane-border-indicators", "off"])
-            try? await runTmux(["-L", server, "set", "-g", "default-terminal", "xterm-256color"])
+            _ = try? await runTmux(["-L", server, "set", "-g", "status", "off"])
+            _ = try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
+            _ = try? await runTmux(["-L", server, "set", "-g", "pane-border-indicators", "off"])
+            _ = try? await runTmux(["-L", server, "set", "-g", "default-terminal", "xterm-256color"])
             // Enable mouse so scroll wheel enters copy-mode and scrolls history
-            try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
+            _ = try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
             // Enable extended key sequences so Shift+Arrow etc. pass through to applications
-            try? await runTmux(["-L", server, "set", "-g", "xterm-keys", "on"])
+            _ = try? await runTmux(["-L", server, "set", "-g", "xterm-keys", "on"])
             // Enable Kitty keyboard protocol so apps can distinguish Shift+Enter from Enter
-            try? await runTmux(["-L", server, "set", "-g", "extended-keys", "on"])
-            try? await runTmux(["-L", server, "set", "-g", "extended-keys-format", "kitty"])
+            _ = try? await runTmux(["-L", server, "set", "-g", "extended-keys", "on"])
+            _ = try? await runTmux(["-L", server, "set", "-g", "extended-keys-format", "kitty"])
             // Set SSH_AUTH_SOCK to stable symlink so shells get a resilient path
-            try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.defaultSymlinkPath])
+            _ = try? await runTmux(["-L", server, "setenv", "-g", "SSH_AUTH_SOCK", SSHAgentResolver.defaultSymlinkPath])
             return output.trimmingCharacters(in: .whitespacesAndNewlines)
         }
     }
@@ -500,7 +500,7 @@ public struct TmuxManager: Sendable {
         // if the option flip stumbles. Detached panes still keep the
         // resize-window dimensions; only client-driven re-sizing depends on
         // window-size being non-manual.
-        try? await runTmux(unfreezeArgs)
+        _ = try? await runTmux(unfreezeArgs)
     }
 
     public func sendKeys(server: String, paneID: String, text: String) async throws {


### PR DESCRIPTION
## Summary
- Follow-up to #399: the Swift 6.3 toolchain surfaced 32 new first-party warnings. This makes the build fully warning-free again under 6.3 (and still clean under 6.2.4).
- **Mechanical half** (`690fa1b9`): `_ =` on fire-and-forget `try?`/`fcntl` results, dropped redundant `_ =`/`await`, and replaced deprecated `String(cString:)` in `DaemonLiveness` with a length-sliced `String(decoding:as:)` that preserves the exact NUL-termination and lossy-repair semantics (empirically verified byte-identical).
- **Concurrency half** (`c3d1895c`): each of the 16 Sendable/main-actor diagnostics was first triaged read-only against its actual runtime contract — **all 16 are false positives** (NIO event-loop confinement via `eventLoop.execute`, serial-queue confinement in `CodeHighlightService`, AppKit/TextKit/KVO main-thread delivery). Fixes are behavior-preserving annotations: unwrap the `@unchecked Sendable` context box *inside* the `execute` closure (never moving channel access off-loop), class-level `@unchecked Sendable` for documented queue confinement, `MainActor.assumeIsolated` on AppKit callbacks (traps loudly if the contract ever breaks), value hoisting, `@MainActor` Coordinator, and the file's existing `_SendableBox` pattern for `TranscriptCardAttachment` (where `assumeIsolated` can't compile — `NSTextAttachmentViewProvider`'s Sendable conformance is unavailable on macOS).
- Code review verified the four riskiest spots independently, including against vendored NIO source (`context.eventLoop` is the one property without an event-loop assertion) and KVO `.initial`+`.new` delivery semantics. No blocking findings.

## Test plan
- [x] `TOOLCHAINS=<6.3.3> swift build` — 0 first-party warnings (only 3 pre-existing package-resource warnings remain)
- [x] `swift build` under default 6.2.4 — clean (annotations are valid 6.2 constructs)
- [x] `swift test --parallel -j 2` — 3,163 tests / 388 suites pass
- [x] `swiftlint --strict` — 0 violations
- [ ] CI green on this PR

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=5FEEF6B8-242F-4CD1-9BEE-12BB0E19F7DA)