### PR TITLE
Feat: Re-run a worktree's setup hook without recreating the worktree

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -291,7 +291,8 @@ extension AppState {
     /// an error on this call.
     func rerunPreSessionHook(worktreeID: UUID) async {
         do {
-            try await daemonClient.rerunPreSessionHook(worktreeID: worktreeID)
+            let size = mainAreaTerminalSize()
+            try await daemonClient.rerunPreSessionHook(worktreeID: worktreeID, cols: size.cols, rows: size.rows)
             logger.info("Re-running setup hook for worktree \(worktreeID, privacy: .public)")
         } catch {
             logger.error("Failed to re-run setup hook: \(error)")

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -281,6 +281,24 @@ extension AppState {
         }
     }
 
+    /// Re-run the worktree's `preSession` hook. The daemon spawns a
+    /// non-focused tab and closes it on a clean exit; a failing hook leaves its
+    /// tab open with the output and raises an `.error` notification. Running
+    /// agents are untouched.
+    ///
+    /// The only thing to surface here is a refusal (no hook, already running,
+    /// still creating) — hook FAILURE arrives later as a notification, not as
+    /// an error on this call.
+    func rerunPreSessionHook(worktreeID: UUID) async {
+        do {
+            try await daemonClient.rerunPreSessionHook(worktreeID: worktreeID)
+            logger.info("Re-running setup hook for worktree \(worktreeID, privacy: .public)")
+        } catch {
+            logger.error("Failed to re-run setup hook: \(error)")
+            showAlert("\(error)", isError: true)
+        }
+    }
+
     /// Revive an archived worktree.
     /// Mirrors `reviveWithSession`'s lingering-snapshot UX: keeps the row
     /// visible with a status pill until the user navigates away, instead

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -539,10 +539,10 @@ actor DaemonClient {
 
     /// Re-run the worktree's `preSession` hook in a fresh, non-focused tab.
     /// Returns as soon as the tab exists; the hook itself runs on in the daemon.
-    func rerunPreSessionHook(worktreeID: UUID) async throws {
+    func rerunPreSessionHook(worktreeID: UUID, cols: Int? = nil, rows: Int? = nil) async throws {
         try await callVoidAsync(
             method: RPCMethod.worktreeRerunPreSession,
-            params: WorktreeRerunPreSessionParams(worktreeID: worktreeID)
+            params: WorktreeRerunPreSessionParams(worktreeID: worktreeID, cols: cols, rows: rows)
         )
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -537,6 +537,15 @@ actor DaemonClient {
         )
     }
 
+    /// Re-run the worktree's `preSession` hook in a fresh, non-focused tab.
+    /// Returns as soon as the tab exists; the hook itself runs on in the daemon.
+    func rerunPreSessionHook(worktreeID: UUID) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.worktreeRerunPreSession,
+            params: WorktreeRerunPreSessionParams(worktreeID: worktreeID)
+        )
+    }
+
     /// Revive an archived worktree. Returns the revived worktree as the daemon
     /// sees it when the RPC completes — still `.creating` while a blocking
     /// `preSession` hook runs, `.active` otherwise.

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -34,6 +34,8 @@ enum RowActionMenu {
         /// Create a child worktree based on THIS worktree's current branch.
         case newWorktreeFromBranch
         case archive
+        /// Re-run this worktree's `preSession` hook in a fresh, non-focused tab.
+        case rerunPreSessionHook
         /// Fork a specific Claude session into a new tab on the same account.
         /// Carries the session's terminal and its own (possibly ambient/nil)
         /// profile, so the dispatcher can resume+fork it.
@@ -120,6 +122,10 @@ enum RowActionMenu {
         /// Forkable Claude sessions in tab order. Drives the per-session
         /// "Fork session" entries (empty → none).
         var claudeSessions: [ClaudeSessionRef]
+        /// A `preSession` hook resolves for this worktree — gates the re-run
+        /// item entirely (no hook, no item). Resolved by the surface via the
+        /// shared `HookResolver`, so `items(...)` stays pure.
+        var hasPreSessionHook: Bool
 
         init(hasHibernatableClaude: Bool = false,
              hasHibernatedClaude: Bool = false,
@@ -132,7 +138,8 @@ enum RowActionMenu {
              status: WorktreeStatus = .active,
              isPromoted: Bool = false,
              branch: String = "",
-             claudeSessions: [ClaudeSessionRef] = []) {
+             claudeSessions: [ClaudeSessionRef] = [],
+             hasPreSessionHook: Bool = false) {
             self.hasHibernatableClaude = hasHibernatableClaude
             self.hasHibernatedClaude = hasHibernatedClaude
             self.hasUnpinnedClaude = hasUnpinnedClaude
@@ -145,6 +152,7 @@ enum RowActionMenu {
             self.isPromoted = isPromoted
             self.branch = branch
             self.claudeSessions = claudeSessions
+            self.hasPreSessionHook = hasPreSessionHook
         }
     }
 
@@ -163,6 +171,7 @@ enum RowActionMenu {
     static let wakeLabel = "Wake"
     static let keepWarmLabel = "Keep warm"
     static let allowHibernationLabel = "Allow hibernation"
+    static let rerunPreSessionLabel = "Re-run setup hook"
 
     /// Title for a fork-session action: plain when the worktree hosts a single
     /// Claude session, suffixed with the session label when there are several.
@@ -181,8 +190,10 @@ enum RowActionMenu {
     /// 2. Hibernation — Wake / Hibernate now / keep-warm toggle (conditional).
     /// 3. Sessions & spawning — per-session Fork entries, plus (regular only)
     ///    Create Nested Worktree / New worktree from this branch.
-    /// 4. Filesystem — Open in Finder, Copy Path.
-    /// 5. (scratch only) Delete Scratch Space, with the promote-hint caption
+    /// 4. Maintenance — Re-run setup hook (only when a `preSession` hook
+    ///    resolves).
+    /// 5. Filesystem — Open in Finder, Copy Path.
+    /// 6. (scratch only) Delete Scratch Space, with the promote-hint caption
     ///    beneath it.
     ///
     /// Sections are joined with a single divider each; empty sections collapse,
@@ -219,6 +230,14 @@ enum RowActionMenu {
             actions.append(Action(kind: .toggleKeepWarm(enable: false), title: allowHibernationLabel))
         }
         return actions
+    }
+
+    /// The maintenance section — currently just the hook re-run. Empty when no
+    /// `preSession` hook resolves, so `joined(...)` collapses the section and no
+    /// dangling divider renders.
+    static func maintenanceActions(context: Context) -> [Action] {
+        guard context.hasPreSessionHook else { return [] }
+        return [Action(kind: .rerunPreSessionHook, title: rerunPreSessionLabel)]
     }
 
     private static func forkActions(context: Context) -> [Action] {
@@ -259,6 +278,7 @@ enum RowActionMenu {
             // Scratch spaces host Claude sessions too — same fork entries as
             // the regular branch.
             forkActions(context: context).map(Item.action),
+            maintenanceActions(context: context).map(Item.action),
             [
                 .action(Action(kind: .openInFinder, title: "Open in Finder")),
                 .action(Action(kind: .copyPath, title: "Copy Path")),
@@ -306,6 +326,7 @@ enum RowActionMenu {
             ],
             hibernationActions(context: context).map(Item.action),
             spawning,
+            maintenanceActions(context: context).map(Item.action),
             [
                 .action(Action(kind: .openInFinder, title: "Open in Finder")),
                 .action(Action(kind: .copyPath, title: "Copy Path")),

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -36,6 +36,27 @@ struct RowActionMenuActions {
         }
     }
 
+    /// Does a `preSession` hook resolve for this worktree? Uses the SAME
+    /// five-step chain the daemon executes (`HookResolver` lives in TBDShared
+    /// precisely so this can't drift): app per-repo config → `.worktree-hooks/`
+    /// → `conductor.json` → `.dmux-hooks/` → global default.
+    ///
+    /// A handful of `fileExists` calls, evaluated when the menu is built on
+    /// right-click — not per frame. Scratch spaces have no `repoID`, so
+    /// `appHookPath` is nil for them and resolution falls through to the
+    /// in-directory hook or the global default.
+    private var hasPreSessionHook: Bool {
+        guard !worktree.path.isEmpty else { return false }
+        let appHookPath = worktree.repoID.map {
+            TBDConstants.hookPath(repoID: $0, eventName: HookEvent.preSession.rawValue)
+        }
+        return HookResolver().resolve(
+            event: .preSession,
+            repoPath: worktree.path,
+            appHookPath: appHookPath
+        ) != nil
+    }
+
     /// Build the pure model context from live `AppState`. Mirrors exactly the
     /// inputs the old `SidebarContextMenu` read inline.
     func context() -> RowActionMenu.Context {
@@ -57,7 +78,8 @@ struct RowActionMenuActions {
             status: worktree.status,
             isPromoted: worktree.promotedToRepoID != nil,
             branch: worktree.branch,
-            claudeSessions: claudeSessions
+            claudeSessions: claudeSessions,
+            hasPreSessionHook: hasPreSessionHook
         )
     }
 
@@ -147,6 +169,10 @@ struct RowActionMenuActions {
         case .archive:
             let wtID = worktree.id
             Task { await appState.archiveWorktree(id: wtID) }
+
+        case .rerunPreSessionHook:
+            let wtID = worktree.id
+            Task { await appState.rerunPreSessionHook(worktreeID: wtID) }
 
         case let .forkSession(terminalID, profileID):
             // Duplicate the conversation into a NEW tab on the SAME account —

--- a/Sources/TBDDaemon/Lifecycle/PreSessionRunRegistry.swift
+++ b/Sources/TBDDaemon/Lifecycle/PreSessionRunRegistry.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Tracks which worktrees currently have a `preSession` hook run in flight.
+///
+/// `WorktreeLifecycle` is a struct, so this must be a reference type for every
+/// copy of the struct to share one set — the same reasoning as
+/// `ConflictSweepCache`.
+///
+/// Deliberately daemon-local and NOT mirrored into app state. After the hook
+/// tab became ephemeral-on-success, a lingering `pre-session` tab means "the
+/// last run failed", not "a run is in progress", so the app cannot infer
+/// running-ness from the tab it already tracks. Surfacing this would need a new
+/// `StateDelta` case plus a transient worktree-snapshot field to survive an app
+/// relaunch mid-run — real state-sync plumbing for a grey menu row the user
+/// would rarely see. The RPC rejects the second run with a clear message instead.
+public actor PreSessionRunRegistry {
+    private var inFlight: Set<UUID> = []
+
+    public init() {}
+
+    /// Claims `id`. Returns false when a run is already in flight for it.
+    public func begin(_ id: UUID) -> Bool {
+        inFlight.insert(id).inserted
+    }
+
+    /// Releases the claim. Idempotent.
+    public func end(_ id: UUID) {
+        inFlight.remove(id)
+    }
+
+    public func isRunning(_ id: UUID) -> Bool {
+        inFlight.contains(id)
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -90,14 +90,22 @@ extension WorktreeLifecycle {
 
     // MARK: - Phase 2b: spawn the pre-session terminal
 
-    /// Resolves the `preSession` hook and, if present, creates its terminal as
-    /// the FIRST window of the worktree's tmux session. Returns nil when no
-    /// hook resolves — callers then spawn the primary terminals directly
-    /// (today's behavior, unchanged).
+    /// Resolves the `preSession` hook and, if present, creates its terminal.
+    /// Returns nil when no hook resolves — callers then spawn the primary
+    /// terminals directly (today's behavior, unchanged).
+    ///
+    /// `claimsFocus` distinguishes the two callers. Create/revive spawn this
+    /// as the FIRST and only window, so they claim tab order and focus. A
+    /// manual re-run lands beside live agent tabs: it appends to the existing
+    /// order and leaves `activeTabID` untouched.
+    ///
+    /// `repo` is optional because scratch spaces have none. `TBD_REPO_PATH`
+    /// then falls back to the worktree's own path.
     func spawnPreSessionTerminal(
-        worktree: Worktree, repo: Repo,
+        worktree: Worktree, repo: Repo?,
         worktreePath: String,
-        cols: Int? = nil, rows: Int? = nil
+        cols: Int? = nil, rows: Int? = nil,
+        claimsFocus: Bool = true
     ) async throws -> PreSessionSpawn? {
         guard let hookPath = hooks.resolve(
             event: .preSession,
@@ -144,7 +152,7 @@ extension WorktreeLifecycle {
             "TBD_EVENT": HookEvent.preSession.rawValue,
             "TBD_WORKTREE_NAME": worktree.name,
             "TBD_WORKTREE_PATH": worktreePath,
-            "TBD_REPO_PATH": repo.path,
+            "TBD_REPO_PATH": repo?.path ?? worktreePath,
             "TBD_BRANCH": worktree.branch,
         ]
         let window = try await tmux.createWindow(
@@ -165,11 +173,30 @@ extension WorktreeLifecycle {
             label: TerminalLabel.preSession,
             kind: .shell
         )
-        // The pre-session terminal is the only tab until phase 3 runs.
-        try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: [terminalID])
-        try await db.worktrees.setActiveTabID(worktreeID: worktreeID, tabID: terminalID)
+        if claimsFocus {
+            // The pre-session terminal is the only tab until phase 3 runs.
+            try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: [terminalID])
+            try await db.worktrees.setActiveTabID(worktreeID: worktreeID, tabID: terminalID)
+        } else {
+            // Manual re-run: append beside the live agent tabs, don't steal focus.
+            var order = try await db.worktrees.getTabOrder(worktreeID: worktreeID)
+            order.append(terminalID)
+            try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: order)
+            // The create/revive path broadcasts terminalCreated for the primaries
+            // later in phase 3; the hook tab there arrives bundled with the
+            // worktree row. A re-run has no such follow-up broadcast, so the app
+            // needs this one to render the tab immediately.
+            subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
+                terminalID: terminalID,
+                worktreeID: worktreeID,
+                label: TerminalLabel.preSession
+            )))
+        }
 
         // Kill the untracked initial window now that a real window exists.
+        // Only the focus-claiming (create/revive) path can have created it —
+        // `ensureServer` returns nil when the server already exists, so this
+        // stays correct for the re-run path without a `claimsFocus` check.
         if let initialWindowID {
             try? await tmux.killWindow(server: tmuxServer, windowID: initialWindowID)
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -284,6 +284,8 @@ extension WorktreeLifecycle {
             return
         }
 
+        let succeeded = outcome == .completed(exitCode: 0)
+
         switch outcome {
         case .completed(exitCode: 0):
             logger.info("preSession hook completed for worktree \(worktree.id, privacy: .public)")
@@ -312,7 +314,9 @@ extension WorktreeLifecycle {
                 archivedClaudeSessions: archivedClaudeSessions,
                 initialPrompt: initialPrompt,
                 cols: cols, rows: rows,
-                preSessionTerminalID: preSession.terminalID,
+                // On success the hook tab is about to be deleted — never splice
+                // it into tab order. On failure it stays, at index 1 as before.
+                preSessionTerminalID: succeeded ? nil : preSession.terminalID,
                 overrideProfileID: overrideProfileID
             )
             for terminal in created {
@@ -321,6 +325,18 @@ extension WorktreeLifecycle {
                     worktreeID: worktree.id,
                     label: terminal.label
                 )))
+            }
+
+            // Close the hook tab only after the primaries exist and
+            // `spawnPrimaryTerminals` has moved activeTabID onto the primary —
+            // the worktree is never momentarily tab-less, and focus never sits
+            // on a tab that is about to vanish. Deliberately INSIDE the `do`:
+            // if the spawn threw, the primaries don't exist, so tearing the
+            // hook tab down would leave the worktree tab-less — keep it instead.
+            // `.paneKilled` already has no window; the kill is best-effort so
+            // the row/tab cleanup still runs.
+            if succeeded {
+                await closePreSessionTerminal(worktree: worktree, preSession: preSession)
             }
         } catch {
             logger.error("phase-3 primary terminal spawn failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -347,6 +363,32 @@ extension WorktreeLifecycle {
             }
         } catch {
             logger.error("phase-3 status update failed for worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Tears the pre-session tab down after a clean run: kill the tmux window,
+    /// delete the terminal + tab rows, broadcast `.terminalRemoved`.
+    ///
+    /// Deliberately NOT reusing `RPCRouter.handleTerminalDelete`: that handler
+    /// also cancels scheduled resumes, clears pending questions, cancels
+    /// auto-login, and reclaims a per-session `ClaudeHookOverlay` — all Claude
+    /// concerns, all no-ops for this `.shell` tab, and several reach for
+    /// `RPCRouter` state the lifecycle doesn't hold.
+    ///
+    /// Best-effort: a failure here must never take down the worktree, whose
+    /// checkout and agent terminals are already valid.
+    func closePreSessionTerminal(worktree: Worktree, preSession: PreSessionSpawn) async {
+        try? await tmux.killWindow(
+            server: worktree.tmuxServer, windowID: preSession.windowID
+        )
+        do {
+            try await db.terminals.delete(id: preSession.terminalID)
+            try await db.tabs.delete(tabID: preSession.terminalID)
+            subscriptions?.broadcast(delta: .terminalRemoved(TerminalIDDelta(
+                terminalID: preSession.terminalID
+            )))
+        } catch {
+            logger.warning("failed to close pre-session terminal \(preSession.terminalID, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -421,7 +421,7 @@ extension WorktreeLifecycle {
 
     /// Records a daemon notification and broadcasts it (same pattern as
     /// `handleNotify` in RPCRouter+TerminalHandlers).
-    private func notifyPreSessionProblem(
+    func notifyPreSessionProblem(
         worktree: Worktree, terminalID: UUID, message: String
     ) async {
         logger.warning("preSession: \(message, privacy: .public) (worktree \(worktree.id, privacy: .public))")
@@ -440,5 +440,124 @@ extension WorktreeLifecycle {
         } catch {
             logger.error("failed to record preSession notification: \(error.localizedDescription, privacy: .public)")
         }
+    }
+}
+
+/// Why a manual `preSession` re-run was refused.
+public enum RerunPreSessionError: Error, Equatable, CustomStringConvertible {
+    case worktreeNotFound(UUID)
+    case noHookConfigured
+    case alreadyRunning
+    case worktreeBusy
+
+    public var description: String {
+        switch self {
+        case .worktreeNotFound(let id):
+            return "Worktree not found: \(id)"
+        case .noHookConfigured:
+            return "No preSession hook is configured for this worktree."
+        case .alreadyRunning:
+            return "Setup hook is already running for this worktree."
+        case .worktreeBusy:
+            return "This worktree is still being created — its setup hook is already running."
+        }
+    }
+
+    public var errorDescription: String? { description }
+}
+
+extension WorktreeLifecycle {
+
+    /// Re-runs the `preSession` hook in a fresh, non-focused tab, leaving the
+    /// worktree's status and its running agents completely alone.
+    ///
+    /// Returns as soon as the hook's terminal exists. A detached task awaits the
+    /// outcome, then closes the tab (clean exit) or leaves it open with its
+    /// output and records an `.error` notification (non-zero / timeout / killed
+    /// pane).
+    func rerunPreSessionHook(
+        worktreeID: UUID, cols: Int? = nil, rows: Int? = nil
+    ) async throws {
+        guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+            throw RerunPreSessionError.worktreeNotFound(worktreeID)
+        }
+        // A `.creating` worktree is already running its hook under phase 3.
+        guard worktree.status != .creating else {
+            throw RerunPreSessionError.worktreeBusy
+        }
+        var repo: Repo?
+        if let repoID = worktree.repoID {
+            repo = try await db.repos.get(id: repoID)
+        }
+
+        // Claim before spawning: the marker path is keyed by worktree ID, so two
+        // concurrent runs would race the same file and each other's teardown.
+        guard await preSessionRuns.begin(worktreeID) else {
+            throw RerunPreSessionError.alreadyRunning
+        }
+
+        let spawn: PreSessionSpawn?
+        do {
+            spawn = try await spawnPreSessionTerminal(
+                worktree: worktree, repo: repo,
+                worktreePath: worktree.path,
+                cols: cols, rows: rows,
+                claimsFocus: false
+            )
+        } catch {
+            await preSessionRuns.end(worktreeID)
+            throw error
+        }
+
+        guard let spawn else {
+            await preSessionRuns.end(worktreeID)
+            throw RerunPreSessionError.noHookConfigured
+        }
+
+        logger.info("preSession hook re-run started for worktree \(worktreeID, privacy: .public)")
+
+        let lifecycle = self
+        Task.detached {
+            await lifecycle.finishRerunPreSession(worktree: worktree, preSession: spawn)
+        }
+    }
+
+    /// Detached tail of a manual re-run: wait, then close-on-success or
+    /// notify-on-failure. Always releases the registry claim — this is a
+    /// single linear function (no early returns, and none of the awaited
+    /// calls below throw), so the final `preSessionRuns.end` at the bottom
+    /// runs on every path.
+    private func finishRerunPreSession(
+        worktree: Worktree, preSession: PreSessionSpawn
+    ) async {
+        let outcome = await waitForPreSessionCompletion(
+            preSession: preSession, tmuxServer: worktree.tmuxServer
+        )
+        // The marker must never outlive the wait, whatever the outcome.
+        try? FileManager.default.removeItem(atPath: preSession.markerPath)
+
+        switch outcome {
+        case .completed(exitCode: 0):
+            logger.info("preSession hook re-run completed for worktree \(worktree.id, privacy: .public)")
+            await closePreSessionTerminal(worktree: worktree, preSession: preSession)
+        case .completed(let exitCode):
+            await notifyPreSessionProblem(
+                worktree: worktree, terminalID: preSession.terminalID,
+                message: "Setup hook failed (exit \(exitCode)) — its tab is left open with the output"
+            )
+        case .timedOut:
+            await notifyPreSessionProblem(
+                worktree: worktree, terminalID: preSession.terminalID,
+                message: "Setup hook timed out after \(Int(preSessionTimeout))s"
+            )
+        case .paneKilled:
+            // Not an error on a re-run: the user closed the tab, a legitimate
+            // cancel. (On the create path this IS a notification, because
+            // there the primary agent is about to start on an unprepared
+            // tree — that concern doesn't apply here.)
+            logger.info("preSession hook re-run pane closed early for worktree \(worktree.id, privacy: .public)")
+        }
+
+        await preSessionRuns.end(worktree.id)
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -74,6 +74,10 @@ public struct WorktreeLifecycle: Sendable {
     /// Dirty gate for the periodic conflict sweep (see `refreshGitStatuses`).
     /// An actor reference, so every copy of this struct shares one cache.
     public let conflictSweepCache = ConflictSweepCache()
+    /// In-flight `preSession` runs, keyed by worktree ID. An actor reference,
+    /// so every copy of this struct shares one registry (same rationale as
+    /// `conflictSweepCache`).
+    public let preSessionRuns = PreSessionRunRegistry()
 
     /// Default `preSession` hook timeout (production value).
     public static let defaultPreSessionTimeout: TimeInterval = 600

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -137,7 +137,7 @@ extension RPCRouter {
     func handleWorktreeRerunPreSession(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeRerunPreSessionParams.self, from: paramsData)
         do {
-            try await lifecycle.rerunPreSessionHook(worktreeID: params.worktreeID)
+            try await lifecycle.rerunPreSessionHook(worktreeID: params.worktreeID, cols: params.cols, rows: params.rows)
             return .ok()
         } catch let error as RerunPreSessionError {
             return RPCResponse(error: error.description)

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -128,6 +128,22 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Re-run the worktree's `preSession` hook. Returns as soon as the hook's
+    /// tab exists; the wait + teardown run detached inside the lifecycle.
+    ///
+    /// Rejections (`no hook`, `already running`, `still creating`) come back as
+    /// RPC errors and surface as an app alert — the menu hides the item when no
+    /// hook resolves, but the app's view can be a keystroke stale.
+    func handleWorktreeRerunPreSession(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeRerunPreSessionParams.self, from: paramsData)
+        do {
+            try await lifecycle.rerunPreSessionHook(worktreeID: params.worktreeID)
+            return .ok()
+        } catch let error as RerunPreSessionError {
+            return RPCResponse(error: error.description)
+        }
+    }
+
     func handleWorktreeForget(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeForgetParams.self, from: paramsData)
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -168,6 +168,8 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeList(request.paramsData)
             case RPCMethod.worktreeArchive:
                 return try await handleWorktreeArchive(request.paramsData)
+            case RPCMethod.worktreeRerunPreSession:
+                return try await handleWorktreeRerunPreSession(request.paramsData)
             case RPCMethod.worktreeRevive:
                 return try await handleWorktreeRevive(request.paramsData)
             case RPCMethod.worktreeAdopt:

--- a/Sources/TBDShared/HookResolver.swift
+++ b/Sources/TBDShared/HookResolver.swift
@@ -1,7 +1,9 @@
 import Foundation
 import os
-import TBDShared
 
+// Subsystem stays `com.tbd.daemon` even though the type now lives in TBDShared:
+// hook resolution is still a daemon-side activity in practice, and existing
+// `log stream --predicate 'category == "hooks"'` recipes must keep working.
 private let hooksLogger = Logger(subsystem: "com.tbd.daemon", category: "hooks")
 
 public enum HookEvent: String, Sendable {
@@ -36,12 +38,12 @@ public struct HookResolver: Sendable {
     public let globalHooksDir: String
 
     public init(globalHooksDir: String? = nil) {
-        // Resolve in this module's compilation context. Cross-module default
-        // expressions that reference `TBDConstants.configDir` get re-emitted
-        // at the caller's site, and under Swift 6 / Xcode 26.3 that re-emission
-        // generates a reference to the property's `unsafeMutableAddressor`
-        // symbol — which doesn't exist for a computed `static var`, breaking
-        // the link step in test targets. See PR #153 CI failure for context.
+        // Resolved here rather than as a cross-module default expression.
+        // When this type lived in TBDDaemon, referencing `TBDConstants.configDir`
+        // in a default argument got re-emitted at each caller's site, generating
+        // a reference to an `unsafeMutableAddressor` symbol that doesn't exist
+        // for a computed `static var` — breaking the link step in test targets
+        // (PR #153). Same-module now, but keep the explicit resolution.
         self.globalHooksDir = globalHooksDir
             ?? TBDConstants.configDir.appendingPathComponent("hooks/default").path
     }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -843,9 +843,15 @@ public struct WorktreeArchiveParams: Codable, Sendable {
 /// Re-run the `preSession` hook for a worktree in a fresh, non-focused tab.
 public struct WorktreeRerunPreSessionParams: Codable, Sendable {
     public let worktreeID: UUID
+    /// Initial tmux window size in cells (see WorktreeCreateParams). Optional
+    /// so older app builds' JSON (no cols/rows) still decodes.
+    public let cols: Int?
+    public let rows: Int?
 
-    public init(worktreeID: UUID) {
+    public init(worktreeID: UUID, cols: Int? = nil, rows: Int? = nil) {
         self.worktreeID = worktreeID
+        self.cols = cols
+        self.rows = rows
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -82,6 +82,7 @@ public enum RPCMethod {
     public static let worktreeCreate = "worktree.create"
     public static let worktreeList = "worktree.list"
     public static let worktreeArchive = "worktree.archive"
+    public static let worktreeRerunPreSession = "worktree.rerunPreSession"
     public static let worktreeRevive = "worktree.revive"
     public static let worktreeAdopt = "worktree.adopt"
     public static let worktreeRename = "worktree.rename"
@@ -836,6 +837,15 @@ public struct WorktreeArchiveParams: Codable, Sendable {
     public let force: Bool
     public init(worktreeID: UUID, force: Bool = false) {
         self.worktreeID = worktreeID; self.force = force
+    }
+}
+
+/// Re-run the `preSession` hook for a worktree in a fresh, non-focused tab.
+public struct WorktreeRerunPreSessionParams: Codable, Sendable {
+    public let worktreeID: UUID
+
+    public init(worktreeID: UUID) {
+        self.worktreeID = worktreeID
     }
 }
 

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -150,6 +150,46 @@ struct RowActionMenuRegularTests {
         #expect(archive?.disabledHelp == nil)
     }
 
+    @Test("re-run item appears only when a preSession hook resolves")
+    func rerunItemGatedOnHook() {
+        let without = RowActionMenu.items(context: .init(hasPreSessionHook: false))
+        #expect(!without.contains(.action(.init(
+            kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
+        ))))
+
+        let with = RowActionMenu.items(context: .init(hasPreSessionHook: true))
+        #expect(with.contains(.action(.init(
+            kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
+        ))))
+    }
+
+    @Test("re-run item sits in its own section directly above Open in Finder")
+    func rerunItemSection() throws {
+        let items = RowActionMenu.items(context: .init(hasPreSessionHook: true))
+        let rerun = try #require(items.firstIndex(of: .action(.init(
+            kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
+        ))))
+        // Divider immediately before and after → its own section.
+        #expect(items[rerun - 1] == .divider)
+        #expect(items[rerun + 1] == .divider)
+        #expect(items[rerun + 2] == .action(.init(kind: .openInFinder, title: "Open in Finder")))
+    }
+
+    @Test("scratch rows get the re-run item, main rows never do")
+    func rerunItemRowScope() {
+        let scratch = RowActionMenu.items(context: .init(isScratch: true, hasPreSessionHook: true))
+        #expect(scratch.contains(.action(.init(
+            kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
+        ))))
+
+        let main = RowActionMenu.items(context: .init(
+            status: .main, hasPreSessionHook: true
+        ))
+        #expect(!main.contains(.action(.init(
+            kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
+        ))))
+    }
+
 }
 
 // MARK: - Scratch branch

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -575,6 +575,106 @@ struct PreSessionHookTests {
         #expect((try await db.terminals.get(id: spawn.terminalID) != nil) == (exitCode != 0))
     }
 
+    // MARK: - Reusable spawn (claimsFocus / optional repo)
+
+    @Test("claimsFocus: false appends the tab and leaves activeTabID alone")
+    func rerunSpawnDoesNotStealFocus() async throws {
+        let (_, cleanupHome) = isolateTBDHome()
+        defer { cleanupHome() }
+        let (db, repoDir, worktree, repo) = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let existing = UUID()
+        _ = try await db.terminals.create(
+            id: existing, worktreeID: worktree.id,
+            tmuxWindowID: "@99", tmuxPaneID: "%99",
+            label: TerminalLabel.claudeCode, kind: .claude
+        )
+        try await db.worktrees.setTabOrder(worktreeID: worktree.id, tabIDs: [existing])
+        try await db.worktrees.setActiveTabID(worktreeID: worktree.id, tabID: existing)
+
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+        let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
+            worktree: worktree, repo: repo, worktreePath: worktree.path,
+            claimsFocus: false
+        ))
+
+        let order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
+        #expect(order == [existing, spawn.terminalID])
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: worktree.id) == existing)
+    }
+
+    @Test("claimsFocus: false broadcasts terminalCreated for the new tab")
+    func rerunSpawnBroadcastsTerminalCreated() async throws {
+        let (_, cleanupHome) = isolateTBDHome()
+        defer { cleanupHome() }
+        let (db, repoDir, worktree, repo) = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let collected = CollectedDeltas()
+        let subscriptions = StateSubscriptionManager()
+        subscriptions.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                collected.append(delta)
+            }
+            return true
+        }
+        let lifecycle = makeLifecycle(db: db, subscriptions: subscriptions, timeout: 2)
+        let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
+            worktree: worktree, repo: repo, worktreePath: worktree.path,
+            claimsFocus: false
+        ))
+
+        let snapshot = collected.snapshot()
+        #expect(snapshot.contains {
+            if case .terminalCreated(let d) = $0 {
+                return d.terminalID == spawn.terminalID && d.label == TerminalLabel.preSession
+            }
+            return false
+        })
+    }
+
+    @Test("claimsFocus: true (default) keeps the original single-tab behavior")
+    func defaultClaimsFocusStillClaimsTheTab() async throws {
+        let (_, cleanupHome) = isolateTBDHome()
+        defer { cleanupHome() }
+        let (db, repoDir, worktree, repo) = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+        let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
+            worktree: worktree, repo: repo, worktreePath: worktree.path
+        ))
+
+        let order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
+        #expect(order == [spawn.terminalID])
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: worktree.id) == spawn.terminalID)
+    }
+
+    @Test("repo: nil resolves TBD_REPO_PATH to the worktree path")
+    func nilRepoFallsBackToWorktreePath() async throws {
+        let (_, cleanupHome) = isolateTBDHome()
+        defer { cleanupHome() }
+        let (db, repoDir, worktree, _) = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let recorder = RecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder, timeout: 2)
+        let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
+            worktree: worktree, repo: nil, worktreePath: worktree.path
+        ))
+        #expect(try await db.terminals.get(id: spawn.terminalID) != nil)
+
+        let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        let body = windowCalls.first?.last ?? ""
+        #expect(body.contains("export TBD_REPO_PATH='\(worktree.path)'"),
+                "with no repo, TBD_REPO_PATH must fall back to the worktree's own path")
+    }
+
     // MARK: - Wait outcome races (marker vs. dead pane / deadline)
 
     @Test func markerWinsWhenPaneDiesInSameIteration() async throws {

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -13,100 +13,10 @@ extension TBDHomeSerialized {
 struct PreSessionHookTests {
 
     // MARK: - Helpers
-
-    /// Creates a unique temp TBD_HOME and points the process at it.
-    /// Caller must call the returned cleanup closure (idempotent).
-    private func isolateTBDHome() -> (home: URL, cleanup: () -> Void) {
-        let home = FileManager.default.temporaryDirectory
-            .appendingPathComponent("tbd-presession-\(UUID().uuidString)")
-        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
-        setenv("TBD_HOME", home.path, 1)
-        return (home, {
-            unsetenv("TBD_HOME")
-            try? FileManager.default.removeItem(at: home)
-        })
-    }
-
-    /// Writes an executable `.worktree-hooks/<name>` into the repo and
-    /// commits it so fresh worktree checkouts contain it.
-    @discardableResult
-    private func installHook(
-        named name: String, repoDir: URL, script: String = "#!/bin/sh\nexit 0\n"
-    ) async throws -> String {
-        let hooksDir = repoDir.appendingPathComponent(".worktree-hooks")
-        try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
-        let hookPath = hooksDir.appendingPathComponent(name)
-        try script.write(to: hookPath, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755], ofItemAtPath: hookPath.path
-        )
-        try await shell("git add -A && git commit -m 'add \(name) hook'", at: repoDir)
-        return hookPath.path
-    }
-
-    @discardableResult
-    private func installPreSessionHook(
-        repoDir: URL, script: String = "#!/bin/sh\nexit 0\n"
-    ) async throws -> String {
-        try await installHook(named: "preSession", repoDir: repoDir, script: script)
-    }
-
-    private func makeLifecycle(
-        db: TBDDatabase,
-        recorder: RecordedCommands? = nil,
-        subscriptions: StateSubscriptionManager? = nil,
-        timeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout,
-        windowIsDead: (@Sendable (String) -> Bool)? = nil,
-        listWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil
-    ) -> WorktreeLifecycle {
-        var dryRunRecorder: (@Sendable ([String]) -> Void)?
-        if let recorder {
-            dryRunRecorder = { args in recorder.append(args) }
-        }
-        return WorktreeLifecycle(
-            db: db,
-            git: GitManager(),
-            tmux: TmuxManager(
-                dryRun: true,
-                dryRunRecorder: dryRunRecorder,
-                dryRunWindowIsDead: windowIsDead,
-                dryRunListWindows: listWindows
-            ),
-            hooks: HookResolver(),
-            subscriptions: subscriptions,
-            preSessionTimeout: timeout,
-            preSessionPollInterval: 0.05
-        )
-    }
-
-    /// Builds a DB + repo + worktree fixture whose `path` IS `repoDir` (no
-    /// real `git worktree add` checkout) — `HookResolver.resolve` only checks
-    /// the filesystem, so pointing the worktree row straight at the repo
-    /// checkout lets a hook installed into `repoDir` after this call still
-    /// resolve. Callers own `repoDir`'s parent temp dir
-    /// (`repoDir.deletingLastPathComponent()`) and must remove it.
-    private func makeWorktreeFixture(
-        status: WorktreeStatus = .creating
-    ) async throws -> (db: TBDDatabase, repoDir: URL, worktree: Worktree, repo: Repo) {
-        let (tempDir, repoDir) = try await createTestRepo()
-        let db = try TBDDatabase(inMemory: true)
-        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
-        let worktree = try await db.worktrees.create(
-            repoID: repo.id, name: "fixture", branch: "tbd/fixture",
-            path: repoDir.path, tmuxServer: "tbd-test", status: status
-        )
-        return (db, repoDir, worktree, repo)
-    }
-
-    /// Writes the completion marker the wrapped hook command would write.
-    private func writeMarker(worktreeID: UUID, exitCode: Int) throws {
-        let path = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
-        try FileManager.default.createDirectory(
-            atPath: (path as NSString).deletingLastPathComponent,
-            withIntermediateDirectories: true
-        )
-        try "\(exitCode)\n".write(toFile: path, atomically: true, encoding: .utf8)
-    }
+    //
+    // isolateTBDHome / installHook / installPreSessionHook / makeLifecycle /
+    // makeWorktreeFixture / writeMarker / PreSessionRecordedCommands live in
+    // PreSessionTestSupport.swift, shared with PreSessionRerunTests.
 
     // MARK: - HookEvent + resolution
 
@@ -220,7 +130,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder)
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
 
@@ -270,7 +180,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder)
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         try await installHook(named: "setup", repoDir: repoDir)
@@ -329,7 +239,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder)
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         try await installPreSessionHook(repoDir: repoDir)
@@ -662,7 +572,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
         try await installPreSessionHook(repoDir: repoDir)
 
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder, timeout: 2)
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
             worktree: worktree, repo: nil, worktreePath: worktree.path
