### PR TITLE
Feat: Make a parked Claude impossible to miss and one click to revive

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1120,6 +1120,12 @@ final class AppState: ObservableObject {
             // (nil from an older daemon — same blank-pane behavior as before).
             terminals[delta.worktreeID]?[idx].suspendedSnapshot = delta.suspendedSnapshot
             terminals[delta.worktreeID]?[idx].hibernateReason = delta.hibernateReason
+            // Parking implies cancellation: the daemon's setHibernated cancels
+            // any scheduled auto-resume in the same write, so nil the mirror
+            // here too — otherwise the tab's ⏳ glyph / "Cancel Scheduled
+            // Resume" item keep advertising a resume that won't happen for
+            // the delta-to-refetch window. No delta field needed.
+            terminals[delta.worktreeID]?[idx].pendingResumeAt = nil
         } else {
             // Woken: clear the reason, keep the snapshot (clearHibernated
             // semantics — reconnect backdrop, overwritten on the next park).

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -367,7 +367,7 @@ struct PanePlaceholder: View {
                     // rows have one too.
                     isSuspendedSnapshot: terminal.isParked,
                     // Reason-phrased hibernate notice, composed INTO the
-                    // frozen snapshot's last row at feed time (in the
+                    // frozen snapshot's last rows at feed time (in the
                     // terminal's own grid/font — see ParkedSnapshotComposer).
                     // nil for a live terminal so the wake/reconnect path
                     // feeds the snapshot untouched.
@@ -383,8 +383,8 @@ struct PanePlaceholder: View {
                     // Full-surface click-to-wake for a PARKED pane: the whole
                     // frozen snapshot is the resume affordance (the old
                     // corner "Click to resume session" chip was easy to miss;
-                    // the in-grid notice bar composed into the snapshot's
-                    // last row carries the text). Gated
+                    // the in-grid notice block composed into the snapshot's
+                    // last rows carries the text). Gated
                     // by ParkedPaneWakeModel so a LIVE terminal never gets a
                     // click-catching layer over it. A transparent plain Button
                     // (not .onTapGesture, which blocks .contextMenu on macOS)

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -366,6 +366,14 @@ struct PanePlaceholder: View {
                     // captures a snapshot into `suspendedSnapshot`, so hibernated
                     // rows have one too.
                     isSuspendedSnapshot: terminal.isParked,
+                    // Reason-phrased hibernate notice, composed INTO the
+                    // frozen snapshot's last row at feed time (in the
+                    // terminal's own grid/font — see ParkedSnapshotComposer).
+                    // nil for a live terminal so the wake/reconnect path
+                    // feeds the snapshot untouched.
+                    parkedNoticeMessage: terminal.isParked
+                        ? HibernatedBannerModel.message(for: terminal.hibernateReason)
+                        : nil,
                     shouldSuppressEvents: { [overlayCoordinator] in
                         shouldSuppressEvents(in: overlayCoordinator, forTerminalID: terminalID)
                     }
@@ -375,7 +383,8 @@ struct PanePlaceholder: View {
                     // Full-surface click-to-wake for a PARKED pane: the whole
                     // frozen snapshot is the resume affordance (the old
                     // corner "Click to resume session" chip was easy to miss;
-                    // the HibernatedNoticeStrip below carries the text). Gated
+                    // the in-grid notice bar composed into the snapshot's
+                    // last row carries the text). Gated
                     // by ParkedPaneWakeModel so a LIVE terminal never gets a
                     // click-catching layer over it. A transparent plain Button
                     // (not .onTapGesture, which blocks .contextMenu on macOS)
@@ -406,24 +415,6 @@ struct PanePlaceholder: View {
                             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                         }
                         .help("Click to resume session")
-                    }
-                }
-                .overlay(alignment: .bottom) {
-                    // Hibernate notice for a PARKED pane: a thin status-line
-                    // strip drawn OVER the frozen snapshot's last text row —
-                    // deliberately not a layout-shifting footer, so the parked
-                    // pane keeps the exact geometry of the live one. Decided
-                    // by the same HibernatedBannerModel that suppresses the
-                    // footer banner (parked → .hibernatedOverlay). Must sit
-                    // AFTER the wake-button overlay (source order) but BEFORE
-                    // the TranscriptOverlayView overlay below so that stays on
-                    // top, and must never intercept clicks — allowsHitTesting
-                    // false lets a click "through" the strip reach the
-                    // full-surface wake button.
-                    if case .hibernatedOverlay(let message) =
-                        HibernatedBannerModel.banner(for: terminal) {
-                        HibernatedNoticeStrip(message: message)
-                            .allowsHitTesting(false)
                     }
                 }
                 .overlay {
@@ -570,36 +561,6 @@ struct PanePlaceholder: View {
             direction: direction,
             newContent: .terminal(terminalID: newTerminal.id)
         )
-    }
-}
-
-// MARK: - HibernatedNoticeStrip
-
-/// One-line hibernate notice overlaid on the bottom edge of a PARKED pane's
-/// frozen snapshot — visually a status line covering roughly the last text
-/// row, not a layout-shifting footer. `.ultraThinMaterial` keeps it readable
-/// over arbitrary snapshot content. The message comes from
-/// `HibernatedBannerModel.message(for:)` so the per-reason phrasing stays
-/// unit-tested; the caller disables hit testing so clicks pass through to the
-/// full-surface wake button underneath.
-private struct HibernatedNoticeStrip: View {
-    let message: String
-
-    var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "moon.zzz")
-                .font(.system(size: 10, weight: .semibold))
-                .frame(width: 12, height: 12)
-            Text(message)
-                .font(.system(size: 11))
-                .lineLimit(1)
-            Spacer(minLength: 0)
-        }
-        .foregroundStyle(Color.indigo)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 3)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.ultraThinMaterial)
     }
 }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -23,6 +23,20 @@ func shouldSuppressEvents(in coordinator: TranscriptOverlayCoordinator, forTermi
     return false
 }
 
+// MARK: - ParkedPaneWakeModel
+
+/// Pure gate behind the parked pane's full-surface click-to-wake overlay:
+/// only a PARKED terminal (hibernated or legacy-suspended) gets the
+/// transparent click-catching layer — a live pane must never have one (it
+/// would eat clicks meant for the terminal). Extracted from the view so both
+/// branches are unit-testable without SwiftUI (same pattern as
+/// `TabParkMenuModel`).
+enum ParkedPaneWakeModel {
+    static func showsWakeOverlay(for terminal: Terminal?) -> Bool {
+        terminal?.isParked == true
+    }
+}
+
 // MARK: - PanePlaceholder
 
 /// Universal leaf wrapper that renders the appropriate pane content
@@ -357,29 +371,41 @@ struct PanePlaceholder: View {
                     }
                 )
                 .id("\(terminal.id)-\(terminal.tmuxWindowID)-\(terminal.isParked)")
-                .overlay(alignment: .topTrailing) {
-                    if terminal.isParked {
+                .overlay {
+                    // Full-surface click-to-wake for a PARKED pane: the whole
+                    // frozen snapshot is the resume affordance (the old
+                    // corner "Click to resume session" chip was easy to miss;
+                    // the bottom HibernatedBanner now carries the text). Gated
+                    // by ParkedPaneWakeModel so a LIVE terminal never gets a
+                    // click-catching layer over it. A transparent plain Button
+                    // (not .onTapGesture, which blocks .contextMenu on macOS)
+                    // — applied BEFORE the TranscriptOverlayView overlay below
+                    // so that overlay stays on top in hit-testing. Plain
+                    // left-clicks reach it: TerminalPanelView's click monitor
+                    // only consumes Cmd+clicks that resolve a file path.
+                    if ParkedPaneWakeModel.showsWakeOverlay(for: terminal) {
                         Button {
                             Task {
                                 // Wake is the single resume path for parked
                                 // sessions (hibernated or legacy-suspended).
-                                try? await appState.daemonClient.terminalWake(terminalID: terminal.id)
-                                await appState.refreshTerminals(worktreeID: worktree.id)
+                                // Singleflighted in AppState; explicit user
+                                // action → surface the failure (single wake,
+                                // so the coalescer yields the bare message).
+                                if let failure = await appState.wakeTerminal(
+                                    terminalID: terminal.id, worktreeID: worktree.id, userInitiated: true
+                                ), let message = AppState.coalescedWakeFailureMessage(failures: [failure]) {
+                                    appState.showAlert(message, isError: true)
+                                }
                             }
                         } label: {
-                            Text("Click to resume session")
-                                .font(.caption2)
-                                .fontWeight(.medium)
-                                .foregroundStyle(.secondary)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 3)
-                                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 4))
-                                .padding(8)
+                            Color.clear
+                                .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                         .onHover { hovering in
                             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                         }
+                        .help("Click to resume session")
                     }
                 }
                 .overlay {

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -375,7 +375,7 @@ struct PanePlaceholder: View {
                     // Full-surface click-to-wake for a PARKED pane: the whole
                     // frozen snapshot is the resume affordance (the old
                     // corner "Click to resume session" chip was easy to miss;
-                    // the bottom HibernatedBanner now carries the text). Gated
+                    // the HibernatedNoticeStrip below carries the text). Gated
                     // by ParkedPaneWakeModel so a LIVE terminal never gets a
                     // click-catching layer over it. A transparent plain Button
                     // (not .onTapGesture, which blocks .contextMenu on macOS)
@@ -406,6 +406,24 @@ struct PanePlaceholder: View {
                             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
                         }
                         .help("Click to resume session")
+                    }
+                }
+                .overlay(alignment: .bottom) {
+                    // Hibernate notice for a PARKED pane: a thin status-line
+                    // strip drawn OVER the frozen snapshot's last text row —
+                    // deliberately not a layout-shifting footer, so the parked
+                    // pane keeps the exact geometry of the live one. Decided
+                    // by the same HibernatedBannerModel that suppresses the
+                    // footer banner (parked → .hibernatedOverlay). Must sit
+                    // AFTER the wake-button overlay (source order) but BEFORE
+                    // the TranscriptOverlayView overlay below so that stays on
+                    // top, and must never intercept clicks — allowsHitTesting
+                    // false lets a click "through" the strip reach the
+                    // full-surface wake button.
+                    if case .hibernatedOverlay(let message) =
+                        HibernatedBannerModel.banner(for: terminal) {
+                        HibernatedNoticeStrip(message: message)
+                            .allowsHitTesting(false)
                     }
                 }
                 .overlay {
@@ -552,6 +570,36 @@ struct PanePlaceholder: View {
             direction: direction,
             newContent: .terminal(terminalID: newTerminal.id)
         )
+    }
+}
+
+// MARK: - HibernatedNoticeStrip
+
+/// One-line hibernate notice overlaid on the bottom edge of a PARKED pane's
+/// frozen snapshot — visually a status line covering roughly the last text
+/// row, not a layout-shifting footer. `.ultraThinMaterial` keeps it readable
+/// over arbitrary snapshot content. The message comes from
+/// `HibernatedBannerModel.message(for:)` so the per-reason phrasing stays
+/// unit-tested; the caller disables hit testing so clicks pass through to the
+/// full-surface wake button underneath.
+private struct HibernatedNoticeStrip: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "moon.zzz")
+                .font(.system(size: 10, weight: .semibold))
+                .frame(width: 12, height: 12)
+            Text(message)
+                .font(.system(size: 11))
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+        .foregroundStyle(Color.indigo)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial)
     }
 }
 

--- a/Sources/TBDApp/Terminal/ParkedSnapshotComposer.swift
+++ b/Sources/TBDApp/Terminal/ParkedSnapshotComposer.swift
@@ -3,78 +3,104 @@ import Foundation
 // MARK: - ParkedSnapshotComposer
 
 /// Render-time composition of a PARKED pane's frozen snapshot with an
-/// in-grid hibernate notice: the notice renders as the snapshot's LAST ROW,
-/// in the terminal's own grid and font — a truecolor status bar — instead of
-/// a SwiftUI overlay strip floating above the content.
+/// in-grid hibernate notice: the notice renders as the snapshot's LAST ROWS,
+/// in the terminal's own grid and font — a truecolor indigo block — instead
+/// of a SwiftUI overlay strip floating above the content.
 ///
