### PR TITLE
Feat: Park a worktree's Claude session when its PR merges, without killing the worktree

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -32,6 +32,9 @@ extension AppState {
             if result.autoArchiveOnMergeDefault != autoArchiveOnMergeDefault {
                 autoArchiveOnMergeDefault = result.autoArchiveOnMergeDefault
             }
+            if result.autoHibernateOnMergeDefault != autoHibernateOnMergeDefault {
+                autoHibernateOnMergeDefault = result.autoHibernateOnMergeDefault
+            }
             if result.nightwatchMode != nightwatchMode {
                 nightwatchMode = result.nightwatchMode
             }
@@ -173,6 +176,17 @@ extension AppState {
             autoArchiveOnMergeDefault = enabled
         } catch {
             logger.error("Failed to set auto-archive default: \(error, privacy: .public)")
+            showAlert("Failed to set default: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set the global default for auto-hibernate-on-PR-merge.
+    func setAutoHibernateOnMergeDefault(_ enabled: Bool) async {
+        do {
+            try await daemonClient.setAutoHibernateOnMergeDefault(enabled)
+            autoHibernateOnMergeDefault = enabled
+        } catch {
+            logger.error("Failed to set auto-hibernate default: \(error, privacy: .public)")
             showAlert("Failed to set default: \(error.localizedDescription)", isError: true)
         }
     }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -727,6 +727,30 @@ extension AppState {
         }
     }
 
+    /// Resolve the effective auto-hibernate-on-merge setting for a worktree.
+    /// Returns the per-worktree override when explicitly set; otherwise falls
+    /// back to the global default (`autoHibernateOnMergeDefault`).
+    func effectiveAutoHibernate(for worktree: Worktree) -> Bool {
+        worktree.autoHibernateOnMerge ?? autoHibernateOnMergeDefault
+    }
+
+    /// Set the per-worktree auto-hibernate override and update local state optimistically.
+    func setAutoHibernate(worktreeID: UUID, enabled: Bool) async {
+        do {
+            try await daemonClient.setWorktreeAutoHibernate(id: worktreeID, enabled: enabled)
+            // Optimistic local update so the toolbar reflects it immediately.
+            for (key, list) in worktrees {
+                if let idx = list.firstIndex(where: { $0.id == worktreeID }) {
+                    worktrees[key]?[idx].autoHibernateOnMerge = enabled
+                    break
+                }
+            }
+        } catch {
+            logger.error("Failed to set auto-hibernate: \(error, privacy: .public)")
+            showAlert("Couldn't update auto-hibernate: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Repo ID of the repo containing the given worktree, if any.
     private func repoIDForWorktree(_ id: UUID) -> UUID? {
         for (rid, rows) in worktrees where rows.contains(where: { $0.id == id }) {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -414,6 +414,9 @@ final class AppState: ObservableObject {
     /// Global default for auto-archive-on-PR-merge. Loaded from the daemon
     /// alongside `globalEnvOverrides` via `loadModelProfiles()`.
     @Published var autoArchiveOnMergeDefault: Bool = false
+    /// Global default for auto-hibernate-on-PR-merge. Loaded from the daemon
+    /// alongside `autoArchiveOnMergeDefault` via `loadModelProfiles()`.
+    @Published var autoHibernateOnMergeDefault: Bool = false
     @Published var nightwatchMode: NightwatchMode = .off
     /// Auto-hibernate master switch. Loaded from the daemon `Config` via
     /// `loadHibernationConfig()`.

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -217,20 +217,25 @@ struct ContentView: View {
                             // split button otherwise accent-tints it); the icon keeps
                             // its baked status color via renderingMode(.original).
                             .tint(.primary)
-                            // Three-way: while child worktrees exist the daemon's
+                            // Build the tooltip as an ordered clause list so
+                            // "more options" is structurally guaranteed to land
+                            // last, whatever combination of arm states applies.
+                            // The archive clause keeps its three-way wording:
+                            // while child worktrees exist the daemon's
                             // AutoArchiveOnMergeCoordinator skips archiving (it
-                            // re-checks at merge time), so an armed-but-blocked
-                            // worktree must not promise "auto-archives on merge".
+                            // re-checks active children at merge time), so an
+                            // armed-but-blocked worktree must not promise
+                            // "auto-archives on merge".
                             .help({
-                                // Keep the three-way archive wording, then append
-                                // the hibernate clause when armed — clearer than a
-                                // combinatorial 6-way string.
-                                let base = armed && blocked
-                                    ? "Open PR #\(prStatus.number) · auto-archive armed (paused while child worktrees exist) · more options"
-                                    : armed
-                                        ? "Open PR #\(prStatus.number) · auto-archives on merge · more options"
-                                        : "Open PR #\(prStatus.number) · more options"
-                                return hibernateArmed ? base + " · auto-hibernates on merge" : base
+                                var clauses = ["Open PR #\(prStatus.number)"]
+                                if armed && blocked {
+                                    clauses.append("auto-archive armed (paused while child worktrees exist)")
+                                } else if armed {
+                                    clauses.append("auto-archives on merge")
+                                }
+                                if hibernateArmed { clauses.append("auto-hibernates on merge") }
+                                clauses.append("more options")
+                                return clauses.joined(separator: " · ")
                             }())
                             // AppKit materializes this split button's NSMenu and
                             // label ONCE; later SwiftUI re-evaluations of the

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -196,7 +196,7 @@ struct ContentView: View {
                                     ))
                                 }
                             } label: {
-                                PRButtonLabel(prStatus: prStatus, isAutoArchiveArmed: armed)
+                                PRButtonLabel(prStatus: prStatus, isAutoArchiveArmed: armed, isAutoHibernateArmed: hibernateArmed)
                             } primaryAction: {
                                 let existingTabs = appState.tabs[worktreeID] ?? []
                                 if let existingIndex = existingTabs.firstIndex(where: {
@@ -432,23 +432,35 @@ private func overlayFrameIsWindowRoot(
 struct PRButtonLabel: View {
     let prStatus: PRStatus
     let isAutoArchiveArmed: Bool
+    let isAutoHibernateArmed: Bool
     // Feeds the baked-icon cache key (and, at the ContentView level, the
     // toolbar item's .id key) so light/dark changes re-bake the non-template
     // icon, which can't auto-adapt the way a tinted template would.
     @Environment(\.colorScheme) private var colorScheme
 
-    /// Baked image geometry: 12×12 status icon, plus (when armed) a 3pt gap
-    /// and a 12×12 archivebox badge composited into the same bitmap.
+    /// Baked image geometry: a 12×12 status icon, followed left→right by up to
+    /// two 12×12 armed badges — an `archivebox` (auto-archive) then a
+    /// `moon.zzz` (auto-hibernate) — each preceded by a 3pt gap and composited
+    /// into the same bitmap. The order is stable regardless of which flags are
+    /// armed: when only hibernate is armed, `moon.zzz` occupies the first badge
+    /// slot immediately after the icon (no empty archivebox gap).
     static let iconSide: CGFloat = 12
     static let badgeGap: CGFloat = 3
 
     /// A queued PR renders the full-color bus (with its position baked in)
-    /// instead of the status icon; the archivebox armed-badge is suppressed in
-    /// that mode, so the baked image stays a single square.
+    /// instead of the status icon; BOTH armed badges are suppressed in that
+    /// mode (the bus owns the label), so the baked image stays a single square.
     var isMergeQueued: Bool { prStatus.mergeQueuePosition != nil }
 
+    /// Number of armed badges to composite. Zero when queued (the bus glyph
+    /// supersedes both badges), otherwise one per armed flag.
+    var badgeCount: Int {
+        guard !isMergeQueued else { return 0 }
+        return (isAutoArchiveArmed ? 1 : 0) + (isAutoHibernateArmed ? 1 : 0)
+    }
+
     var bakedWidth: CGFloat {
-        (isAutoArchiveArmed && !isMergeQueued) ? Self.iconSide + Self.badgeGap + Self.iconSide : Self.iconSide
+        Self.iconSide + CGFloat(badgeCount) * (Self.badgeGap + Self.iconSide)
     }
 
     /// The `.id` key for the PR split-button toolbar item. AppKit materializes
@@ -518,21 +530,26 @@ struct PRButtonLabel: View {
             // macOS 26 flattens a toolbar split-button (Menu) label to exactly
             // ONE image + ONE plain text string: a separate trailing Image is
             // dropped, and an inline Text(Image(...)) attachment is stripped
-            // entirely. Any badge (like the auto-archive-armed archivebox)
-            // must therefore be composited INTO the single baked NSImage.
+            // entirely. Any badge (like the auto-archive-armed archivebox or
+            // the auto-hibernate-armed moon.zzz) must therefore be composited
+            // INTO the single baked NSImage.
             Text(verbatim: "#\(prStatus.number)")
                 .font(.caption)
                 .fontWeight(.medium)
         }
-        .accessibilityLabel(
-            isAutoArchiveArmed
-                ? "PR #\(prStatus.number), auto-archive on merge is on"
-                : "PR #\(prStatus.number)"
-        )
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        var clauses = ["PR #\(prStatus.number)"]
+        if isAutoArchiveArmed { clauses.append("auto-archive on merge is on") }
+        if isAutoHibernateArmed { clauses.append("auto-hibernate on merge is on") }
+        return clauses.joined(separator: ", ")
     }
 
     /// Cache for baked `.asset` icons, keyed by (asset name, colorSemantic,
-    /// armed, colorScheme). (The `.emoji` bus glyph is cached separately by
+    /// archiveArmed, hibernateArmed, colorScheme). (The `.emoji` bus glyph is
+    /// cached separately by
     /// `PRStatusPresentation.busImage`.) The bake does disk I/O (`Bundle.module.url` +
     /// `NSImage(contentsOf:)`) plus symbol creation on every body evaluation,
     /// and — per the materialize-once behavior documented at the `.id` call
@@ -547,29 +564,42 @@ struct PRButtonLabel: View {
     /// split-button labels render template images monochrome (AppKit tints
     /// them with the control color and ignores `.foregroundStyle`), so the
     /// icon must carry its own color and be drawn with `.renderingMode(.original)`.
-    /// When auto-archive is armed, an `archivebox` badge (tinted
-    /// `secondaryLabelColor`) is composited to the right of the status icon —
-    /// the flattened toolbar label keeps only this one image, so the badge
-    /// must live inside it.
+    /// When auto-archive and/or auto-hibernate are armed, an `archivebox`
+    /// and/or `moon.zzz` badge (each tinted `secondaryLabelColor`) is
+    /// composited left→right after the status icon — the flattened toolbar
+    /// label keeps only this one image, so the badges must live inside it.
     @MainActor
     func coloredIcon(_ presentation: PRStatusPresentation, colorScheme: ColorScheme) -> NSImage? {
         // Merge-queue bus: full-color glyph with its position baked in via the
         // SAME shared helper the sidebar uses. It must NOT be tinted, so skip
-        // the color-baking fill path entirely (and the archivebox armed-badge —
-        // queue mode supersedes it, matching `bakedWidth`).
+        // the color-baking fill path entirely (and both armed badges — queue
+        // mode supersedes them, matching `bakedWidth`).
         if case .emoji = presentation.glyph {
             return PRStatusPresentation.busImage(position: presentation.badge, side: Self.iconSide)
         }
         guard case .asset(let name) = presentation.glyph else { return nil }
-        let cacheKey = "\(name)-\(presentation.colorSemantic)-\(isAutoArchiveArmed)-\(colorScheme)"
+        // Both armed flags MUST be in the key: an armed/unarmed pair otherwise
+        // renders from the same cached bitmap and the badge silently never
+        // updates.
+        let cacheKey = "\(name)-\(presentation.colorSemantic)"
+            + "-\(isAutoArchiveArmed)-\(isAutoHibernateArmed)-\(colorScheme)"
         if let cached = Self.bakedIconCache[cacheKey] { return cached }
         let nsColor = presentation.nsColor
         guard let url = Bundle.module.url(forResource: name, withExtension: "svg", subdirectory: "Icons"),
               let base = NSImage(contentsOf: url) else { return nil }
         base.isTemplate = true
-        let badge: NSImage? = isAutoArchiveArmed
-            ? NSImage(systemSymbolName: "archivebox", accessibilityDescription: "Auto-archive on merge is on")
-            : nil
+        // Ordered list of armed badge symbols, left→right: archivebox then
+        // moon.zzz. Only the armed ones are included, so when only hibernate is
+        // armed moon.zzz takes the first slot immediately after the status icon.
+        var badges: [NSImage] = []
+        if isAutoArchiveArmed,
+           let archive = NSImage(systemSymbolName: "archivebox", accessibilityDescription: "Auto-archive on merge is on") {
+            badges.append(archive)
+        }
+        if isAutoHibernateArmed,
+           let moon = NSImage(systemSymbolName: "moon.zzz", accessibilityDescription: "Auto-hibernate on merge is on") {
+            badges.append(moon)
+        }
         let side = Self.iconSide
         let img = NSImage(size: NSSize(width: bakedWidth, height: side), flipped: false) { _ in
             // Colors are resolved inside this draw handler, so dynamic colors
@@ -578,11 +608,12 @@ struct PRButtonLabel: View {
             base.draw(in: iconRect, from: .zero, operation: .sourceOver, fraction: 1)
             nsColor.set()
             iconRect.fill(using: .sourceAtop)
-            if let badge {
-                // Aspect-fit: the archivebox symbol's intrinsic size is
-                // non-square (~16×14); drawing it straight into the square
-                // slot would stretch it ~12% vertically.
-                let slot = NSRect(x: side + Self.badgeGap, y: 0, width: side, height: side)
+            for (index, badge) in badges.enumerated() {
+                // Aspect-fit: the badge symbols' intrinsic sizes are non-square
+                // (archivebox ~16×14); drawing them straight into the square
+                // slot would stretch them.
+                let slotX = side + CGFloat(index + 1) * Self.badgeGap + CGFloat(index) * side
+                let slot = NSRect(x: slotX, y: 0, width: side, height: side)
                 let badgeRect = Self.aspectFitRect(for: badge.size, in: slot)
                 badge.draw(in: badgeRect, from: .zero, operation: .sourceOver, fraction: 1)
                 NSColor.secondaryLabelColor.set()

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -161,6 +161,7 @@ struct ContentView: View {
                    let prURL = URL(string: prStatus.url) {
                     let worktree = appState.findWorktree(id: worktreeID)
                     let armed = worktree.map { appState.effectiveAutoArchive(for: $0) } ?? false
+                    let hibernateArmed = worktree.map { appState.effectiveAutoHibernate(for: $0) } ?? false
                     let blocked = !appState.children(of: worktreeID).isEmpty
                     ToolbarItem(placement: .primaryAction) {
                         ControlGroup {
@@ -178,6 +179,21 @@ struct ContentView: View {
                                         }
                                     ))
                                     .disabled(blocked)
+                                    // Plain 2-state toggle bound to the EFFECTIVE
+                                    // value; the setter always writes explicit
+                                    // true/false (no UI path back to nil — the
+                                    // tri-state stays reachable via daemon/DB only,
+                                    // matching auto-archive). Deliberately NOT
+                                    // `.disabled(blocked)`: `blocked` is the
+                                    // archive-specific active-children rule, and the
+                                    // daemon's precedence lets an armed-but-blocked
+                                    // archive still hibernate.
+                                    Toggle("Auto-hibernate sessions on PR merge", isOn: Binding(
+                                        get: { hibernateArmed },
+                                        set: { newValue in
+                                            Task { await appState.setAutoHibernate(worktreeID: worktreeID, enabled: newValue) }
+                                        }
+                                    ))
                                 }
                             } label: {
                                 PRButtonLabel(prStatus: prStatus, isAutoArchiveArmed: armed)
@@ -205,28 +221,33 @@ struct ContentView: View {
                             // AutoArchiveOnMergeCoordinator skips archiving (it
                             // re-checks at merge time), so an armed-but-blocked
                             // worktree must not promise "auto-archives on merge".
-                            .help(
-                                armed && blocked
+                            .help({
+                                // Keep the three-way archive wording, then append
+                                // the hibernate clause when armed — clearer than a
+                                // combinatorial 6-way string.
+                                let base = armed && blocked
                                     ? "Open PR #\(prStatus.number) · auto-archive armed (paused while child worktrees exist) · more options"
                                     : armed
                                         ? "Open PR #\(prStatus.number) · auto-archives on merge · more options"
                                         : "Open PR #\(prStatus.number) · more options"
-                            )
+                                return hibernateArmed ? base + " · auto-hibernates on merge" : base
+                            }())
                             // AppKit materializes this split button's NSMenu and
                             // label ONCE; later SwiftUI re-evaluations of the
                             // Toggle checkmark and armed badge never reach the
                             // already-built NSMenuToolbarItem. Changing the id
                             // forces the item to be recreated, so the key must
                             // include EVERYTHING the label/menu render: worktree
-                            // + whether its row has loaded (gates the menu's only
-                            // item), armed + blocked (menu + help), the rendered
-                            // PRStatus fields (number, state, url — not reason,
-                            // which presentation ignores), and colorScheme
-                            // (baked icon colors).
+                            // + whether its row has loaded (gates the menu's
+                            // items), armed + hibernateArmed + blocked (menu +
+                            // help), the rendered PRStatus fields (number, state,
+                            // url — not reason, which presentation ignores), and
+                            // colorScheme (baked icon colors).
                             .id(PRButtonLabel.prSplitButtonID(
                                 worktreeID: worktreeID,
                                 worktreeFound: worktree != nil,
                                 armed: armed,
+                                hibernateArmed: hibernateArmed,
                                 blocked: blocked,
                                 prStatus: prStatus,
                                 colorScheme: colorScheme
@@ -429,9 +450,11 @@ struct PRButtonLabel: View {
     /// the split button's NSMenu and label ONCE, so the key must include
     /// EVERYTHING the label/menu render — anything omitted here can change in
     /// SwiftUI state without ever reaching the materialized AppKit item.
-    /// `worktreeFound` matters because the menu's only item (the auto-archive
-    /// Toggle) is gated on the worktree row having loaded: a menu materialized
-    /// before the row appears would otherwise stay permanently empty. The key
+    /// `worktreeFound` matters because the menu's items (the auto-archive and
+    /// auto-hibernate Toggles) are gated on the worktree row having loaded: a
+    /// menu materialized before the row appears would otherwise stay
+    /// permanently empty. `hibernateArmed` mirrors `armed`: without it the
+    /// hibernate Toggle's checkmark would freeze at its first-render value. The key
     /// contains exactly the `PRStatus` fields the label/menu/primaryAction
     /// consume: `number` (label text/help), `state` (icon via
     /// `PRStatusPresentation`), `url` (captured by `primaryAction`, so a
@@ -451,11 +474,12 @@ struct PRButtonLabel: View {
         worktreeID: UUID,
         worktreeFound: Bool,
         armed: Bool,
+        hibernateArmed: Bool,
         blocked: Bool,
         prStatus: PRStatus,
         colorScheme: ColorScheme
     ) -> String {
-        "pr-split-\(worktreeID)-\(worktreeFound)-\(armed)-\(blocked)"
+        "pr-split-\(worktreeID)-\(worktreeFound)-\(armed)-\(hibernateArmed)-\(blocked)"
             + "-\(prStatus.number)-\(prStatus.state.rawValue)-\(prStatus.url)"
             + "-\(prStatus.mergeQueuePosition.map(String.init) ?? "nil")"
             + "-\(colorScheme)"

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -745,6 +745,22 @@ actor DaemonClient {
         )
     }
 
+    /// Set the per-worktree auto-hibernate-on-PR-merge override.
+    func setWorktreeAutoHibernate(id: UUID, enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.worktreeSetAutoHibernate,
+            params: WorktreeSetAutoHibernateParams(worktreeID: id, enabled: enabled)
+        )
+    }
+
+    /// Set the global default for auto-hibernate-on-PR-merge.
+    func setAutoHibernateOnMergeDefault(_ enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetAutoHibernateOnMergeDefault,
+            params: ConfigSetAutoHibernateDefaultParams(enabled: enabled)
+        )
+    }
+
     /// Set the global session-limit auto-resume gate.
     func setAutoResumeOnLimitReset(_ enabled: Bool) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -136,6 +136,12 @@ struct GeneralSettingsTab: View {
                 ))
                 .help("Default for new worktrees. Each worktree can override this from its toolbar toggle.")
 
+                Toggle("Auto-hibernate sessions when their PR merges", isOn: Binding(
+                    get: { appState.autoHibernateOnMergeDefault },
+                    set: { newValue in Task { await appState.setAutoHibernateOnMergeDefault(newValue) } }
+                ))
+                .help("Default for new worktrees. Parks each idle Claude session (freeing its memory, keeping the frozen screen and resumability) instead of archiving the worktree. Each worktree can override this from its PR toolbar menu.")
+
                 Toggle("Show Scratch section", isOn: $showScratchSection)
                     .help("Hide the repo-less Scratch section. Existing scratch spaces and their terminals keep running.")
             }

--- a/Sources/TBDCLI/Commands/ConfigCommands.swift
+++ b/Sources/TBDCLI/Commands/ConfigCommands.swift
@@ -23,6 +23,7 @@ struct ConfigGet: AsyncParsableCommand {
             printJSON(config)
         } else {
             print("auto-archive-on-merge: \(config.autoArchiveOnMergeDefault ? "on" : "off")")
+            print("auto-hibernate-on-merge: \(config.autoHibernateOnMergeDefault ? "on" : "off")")
         }
     }
 }
@@ -30,7 +31,7 @@ struct ConfigGet: AsyncParsableCommand {
 struct ConfigSet: AsyncParsableCommand {
     static let configuration = CommandConfiguration(commandName: "set", abstract: "Set a global setting")
 
-    @Argument(help: "Setting key (currently: auto-archive-on-merge)")
+    @Argument(help: "Setting key (currently: auto-archive-on-merge, auto-hibernate-on-merge)")
     var key: String
 
     @Argument(help: "on or off")
@@ -44,8 +45,13 @@ struct ConfigSet: AsyncParsableCommand {
                 method: RPCMethod.configSetAutoArchiveOnMergeDefault,
                 params: ConfigSetAutoArchiveDefaultParams(enabled: value.boolValue))
             print("Set auto-archive-on-merge default to \(value.rawValue).")
+        case "auto-hibernate-on-merge":
+            try client.callVoid(
+                method: RPCMethod.configSetAutoHibernateOnMergeDefault,
+                params: ConfigSetAutoHibernateDefaultParams(enabled: value.boolValue))
+            print("Set auto-hibernate-on-merge default to \(value.rawValue).")
         default:
-            throw CLIError.invalidArgument("Unknown config key '\(key)'. Known keys: auto-archive-on-merge")
+            throw CLIError.invalidArgument("Unknown config key '\(key)'. Known keys: auto-archive-on-merge, auto-hibernate-on-merge")
         }
     }
 }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -419,16 +419,6 @@ public final class Daemon: Sendable {
             try? await database.audit.logAction(entry)
         }
 
-        // 7a. Wire auto-archive-on-merge: when a worktree's cached PR state
-        // transitions into `.merged`, the coordinator evaluates the effective
-        // setting and archives the worktree (no active children) in the
-        // background.
-        let autoArchiveCoordinator = AutoArchiveOnMergeCoordinator(
-            db: database, lifecycle: lifecycle, subscriptions: subs)
-        await prManager.setOnMergedTransition { worktreeID, prNumber in
-            await autoArchiveCoordinator.handleMergedTransition(worktreeID: worktreeID, prNumber: prNumber)
-        }
-
         // 8. Initialize RPC router
         let rpcRouter = RPCRouter(
             db: database,
@@ -449,6 +439,30 @@ public final class Daemon: Sendable {
         await rpcRouter.hibernationCoordinator.setOnServerCreated { server in
             await controlModeBridge.enableIfGated(serverName: server)
         }
+
+        // 8a. Wire the merged-PR transition fan-out. When a worktree's cached PR
+        // state transitions into `.merged`, the dispatcher evaluates auto-archive
+        // (archive supersedes hibernate) and, if the worktree survives, auto-park
+        // its idle Claude sessions. `PRStatusManager.onMergedTransition` is a
+        // SINGLE callback, so the dispatcher owns both coordinators.
+        //
+        // ORDERING CONSTRAINT — do NOT move this earlier: the hibernate
+        // coordinator needs `rpcRouter.hibernationCoordinator`, which only exists
+        // after the RPCRouter is constructed above. It's safe here because the
+        // only thing that fires a merged transition is `PRStatusManager.fetchAll`
+        // / `refresh`, both reachable ONLY via the `pr.list` / `pr.refresh` RPC
+        // handlers — and the socket server that serves those doesn't start until
+        // step 9 below. So no merge can be observed between construction and here.
+        let autoArchiveCoordinator = AutoArchiveOnMergeCoordinator(
+            db: database, lifecycle: lifecycle, subscriptions: subs)
+        let autoHibernateCoordinator = AutoHibernateOnMergeCoordinator(
+            db: database, hibernation: rpcRouter.hibernationCoordinator, subscriptions: subs)
+        let mergedTransitionDispatcher = MergedTransitionDispatcher(
+            archive: autoArchiveCoordinator, hibernate: autoHibernateCoordinator)
+        await prManager.setOnMergedTransition { worktreeID, prNumber in
+            await mergedTransitionDispatcher.handleMergedTransition(worktreeID: worktreeID, prNumber: prNumber)
+        }
+
         self.router = rpcRouter
 
         // Shared foreground gate: the app reports its active/inactive state via

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -17,6 +17,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     /// JSON-encoded `[String: String]` free-form env overrides (global scope).
     var env_overrides: String?
     var auto_archive_on_merge_default: Bool?
+    var auto_hibernate_on_merge_default: Bool?
     var auto_resume_on_limit_reset: Bool?
     var scratch_instructions: String?
     var scratch_rename_prompt: String?
@@ -36,6 +37,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             envSettingOverrides: ConfigStore.decodeOverrides(claude_env_settings),
             envOverrides: EnvOverridesCoding.decode(env_overrides),
             autoArchiveOnMergeDefault: auto_archive_on_merge_default ?? false,
+            autoHibernateOnMergeDefault: auto_hibernate_on_merge_default ?? false,
             autoResumeOnLimitReset: auto_resume_on_limit_reset ?? false,
             scratchInstructions: scratch_instructions,
             scratchRenamePrompt: scratch_rename_prompt,
@@ -129,6 +131,18 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET auto_archive_on_merge_default = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the global auto-hibernate-on-merge default. When true, every
+    /// worktree that hasn't overridden `autoHibernateOnMerge` will have its
+    /// Claude sessions hibernated when its PR merges.
+    public func setAutoHibernateOnMergeDefault(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_hibernate_on_merge_default = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -816,6 +816,23 @@ public final class TBDDatabase: Sendable {
                 table: "terminal", column: "hibernateReason", type: .text)
         }
 
+        // Per-worktree auto-hibernate-on-PR-merge override (sibling of
+        // v32_worktree_auto_archive). NULLABLE with NO default — tri-state:
+        // NULL = follow the global default (`config.auto_hibernate_on_merge_default`),
+        // `true`/`false` = explicit user override. Set only by user action.
+        migrator.registerMigration("v48_worktree_auto_hibernate") { db in
+            try db.addColumnIfMissing(table: "worktree", column: "autoHibernateOnMerge", type: .boolean)
+        }
+
+        // Global default for auto-hibernate-on-PR-merge (sibling of
+        // v33_config_auto_archive_default). Defaults false so existing rows
+        // decode to "feature OFF".
+        migrator.registerMigration("v49_config_auto_hibernate_default") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "auto_hibernate_on_merge_default",
+                type: .boolean, defaults: false)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -27,6 +27,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var activeTabID: String?
     var parentWorktreeID: String?
     var autoArchiveOnMerge: Bool?
+    var autoHibernateOnMerge: Bool?
     var prStatus: String?  // JSON-encoded PRStatus, nil when never observed
     var promotedToRepoID: String?  // set only on promoted scratch rows
 
@@ -52,6 +53,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.activeTabID = nil  // new worktrees start with no stored selection
         self.parentWorktreeID = wt.parentWorktreeID?.uuidString
         self.autoArchiveOnMerge = wt.autoArchiveOnMerge
+        self.autoHibernateOnMerge = wt.autoHibernateOnMerge
         self.prStatus = wt.prStatus.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         self.promotedToRepoID = wt.promotedToRepoID?.uuidString
     }
@@ -107,6 +109,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             archivedHeadSHA: archivedHeadSHA,
             parentWorktreeID: parentWorktreeID.flatMap { UUID(uuidString: $0) },
             autoArchiveOnMerge: autoArchiveOnMerge,
+            autoHibernateOnMerge: autoHibernateOnMerge,
             promotedToRepoID: promotedToRepoID.flatMap { UUID(uuidString: $0) },
             prStatus: pr
         )
@@ -783,6 +786,17 @@ public struct WorktreeStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE worktree SET autoArchiveOnMerge = ? WHERE id = ?",
+                arguments: [value, id.uuidString]
+            )
+        }
+    }
+
+    /// Set or clear the per-worktree auto-hibernate-on-merge override.
+    /// `nil` means follow the global default; `true`/`false` override it.
+    public func setAutoHibernateOnMerge(id: UUID, value: Bool?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE worktree SET autoHibernateOnMerge = ? WHERE id = ?",
                 arguments: [value, id.uuidString]
             )
         }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -203,6 +203,35 @@ public actor HibernationCoordinator {
         }
     }
 
+    /// Park a session because its worktree's PR merged. Honors every safety rail
+    /// (including keep-warm, unlike `manualHibernate`) but NOT the idle window or
+    /// the idle-sweep master switch — see `HibernationGate.decideForMerge`.
+    public func hibernateForMerge(terminalID: UUID) async -> HibernateResult {
+        guard let terminal = try? await db.terminals.get(id: terminalID) else {
+            return .notFound
+        }
+        guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
+        if let blocked = HibernationGate.blockingRail(terminal: terminal) {
+            return .notEligible(reason: Self.mergeBlockReason(blocked))
+        }
+        return await performHibernate(terminal: terminal, reason: .merged)
+    }
+
+    /// The reason a merge-park was refused, for logging/telemetry. Mirrors
+    /// `manualBlockReason` but maps every `blockingRail` case — including
+    /// keep-warm, which merge-park honors but manual bypasses.
+    private static func mergeBlockReason(_ decision: HibernationGate.Decision) -> String {
+        switch decision {
+        case .notClaudeResumable: return "Not a resumable Claude session"
+        case .alreadyHibernated: return "Terminal is already hibernated"
+        case .suspended: return "Terminal is suspended"
+        case .keepWarm: return "Terminal is pinned keep-warm"
+        case .running: return "Session is actively running"
+        case .waitingForUser: return "Session is waiting on a permission prompt"
+        case .eligible, .featureDisabled, .notIdleLongEnough: return "Not hibernatable"
+        }
+    }
+
     /// Gracefully terminate the pane's Claude and swap the pane to a bare shell
     /// via `respawn-window` (window + tab survive). Marks the row hibernated.
     ///

--- a/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
@@ -45,8 +45,26 @@ public enum HibernationGate {
         now: Date
     ) -> Decision {
         guard autoHibernateEnabled else { return .featureDisabled }
-        // Rails that don't depend on idle duration, ordered so the returned
-        // reason is the most specific blocker.
+        // Hard safety rails that don't depend on idle duration (returns the most
+        // specific blocker, or nil when all pass).
+        if let blocked = blockingRail(terminal: terminal) { return blocked }
+        // Idle-duration rail: needs a marker and enough elapsed time.
+        guard let idleSince, now.timeIntervalSince(idleSince) >= idleTimeout else {
+            return .notIdleLongEnough
+        }
+        return .eligible
+    }
+
+    /// The hard safety rails shared by EVERY park path — the ones that don't
+    /// depend on the idle-sweep master switch or the idle-duration window.
+    /// Returns the blocking `Decision` (the most specific blocker) or `nil` when
+    /// all rails pass.
+    ///
+    /// Ordered so the returned reason is the most specific blocker; callers rely
+    /// on this exact precedence (e.g. an already-hibernated running terminal
+    /// reports `.alreadyHibernated`, not `.running`). Kept identical to the cascade
+    /// that used to be inlined in `decide` so existing behavior is preserved.
+    static func blockingRail(terminal: Terminal) -> Decision? {
         guard terminal.isClaudeResumable else { return .notClaudeResumable }
         guard terminal.hibernatedAt == nil else { return .alreadyHibernated }
         guard terminal.suspendedAt == nil else { return .suspended }
@@ -57,12 +75,29 @@ public enum HibernationGate {
         case .waitingForUser:
             return .waitingForUser
         case .idle, .unknown:
-            break
+            return nil
         }
-        // Idle-duration rail: needs a marker and enough elapsed time.
-        guard let idleSince, now.timeIntervalSince(idleSince) >= idleTimeout else {
-            return .notIdleLongEnough
-        }
-        return .eligible
+    }
+
+    /// The park decision for a MERGE-triggered hibernate (PR merged →
+    /// auto-park the worktree's idle sessions).
+    ///
+    /// Deliberately consults NEITHER the idle-sweep master switch NOR the
+    /// idle-duration window — and this is the single most likely thing a future
+    /// reader gets wrong, so it is spelled out:
+    ///
+    ///  - No master switch: `config.autoHibernateEnabled` is the *idle sweep's*
+    ///    on/off. Merge-park is an independent feature armed by the per-worktree
+    ///    tri-state + `config.autoHibernateOnMergeDefault`, so gating it on the
+    ///    idle sweep's switch would wrongly couple the two.
+    ///  - No idle window: the trigger is the merge event, not "has been at rest
+    ///    for N minutes". A session that just went idle when its PR merged is a
+    ///    valid park target.
+    ///
+    /// It still honors every hard safety rail via `blockingRail` — including
+    /// keep-warm, unlike `manualHibernate` — because this is system-initiated,
+    /// not an explicit user request.
+    public static func decideForMerge(terminal: Terminal) -> Decision {
+        blockingRail(terminal: terminal) ?? .eligible
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -335,12 +335,18 @@ extension WorktreeLifecycle {
         // otherwise preserve them so a subsequent revive (without skipClaude) can use them.
         try await db.worktrees.revive(id: worktreeID, clearSessions: !skipClaude)
 
-        // Deliberate revive: disarm auto-archive so a still-merged PR doesn't
-        // immediately re-archive the worktree the user just revived.
+        // Deliberate revive: disarm auto-archive AND auto-hibernate so a
+        // still-merged PR doesn't immediately re-archive or re-park the
+        // worktree the user just revived.
         do {
             try await db.worktrees.setAutoArchiveOnMerge(id: worktreeID, value: false)
         } catch {
             archiveLogger.warning("failed to disarm auto-archive for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+        }
+        do {
+            try await db.worktrees.setAutoHibernateOnMerge(id: worktreeID, value: false)
+        } catch {
+            archiveLogger.warning("failed to disarm auto-hibernate for \(worktreeID, privacy: .public): \(error, privacy: .public)")
         }
 
         // Return updated worktree

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -344,6 +344,14 @@ extension WorktreeLifecycle {
                 } catch {
                     logger.warning("failed to disarm auto-archive for \(worktree.id, privacy: .public): \(error, privacy: .public)")
                 }
+                // Likewise disarm auto-hibernate-on-merge: a still-merged PR would
+                // otherwise immediately re-park the sessions in the worktree the
+                // user just deliberately revived.
+                do {
+                    try await db.worktrees.setAutoHibernateOnMerge(id: worktree.id, value: false)
+                } catch {
+                    logger.warning("failed to disarm auto-hibernate for \(worktree.id, privacy: .public): \(error, privacy: .public)")
+                }
             }
         } catch {
             logger.error("phase-3 status update failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Mock/MockSeeder.swift
+++ b/Sources/TBDDaemon/Mock/MockSeeder.swift
@@ -130,6 +130,9 @@ public struct MockSeeder: Sendable {
                 if let aam = wtSeed.autoArchiveOnMerge {
                     try await db.worktrees.setAutoArchiveOnMerge(id: wt.id, value: aam)
                 }
+                if let ahm = wtSeed.autoHibernateOnMerge {
+                    try await db.worktrees.setAutoHibernateOnMerge(id: wt.id, value: ahm)
+                }
             }
 
             for (termIdx, tSeed) in (wtSeed.terminals ?? []).enumerated() {

--- a/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
+++ b/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
@@ -17,12 +17,19 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
         self.subscriptions = subscriptions
     }
 
-    public func handleMergedTransition(worktreeID: UUID, prNumber: Int) async {
+    /// Returns `true` ONLY when it actually began archiving the worktree (i.e.
+    /// `beginArchiveWorktree` succeeded). Every early return — not active, not
+    /// effective, active children, or the outer catch — returns `false`. The
+    /// `MergedTransitionDispatcher` keys the archive-supersedes-hibernate
+    /// precedence off this Bool: an armed-but-blocked archive returns `false`, so
+    /// the worktree survives and its idle sessions are still eligible for merge-park.
+    @discardableResult
+    public func handleMergedTransition(worktreeID: UUID, prNumber: Int) async -> Bool {
         do {
-            guard let wt = try await db.worktrees.get(id: worktreeID), wt.status == .active else { return }
+            guard let wt = try await db.worktrees.get(id: worktreeID), wt.status == .active else { return false }
             let config = try await db.config.get()
             let effective = wt.autoArchiveOnMerge ?? config.autoArchiveOnMergeDefault
-            guard effective else { return }
+            guard effective else { return false }
 
             // Worktrees with active children are not auto-archivable. Narrow the
             // catch to the children guard so DB errors fall through to the outer
@@ -31,7 +38,7 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
                 try await db.worktrees.assertArchivable(id: worktreeID)
             } catch WorktreeArchiveError.hasActiveChildren {
                 logger.info("auto-archive skipped (active children): \(worktreeID, privacy: .public)")
-                return
+                return false
             }
 
             let (worktree, repo) = try await lifecycle.beginArchiveWorktree(worktreeID: worktreeID)
@@ -54,8 +61,10 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
                 await lifecycle.completeArchiveWorktree(worktree: worktree, repo: repo, force: false)
             }
             logger.info("auto-archived \(worktreeID, privacy: .public) on PR #\(prNumber, privacy: .public) merge")
+            return true
         } catch {
             logger.error("auto-archive failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+            return false
         }
     }
 }

--- a/Sources/TBDDaemon/PR/AutoHibernateOnMergeCoordinator.swift
+++ b/Sources/TBDDaemon/PR/AutoHibernateOnMergeCoordinator.swift
@@ -1,0 +1,81 @@
+import Foundation
+import TBDShared
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "AutoHibernateOnMerge")
+
+/// Evaluates the effective auto-hibernate-on-merge decision when a worktree's PR
+/// merges and parks its idle Claude sessions when armed. Unlike auto-archive,
+/// this leaves the worktree alive — it only tears down the sessions' claude
+/// processes (window/tab survive), so a later focus wakes them.
+///
+/// Reached via `MergedTransitionDispatcher`, which enforces the precedence rule
+/// (archive supersedes hibernate): this only runs when the worktree was NOT
+/// actually archived.
+public struct AutoHibernateOnMergeCoordinator: Sendable {
+    let db: TBDDatabase
+    let hibernation: HibernationCoordinator
+    let subscriptions: StateSubscriptionManager
+
+    public init(
+        db: TBDDatabase,
+        hibernation: HibernationCoordinator,
+        subscriptions: StateSubscriptionManager
+    ) {
+        self.db = db
+        self.hibernation = hibernation
+        self.subscriptions = subscriptions
+    }
+
+    public func handleMergedTransition(worktreeID: UUID, prNumber: Int) async {
+        do {
+            guard let wt = try await db.worktrees.get(id: worktreeID), wt.status == .active else { return }
+            let config = try await db.config.get()
+            // NOTE: this deliberately does NOT consult `config.autoHibernateEnabled`
+            // — that is the *idle sweep's* master switch. Merge-park is an
+            // independent feature armed by the per-worktree tri-state +
+            // `config.autoHibernateOnMergeDefault`. (See HibernationGate.decideForMerge.)
+            let effective = wt.autoHibernateOnMerge ?? config.autoHibernateOnMergeDefault
+            guard effective else { return }
+
+            // The setting is per-WORKTREE; hibernation is per-TERMINAL — fan out.
+            let terminals = try await db.terminals.list(worktreeID: worktreeID)
+            var parked = 0
+            for terminal in terminals {
+                let result = await hibernation.hibernateForMerge(terminalID: terminal.id)
+                switch result {
+                case .ok:
+                    parked += 1
+                case .alreadyHibernated:
+                    logger.debug("merge-park skipped \(terminal.id, privacy: .public): already hibernated")
+                case .notFound:
+                    logger.debug("merge-park skipped \(terminal.id, privacy: .public): not found")
+                case .notEligible(let reason):
+                    logger.debug("merge-park skipped \(terminal.id, privacy: .public): \(reason, privacy: .public)")
+                }
+            }
+
+            guard parked > 0 else {
+                logger.debug("auto-hibernate armed for \(worktreeID, privacy: .public) but parked 0 sessions on PR #\(prNumber, privacy: .public) merge")
+                return
+            }
+
+            // `performHibernate` already broadcast a per-terminal hibernation
+            // delta for each parked session, so DON'T broadcast one here — just
+            // surface the summary as a non-activating notification.
+            let sessionWord = parked == 1 ? "session" : "sessions"
+            let notification = try await db.notifications.create(
+                worktreeID: worktreeID,
+                type: .taskComplete,
+                message: "Hibernated \(parked) \(sessionWord) in \(wt.displayName) — PR #\(prNumber) merged",
+                terminalID: nil)
+            subscriptions.broadcast(delta: .notificationReceived(NotificationDelta(
+                notificationID: notification.id, worktreeID: notification.worktreeID,
+                type: notification.type, message: notification.message,
+                terminalID: notification.terminalID, activate: false)))
+            logger.info("auto-hibernated \(parked, privacy: .public) session(s) in \(worktreeID, privacy: .public) on PR #\(prNumber, privacy: .public) merge")
+        } catch {
+            logger.error("auto-hibernate failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/PR/MergedTransitionDispatcher.swift
+++ b/Sources/TBDDaemon/PR/MergedTransitionDispatcher.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Fans a merged-PR transition out to the auto-archive and auto-hibernate
+/// coordinators, enforcing the precedence rule: archive supersedes hibernate.
+///
+/// If the worktree was ACTUALLY archived, hibernating its sessions is pointless
+/// (they'd be torn down with the worktree anyway), so hibernate is skipped. But
+/// the key asymmetry: precedence keys off "did archive actually begin", not "was
+/// archive armed". An armed-but-blocked archive (e.g. the worktree has active
+/// children) returns `false`, the worktree survives, and its idle sessions are
+/// still parked — parking an idle session on a surviving worktree is correct.
+public struct MergedTransitionDispatcher: Sendable {
+    let archive: AutoArchiveOnMergeCoordinator
+    let hibernate: AutoHibernateOnMergeCoordinator
+
+    public init(
+        archive: AutoArchiveOnMergeCoordinator,
+        hibernate: AutoHibernateOnMergeCoordinator
+    ) {
+        self.archive = archive
+        self.hibernate = hibernate
+    }
+
+    public func handleMergedTransition(worktreeID: UUID, prNumber: Int) async {
+        let archived = await archive.handleMergedTransition(worktreeID: worktreeID, prNumber: prNumber)
+        guard !archived else { return }
+        await hibernate.handleMergedTransition(worktreeID: worktreeID, prNumber: prNumber)
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -15,6 +15,14 @@ extension RPCRouter {
         return .ok()
     }
 
+    func handleConfigSetAutoHibernateDefault(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetAutoHibernateDefaultParams.self, from: paramsData)
+        try await db.config.setAutoHibernateOnMergeDefault(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the session-limit auto-resume gate. Turning it OFF cancels only
     /// the session-limit pending resumes (`.limitOnly` scope) — the transient
     /// API-error toggle owns its own rows (spec: each toggle cancels only its

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -57,6 +57,7 @@ extension RPCRouter {
             primaryAgentPreference: config.primaryAgentPreference,
             globalEnvOverrides: config.envOverrides,
             autoArchiveOnMergeDefault: config.autoArchiveOnMergeDefault,
+            autoHibernateOnMergeDefault: config.autoHibernateOnMergeDefault,
             nightwatchMode: config.nightwatchMode,
             autoResumeOnLimitReset: config.autoResumeOnLimitReset,
             autoResumeOnApiError: config.autoResumeOnApiError

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -259,4 +259,10 @@ extension RPCRouter {
         try await db.worktrees.setAutoArchiveOnMerge(id: params.worktreeID, value: params.enabled)
         return .ok()
     }
+
+    func handleWorktreeSetAutoHibernate(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeSetAutoHibernateParams.self, from: paramsData)
+        try await db.worktrees.setAutoHibernateOnMerge(id: params.worktreeID, value: params.enabled)
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -325,10 +325,14 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeSetActiveTab(request.paramsData)
             case RPCMethod.worktreeSetAutoArchive:
                 return try await handleWorktreeSetAutoArchive(request.paramsData)
+            case RPCMethod.worktreeSetAutoHibernate:
+                return try await handleWorktreeSetAutoHibernate(request.paramsData)
             case RPCMethod.configGet:
                 return try await handleConfigGet()
             case RPCMethod.configSetAutoArchiveOnMergeDefault:
                 return try await handleConfigSetAutoArchiveDefault(request.paramsData)
+            case RPCMethod.configSetAutoHibernateOnMergeDefault:
+                return try await handleConfigSetAutoHibernateDefault(request.paramsData)
             case RPCMethod.configSetAutoResumeOnLimitReset:
                 return try await handleConfigSetAutoResumeOnLimitReset(request.paramsData)
             case RPCMethod.configSetAutoResumeOnApiError:

--- a/Sources/TBDShared/MockScenario.swift
+++ b/Sources/TBDShared/MockScenario.swift
@@ -64,6 +64,7 @@ public struct MockScenario: Codable, Sendable {
         public var hasConflicts: Bool?
         public var prStatus: PRStatus?
         public var autoArchiveOnMerge: Bool?
+        public var autoHibernateOnMerge: Bool?
         /// `name` of another worktree in the SAME repo, listed EARLIER in the array.
         public var parentName: String?
         public var terminals: [TerminalSeed]?
@@ -71,7 +72,8 @@ public struct MockScenario: Codable, Sendable {
         public init(name: String, branch: String, displayName: String? = nil,
                     pathSuffix: String? = nil, status: WorktreeStatus? = nil,
                     hasConflicts: Bool? = nil, prStatus: PRStatus? = nil,
-                    autoArchiveOnMerge: Bool? = nil, parentName: String? = nil,
+                    autoArchiveOnMerge: Bool? = nil, autoHibernateOnMerge: Bool? = nil,
+                    parentName: String? = nil,
                     terminals: [TerminalSeed]? = nil) {
             self.name = name
             self.branch = branch
@@ -81,6 +83,7 @@ public struct MockScenario: Codable, Sendable {
             self.hasConflicts = hasConflicts
             self.prStatus = prStatus
             self.autoArchiveOnMerge = autoArchiveOnMerge
+            self.autoHibernateOnMerge = autoHibernateOnMerge
             self.parentName = parentName
             self.terminals = terminals
         }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -139,6 +139,11 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// explicit. Only set explicitly by user action (toolbar toggle / CLI);
     /// there is no UI to return to `nil`.
     public var autoArchiveOnMerge: Bool?
+    /// Per-worktree auto-hibernate-on-PR-merge override. `nil` = follow the
+    /// global default (`Config.autoHibernateOnMergeDefault`); `true`/`false` =
+    /// explicit. Only set explicitly by user action (toolbar toggle / CLI);
+    /// there is no UI to return to `nil`.
+    public var autoHibernateOnMerge: Bool?
     /// Last-known GitHub PR status, persisted in the DB so the PR icon survives
     /// app/daemon restarts. nil = never observed. Refreshed live by the daemon's
     /// PR poll; the app seeds from this only when it has no fresher live value.
@@ -165,6 +170,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 liveClaudeSessionCount: Int? = nil,
                 parentWorktreeID: UUID? = nil,
                 autoArchiveOnMerge: Bool? = nil,
+                autoHibernateOnMerge: Bool? = nil,
                 promotedToRepoID: UUID? = nil,
                 prStatus: PRStatus? = nil) {
         self.id = id
@@ -184,6 +190,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.liveClaudeSessionCount = liveClaudeSessionCount
         self.parentWorktreeID = parentWorktreeID
         self.autoArchiveOnMerge = autoArchiveOnMerge
+        self.autoHibernateOnMerge = autoHibernateOnMerge
         self.promotedToRepoID = promotedToRepoID
         self.prStatus = prStatus
     }
@@ -193,6 +200,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         case hasConflicts, createdAt, archivedAt, tmuxServer
         case archivedClaudeSessions, sortOrder, archivedHeadSHA
         case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge
+        case autoHibernateOnMerge
         case promotedToRepoID, prStatus
     }
 
@@ -215,6 +223,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         liveClaudeSessionCount = try c.decodeIfPresent(Int.self, forKey: .liveClaudeSessionCount)
         parentWorktreeID = try c.decodeIfPresent(UUID.self, forKey: .parentWorktreeID)
         autoArchiveOnMerge = try c.decodeIfPresent(Bool.self, forKey: .autoArchiveOnMerge)
+        autoHibernateOnMerge = try c.decodeIfPresent(Bool.self, forKey: .autoHibernateOnMerge)
         promotedToRepoID = try c.decodeIfPresent(UUID.self, forKey: .promotedToRepoID)
         prStatus = try c.decodeIfPresent(PRStatus.self, forKey: .prStatus)
     }
@@ -238,6 +247,23 @@ public enum HibernateReason: String, Codable, Sendable {
     case manual
     /// Crash-recovery / reconcile parking (window or server gone).
     case recovery
+    /// Parked because the worktree's PR merged — system-initiated, so it
+    /// auto-wakes on focus like `.auto`.
+    case merged
+
+    // Custom lenient decoder: the SYNTHESIZED `Decodable` throws
+    // `DecodingError.dataCorrupted` on any raw value this build doesn't know.
+    // Because `Terminal.hibernateReason` and `TerminalHibernationDelta`
+    // .hibernateReason ride the RPC wire, a `.merged` (or any future case)
+    // written by a newer daemon would fail the ENTIRE Terminal/delta decode on
+    // an older app binary — the blank-app class of failure. Falling back to
+    // `.auto` is semantically safe: wake-on-focus only special-cases `.manual`,
+    // so an unknown reason and `.auto` behave identically. `Encodable` stays
+    // synthesized (always writes the true raw value).
+    public init(from decoder: any Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = HibernateReason(rawValue: raw) ?? .auto
+    }
 }
 public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
@@ -684,6 +710,9 @@ public struct Config: Codable, Sendable, Equatable {
     /// Global default for auto-archive-on-PR-merge, applied to worktrees whose
     /// per-worktree override is `nil`.
     public var autoArchiveOnMergeDefault: Bool
+    /// Global default for auto-hibernate-on-PR-merge, applied to worktrees whose
+    /// per-worktree override is `nil`.
+    public var autoHibernateOnMergeDefault: Bool
     /// Global gate for session-limit auto-resume (spec 2026-07-03). Daemon-
     /// side because the daemon must act while the app is closed. Default OFF.
     public var autoResumeOnLimitReset: Bool
@@ -727,6 +756,7 @@ public struct Config: Codable, Sendable, Equatable {
                 envSettingOverrides: [String: ClaudeEnvValue] = [:],
                 envOverrides: [String: String] = [:],
                 autoArchiveOnMergeDefault: Bool = false,
+                autoHibernateOnMergeDefault: Bool = false,
                 autoResumeOnLimitReset: Bool = false,
                 scratchInstructions: String? = nil,
                 scratchRenamePrompt: String? = nil,
@@ -741,6 +771,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.envSettingOverrides = envSettingOverrides
         self.envOverrides = envOverrides
         self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
+        self.autoHibernateOnMergeDefault = autoHibernateOnMergeDefault
         self.autoResumeOnLimitReset = autoResumeOnLimitReset
         self.scratchInstructions = scratchInstructions
         self.scratchRenamePrompt = scratchRenamePrompt
@@ -765,6 +796,8 @@ public struct Config: Codable, Sendable, Equatable {
             [String: String].self, forKey: .envOverrides) ?? [:]
         autoArchiveOnMergeDefault = try c.decodeIfPresent(
             Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
+        autoHibernateOnMergeDefault = try c.decodeIfPresent(
+            Bool.self, forKey: .autoHibernateOnMergeDefault) ?? false
         autoResumeOnLimitReset = try c.decodeIfPresent(
             Bool.self, forKey: .autoResumeOnLimitReset) ?? false
         scratchInstructions = try c.decodeIfPresent(String.self, forKey: .scratchInstructions) ?? nil

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -164,8 +164,10 @@ public enum RPCMethod {
     public static let repoSetEnvOverrides         = "repo.setEnvOverrides"
     public static let modelProfileSetEnvOverrides = "modelProfile.setEnvOverrides"
     public static let worktreeSetAutoArchive = "worktree.setAutoArchive"
+    public static let worktreeSetAutoHibernate = "worktree.setAutoHibernate"
     public static let configGet = "config.get"
     public static let configSetAutoArchiveOnMergeDefault = "config.setAutoArchiveOnMergeDefault"
+    public static let configSetAutoHibernateOnMergeDefault = "config.setAutoHibernateOnMergeDefault"
     public static let configSetAutoResumeOnLimitReset = "config.setAutoResumeOnLimitReset"
     public static let configSetAutoResumeOnApiError = "config.setAutoResumeOnApiError"
     public static let configSetScratchInstructions = "config.setScratchInstructions"
@@ -500,6 +502,7 @@ public struct ModelProfileListResult: Codable, Sendable {
     /// other config-derived fields so the app loads it in one round-trip.
     public let globalEnvOverrides: [String: String]
     public let autoArchiveOnMergeDefault: Bool
+    public let autoHibernateOnMergeDefault: Bool
     public let nightwatchMode: NightwatchMode
     public let autoResumeOnLimitReset: Bool
     public let autoResumeOnApiError: Bool
@@ -509,6 +512,7 @@ public struct ModelProfileListResult: Codable, Sendable {
         primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
         globalEnvOverrides: [String: String] = [:],
         autoArchiveOnMergeDefault: Bool = false,
+        autoHibernateOnMergeDefault: Bool = false,
         nightwatchMode: NightwatchMode = .off,
         autoResumeOnLimitReset: Bool = false,
         autoResumeOnApiError: Bool = false
@@ -518,6 +522,7 @@ public struct ModelProfileListResult: Codable, Sendable {
         self.primaryAgentPreference = primaryAgentPreference
         self.globalEnvOverrides = globalEnvOverrides
         self.autoArchiveOnMergeDefault = autoArchiveOnMergeDefault
+        self.autoHibernateOnMergeDefault = autoHibernateOnMergeDefault
         self.nightwatchMode = nightwatchMode
         self.autoResumeOnLimitReset = autoResumeOnLimitReset
         self.autoResumeOnApiError = autoResumeOnApiError
@@ -537,6 +542,8 @@ public struct ModelProfileListResult: Codable, Sendable {
         ) ?? [:]
         autoArchiveOnMergeDefault = try c.decodeIfPresent(
             Bool.self, forKey: .autoArchiveOnMergeDefault) ?? false
+        autoHibernateOnMergeDefault = try c.decodeIfPresent(
+            Bool.self, forKey: .autoHibernateOnMergeDefault) ?? false
         nightwatchMode = try c.decodeIfPresent(
             NightwatchMode.self, forKey: .nightwatchMode) ?? .off
         autoResumeOnLimitReset = try c.decodeIfPresent(
@@ -1038,6 +1045,19 @@ public struct WorktreeSetAutoArchiveParams: Codable, Sendable {
 }
 
 public struct ConfigSetAutoArchiveDefaultParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+public struct WorktreeSetAutoHibernateParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let enabled: Bool
+    public init(worktreeID: UUID, enabled: Bool) {
+        self.worktreeID = worktreeID; self.enabled = enabled
+    }
+}
+
+public struct ConfigSetAutoHibernateDefaultParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }

--- a/Tests/TBDAppTests/EffectiveAutoHibernateTests.swift
+++ b/Tests/TBDAppTests/EffectiveAutoHibernateTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for `effectiveAutoHibernate(for:)` — the per-worktree auto-hibernate resolver.
+///
+/// The rule mirrors auto-archive: return the worktree's per-worktree override
+/// when set; otherwise fall back to the global default
+/// (`autoHibernateOnMergeDefault`).
+///
+/// Every test constructs `AppState(userDefaults:)` against a unique throwaway
+/// suite — TBDApp ships as an unbundled SPM executable, so `UserDefaults.standard`
+/// is the running developer's real `TBDApp.plist`.
+@MainActor
+@Suite("EffectiveAutoHibernate")
+struct EffectiveAutoHibernateTests {
+
+    private func withAppState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.EffectiveAutoHibernate.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func sampleWorktree(autoHibernateOnMerge: Bool? = nil) -> Worktree {
+        Worktree(
+            repoID: UUID(),
+            name: "acme",
+            displayName: "acme",
+            branch: "tbd/acme",
+            path: "/tmp/acme",
+            tmuxServer: "tbd-test",
+            autoHibernateOnMerge: autoHibernateOnMerge
+        )
+    }
+
+    @Test func nilFollowsDefaultOff() {
+        withAppState { app in
+            app.autoHibernateOnMergeDefault = false
+            let wt = sampleWorktree(autoHibernateOnMerge: nil)
+            #expect(app.effectiveAutoHibernate(for: wt) == false)
+        }
+    }
+
+    @Test func nilFollowsDefaultOn() {
+        withAppState { app in
+            app.autoHibernateOnMergeDefault = true
+            let wt = sampleWorktree(autoHibernateOnMerge: nil)
+            #expect(app.effectiveAutoHibernate(for: wt) == true)
+        }
+    }
+
+    @Test func explicitFalseOverridesDefaultOn() {
+        withAppState { app in
+            app.autoHibernateOnMergeDefault = true
+            let wt = sampleWorktree(autoHibernateOnMerge: false)
+            #expect(app.effectiveAutoHibernate(for: wt) == false)
+        }
+    }
+
+    @Test func explicitTrueOverridesDefaultOff() {
+        withAppState { app in
+            app.autoHibernateOnMergeDefault = false
+            let wt = sampleWorktree(autoHibernateOnMerge: true)
+            #expect(app.effectiveAutoHibernate(for: wt) == true)
+        }
+    }
+}

--- a/Tests/TBDAppTests/PRButtonLabelTests.swift
+++ b/Tests/TBDAppTests/PRButtonLabelTests.swift
@@ -39,40 +39,84 @@ struct PRButtonLabelTests {
         )
     }
 
-    // MARK: - bakedWidth (armed gate, both branches)
-
-    @Test("bakedWidth is the bare icon side when auto-archive is not armed")
-    func bakedWidthUnarmed() {
-        let label = PRButtonLabel(prStatus: Self.makeStatus(), isAutoArchiveArmed: false)
-        #expect(label.bakedWidth == PRButtonLabel.iconSide)
-    }
-
-    @Test("bakedWidth widens by gap + badge when auto-archive is armed")
-    func bakedWidthArmed() {
-        let label = PRButtonLabel(prStatus: Self.makeStatus(), isAutoArchiveArmed: true)
-        let expected = PRButtonLabel.iconSide + PRButtonLabel.badgeGap + PRButtonLabel.iconSide
-        #expect(label.bakedWidth == expected)
-        #expect(label.bakedWidth > PRButtonLabel(prStatus: Self.makeStatus(), isAutoArchiveArmed: false).bakedWidth)
-    }
-
-    @Test("bakedWidth stays a single square for a queued PR even when armed")
-    func bakedWidthQueuedSuppressesArchiveBadge() {
-        // Queue mode supersedes the archivebox armed-badge: the bus is one
-        // full-color square with its position baked in, so the label must not
-        // reserve the extra gap+badge width.
-        let queuedArmed = PRButtonLabel(
-            prStatus: Self.makeStatus(state: .pending, mergeQueuePosition: 2),
-            isAutoArchiveArmed: true
+    private static func makeLabel(
+        prStatus: PRStatus? = nil,
+        isAutoArchiveArmed: Bool = false,
+        isAutoHibernateArmed: Bool = false
+    ) -> PRButtonLabel {
+        PRButtonLabel(
+            prStatus: prStatus ?? makeStatus(),
+            isAutoArchiveArmed: isAutoArchiveArmed,
+            isAutoHibernateArmed: isAutoHibernateArmed
         )
-        #expect(queuedArmed.isMergeQueued)
-        #expect(queuedArmed.bakedWidth == PRButtonLabel.iconSide)
+    }
+
+    // MARK: - bakedWidth (three-state: 0, 1, or 2 badges)
+
+    @Test("bakedWidth is the bare icon side when neither flag is armed")
+    func bakedWidthUnarmed() {
+        let label = Self.makeLabel()
+        // 12 (iconSide) with no badges.
+        #expect(label.bakedWidth == PRButtonLabel.iconSide)
+        #expect(label.bakedWidth == 12)
+        #expect(label.badgeCount == 0)
+    }
+
+    @Test("bakedWidth widens by one gap + badge when only auto-archive is armed")
+    func bakedWidthArchiveArmed() {
+        let label = Self.makeLabel(isAutoArchiveArmed: true)
+        // 12 + 1*(3 + 12) = 27
+        let expected = PRButtonLabel.iconSide + (PRButtonLabel.badgeGap + PRButtonLabel.iconSide)
+        #expect(label.bakedWidth == expected)
+        #expect(label.bakedWidth == 27)
+        #expect(label.badgeCount == 1)
+    }
+
+    @Test("bakedWidth widens by one gap + badge when only auto-hibernate is armed")
+    func bakedWidthHibernateArmed() {
+        let label = Self.makeLabel(isAutoHibernateArmed: true)
+        // 12 + 1*(3 + 12) = 27 — same single-badge width as archive-only.
+        let expected = PRButtonLabel.iconSide + (PRButtonLabel.badgeGap + PRButtonLabel.iconSide)
+        #expect(label.bakedWidth == expected)
+        #expect(label.bakedWidth == 27)
+        #expect(label.badgeCount == 1)
+    }
+
+    @Test("bakedWidth widens by two gaps + badges when both flags are armed")
+    func bakedWidthBothArmed() {
+        let label = Self.makeLabel(isAutoArchiveArmed: true, isAutoHibernateArmed: true)
+        // 12 + 2*(3 + 12) = 42
+        let expected = PRButtonLabel.iconSide + 2 * (PRButtonLabel.badgeGap + PRButtonLabel.iconSide)
+        #expect(label.bakedWidth == expected)
+        #expect(label.bakedWidth == 42)
+        #expect(label.badgeCount == 2)
+    }
+
+    @Test("bakedWidth stays a single square for a queued PR for every armed combination")
+    func bakedWidthQueuedSuppressesBothBadges() {
+        // Queue mode supersedes BOTH armed badges: the bus is one full-color
+        // square with its position baked in, so the label must not reserve any
+        // extra gap+badge width regardless of which flags are armed.
+        for archive in [false, true] {
+            for hibernate in [false, true] {
+                let label = Self.makeLabel(
+                    prStatus: Self.makeStatus(state: .pending, mergeQueuePosition: 2),
+                    isAutoArchiveArmed: archive,
+                    isAutoHibernateArmed: hibernate
+                )
+                #expect(label.isMergeQueued)
+                #expect(label.badgeCount == 0)
+                #expect(label.bakedWidth == PRButtonLabel.iconSide)
+            }
+        }
     }
 
     @Test("coloredIcon bakes a single square for a queued PR (bus, untinted)")
     func coloredIconQueuedIsSquare() throws {
-        let label = PRButtonLabel(
+        let label = Self.makeLabel(
             prStatus: Self.makeStatus(state: .pending, mergeQueuePosition: 3),
-            isAutoArchiveArmed: true
+            isAutoArchiveArmed: true,
+            isAutoHibernateArmed: true
         )
         let presentation = try #require(PRStatusPresentation.make(for: label.prStatus))
         let icon = try #require(label.coloredIcon(presentation, colorScheme: .light))
@@ -80,24 +124,55 @@ struct PRButtonLabelTests {
         #expect(icon.isTemplate == false)
     }
 
-    // MARK: - coloredIcon baked image size (armed gate, both branches)
+    // MARK: - coloredIcon baked image size (0, 1, 2 badges)
 
-    @Test("coloredIcon bakes a square image when not armed and a wide badge composite when armed")
+    @Test("coloredIcon baked image width matches the armed-badge count")
     func coloredIconSizeMatchesArmedState() throws {
-        let unarmed = PRButtonLabel(prStatus: Self.makeStatus(), isAutoArchiveArmed: false)
-        let armed = PRButtonLabel(prStatus: Self.makeStatus(), isAutoArchiveArmed: true)
         let presentation = PRStatusPresentation(glyph: .asset("git-merge"), colorSemantic: .merged)
 
-        let unarmedIcon = try #require(unarmed.coloredIcon(presentation, colorScheme: .light))
-        let armedIcon = try #require(armed.coloredIcon(presentation, colorScheme: .light))
+        let none = try #require(Self.makeLabel().coloredIcon(presentation, colorScheme: .light))
+        let archive = try #require(
+            Self.makeLabel(isAutoArchiveArmed: true).coloredIcon(presentation, colorScheme: .light))
+        let hibernate = try #require(
+            Self.makeLabel(isAutoHibernateArmed: true).coloredIcon(presentation, colorScheme: .light))
+        let both = try #require(
+            Self.makeLabel(isAutoArchiveArmed: true, isAutoHibernateArmed: true)
+                .coloredIcon(presentation, colorScheme: .light))
 
-        #expect(unarmedIcon.size == NSSize(width: PRButtonLabel.iconSide, height: PRButtonLabel.iconSide))
-        #expect(armedIcon.size == NSSize(
-            width: PRButtonLabel.iconSide + PRButtonLabel.badgeGap + PRButtonLabel.iconSide,
-            height: PRButtonLabel.iconSide
-        ))
-        #expect(unarmedIcon.isTemplate == false)
-        #expect(armedIcon.isTemplate == false)
+        let side = PRButtonLabel.iconSide
+        let step = PRButtonLabel.badgeGap + PRButtonLabel.iconSide
+        #expect(none.size == NSSize(width: side, height: side))
+        #expect(archive.size == NSSize(width: side + step, height: side))
+        #expect(hibernate.size == NSSize(width: side + step, height: side))
+        #expect(both.size == NSSize(width: side + 2 * step, height: side))
+        for icon in [none, archive, hibernate, both] {
+            #expect(icon.isTemplate == false)
+        }
+    }
+
+    // The baked-icon cache is keyed on BOTH armed flags. If hibernateArmed were
+    // omitted from the key, an armed/unarmed pair sharing the same asset name,
+    // colorSemantic, and colorScheme would render from the same cached bitmap
+    // and the moon.zzz badge would silently never appear. The cache key isn't
+    // reachable from tests, so assert the observable consequence: differing
+    // hibernateArmed yields differently-sized baked images.
+    @Test("coloredIcon width reflects hibernateArmed independently (cache-key guard)")
+    func coloredIconWidthDistinguishesHibernateArmed() throws {
+        let presentation = PRStatusPresentation(glyph: .asset("git-merge"), colorSemantic: .merged)
+
+        // archive fixed off: hibernate off → 1 square, hibernate on → 1 badge.
+        let hOff = try #require(Self.makeLabel().coloredIcon(presentation, colorScheme: .light))
+        let hOn = try #require(
+            Self.makeLabel(isAutoHibernateArmed: true).coloredIcon(presentation, colorScheme: .light))
+        #expect(hOff.size.width != hOn.size.width)
+
+        // archive fixed on: hibernate off → 1 badge, hibernate on → 2 badges.
+        let aOnly = try #require(
+            Self.makeLabel(isAutoArchiveArmed: true).coloredIcon(presentation, colorScheme: .light))
+        let aAndH = try #require(
+            Self.makeLabel(isAutoArchiveArmed: true, isAutoHibernateArmed: true)
+                .coloredIcon(presentation, colorScheme: .light))
+        #expect(aOnly.size.width != aAndH.size.width)
     }
 
     // MARK: - aspectFitRect (badge distortion fix)

--- a/Tests/TBDAppTests/PRButtonLabelTests.swift
+++ b/Tests/TBDAppTests/PRButtonLabelTests.swift
@@ -23,6 +23,7 @@ struct PRButtonLabelTests {
         worktreeID: UUID,
         worktreeFound: Bool = true,
         armed: Bool = false,
+        hibernateArmed: Bool = false,
         blocked: Bool = false,
         prStatus: PRStatus,
         colorScheme: ColorScheme = .light
@@ -31,6 +32,7 @@ struct PRButtonLabelTests {
             worktreeID: worktreeID,
             worktreeFound: worktreeFound,
             armed: armed,
+            hibernateArmed: hibernateArmed,
             blocked: blocked,
             prStatus: prStatus,
             colorScheme: colorScheme
@@ -133,6 +135,18 @@ struct PRButtonLabelTests {
         let armed = Self.makeKey(worktreeID: worktreeID, armed: true, prStatus: status)
         let unarmed = Self.makeKey(worktreeID: worktreeID, armed: false, prStatus: status)
         #expect(armed != unarmed)
+    }
+
+    // Stale-checkmark regression guard: AppKit materializes the split-button
+    // NSMenu once, so the hibernate Toggle's checkmark would freeze at its
+    // first-render value unless hibernateArmed is part of the .id key.
+    @Test("id key differs between hibernate-armed and not, all else equal")
+    func idKeyDiffersByHibernateArmed() {
+        let worktreeID = UUID()
+        let status = Self.makeStatus()
+        let hibernateArmed = Self.makeKey(worktreeID: worktreeID, hibernateArmed: true, prStatus: status)
+        let notArmed = Self.makeKey(worktreeID: worktreeID, hibernateArmed: false, prStatus: status)
+        #expect(hibernateArmed != notArmed)
     }
 
     @Test("id key differs between PR states, PR numbers, and PR urls")

--- a/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
+++ b/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
@@ -109,6 +109,20 @@ struct WakeOnFocusDecisionTests {
         #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == recovery)
     }
 
+    /// A merge-parked session (`hibernateReason == .merged`) still wakes on
+    /// focus: auto-hibernate-on-merge is system-initiated, not an explicit
+    /// user "Hibernate now", so navigating back to the worktree wakes it —
+    /// unlike a `.manual` park. Pins the design decision.
+    @Test func wakesMergedReasonParkedTerminalOnFocus() {
+        let state = AppState()
+        let wt = UUID()
+        let merged = UUID()
+        state.terminals[wt] = [parkedTerminal(merged, reason: .merged)]
+        focus(state, worktreeID: wt, terminalID: merged)
+
+        #expect(state.terminalIDToWakeOnFocus(worktreeID: wt) == merged)
+    }
+
     /// A legacy parked row with NO reason (pre-v46) still wakes on focus —
     /// the old behavior is preserved for rows the migration can't attribute.
     @Test func wakesLegacyNilReasonParkedTerminalOnFocus() {

--- a/Tests/TBDDaemonTests/AutoArchiveRuleTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveRuleTests.swift
@@ -177,3 +177,34 @@ import TestSupport
     #expect(after?.autoArchiveOnMerge == false,
             "reviving a worktree must disarm its auto-archive flag so a still-merged PR can't re-archive it immediately")
 }
+
+/// Companion to `reviveDisarmsWorktree`, exercising the same bare inline (no
+/// preSession hook) revive path but asserting the auto-HIBERNATE override is
+/// disarmed too — a still-merged PR would otherwise immediately re-park the
+/// sessions in the worktree the user just deliberately revived.
+@Test func reviveDisarmsAutoHibernate() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Create and archive a worktree, then arm both merge overrides.
+    let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+    try await db.worktrees.setAutoHibernateOnMerge(id: wt.id, value: true)
+    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+    // Revive it — this should disarm the auto-hibernate flag.
+    let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
+
+    #expect(revived.status == .active)
+    let after = try await db.worktrees.get(id: wt.id)
+    #expect(after?.autoHibernateOnMerge == false,
+            "reviving a worktree must disarm its auto-hibernate flag (explicitly false, not nil) so a still-merged PR can't re-park it immediately")
+}

--- a/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
@@ -137,4 +137,70 @@ struct AutoHibernateOnMergeCoordinatorTests {
         let notifications = try await db.notifications.unread(worktreeID: wtID)
         #expect(notifications.isEmpty)
     }
+
+    // MARK: - Already-parked terminal is untouched (idempotent late/repeat merge)
+
+    /// A merged transition fired against a worktree whose terminal is ALREADY
+    /// parked must be a silent no-op: `hibernateForMerge` returns
+    /// `.alreadyHibernated`, so the existing `hibernatedAt` / `hibernateReason`
+    /// are NOT overwritten and — because `parked == 0` — no notification is
+    /// created. This pins the "a repeat/late merge event can't stomp a manual
+    /// park" property: merged transitions re-fire after every daemon restart
+    /// while the PR stays merged.
+    @Test func alreadyParkedTerminalNotOverwrittenAndNoNotification() async throws {
+        let (coord, db, wtID, terminalID) = try await makeDeps()
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        // Park the terminal FIRST with a distinctive manual reason + old stamp.
+        let originalStamp = Date(timeIntervalSince1970: 1_000_000)
+        try await db.terminals.setHibernated(
+            id: terminalID, sessionID: "sess-1", snapshot: nil,
+            reason: .manual, at: originalStamp)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 10)
+
+        let after = try await db.terminals.get(id: terminalID)
+        // The manual park survives — reason and timestamp are both unchanged
+        // (NOT re-stamped to `.merged` / now).
+        #expect(after?.hibernateReason == .manual)
+        #expect(after?.hibernatedAt == originalStamp)
+        // parked == 0 → no summary notification.
+        let notifications = try await db.notifications.unread(worktreeID: wtID)
+        #expect(notifications.isEmpty)
+    }
+
+    // MARK: - Notification pluralization (plural branch)
+
+    /// Two parkable Claude terminals on one armed worktree → BOTH park with
+    /// `.merged`, and exactly ONE summary notification is created whose message
+    /// uses the plural "sessions" ("Hibernated 2 sessions …"). Every other test
+    /// parks a single terminal, so this is the only cover for the
+    /// `parked == 1 ? "session" : "sessions"` plural arm.
+    @Test func twoParkedTerminalsPluralNotification() async throws {
+        let (coord, db, wtID, terminalID1) = try await makeDeps()
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        // Add a SECOND idle Claude terminal on the same worktree.
+        let terminal2 = try await db.terminals.create(
+            worktreeID: wtID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude2", claudeSessionID: "sess-2", kind: .claude)
+        try await db.terminals.setActivityState(id: terminal2.id, activityState: .idle)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 11)
+
+        // Both terminals parked with the merge reason.
+        let after1 = try await db.terminals.get(id: terminalID1)
+        let after2 = try await db.terminals.get(id: terminal2.id)
+        #expect(after1?.hibernatedAt != nil)
+        #expect(after1?.hibernateReason == .merged)
+        #expect(after2?.hibernatedAt != nil)
+        #expect(after2?.hibernateReason == .merged)
+
+        // Exactly one summary notification, using the plural wording.
+        let notifications = try await db.notifications.unread(worktreeID: wtID)
+        #expect(notifications.count == 1)
+        #expect(notifications.first?.type == .taskComplete)
+        #expect(notifications.first?.message?.contains("2 sessions") == true)
+        #expect(notifications.first?.message?.contains("#11") == true)
+    }
 }

--- a/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
@@ -1,0 +1,140 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// A `ClaudeProfileConfigDirManager` pointed at fresh temp dirs so nothing
+/// touches the developer's real `~/.claude` (mirrors HibernationCoordinatorTests).
+private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
+    let home = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-authib-claude-\(UUID().uuidString)", isDirectory: true)
+    return ClaudeProfileConfigDirManager(
+        baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+        hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
+    )
+}
+
+@Suite("AutoHibernateOnMergeCoordinator")
+struct AutoHibernateOnMergeCoordinatorTests {
+
+    /// In-memory DB + coordinator + a repo + one active worktree with a single
+    /// idle Claude terminal. Returns the pieces each test flips.
+    private func makeDeps(
+        activityState: TerminalActivityState = .idle,
+        keepWarm: Bool = false,
+        sessionID: String? = "sess-1",
+        kind: TerminalKind? = .claude,
+        status: WorktreeStatus = .active
+    ) async throws -> (AutoHibernateOnMergeCoordinator, TBDDatabase, wtID: UUID, terminalID: UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let hibernation = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            subscriptions: subs, configDirManager: isolatedConfigDirManager())
+        let coord = AutoHibernateOnMergeCoordinator(
+            db: db, hibernation: hibernation, subscriptions: subs)
+
+        let repo = try await db.repos.create(
+            path: "/tmp/repoAH-\(UUID().uuidString)", displayName: "repoAH", defaultBranch: "main")
+        let wt = try await db.worktrees.create(repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/repoAH/w-\(UUID().uuidString)", tmuxServer: "s")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: sessionID, kind: kind)
+        if activityState != .unknown {
+            try await db.terminals.setActivityState(id: terminal.id, activityState: activityState)
+        }
+        if keepWarm {
+            try await db.terminals.setKeepWarm(id: terminal.id, keepWarm: true)
+        }
+        if status != .active {
+            try await db.worktrees.updateStatus(id: wt.id, status: status)
+        }
+        return (coord, db, wt.id, terminal.id)
+    }
+
+    // MARK: - Feature off / on matrix
+
+    @Test func featureOffDoesNotPark() async throws {
+        // worktree override nil + global default false → not armed → no park.
+        let (coord, db, wtID, terminalID) = try await makeDeps()
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 1)
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func globalDefaultTrueOverrideNilParks() async throws {
+        let (coord, db, wtID, terminalID) = try await makeDeps()
+        try await db.config.setAutoHibernateOnMergeDefault(true)
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 2)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt != nil)
+        #expect(after?.hibernateReason == .merged)
+    }
+
+    @Test func overrideFalseBeatsGlobalTrue() async throws {
+        let (coord, db, wtID, terminalID) = try await makeDeps()
+        try await db.config.setAutoHibernateOnMergeDefault(true)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: false)
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 3)
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func overrideTrueBeatsGlobalFalse() async throws {
+        let (coord, db, wtID, terminalID) = try await makeDeps()
+        // global default stays false; worktree override on.
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 4)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt != nil)
+        #expect(after?.hibernateReason == .merged)
+    }
+
+    // MARK: - Safety rails hold even when armed
+
+    @Test func keepWarmNotParkedWhenArmed() async throws {
+        // Merge-park HONORS keep-warm (unlike manual hibernate).
+        let (coord, db, wtID, terminalID) = try await makeDeps(keepWarm: true)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 5)
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func workingTerminalNotParkedWhenArmed() async throws {
+        let (coord, db, wtID, terminalID) = try await makeDeps(activityState: .working)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 6)
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    // MARK: - Worktree status gate
+
+    @Test func nonActiveWorktreeIsNoOp() async throws {
+        let (coord, db, wtID, terminalID) = try await makeDeps(status: .archived)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 7)
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    // MARK: - Notification only when something parked
+
+    @Test func notificationCreatedWhenAtLeastOneParked() async throws {
+        let (coord, db, wtID, _) = try await makeDeps()
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 8)
+        let notifications = try await db.notifications.unread(worktreeID: wtID)
+        #expect(notifications.count == 1)
+        #expect(notifications.first?.type == .taskComplete)
+        #expect(notifications.first?.message?.contains("#8") == true)
+        // Singular "session" for exactly one parked terminal.
+        #expect(notifications.first?.message?.contains("1 session") == true)
+    }
+
+    @Test func noNotificationWhenZeroParked() async throws {
+        // Armed, but the single terminal is keep-warm → 0 parked → no notification.
+        let (coord, db, wtID, _) = try await makeDeps(keepWarm: true)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 9)
+        let notifications = try await db.notifications.unread(worktreeID: wtID)
+        #expect(notifications.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct AutoHibernateRPCTests {
+
+    private func makeRouter() throws -> (RPCRouter, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+        return (router, db)
+    }
+
+    @Test func setWorktreeAutoHibernatePersists() async throws {
+        let (router, db) = try makeRouter()
+        let repo = try await db.repos.create(
+            path: "/tmp/repoH-\(UUID().uuidString)",
+            displayName: "repoH",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "w",
+            branch: "b",
+            path: "/tmp/repoH-w-\(UUID().uuidString)",
+            tmuxServer: "s"
+        )
+
+        let req = try RPCRequest(
+            method: RPCMethod.worktreeSetAutoHibernate,
+            params: WorktreeSetAutoHibernateParams(worktreeID: wt.id, enabled: true)
+        )
+        let resp = await router.handle(req)
+        #expect(resp.success)
+        let after = try await db.worktrees.get(id: wt.id)
+        #expect(after?.autoHibernateOnMerge == true)
+    }
+
+    @Test func configGetAndSetDefault() async throws {
+        let (router, db) = try makeRouter()
+        let setReq = try RPCRequest(
+            method: RPCMethod.configSetAutoHibernateOnMergeDefault,
+            params: ConfigSetAutoHibernateDefaultParams(enabled: true)
+        )
+        #expect(await router.handle(setReq).success)
+
+        let getReq = RPCRequest(method: RPCMethod.configGet)
+        let getResp = await router.handle(getReq)
+        let cfg = try getResp.decodeResult(Config.self)
+        #expect(cfg.autoHibernateOnMergeDefault == true)
+        _ = db
+    }
+}

--- a/Tests/TBDDaemonTests/AutoHibernateStoreTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateStoreTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+import TBDShared
+@testable import TBDDaemonLib
+
+@Suite struct AutoHibernateStoreTests {
+
+    @Test func worktreeAutoHibernateRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/repoA", displayName: "repoA", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", displayName: "w", branch: "b",
+            path: "/tmp/repoA/w", tmuxServer: "s", status: .active)
+        #expect(wt.autoHibernateOnMerge == nil)
+
+        try await db.worktrees.setAutoHibernateOnMerge(id: wt.id, value: true)
+        let on = try await db.worktrees.get(id: wt.id)
+        #expect(on?.autoHibernateOnMerge == true)
+
+        try await db.worktrees.setAutoHibernateOnMerge(id: wt.id, value: false)
+        let off = try await db.worktrees.get(id: wt.id)
+        #expect(off?.autoHibernateOnMerge == false)
+
+        try await db.worktrees.setAutoHibernateOnMerge(id: wt.id, value: nil)
+        let cleared = try await db.worktrees.get(id: wt.id)
+        #expect(cleared?.autoHibernateOnMerge == nil)
+    }
+
+    @Test func configDefaultPersistsAndDefaultsFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let initial = try await db.config.get()
+        #expect(initial.autoHibernateOnMergeDefault == false)
+        try await db.config.setAutoHibernateOnMergeDefault(true)
+        let updated = try await db.config.get()
+        #expect(updated.autoHibernateOnMergeDefault == true)
+    }
+}

--- a/Tests/TBDDaemonTests/HibernationGateMergeTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateMergeTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Every branch of the MERGE-triggered park decision (`decideForMerge`). Proves
+/// it (a) has NO idle window and NO master switch, and (b) still enforces every
+/// hard safety rail. Pure: no DB, no tmux, no actor. One test per rail per
+/// CLAUDE.md's "test every gated branch" rule.
+@Suite("HibernationGateMerge")
+struct HibernationGateMergeTests {
+    private func claudeTerminal(
+        activityState: TerminalActivityState = .idle,
+        keepWarm: Bool = false,
+        hibernatedAt: Date? = nil,
+        suspendedAt: Date? = nil,
+        sessionID: String? = "sess-1",
+        kind: TerminalKind? = .claude
+    ) -> Terminal {
+        Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: sessionID,
+            suspendedAt: suspendedAt, kind: kind,
+            activityState: activityState, hibernatedAt: hibernatedAt, keepWarm: keepWarm
+        )
+    }
+
+    // MARK: - The go path: no idle window at all
+
+    @Test func eligibleForIdleResumableWithNoIdleMarker() {
+        // No idleSince is even passed — proving the idle window is absent from
+        // merge-park. An idle resumable Claude terminal is a valid park target
+        // the instant its PR merges.
+        let t = claudeTerminal(activityState: .idle)
+        #expect(HibernationGate.decideForMerge(terminal: t) == .eligible)
+    }
+
+    @Test func eligibleForUnknownActivity() {
+        // `.unknown` (hook hasn't fired) is treated as at-rest, same as the sweep.
+        let t = claudeTerminal(activityState: .unknown)
+        #expect(HibernationGate.decideForMerge(terminal: t) == .eligible)
+    }
+
+    // MARK: - Independence from the idle-sweep master switch
+
+    @Test func eligibleEvenThoughMasterSwitchWouldBeOff() {
+        // `decideForMerge` takes NO `autoHibernateEnabled` argument, so there is
+        // structurally no way for the idle sweep's master switch to gate it.
+        // Cross-check against `decide(...)` with the switch OFF: that would return
+        // `.featureDisabled`, but merge-park stays `.eligible`.
+        let t = claudeTerminal(activityState: .idle)
+        let sweepWithSwitchOff = HibernationGate.decide(
+            terminal: t, autoHibernateEnabled: false,
+            idleTimeout: 30 * 60,
+            idleSince: Date(timeIntervalSince1970: 0), now: Date()
+        )
+        #expect(sweepWithSwitchOff == .featureDisabled)
+        #expect(HibernationGate.decideForMerge(terminal: t) == .eligible)
+    }
+
+    // MARK: - Hard safety rails (each blocks)
+
+    @Test func keepWarmBlocks() {
+        // Merge-park HONORS keep-warm (unlike manualHibernate).
+        let t = claudeTerminal(keepWarm: true)
+        #expect(HibernationGate.decideForMerge(terminal: t) == .keepWarm)
+    }
+
+    @Test func runningTurnBlocks() {
+        let t = claudeTerminal(activityState: .working)
+        #expect(HibernationGate.decideForMerge(terminal: t) == .running)
+    }
+
+    @Test func waitingForUserBlocks() {
+        let t = claudeTerminal(activityState: .waitingForUser)
+        #expect(HibernationGate.decideForMerge(terminal: t) == .waitingForUser)
+    }
+
+    @Test func alreadyHibernatedBlocks() {
+        let t = claudeTerminal(hibernatedAt: Date(timeIntervalSince1970: 1))
+        #expect(HibernationGate.decideForMerge(terminal: t) == .alreadyHibernated)
+    }
+
+    @Test func suspendedBlocks() {
+        let t = claudeTerminal(suspendedAt: Date(timeIntervalSince1970: 1))
+        #expect(HibernationGate.decideForMerge(terminal: t) == .suspended)
+    }
+
+    @Test func nonClaudeBlocks() {
+        let t = claudeTerminal(sessionID: nil, kind: .shell)
+        #expect(HibernationGate.decideForMerge(terminal: t) == .notClaudeResumable)
+    }
+}

--- a/Tests/TBDDaemonTests/MergedTransitionPrecedenceTests.swift
+++ b/Tests/TBDDaemonTests/MergedTransitionPrecedenceTests.swift
@@ -1,0 +1,150 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// The precedence rule when a PR merges: archive supersedes hibernate, but only
+/// when archive ACTUALLY began. The important asymmetry — an armed-but-blocked
+/// archive must NOT suppress hibernate — gets its own test.
+@Suite("MergedTransitionPrecedence")
+struct MergedTransitionPrecedenceTests {
+
+    private struct Deps {
+        let dispatcher: MergedTransitionDispatcher
+        let archive: AutoArchiveOnMergeCoordinator
+        let db: TBDDatabase
+    }
+
+    private func makeDeps() throws -> Deps {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver(),
+            subscriptions: subs
+        )
+        let archive = AutoArchiveOnMergeCoordinator(db: db, lifecycle: lifecycle, subscriptions: subs)
+        let hibernation = HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            subscriptions: subs, configDirManager: mergeIsolatedConfigDirManager())
+        let hibernate = AutoHibernateOnMergeCoordinator(db: db, hibernation: hibernation, subscriptions: subs)
+        let dispatcher = MergedTransitionDispatcher(archive: archive, hibernate: hibernate)
+        return Deps(dispatcher: dispatcher, archive: archive, db: db)
+    }
+
+    /// Create an active worktree with a single idle Claude terminal.
+    private func makeWorktreeWithTerminal(
+        _ db: TBDDatabase, parentID: UUID? = nil
+    ) async throws -> (wtID: UUID, terminalID: UUID) {
+        let repo = try await db.repos.create(
+            path: "/tmp/repoMTP-\(UUID().uuidString)", displayName: "repoMTP", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/repoMTP/w-\(UUID().uuidString)", tmuxServer: "s",
+            parentWorktreeID: parentID)
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+        return (wt.id, terminal.id)
+    }
+
+    // MARK: - Precedence via the dispatcher
+
+    @Test func bothArmedArchivesAndDoesNotPark() async throws {
+        let deps = try makeDeps()
+        let (wtID, terminalID) = try await makeWorktreeWithTerminal(deps.db)
+        try await deps.db.worktrees.setAutoArchiveOnMerge(id: wtID, value: true)
+        try await deps.db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        await deps.dispatcher.handleMergedTransition(worktreeID: wtID, prNumber: 1)
+
+        #expect(try await deps.db.worktrees.get(id: wtID)?.status == .archived)
+        // Archive superseded hibernate → the terminal was NOT parked.
+        #expect(try await deps.db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    @Test func archiveBlockedByChildrenStillParks() async throws {
+        // The important asymmetry: archive is armed but BLOCKED by active
+        // children, so the worktree survives — its idle sessions ARE parked.
+        let deps = try makeDeps()
+        let (parentID, parentTerminalID) = try await makeWorktreeWithTerminal(deps.db)
+        _ = try await makeWorktreeWithTerminal(deps.db, parentID: parentID)  // active child
+        try await deps.db.worktrees.setAutoArchiveOnMerge(id: parentID, value: true)
+        try await deps.db.worktrees.setAutoHibernateOnMerge(id: parentID, value: true)
+
+        await deps.dispatcher.handleMergedTransition(worktreeID: parentID, prNumber: 2)
+
+        #expect(try await deps.db.worktrees.get(id: parentID)?.status == .active)
+        let after = try await deps.db.terminals.get(id: parentTerminalID)
+        #expect(after?.hibernatedAt != nil)
+        #expect(after?.hibernateReason == .merged)
+    }
+
+    @Test func onlyHibernateArmedParksNotArchived() async throws {
+        let deps = try makeDeps()
+        let (wtID, terminalID) = try await makeWorktreeWithTerminal(deps.db)
+        try await deps.db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        await deps.dispatcher.handleMergedTransition(worktreeID: wtID, prNumber: 3)
+
+        #expect(try await deps.db.worktrees.get(id: wtID)?.status == .active)
+        #expect(try await deps.db.terminals.get(id: terminalID)?.hibernatedAt != nil)
+    }
+
+    @Test func onlyArchiveArmedArchives() async throws {
+        let deps = try makeDeps()
+        let (wtID, terminalID) = try await makeWorktreeWithTerminal(deps.db)
+        try await deps.db.worktrees.setAutoArchiveOnMerge(id: wtID, value: true)
+
+        await deps.dispatcher.handleMergedTransition(worktreeID: wtID, prNumber: 4)
+
+        #expect(try await deps.db.worktrees.get(id: wtID)?.status == .archived)
+        #expect(try await deps.db.terminals.get(id: terminalID)?.hibernatedAt == nil)
+    }
+
+    // MARK: - Direct Bool contract on the archive coordinator
+
+    @Test func archiveReturnsTrueOnlyWhenItBeganArchiving() async throws {
+        let deps = try makeDeps()
+
+        // Armed + no children → began archiving → true.
+        let (armedID, _) = try await makeWorktreeWithTerminal(deps.db)
+        try await deps.db.worktrees.setAutoArchiveOnMerge(id: armedID, value: true)
+        let began = await deps.archive.handleMergedTransition(worktreeID: armedID, prNumber: 10)
+        #expect(began == true)
+
+        // Not armed → false.
+        let (offID, _) = try await makeWorktreeWithTerminal(deps.db)
+        try await deps.db.worktrees.setAutoArchiveOnMerge(id: offID, value: false)
+        let notArmed = await deps.archive.handleMergedTransition(worktreeID: offID, prNumber: 11)
+        #expect(notArmed == false)
+
+        // Armed but active children → false.
+        let (parentID, _) = try await makeWorktreeWithTerminal(deps.db)
+        _ = try await makeWorktreeWithTerminal(deps.db, parentID: parentID)
+        try await deps.db.worktrees.setAutoArchiveOnMerge(id: parentID, value: true)
+        let blocked = await deps.archive.handleMergedTransition(worktreeID: parentID, prNumber: 12)
+        #expect(blocked == false)
+
+        // Not active (already archived) → false.
+        let (goneID, _) = try await makeWorktreeWithTerminal(deps.db)
+        try await deps.db.worktrees.updateStatus(id: goneID, status: .archived)
+        try await deps.db.worktrees.setAutoArchiveOnMerge(id: goneID, value: true)
+        let notActive = await deps.archive.handleMergedTransition(worktreeID: goneID, prNumber: 13)
+        #expect(notActive == false)
+    }
+}
+
+/// Isolated Claude config dir (mirrors HibernationCoordinatorTests) so nothing
+/// touches the developer's real `~/.claude`.
+private func mergeIsolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
+    let home = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-mtp-claude-\(UUID().uuidString)", isDirectory: true)
+    return ClaudeProfileConfigDirManager(
+        baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+        hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
+    )
+}

--- a/Tests/TBDSharedTests/AutoHibernateCodableTests.swift
+++ b/Tests/TBDSharedTests/AutoHibernateCodableTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct AutoHibernateCodableTests {
+    @Test func worktreeDefaultsToNilWhenKeyMissing() throws {
+        // JSON without the new key must still decode (backward compat).
+        let json = """
+        {"id":"\(UUID().uuidString)","repoID":"\(UUID().uuidString)","name":"w",
+         "displayName":"w","branch":"b","path":"/p","status":"active",
+         "createdAt":0,"tmuxServer":"s"}
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let wt = try decoder.decode(Worktree.self, from: json)
+        #expect(wt.autoHibernateOnMerge == nil)
+    }
+
+    @Test func worktreeRoundTripsExplicitValues() throws {
+        for value: Bool? in [nil, true, false] {
+            var wt = Worktree(repoID: UUID(), name: "w", displayName: "w",
+                              branch: "b", path: "/p", tmuxServer: "s")
+            wt.autoHibernateOnMerge = value
+            let data = try JSONEncoder().encode(wt)
+            let back = try JSONDecoder().decode(Worktree.self, from: data)
+            #expect(back.autoHibernateOnMerge == value)
+        }
+    }
+
+    @Test func configDefaultsToFalseWhenKeyMissing() throws {
+        let data = "{}".data(using: .utf8)!
+        let cfg = try JSONDecoder().decode(Config.self, from: data)
+        #expect(cfg.autoHibernateOnMergeDefault == false)
+    }
+}

--- a/Tests/TBDSharedTests/HibernateReasonCodableTests.swift
+++ b/Tests/TBDSharedTests/HibernateReasonCodableTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct HibernateReasonCodableTests {
+    @Test func allKnownCasesRoundTrip() throws {
+        for reason: HibernateReason in [.auto, .manual, .recovery, .merged] {
+            let data = try JSONEncoder().encode(reason)
+            let back = try JSONDecoder().decode(HibernateReason.self, from: data)
+            #expect(back == reason)
+        }
+    }
+
+    @Test func mergedEncodesToMergedRawValue() throws {
+        let data = try JSONEncoder().encode(HibernateReason.merged)
+        let text = String(data: data, encoding: .utf8)
+        #expect(text == "\"merged\"")
+    }
+
+    @Test func unknownRawValueDecodesToAutoWithoutThrowing() throws {
+        // The lenient custom decoder must NOT throw on a value a newer daemon
+        // might send — it falls back to `.auto`.
+        let data = "\"future_reason\"".data(using: .utf8)!
+        let reason = try JSONDecoder().decode(HibernateReason.self, from: data)
+        #expect(reason == .auto)
+    }
+
+    @Test func terminalWithMergedReasonDecodes() throws {
+        let json = """
+        {"id":"\(UUID().uuidString)","worktreeID":"\(UUID().uuidString)",
+         "tmuxWindowID":"@1","tmuxPaneID":"%1","createdAt":0,
+         "activityState":"idle","keepWarm":false,
+         "hibernatedAt":0,"hibernateReason":"merged"}
+        """.data(using: .utf8)!
+        let terminal = try JSONDecoder().decode(Terminal.self, from: json)
+        #expect(terminal.hibernateReason == .merged)
+    }
+
+    @Test func terminalWithUnknownReasonDecodesToAutoWithoutThrowing() throws {
+        // Regression guard for the whole feature: an UNKNOWN hibernateReason on
+        // the wire must NOT fail the entire Terminal decode on an older binary.
+        let json = """
+        {"id":"\(UUID().uuidString)","worktreeID":"\(UUID().uuidString)",
+         "tmuxWindowID":"@1","tmuxPaneID":"%1","createdAt":0,
+         "activityState":"idle","keepWarm":false,
+         "hibernatedAt":0,"hibernateReason":"future_reason"}
+        """.data(using: .utf8)!
+        let terminal = try JSONDecoder().decode(Terminal.self, from: json)
+        #expect(terminal.hibernateReason == .auto)
+    }
+
+    @Test func terminalWithAbsentReasonDecodesToNil() throws {
+        // `decodeIfPresent` short-circuits before the custom init when the key
+        // is absent, so an absent key yields nil (NOT `.auto`).
+        let json = """
+        {"id":"\(UUID().uuidString)","worktreeID":"\(UUID().uuidString)",
+         "tmuxWindowID":"@1","tmuxPaneID":"%1","createdAt":0,
+         "activityState":"idle","keepWarm":false}
+        """.data(using: .utf8)!
+        let terminal = try JSONDecoder().decode(Terminal.self, from: json)
+        #expect(terminal.hibernateReason == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Auto-hibernate sessions on PR merge** as a sibling of the existing *Auto-archive worktree on PR merge*.

After a PR merges you often want to keep the worktree but stop paying for its idle Claude session. Archive is all-or-nothing: it tears down the whole worktree. This is the gentler option — it parks the session (freeing the `claude` process and its RSS) while keeping the tmux window, the frozen ANSI screen, and full resumability. The worktree stays exactly where it was.

Armed per-worktree via a tri-state `Worktree.autoHibernateOnMerge: Bool?` (`nil` = inherit) plus a global `Config.autoHibernateOnMergeDefault` — the same shape as auto-archive. Surfaced in Settings beside its sibling, as a Toggle in the PR split-button dropdown, as a `moon.zzz` armed-badge on the toolbar icon (matching the parked-tab iconography), and as `tbd config set auto-hibernate-on-merge on|off`. Migrations `v48`/`v49`; a new `AutoHibernateOnMergeCoordinator` hangs off the same `PRStatusManager.onMergedTransition` hook.

## Design decisions

**Archive supersedes hibernate.** A new `MergedTransitionDispatcher` runs archive first and only hibernates if archive did *not* actually begin — parking a session we're about to delete is pointless. The asymmetry matters: precedence keys off *"did archive begin"*, not *"was archive armed"*. An armed-but-blocked archive (the worktree has active children) returns `false`, the worktree survives, and its sessions **are** parked. That branch has its own test.

**Merge-park honors keep-warm and every safety rail** — unlike `manualHibernate`, which bypasses keep-warm because the user asked explicitly. Implemented by extracting `HibernationGate.blockingRail(terminal:)` (a pure extract-method; `decide()` is provably unchanged) and adding `decideForMerge(terminal:)` = rails, no idle window, no master switch. It routes into the existing `performHibernate(reason: .merged)`, so the ANSI snapshot capture, the typed-but-unsent-input rail, the transcript-tail rail, and the `TerminalHibernationDelta` broadcast all come for free. There is no bespoke kill path.

**Merge-park deliberately does not consult `config.autoHibernateEnabled`.** That flag is the *idle sweep's* master switch; merge-park is an independent feature with its own arming. This is called out in a code comment because it's the single most likely thing a future reader gets wrong.

**New `HibernateReason.merged` rather than reusing `.auto`,** for telemetry. This has a real compat cost worth stating plainly: `HibernateReason` is a `String` enum whose *synthesized* `Decodable` throws `DecodingError.dataCorrupted` on an unknown raw value — and it rides the RPC wire on both `Terminal` and `TerminalHibernationDelta`. A new daemon emitting `"merged"` would fail the **entire** decode on an older app binary (the blank-app class of failure). Mitigated by giving the enum a lenient custom `init(from:)` that maps unknown raw values to `.auto`. That fallback is semantically exact rather than merely convenient: wake-on-focus only special-cases `.manual`, so an unknown reason and `.auto` behave identically. Apps predating this shim need one restart. `Encodable` stays synthesized.

**Merge-parks auto-wake on focus,** because they're system-initiated rather than an expression of user intent. Wake-on-focus filters only `.manual`, so `.merged` transparently wakes. Pinned by a test.

**Accepted behavior:** `.merged` is never persisted to the DB, so a still-merged PR re-fires the merged transition after each daemon restart. An already-parked terminal no-ops (`.alreadyHibernated`) and the rails refuse to park an active session, so the only observable effect is re-parking a session the user woke and then left idle. A deliberate revive disarms the flag.

## Bug found and fixed along the way

There are **two** revive paths, and only the preSession-hook one disarmed auto-archive's sibling. `WorktreeLifecycle+Archive.swift` — the common, no-hook path — was missing the auto-hibernate disarm, so reviving a worktree whose PR was still merged would immediately re-park the session the user had just deliberately brought back. Caught by writing the test the project's test-per-gated-branch rule demanded, and fixed with red-then-green evidence.

## Pre-existing issue observed (not fixed here)

In `AutoArchiveOnMergeCoordinator`, if `db.notifications.create` throws *after* `beginArchiveWorktree` has succeeded, the worktree is left `.archived` in the DB but is never removed from disk and phase 2 is never scheduled. This predates this branch and is out of scope. The new dispatcher is unaffected: the hibernate coordinator independently re-checks `status == .active`, so it correctly no-ops on a half-archived worktree.

## Test plan

Full suite: **3230 tests green**. A test per gated branch, per the project rule:

- [x] Tri-state matrix, all four combinations, both app-side (`effectiveAutoHibernate`) and daemon-side (coordinator)
- [x] Every `blockingRail` rail: keep-warm, running, waiting-for-user, suspended, already-hibernated, not-Claude-resumable
- [x] `decideForMerge` is `.eligible` with no idle marker and with the idle master switch off (proves independence)
- [x] Archive-beats-hibernate precedence, including the blocked-by-children asymmetry, and `handleMergedTransition` returning `true` iff it began archiving
- [x] `HibernateReason` decode: `.merged` round-trips; an unknown raw value yields `.auto` without throwing; an absent key still yields `nil`
- [x] Already-parked no-op does not stomp an existing `.manual` reason or timestamp; plural-notification branch
- [x] Revive disarms auto-hibernate (red before the fix, green after)
- [x] Toolbar `.id` key and baked-icon cache key both include `hibernateArmed` — the stale-NSMenu-checkmark / stale-bitmap regression guards
- [x] Verified live: migrations `v48`/`v49` applied to `~/tbd/state.db`; `tbd config set auto-hibernate-on-merge on|off` round-trips through RPC → daemon → DB

[20260708-large-locust](https://cheapsteak.github.io/tbd/open/?worktree=C5309965-2CA7-4863-A018-91E5EFCA3EEA)