@@ -797,7 +707,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder)
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         try await installPreSessionHook(repoDir: repoDir)
@@ -834,7 +744,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder)
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         try await installPreSessionHook(repoDir: repoDir)
@@ -1173,7 +1083,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         // The tmux server reports the active agent window, the .creating
         // worktree's pre-session window, and one genuinely orphaned window.
         let lifecycle = makeLifecycle(db: db, recorder: recorder, listWindows: { _, _ in
@@ -1232,7 +1142,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder, listWindows: { _, _ in
             [(windowID: "@mock-pre", paneID: "%mock-pre")]
         })
@@ -1267,7 +1177,7 @@ struct PreSessionHookTests {
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
-        let recorder = RecordedCommands()
+        let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder, listWindows: { _, _ in
             [(windowID: "@mock-pre", paneID: "%mock-pre")]
         })
@@ -1455,22 +1365,6 @@ struct PreSessionHookTests {
 private func hasProcessEnvFlag(_ args: [String], _ assignment: String) -> Bool {
     guard let index = args.firstIndex(of: assignment), index > 0 else { return false }
     return args[index - 1] == "-e"
-}
-
-/// Thread-safe collector for TmuxManager dryRun recorded args.
-private final class RecordedCommands: @unchecked Sendable {
-    private let lock = NSLock()
-    private var commands: [[String]] = []
-
-    func append(_ args: [String]) {
-        lock.lock(); defer { lock.unlock() }
-        commands.append(args)
-    }
-
-    func snapshot() -> [[String]] {
-        lock.lock(); defer { lock.unlock() }
-        return commands
-    }
 }
 
 /// Thread-safe collector for broadcast StateDeltas.

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -79,6 +79,25 @@ struct PreSessionHookTests {
         )
     }
 
+    /// Builds a DB + repo + worktree fixture whose `path` IS `repoDir` (no
+    /// real `git worktree add` checkout) — `HookResolver.resolve` only checks
+    /// the filesystem, so pointing the worktree row straight at the repo
+    /// checkout lets a hook installed into `repoDir` after this call still
+    /// resolve. Callers own `repoDir`'s parent temp dir
+    /// (`repoDir.deletingLastPathComponent()`) and must remove it.
+    private func makeWorktreeFixture(
+        status: WorktreeStatus = .creating
+    ) async throws -> (db: TBDDatabase, repoDir: URL, worktree: Worktree, repo: Repo) {
+        let (tempDir, repoDir) = try await createTestRepo()
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "fixture", branch: "tbd/fixture",
+            path: repoDir.path, tmuxServer: "tbd-test", status: status
+        )
+        return (db, repoDir, worktree, repo)
+    }
+
     /// Writes the completion marker the wrapped hook command would write.
     private func writeMarker(worktreeID: UUID, exitCode: Int) throws {
         let path = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
@@ -364,12 +383,15 @@ struct PreSessionHookTests {
         await phase3.value
 
         terminals = try await db.terminals.list(worktreeID: pending.id)
-        #expect(terminals.count == 3)
+        // Exit 0 closes the pre-session tab: only the two primaries remain.
+        #expect(terminals.count == 2)
+        #expect(try await db.terminals.get(id: pre.id) == nil,
+                "a clean hook run must delete its own terminal row")
         let claude = try #require(terminals.first { $0.label == "Claude Code" })
         let setup = try #require(terminals.first { $0.label == "setup" })
         #expect(try await db.worktrees.getTabOrder(worktreeID: pending.id)
-                == [claude.id, pre.id, setup.id],
-                "tab order must be [claude, preSession, setup]")
+                == [claude.id, setup.id],
+                "tab order must be [claude, setup] once the pre-session tab is closed")
         #expect(try await db.worktrees.getActiveTabID(worktreeID: pending.id) == claude.id)
         #expect(try await db.worktrees.get(id: pending.id)?.status == .active)
         // Exit 0 → no notification.