-/// The bottom row of a parked Claude capture is usually Claude's own status
-/// bar, so the composer OVERWRITES it (drop the final content line, append
-/// the bar): nothing meaningful is lost and the pane never shifts. The
-/// stored snapshot stays clean — this composition happens only at feed time
-/// (see `TerminalPanelRepresentable.makeNSView`'s `onReady`), never
-/// daemon-side.
+/// The block is `blockRows` (3) rows tall: one blank full-width padding row,
+/// the text row (two-space left inset + moon glyph + message), one more
+/// padding row — all on the same background. To preserve the zero-shift
+/// property the composer consumes exactly as many trailing content rows as
+/// the block emits: the bottom rows of a parked Claude capture are its own
+/// status bar + input-box chrome, so overwriting them loses nothing
+/// meaningful and the pane never shifts. The stored snapshot stays clean —
+/// this composition happens only at feed time (see
+/// `TerminalPanelRepresentable.makeNSView`'s `onReady`), never daemon-side.
 ///
 /// Pure and stateless so every branch is unit-testable without SwiftUI
 /// (same pattern as `HibernatedBannerModel` / `ParkedPaneWakeModel`).
 enum ParkedSnapshotComposer {
-    /// Truecolor bar background — slightly darker than pastel blue
-    /// (pastel blue ≈ 174/198/232) so it reads as a distinct status line
-    /// over arbitrary snapshot content.
-    static let barBackgroundSGR = "\u{1B}[48;2;135;165;210m"
-    /// Near-black foreground, readable on the muted blue background.
-    static let barForegroundSGR = "\u{1B}[38;2;20;30;50m"
-    /// Full SGR reset. Emitted BEFORE the bar (the retained snapshot lines
-    /// may leave dangling SGR state — color, bold — that would bleed into
-    /// the bar's own styling) and AFTER it (so the bar's colors don't bleed
-    /// into whatever tmux feeds next on wake).
+    /// Height of the notice block in terminal rows (padding + text +
+    /// padding), and therefore also how many trailing content rows the
+    /// composer drops from the snapshot — the two must match or the pane
+    /// shifts. One-line tunable.
+    static let blockRows = 3
+    /// Truecolor block background — Apple systemIndigo (88/86/214), the
+    /// same family the deleted SwiftUI banner strip used.
+    static let barBackgroundSGR = "\u{1B}[48;2;88;86;214m"
+    /// Pure white foreground for contrast on the indigo background.
+    static let barForegroundSGR = "\u{1B}[38;2;255;255;255m"
+    /// Full SGR reset. Emitted BEFORE each block row (the retained snapshot
+    /// lines may leave dangling SGR state — color, bold — that would bleed
+    /// into the block's own styling) and AFTER it (so the block's colors
+    /// don't bleed into whatever tmux feeds next on wake).
     static let sgrReset = "\u{1B}[0m"
+    /// Two spaces of breathing room inside the colored bar, before the glyph.
+    private static let leftInset = "  "
     /// Single-cell moon glyph — deliberately NOT the emoji (double-width
     /// cell, would break the character-count padding math below).
     private static let moonGlyph = "☾"
 
     /// Compose the feed text for a parked pane.
     ///
-    /// - `snapshot` non-nil with 2+ content lines → trailing whitespace-only
-    ///   lines trimmed, the final content line (the frozen status bar)
-    ///   dropped, then the styled notice bar appended as the new last row.
-    /// - `snapshot` nil / empty / single-line → just the bar (a capture-less
-    ///   parked pane previously rendered pitch black; now it explains itself).
-    /// - `message` longer than `columns` → truncated with an ellipsis;
-    ///   otherwise padded with spaces to `columns` so the bar's background
+    /// - `snapshot` with more than `blockRows` content lines → trailing
+    ///   whitespace-only lines trimmed, the last `blockRows` content lines
+    ///   (the frozen status bar + input-box chrome) dropped, then the styled
+    ///   notice block appended as the new last rows.
+    /// - `snapshot` nil / empty / `blockRows`-or-fewer content lines → just
+    ///   the block (a capture-less parked pane previously rendered pitch
+    ///   black; now it explains itself).
+    /// - Text longer than `columns` → truncated with an ellipsis; otherwise
+    ///   every block row is space-padded to `columns` so the background
     ///   spans the full row. `columns <= 0` → no truncation or padding
     ///   (defensive: emit the styled text as-is).
     ///
     /// Lines are joined with plain `\n`; the caller feeds the result through
-    /// the same `\n → \r\n` normalization as a raw snapshot, so the bar
+    /// the same `\n → \r\n` normalization as a raw snapshot, so the block
     /// cannot stair-step.
     static func compose(snapshot: String?, message: String, columns: Int) -> String {
-        let bar = barLine(message: message, columns: columns)
-        guard let snapshot, !snapshot.isEmpty else { return bar }
+        let block = noticeBlock(message: message, columns: columns)
+        guard let snapshot, !snapshot.isEmpty else { return block }
 
         // Split on \n only: a \r\n snapshot leaves a trailing \r on each
         // line, which the whitespace trim below treats as blank content and
         // the caller's normalization collapses on rejoin.
         var lines = snapshot.components(separatedBy: "\n")
 
-        // Trim trailing whitespace-only lines so the bar lands directly
+        // Trim trailing whitespace-only lines so the block lands directly
         // after the last REAL content row, not below a run of blanks.
         while let last = lines.last,
               last.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             lines.removeLast()
         }
 
-        // Drop the final content line — the frozen status bar the notice
-        // replaces. A single-line snapshot is replaced entirely.
-        guard lines.count > 1 else { return bar }
-        lines.removeLast()
+        // Drop as many trailing content lines as the block emits — the
+        // frozen status bar + input-box chrome it replaces. A snapshot with
+        // `blockRows` or fewer content lines is replaced entirely.
+        guard lines.count > blockRows else { return block }
+        lines.removeLast(blockRows)
 
-        return lines.joined(separator: "\n") + "\n" + bar
+        return lines.joined(separator: "\n") + "\n" + block
     }
 
