### PR TITLE
Feat: Open the new-worktree profile menu on hover instead of behind a long-press

### DIFF
--- a/Sources/TBDApp/Sidebar/BranchPickerView.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerView.swift
@@ -25,6 +25,11 @@ struct BranchListView: View {
     let repoID: UUID
     /// Forwarded so a branch chosen from a nested `+` creates a child worktree.
     var parentWorktreeID: UUID? = nil
+    /// Explicit close hook for the `FloatingPanel` presentation (no
+    /// `@Environment(\.dismiss)` there); forwarded from
+    /// `WorktreeProfilePickerView`. The standalone `BranchPickerView` wrapper
+    /// is currently unused, so its default empty closure is harmless.
+    var onClose: () -> Void = {}
     @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) private var dismiss
 
@@ -103,6 +108,7 @@ struct BranchListView: View {
 
     private func pick(_ branch: BranchInfo) {
         dismiss()
+        onClose()
         // Branch selection always uses the default model (no profile override).
         appState.createWorktree(repoID: repoID, parentWorktreeID: parentWorktreeID, existingBranch: branch)
     }

--- a/Sources/TBDApp/Sidebar/BranchPickerView.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerView.swift
@@ -23,6 +23,8 @@ struct BranchPickerView: View {
 /// under the back bar.
 struct BranchListView: View {
     let repoID: UUID
+    /// Forwarded so a branch chosen from a nested `+` creates a child worktree.
+    var parentWorktreeID: UUID? = nil
     @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) private var dismiss
 
@@ -102,7 +104,7 @@ struct BranchListView: View {
     private func pick(_ branch: BranchInfo) {
         dismiss()
         // Branch selection always uses the default model (no profile override).
-        appState.createWorktree(repoID: repoID, existingBranch: branch)
+        appState.createWorktree(repoID: repoID, parentWorktreeID: parentWorktreeID, existingBranch: branch)
     }
 
     private func selectFirstMatch() {

--- a/Sources/TBDApp/Sidebar/FloatingMenuAnchor.swift
+++ b/Sources/TBDApp/Sidebar/FloatingMenuAnchor.swift
@@ -1,0 +1,46 @@
+import AppKit
+import SwiftUI
+
+/// Presents `content` in a borderless, arrow-less, animation-less `FloatingPanel`
+/// anchored to the trailing side of the host view — the replacement for `.popover`
+/// on the worktree hover menu (no NSPopover arrow, no present/dismiss animation).
+/// Driven by `isPresented`; `HoverMenuModel`'s hover close-grace still decides when
+/// `isPresented` flips false.
+struct FloatingMenuAnchor<Content: View>: NSViewRepresentable {
+    let isPresented: Bool
+    let content: Content
+
+    func makeNSView(context: Context) -> NSView {
+        let anchor = NSView(frame: .zero)
+        context.coordinator.anchor = anchor
+        return anchor
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        let coordinator = context.coordinator
+        if isPresented {
+            if let panel = coordinator.panel {
+                panel.updateContent(content)          // refresh (e.g. default-row highlight); no reposition
+            } else {
+                let panel = FloatingPanel(content: content)
+                coordinator.panel = panel
+                panel.showAsMenu(relativeTo: nsView)
+            }
+        } else {
+            coordinator.panel?.dismiss()
+            coordinator.panel = nil
+        }
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.panel?.dismiss()
+        coordinator.panel = nil
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        var anchor: NSView?
+        var panel: FloatingPanel?
+    }
+}

--- a/Sources/TBDApp/Sidebar/FloatingPanel.swift
+++ b/Sources/TBDApp/Sidebar/FloatingPanel.swift
@@ -57,9 +57,11 @@ class FloatingPanel: NSPanel {
         }
     }
 
-    /// Show to the trailing (right) side of `view`, top-aligned with it, clamped
-    /// to the screen's visible frame so a tall menu near an edge stays on-screen.
-    /// Falls back to the leading side if the menu won't fit on the right.
+    /// Show to the trailing (right) side of `view`, vertically centered on it —
+    /// the menu's leading edge sits at the trigger, its mid-height aligned with
+    /// the trigger's center — clamped to the screen's visible frame so a tall
+    /// menu near an edge stays on-screen. Falls back to the leading side if the
+    /// menu won't fit on the right.
     func showAsMenu(relativeTo view: NSView) {
         guard let window = view.window else { return }
         let anchor = window.convertToScreen(view.convert(view.bounds, to: nil))
@@ -71,7 +73,7 @@ class FloatingPanel: NSPanel {
         var x = anchor.maxX + gap
         if x + size.width > screen.maxX { x = anchor.minX - size.width - gap }
         x = max(screen.minX, min(x, screen.maxX - size.width))
-        var y = anchor.maxY - size.height           // top-align, grow downward
+        var y = anchor.midY - size.height / 2       // vertically center on the anchor
         y = max(screen.minY, min(y, screen.maxY - size.height))
         setFrame(NSRect(x: x, y: y, width: size.width, height: size.height), display: true)
         if !isVisible { orderFront(nil) }

--- a/Sources/TBDApp/Sidebar/FloatingPanel.swift
+++ b/Sources/TBDApp/Sidebar/FloatingPanel.swift
@@ -18,6 +18,7 @@ class FloatingPanel: NSPanel {
         level = .popUpMenu
         hasShadow = true
         isMovableByWindowBackground = false
+        animationBehavior = .none
 
         let hosting = NSHostingView(rootView: AnyView(content))
         contentView = hosting
@@ -54,6 +55,26 @@ class FloatingPanel: NSPanel {
         if !isVisible {
             orderFront(nil)
         }
+    }
+
+    /// Show to the trailing (right) side of `view`, top-aligned with it, clamped
+    /// to the screen's visible frame so a tall menu near an edge stays on-screen.
+    /// Falls back to the leading side if the menu won't fit on the right.
+    func showAsMenu(relativeTo view: NSView) {
+        guard let window = view.window else { return }
+        let anchor = window.convertToScreen(view.convert(view.bounds, to: nil))
+        hostingView?.invalidateIntrinsicContentSize()
+        let size = hostingView?.fittingSize ?? CGSize(width: 300, height: 400)
+        let gap: CGFloat = 4
+        let screen = (NSScreen.screens.first { $0.frame.contains(anchor.origin) }
+            ?? NSScreen.main)?.visibleFrame ?? anchor
+        var x = anchor.maxX + gap
+        if x + size.width > screen.maxX { x = anchor.minX - size.width - gap }
+        x = max(screen.minX, min(x, screen.maxX - size.width))
+        var y = anchor.maxY - size.height           // top-align, grow downward
+        y = max(screen.minY, min(y, screen.maxY - size.height))
+        setFrame(NSRect(x: x, y: y, width: size.width, height: size.height), display: true)
+        if !isVisible { orderFront(nil) }
     }
 
     func dismiss() {

--- a/Sources/TBDApp/Sidebar/HoverMenuModel.swift
+++ b/Sources/TBDApp/Sidebar/HoverMenuModel.swift
@@ -52,7 +52,7 @@ final class HoverMenuModel: ObservableObject {
     /// ⌥-click: open immediately, skipping the hover-intent delay.
     func openImmediately() {
         cancelTasks()
-        isOpen = true
+        setOpen(true)
     }
 
     /// A row was chosen, or the popover was dismissed by an outside click.
@@ -60,7 +60,17 @@ final class HoverMenuModel: ObservableObject {
         cancelTasks()
         isTriggerHovered = false
         overMenu = false
-        isOpen = false
+        setOpen(false)
+    }
+
+    /// Flip `isOpen` without the popover's present/dismiss animation — the menu
+    /// should snap in and out, not fade/scale. SwiftUI's `.popover` (AppKit
+    /// `NSPopover`) animates by default; a transaction with `disablesAnimations`
+    /// around the state change is the public lever to turn that off.
+    private func setOpen(_ value: Bool) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) { isOpen = value }
     }
 
     /// Binding for `.popover(isPresented:)`. SwiftUI sets it false on an outside
@@ -86,7 +96,7 @@ final class HoverMenuModel: ObservableObject {
                 guard let self else { return }
                 if self.openTaskGeneration == generation { self.openTask = nil }
                 guard !Task.isCancelled, self.pointerInside else { return }
-                self.isOpen = true
+                self.setOpen(true)
             }
         } else {
             openTask?.cancel(); openTask = nil
@@ -98,7 +108,7 @@ final class HoverMenuModel: ObservableObject {
                 guard let self else { return }
                 if self.closeTaskGeneration == generation { self.closeTask = nil }
                 guard !Task.isCancelled, !self.pointerInside else { return }
-                self.isOpen = false
+                self.setOpen(false)
             }
         }
     }

--- a/Sources/TBDApp/Sidebar/HoverMenuModel.swift
+++ b/Sources/TBDApp/Sidebar/HoverMenuModel.swift
@@ -30,7 +30,7 @@ final class HoverMenuModel: ObservableObject {
     private let openDelay: Duration
     private let closeGrace: Duration
 
-    init(openDelay: Duration = .milliseconds(200), closeGrace: Duration = .milliseconds(100)) {
+    init(openDelay: Duration = .milliseconds(400), closeGrace: Duration = .milliseconds(100)) {
         self.openDelay = openDelay
         self.closeGrace = closeGrace
     }

--- a/Sources/TBDApp/Sidebar/HoverMenuModel.swift
+++ b/Sources/TBDApp/Sidebar/HoverMenuModel.swift
@@ -73,13 +73,6 @@ final class HoverMenuModel: ObservableObject {
         withTransaction(transaction) { isOpen = value }
     }
 
-    /// Binding for `.popover(isPresented:)`. SwiftUI sets it false on an outside
-    /// click or `dismiss()`; we route that through `closeNow()`. We never drive
-    /// it true from here (opening happens via the hover/⌥-click methods).
-    var isOpenBinding: Binding<Bool> {
-        Binding(get: { self.isOpen }, set: { newValue in if !newValue { self.closeNow() } })
-    }
-
     private func cancelTasks() {
         openTask?.cancel(); openTask = nil
         closeTask?.cancel(); closeTask = nil

--- a/Sources/TBDApp/Sidebar/HoverMenuModel.swift
+++ b/Sources/TBDApp/Sidebar/HoverMenuModel.swift
@@ -19,6 +19,14 @@ final class HoverMenuModel: ObservableObject {
     private var openTask: Task<Void, Never>?
     private var closeTask: Task<Void, Never>?
 
+    // Monotonic counters let a task's continuation verify — after its
+    // `Task.sleep` resumes — that it is still the current open/close task
+    // before nil-ing the ivar. Without this, a cancelled task whose
+    // continuation resumes after a newer task has already been assigned to
+    // the same ivar would nil out that newer, still-live task.
+    private var openTaskGeneration = 0
+    private var closeTaskGeneration = 0
+
     private let openDelay: Duration
     private let closeGrace: Duration
 
@@ -71,20 +79,24 @@ final class HoverMenuModel: ObservableObject {
         if pointerInside {
             closeTask?.cancel(); closeTask = nil
             guard !isOpen, openTask == nil else { return }
+            openTaskGeneration += 1
+            let generation = openTaskGeneration
             openTask = Task { [weak self] in
                 try? await Task.sleep(for: self?.openDelay ?? .zero)
                 guard let self else { return }
-                self.openTask = nil
+                if self.openTaskGeneration == generation { self.openTask = nil }
                 guard !Task.isCancelled, self.pointerInside else { return }
                 self.isOpen = true
             }
         } else {
             openTask?.cancel(); openTask = nil
             guard isOpen, closeTask == nil else { return }
+            closeTaskGeneration += 1
+            let generation = closeTaskGeneration
             closeTask = Task { [weak self] in
                 try? await Task.sleep(for: self?.closeGrace ?? .zero)
                 guard let self else { return }
-                self.closeTask = nil
+                if self.closeTaskGeneration == generation { self.closeTask = nil }
                 guard !Task.isCancelled, !self.pointerInside else { return }
                 self.isOpen = false
             }

--- a/Sources/TBDApp/Sidebar/HoverMenuModel.swift
+++ b/Sources/TBDApp/Sidebar/HoverMenuModel.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+/// Drives the hover-to-open worktree menu shared by the repo `+`
+/// (`RepoSectionView`) and the per-row nested `+` (`WorktreeRowView`).
+///
+/// Owns two timings: a hover-intent delay before opening (so scrubbing the
+/// pointer across the sidebar doesn't flash menus open) and a close grace that
+/// bridges the pixel gap between the `+` button and its `.popover`. The popover
+/// renders in a separate window, so moving the pointer into it flips the
+/// button's `onHover` to false; the grace, plus a second `onHover` on the
+/// popover content (`menuHover`), keeps the menu open while the pointer is over
+/// EITHER surface.
+@MainActor
+final class HoverMenuModel: ObservableObject {
+    @Published private(set) var isOpen = false
+
+    private var overTrigger = false
+    private var overMenu = false
+    private var openTask: Task<Void, Never>?
+    private var closeTask: Task<Void, Never>?
+
+    private let openDelay: Duration
+    private let closeGrace: Duration
+
+    init(openDelay: Duration = .milliseconds(200), closeGrace: Duration = .milliseconds(100)) {
+        self.openDelay = openDelay
+        self.closeGrace = closeGrace
+    }
+
+    private var pointerInside: Bool { overTrigger || overMenu }
+
+    /// Pointer entered/left the `+` button.
+    func triggerHover(_ inside: Bool) {
+        overTrigger = inside
+        reconcile()
+    }
+
+    /// Pointer entered/left the popover content.
+    func menuHover(_ inside: Bool) {
+        overMenu = inside
+        reconcile()
+    }
+
+    /// ⌥-click: open immediately, skipping the hover-intent delay.
+    func openImmediately() {
+        cancelTasks()
+        isOpen = true
+    }
+
+    /// A row was chosen, or the popover was dismissed by an outside click.
+    func closeNow() {
+        cancelTasks()
+        overTrigger = false
+        overMenu = false
+        isOpen = false
+    }
+
+    /// Binding for `.popover(isPresented:)`. SwiftUI sets it false on an outside
+    /// click or `dismiss()`; we route that through `closeNow()`. We never drive
+    /// it true from here (opening happens via the hover/⌥-click methods).
+    var isOpenBinding: Binding<Bool> {
+        Binding(get: { self.isOpen }, set: { newValue in if !newValue { self.closeNow() } })
+    }
+
+    private func cancelTasks() {
+        openTask?.cancel(); openTask = nil
+        closeTask?.cancel(); closeTask = nil
+    }
+
+    private func reconcile() {
+        if pointerInside {
+            closeTask?.cancel(); closeTask = nil
+            guard !isOpen, openTask == nil else { return }
+            openTask = Task { [weak self] in
+                try? await Task.sleep(for: self?.openDelay ?? .zero)
+                guard let self else { return }
+                self.openTask = nil
+                guard !Task.isCancelled, self.pointerInside else { return }
+                self.isOpen = true
+            }
+        } else {
+            openTask?.cancel(); openTask = nil
+            guard isOpen, closeTask == nil else { return }
+            closeTask = Task { [weak self] in
+                try? await Task.sleep(for: self?.closeGrace ?? .zero)
+                guard let self else { return }
+                self.closeTask = nil
+                guard !Task.isCancelled, !self.pointerInside else { return }
+                self.isOpen = false
+            }
+        }
+    }
+
+    // MARK: - Pure decision helpers (unit-tested; document the gating branches)
+
+    enum PlusButtonOutcome: Equatable {
+        case createDefault  // plain click
+        case openMenu       // ⌥-click
+    }
+
+    /// A plain click on the `+` creates a default worktree; ⌥-click opens the
+    /// profile-picker menu without waiting for the hover-intent delay.
+    static func plusOutcome(optionHeld: Bool) -> PlusButtonOutcome {
+        optionHeld ? .openMenu : .createDefault
+    }
+
+    /// The `+` shows while its section/row is hovered OR its menu is open — so
+    /// moving the pointer into the popover (which drops the row/section hover)
+    /// doesn't unmount the popover's own anchor and slam it shut.
+    static func shouldShowPlus(hovered: Bool, menuOpen: Bool) -> Bool {
+        hovered || menuOpen
+    }
+
+    // MARK: - Testing
+
+    /// Await any in-flight open/close transition so tests can assert final state
+    /// deterministically. Construct the model with `.zero` delays first.
+    func _drainForTesting() async {
+        await openTask?.value
+        await closeTask?.value
+    }
+}

--- a/Sources/TBDApp/Sidebar/HoverMenuModel.swift
+++ b/Sources/TBDApp/Sidebar/HoverMenuModel.swift
@@ -14,7 +14,7 @@ import SwiftUI
 final class HoverMenuModel: ObservableObject {
     @Published private(set) var isOpen = false
 
-    private var overTrigger = false
+    @Published private(set) var isTriggerHovered = false
     private var overMenu = false
     private var openTask: Task<Void, Never>?
     private var closeTask: Task<Void, Never>?
@@ -35,11 +35,11 @@ final class HoverMenuModel: ObservableObject {
         self.closeGrace = closeGrace
     }
 
-    private var pointerInside: Bool { overTrigger || overMenu }
+    private var pointerInside: Bool { isTriggerHovered || overMenu }
 
     /// Pointer entered/left the `+` button.
     func triggerHover(_ inside: Bool) {
-        overTrigger = inside
+        isTriggerHovered = inside
         reconcile()
     }
 
@@ -58,7 +58,7 @@ final class HoverMenuModel: ObservableObject {
     /// A row was chosen, or the popover was dismissed by an outside click.
     func closeNow() {
         cancelTasks()
-        overTrigger = false
+        isTriggerHovered = false
         overMenu = false
         isOpen = false
     }

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -146,11 +146,20 @@ struct RepoSectionView: View {
                     )
                     .disabled(repo.status == .missing)
                     .onHover { newWorktreeMenu.triggerHover($0) }
-                    .popover(isPresented: newWorktreeMenu.isOpenBinding, arrowEdge: .trailing) {
-                        WorktreeProfilePickerView(repoID: repo.id, highlightDefaultProfile: newWorktreeMenu.isTriggerHovered)
+                    .background(
+                        FloatingMenuAnchor(
+                            isPresented: newWorktreeMenu.isOpen,
+                            content: WorktreeProfilePickerView(
+                                repoID: repo.id,
+                                highlightDefaultProfile: newWorktreeMenu.isTriggerHovered,
+                                onClose: { newWorktreeMenu.closeNow() }
+                            )
                             .environmentObject(appState)
+                            .background(.ultraThickMaterial)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
                             .onHover { newWorktreeMenu.menuHover($0) }
-                    }
+                        )
+                    )
                 } else {
                     Color.clear
                 }

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -33,13 +33,9 @@ struct RepoSectionView: View {
     @State private var isChevronHovered = false
     @State private var hoverDebounceTask: Task<Void, Error>?
     @State private var showRemoveConfirm = false
-    // Long-press or Option-click the `+` opens the model-profile picker; a plain
-    // click creates a worktree with the default profile.
-    @State private var showProfilePicker = false
-    // Set when a long-press opens the profile picker, so the Button's own tap
-    // action (which fires on finger-up, after the long-press's onEnded) doesn't
-    // ALSO create a default worktree. Reset on the next plain click.
-    @State private var longPressTriggered = false
+    // Hover the `+` (or ⌥-click it) to open the model-profile picker; a plain
+    // click still creates a worktree with the default profile.
+    @StateObject private var newWorktreeMenu = HoverMenuModel()
 
     private func onSectionHoverChange(_ hovering: Bool) {
         if hovering {
@@ -140,38 +136,20 @@ struct RepoSectionView: View {
             Spacer()
 
             Group {
-                if isSectionHovered || showProfilePicker {
+                if HoverMenuModel.shouldShowPlus(hovered: isSectionHovered, menuOpen: newWorktreeMenu.isOpen) {
                     SectionHeaderPlusButton(
-                        // Long-press or Option-click opens the unified profile
-                        // picker; its "Choose a branch…" row drills into the
-                        // (former standalone) branch picker.
-                        help: "New worktree (long-press or \u{2325}-click to pick a model profile)",
+                        // Hover opens the unified profile picker; its "Choose a
+                        // branch…" row drills into the branch list. ⌥-click opens
+                        // it immediately.
+                        help: "New worktree (hover to pick a model profile, or \u{2325}-click)",
                         action: handlePlusButton
                     )
                     .disabled(repo.status == .missing)
-                    // Long-press (~0.3s) opens the profile picker. `.simultaneousGesture`
-                    // runs ALONGSIDE the Button's tap recognizer, so a plain click still
-                    // fires `handlePlusButton` (create-with-default) and long-press doesn't
-                    // swallow it — the guard flag prevents a create on the long-press release.
-                    .simultaneousGesture(
-                        LongPressGesture(minimumDuration: 0.3)
-                            .onEnded { _ in
-                                guard repo.status != .missing else { return }
-                                longPressTriggered = true
-                                showProfilePicker = true
-                            }
-                    )
-                    .popover(isPresented: $showProfilePicker, arrowEdge: .trailing) {
+                    .onHover { newWorktreeMenu.triggerHover($0) }
+                    .popover(isPresented: newWorktreeMenu.isOpenBinding, arrowEdge: .trailing) {
                         WorktreeProfilePickerView(repoID: repo.id)
                             .environmentObject(appState)
-                    }
-                    // Safety net for the orphaned-flag cases: if the long-press
-                    // opened the picker but no follow-up tap on `+` ever cleared
-                    // the flag (press released off-button, or picker dismissed /
-                    // a profile chosen), clear it when the popover closes so the
-                    // next plain click isn't swallowed by the guard.
-                    .onChange(of: showProfilePicker) { _, isShown in
-                        if !isShown { longPressTriggered = false }
+                            .onHover { newWorktreeMenu.menuHover($0) }
                     }
                 } else {
                     Color.clear
@@ -248,18 +226,14 @@ struct RepoSectionView: View {
     }
 
     private func handlePlusButton() {
-        // A long-press already handled this interaction (it opened the profile
-        // picker and set the flag); the Button's tap fires on finger-up right
-        // after, so consume it here instead of creating a default worktree.
-        if longPressTriggered {
-            longPressTriggered = false
-            return
-        }
-        // Option-click (like long-press) opens the unified model-profile
-        // picker; branch selection now lives inside it under "Choose a branch…".
-        if NSEvent.modifierFlags.contains(.option) {
-            showProfilePicker = true
-        } else {
+        guard repo.status != .missing else { return }
+        switch HoverMenuModel.plusOutcome(optionHeld: NSEvent.modifierFlags.contains(.option)) {
+        case .openMenu:
+            newWorktreeMenu.openImmediately()
+        case .createDefault:
+            // A plain click short-circuits any hover-opened menu to the fast
+            // default-create path.
+            newWorktreeMenu.closeNow()
             createWorktree()
         }
     }

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -147,7 +147,7 @@ struct RepoSectionView: View {
                     .disabled(repo.status == .missing)
                     .onHover { newWorktreeMenu.triggerHover($0) }
                     .popover(isPresented: newWorktreeMenu.isOpenBinding, arrowEdge: .trailing) {
-                        WorktreeProfilePickerView(repoID: repo.id)
+                        WorktreeProfilePickerView(repoID: repo.id, highlightDefaultProfile: newWorktreeMenu.isTriggerHovered)
                             .environmentObject(appState)
                             .onHover { newWorktreeMenu.menuHover($0) }
                     }

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -145,7 +145,10 @@ struct RepoSectionView: View {
                         action: handlePlusButton
                     )
                     .disabled(repo.status == .missing)
-                    .onHover { newWorktreeMenu.triggerHover($0) }
+                    // `.disabled` blocks the click path but NOT `.onHover`
+                    // tracking-area events, so gate the hover-open explicitly —
+                    // a missing repo must never open the picker.
+                    .onHover { if repo.status != .missing { newWorktreeMenu.triggerHover($0) } }
                     .background(
                         FloatingMenuAnchor(
                             isPresented: newWorktreeMenu.isOpen,

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 import TBDShared
 
-/// Popover content rendered when the user long-presses or Option-clicks the
-/// `+` button next to a repo in the sidebar.
+/// Menu content shown when the user hovers (or ⌥-clicks) the `+` button next to
+/// a repo in the sidebar. Presented in a borderless `FloatingPanel` (see
+/// `FloatingMenuAnchor`), not a SwiftUI popover.
 ///
 /// Two in-place pages (NOT nested popovers — those are fragile on macOS):
 ///  - `.profiles` (default): a fixed "Choose a branch…" drill-in row at the

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -27,6 +27,10 @@ struct WorktreeProfilePickerView: View {
     /// menu. Fades once the pointer moves into the menu and normal per-row
     /// hover takes over.
     var highlightDefaultProfile: Bool = false
+    /// Explicit close hook for the `FloatingPanel` presentation, which has no
+    /// `@Environment(\.dismiss)` of its own (that's a SwiftUI popover/sheet
+    /// concept). Wired to the owning `HoverMenuModel.closeNow()`.
+    var onClose: () -> Void = {}
     @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) private var dismiss
 
@@ -158,12 +162,13 @@ struct WorktreeProfilePickerView: View {
 
             // Reused branch list: selecting a branch creates on that existing
             // branch with the default model and dismisses the whole popover.
-            BranchListView(repoID: repoID, parentWorktreeID: parentWorktreeID)
+            BranchListView(repoID: repoID, parentWorktreeID: parentWorktreeID, onClose: onClose)
         }
     }
 
     private func pick(profileID: UUID?) {
         dismiss()
+        onClose()
         appState.createWorktree(repoID: repoID, parentWorktreeID: parentWorktreeID, profileID: profileID)
     }
 

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -6,10 +6,11 @@ import TBDShared
 ///
 /// Two in-place pages (NOT nested popovers — those are fragile on macOS):
 ///  - `.profiles` (default): a fixed "Choose a branch…" drill-in row at the
-///    top, then "Resolve automatically" and one row per configured model
-///    profile. Selecting a profile row one-click-creates a worktree pinned to
-///    that profile; "Resolve automatically" creates one with no override
-///    (repo → scratch → global default precedence).
+///    top, then one row per configured model profile. Selecting a profile row
+///    one-click-creates a worktree pinned to that profile. (A plain click on
+///    the `+` — without opening this menu — already creates a default
+///    worktree via repo → scratch → global default precedence, so there is no
+///    separate "resolve automatically" row here.)
 ///  - `.branches`: the reused searchable branch list (`BranchListView`) behind
 ///    a back affordance. Selecting a branch creates a worktree on that existing
 ///    branch using the DEFAULT model (accepted tradeoff).
@@ -20,6 +21,12 @@ struct WorktreeProfilePickerView: View {
     /// When set, created worktrees are nested under this parent (the nested `+`
     /// on a worktree row). Nil for the repo-header `+` (top-level worktrees).
     var parentWorktreeID: UUID? = nil
+    /// True while the pointer is over the trigger `+` button (not the popover
+    /// itself) — highlights whichever profile row is the default so the user
+    /// can preview the plain-click outcome before the pointer even reaches the
+    /// menu. Fades once the pointer moves into the menu and normal per-row
+    /// hover takes over.
+    var highlightDefaultProfile: Bool = false
     @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) private var dismiss
 
@@ -81,27 +88,13 @@ struct WorktreeProfilePickerView: View {
 
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    // Default / automatic resolution (no explicit override).
-                    ProfilePickerRow(
-                        title: "Resolve automatically",
-                        subtitle: "Use the repo / global default",
-                        systemImage: "wand.and.stars",
-                        isDefault: true
-                    ) {
-                        pick(profileID: nil)
-                    }
-
-                    if !appState.modelProfiles.isEmpty {
-                        Divider()
-                            .padding(.vertical, 2)
-                    }
-
                     ForEach(appState.modelProfiles, id: \.profile.id) { entry in
                         // A not-logged-in OAuth profile is not selectable: dim it
                         // and disable its Button so its tap can't create a
                         // worktree pinned to an account that can't run. apiKey /
                         // bedrock rows report selectable and stay actionable.
                         let isSelectable = ProfileUsagePresentation.isSelectable(entry)
+                        let isTheDefault = entry.profile.id == appState.defaultProfileID
                         Group {
                             if showsUsageBars(for: entry) {
                                 // OAuth profile with a usage snapshot that has
@@ -109,7 +102,7 @@ struct WorktreeProfilePickerView: View {
                                 // single-line usage text.
                                 UsageBarsProfileRow(
                                     entry: entry,
-                                    isDefault: entry.profile.id == appState.defaultProfileID
+                                    highlighted: isTheDefault && highlightDefaultProfile
                                 ) {
                                     pick(profileID: entry.profile.id)
                                 }
@@ -120,7 +113,7 @@ struct WorktreeProfilePickerView: View {
                                     title: line.primary,
                                     subtitle: subtitle.text,
                                     systemImage: "person.crop.circle",
-                                    isDefault: entry.profile.id == appState.defaultProfileID,
+                                    highlighted: isTheDefault && highlightDefaultProfile,
                                     // Always reserve subtitle height so the row never
                                     // shifts, whichever state it resolves to.
                                     reservesSubtitle: true,
@@ -220,7 +213,7 @@ struct WorktreeProfilePickerView: View {
 /// fixed-single-line reservation only applies to the text rows.
 private struct UsageBarsProfileRow: View {
     let entry: ModelProfileWithUsage
-    var isDefault: Bool = false
+    var highlighted: Bool = false
     let onSelect: () -> Void
 
     @State private var isHovered = false
@@ -240,24 +233,13 @@ private struct UsageBarsProfileRow: View {
                     UsageBarsView(snapshot: entry.usageSnapshot)
                 }
                 Spacer(minLength: 4)
-                if isDefault {
-                    Text("default")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(
-                            RoundedRectangle(cornerRadius: 3)
-                                .fill(Color.secondary.opacity(0.10))
-                        )
-                }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(isHovered ? Color.accentColor.opacity(0.15) : Color.clear)
+                    .fill(isHovered || highlighted ? Color.accentColor.opacity(0.15) : Color.clear)
             )
             .contentShape(Rectangle())
         }
@@ -270,7 +252,7 @@ private struct ProfilePickerRow: View {
     let title: String
     let subtitle: String?
     let systemImage: String
-    var isDefault: Bool = false
+    var highlighted: Bool = false
     /// When true, a subtitle line is always rendered at full height — real text
     /// when available, otherwise an invisible placeholder — so the row height
     /// never changes across states (no pop-in).
@@ -308,16 +290,6 @@ private struct ProfilePickerRow: View {
                     Image(systemName: "chevron.right")
                         .font(.system(size: 10, weight: .semibold))
                         .foregroundStyle(.secondary)
-                } else if isDefault {
-                    Text("default")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(
-                            RoundedRectangle(cornerRadius: 3)
-                                .fill(Color.secondary.opacity(0.10))
-                        )
                 }
             }
             .padding(.horizontal, 10)
@@ -325,7 +297,7 @@ private struct ProfilePickerRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(isHovered ? Color.accentColor.opacity(0.15) : Color.clear)
+                    .fill(isHovered || highlighted ? Color.accentColor.opacity(0.15) : Color.clear)
             )
             .contentShape(Rectangle())
         }

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -17,6 +17,9 @@ import TBDShared
 /// Modeled on `BranchPickerView` for consistent popover sizing/styling.
 struct WorktreeProfilePickerView: View {
     let repoID: UUID
+    /// When set, created worktrees are nested under this parent (the nested `+`
+    /// on a worktree row). Nil for the repo-header `+` (top-level worktrees).
+    var parentWorktreeID: UUID? = nil
     @EnvironmentObject var appState: AppState
     @Environment(\.dismiss) private var dismiss
 
@@ -162,13 +165,13 @@ struct WorktreeProfilePickerView: View {
 
             // Reused branch list: selecting a branch creates on that existing
             // branch with the default model and dismisses the whole popover.
-            BranchListView(repoID: repoID)
+            BranchListView(repoID: repoID, parentWorktreeID: parentWorktreeID)
         }
     }
 
     private func pick(profileID: UUID?) {
         dismiss()
-        appState.createWorktree(repoID: repoID, profileID: profileID)
+        appState.createWorktree(repoID: repoID, parentWorktreeID: parentWorktreeID, profileID: profileID)
     }
 
     /// Whether a profile row should render the two-bar usage meter (instead of

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -50,7 +50,8 @@ struct WorktreeProfilePickerView: View {
                 branchesPage
             }
         }
-        .frame(width: 300, height: 400)
+        .frame(width: 300)
+        .frame(minHeight: 320)
         .task {
             // Ensure the list (and usage suffixes) are populated even if the
             // user hasn't opened Settings yet this session.
@@ -90,48 +91,46 @@ struct WorktreeProfilePickerView: View {
             Divider()
                 .padding(.vertical, 2)
 
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(appState.modelProfiles, id: \.profile.id) { entry in
-                        // A not-logged-in OAuth profile is not selectable: dim it
-                        // and disable its Button so its tap can't create a
-                        // worktree pinned to an account that can't run. apiKey /
-                        // bedrock rows report selectable and stay actionable.
-                        let isSelectable = ProfileUsagePresentation.isSelectable(entry)
-                        let isTheDefault = entry.profile.id == appState.defaultProfileID
-                        Group {
-                            if showsUsageBars(for: entry) {
-                                // OAuth profile with a usage snapshot that has
-                                // buckets: render the two-bar meter instead of the
-                                // single-line usage text.
-                                UsageBarsProfileRow(
-                                    entry: entry,
-                                    highlighted: isTheDefault && highlightDefaultProfile
-                                ) {
-                                    pick(profileID: entry.profile.id)
-                                }
-                            } else {
-                                let line = ProfileUsagePresentation.menuLine(for: entry)
-                                let subtitle = profileSubtitle(for: entry, usageNote: line.secondary)
-                                ProfilePickerRow(
-                                    title: line.primary,
-                                    subtitle: subtitle.text,
-                                    systemImage: "person.crop.circle",
-                                    highlighted: isTheDefault && highlightDefaultProfile,
-                                    // Always reserve subtitle height so the row never
-                                    // shifts, whichever state it resolves to.
-                                    reservesSubtitle: true,
-                                    // Skeleton is reserved for the ONE genuine loading
-                                    // case (logged-in OAuth awaiting its first poll).
-                                    showsSubtitleSkeleton: subtitle.showsSkeleton
-                                ) {
-                                    pick(profileID: entry.profile.id)
-                                }
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(appState.modelProfiles, id: \.profile.id) { entry in
+                    // A not-logged-in OAuth profile is not selectable: dim it
+                    // and disable its Button so its tap can't create a
+                    // worktree pinned to an account that can't run. apiKey /
+                    // bedrock rows report selectable and stay actionable.
+                    let isSelectable = ProfileUsagePresentation.isSelectable(entry)
+                    let isTheDefault = entry.profile.id == appState.defaultProfileID
+                    Group {
+                        if showsUsageBars(for: entry) {
+                            // OAuth profile with a usage snapshot that has
+                            // buckets: render the two-bar meter instead of the
+                            // single-line usage text.
+                            UsageBarsProfileRow(
+                                entry: entry,
+                                highlighted: isTheDefault && highlightDefaultProfile
+                            ) {
+                                pick(profileID: entry.profile.id)
+                            }
+                        } else {
+                            let line = ProfileUsagePresentation.menuLine(for: entry)
+                            let subtitle = profileSubtitle(for: entry, usageNote: line.secondary)
+                            ProfilePickerRow(
+                                title: line.primary,
+                                subtitle: subtitle.text,
+                                systemImage: "person.crop.circle",
+                                highlighted: isTheDefault && highlightDefaultProfile,
+                                // Always reserve subtitle height so the row never
+                                // shifts, whichever state it resolves to.
+                                reservesSubtitle: true,
+                                // Skeleton is reserved for the ONE genuine loading
+                                // case (logged-in OAuth awaiting its first poll).
+                                showsSubtitleSkeleton: subtitle.showsSkeleton
+                            ) {
+                                pick(profileID: entry.profile.id)
                             }
                         }
-                        .disabled(!isSelectable)
-                        .opacity(isSelectable ? 1 : 0.5)
                     }
+                    .disabled(!isSelectable)
+                    .opacity(isSelectable ? 1 : 0.5)
                 }
             }
         }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -55,7 +55,7 @@ struct WorktreeRowView: View {
         )
         .onHover { newChildMenu.triggerHover($0) }
         .popover(isPresented: newChildMenu.isOpenBinding, arrowEdge: .trailing) {
-            WorktreeProfilePickerView(repoID: repoID, parentWorktreeID: worktree.id)
+            WorktreeProfilePickerView(repoID: repoID, parentWorktreeID: worktree.id, highlightDefaultProfile: newChildMenu.isTriggerHovered)
                 .environmentObject(appState)
                 .onHover { newChildMenu.menuHover($0) }
         }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -54,11 +54,21 @@ struct WorktreeRowView: View {
             action: { handleNestedPlus(repoID: repoID) }
         )
         .onHover { newChildMenu.triggerHover($0) }
-        .popover(isPresented: newChildMenu.isOpenBinding, arrowEdge: .trailing) {
-            WorktreeProfilePickerView(repoID: repoID, parentWorktreeID: worktree.id, highlightDefaultProfile: newChildMenu.isTriggerHovered)
+        .background(
+            FloatingMenuAnchor(
+                isPresented: newChildMenu.isOpen,
+                content: WorktreeProfilePickerView(
+                    repoID: repoID,
+                    parentWorktreeID: worktree.id,
+                    highlightDefaultProfile: newChildMenu.isTriggerHovered,
+                    onClose: { newChildMenu.closeNow() }
+                )
                 .environmentObject(appState)
+                .background(.ultraThickMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
                 .onHover { newChildMenu.menuHover($0) }
-        }
+            )
+        )
         .padding(.trailing, 4)
     }
 

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -12,6 +12,7 @@ struct WorktreeRowView: View {
     @State private var isRowHovered: Bool = false
     @State private var isPRIconHovered: Bool = false
     @State private var isNameTruncated = false
+    @StateObject private var newChildMenu = HoverMenuModel()
 
     private var isPending: Bool {
         worktree.status == .creating
@@ -46,13 +47,29 @@ struct WorktreeRowView: View {
         return terminals.contains { $0.activityState == .working }
     }
 
-    /// Hover card for the "+" affordance: what the button does, and which
-    /// worktree the new child is created under.
-    private var newNestedWorktreeHoverCard: HoverCardModel {
-        HoverCardModel(
-            title: "New nested worktree",
-            titleCaption: "Creates a child worktree under \(worktree.displayName)"
+    @ViewBuilder
+    private func nestedPlusButton(repoID: UUID) -> some View {
+        SectionHeaderPlusButton(
+            help: "New nested worktree under \(worktree.displayName) (hover to pick a model profile, or \u{2325}-click)",
+            action: { handleNestedPlus(repoID: repoID) }
         )
+        .onHover { newChildMenu.triggerHover($0) }
+        .popover(isPresented: newChildMenu.isOpenBinding, arrowEdge: .trailing) {
+            WorktreeProfilePickerView(repoID: repoID, parentWorktreeID: worktree.id)
+                .environmentObject(appState)
+                .onHover { newChildMenu.menuHover($0) }
+        }
+        .padding(.trailing, 4)
+    }
+
+    private func handleNestedPlus(repoID: UUID) {
+        switch HoverMenuModel.plusOutcome(optionHeld: NSEvent.modifierFlags.contains(.option)) {
+        case .openMenu:
+            newChildMenu.openImmediately()
+        case .createDefault:
+            newChildMenu.closeNow()
+            appState.createWorktree(repoID: repoID, parentWorktreeID: worktree.id)
+        }
     }
 
     @ViewBuilder
@@ -253,21 +270,10 @@ struct WorktreeRowView: View {
             }
         }
         .overlay(alignment: .trailing) {
-            if isRowHovered && !isMain {
-                Button(action: {
-                    let parentID = worktree.id
-                    // Scratch spaces have no repo, so nested-worktree creation
-                    // isn't offered for them — this affordance is repo-only.
-                    guard let repoID = worktree.repoID else { return }
-                    appState.createWorktree(repoID: repoID, parentWorktreeID: parentID)
-                }) {
-                    Image(systemName: "plus")
-                        .font(.caption)
-                        .frame(width: 20, height: 20)
-                }
-                .buttonStyle(HoverPressButtonStyle())
-                .hoverCard(newNestedWorktreeHoverCard)
-                .padding(.trailing, 4)
+            if HoverMenuModel.shouldShowPlus(hovered: isRowHovered, menuOpen: newChildMenu.isOpen),
+               !isMain,
+               let repoID = worktree.repoID {
+                nestedPlusButton(repoID: repoID)
             }
         }
         .onHover { isRowHovered = $0 }

--- a/Tests/TBDAppTests/HoverMenuModelTests.swift
+++ b/Tests/TBDAppTests/HoverMenuModelTests.swift
@@ -85,4 +85,24 @@ struct HoverMenuModelTests {
         m.isOpenBinding.wrappedValue = false
         #expect(!m.isOpen)
     }
+
+    // MARK: isTriggerHovered
+
+    @Test("triggerHover toggles isTriggerHovered")
+    func triggerHoverTogglesIsTriggerHovered() {
+        let m = HoverMenuModel()
+        m.triggerHover(true)
+        #expect(m.isTriggerHovered)
+        m.triggerHover(false)
+        #expect(!m.isTriggerHovered)
+    }
+
+    @Test("closeNow clears isTriggerHovered")
+    func closeNowClearsIsTriggerHovered() {
+        let m = HoverMenuModel()
+        m.openImmediately()
+        m.triggerHover(true)
+        m.closeNow()
+        #expect(!m.isTriggerHovered)
+    }
 }

--- a/Tests/TBDAppTests/HoverMenuModelTests.swift
+++ b/Tests/TBDAppTests/HoverMenuModelTests.swift
@@ -1,0 +1,88 @@
+import Testing
+import SwiftUI
+@testable import TBDApp
+
+@Suite("HoverMenuModel")
+@MainActor
+struct HoverMenuModelTests {
+    // MARK: pure gating helpers
+
+    @Test("plain click creates a default worktree")
+    func plainClickOutcome() {
+        #expect(HoverMenuModel.plusOutcome(optionHeld: false) == .createDefault)
+    }
+
+    @Test("option-click opens the menu")
+    func optionClickOutcome() {
+        #expect(HoverMenuModel.plusOutcome(optionHeld: true) == .openMenu)
+    }
+
+    @Test("plus is hidden when neither hovered nor open")
+    func plusHiddenWhenIdle() {
+        #expect(HoverMenuModel.shouldShowPlus(hovered: false, menuOpen: false) == false)
+    }
+
+    @Test("plus shows when hovered")
+    func plusShownWhenHovered() {
+        #expect(HoverMenuModel.shouldShowPlus(hovered: true, menuOpen: false) == true)
+    }
+
+    @Test("plus stays mounted while its menu is open even if hover dropped")
+    func plusShownWhenMenuOpen() {
+        #expect(HoverMenuModel.shouldShowPlus(hovered: false, menuOpen: true) == true)
+    }
+
+    // MARK: open/close state (zero delays for determinism)
+
+    @Test("hovering the trigger opens the menu after intent")
+    func hoverOpens() async {
+        let m = HoverMenuModel(openDelay: .zero, closeGrace: .zero)
+        m.triggerHover(true)
+        await m._drainForTesting()
+        #expect(m.isOpen)
+    }
+
+    @Test("leaving both trigger and menu closes it")
+    func leavingCloses() async {
+        let m = HoverMenuModel(openDelay: .zero, closeGrace: .zero)
+        m.openImmediately()
+        m.triggerHover(false)
+        m.menuHover(false)
+        await m._drainForTesting()
+        #expect(!m.isOpen)
+    }
+
+    @Test("moving from trigger into menu keeps it open (close is cancelled)")
+    func reenterCancelsClose() async {
+        let m = HoverMenuModel(openDelay: .zero, closeGrace: .zero)
+        m.openImmediately()
+        m.triggerHover(false)  // leaving the button schedules a close
+        m.menuHover(true)      // ...but the pointer landed in the popover
+        await m._drainForTesting()
+        #expect(m.isOpen)
+    }
+
+    @Test("openImmediately opens without waiting")
+    func openImmediatelyOpens() {
+        let m = HoverMenuModel()
+        m.openImmediately()
+        #expect(m.isOpen)
+    }
+
+    @Test("closeNow closes")
+    func closeNowCloses() {
+        let m = HoverMenuModel()
+        m.openImmediately()
+        m.closeNow()
+        #expect(!m.isOpen)
+    }
+
+    @Test("popover binding set to false routes through closeNow")
+    func bindingDismissCloses() {
+        let m = HoverMenuModel()
+        m.openImmediately()
+        #expect(m.isOpenBinding.wrappedValue == true)
+        m.isOpenBinding.wrappedValue = false
+        #expect(!m.isOpen)
+    }
+}

--- a/Tests/TBDAppTests/HoverMenuModelTests.swift
+++ b/Tests/TBDAppTests/HoverMenuModelTests.swift
@@ -77,15 +77,6 @@ struct HoverMenuModelTests {
         #expect(!m.isOpen)
     }
 
-    @Test("popover binding set to false routes through closeNow")
-    func bindingDismissCloses() {
-        let m = HoverMenuModel()
-        m.openImmediately()
-        #expect(m.isOpenBinding.wrappedValue == true)
-        m.isOpenBinding.wrappedValue = false
-        #expect(!m.isOpen)
-    }
-
     // MARK: isTriggerHovered
 
     @Test("triggerHover toggles isTriggerHovered")


### PR DESCRIPTION
## Summary

Makes the new-worktree profile menu **discoverable on hover** (instead of hidden behind a long-press / ⌥-click), extends it to the **nested `+`** buttons, and replaces the native `NSPopover` with a custom panel so the menu reads as a clean, instant flyout.

**Interaction**
- Hovering a `+` opens the profile picker after a ~400ms intent delay; the menu stays open while the pointer is over the `+` **or** the menu (a ~100ms close-grace bridges the gap). ⌥-click opens it immediately; a plain click still fast-creates a default worktree.
- The menu now also appears on the **nested (child) `+`** in each worktree row, with `parentWorktreeID` threaded through the picker + branch list so it creates children.
- While the pointer is on the `+`, the **default profile row is highlighted** as a preview of what a plain click would create (replaces the old "default" text badge, which also skewed the usage-bar widths). The redundant "Resolve automatically" row is gone — a plain `+` click covers it.

**Presentation** (the reason for most of the diff)
- `.popover` wraps `NSPopover`, whose **arrow nub** and **open/close animation** aren't reachable from SwiftUI. Swapped it for the app's existing `FloatingPanel` (borderless `NSPanel` + `NSHostingView`, same pattern as the emoji picker / jump menu): no arrow, no animation — the menu snaps in and out.
- The panel sizes to its content (no more fixed 400pt dead space) and spawns with its leading edge at the trigger, vertically centered on it, clamped to the visible screen (flips to the left / shifts vertically near an edge).

**Core**
- New `HoverMenuModel` (`@MainActor`) owns the open/close timing; two pure static helpers (`plusOutcome`, `shouldShowPlus`) carry the gating branches and are unit-tested. Task cleanup is generation-counter guarded so a stale/cancelled timer can't clobber a newer one.

## Test plan
- [x] `swift test --filter TBDAppTests` — green (incl. the `HoverMenuModel` suite)
- [x] Full `swift test` — the only failures are pre-existing/environmental (local `commit.gpgsign=true` with no ssh-agent → daemon git tests can't write commit objects); pass with `GIT_CONFIG_GLOBAL=/dev/null`
- [x] Live: hover opens after a beat; moving into the menu keeps it open; picking a profile/branch creates the worktree (child for nested rows) and closes; ⌥-click opens instantly; quick plain click creates a default; no arrow, no animation, content-sized, centered on the trigger, clamps near screen edges

Note: the profiles list is a plain stack (no scroll) — fine for realistic profile counts; a very long list grows the panel (screen-clamped) rather than scrolling.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=1CE9029B-6DB6-4F2B-A8BB-595A3235D6A5)