@@ -465,6 +487,92 @@ struct PreSessionHookTests {
         // No marker may remain after a timeout outcome.
         let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: pending.id)
         #expect(!FileManager.default.fileExists(atPath: markerPath))
+    }
+
+    // MARK: - Ephemeral hook tab: close on success, keep on failure
+
+    @Test("exit 0 closes the pre-session tab and broadcasts terminalRemoved")
+    func successfulHookClosesItsTab() async throws {
+        let (_, cleanupHome) = isolateTBDHome()
+        defer { cleanupHome() }
+        let (db, repoDir, worktree, repo) = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let subscriptions = StateSubscriptionManager()
+        let lifecycle = makeLifecycle(db: db, subscriptions: subscriptions, timeout: 2)
+        let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
+            worktree: worktree, repo: repo, worktreePath: worktree.path
+        ))
+        // tmux is dry-run, so the hook never really runs. Stand in for its
+        // clean exit. Must come AFTER the spawn, which deletes any stale
+        // marker for this worktree ID.
+        try writeMarker(worktreeID: worktree.id, exitCode: 0)
+
+        await lifecycle.runPreSessionPhase3(
+            preSession: spawn, worktree: worktree, repo: repo,
+            worktreePath: worktree.path, skipClaude: true,
+            completionAction: .markActive
+        )
+
+        #expect(try await db.terminals.get(id: spawn.terminalID) == nil)
+        let order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
+        #expect(!order.contains(spawn.terminalID))
+    }
+
+    @Test("non-zero exit keeps the pre-session tab and records an error notification")
+    func failingHookKeepsItsTab() async throws {
+        let (_, cleanupHome) = isolateTBDHome()
+        defer { cleanupHome() }
+        let (db, repoDir, worktree, repo) = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+        let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
+            worktree: worktree, repo: repo, worktreePath: worktree.path
+        ))
+        try writeMarker(worktreeID: worktree.id, exitCode: 3)
+
+        await lifecycle.runPreSessionPhase3(
+            preSession: spawn, worktree: worktree, repo: repo,
+            worktreePath: worktree.path, skipClaude: true,
+            completionAction: .markActive
+        )
+
+        #expect(try await db.terminals.get(id: spawn.terminalID) != nil)
+        let notifications = try await db.notifications.unread(worktreeID: worktree.id)
+        #expect(notifications.contains { $0.type == .error })
+    }
+
+    @Test("create path still spawns primaries and marks active on both outcomes",
+          arguments: [0, 7])
+    func primariesSpawnRegardlessOfOutcome(exitCode: Int) async throws {
+        let (_, cleanupHome) = isolateTBDHome()
+        defer { cleanupHome() }
+        let (db, repoDir, worktree, repo) = try await makeWorktreeFixture()
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+        let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
+            worktree: worktree, repo: repo, worktreePath: worktree.path
+        ))
+        try writeMarker(worktreeID: worktree.id, exitCode: exitCode)
+
+        await lifecycle.runPreSessionPhase3(
+            preSession: spawn, worktree: worktree, repo: repo,
+            worktreePath: worktree.path, skipClaude: true,
+            completionAction: .markActive
+        )
+
+        let refreshed = try #require(try await db.worktrees.get(id: worktree.id))
+        #expect(refreshed.status == .active)
+        let terminals = try await db.terminals.list(worktreeID: worktree.id)
+        // Primaries spawn either way.
+        #expect(terminals.contains { $0.label != TerminalLabel.preSession })
+        // And the hook tab's survival tracks the exit code exactly.
+        #expect((try await db.terminals.get(id: spawn.terminalID) != nil) == (exitCode != 0))
     }
 
     // MARK: - Wait outcome races (marker vs. dead pane / deadline)