-    /// The styled notice row: `SGR-reset` + truecolor bg/fg + moon glyph +
-    /// message, space-padded (or ellipsis-truncated) to `columns`, + reset.
-    private static func barLine(message: String, columns: Int) -> String {
-        var text = "\(moonGlyph) \(message)"
+    /// The full notice block: padding row, text row, padding row — each on
+    /// its own line, each reset-prefixed and reset-terminated.
+    private static func noticeBlock(message: String, columns: Int) -> String {
+        let padding = paddingRow(columns: columns)
+        return padding + "\n" + textRow(message: message, columns: columns) + "\n" + padding
+    }
+
+    /// A blank full-width row carrying only the block background.
+    private static func paddingRow(columns: Int) -> String {
+        let fill = columns > 0 ? String(repeating: " ", count: columns) : ""
+        return sgrReset + barBackgroundSGR + fill + sgrReset
+    }
+
+    /// The styled text row: `SGR-reset` + truecolor bg/fg + left inset +
+    /// moon glyph + message, space-padded (or ellipsis-truncated) to
+    /// `columns`, + reset.
+    private static func textRow(message: String, columns: Int) -> String {
+        var text = "\(leftInset)\(moonGlyph) \(message)"
         if columns > 0 {
             if text.count > columns {
                 text = String(text.prefix(max(columns - 1, 0))) + "…"

--- a/Sources/TBDApp/Terminal/ParkedSnapshotComposer.swift
+++ b/Sources/TBDApp/Terminal/ParkedSnapshotComposer.swift
@@ -7,10 +7,13 @@ import Foundation
 /// in the terminal's own grid and font — a truecolor indigo block — instead
 /// of a SwiftUI overlay strip floating above the content.
 ///
-/// The block is `blockRows` (3) rows tall: one blank full-width padding row,
-/// the text row (two-space left inset + moon glyph + message), one more
-/// padding row — all on the same background. To preserve the zero-shift
-/// property the composer consumes exactly as many trailing content rows as
+/// The block is `blockRows` (3) grid rows tall: a HALF row of indigo above
+/// (a full-width run of U+2584 LOWER HALF BLOCK in indigo foreground on the
+/// default background, so the color hugs the top of the bar), the text row
+/// (white on indigo, two-space left inset + moon glyph + message), and a
+/// half row below (U+2580 UPPER HALF BLOCK, same styling). To preserve the
+/// zero-shift property the composer consumes exactly as many trailing
+/// content rows as
 /// the block emits: the bottom rows of a parked Claude capture are its own
 /// status bar + input-box chrome, so overwriting them loses nothing
 /// meaningful and the pane never shifts. The stored snapshot stays clean —
@@ -25,11 +28,15 @@ enum ParkedSnapshotComposer {
     /// composer drops from the snapshot — the two must match or the pane
     /// shifts. One-line tunable.
     static let blockRows = 3
-    /// Truecolor block background — Apple systemIndigo (88/86/214), the
+    /// Truecolor text-row background — Apple systemIndigo (88/86/214), the
     /// same family the deleted SwiftUI banner strip used.
     static let barBackgroundSGR = "\u{1B}[48;2;88;86;214m"
     /// Pure white foreground for contrast on the indigo background.
     static let barForegroundSGR = "\u{1B}[38;2;255;255;255m"
+    /// The same indigo as a FOREGROUND color — the padding rows draw their
+    /// half-block glyphs with it on the default background, so each reads
+    /// as half a row of indigo rather than a full colored stripe.
+    static let paddingForegroundSGR = "\u{1B}[38;2;88;86;214m"
     /// Full SGR reset. Emitted BEFORE each block row (the retained snapshot
     /// lines may leave dangling SGR state — color, bold — that would bleed
     /// into the block's own styling) and AFTER it (so the block's colors
@@ -37,6 +44,13 @@ enum ParkedSnapshotComposer {
     static let sgrReset = "\u{1B}[0m"
     /// Two spaces of breathing room inside the colored bar, before the glyph.
     private static let leftInset = "  "
+    /// U+2584 LOWER HALF BLOCK: fills the BOTTOM half of its cell, so an
+    /// indigo-foreground run of it above the text row reads as a half row
+    /// of indigo attached to the top of the bar.
+    private static let lowerHalfBlock = "▄"
+    /// U+2580 UPPER HALF BLOCK: fills the TOP half of its cell — the
+    /// mirror-image half row below the text row.
+    private static let upperHalfBlock = "▀"
     /// Single-cell moon glyph — deliberately NOT the emoji (double-width
     /// cell, would break the character-count padding math below).
     private static let moonGlyph = "☾"
@@ -51,9 +65,10 @@ enum ParkedSnapshotComposer {
     ///   the block (a capture-less parked pane previously rendered pitch
     ///   black; now it explains itself).
     /// - Text longer than `columns` → truncated with an ellipsis; otherwise
-    ///   every block row is space-padded to `columns` so the background
-    ///   spans the full row. `columns <= 0` → no truncation or padding
-    ///   (defensive: emit the styled text as-is).
+    ///   every block row is filled to `columns` (spaces on the text row,
+    ///   half-block glyphs on the padding rows) so the block spans the full
+    ///   row. `columns <= 0` → no truncation or fill (defensive: emit the
+    ///   styled text as-is).
     ///
     /// Lines are joined with plain `\n`; the caller feeds the result through
     /// the same `\n → \r\n` normalization as a raw snapshot, so the block
@@ -83,17 +98,21 @@ enum ParkedSnapshotComposer {
         return lines.joined(separator: "\n") + "\n" + block
     }
 
-    /// The full notice block: padding row, text row, padding row — each on
-    /// its own line, each reset-prefixed and reset-terminated.
+    /// The full notice block: half-row padding (▄), text row, half-row
+    /// padding (▀) — each on its own line, each reset-prefixed and
+    /// reset-terminated.
     private static func noticeBlock(message: String, columns: Int) -> String {
-        let padding = paddingRow(columns: columns)
-        return padding + "\n" + textRow(message: message, columns: columns) + "\n" + padding
+        return paddingRow(glyph: lowerHalfBlock, columns: columns)
+            + "\n" + textRow(message: message, columns: columns)
+            + "\n" + paddingRow(glyph: upperHalfBlock, columns: columns)
     }
 
-    /// A blank full-width row carrying only the block background.
-    private static func paddingRow(columns: Int) -> String {
-        let fill = columns > 0 ? String(repeating: " ", count: columns) : ""
-        return sgrReset + barBackgroundSGR + fill + sgrReset
+    /// A half row of indigo: the given half-block glyph repeated to the full
+    /// column width, drawn as indigo FOREGROUND on the terminal's default
+    /// background (no bg SGR) so only half the cell height is colored.
+    private static func paddingRow(glyph: String, columns: Int) -> String {
+        let fill = columns > 0 ? String(repeating: glyph, count: columns) : ""
+        return sgrReset + paddingForegroundSGR + fill + sgrReset
     }
 
     /// The styled text row: `SGR-reset` + truecolor bg/fg + left inset +

--- a/Sources/TBDApp/Terminal/ParkedSnapshotComposer.swift
+++ b/Sources/TBDApp/Terminal/ParkedSnapshotComposer.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+// MARK: - ParkedSnapshotComposer
+
+/// Render-time composition of a PARKED pane's frozen snapshot with an
+/// in-grid hibernate notice: the notice renders as the snapshot's LAST ROW,
+/// in the terminal's own grid and font — a truecolor status bar — instead of
+/// a SwiftUI overlay strip floating above the content.
+///
+/// The bottom row of a parked Claude capture is usually Claude's own status
+/// bar, so the composer OVERWRITES it (drop the final content line, append
+/// the bar): nothing meaningful is lost and the pane never shifts. The
+/// stored snapshot stays clean — this composition happens only at feed time
+/// (see `TerminalPanelRepresentable.makeNSView`'s `onReady`), never
+/// daemon-side.
+///
+/// Pure and stateless so every branch is unit-testable without SwiftUI
+/// (same pattern as `HibernatedBannerModel` / `ParkedPaneWakeModel`).
+enum ParkedSnapshotComposer {
+    /// Truecolor bar background — slightly darker than pastel blue
+    /// (pastel blue ≈ 174/198/232) so it reads as a distinct status line
+    /// over arbitrary snapshot content.
+    static let barBackgroundSGR = "\u{1B}[48;2;135;165;210m"
+    /// Near-black foreground, readable on the muted blue background.
+    static let barForegroundSGR = "\u{1B}[38;2;20;30;50m"
+    /// Full SGR reset. Emitted BEFORE the bar (the retained snapshot lines
+    /// may leave dangling SGR state — color, bold — that would bleed into
+    /// the bar's own styling) and AFTER it (so the bar's colors don't bleed
+    /// into whatever tmux feeds next on wake).
+    static let sgrReset = "\u{1B}[0m"
+    /// Single-cell moon glyph — deliberately NOT the emoji (double-width
+    /// cell, would break the character-count padding math below).
+    private static let moonGlyph = "☾"
+
+    /// Compose the feed text for a parked pane.
+    ///
+    /// - `snapshot` non-nil with 2+ content lines → trailing whitespace-only
+    ///   lines trimmed, the final content line (the frozen status bar)
+    ///   dropped, then the styled notice bar appended as the new last row.
+    /// - `snapshot` nil / empty / single-line → just the bar (a capture-less
+    ///   parked pane previously rendered pitch black; now it explains itself).
+    /// - `message` longer than `columns` → truncated with an ellipsis;
+    ///   otherwise padded with spaces to `columns` so the bar's background
+    ///   spans the full row. `columns <= 0` → no truncation or padding
+    ///   (defensive: emit the styled text as-is).
+    ///
+    /// Lines are joined with plain `\n`; the caller feeds the result through
+    /// the same `\n → \r\n` normalization as a raw snapshot, so the bar
+    /// cannot stair-step.
+    static func compose(snapshot: String?, message: String, columns: Int) -> String {
+        let bar = barLine(message: message, columns: columns)
+        guard let snapshot, !snapshot.isEmpty else { return bar }
+
+        // Split on \n only: a \r\n snapshot leaves a trailing \r on each
+        // line, which the whitespace trim below treats as blank content and
+        // the caller's normalization collapses on rejoin.
+        var lines = snapshot.components(separatedBy: "\n")
+
+        // Trim trailing whitespace-only lines so the bar lands directly
+        // after the last REAL content row, not below a run of blanks.
+        while let last = lines.last,
+              last.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.removeLast()
+        }
+
+        // Drop the final content line — the frozen status bar the notice
+        // replaces. A single-line snapshot is replaced entirely.
+        guard lines.count > 1 else { return bar }
+        lines.removeLast()
+
+        return lines.joined(separator: "\n") + "\n" + bar
+    }
+
+    /// The styled notice row: `SGR-reset` + truecolor bg/fg + moon glyph +
+    /// message, space-padded (or ellipsis-truncated) to `columns`, + reset.
+    private static func barLine(message: String, columns: Int) -> String {
+        var text = "\(moonGlyph) \(message)"
+        if columns > 0 {
+            if text.count > columns {
+                text = String(text.prefix(max(columns - 1, 0))) + "…"
+            }
+            if text.count < columns {
+                text += String(repeating: " ", count: columns - text.count)
+            }
+        }
+        return sgrReset + barBackgroundSGR + barForegroundSGR + text + sgrReset
+    }
+}

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -206,14 +206,25 @@ struct SingleWorktreeView: View {
                         Color.clear.preference(key: MainAreaSizeKey.self, value: geometry.size)
                     })
 
-                // Thin footer when the active tab's terminal has a scheduled
-                // auto-resume: the wide "⏳ resumes ..." text used to live in
-                // the tab label (inflating tab width), now shown here at the
-                // bottom of the pane once per active tab instead of per
-                // background tab.
-                if let resumeAt = activeTabTerminal?.pendingResumeAt {
+                // Thin footer for the active tab's terminal. Two mutually
+                // exclusive banners share this slot (precedence encoded in
+                // HibernatedBannerModel.banner(for:)):
+                // - Parked (hibernated / legacy-suspended): tell the user the
+                //   whole pane is click-to-resume. Wins over scheduled-resume —
+                //   a parked session's "TBD types continue at ..." text would
+                //   be misleading because nothing is running to receive it.
+                // - Scheduled auto-resume: the wide "⏳ resumes ..." text that
+                //   used to live in the tab label (inflating tab width), shown
+                //   here once per active tab instead of per background tab.
+                switch HibernatedBannerModel.banner(for: activeTabTerminal) {
+                case .hibernated(let message)?:
+                    Divider()
+                    HibernatedBanner(message: message)
+                case .scheduledResume(let resumeAt)?:
                     Divider()
                     ScheduledResumeBanner(resumeAt: resumeAt)
+                case nil:
+                    EmptyView()
                 }
             }
             .sheet(isPresented: $showAccountPicker) {
@@ -311,6 +322,83 @@ struct SingleWorktreeView: View {
 
     private func closeTab(at index: Int) {
         appState.closeTab(worktreeID: worktreeID, index: index)
+    }
+}
+
+// MARK: - HibernatedBannerModel
+
+/// Pure decision behind the bottom-of-pane footer banner: which banner (if
+/// any) the active tab's terminal gets, and the exact hibernated phrasing per
+/// `hibernateReason`. Extracted from the view so each branch — including the
+/// parked-beats-scheduled precedence — is unit-testable without SwiftUI (same
+/// pattern as `TabParkMenuModel` / `terminalIDToWakeOnFocus`).
+enum HibernatedBannerModel {
+    enum Banner: Equatable {
+        /// Terminal is parked (hibernated or legacy-suspended) → tell the
+        /// user the pane is click-to-resume, phrased per park reason.
+        case hibernated(message: String)
+        /// Terminal has a scheduled auto-resume → the "⏳ resumes ..." footer.
+        case scheduledResume(Date)
+    }
+
+    /// nil = no footer banner. Precedence: a parked terminal shows ONLY the
+    /// hibernated banner even when `pendingResumeAt` is also set (possible —
+    /// #404 parks on PR merge while limit-resume scheduling exists): the
+    /// scheduled text promises TBD will type "continue", but nothing is
+    /// running in a parked session to receive it.
+    static func banner(for terminal: Terminal?) -> Banner? {
+        guard let terminal else { return nil }
+        if terminal.isParked {
+            return .hibernated(message: message(for: terminal.hibernateReason))
+        }
+        if let resumeAt = terminal.pendingResumeAt {
+            return .scheduledResume(resumeAt)
+        }
+        return nil
+    }
+
+    /// One-line phrasing per park reason. nil (legacy pre-v46 rows) reads the
+    /// same as `.auto` — the reason the migration can't attribute is almost
+    /// always the idle sweep.
+    static func message(for reason: HibernateReason?) -> String {
+        switch reason {
+        case .manual:
+            return "Hibernated — click anywhere in the pane to resume"
+        case .recovery:
+            return "Parked after a restart — click anywhere in the pane to resume"
+        case .merged:
+            return "Hibernated after the PR merged — click anywhere in the pane to resume"
+        case .auto, nil:
+            return "Hibernated while idle — click anywhere in the pane to resume"
+        }
+    }
+}
+
+// MARK: - HibernatedBanner
+
+/// Slim footer bar shown at the bottom of the pane when the active tab's
+/// terminal is parked (hibernated or legacy-suspended). Same visual idiom as
+/// `ScheduledResumeBanner` below; the message comes from
+/// `HibernatedBannerModel.message(for:)` so phrasing stays unit-tested.
+private struct HibernatedBanner: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "moon.zzz")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Color.indigo)
+                .frame(width: 12, height: 12)
+            Text(message)
+                .font(.system(size: 11))
+                .foregroundStyle(Color.indigo)
+                .lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.indigo.opacity(0.15))
     }
 }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -212,8 +212,9 @@ struct SingleWorktreeView: View {
                 //   used to live in the tab label (inflating tab width), shown
                 //   here once per active tab instead of per background tab.
                 // - Parked (hibernated / legacy-suspended): NO footer at all —
-                //   the hibernate notice renders as a strip OVER the frozen
-                //   pane's bottom edge (see PanePlaceholder), which also wins
+                //   the hibernate notice is composed INTO the frozen
+                //   snapshot's last row at feed time (see
+                //   ParkedSnapshotComposer), which also wins
                 //   over scheduled-resume: a parked session's "TBD types
                 //   continue at ..." text would be misleading because nothing
                 //   is running to receive it.
@@ -333,9 +334,9 @@ struct SingleWorktreeView: View {
 enum HibernatedBannerModel {
     enum Banner: Equatable {
         /// Terminal is parked (hibernated or legacy-suspended) → the footer
-        /// slot stays EMPTY; the hibernate notice renders as a thin strip
-        /// overlaid on the frozen pane's bottom edge instead (see
-        /// `HibernatedNoticeStrip` in PanePlaceholder), carrying this
+        /// slot stays EMPTY; the hibernate notice is composed into the frozen
+        /// snapshot's last row instead (see `ParkedSnapshotComposer` and the
+        /// `parkedNoticeMessage` wiring in PanePlaceholder), carrying this
         /// reason-phrased message.
         case hibernatedOverlay(message: String)
         /// Terminal has a scheduled auto-resume → the "⏳ resumes ..." footer.

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -213,7 +213,7 @@ struct SingleWorktreeView: View {
                 //   here once per active tab instead of per background tab.
                 // - Parked (hibernated / legacy-suspended): NO footer at all —
                 //   the hibernate notice is composed INTO the frozen
-                //   snapshot's last row at feed time (see
+                //   snapshot's last rows at feed time (see
                 //   ParkedSnapshotComposer), which also wins
                 //   over scheduled-resume: a parked session's "TBD types
                 //   continue at ..." text would be misleading because nothing
@@ -335,7 +335,7 @@ enum HibernatedBannerModel {
     enum Banner: Equatable {
         /// Terminal is parked (hibernated or legacy-suspended) → the footer
         /// slot stays EMPTY; the hibernate notice is composed into the frozen
-        /// snapshot's last row instead (see `ParkedSnapshotComposer` and the
+        /// snapshot's last rows instead (see `ParkedSnapshotComposer` and the
         /// `parkedNoticeMessage` wiring in PanePlaceholder), carrying this
         /// reason-phrased message.
         case hibernatedOverlay(message: String)

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -206,24 +206,22 @@ struct SingleWorktreeView: View {
                         Color.clear.preference(key: MainAreaSizeKey.self, value: geometry.size)
                     })
 
-                // Thin footer for the active tab's terminal. Two mutually
-                // exclusive banners share this slot (precedence encoded in
+                // Thin footer for the active tab's LIVE terminal (decision in
                 // HibernatedBannerModel.banner(for:)):
-                // - Parked (hibernated / legacy-suspended): tell the user the
-                //   whole pane is click-to-resume. Wins over scheduled-resume —
-                //   a parked session's "TBD types continue at ..." text would
-                //   be misleading because nothing is running to receive it.
                 // - Scheduled auto-resume: the wide "⏳ resumes ..." text that
                 //   used to live in the tab label (inflating tab width), shown
                 //   here once per active tab instead of per background tab.
+                // - Parked (hibernated / legacy-suspended): NO footer at all —
+                //   the hibernate notice renders as a strip OVER the frozen
+                //   pane's bottom edge (see PanePlaceholder), which also wins
+                //   over scheduled-resume: a parked session's "TBD types
+                //   continue at ..." text would be misleading because nothing
+                //   is running to receive it.
                 switch HibernatedBannerModel.banner(for: activeTabTerminal) {
-                case .hibernated(let message)?:
-                    Divider()
-                    HibernatedBanner(message: message)
                 case .scheduledResume(let resumeAt)?:
                     Divider()
                     ScheduledResumeBanner(resumeAt: resumeAt)
-                case nil:
+                case .hibernatedOverlay?, nil:
                     EmptyView()
                 }
             }
@@ -327,29 +325,33 @@ struct SingleWorktreeView: View {
 
 // MARK: - HibernatedBannerModel
 
-/// Pure decision behind the bottom-of-pane footer banner: which banner (if
-/// any) the active tab's terminal gets, and the exact hibernated phrasing per
+/// Pure decision behind the pane's bottom edge: which presentation (if any)
+/// the active tab's terminal gets, and the exact hibernated phrasing per
 /// `hibernateReason`. Extracted from the view so each branch — including the
 /// parked-beats-scheduled precedence — is unit-testable without SwiftUI (same
 /// pattern as `TabParkMenuModel` / `terminalIDToWakeOnFocus`).
 enum HibernatedBannerModel {
     enum Banner: Equatable {
-        /// Terminal is parked (hibernated or legacy-suspended) → tell the
-        /// user the pane is click-to-resume, phrased per park reason.
-        case hibernated(message: String)
+        /// Terminal is parked (hibernated or legacy-suspended) → the footer
+        /// slot stays EMPTY; the hibernate notice renders as a thin strip
+        /// overlaid on the frozen pane's bottom edge instead (see
+        /// `HibernatedNoticeStrip` in PanePlaceholder), carrying this
+        /// reason-phrased message.
+        case hibernatedOverlay(message: String)
         /// Terminal has a scheduled auto-resume → the "⏳ resumes ..." footer.
         case scheduledResume(Date)
     }
 
-    /// nil = no footer banner. Precedence: a parked terminal shows ONLY the
-    /// hibernated banner even when `pendingResumeAt` is also set (possible —
-    /// #404 parks on PR merge while limit-resume scheduling exists): the
-    /// scheduled text promises TBD will type "continue", but nothing is
-    /// running in a parked session to receive it.
+    /// nil = neither footer nor overlay strip. Precedence: a parked terminal
+    /// gets ONLY the hibernated overlay even when `pendingResumeAt` is also
+    /// set (a stale mirror is possible in the delta-to-refetch window even
+    /// though parking now cancels the scheduled resume): the scheduled text
+    /// promises TBD will type "continue", but nothing is running in a parked
+    /// session to receive it.
     static func banner(for terminal: Terminal?) -> Banner? {
         guard let terminal else { return nil }
         if terminal.isParked {
-            return .hibernated(message: message(for: terminal.hibernateReason))
+            return .hibernatedOverlay(message: message(for: terminal.hibernateReason))
         }
         if let resumeAt = terminal.pendingResumeAt {
             return .scheduledResume(resumeAt)
@@ -371,34 +373,6 @@ enum HibernatedBannerModel {
         case .auto, nil:
             return "Hibernated while idle — click anywhere in the pane to resume"
         }
-    }
-}
-
-// MARK: - HibernatedBanner
-
-/// Slim footer bar shown at the bottom of the pane when the active tab's
-/// terminal is parked (hibernated or legacy-suspended). Same visual idiom as
-/// `ScheduledResumeBanner` below; the message comes from
-/// `HibernatedBannerModel.message(for:)` so phrasing stays unit-tested.
-private struct HibernatedBanner: View {
-    let message: String
-
-    var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "moon.zzz")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(Color.indigo)
-                .frame(width: 12, height: 12)
-            Text(message)
-                .font(.system(size: 11))
-                .foregroundStyle(Color.indigo)
-                .lineLimit(1)
-            Spacer()
-        }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.indigo.opacity(0.15))
     }
 }
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -47,7 +47,7 @@ struct TerminalPanelView: View {
     /// Reason-phrased hibernate notice for a PARKED pane (see
     /// `HibernatedBannerModel.message(for:)`). When set alongside
     /// `isSuspendedSnapshot`, the notice is composed INTO the fed snapshot as
-    /// its last row — in the terminal's own grid/font — via
+    /// its last rows — in the terminal's own grid/font — via
     /// `ParkedSnapshotComposer` (render-time only; the stored snapshot stays
     /// clean). nil for live terminals: the snapshot is fed untouched (it is
     /// the reconnect backdrop on wake).
@@ -260,11 +260,12 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         tv.onReady = { [weak tv] in
             guard let tv else { return }
             // PARKED pane: compose the hibernate notice INTO the snapshot as
-            // its last row (overwriting the frozen status bar), padded to the
+            // its last rows (a notice block overwriting the frozen status-bar
+            // chrome), padded to the
             // view's REAL column count — onReady fires once layout has given
             // the terminal its true dimensions, so `tv.terminal.cols` is the
             // same source the resize paths use. A nil snapshot still yields
-            // the bar alone (a capture-less parked pane used to be pitch
+            // the block alone (a capture-less parked pane used to be pitch
             // black). The live/wake path (`suspendedOnCreate == false`) feeds
             // the snapshot untouched — it is the reconnect backdrop.
             let feedText: String?
@@ -277,8 +278,8 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             if let feedText {
                 // SwiftTerm expects \r\n line endings. Normalize first to avoid
                 // doubling any \r\n that might already exist in the snapshot.
-                // The composed notice bar rides the same normalization so it
-                // cannot stair-step.
+                // The composed notice block rides the same normalization so
+                // it cannot stair-step.
                 let normalized = feedText
                     .replacingOccurrences(of: "\r\n", with: "\n")
                     .replacingOccurrences(of: "\n", with: "\r\n")

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -44,6 +44,14 @@ struct TerminalPanelView: View {
     /// `tmuxWindowID` changes, the view is recreated (`.id` changes) with
     /// this flag false, and tmux connects normally.
     var isSuspendedSnapshot: Bool = false
+    /// Reason-phrased hibernate notice for a PARKED pane (see
+    /// `HibernatedBannerModel.message(for:)`). When set alongside
+    /// `isSuspendedSnapshot`, the notice is composed INTO the fed snapshot as
+    /// its last row — in the terminal's own grid/font — via
+    /// `ParkedSnapshotComposer` (render-time only; the stored snapshot stays
+    /// clean). nil for live terminals: the snapshot is fed untouched (it is
+    /// the reconnect backdrop on wake).
+    var parkedNoticeMessage: String? = nil
     /// Called on every scroll/click event. When it returns `true`, both
     /// NSEvent monitors short-circuit — the terminal does NOT consume the
     /// event, leaving it for whatever SwiftUI overlay (currently a
@@ -117,6 +125,7 @@ struct TerminalPanelView: View {
                 onDeadWindow: onDeadWindow,
                 initialSnapshot: initialSnapshot,
                 isSuspendedSnapshot: isSuspendedSnapshot,
+                parkedNoticeMessage: parkedNoticeMessage,
                 shouldSuppressEvents: shouldSuppressEvents
             )
         }
@@ -197,6 +206,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
     var onDeadWindow: (() -> Void)?
     var initialSnapshot: String?
     var isSuspendedSnapshot: Bool = false
+    var parkedNoticeMessage: String? = nil
     var shouldSuppressEvents: @MainActor () -> Bool = { false }
 
     func makeNSView(context: Context) -> TBDTerminalView {
@@ -233,6 +243,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         // Feed snapshot before tmux connects so the user sees the last state
         let snapshot = initialSnapshot
         let suspendedOnCreate = isSuspendedSnapshot
+        let parkedMessage = parkedNoticeMessage
         // Control-mode branch (Phase 2, opt-in): gate on the DAEMON-reported
         // capability — the app cannot read TBD_TMUX_CONTROL_MODE itself (it is
         // launched via `open`, which drops shell env). Resolve the terminal's
@@ -248,10 +259,27 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         // Start tmux client as soon as the view has real dimensions from layout
         tv.onReady = { [weak tv] in
             guard let tv else { return }
-            if let snapshot {
+            // PARKED pane: compose the hibernate notice INTO the snapshot as
+            // its last row (overwriting the frozen status bar), padded to the
+            // view's REAL column count — onReady fires once layout has given
+            // the terminal its true dimensions, so `tv.terminal.cols` is the
+            // same source the resize paths use. A nil snapshot still yields
+            // the bar alone (a capture-less parked pane used to be pitch
+            // black). The live/wake path (`suspendedOnCreate == false`) feeds
+            // the snapshot untouched — it is the reconnect backdrop.
+            let feedText: String?
+            if suspendedOnCreate, let parkedMessage {
+                feedText = ParkedSnapshotComposer.compose(
+                    snapshot: snapshot, message: parkedMessage, columns: tv.terminal.cols)
+            } else {
+                feedText = snapshot
+            }
+            if let feedText {
                 // SwiftTerm expects \r\n line endings. Normalize first to avoid
                 // doubling any \r\n that might already exist in the snapshot.
-                let normalized = snapshot
+                // The composed notice bar rides the same normalization so it
+                // cannot stair-step.
+                let normalized = feedText
                     .replacingOccurrences(of: "\r\n", with: "\n")
                     .replacingOccurrences(of: "\n", with: "\r\n")
                 tv.feed(text: normalized)

--- a/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
+++ b/Sources/TBDDaemon/Database/ScheduledResumeStore.swift
@@ -184,18 +184,30 @@ public struct ScheduledResumeStore: Sendable {
     @discardableResult
     public func cancelPending(terminalID: UUID) async throws -> Bool {
         try await writer.write { db in
-            guard var record = try ScheduledResumeRecord
-                .filter(Column("terminalID") == terminalID.uuidString)
-                .filter(Column("status") == ScheduledResumeStatus.pending.rawValue)
-                .fetchOne(db)
-            else { return false }
-            record.status = ScheduledResumeStatus.cancelled.rawValue
-            try record.update(db)
-            try db.execute(
-                sql: "UPDATE terminal SET pendingResumeAt = NULL WHERE id = ?",
-                arguments: [terminalID.uuidString])
-            return true
+            try Self.cancelPendingInTransaction(db, terminalID: terminalID.uuidString)
         }
+    }
+
+    /// The single cancellation routine, usable inside an ALREADY-OPEN write
+    /// transaction: flips the terminal's pending row to `.cancelled` and nils
+    /// the `terminal.pendingResumeAt` mirror in the same transaction. Shared
+    /// by `cancelPending` above and `TerminalStore.setHibernated` — parking a
+    /// session cancels its scheduled auto-resume atomically with the park
+    /// write (the Claude process is dead; a resume firing later would hit a
+    /// bare shell). Returns true when a pending row existed.
+    @discardableResult
+    static func cancelPendingInTransaction(_ db: Database, terminalID: String) throws -> Bool {
+        guard var record = try ScheduledResumeRecord
+            .filter(Column("terminalID") == terminalID)
+            .filter(Column("status") == ScheduledResumeStatus.pending.rawValue)
+            .fetchOne(db)
+        else { return false }
+        record.status = ScheduledResumeStatus.cancelled.rawValue
+        try record.update(db)
+        try db.execute(
+            sql: "UPDATE terminal SET pendingResumeAt = NULL WHERE id = ?",
+            arguments: [terminalID])
+        return true
     }
 
     /// Cancel pending rows matching `scope` (global toggle switched off). Returns count.

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -317,6 +317,15 @@ public struct TerminalStore: Sendable {
     /// crash-recovery reconcile) — see `HibernateReason`. It is stamped
     /// unconditionally (a re-park overwrites any stale reason); `nil` keeps
     /// legacy semantics (the row is still eligible for wake-on-focus).
+    ///
+    /// This is the choke point EVERY park site flows through
+    /// (`HibernationCoordinator.performHibernate`, the reconcile recovery park,
+    /// and `handleTerminalRecreateWindow`'s dead-window park), so it also
+    /// cancels any scheduled auto-resume in the same write transaction: a
+    /// parked session's Claude process is dead — a resume firing later would
+    /// type "continue" into a bare shell — and `pendingResumeAt` must not
+    /// keep advertising a resume that will never happen. Wake
+    /// (`clearHibernated`) deliberately does NOT resurrect the cancelled row.
     public func setHibernated(id: UUID, sessionID: String, snapshot: String? = nil, reason: HibernateReason? = nil, at date: Date = Date()) async throws {
         try await writer.write { db in
             guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
@@ -330,6 +339,10 @@ public struct TerminalStore: Sendable {
             }
             record.activityState = TerminalActivityState.idle.rawValue
             try record.update(db)
+            // AFTER record.update: the routine nils pendingResumeAt via raw
+            // SQL, and an update of the (stale-fetched) record afterward
+            // would write the old value back.
+            try ScheduledResumeStore.cancelPendingInTransaction(db, terminalID: id.uuidString)
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -324,6 +324,11 @@ public actor HibernationCoordinator {
         await verifyHibernationTookEffect(server: server, paneID: paneID, terminalID: terminal.id)
 
         do {
+            // setHibernated also cancels any scheduled auto-resume in the
+            // same write transaction (spec §Cancellation): parking kills the
+            // Claude process, so a pending "TBD types continue at ..." row
+            // must die with it. The actuator's fire-time `isParked` check is
+            // the backstop for a park that races an in-flight actuation.
             try await db.terminals.setHibernated(
                 id: terminal.id, sessionID: sessionID, snapshot: capturedSnapshot,
                 reason: reason, at: now()
@@ -331,10 +336,6 @@ public actor HibernationCoordinator {
         } catch {
             logger.warning("hibernate: failed to mark hibernated for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
-        // Hibernation = parking; a parked pane must not receive a scheduled
-        // auto-resume send (spec §Cancellation); fire-time eligibility
-        // re-checks are the backstop.
-        _ = try? await db.scheduledResumes.cancelPending(terminalID: terminal.id)
         idleSince[terminal.id] = nil
         pendingKillSince[terminal.id] = nil
         // The delta must carry the just-captured snapshot and the park reason:

--- a/Tests/TBDAppTests/HibernatedBannerModelTests.swift
+++ b/Tests/TBDAppTests/HibernatedBannerModelTests.swift
@@ -6,7 +6,7 @@ import TBDShared
 /// The parked-pane bottom-edge notice + full-surface click-to-wake gate.
 /// Tests the two pure decisions — `HibernatedBannerModel.banner(for:)`
 /// (parked → `.hibernatedOverlay`: the footer slot stays empty and the
-/// reason-phrased message is composed into the frozen snapshot's last row
+/// reason-phrased message is composed into the frozen snapshot's last rows
 /// via `ParkedSnapshotComposer`;
 /// live + scheduled → the `.scheduledResume` footer; parked beats scheduled)
 /// and `ParkedPaneWakeModel.showsWakeOverlay(for:)` (parked panes get the
@@ -28,7 +28,8 @@ struct HibernatedBannerModelTests {
     // MARK: - Hibernated overlay message per park reason
     //
     // Parked → `.hibernatedOverlay(message:)`: no footer banner (the notice
-    // bar composed into the snapshot's last row carries the message instead).
+    // block composed into the snapshot's last rows carries the message
+    // instead).
 
     /// Manual park ("Hibernate now") → plain "Hibernated" phrasing.
     @Test func manualParkMessage() {

--- a/Tests/TBDAppTests/HibernatedBannerModelTests.swift
+++ b/Tests/TBDAppTests/HibernatedBannerModelTests.swift
@@ -5,8 +5,9 @@ import TBDShared
 
 /// The parked-pane bottom-edge notice + full-surface click-to-wake gate.
 /// Tests the two pure decisions — `HibernatedBannerModel.banner(for:)`
-/// (parked → `.hibernatedOverlay`: the footer slot stays empty and a thin
-/// strip over the frozen pane's last row carries the reason-phrased message;
+/// (parked → `.hibernatedOverlay`: the footer slot stays empty and the
+/// reason-phrased message is composed into the frozen snapshot's last row
+/// via `ParkedSnapshotComposer`;
 /// live + scheduled → the `.scheduledResume` footer; parked beats scheduled)
 /// and `ParkedPaneWakeModel.showsWakeOverlay(for:)` (parked panes get the
 /// click-catching overlay, live panes never do) — without SwiftUI, in the
@@ -27,7 +28,7 @@ struct HibernatedBannerModelTests {
     // MARK: - Hibernated overlay message per park reason
     //
     // Parked → `.hibernatedOverlay(message:)`: no footer banner (the notice
-    // strip over the pane's bottom edge carries the message instead).
+    // bar composed into the snapshot's last row carries the message instead).
 
     /// Manual park ("Hibernate now") → plain "Hibernated" phrasing.
     @Test func manualParkMessage() {

--- a/Tests/TBDAppTests/HibernatedBannerModelTests.swift
+++ b/Tests/TBDAppTests/HibernatedBannerModelTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// The parked-pane footer banner + full-surface click-to-wake gate. Tests the
+/// two pure decisions — `HibernatedBannerModel.banner(for:)` (which footer
+/// banner, with the parked-beats-scheduled precedence) and
+/// `ParkedPaneWakeModel.showsWakeOverlay(for:)` (parked panes get the
+/// click-catching overlay, live panes never do) — without SwiftUI, in the
+/// same fixture style as `WakeOnFocusDecisionTests`.
+@Suite("Hibernated banner + parked-pane wake gate")
+struct HibernatedBannerModelTests {
+    private func terminal(hibernatedAt: Date? = nil,
+                          hibernateReason: HibernateReason? = nil,
+                          suspendedAt: Date? = nil,
+                          pendingResumeAt: Date? = nil) -> Terminal {
+        Terminal(id: UUID(), worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+                 suspendedAt: suspendedAt,
+                 hibernatedAt: hibernatedAt,
+                 hibernateReason: hibernateReason,
+                 pendingResumeAt: pendingResumeAt)
+    }
+
+    // MARK: - Hibernated message per park reason
+
+    /// Manual park ("Hibernate now") → plain "Hibernated" phrasing.
+    @Test func manualParkMessage() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: .manual)
+        )
+        #expect(banner == .hibernated(
+            message: "Hibernated — click anywhere in the pane to resume"
+        ))
+    }
+
+    /// Idle-sweep auto park → "while idle" phrasing.
+    @Test func autoParkMessage() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: .auto)
+        )
+        #expect(banner == .hibernated(
+            message: "Hibernated while idle — click anywhere in the pane to resume"
+        ))
+    }
+
+    /// Crash-recovery park → "after a restart" phrasing.
+    @Test func recoveryParkMessage() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: .recovery)
+        )
+        #expect(banner == .hibernated(
+            message: "Parked after a restart — click anywhere in the pane to resume"
+        ))
+    }
+
+    /// PR-merge park (#404) → "after the PR merged" phrasing.
+    @Test func mergedParkMessage() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: .merged)
+        )
+        #expect(banner == .hibernated(
+            message: "Hibernated after the PR merged — click anywhere in the pane to resume"
+        ))
+    }
+
+    /// Legacy pre-v46 park with no persisted reason → reads like `.auto`.
+    @Test func nilReasonParkMessage() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: nil)
+        )
+        #expect(banner == .hibernated(
+            message: "Hibernated while idle — click anywhere in the pane to resume"
+        ))
+    }
+
+    /// A legacy-suspended row (`suspendedAt` only, never migrated) is parked
+    /// too — it gets the hibernated banner via `isParked`, not nothing.
+    @Test func legacySuspendedRowGetsHibernatedBanner() {
+        let banner = HibernatedBannerModel.banner(for: terminal(suspendedAt: Date()))
+        #expect(banner == .hibernated(
+            message: "Hibernated while idle — click anywhere in the pane to resume"
+        ))
+    }
+
+    // MARK: - No banner / scheduled-resume branches
+
+    /// A live terminal with nothing scheduled → no footer banner at all.
+    @Test func liveTerminalShowsNoBanner() {
+        #expect(HibernatedBannerModel.banner(for: terminal()) == nil)
+    }
+
+    /// No terminal resolvable for the active tab → no banner.
+    @Test func nilTerminalShowsNoBanner() {
+        #expect(HibernatedBannerModel.banner(for: nil) == nil)
+    }
+
+    /// A live terminal with a scheduled auto-resume → the scheduled banner,
+    /// carrying the exact `resumeAt`.
+    @Test func liveTerminalWithPendingResumeShowsScheduledBanner() {
+        let resumeAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let banner = HibernatedBannerModel.banner(for: terminal(pendingResumeAt: resumeAt))
+        #expect(banner == .scheduledResume(resumeAt))
+    }
+
+    /// Precedence: parked AND `pendingResumeAt` set (possible — #404 parks on
+    /// PR merge while limit-resume scheduling exists) → the PARKED banner
+    /// wins and the scheduled banner is NOT shown; "TBD types continue at..."
+    /// would be misleading for a session with nothing running.
+    @Test func parkedBeatsScheduledResume() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: .merged,
+                          pendingResumeAt: Date(timeIntervalSince1970: 1_800_000_000))
+        )
+        #expect(banner == .hibernated(
+            message: "Hibernated after the PR merged — click anywhere in the pane to resume"
+        ))
+    }
+
+    // MARK: - Full-pane wake overlay gate
+
+    /// A parked terminal gets the full-surface click-to-wake overlay.
+    @Test func parkedTerminalGetsWakeOverlay() {
+        #expect(ParkedPaneWakeModel.showsWakeOverlay(for: terminal(hibernatedAt: Date())))
+    }
+
+    /// A legacy-suspended terminal is parked → overlay too.
+    @Test func legacySuspendedTerminalGetsWakeOverlay() {
+        #expect(ParkedPaneWakeModel.showsWakeOverlay(for: terminal(suspendedAt: Date())))
+    }
+
+    /// A LIVE terminal must never get a click-catching overlay — it would
+    /// eat clicks meant for the terminal itself.
+    @Test func liveTerminalGetsNoWakeOverlay() {
+        #expect(!ParkedPaneWakeModel.showsWakeOverlay(for: terminal()))
+    }
+
+    /// No terminal resolved → no overlay.
+    @Test func nilTerminalGetsNoWakeOverlay() {
+        #expect(!ParkedPaneWakeModel.showsWakeOverlay(for: nil))
+    }
+}