@@ -646,9 +754,12 @@ struct PreSessionHookTests {
         // not the deleted-row teardown that kills the live pre-session
         // window of a perfectly valid worktree. (The spawn attempt itself
         // then fails on the closed DB and is logged/swallowed — what matters
-        // here is which branch the guard took.)
+        // here is which branch the guard took.) A non-zero exit keeps the
+        // hook "failed", so the separate close-on-success path (which would
+        // also kill this window, for an unrelated reason) never fires and
+        // can't be confused with the deleted-row teardown this test targets.
         try db.writerForTests.close()
-        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        try writeMarker(worktreeID: pending.id, exitCode: 1)
         await phase3.value
 
         let kills = recorder.snapshot().filter { $0.contains("kill-window") }
@@ -758,8 +869,9 @@ struct PreSessionHookTests {
         #expect(revived?.archivedClaudeSessions == ["aaaa-session"],
                 "skipClaude revive must preserve archived sessions for a later revive")
         terminals = try await db.terminals.list(worktreeID: wt.id)
-        #expect(terminals.count == 3)
-        #expect(terminals.contains { $0.label == "pre-session" })
+        // Exit 0 closes the pre-session tab: only the two primaries remain.
+        #expect(terminals.count == 2)
+        #expect(!terminals.contains { $0.label == "pre-session" })
         let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: wt.id)
         #expect(!FileManager.default.fileExists(atPath: markerPath))
     }