--- a/Tests/TBDAppTests/HibernatedBannerModelTests.swift
+++ b/Tests/TBDAppTests/HibernatedBannerModelTests.swift
@@ -3,10 +3,12 @@ import Testing
 import TBDShared
 @testable import TBDApp
 
-/// The parked-pane footer banner + full-surface click-to-wake gate. Tests the
-/// two pure decisions — `HibernatedBannerModel.banner(for:)` (which footer
-/// banner, with the parked-beats-scheduled precedence) and
-/// `ParkedPaneWakeModel.showsWakeOverlay(for:)` (parked panes get the
+/// The parked-pane bottom-edge notice + full-surface click-to-wake gate.
+/// Tests the two pure decisions — `HibernatedBannerModel.banner(for:)`
+/// (parked → `.hibernatedOverlay`: the footer slot stays empty and a thin
+/// strip over the frozen pane's last row carries the reason-phrased message;
+/// live + scheduled → the `.scheduledResume` footer; parked beats scheduled)
+/// and `ParkedPaneWakeModel.showsWakeOverlay(for:)` (parked panes get the
 /// click-catching overlay, live panes never do) — without SwiftUI, in the
 /// same fixture style as `WakeOnFocusDecisionTests`.
 @Suite("Hibernated banner + parked-pane wake gate")
@@ -22,14 +24,17 @@ struct HibernatedBannerModelTests {
                  pendingResumeAt: pendingResumeAt)
     }
 
-    // MARK: - Hibernated message per park reason
+    // MARK: - Hibernated overlay message per park reason
+    //
+    // Parked → `.hibernatedOverlay(message:)`: no footer banner (the notice
+    // strip over the pane's bottom edge carries the message instead).
 
     /// Manual park ("Hibernate now") → plain "Hibernated" phrasing.
     @Test func manualParkMessage() {
         let banner = HibernatedBannerModel.banner(
             for: terminal(hibernatedAt: Date(), hibernateReason: .manual)
         )
-        #expect(banner == .hibernated(
+        #expect(banner == .hibernatedOverlay(
             message: "Hibernated — click anywhere in the pane to resume"
         ))
     }
@@ -39,7 +44,7 @@ struct HibernatedBannerModelTests {
         let banner = HibernatedBannerModel.banner(
             for: terminal(hibernatedAt: Date(), hibernateReason: .auto)
         )
-        #expect(banner == .hibernated(
+        #expect(banner == .hibernatedOverlay(
             message: "Hibernated while idle — click anywhere in the pane to resume"
         ))
     }
@@ -49,7 +54,7 @@ struct HibernatedBannerModelTests {
         let banner = HibernatedBannerModel.banner(
             for: terminal(hibernatedAt: Date(), hibernateReason: .recovery)
         )
-        #expect(banner == .hibernated(
+        #expect(banner == .hibernatedOverlay(
             message: "Parked after a restart — click anywhere in the pane to resume"
         ))
     }
@@ -59,7 +64,7 @@ struct HibernatedBannerModelTests {
         let banner = HibernatedBannerModel.banner(
             for: terminal(hibernatedAt: Date(), hibernateReason: .merged)
         )
-        #expect(banner == .hibernated(
+        #expect(banner == .hibernatedOverlay(
             message: "Hibernated after the PR merged — click anywhere in the pane to resume"
         ))
     }
@@ -69,23 +74,24 @@ struct HibernatedBannerModelTests {
         let banner = HibernatedBannerModel.banner(
             for: terminal(hibernatedAt: Date(), hibernateReason: nil)
         )
-        #expect(banner == .hibernated(
+        #expect(banner == .hibernatedOverlay(
             message: "Hibernated while idle — click anywhere in the pane to resume"
         ))
     }
 
     /// A legacy-suspended row (`suspendedAt` only, never migrated) is parked
-    /// too — it gets the hibernated banner via `isParked`, not nothing.
+    /// too — it gets the hibernated overlay via `isParked`, not nothing.
     @Test func legacySuspendedRowGetsHibernatedBanner() {
         let banner = HibernatedBannerModel.banner(for: terminal(suspendedAt: Date()))
-        #expect(banner == .hibernated(
+        #expect(banner == .hibernatedOverlay(
             message: "Hibernated while idle — click anywhere in the pane to resume"
         ))
     }
 
     // MARK: - No banner / scheduled-resume branches
 