@@ -890,10 +1002,13 @@ struct PreSessionHookTests {
         #expect(after?.archivedAt == nil)
         #expect(after?.archivedClaudeSessions == nil)
         let terminals = try await db.terminals.list(worktreeID: wt.id)
-        #expect(terminals.count == 3,
+        // Exit 0 closes the resumed pre-session tab: only the two primaries
+        // remain.
+        #expect(terminals.count == 2,
                 "resumed phase 3 must spawn the primary terminals")
         #expect(terminals.contains { $0.label == "Claude Code" })
         #expect(terminals.contains { $0.label == "setup" })
+        #expect(!terminals.contains { $0.label == "pre-session" })
         let markerPath = WorktreeLifecycle.preSessionMarkerPath(worktreeID: wt.id)
         #expect(!FileManager.default.fileExists(atPath: markerPath))
     }
@@ -1090,7 +1205,9 @@ struct PreSessionHookTests {
         for task in resumed { await task.value }
 
         #expect(try await db.worktrees.get(id: wt.id)?.status == .active)
-        #expect(try await db.terminals.list(worktreeID: wt.id).count == 3)
+        // Exit 0 closes the resumed pre-session tab: only the two primaries
+        // remain.
+        #expect(try await db.terminals.list(worktreeID: wt.id).count == 2)
         #expect(try await db.notifications.unread(worktreeID: wt.id).isEmpty,
                 "no spurious paneKilled notification may be recorded")
     }

--- a/Tests/TBDDaemonTests/PreSessionRerunTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionRerunTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: these tests mutate the process-global
+// `TBD_HOME` env var via isolateTBDHome() (shared with PreSessionHookTests,
+// see PreSessionTestSupport.swift). See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+@Suite("Pre-session re-run")
+struct PreSessionRerunTests {
+
+    @Test("re-run spawns a hook tab without touching status or agents")
+    func rerunIsIsolated() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (db, repoDir, worktree, _) = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir, script: "#!/bin/sh\nexit 0\n")
+
+        let agent = UUID()
+        _ = try await db.terminals.create(
+            id: agent, worktreeID: worktree.id,
+            tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, kind: .claude
+        )
+        try await db.worktrees.setTabOrder(worktreeID: worktree.id, tabIDs: [agent])
+        try await db.worktrees.setActiveTabID(worktreeID: worktree.id, tabID: agent)
+
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+        try await lifecycle.rerunPreSessionHook(worktreeID: worktree.id)
+
+        let refreshed = try #require(try await db.worktrees.get(id: worktree.id))
+        #expect(refreshed.status == .active)          // never flips to .creating
+        // `Worktree` has no `activeTabID` property — read it via the store.
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: worktree.id) == agent)  // focus untouched
+        #expect(try await db.terminals.get(id: agent) != nil)  // agent survives
+
+        let terminals = try await db.terminals.list(worktreeID: worktree.id)
+        #expect(terminals.contains { $0.label == TerminalLabel.preSession })
+        // Exactly one primary agent terminal — the re-run must not spawn more.
+        #expect(terminals.filter { $0.kind == .claude }.count == 1)
+    }
+
+    @Test("re-run with no hook configured throws noHookConfigured")
+    func rerunWithoutHookThrows() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (db, repoDir, worktree, _) = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+
+        await #expect(throws: RerunPreSessionError.noHookConfigured) {
+            try await lifecycle.rerunPreSessionHook(worktreeID: worktree.id)
+        }
+    }
+
+    @Test("a second re-run while one is in flight throws alreadyRunning")
+    func concurrentRerunRejected() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (db, repoDir, worktree, _) = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        // dryRun tmux never actually runs the hook, so no marker ever appears
+        // and the first run's detached wait stays in flight for the full
+        // `timeout: 2` — that IS the in-flight window this test needs. No
+        // marker write, no sleep script required.
+        try await installPreSessionHook(repoDir: repoDir, script: "#!/bin/sh\nexit 0\n")
+
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+        try await lifecycle.rerunPreSessionHook(worktreeID: worktree.id)
+
+        await #expect(throws: RerunPreSessionError.alreadyRunning) {
+            try await lifecycle.rerunPreSessionHook(worktreeID: worktree.id)
+        }
+    }
+
+    @Test("re-run on a .creating worktree throws worktreeBusy")
+    func rerunDuringCreateRejected() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (db, repoDir, worktree, _) = try await makeWorktreeFixture(status: .creating)
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir, script: "#!/bin/sh\nexit 0\n")
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+
+        await #expect(throws: RerunPreSessionError.worktreeBusy) {
+            try await lifecycle.rerunPreSessionHook(worktreeID: worktree.id)
+        }
+    }
+
+    @Test("an unknown worktree throws worktreeNotFound")
+    func rerunUnknownWorktree() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (db, repoDir, _, _) = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+        let ghost = UUID()
+
+        await #expect(throws: RerunPreSessionError.worktreeNotFound(ghost)) {
+            try await lifecycle.rerunPreSessionHook(worktreeID: ghost)
+        }
+    }
+}
+}

--- a/Tests/TBDDaemonTests/PreSessionRerunTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionRerunTests.swift
@@ -102,5 +102,29 @@ struct PreSessionRerunTests {
             try await lifecycle.rerunPreSessionHook(worktreeID: ghost)
         }
     }
+
+    @Test("RPC surfaces the rejection message verbatim")
+    func rpcReportsAlreadyRunning() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (db, repoDir, worktree, _) = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        // dryRun tmux never actually runs the hook, so no marker ever appears
+        // and the first run's detached wait stays in flight for the full
+        // `timeout: 2` — that IS the in-flight window this test needs.
+        try await installPreSessionHook(repoDir: repoDir, script: "#!/bin/sh\nexit 0\n")
+
+        let lifecycle = makeLifecycle(db: db, timeout: 2)
+        let router = RPCRouter(db: db, lifecycle: lifecycle, tmux: TmuxManager(dryRun: true))
+        let params = try JSONEncoder().encode(
+            WorktreeRerunPreSessionParams(worktreeID: worktree.id)
+        )
+
+        let first = try await router.handleWorktreeRerunPreSession(params)
+        #expect(first.error == nil)
+
+        let second = try await router.handleWorktreeRerunPreSession(params)
+        #expect(second.error == "Setup hook is already running for this worktree.")
+    }
 }
 }