-    /// A live terminal with nothing scheduled → no footer banner at all.
+    /// A live terminal with nothing scheduled → no footer banner and no
+    /// overlay strip.
     @Test func liveTerminalShowsNoBanner() {
         #expect(HibernatedBannerModel.banner(for: terminal()) == nil)
     }
@@ -95,7 +101,8 @@ struct HibernatedBannerModelTests {
         #expect(HibernatedBannerModel.banner(for: nil) == nil)
     }
 
-    /// A live terminal with a scheduled auto-resume → the scheduled banner,
+    /// A live terminal with a scheduled auto-resume → the scheduled FOOTER
+    /// banner (the only banner that still occupies the footer slot),
     /// carrying the exact `resumeAt`.
     @Test func liveTerminalWithPendingResumeShowsScheduledBanner() {
         let resumeAt = Date(timeIntervalSince1970: 1_800_000_000)
@@ -103,16 +110,17 @@ struct HibernatedBannerModelTests {
         #expect(banner == .scheduledResume(resumeAt))
     }
 
-    /// Precedence: parked AND `pendingResumeAt` set (possible — #404 parks on
-    /// PR merge while limit-resume scheduling exists) → the PARKED banner
-    /// wins and the scheduled banner is NOT shown; "TBD types continue at..."
-    /// would be misleading for a session with nothing running.
+    /// Precedence: parked AND `pendingResumeAt` set (parking now cancels the
+    /// scheduled resume daemon-side, but the stale mirror is possible in the
+    /// delta-to-refetch window) → the PARKED overlay wins and the scheduled
+    /// footer is NOT shown; "TBD types continue at..." would be misleading
+    /// for a session with nothing running.
     @Test func parkedBeatsScheduledResume() {
         let banner = HibernatedBannerModel.banner(
             for: terminal(hibernatedAt: Date(), hibernateReason: .merged,
                           pendingResumeAt: Date(timeIntervalSince1970: 1_800_000_000))
         )
-        #expect(banner == .hibernated(
+        #expect(banner == .hibernatedOverlay(
             message: "Hibernated after the PR merged — click anywhere in the pane to resume"
         ))
     }

--- a/Tests/TBDAppTests/ParkedSnapshotComposerTests.swift
+++ b/Tests/TBDAppTests/ParkedSnapshotComposerTests.swift
@@ -4,16 +4,18 @@ import Testing
 
 /// The parked pane's in-grid hibernate notice: `ParkedSnapshotComposer`
 /// composes the frozen snapshot with a truecolor indigo notice BLOCK as its
-/// last `blockRows` (3) rows — padding row, text row, padding row —
-/// consuming the same number of trailing content rows (the frozen status
-/// bar + input-box chrome) so the pane never shifts. Every branch of the
-/// pure compose function is exercised here without SwiftUI, in the same
-/// fixture style as `HibernatedBannerModelTests`.
+/// last `blockRows` (3) rows — a ▄ half-row of indigo, the text row (white
+/// on indigo), a ▀ half-row — consuming the same number of trailing content
+/// rows (the frozen status bar + input-box chrome) so the pane never
+/// shifts. Every branch of the pure compose function is exercised here
+/// without SwiftUI, in the same fixture style as
+/// `HibernatedBannerModelTests`.
 @Suite("Parked snapshot composer")
 struct ParkedSnapshotComposerTests {
     private let message = "Hibernated — click anywhere in the pane to resume"
     private let bgSGR = ParkedSnapshotComposer.barBackgroundSGR
     private let fgSGR = ParkedSnapshotComposer.barForegroundSGR
+    private let padFgSGR = ParkedSnapshotComposer.paddingForegroundSGR
     private let reset = ParkedSnapshotComposer.sgrReset
     private let blockRows = ParkedSnapshotComposer.blockRows
 
@@ -40,19 +42,22 @@ struct ParkedSnapshotComposerTests {
     // MARK: - Colors
 
     /// The bar colors are the indigo family the deleted SwiftUI banner used:
-    /// truecolor systemIndigo background (88/86/214), pure white foreground.
+    /// truecolor systemIndigo background (88/86/214), pure white foreground
+    /// — and the padding rows draw the SAME indigo as a foreground.
     @Test func colorsAreSystemIndigoOnWhite() {
         #expect(bgSGR == "\u{1B}[48;2;88;86;214m")
         #expect(fgSGR == "\u{1B}[38;2;255;255;255m")
+        #expect(padFgSGR == "\u{1B}[38;2;88;86;214m")
         let composed = compose(nil)
         #expect(composed.contains(bgSGR))
         #expect(composed.contains(fgSGR))
+        #expect(composed.contains(padFgSGR))
     }
 
     // MARK: - Block shape
 
-    /// The notice is a 3-row block: blank padding row, text row, blank
-    /// padding row — the height matches the `blockRows` constant.
+    /// The notice is a 3-row block: half-row padding, text row, half-row
+    /// padding — the height matches the `blockRows` constant.
     @Test func blockIsThreeRows() {
         #expect(blockRows == 3)
         let composed = compose(nil)
@@ -63,15 +68,19 @@ struct ParkedSnapshotComposerTests {
         #expect(!rows[2].contains(message))
     }
 
-    /// Both padding rows carry the block background SGR and are space-padded
-    /// to the full column width so the background spans the row.
-    @Test func paddingRowsCarryBackgroundAndFullWidth() {
+    /// The padding rows are HALF rows of indigo: full-width runs of the
+    /// half-block glyphs (▄ above the bar, ▀ below), drawn as indigo
+    /// FOREGROUND on the default background — no background SGR, so only
+    /// half the cell height is colored.
+    @Test func paddingRowsAreIndigoHalfBlocksOnDefaultBackground() {
         let composed = compose(nil, columns: 60)
         let rows = lines(of: composed)
+        #expect(visibleText(of: rows[0]) == String(repeating: "▄", count: 60))
+        #expect(visibleText(of: rows[2]) == String(repeating: "▀", count: 60))
         for row in [rows[0], rows[2]] {
-            #expect(row.contains(bgSGR))
+            #expect(row.contains(padFgSGR))
+            #expect(!row.contains(bgSGR))
             #expect(row.hasSuffix(reset))
-            #expect(visibleText(of: row) == String(repeating: " ", count: 60))
         }
     }
 
@@ -188,11 +197,12 @@ struct ParkedSnapshotComposerTests {
     }
 
     /// Dangling SGR state from the retained snapshot lines (e.g. an unclosed
-    /// red foreground) must be reset BEFORE the block's own styling starts.
+    /// red foreground) must be reset BEFORE the block's own styling starts
+    /// (the top padding row's indigo foreground is the block's first SGR).
     @Test func resetPrecedesBlockAfterDanglingSGR() {
         let composed = compose("\u{1B}[31mred text\na\nb\nc")
-        guard let blockStart = composed.range(of: bgSGR) else {
-            Issue.record("block background SGR missing")
+        guard let blockStart = composed.range(of: padFgSGR) else {
+            Issue.record("block padding foreground SGR missing")
             return
         }
         let beforeBlock = String(composed[..<blockStart.lowerBound])

--- a/Tests/TBDAppTests/ParkedSnapshotComposerTests.swift
+++ b/Tests/TBDAppTests/ParkedSnapshotComposerTests.swift
@@ -3,124 +3,204 @@ import Testing
 @testable import TBDApp
 
 /// The parked pane's in-grid hibernate notice: `ParkedSnapshotComposer`
-/// composes the frozen snapshot with a truecolor notice bar as its LAST ROW
-/// (overwriting the frozen status bar). Every branch of the pure compose
-/// function is exercised here without SwiftUI, in the same fixture style as
-/// `HibernatedBannerModelTests`.
+/// composes the frozen snapshot with a truecolor indigo notice BLOCK as its
+/// last `blockRows` (3) rows — padding row, text row, padding row —
+/// consuming the same number of trailing content rows (the frozen status
+/// bar + input-box chrome) so the pane never shifts. Every branch of the
+/// pure compose function is exercised here without SwiftUI, in the same
+/// fixture style as `HibernatedBannerModelTests`.
 @Suite("Parked snapshot composer")
 struct ParkedSnapshotComposerTests {
     private let message = "Hibernated — click anywhere in the pane to resume"
     private let bgSGR = ParkedSnapshotComposer.barBackgroundSGR
     private let fgSGR = ParkedSnapshotComposer.barForegroundSGR
     private let reset = ParkedSnapshotComposer.sgrReset
+    private let blockRows = ParkedSnapshotComposer.blockRows
 
     private func compose(_ snapshot: String?, columns: Int = 80) -> String {
         ParkedSnapshotComposer.compose(snapshot: snapshot, message: message, columns: columns)
     }
 
-    /// The bar's visible text: everything with SGR escape sequences stripped.
+    /// Visible text: everything with SGR escape sequences stripped.
     private func visibleText(of composed: String) -> String {
         composed.replacingOccurrences(
             of: "\u{1B}\\[[0-9;]*m", with: "", options: .regularExpression)
     }
 
-    /// The bar line alone (last line of the composed output).
-    private func lastLine(of composed: String) -> String {
-        composed.components(separatedBy: "\n").last ?? ""
+    private func lines(of composed: String) -> [String] {
+        composed.components(separatedBy: "\n")
     }
 
-    // MARK: - Snapshot line handling
+    /// The text row — the middle row of the trailing notice block.
+    private func textRow(of composed: String) -> String {
+        let all = lines(of: composed)
+        return all[all.count - 2]
+    }
 
-    /// Multi-line snapshot → the final content line (the frozen status bar)
-    /// is dropped, earlier lines are intact, and the bar is the new last row.
-    @Test func multiLineSnapshotReplacesLastContentLine() {
-        let composed = compose("line one\nline two\nclaude status bar")
-        let lines = composed.components(separatedBy: "\n")
-        #expect(lines.count == 3)
-        #expect(lines[0] == "line one")
-        #expect(lines[1] == "line two")
-        #expect(!composed.contains("claude status bar"))
-        #expect(lines[2].contains(message))
+    // MARK: - Colors
+
+    /// The bar colors are the indigo family the deleted SwiftUI banner used:
+    /// truecolor systemIndigo background (88/86/214), pure white foreground.
+    @Test func colorsAreSystemIndigoOnWhite() {
+        #expect(bgSGR == "\u{1B}[48;2;88;86;214m")
+        #expect(fgSGR == "\u{1B}[38;2;255;255;255m")
+        let composed = compose(nil)
+        #expect(composed.contains(bgSGR))
+        #expect(composed.contains(fgSGR))
+    }
+
+    // MARK: - Block shape
+
+    /// The notice is a 3-row block: blank padding row, text row, blank
+    /// padding row — the height matches the `blockRows` constant.
+    @Test func blockIsThreeRows() {
+        #expect(blockRows == 3)
+        let composed = compose(nil)
+        let rows = lines(of: composed)
+        #expect(rows.count == blockRows)
+        #expect(rows[1].contains(message))
+        #expect(!rows[0].contains(message))
+        #expect(!rows[2].contains(message))
+    }
+
+    /// Both padding rows carry the block background SGR and are space-padded
+    /// to the full column width so the background spans the row.
+    @Test func paddingRowsCarryBackgroundAndFullWidth() {
+        let composed = compose(nil, columns: 60)
+        let rows = lines(of: composed)
+        for row in [rows[0], rows[2]] {
+            #expect(row.contains(bgSGR))
+            #expect(row.hasSuffix(reset))
+            #expect(visibleText(of: row) == String(repeating: " ", count: 60))
+        }
+    }
+
+    /// The text row leads with the two-space inset then the moon glyph,
+    /// inside the colored bar.
+    @Test func textRowHasTwoSpaceInsetBeforeMoonGlyph() {
+        let composed = compose(nil)
+        #expect(visibleText(of: textRow(of: composed)).hasPrefix("  ☾ "))
+    }
+
+    // MARK: - Snapshot line handling (drop = blockRows)
+
+    /// Multi-line snapshot → the last `blockRows` content lines (status bar
+    /// + input-box chrome) are dropped, earlier lines intact, and the block
+    /// forms the new last rows — total row count unchanged (zero shift).
+    @Test func multiLineSnapshotReplacesLastThreeContentLines() {
+        let composed = compose("line one\nline two\nchrome a\nchrome b\nstatus bar")
+        let rows = lines(of: composed)
+        #expect(rows.count == 5)
+        #expect(rows[0] == "line one")
+        #expect(rows[1] == "line two")
+        #expect(!composed.contains("chrome a"))
+        #expect(!composed.contains("chrome b"))
+        #expect(!composed.contains("status bar"))
+        #expect(rows[3].contains(message))
     }
 
     /// Trailing whitespace-only lines are trimmed BEFORE the drop, so the
-    /// bar lands directly after the last real content line — the dropped
-    /// line is the status bar, not a blank.
+    /// three dropped lines are real content (the chrome), not blanks.
     @Test func trailingBlankLinesTrimmedBeforeDrop() {
-        let composed = compose("line one\nclaude status bar\n   \n\n")
-        let lines = composed.components(separatedBy: "\n")
-        #expect(lines.count == 2)
-        #expect(lines[0] == "line one")
-        #expect(!composed.contains("claude status bar"))
-        #expect(lines[1].contains(message))
+        let composed = compose("line one\nchrome a\nchrome b\nstatus bar\n   \n\n")
+        let rows = lines(of: composed)
+        #expect(rows.count == 1 + blockRows)
+        #expect(rows[0] == "line one")
+        #expect(!composed.contains("chrome"))
+        #expect(!composed.contains("status bar"))
+        #expect(rows[2].contains(message))
     }
 
     /// \r\n snapshots: the trailing \r on each split line is whitespace, so
-    /// blank-trimming and the status-bar drop behave identically.
+    /// blank-trimming and the chrome drop behave identically.
     @Test func crlfSnapshotHandled() {
-        let composed = compose("line one\r\nclaude status bar\r\n")
+        let composed = compose("line one\r\nchrome a\r\nchrome b\r\nstatus bar\r\n")
         #expect(composed.hasPrefix("line one"))
-        #expect(!composed.contains("claude status bar"))
-        #expect(lastLine(of: composed).contains(message))
+        #expect(!composed.contains("status bar"))
+        #expect(textRow(of: composed).contains(message))
     }
 
-    /// nil snapshot (a capture-less parked pane) → just the bar, so the pane
-    /// explains itself instead of rendering pitch black.
-    @Test func nilSnapshotProducesBarOnly() {
+    /// nil snapshot (a capture-less parked pane) → just the block, so the
+    /// pane explains itself instead of rendering pitch black.
+    @Test func nilSnapshotProducesBlockOnly() {
         let composed = compose(nil)
-        #expect(!composed.contains("\n"))
+        #expect(lines(of: composed).count == blockRows)
         #expect(composed.contains(message))
     }
 
-    /// Empty-string snapshot → bar only, same as nil.
-    @Test func emptySnapshotProducesBarOnly() {
+    /// Empty-string snapshot → block only, same as nil.
+    @Test func emptySnapshotProducesBlockOnly() {
         let composed = compose("")
-        #expect(!composed.contains("\n"))
+        #expect(lines(of: composed).count == blockRows)
         #expect(composed.contains(message))
     }
 
-    /// Whitespace-only snapshot → every line trims away → bar only.
-    @Test func whitespaceOnlySnapshotProducesBarOnly() {
+    /// Whitespace-only snapshot → every line trims away → block only.
+    @Test func whitespaceOnlySnapshotProducesBlockOnly() {
         let composed = compose("   \n\n  \n")
-        #expect(!composed.contains("\n"))
+        #expect(lines(of: composed).count == blockRows)
         #expect(composed.contains(message))
     }
 
-    /// Single-line snapshot → the bar replaces it entirely (acceptable: the
-    /// sole line of a parked capture is the status bar being overwritten).
+    /// Single-line snapshot → fewer content lines than the block consumes →
+    /// replaced entirely by the block.
     @Test func singleLineSnapshotReplacedEntirely() {
         let composed = compose("only status line")
         #expect(!composed.contains("only status line"))
-        #expect(!composed.contains("\n"))
+        #expect(lines(of: composed).count == blockRows)
         #expect(composed.contains(message))
     }
 
-    // MARK: - Bar styling
+    /// Two-line snapshot (fewer than `blockRows`) → both lines dropped, the
+    /// block stands alone — no partial retention.
+    @Test func twoLineSnapshotReplacedEntirely() {
+        let composed = compose("line one\nstatus bar")
+        #expect(!composed.contains("line one"))
+        #expect(!composed.contains("status bar"))
+        #expect(lines(of: composed).count == blockRows)
+        #expect(composed.contains(message))
+    }
 
-    /// The bar carries the truecolor background + foreground SGR and ends
-    /// with a full reset so its colors can't bleed into later output.
-    @Test func barContainsTruecolorSGRAndReset() {
-        let composed = compose("line one\nstatus")
-        let bar = lastLine(of: composed)
-        #expect(bar.contains(bgSGR))
-        #expect(bar.contains(fgSGR))
-        #expect(bar.hasSuffix(reset))
+    /// Exactly `blockRows` content lines → all consumed, block only; one
+    /// more line and the first survives (the boundary of the drop rule).
+    @Test func exactlyBlockRowsLinesReplacedEntirely() {
+        let atBoundary = compose("a\nb\nc")
+        #expect(lines(of: atBoundary).count == blockRows)
+        #expect(!atBoundary.contains("a\n"))
+
+        let overBoundary = compose("keep\na\nb\nc")
+        let rows = lines(of: overBoundary)
+        #expect(rows.count == 1 + blockRows)
+        #expect(rows[0] == "keep")
+    }
+
+    // MARK: - Styling / SGR hygiene
+
+    /// Every block row starts fresh and ends reset: the text row carries the
+    /// truecolor bg + fg SGR and a trailing reset so the block's colors
+    /// can't bleed into later output.
+    @Test func textRowContainsTruecolorSGRAndReset() {
+        let composed = compose("one\ntwo\nthree\nfour")
+        let row = textRow(of: composed)
+        #expect(row.contains(bgSGR))
+        #expect(row.contains(fgSGR))
+        #expect(row.hasSuffix(reset))
     }
 
     /// Dangling SGR state from the retained snapshot lines (e.g. an unclosed
-    /// red foreground) must be reset BEFORE the bar's own styling starts.
-    @Test func resetPrecedesBarAfterDanglingSGR() {
-        let composed = compose("\u{1B}[31mred text\nstatus")
-        guard let barStart = composed.range(of: bgSGR) else {
-            Issue.record("bar background SGR missing")
+    /// red foreground) must be reset BEFORE the block's own styling starts.
+    @Test func resetPrecedesBlockAfterDanglingSGR() {
+        let composed = compose("\u{1B}[31mred text\na\nb\nc")
+        guard let blockStart = composed.range(of: bgSGR) else {
+            Issue.record("block background SGR missing")
             return
         }
-        let beforeBar = String(composed[..<barStart.lowerBound])
-        #expect(beforeBar.contains("red text"))
-        // A reset must sit between the retained content and the bar's SGR.
-        guard let resetRange = beforeBar.range(of: reset, options: .backwards),
-              let redRange = beforeBar.range(of: "red text") else {
-            Issue.record("expected a reset between the retained content and the bar")
+        let beforeBlock = String(composed[..<blockStart.lowerBound])
+        #expect(beforeBlock.contains("red text"))
+        // A reset must sit between the retained content and the block's SGR.
+        guard let resetRange = beforeBlock.range(of: reset, options: .backwards),
+              let redRange = beforeBlock.range(of: "red text") else {
+            Issue.record("expected a reset between the retained content and the block")
             return
         }
         #expect(resetRange.lowerBound >= redRange.upperBound)
@@ -128,41 +208,34 @@ struct ParkedSnapshotComposerTests {
 
     // MARK: - Column padding / truncation
 
-    /// The bar's visible text is padded with spaces to exactly `columns`, so
-    /// the background spans the full row.
-    @Test func barPaddedToColumnWidth() {
+    /// The text row's visible text is padded with spaces to exactly
+    /// `columns`, so the background spans the full row.
+    @Test func textRowPaddedToColumnWidth() {
         let composed = compose(nil, columns: 120)
-        #expect(visibleText(of: composed).count == 120)
-        #expect(visibleText(of: composed).hasSuffix(" "))
+        let visible = visibleText(of: textRow(of: composed))
+        #expect(visible.count == 120)
+        #expect(visible.hasSuffix(" "))
     }
 
     /// Message longer than the column count → truncated with an ellipsis to
     /// exactly `columns` visible cells.
     @Test func longMessageTruncatedWithEllipsis() {
         let composed = compose(nil, columns: 10)
-        let visible = visibleText(of: composed)
+        let visible = visibleText(of: textRow(of: composed))
         #expect(visible.count == 10)
         #expect(visible.hasSuffix("…"))
     }
 
     /// columns <= 0 (defensive: dimensions not yet known) → no padding and
-    /// no truncation, just the styled glyph + message.
+    /// no truncation, just the inset + styled glyph + message.
     @Test func zeroColumnsEmitsUnpaddedText() {
         let composed = compose(nil, columns: 0)
-        let visible = visibleText(of: composed)
-        #expect(visible == "☾ \(message)")
+        #expect(visibleText(of: textRow(of: composed)) == "  ☾ \(message)")
     }
 
     /// Negative columns behave like zero (defensive).
     @Test func negativeColumnsEmitsUnpaddedText() {
         let composed = compose(nil, columns: -5)
-        #expect(visibleText(of: composed) == "☾ \(message)")
-    }
-
-    /// The moon glyph leads the bar so the notice reads as a hibernate state
-    /// at a glance.
-    @Test func barLeadsWithMoonGlyph() {
-        let composed = compose(nil)
-        #expect(visibleText(of: composed).hasPrefix("☾ "))
+        #expect(visibleText(of: textRow(of: composed)) == "  ☾ \(message)")
     }
 }

--- a/Tests/TBDAppTests/ParkedSnapshotComposerTests.swift
+++ b/Tests/TBDAppTests/ParkedSnapshotComposerTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// The parked pane's in-grid hibernate notice: `ParkedSnapshotComposer`
+/// composes the frozen snapshot with a truecolor notice bar as its LAST ROW
+/// (overwriting the frozen status bar). Every branch of the pure compose
+/// function is exercised here without SwiftUI, in the same fixture style as
+/// `HibernatedBannerModelTests`.
+@Suite("Parked snapshot composer")
+struct ParkedSnapshotComposerTests {
+    private let message = "Hibernated — click anywhere in the pane to resume"
+    private let bgSGR = ParkedSnapshotComposer.barBackgroundSGR
+    private let fgSGR = ParkedSnapshotComposer.barForegroundSGR
+    private let reset = ParkedSnapshotComposer.sgrReset
+
+    private func compose(_ snapshot: String?, columns: Int = 80) -> String {
+        ParkedSnapshotComposer.compose(snapshot: snapshot, message: message, columns: columns)
+    }
+
+    /// The bar's visible text: everything with SGR escape sequences stripped.
+    private func visibleText(of composed: String) -> String {
+        composed.replacingOccurrences(
+            of: "\u{1B}\\[[0-9;]*m", with: "", options: .regularExpression)
+    }
+
+    /// The bar line alone (last line of the composed output).
+    private func lastLine(of composed: String) -> String {
+        composed.components(separatedBy: "\n").last ?? ""
+    }
+
+    // MARK: - Snapshot line handling
+
+    /// Multi-line snapshot → the final content line (the frozen status bar)
+    /// is dropped, earlier lines are intact, and the bar is the new last row.
+    @Test func multiLineSnapshotReplacesLastContentLine() {
+        let composed = compose("line one\nline two\nclaude status bar")
+        let lines = composed.components(separatedBy: "\n")
+        #expect(lines.count == 3)
+        #expect(lines[0] == "line one")
+        #expect(lines[1] == "line two")
+        #expect(!composed.contains("claude status bar"))
+        #expect(lines[2].contains(message))
+    }
+
+    /// Trailing whitespace-only lines are trimmed BEFORE the drop, so the
+    /// bar lands directly after the last real content line — the dropped
+    /// line is the status bar, not a blank.
+    @Test func trailingBlankLinesTrimmedBeforeDrop() {
+        let composed = compose("line one\nclaude status bar\n   \n\n")
+        let lines = composed.components(separatedBy: "\n")
+        #expect(lines.count == 2)
+        #expect(lines[0] == "line one")
+        #expect(!composed.contains("claude status bar"))
+        #expect(lines[1].contains(message))
+    }
+
+    /// \r\n snapshots: the trailing \r on each split line is whitespace, so
+    /// blank-trimming and the status-bar drop behave identically.
+    @Test func crlfSnapshotHandled() {
+        let composed = compose("line one\r\nclaude status bar\r\n")
+        #expect(composed.hasPrefix("line one"))
+        #expect(!composed.contains("claude status bar"))
+        #expect(lastLine(of: composed).contains(message))
+    }
+
+    /// nil snapshot (a capture-less parked pane) → just the bar, so the pane
+    /// explains itself instead of rendering pitch black.
+    @Test func nilSnapshotProducesBarOnly() {
+        let composed = compose(nil)
+        #expect(!composed.contains("\n"))
+        #expect(composed.contains(message))
+    }
+
+    /// Empty-string snapshot → bar only, same as nil.
+    @Test func emptySnapshotProducesBarOnly() {
+        let composed = compose("")
+        #expect(!composed.contains("\n"))
+        #expect(composed.contains(message))
+    }
+
+    /// Whitespace-only snapshot → every line trims away → bar only.
+    @Test func whitespaceOnlySnapshotProducesBarOnly() {
+        let composed = compose("   \n\n  \n")
+        #expect(!composed.contains("\n"))
+        #expect(composed.contains(message))
+    }
+
+    /// Single-line snapshot → the bar replaces it entirely (acceptable: the
+    /// sole line of a parked capture is the status bar being overwritten).
+    @Test func singleLineSnapshotReplacedEntirely() {
+        let composed = compose("only status line")
+        #expect(!composed.contains("only status line"))
+        #expect(!composed.contains("\n"))
+        #expect(composed.contains(message))
+    }
+
+    // MARK: - Bar styling
+
+    /// The bar carries the truecolor background + foreground SGR and ends
+    /// with a full reset so its colors can't bleed into later output.
+    @Test func barContainsTruecolorSGRAndReset() {
+        let composed = compose("line one\nstatus")
+        let bar = lastLine(of: composed)
+        #expect(bar.contains(bgSGR))
+        #expect(bar.contains(fgSGR))
+        #expect(bar.hasSuffix(reset))
+    }
+
+    /// Dangling SGR state from the retained snapshot lines (e.g. an unclosed
+    /// red foreground) must be reset BEFORE the bar's own styling starts.
+    @Test func resetPrecedesBarAfterDanglingSGR() {
+        let composed = compose("\u{1B}[31mred text\nstatus")
+        guard let barStart = composed.range(of: bgSGR) else {
+            Issue.record("bar background SGR missing")
+            return
+        }
+        let beforeBar = String(composed[..<barStart.lowerBound])
+        #expect(beforeBar.contains("red text"))
+        // A reset must sit between the retained content and the bar's SGR.
+        guard let resetRange = beforeBar.range(of: reset, options: .backwards),
+              let redRange = beforeBar.range(of: "red text") else {
+            Issue.record("expected a reset between the retained content and the bar")
+            return
+        }
+        #expect(resetRange.lowerBound >= redRange.upperBound)
+    }
+
+    // MARK: - Column padding / truncation
+
+    /// The bar's visible text is padded with spaces to exactly `columns`, so
+    /// the background spans the full row.
+    @Test func barPaddedToColumnWidth() {
+        let composed = compose(nil, columns: 120)
+        #expect(visibleText(of: composed).count == 120)
+        #expect(visibleText(of: composed).hasSuffix(" "))
+    }
+
+    /// Message longer than the column count → truncated with an ellipsis to
+    /// exactly `columns` visible cells.
+    @Test func longMessageTruncatedWithEllipsis() {
+        let composed = compose(nil, columns: 10)
+        let visible = visibleText(of: composed)
+        #expect(visible.count == 10)
+        #expect(visible.hasSuffix("…"))
+    }
+
+    /// columns <= 0 (defensive: dimensions not yet known) → no padding and
+    /// no truncation, just the styled glyph + message.
+    @Test func zeroColumnsEmitsUnpaddedText() {
+        let composed = compose(nil, columns: 0)
+        let visible = visibleText(of: composed)
+        #expect(visible == "☾ \(message)")
+    }
+
+    /// Negative columns behave like zero (defensive).
+    @Test func negativeColumnsEmitsUnpaddedText() {
+        let composed = compose(nil, columns: -5)
+        #expect(visibleText(of: composed) == "☾ \(message)")
+    }
+
+    /// The moon glyph leads the bar so the notice reads as a hibernate state
+    /// at a glance.
+    @Test func barLeadsWithMoonGlyph() {
+        let composed = compose(nil)
+        #expect(visibleText(of: composed).hasPrefix("☾ "))
+    }
+}

--- a/Tests/TBDAppTests/TerminalHibernationDeltaAppStateTests.swift
+++ b/Tests/TBDAppTests/TerminalHibernationDeltaAppStateTests.swift
@@ -45,6 +45,57 @@ struct TerminalHibernationDeltaAppStateTests {
         }
     }
 
+    /// Parking implies cancellation: the daemon's `setHibernated` cancels any
+    /// scheduled auto-resume in the same write, so a `hibernated == true`
+    /// delta must nil the cached row's `pendingResumeAt` mirror too —
+    /// otherwise the tab's ⏳ glyph and "Cancel Scheduled Resume" item keep
+    /// advertising a resume that won't happen for the delta-to-refetch window.
+    @Test func hibernateDelta_clearsPendingResumeAt() {
+        withState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            state.terminals = [worktreeID: [
+                Terminal(id: terminalID, worktreeID: worktreeID,
+                         tmuxWindowID: "@1", tmuxPaneID: "%1", kind: .claude,
+                         pendingResumeAt: Date(timeIntervalSince1970: 1_800_000_000))
+            ]]
+
+            state.handleDelta(.terminalHibernationChanged(TerminalHibernationDelta(
+                terminalID: terminalID, worktreeID: worktreeID,
+                hibernated: true, keepWarm: false,
+                suspendedSnapshot: nil, hibernateReason: .merged
+            )))
+
+            #expect(state.terminals[worktreeID]?[0].pendingResumeAt == nil,
+                    "parking cancels the scheduled resume — the cached mirror must clear with the flip")
+        }
+    }
+
+    /// A wake delta carries no scheduled-resume information, so it must leave
+    /// `pendingResumeAt` alone — the refetch is the source of truth for any
+    /// resume scheduled after the wake.
+    @Test func wakeDelta_leavesPendingResumeAtAlone() {
+        withState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            let resumeAt = Date(timeIntervalSince1970: 1_800_000_000)
+            state.terminals = [worktreeID: [
+                Terminal(id: terminalID, worktreeID: worktreeID,
+                         tmuxWindowID: "@1", tmuxPaneID: "%1", kind: .claude,
+                         hibernatedAt: Date(), hibernateReason: .auto,
+                         pendingResumeAt: resumeAt)
+            ]]
+
+            state.handleDelta(.terminalHibernationChanged(TerminalHibernationDelta(
+                terminalID: terminalID, worktreeID: worktreeID,
+                hibernated: false, keepWarm: false
+            )))
+
+            #expect(state.terminals[worktreeID]?[0].pendingResumeAt == resumeAt,
+                    "a wake delta says nothing about scheduled resumes — leave the mirror for the refetch")
+        }
+    }
+
     @Test func wakeDelta_clearsReasonAndParkFlag_keepsSnapshot() {
         withState { state in
             let worktreeID = UUID()

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -190,6 +190,39 @@ struct HibernationCoordinatorTests {
         #expect(after?.hibernatedAt != nil)
     }
 
+    // MARK: - Park cancels the scheduled auto-resume
+
+    /// A hibernated terminal must never carry a scheduled auto-resume — the
+    /// Claude process is dead, so a resume firing later would type "continue"
+    /// into a bare shell. The park write (`setHibernated`, reached here via
+    /// `performHibernate`) cancels the pending row and clears the
+    /// `pendingResumeAt` mirror atomically; wake does NOT resurrect it.
+    @Test func parkCancelsScheduledResumeAndWakeDoesNotResurrect() async throws {
+        let (db, worktreeID, terminalID) = try await setup(activityState: .idle)
+        let resume = ScheduledResume(
+            terminalID: terminalID, worktreeID: worktreeID,
+            claudeSessionID: "sess-1",
+            resetsAt: Date().addingTimeInterval(60),
+            fireAt: Date().addingTimeInterval(90),
+            limitType: "session", rawMessage: "You've hit your session limit")
+        _ = try await db.scheduledResumes.insertPending(resume)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt != nil)
+
+        let coord = coordinator(db)
+        let parked = await coord.manualHibernate(terminalID: terminalID)
+        #expect(parked == .ok)
+        #expect(try await db.scheduledResumes.pending(terminalID: terminalID) == nil,
+                "parking must cancel the pending scheduled resume")
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil,
+                "the pendingResumeAt mirror must clear with the park write")
+
+        let woke = await coord.wake(terminalID: terminalID)
+        #expect(woke == .ok)
+        #expect(try await db.scheduledResumes.pending(terminalID: terminalID) == nil,
+                "wake must not resurrect the cancelled resume")
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
+    }
+
     // MARK: - Auto-off: manual park still works
 
     /// Manual "Hibernate now" must NOT consult `auto_hibernate_enabled`. With the

--- a/Tests/TBDDaemonTests/ScheduledResumeStoreTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumeStoreTests.swift
@@ -131,6 +131,42 @@ import Testing
         #expect(abs(terminal!.pendingResumeAt!.timeIntervalSince(newFireAt)) < 0.01)
     }
 
+    /// Parking cancels the scheduled auto-resume atomically with the park
+    /// write: `TerminalStore.setHibernated` is the choke point EVERY park site
+    /// flows through (performHibernate, the reconcile recovery park, the
+    /// recreate-window dead-window park), and it runs the same
+    /// `cancelPendingInTransaction` routine as an explicit user cancel. Wake
+    /// (`clearHibernated`) must NOT resurrect the cancelled row.
+    @Test func setHibernatedCancelsPendingAndWakeDoesNotResurrect() async throws {
+        let resume = makeResume()
+        _ = try await db.scheduledResumes.insertPending(resume)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt != nil)
+
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+
+        #expect(try await db.scheduledResumes.get(id: resume.id)?.status == .cancelled,
+                "parking must cancel the pending row — the Claude process is dead")
+        #expect(try await db.scheduledResumes.pending(terminalID: terminalID) == nil)
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil,
+                "the pendingResumeAt mirror must clear in the same write")
+
+        try await db.terminals.clearHibernated(id: terminalID)
+        #expect(try await db.scheduledResumes.get(id: resume.id)?.status == .cancelled,
+                "wake must not resurrect the cancelled resume")
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
+    }
+
+    /// The other branch of the park-time cancel: a terminal with NO pending
+    /// resume parks cleanly (the in-transaction cancel is a no-op, not an
+    /// error) and stays parked.
+    @Test func setHibernatedWithoutPendingResumeStillParks() async throws {
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let terminal = try await db.terminals.get(id: terminalID)
+        #expect(terminal?.hibernatedAt != nil)
+        #expect(terminal?.pendingResumeAt == nil)
+        #expect(try await db.scheduledResumes.all(terminalID: terminalID).isEmpty)
+    }
+
     @Test func cancelPendingByTerminal() async throws {
         let resume = makeResume()
         _ = try await db.scheduledResumes.insertPending(resume)


### PR DESCRIPTION
## Summary

- **The parked notice is now part of the terminal content.** The old wake affordance was a small "Click to resume session" button in the pane's top corner — easy to miss. A parked pane now renders an indigo status bar composed into the frozen snapshot itself (`☾ Hibernated — click anywhere in the pane to resume`, phrased per park reason: manual / idle / restart-recovery / PR-merged), replacing Claude's own bottom status-bar rows so nothing shifts and nothing of value is covered. Composition is render-time only (pure `ParkedSnapshotComposer`) — the stored snapshot stays pristine for the post-wake reconnect backdrop, and a capture-less parked pane now explains itself instead of rendering black. Half-block glyph padding gives the bar breathing room without eating full rows.
- **The whole pane is click-to-wake.** A full-surface transparent button (gated to parked panes only — live panes get no click-catcher; deliberately not `.onTapGesture`, which eats `.contextMenu` on macOS) wakes via the singleflighted `wakeTerminal(userInitiated: true)`.
- **Parking now cancels the session's scheduled auto-resume.** A hibernated terminal could still advertise "⏳ resumes at…" from a usage-limit or transient-API-error schedule — a resume that would fire into a bare shell. Parking now cancels it atomically inside `setHibernated`'s own transaction (same routine as the user's explicit Cancel), covering all four park sites (manual/idle, recovery reconcile, dead-window recreate, PR-merge). The actuator's parked-row guard remains as fire-time backstop; the tab's ⏳ glyph and "Cancel Scheduled Resume" item disappear immediately via the delta apply.

## Note for #396

The full-pane click-to-wake here supersedes the pane-tap portion of #396's `PanePlaceholder` changes (the corner button that PR taps into no longer exists); its tab-activation wake and `isClaudeResumable` filtering remain complementary. cc @zionts

## Test plan

- [ ] Full suite green: 3290 tests / 401 suites (+38 across the branch: composer branches incl. nil/short/CRLF/dangling-SGR snapshots and truncation, banner-model contract, park-cancels-schedule incl. wake-does-not-resurrect, delta apply)
- [ ] Live: park a Claude tab → frozen screen ends in the indigo bar with half-row padding, nothing shifts; click anywhere (including the bar) → wakes; woken backdrop shows no stale notice
- [ ] Live: park a session that had a scheduled resume → ⏳ tab glyph and "Cancel Scheduled Resume" menu item vanish; wake does not resurrect the schedule
- [ ] Live: live panes take clicks normally; right-click menus intact

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=DD23E916-C861-41EC-9930-2947FA9284B6)