--- a/Tests/TBDDaemonTests/PreSessionRerunTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionRerunTests.swift
@@ -103,6 +103,40 @@ struct PreSessionRerunTests {
         }
     }
 
+    @Test("RPC handler forwards params.cols/rows to the spawned window's resize-window")
+    func rpcForwardsColsAndRows() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (db, repoDir, worktree, _) = try await makeWorktreeFixture(status: .active)
+        defer { try? FileManager.default.removeItem(at: repoDir.deletingLastPathComponent()) }
+        try await installPreSessionHook(repoDir: repoDir, script: "#!/bin/sh\nexit 0\n")
+
+        let recorder = PreSessionRecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder, timeout: 2)
+        let router = RPCRouter(db: db, lifecycle: lifecycle, tmux: TmuxManager(dryRun: true))
+        let params = try JSONEncoder().encode(
+            WorktreeRerunPreSessionParams(worktreeID: worktree.id, cols: 180, rows: 45)
+        )
+
+        let response = try await router.handleWorktreeRerunPreSession(params)
+        #expect(response.error == nil)
+
+        // createWindow's dry-run records the new-window shape (tmux new-window
+        // itself has no -x/-y), then issues an explicit resize-window to lock
+        // in the requested size — see TmuxManager.createWindow. That
+        // resize-window command is where cols/rows become observable, and
+        // going through the RPCRouter (not the lifecycle directly) is what
+        // proves handleWorktreeRerunPreSession actually forwards
+        // params.cols/params.rows instead of dropping them.
+        let resize = try #require(
+            recorder.snapshot().first { $0.contains("resize-window") }
+        )
+        #expect(resize.contains("-x"))
+        #expect(resize.contains("180"))
+        #expect(resize.contains("-y"))
+        #expect(resize.contains("45"))
+    }
+
     @Test("RPC surfaces the rejection message verbatim")
     func rpcReportsAlreadyRunning() async throws {
         let (_, cleanup) = isolateTBDHome()

--- a/Tests/TBDDaemonTests/PreSessionRunRegistryTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionRunRegistryTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("Pre-session run registry")
+struct PreSessionRunRegistryTests {
+
+    @Test("begin claims an id exactly once")
+    func beginIsExclusive() async {
+        let registry = PreSessionRunRegistry()
+        let id = UUID()
+
+        #expect(await registry.begin(id) == true)
+        #expect(await registry.begin(id) == false)
+        #expect(await registry.isRunning(id) == true)
+    }
+
+    @Test("end releases the claim so a later run can begin")
+    func endReleases() async {
+        let registry = PreSessionRunRegistry()
+        let id = UUID()
+
+        _ = await registry.begin(id)
+        await registry.end(id)
+
+        #expect(await registry.isRunning(id) == false)
+        #expect(await registry.begin(id) == true)
+    }
+
+    @Test("claims are per worktree id")
+    func claimsAreIndependent() async {
+        let registry = PreSessionRunRegistry()
+        let a = UUID()
+        let b = UUID()
+
+        #expect(await registry.begin(a) == true)
+        #expect(await registry.begin(b) == true)
+        #expect(await registry.isRunning(a) == true)
+        #expect(await registry.isRunning(b) == true)
+    }
+}

--- a/Tests/TBDDaemonTests/PreSessionTestSupport.swift
+++ b/Tests/TBDDaemonTests/PreSessionTestSupport.swift
@@ -1,0 +1,130 @@
+import Foundation
+import GRDB
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Shared fixtures for the pre-session hook suites (`PreSessionHookTests`,
+// `PreSessionRerunTests`). Both are nested under `extension TBDHomeSerialized`
+// because `isolateTBDHome()` mutates the process-global `TBD_HOME` env var —
+// see TBDHomeSerializedSuites.swift for why that requires serialization.
+//
+// These are plain (non-private) top-level functions rather than methods on
+// `TBDHomeSerialized` itself: none of them touch instance state, and
+// `TBDHomeSerialized` is an empty enum used purely as a serialization
+// namespace, not a real type to hang methods off of.
+
+/// Creates a unique temp TBD_HOME and points the process at it.
+/// Caller must call the returned cleanup closure (idempotent).
+func isolateTBDHome() -> (home: URL, cleanup: () -> Void) {
+    let home = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-presession-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+    setenv("TBD_HOME", home.path, 1)
+    return (home, {
+        unsetenv("TBD_HOME")
+        try? FileManager.default.removeItem(at: home)
+    })
+}
+
+/// Writes an executable `.worktree-hooks/<name>` into the repo and commits it
+/// so fresh worktree checkouts contain it.
+@discardableResult
+func installHook(
+    named name: String, repoDir: URL, script: String = "#!/bin/sh\nexit 0\n"
+) async throws -> String {
+    let hooksDir = repoDir.appendingPathComponent(".worktree-hooks")
+    try FileManager.default.createDirectory(at: hooksDir, withIntermediateDirectories: true)
+    let hookPath = hooksDir.appendingPathComponent(name)
+    try script.write(to: hookPath, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes(
+        [.posixPermissions: 0o755], ofItemAtPath: hookPath.path
+    )
+    try await shell("git add -A && git commit -m 'add \(name) hook'", at: repoDir)
+    return hookPath.path
+}
+
+@discardableResult
+func installPreSessionHook(
+    repoDir: URL, script: String = "#!/bin/sh\nexit 0\n"
+) async throws -> String {
+    try await installHook(named: "preSession", repoDir: repoDir, script: script)
+}
+
+func makeLifecycle(
+    db: TBDDatabase,
+    recorder: PreSessionRecordedCommands? = nil,
+    subscriptions: StateSubscriptionManager? = nil,
+    timeout: TimeInterval = WorktreeLifecycle.defaultPreSessionTimeout,
+    windowIsDead: (@Sendable (String) -> Bool)? = nil,
+    listWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil
+) -> WorktreeLifecycle {
+    var dryRunRecorder: (@Sendable ([String]) -> Void)?
+    if let recorder {
+        dryRunRecorder = { args in recorder.append(args) }
+    }
+    return WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(
+            dryRun: true,
+            dryRunRecorder: dryRunRecorder,
+            dryRunWindowIsDead: windowIsDead,
+            dryRunListWindows: listWindows
+        ),
+        hooks: HookResolver(),
+        subscriptions: subscriptions,
+        preSessionTimeout: timeout,
+        preSessionPollInterval: 0.05
+    )
+}
+
+/// Builds a DB + repo + worktree fixture whose `path` IS `repoDir` (no real
+/// `git worktree add` checkout) — `HookResolver.resolve` only checks the
+/// filesystem, so pointing the worktree row straight at the repo checkout
+/// lets a hook installed into `repoDir` after this call still resolve.
+/// Callers own `repoDir`'s parent temp dir
+/// (`repoDir.deletingLastPathComponent()`) and must remove it.
+func makeWorktreeFixture(
+    status: WorktreeStatus = .creating
+) async throws -> (db: TBDDatabase, repoDir: URL, worktree: Worktree, repo: Repo) {
+    let (tempDir, repoDir) = try await createTestRepo()
+    let db = try TBDDatabase(inMemory: true)
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+    let worktree = try await db.worktrees.create(
+        repoID: repo.id, name: "fixture", branch: "tbd/fixture",
+        path: repoDir.path, tmuxServer: "tbd-test", status: status
+    )
+    return (db, repoDir, worktree, repo)
+}
+
+/// Writes the completion marker the wrapped hook command would write.
+func writeMarker(worktreeID: UUID, exitCode: Int) throws {
+    let path = WorktreeLifecycle.preSessionMarkerPath(worktreeID: worktreeID)
+    try FileManager.default.createDirectory(
+        atPath: (path as NSString).deletingLastPathComponent,
+        withIntermediateDirectories: true
+    )
+    try "\(exitCode)\n".write(toFile: path, atomically: true, encoding: .utf8)
+}
+
+/// Thread-safe collector for TmuxManager dryRun recorded args. Shared because
+/// both pre-session suites assert on window-creation call order/content.
+/// Named distinctly from other files' file-private `RecordedCommands` types
+/// (e.g. `TBDWorktreeIDLeakTests.swift`) since this one must be visible
+/// module-wide to be shared.
+final class PreSessionRecordedCommands: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [[String]] = []
+
+    func append(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        commands.append(args)
+    }
+
+    func snapshot() -> [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return commands
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeLifecycleReaperTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleReaperTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import TBDDaemonLib
+@testable import TBDShared
 
 @Suite struct WorktreeLifecycleReaperTests {
     /// Builds a WorktreeLifecycle with a dryRun tmux (panePID → "0",

--- a/Tests/TBDSharedTests/HookResolverTests.swift
+++ b/Tests/TBDSharedTests/HookResolverTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-@testable import TBDDaemonLib
+@testable import TBDShared
 
 private func makeTempDir() throws -> URL {
     let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)

--- a/Tests/TBDSharedTests/WorktreeRerunPreSessionParamsTests.swift
+++ b/Tests/TBDSharedTests/WorktreeRerunPreSessionParamsTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("WorktreeRerunPreSessionParams")
+struct WorktreeRerunPreSessionParamsTests {
+    @Test func roundTripsColsAndRowsThroughJSON() throws {
+        let id = UUID()
+        let params = WorktreeRerunPreSessionParams(worktreeID: id, cols: 180, rows: 45)
+        let data = try JSONEncoder().encode(params)
+        let decoded = try JSONDecoder().decode(WorktreeRerunPreSessionParams.self, from: data)
+        #expect(decoded.worktreeID == id)
+        #expect(decoded.cols == 180)
+        #expect(decoded.rows == 45)
+    }
+
+    /// Backward compatibility: an older app build's JSON has no `cols`/`rows`
+    /// keys at all. `cols`/`rows` must decode to nil rather than failing, so
+    /// old app + new daemon (or vice versa) keeps working — see the repo's
+    /// CLAUDE.md rule that shared Codable model fields must be optional or
+    /// defaulted.
+    @Test func decodesWhenColsAndRowsAreOmitted() throws {
+        let id = UUID()
+        let json = """
+        {"worktreeID":"\(id.uuidString)"}
+        """
+        let decoded = try JSONDecoder().decode(
+            WorktreeRerunPreSessionParams.self, from: Data(json.utf8)
+        )
+        #expect(decoded.worktreeID == id)
+        #expect(decoded.cols == nil)
+        #expect(decoded.rows == nil)
+    }
+}

--- a/docs/superpowers/specs/2026-07-08-rerun-presession-hook-design.md
+++ b/docs/superpowers/specs/2026-07-08-rerun-presession-hook-design.md
@@ -1,0 +1,228 @@
+# Re-run the preSession hook from the worktree context menu
+
+**Date:** 2026-07-08
+**Status:** Approved, pending implementation
+
+## Problem
+
+The `preSession` hook runs exactly once per worktree lifecycle event — at create, at revive,
+and on daemon-crash recovery. In practice it sometimes needs to run more than once: a `npm
+install` that raced a lockfile change, a `brew bundle` that failed on a transient network
+error, a hook the user just edited and wants to try again.
+
+Today the only ways to re-run it are to archive and revive the worktree (destroying the live
+Claude session) or to create a fresh worktree. Both are wildly disproportionate to "run that
+script again".
+
+Separately, the hook's terminal tab lingers forever. `preSessionCommand` ends in `exec $shell`,
+so every worktree that has a hook carries a spent `pre-session` tab for the rest of its life.
+With a re-run action that lingering becomes N tabs.
+
+## Goals
+
+- Add a **Re-run setup hook** item to the worktree context menu.
+- Make the hook tab **ephemeral on success**, in both the create flow and the re-run flow.
+- Keep the tab **on failure**, because that's where the error output is.
+- Never disturb a running agent.
+
+## Non-goals
+
+- No CLI command (`tbd hook run preSession`). Not requested; the RPC makes it trivial later.
+- No re-running of the other four hooks (`setup`, `archive`, `preMerge`, `postMerge`).
+- No progress banner for the re-run. The existing banner exists to explain why the agent hasn't
+  started yet; on a re-run the agent is already running, so there is nothing to explain.
+
+## Behavior
+
+Right-click a worktree row → **Re-run setup hook**, in its own section between the
+spawning group and `Open in Finder`:
+
+```
+Rename...
+Archive
+─────────────────────
+Wake
+Hibernate now
+─────────────────────
+Fork session
+Create Nested Worktree
+New worktree from this branch…
+─────────────────────
+Re-run setup hook
+─────────────────────
+Open in Finder
+Copy Path
+```
+
+- Shown on **regular worktree rows and scratch-space rows**. Absent from main/creating rows.
+- Shown **only when a `preSession` hook resolves** for that worktree. No hook, no item.
+- Clicking it spawns a `pre-session` tab that runs the hook. **Focus does not move to it**, and
+  running agents are left completely alone — not killed, not parked.
+- Exit 0 → the tab closes itself.
+- Non-zero exit, timeout, or the user killing the pane → the tab stays open, dropped into a
+  shell with the output on screen, and the existing `.error` notification fires.
+- Clicking it while a run is already in flight → the daemon rejects it and the app shows
+  `Setup hook is already running for this worktree.`
+
+## Design
+
+### 1. Ephemeral hook tab
+
+`waitForPreSessionCompletion` (`WorktreeLifecycle+PreSession.swift:201-234`) already resolves the
+marker-vs-pane-death race correctly: it re-reads the marker before concluding `.paneKilled`, and
+again after the deadline before concluding `.timedOut`. Making the hook's shell command exit on
+success would fight that machinery and reintroduce the race it was written to close.
+
+So **`preSessionCommand` is unchanged**. Teardown happens at the observer instead.
+
+In `runPreSessionPhase3`, after the outcome is known:
+
+| Outcome | Tab | Notification |
+| --- | --- | --- |
+| `.completed(exitCode: 0)` | killed, row deleted, `.terminalRemoved` broadcast | none |
+| `.completed(non-zero)` | kept | `.error` (existing) |
+| `.timedOut` | kept | `.error` (existing) |
+| `.paneKilled` | already gone | `.error` (existing) |
+
+Ordering constraint: on the success path, **spawn the primary terminals first, then close the
+hook tab**, so the worktree is never momentarily tab-less.
+
+`spawnPrimaryTerminals(preSessionTerminalID:)` splices the hook tab into tab order at index 1
+(`WorktreeLifecycle+Create.swift:735-736`). On the success path phase 3 passes `nil` instead, so
+the tab is never inserted rather than inserted-then-removed.
+
+Teardown reuses the kill-window + delete-row + broadcast sequence that `handleTerminalDelete`
+(`RPCRouter+TerminalHandlers.swift:433`) already performs; that sequence is extracted into a
+lifecycle helper both call sites share.
+
+### 2. Manual re-run
+
+New RPC method `worktree.rerunPreSession`, params `{ worktreeID: UUID }`.
+
+Handler (`RPCRouter+WorktreeHandlers.swift`):
+
+1. Load the worktree; resolve the hook. Unresolved → `RPCError`. (Defense in depth — the app
+   already hides the item — but the app's view can be stale by a keystroke.)
+2. Reject if a run is already in flight for this worktree ID (see §3).
+3. `spawnPreSessionTerminal(...)`, reusing phase 2b.
+4. Return `.ok()` immediately. A detached task awaits the outcome and applies §1's teardown or
+   notification.
+
+Two changes to `spawnPreSessionTerminal` to make it reusable:
+
+- Lines 169-170 unconditionally call `setTabOrder(tabIDs: [terminalID])` and
+  `setActiveTabID(...)`. That's correct for create — the hook tab is the *only* tab — and wrong
+  for a re-run. Gate both behind a parameter (`claimsFocus: Bool`, true from phase 2b, false from
+  the re-run path); the re-run path appends to the existing tab order and leaves `activeTabID`
+  alone.
+- The stale-marker delete at line 130 stays; it is exactly what a re-run needs.
+
+The wait → teardown/notify tail becomes a shared `finishPreSessionRun(...)`. Phase 3 calls it and
+then does its create/revive-specific work (primary spawn, status flip). The re-run path calls it
+and stops. **The re-run path never touches worktree status and never spawns primary terminals.**
+
+### 3. Concurrency guard
+
+`WorktreeLifecycle` holds an in-memory `Set<UUID>` of worktree IDs with a pre-session run in
+flight. Inserted before the terminal spawn, removed in the detached task's `defer`. The RPC
+rejects a second run with a distinct error.
+
+Explicitly **not** modeled as UI state. After §1, a lingering `pre-session` tab means "the last
+run failed", not "a run is in progress", so the app cannot infer running-ness from the tab
+existence it already tracks (`AppState+Terminals.swift:47`). A true disabled menu item would need
+a new `StateDelta` case plus a transient field on the worktree snapshot to survive an app relaunch
+mid-run — real state-sync plumbing for a grey row the user would rarely see, since the common
+case is re-running *after* a failure, when nothing is in flight. A clear alert is the better
+trade.
+
+### 4. Sharing the resolver
+
+`HookEvent` and `HookResolver` move from `Sources/TBDDaemon/Hooks/HookResolver.swift` to
+`Sources/TBDShared/`. `resolve` is `FileManager` calls plus one JSON read — nothing
+daemon-specific. `execute` moves with it and the app simply never calls it.
+
+The daemon's call sites are unchanged. The app gains the ability to answer "does this worktree
+have a preSession hook?" with the *identical* five-step chain (app config → `.worktree-hooks/` →
+`conductor.json` → `.dmux-hooks/` → global default) rather than a copy that drifts.
+
+Note `hooksLogger` uses subsystem `com.tbd.daemon`; it keeps that subsystem, category `hooks`, so
+existing log predicates keep working.
+
+### 5. App wiring
+
+Following the existing data-driven menu split:
+
+- `RowActionMenu.ActionKind.rerunPreSessionHook`, title `"Re-run setup hook"`.
+- New `hasPreSessionHook: Bool` on the menu `Context`. `RowActionMenu.items(context:)` **stays
+  pure** — the filesystem resolve happens in `SidebarContextMenu` while building the Context, not
+  inside `items()`. Context menus are built on right-click, not per-frame, so a handful of
+  `fileExists` calls is fine.
+- Emitted as its own section in `regularItems` and `scratchItems`. Absent from `mainItems`.
+- `RowActionMenuActions.run(.rerunPreSessionHook)` → `Task { await
+  appState.rerunPreSessionHook(worktreeID:) }` → `DaemonClient.rerunPreSessionHook(worktreeID:)` →
+  the new RPC.
+- Failures surface through the existing `showAlert(_:isError:)` → `ContentView.swift:281` alert,
+  matching `archiveWorktree`'s pattern.
+
+Scratch rows may have no `repoID`, so `appHookPath` is nil for them; `resolve` handles that and
+falls through to `.worktree-hooks/` in the scratch directory or the global default. A global
+default hook therefore surfaces the item on every row — which is correct.
+
+## Error handling
+
+| Condition | Surface |
+| --- | --- |
+| No hook resolves | Item hidden. RPC also errors if called anyway. |
+| Run already in flight | Alert: `Setup hook is already running for this worktree.` |
+| Hook exits non-zero | Tab kept with output; `.error` notification. |
+| Hook times out (600s) | Tab kept; `.error` notification. |
+| User kills the pane | `.error` notification. |
+| Worktree row vanishes mid-run | Existing phase-3 guard (`:272-285`) applies: kill the window, no notification, no spawn. |
+
+Failure messages drop the create-path suffix "— starting the agent anyway", which is false on a
+re-run. `notifyPreSessionProblem` takes the message already; the two call paths pass different text.
+
+## Testing
+
+Per CLAUDE.md, the new exit-code branch gates behavior, so both sides are tested.
+
+**Daemon** (`Tests/TBDDaemonTests/PreSessionHookTests.swift` and a new re-run suite):
+
+- Teardown gate, exit 0: terminal row deleted, `.terminalRemoved` broadcast, tab order excludes it.
+- Teardown gate, non-zero: row survives, `.error` notification recorded.
+- Create path still spawns primary terminals and flips `.active` / revive on **both** success and
+  failure (regression guard on §1's reordering).
+- Re-run isolation: spawns a hook terminal; does not flip worktree status; does not spawn primary
+  terminals; does not reassign `activeTabID`.
+- Re-run guards: no hook → error; second call while in flight → error.
+
+**Shared:** `HookResolverTests` moves to `Tests/TBDSharedTests` with the type; chain behavior
+unchanged.
+
+**App** (`Tests/TBDAppTests`): item present iff `hasPreSessionHook`; present on regular and scratch
+rows, absent on main; correct section position relative to `Open in Finder`.
+
+**Live verification** (not assertable headlessly): closing the hook tab while it is the *focused*
+tab. The create flow auto-follows to the pre-session tab, so on success the app is sitting on a
+tab that is about to vanish. Confirm the app lands on the Claude tab, not an empty pane.
+
+Daemon + shared code change, so full `scripts/restart.sh` (relative, from the worktree) and
+`swift test` before commit.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `Sources/TBDShared/HookResolver.swift` | new — moved from `TBDDaemon/Hooks/` |
+| `Sources/TBDShared/RPCProtocol.swift` | `RPCMethod.worktreeRerunPreSession` (`"worktree.rerunPreSession"`) + `WorktreeRerunPreSessionParams` |
+| `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift` | `claimsFocus`, `finishPreSessionRun`, teardown, in-flight set |
+| `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift` | pass `nil` `preSessionTerminalID` on the success path |
+| `Sources/TBDDaemon/Server/RPCRouter.swift` | dispatch |
+| `Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift` | `handleWorktreeRerunPreSession` |
+| `Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift` | extract shared teardown helper |
+| `Sources/TBDApp/DaemonClient.swift` | `rerunPreSessionHook(worktreeID:)` |
+| `Sources/TBDApp/AppState+Worktrees.swift` | `rerunPreSessionHook(worktreeID:)` + alert |
+| `Sources/TBDApp/Helpers/RowActionMenu.swift` | `ActionKind`, `Context.hasPreSessionHook`, section |
+| `Sources/TBDApp/Sidebar/RowActionMenuActions.swift` | dispatch |
+| `Sources/TBDApp/Sidebar/SidebarContextMenu.swift` | resolve the hook when building Context |
+| `docs/worktree-hooks.md` | document the re-run action and the ephemeral tab |

--- a/docs/superpowers/specs/2026-07-08-rerun-presession-hook-design.md
+++ b/docs/superpowers/specs/2026-07-08-rerun-presession-hook-design.md
@@ -226,3 +226,41 @@ Daemon + shared code change, so full `scripts/restart.sh` (relative, from the wo
 | `Sources/TBDApp/Sidebar/RowActionMenuActions.swift` | dispatch |
 | `Sources/TBDApp/Sidebar/SidebarContextMenu.swift` | resolve the hook when building Context |
 | `docs/worktree-hooks.md` | document the re-run action and the ephemeral tab |
+
+## Amendments (2026-07-08, during planning and implementation)
+
+This spec's plan and implementation diverged from the text above in five places. Each is recorded
+here with the reasoning, so the spec stays an accurate description of what shipped rather than what
+was originally proposed.
+
+a. **No shared teardown helper was extracted from `handleTerminalDelete`.** That handler also
+   cancels scheduled resumes, clears pending questions, cancels auto-login, and reclaims a
+   `ClaudeHookOverlay` — all Claude-session concerns that are no-ops for a `.shell` hook tab, and
+   several of which need `RPCRouter` state that the lifecycle does not hold. Extracting a shared
+   helper would have meant threading that state down into `WorktreeLifecycle` for no benefit.
+   Instead, `WorktreeLifecycle.closePreSessionTerminal` implements only the minimal teardown a hook
+   tab actually needs: kill the tmux window, delete the terminal and tab rows, and broadcast
+   `.terminalRemoved`.
+
+b. **The hook resolve for the menu item lives in `RowActionMenuActions.context()`, not
+   `SidebarContextMenu`.** `context()` is where every other field on `RowActionMenu.Context` is
+   already built from live `AppState`, so resolving `hasPreSessionHook` there keeps all of the
+   context's derivations in one place instead of splitting them across two files.
+
+c. **`spawnPreSessionTerminal` takes `repo: Repo?` instead of `repo: Repo`.** Scratch spaces have
+   no backing repo, so before this change they could never run a `preSession` hook at all — the
+   spawn path required a non-optional `Repo`. Making the parameter optional lets a scratch space
+   resolve and run its hook; `TBD_REPO_PATH` falls back to the worktree's own path when there is no
+   repo to point it at.
+
+d. **The teardown call sits inside the `do` block of `runPreSessionPhase3`, after the primary
+   terminal spawn succeeds — not after the `do`/`catch`.** If the primary spawn throws, the hook
+   tab is still the worktree's only tab; tearing it down at that point would leave the worktree
+   tab-less. This was discovered during implementation, via the
+   `dbErrorDuringRowCheckDoesNotTearDownPreSessionWindow` test, which failed against the original
+   placement.
+
+e. **`.paneKilled` on a manual re-run is logged, not surfaced as an error notification.** A user
+   closing the re-run's tab mid-hook is a legitimate cancel, not a failure worth interrupting them
+   about. On the create path `.paneKilled` remains an error notification, because there the agent
+   is about to start on a worktree whose setup never finished.

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -23,9 +23,17 @@ Both run on worktree creation — and again when an archived worktree is revived
 - **`preSession` is blocking.** Its terminal is created first, and the agent (Claude/Codex/shell) does not spawn until the hook exits. Use it for anything the agent must not start without — copying `.env` files, writing local config, linking caches.
 - **`setup` is parallel.** It runs in its own terminal alongside the agent, which is already started. Use it for slow work the agent doesn't need on its first turn — `npm install`, warming build caches.
 
-The split is your repo's choice; the rule of thumb is *preSession = "the agent must not start before this finishes"*. The `preSession` hook runs in a visible terminal tab (labeled `pre-session`), so you can watch its output live; the pane drops into a regular shell when the hook exits.
+The split is your repo's choice; the rule of thumb is *preSession = "the agent must not start before this finishes"*. The `preSession` hook runs in a visible terminal tab (labeled `pre-session`), so you can watch its output live. That tab is **ephemeral on success**: once the hook exits 0 and the agent terminals exist, TBD closes it automatically. If the hook exits non-zero, times out, or its pane gets killed, the tab is left open instead — dropped into a regular shell with the hook's output still on screen — and TBD raises an error notification.
 
-`preSession` has a 600-second timeout. A non-zero exit status or a timeout does **not** abort worktree creation or block the agent forever — TBD posts a notification and starts the agent anyway.
+`preSession` has a 600-second timeout. A non-zero exit status, a timeout, or a killed pane does **not** abort worktree creation or block the agent forever — TBD posts a notification and starts the agent anyway, leaving the hook's tab open as described above.
+
+## Re-running `preSession`
+
+You can re-run a worktree's `preSession` hook at any time, without recreating the worktree: right-click it in the sidebar and choose **Re-run setup hook**. It runs in a fresh background tab that does not steal focus, and it does not disturb anything already running — no restart, no hibernation, no status change. The menu item only appears when a `preSession` hook actually resolves for that worktree; where none does, it's simply absent from the menu.
+
+Only one run is allowed per worktree at a time. Triggering a second one while the first is still in flight is refused with: `Setup hook is already running for this worktree.`
+
+Scratch spaces can run a `preSession` hook too. Previously they couldn't, because hook spawning required a backing repo. A scratch space has no repo, so for it `TBD_REPO_PATH` (see below) falls back to the worktree's own path.
 
 ## Environment
 


### PR DESCRIPTION
## Summary

- The `preSession` hook runs exactly once per worktree lifecycle event. When it needs a second pass — an `npm install` that raced a lockfile change, a `brew bundle` that hit a flaky network, a hook you just edited — your only options were archive+revive (which destroys the live Claude session) or a fresh worktree. Right-clicking a worktree now offers **Re-run setup hook**: it runs in a fresh background tab, doesn't steal focus, and leaves running agents completely alone.
- The hook's tab is now **ephemeral on success**. It used to `exec $shell` and linger forever, so every worktree with a hook carried a spent `pre-session` tab for life — and a re-run action would have turned that into N tabs. It now closes itself once the hook exits 0 and the agent terminals exist. On a non-zero exit, timeout, or killed pane it stays open with the output on screen, because that's the one time you need it.
- The item only appears when a `preSession` hook actually resolves for that worktree, and only one run is allowed at a time — a second request is refused with `Setup hook is already running for this worktree.`

## Notable design points

**`HookResolver` moved to `TBDShared`.** The app has to answer "does this worktree have a preSession hook?" to decide whether to show the menu item, and the resolution chain is five steps deep (app config → `.worktree-hooks/` → `conductor.json` → `.dmux-hooks/` → global default). Sharing the type beats a copy in the app that silently drifts from what the daemon executes.

**`preSessionCommand` is deliberately untouched.** `waitForPreSessionCompletion` already resolves the marker-vs-pane-death race by re-reading the marker before concluding `.paneKilled`. Making the pane exit on success would have reintroduced exactly that race, so the daemon tears the tab down *after* observing the outcome instead.

**Teardown sits inside the `do` block**, after `spawnPrimaryTerminals` succeeds — not after the `do/catch`. If the primary spawn throws, the hook tab is the worktree's only remaining tab and closing it would leave the worktree tab-less. `spawnPrimaryTerminals` also reassigns `activeTabID` to the primary first, so focus never sits on a tab that's about to vanish. Regression-guarded by `dbErrorDuringRowCheckDoesNotTearDownPreSessionWindow`.

**Scratch spaces could never run a `preSession` hook before this.** `spawnPreSessionTerminal` required a `Repo`, and scratch spaces have none. It now takes `repo: Repo?` and falls `TBD_REPO_PATH` back to the worktree's own path.

**Concurrency is guarded daemon-side, not in the UI.** Once the tab is ephemeral, a lingering `pre-session` tab means "the last run failed", not "a run is in progress" — so the app can't infer running-ness from the tab it already tracks. A true greyed-out menu item would need a new `StateDelta` case plus a transient worktree-snapshot field to survive an app relaunch mid-run. That's real state-sync plumbing for a row you'd rarely see; the daemon rejects the second run with a clear message instead. `PreSessionRunRegistry` is an actor because `WorktreeLifecycle` is a struct (same reasoning as the existing `conflictSweepCache`).

## Test plan

3182 tests pass (`swift test --parallel -j 2`), `swift build` and `swiftlint --strict` clean. New coverage: both branches of the exit-code gate, re-run isolation (no status flip, no primary spawn, no focus steal), all three re-run rejections, and menu presence/placement/row-scope.

Verified live against a running daemon with a throwaway repo, driving `worktree.rerunPreSession` over the unix socket:

- [x] Worktree create with an `exit 0` hook → `pre-session` tab appears, then disappears; only `Claude Code` + `setup` remain, tmux window gone.
- [x] Re-run → tab appended **last** (focus not stolen), Claude terminal ID unchanged throughout, tab self-closes on completion.
- [x] Second re-run while one is in flight → `{"success":false,"error":"Setup hook is already running for this worktree."}`
- [x] Re-run with an `exit 7` hook → tab remains, pane still shows `THIS HOOK WILL FAIL` dropped into a shell, and an `.error` notification is recorded reading `Setup hook failed (exit 7) — its tab is left open with the output` (no misleading "starting the agent anyway").
- [ ] GUI pass: right-click a worktree and confirm the item renders in its own section above `Open in Finder`, and is absent for a repo with no `preSession` hook (no dangling divider).

## Known limitation

The `claimsFocus: false` tab-order append is a non-atomic read-modify-write that can race a concurrent drag-reorder. The tab isn't lost — `applyStoredOrder` appends unknown tab IDs — only its persisted position can be, until the next reorder. This matches the existing terminal-create path; not addressed here.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=94854A36-B61C-4E47-8459-BC632BAA76DA)