### PR TITLE
Fix: Menu said "Re-run setup hook" while running the pre-session hook -- two different hooks

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -293,9 +293,9 @@ extension AppState {
         do {
             let size = mainAreaTerminalSize()
             try await daemonClient.rerunPreSessionHook(worktreeID: worktreeID, cols: size.cols, rows: size.rows)
-            logger.info("Re-running setup hook for worktree \(worktreeID, privacy: .public)")
+            logger.info("Re-running pre-session hook for worktree \(worktreeID, privacy: .public)")
         } catch {
-            logger.error("Failed to re-run setup hook: \(error)")
+            logger.error("Failed to re-run pre-session hook: \(error)")
             showAlert("\(error)", isError: true)
         }
     }
@@ -537,6 +537,18 @@ extension AppState {
         selectedRepoID = id
         selectedScratchSection = false
         Task { await refreshArchivedWorktrees(repoID: id) }
+    }
+
+    /// Reveal the repo's pre-session hook editor: select the repo, switch its
+    /// detail pane to Settings, scroll to and focus the hook's editor.
+    ///
+    /// Ordering matters. `selectRepo` clears the worktree/scratch selection so
+    /// `ContentView` swaps in `RepoDetailView`; the reveal is posted after, and
+    /// survives until that view consumes it — whether it mounts fresh (onAppear)
+    /// or is reused from another repo (onChange).
+    func revealPreSessionHookEditor(repoID: UUID) {
+        selectRepo(id: repoID)
+        repoDetailReveal = .preSessionHook(repoID: repoID)
     }
 
     /// User-facing label for the repo-less scratch section. Single source for

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -134,6 +134,15 @@ final class AppState: ObservableObject {
     @Published var selectionOrder: [UUID] = [] {
         didSet { persistSelectionOrder() }
     }
+    /// A one-shot request to reveal a specific section of a repo's detail pane.
+    /// Set by `revealPreSessionHookEditor`, cleared by `RepoDetailView` once
+    /// applied so navigating back does not replay it.
+    enum RepoDetailReveal: Equatable {
+        case preSessionHook(repoID: UUID)
+    }
+
+    @Published var repoDetailReveal: RepoDetailReveal?
+
     /// Selected repo ID — set when a repo header is clicked, shows archived worktrees in content pane.
     @Published var selectedRepoID: UUID? = nil {
         didSet {

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -36,6 +36,8 @@ enum RowActionMenu {
         case archive
         /// Re-run this worktree's `preSession` hook in a fresh, non-focused tab.
         case rerunPreSessionHook
+        /// Reveal the repo's pre-session hook editor so the user can author one.
+        case createPreSessionHook
         /// Fork a specific Claude session into a new tab on the same account.
         /// Carries the session's terminal and its own (possibly ambient/nil)
         /// profile, so the dispatcher can resume+fork it.
@@ -122,9 +124,9 @@ enum RowActionMenu {
         /// Forkable Claude sessions in tab order. Drives the per-session
         /// "Fork session" entries (empty → none).
         var claudeSessions: [ClaudeSessionRef]
-        /// A `preSession` hook resolves for this worktree — gates the re-run
-        /// item entirely (no hook, no item). Resolved by the surface via the
-        /// shared `HookResolver`, so `items(...)` stays pure.
+        /// A `preSession` hook resolves for this worktree. Selects between the
+        /// re-run and create items. Resolved by the surface via the shared
+        /// `HookResolver`, so `items(...)` stays pure.
         var hasPreSessionHook: Bool
 
         init(hasHibernatableClaude: Bool = false,
@@ -171,7 +173,10 @@ enum RowActionMenu {
     static let wakeLabel = "Wake"
     static let keepWarmLabel = "Keep warm"
     static let allowHibernationLabel = "Allow hibernation"
-    static let rerunPreSessionLabel = "Re-run setup hook"
+    static let rerunPreSessionLabel = "Re-run pre-session hook"
+    /// Trailing character is U+2026 HORIZONTAL ELLIPSIS — the macOS convention
+    /// for an item that opens further UI rather than acting immediately.
+    static let createPreSessionLabel = "Create pre-session hook…"
 
     /// Title for a fork-session action: plain when the worktree hosts a single
     /// Claude session, suffixed with the session label when there are several.
@@ -190,8 +195,8 @@ enum RowActionMenu {
     /// 2. Hibernation — Wake / Hibernate now / keep-warm toggle (conditional).
     /// 3. Sessions & spawning — per-session Fork entries, plus (regular only)
     ///    Create Nested Worktree / New worktree from this branch.
-    /// 4. Maintenance — Re-run setup hook (only when a `preSession` hook
-    ///    resolves).
+    /// 4. Maintenance — Re-run pre-session hook when one resolves, else Create
+    ///    pre-session hook… (repo-backed rows only).
     /// 5. Filesystem — Open in Finder, Copy Path.
     /// 6. (scratch only) Delete Scratch Space, with the promote-hint caption
     ///    beneath it.
@@ -232,12 +237,16 @@ enum RowActionMenu {
         return actions
     }
 
-    /// The maintenance section — currently just the hook re-run. Empty when no
-    /// `preSession` hook resolves, so `joined(...)` collapses the section and no
-    /// dangling divider renders.
+    /// The maintenance section. Three states: re-run when a `preSession` hook
+    /// resolves; otherwise an offer to create one; and, for a scratch space,
+    /// nothing at all — it has no repo, so there is no hooks editor to reveal,
+    /// and `joined(...)` collapses the empty section with no dangling divider.
     static func maintenanceActions(context: Context) -> [Action] {
-        guard context.hasPreSessionHook else { return [] }
-        return [Action(kind: .rerunPreSessionHook, title: rerunPreSessionLabel)]
+        if context.hasPreSessionHook {
+            return [Action(kind: .rerunPreSessionHook, title: rerunPreSessionLabel)]
+        }
+        guard context.hasRepoID else { return [] }
+        return [Action(kind: .createPreSessionHook, title: createPreSessionLabel)]
     }
 
     private static func forkActions(context: Context) -> [Action] {

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -12,15 +12,11 @@ struct RepoDetailView: View {
 
     @EnvironmentObject var appState: AppState
     @State private var selectedTab: Tab = .archived
-    /// Bumped each time a reveal lands, so `RepoSettingsView` re-runs its
-    /// scroll even if the Settings tab was already showing.
-    @State private var revealNonce: Int = 0
-    /// The repo the most recent reveal targeted. `RepoDetailView` itself is
-    /// NOT `.id(repoID)`-keyed, so it is reused across repo switches and
-    /// `revealNonce` alone would leak into whichever repo is shown next.
-    /// Gating on the target repo makes the reveal order-independent: only
-    /// the repo the nonce was actually bumped for ever sees it.
-    @State private var revealTargetRepoID: UUID?
+    /// The repo whose pre-session hook editor should be revealed, pending
+    /// consumption by `RepoSettingsView`. Cleared the moment that view scrolls,
+    /// so a later remount (repo switch, or tabbing away and back) does not
+    /// re-scroll or re-steal focus.
+    @State private var pendingHookReveal: UUID?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -42,11 +38,8 @@ struct RepoDetailView: View {
                 RepoInstructionsView(repoID: repoID)
                     .id(repoID)
             case .settings:
-                RepoSettingsView(
-                    repoID: repoID,
-                    revealHookNonce: revealTargetRepoID == repoID ? revealNonce : 0
-                )
-                .id(repoID)
+                RepoSettingsView(repoID: repoID, pendingHookReveal: $pendingHookReveal)
+                    .id(repoID)
             }
         }
         // Fresh mount (no repo was selected before).
@@ -60,16 +53,16 @@ struct RepoDetailView: View {
     private func consumeReveal(_ reveal: AppState.RepoDetailReveal?) {
         guard case let .preSessionHook(id) = reveal, id == repoID else { return }
         selectedTab = .settings
-        revealNonce += 1
-        revealTargetRepoID = repoID
+        pendingHookReveal = repoID
         appState.repoDetailReveal = nil
     }
 }
 
 struct RepoSettingsView: View {
     let repoID: UUID
-    /// Changes whenever a pre-session-hook reveal lands. `0` = no reveal.
-    var revealHookNonce: Int = 0
+    /// Set by `RepoDetailView` when a pre-session-hook reveal targets this
+    /// repo; consumed (set back to `nil`) the moment this view acts on it.
+    @Binding var pendingHookReveal: UUID?
     @EnvironmentObject var appState: AppState
     /// Drives focus into the pre-session TextEditor once scrolled.
     @FocusState private var focusedHook: RepoHooksSettingsView.HookField?
@@ -112,17 +105,20 @@ struct RepoSettingsView: View {
                     }
                     .padding()
                 }
-                .onAppear { scrollToHookIfRequested(proxy) }
-                .onChange(of: revealHookNonce) { _, _ in scrollToHookIfRequested(proxy) }
+                .onAppear { consumeHookReveal(proxy) }
+                .onChange(of: pendingHookReveal) { _, _ in consumeHookReveal(proxy) }
             }
         }
     }
 
-    /// Scroll the pre-session hook section into view and focus its editor.
-    /// A nonce of 0 means the user opened Settings themselves — leave the
-    /// scroll position and focus alone.
-    private func scrollToHookIfRequested(_ proxy: ScrollViewProxy) {
-        guard revealHookNonce > 0 else { return }
+    /// Scroll the pre-session hook section into view and focus its editor,
+    /// but only if a reveal is pending for this repo. Consumes the reveal
+    /// (clears it to `nil`) before acting, so it is a true one-shot: a later
+    /// remount of this view (repo switch, or tab away and back) does not
+    /// re-scroll or re-steal focus.
+    private func consumeHookReveal(_ proxy: ScrollViewProxy) {
+        guard pendingHookReveal == repoID else { return }
+        pendingHookReveal = nil
         withAnimation { proxy.scrollTo(RepoHooksSettingsView.preSessionAnchor, anchor: .top) }
         focusedHook = .preSession
     }

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -10,7 +10,11 @@ struct RepoDetailView: View {
         case settings = "Settings"
     }
 
+    @EnvironmentObject var appState: AppState
     @State private var selectedTab: Tab = .archived
+    /// Bumped each time a reveal lands, so `RepoSettingsView` re-runs its
+    /// scroll even if the Settings tab was already showing.
+    @State private var revealNonce: Int = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -32,16 +36,33 @@ struct RepoDetailView: View {
                 RepoInstructionsView(repoID: repoID)
                     .id(repoID)
             case .settings:
-                RepoSettingsView(repoID: repoID)
+                RepoSettingsView(repoID: repoID, revealHookNonce: revealNonce)
                     .id(repoID)
             }
         }
+        // Fresh mount (no repo was selected before).
+        .onAppear { consumeReveal(appState.repoDetailReveal) }
+        // Reused instance (another repo was selected, or this one on another tab).
+        .onChange(of: appState.repoDetailReveal) { _, reveal in consumeReveal(reveal) }
+    }
+
+    /// Apply a reveal addressed to this repo, then clear it so navigating back
+    /// does not replay it. Reveals for another repo are ignored, not consumed.
+    private func consumeReveal(_ reveal: AppState.RepoDetailReveal?) {
+        guard case let .preSessionHook(id) = reveal, id == repoID else { return }
+        selectedTab = .settings
+        revealNonce += 1
+        appState.repoDetailReveal = nil
     }
 }
 
 struct RepoSettingsView: View {
     let repoID: UUID
+    /// Changes whenever a pre-session-hook reveal lands. `0` = no reveal.
+    var revealHookNonce: Int = 0
     @EnvironmentObject var appState: AppState
+    /// Drives focus into the pre-session TextEditor once scrolled.
+    @FocusState private var focusedHook: RepoHooksSettingsView.HookField?
 
     private var repo: Repo? {
         appState.repos.first { $0.id == repoID }
@@ -49,38 +70,51 @@ struct RepoSettingsView: View {
 
     var body: some View {
         if let repo = repo {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 12) {
-                    Picker("Model profile override", selection: profileOverrideBinding(repo: repo)) {
-                        Text("Inherit global default").tag(UUID?.none)
-                        ForEach(appState.modelProfiles, id: \.profile.id) { entry in
-                            Text(profileLabel(entry: entry)).tag(UUID?.some(entry.profile.id))
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Picker("Model profile override", selection: profileOverrideBinding(repo: repo)) {
+                            Text("Inherit global default").tag(UUID?.none)
+                            ForEach(appState.modelProfiles, id: \.profile.id) { entry in
+                                Text(profileLabel(entry: entry)).tag(UUID?.some(entry.profile.id))
+                            }
                         }
+                        .pickerStyle(.menu)
+
+                        if let caption = profileOverrideCaption(repo: repo) {
+                            Text(caption)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Divider()
+                            .padding(.vertical, 4)
+
+                        EnvOverridesEditor(
+                            initial: repo.envOverrides,
+                            caption: "Overrides global; overridden by the repo's model profile."
+                        ) { await appState.setRepoEnvOverrides(repoID: repo.id, overrides: $0) }
+
+                        Divider()
+                            .padding(.vertical, 4)
+
+                        RepoHooksSettingsView(repoID: repoID, focusedHook: $focusedHook)
                     }
-                    .pickerStyle(.menu)
-
-                    if let caption = profileOverrideCaption(repo: repo) {
-                        Text(caption)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Divider()
-                        .padding(.vertical, 4)
-
-                    EnvOverridesEditor(
-                        initial: repo.envOverrides,
-                        caption: "Overrides global; overridden by the repo's model profile."
-                    ) { await appState.setRepoEnvOverrides(repoID: repo.id, overrides: $0) }
-
-                    Divider()
-                        .padding(.vertical, 4)
-
-                    RepoHooksSettingsView(repoID: repoID)
+                    .padding()
                 }
-                .padding()
+                .onAppear { scrollToHookIfRequested(proxy) }
+                .onChange(of: revealHookNonce) { _, _ in scrollToHookIfRequested(proxy) }
             }
         }
+    }
+
+    /// Scroll the pre-session hook section into view and focus its editor.
+    /// A nonce of 0 means the user opened Settings themselves — leave the
+    /// scroll position and focus alone.
+    private func scrollToHookIfRequested(_ proxy: ScrollViewProxy) {
+        guard revealHookNonce > 0 else { return }
+        withAnimation { proxy.scrollTo(RepoHooksSettingsView.preSessionAnchor, anchor: .top) }
+        focusedHook = .preSession
     }
 
     private func profileOverrideBinding(repo: Repo) -> Binding<UUID?> {

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -15,6 +15,12 @@ struct RepoDetailView: View {
     /// Bumped each time a reveal lands, so `RepoSettingsView` re-runs its
     /// scroll even if the Settings tab was already showing.
     @State private var revealNonce: Int = 0
+    /// The repo the most recent reveal targeted. `RepoDetailView` itself is
+    /// NOT `.id(repoID)`-keyed, so it is reused across repo switches and
+    /// `revealNonce` alone would leak into whichever repo is shown next.
+    /// Gating on the target repo makes the reveal order-independent: only
+    /// the repo the nonce was actually bumped for ever sees it.
+    @State private var revealTargetRepoID: UUID?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -36,8 +42,11 @@ struct RepoDetailView: View {
                 RepoInstructionsView(repoID: repoID)
                     .id(repoID)
             case .settings:
-                RepoSettingsView(repoID: repoID, revealHookNonce: revealNonce)
-                    .id(repoID)
+                RepoSettingsView(
+                    repoID: repoID,
+                    revealHookNonce: revealTargetRepoID == repoID ? revealNonce : 0
+                )
+                .id(repoID)
             }
         }
         // Fresh mount (no repo was selected before).
@@ -52,6 +61,7 @@ struct RepoDetailView: View {
         guard case let .preSessionHook(id) = reveal, id == repoID else { return }
         selectedTab = .settings
         revealNonce += 1
+        revealTargetRepoID = repoID
         appState.repoDetailReveal = nil
     }
 }

--- a/Sources/TBDApp/Settings/RepoHooksSettingsView.swift
+++ b/Sources/TBDApp/Settings/RepoHooksSettingsView.swift
@@ -2,7 +2,16 @@ import SwiftUI
 import TBDShared
 
 struct RepoHooksSettingsView: View {
+    /// Scroll target for the pre-session section (see `RepoSettingsView`).
+    static let preSessionAnchor = "hook-section-preSession"
+
+    /// Focusable hook editors. Only `.preSession` is targeted today.
+    enum HookField: Hashable {
+        case preSession
+    }
+
     let repoID: UUID
+    var focusedHook: FocusState<HookField?>.Binding
 
     @State private var preSessionDraft: String = ""
     @State private var setupDraft: String = ""
@@ -25,8 +34,10 @@ struct RepoHooksSettingsView: View {
                     + "10 minutes; on failure the agent starts anyway.",
                 draft: $preSessionDraft,
                 filePath: preSessionPath,
-                showSaved: $preSessionSaved
+                showSaved: $preSessionSaved,
+                field: .preSession
             )
+            .id(Self.preSessionAnchor)
 
             Divider()
 
@@ -62,7 +73,8 @@ struct RepoHooksSettingsView: View {
         description: String,
         draft: Binding<String>,
         filePath: String,
-        showSaved: Binding<Bool>
+        showSaved: Binding<Bool>,
+        field: HookField? = nil
     ) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
@@ -73,12 +85,19 @@ struct RepoHooksSettingsView: View {
                 .foregroundStyle(.secondary)
 
             ZStack(alignment: .topLeading) {
-                TextEditor(text: draft)
-                    .font(.body.monospaced())
-                    .frame(minHeight: 100)
-                    .scrollContentBackground(.hidden)
-                    .padding(8)
-                    .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+                Group {
+                    if let field {
+                        TextEditor(text: draft)
+                            .focused(focusedHook, equals: field)
+                    } else {
+                        TextEditor(text: draft)
+                    }
+                }
+                .font(.body.monospaced())
+                .frame(minHeight: 100)
+                .scrollContentBackground(.hidden)
+                .padding(8)
+                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
 
                 if draft.wrappedValue.isEmpty {
                     Text("e.g. npm install && brew bundle")

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -174,6 +174,11 @@ struct RowActionMenuActions {
             let wtID = worktree.id
             Task { await appState.rerunPreSessionHook(worktreeID: wtID) }
 
+        case .createPreSessionHook:
+            // TODO: wired up in a follow-on task — reveal the repo's
+            // pre-session hook editor so the user can author one.
+            break
+
         case let .forkSession(terminalID, profileID):
             // Duplicate the conversation into a NEW tab on the SAME account —
             // swapTerminalProfile with the session's own profileID (nil = same

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -175,9 +175,11 @@ struct RowActionMenuActions {
             Task { await appState.rerunPreSessionHook(worktreeID: wtID) }
 
         case .createPreSessionHook:
-            // TODO: wired up in a follow-on task — reveal the repo's
-            // pre-session hook editor so the user can author one.
-            break
+            // Regular rows always have a repo (isScratch IS repoID == nil), and
+            // the menu never offers this to a scratch row. Return rather than
+            // assert — a context menu is not a place to crash.
+            guard let repoID = worktree.repoID else { return }
+            appState.revealPreSessionHookEditor(repoID: repoID)
 
         case let .forkSession(terminalID, profileID):
             // Duplicate the conversation into a NEW tab on the SAME account —

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -284,7 +284,7 @@ struct WorktreeRowView: View {
 
     /// Subtitle under the name while the worktree is `.creating`. A visible
     /// pre-session hook terminal means the git checkout is done and the
-    /// blocking setup hook is what the user is waiting on.
+    /// blocking pre-session hook is what the user is waiting on.
     static func creatingSubtitle(hasPreSessionTerminal: Bool) -> String {
         hasPreSessionTerminal ? "Running setup…" : "Creating worktree…"
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -463,11 +463,11 @@ public enum RerunPreSessionError: Error, Equatable, CustomStringConvertible {
         case .worktreeNotFound(let id):
             return "Worktree not found: \(id)"
         case .noHookConfigured:
-            return "No preSession hook is configured for this worktree."
+            return "No pre-session hook is configured for this worktree."
         case .alreadyRunning:
-            return "Setup hook is already running for this worktree."
+            return "Pre-session hook is already running for this worktree."
         case .worktreeBusy:
-            return "This worktree is still being created — its setup hook is already running."
+            return "This worktree is still being created — its pre-session hook is already running."
         }
     }
 
@@ -551,12 +551,12 @@ extension WorktreeLifecycle {
         case .completed(let exitCode):
             await notifyPreSessionProblem(
                 worktree: worktree, terminalID: preSession.terminalID,
-                message: "Setup hook failed (exit \(exitCode)) — its tab is left open with the output"
+                message: "Pre-session hook failed (exit \(exitCode)) — its tab is left open with the output"
             )
         case .timedOut:
             await notifyPreSessionProblem(
                 worktree: worktree, terminalID: preSession.terminalID,
-                message: "Setup hook timed out after \(Int(preSessionTimeout))s"
+                message: "Pre-session hook timed out after \(Int(preSessionTimeout))s"
             )
         case .paneKilled:
             // Not an error on a re-run: the user closed the tab, a legitimate

--- a/Tests/TBDAppTests/PreSessionAppStateTests.swift
+++ b/Tests/TBDAppTests/PreSessionAppStateTests.swift
@@ -426,4 +426,32 @@ struct PreSessionAppStateTests {
             #expect(!state.showsPreSessionBanner(for: worktree))
         }
     }
+
+    // MARK: - Repo detail reveal
+
+    @Test("revealPreSessionHookEditor selects the repo and posts the reveal request")
+    func revealSelectsRepoAndPostsRequest() throws {
+        try withAppState { appState in
+            let repoID = UUID()
+            #expect(appState.repoDetailReveal == nil)
+
+            appState.revealPreSessionHookEditor(repoID: repoID)
+
+            #expect(appState.selectedRepoID == repoID)
+            #expect(appState.repoDetailReveal == .preSessionHook(repoID: repoID))
+            // selectRepo clears any worktree/scratch selection so ContentView
+            // swaps in RepoDetailView.
+            #expect(appState.selectedWorktreeIDs.isEmpty)
+            #expect(appState.selectedScratchSection == false)
+        }
+    }
+
+    @Test("a consumed reveal can be cleared so it is not replayed on navigate-back")
+    func revealIsClearable() throws {
+        try withAppState { appState in
+            appState.revealPreSessionHookEditor(repoID: UUID())
+            appState.repoDetailReveal = nil
+            #expect(appState.repoDetailReveal == nil)
+        }
+    }
 }

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -47,7 +47,8 @@ private func expectWellFormedDividers(_ items: [RowActionMenu.Item]) {
 struct RowActionMenuRegularTests {
     @Test func fullShapeWithAllSectionsPresent() {
         // Every conditional on: rename/archive | hibernation | fork/nested |
-        // finder/copy — four sections, three dividers.
+        // maintenance | finder/copy — five sections, four dividers. A
+        // repo-backed row with no hook resolving offers Create.
         let s = session("Claude 1")
         let ctx = RowActionMenu.Context(hasHibernatableClaude: true,
                                         hasHibernatedClaude: true,
@@ -67,19 +68,20 @@ struct RowActionMenuRegularTests {
             .forkSession(terminalID: s.terminalID, profileID: s.profileID),
             .createNestedWorktree,
             .newWorktreeFromBranch,
+            .createPreSessionHook,
             .openInFinder,
             .copyPath,
         ])
-        // Section boundaries: after archive, after the hibernation block, and
-        // after the fork/nested block.
-        #expect(dividerIndices(items) == [2, 7, 11])
+        // Section boundaries: after archive, after the hibernation block,
+        // after the fork/nested block, and after the maintenance item.
+        #expect(dividerIndices(items) == [2, 7, 11, 13])
         expectWellFormedDividers(items)
     }
 
     @Test func emptyHibernationSectionCollapses() {
         // No Claude sessions at all: the hibernation and fork sections are
-        // empty, so exactly two dividers remain — rename/archive | nested |
-        // finder/copy — with no doubled or dangling dividers.
+        // empty, so exactly three dividers remain — rename/archive | nested |
+        // maintenance | finder/copy — with no doubled or dangling dividers.
         let ctx = RowActionMenu.Context(hasRepoID: true, branch: "tbd/x")
         let items = RowActionMenu.items(context: ctx)
         #expect(kinds(items) == [
@@ -87,10 +89,11 @@ struct RowActionMenuRegularTests {
             .archive,
             .createNestedWorktree,
             .newWorktreeFromBranch,
+            .createPreSessionHook,
             .openInFinder,
             .copyPath,
         ])
-        #expect(dividerIndices(items) == [2, 5])
+        #expect(dividerIndices(items) == [2, 5, 7])
         expectWellFormedDividers(items)
     }
 
@@ -150,17 +153,31 @@ struct RowActionMenuRegularTests {
         #expect(archive?.disabledHelp == nil)
     }
 
-    @Test("re-run item appears only when a preSession hook resolves")
-    func rerunItemGatedOnHook() {
-        let without = RowActionMenu.items(context: .init(hasPreSessionHook: false))
-        #expect(!without.contains(.action(.init(
-            kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
-        ))))
-
+    @Test("regular row with a hook offers Re-run; without one, offers Create")
+    func maintenanceItemThreeStates() {
         let with = RowActionMenu.items(context: .init(hasPreSessionHook: true))
         #expect(with.contains(.action(.init(
             kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
         ))))
+        #expect(!kinds(with).contains(.createPreSessionHook))
+
+        let without = RowActionMenu.items(context: .init(hasPreSessionHook: false))
+        #expect(without.contains(.action(.init(
+            kind: .createPreSessionHook, title: RowActionMenu.createPreSessionLabel
+        ))))
+        #expect(!kinds(without).contains(.rerunPreSessionHook))
+    }
+
+    @Test("the create item sits in its own section directly above Open in Finder")
+    func createItemSection() throws {
+        let items = RowActionMenu.items(context: .init(hasPreSessionHook: false))
+        let create = try #require(items.firstIndex(of: .action(.init(
+            kind: .createPreSessionHook, title: RowActionMenu.createPreSessionLabel
+        ))))
+        #expect(items[create - 1] == .divider)
+        #expect(items[create + 1] == .divider)
+        #expect(items[create + 2] == .action(.init(kind: .openInFinder, title: "Open in Finder")))
+        expectWellFormedDividers(items)
     }
 
     @Test("re-run item sits in its own section directly above Open in Finder")
@@ -169,25 +186,38 @@ struct RowActionMenuRegularTests {
         let rerun = try #require(items.firstIndex(of: .action(.init(
             kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
         ))))
-        // Divider immediately before and after → its own section.
         #expect(items[rerun - 1] == .divider)
         #expect(items[rerun + 1] == .divider)
         #expect(items[rerun + 2] == .action(.init(kind: .openInFinder, title: "Open in Finder")))
+        expectWellFormedDividers(items)
     }
 
-    @Test("scratch rows get the re-run item, main rows never do")
-    func rerunItemRowScope() {
-        let scratch = RowActionMenu.items(context: .init(isScratch: true, hasPreSessionHook: true))
-        #expect(scratch.contains(.action(.init(
-            kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
-        ))))
-
-        let main = RowActionMenu.items(context: .init(
-            status: .main, hasPreSessionHook: true
+    @Test("scratch rows get Re-run but never Create; the section collapses cleanly")
+    func maintenanceItemRowScopeScratch() {
+        // A scratch space has no repo hooks editor to reveal (isScratch IS repoID == nil).
+        let scratchWith = RowActionMenu.items(context: .init(
+            hasRepoID: false, isScratch: true, hasPreSessionHook: true
         ))
-        #expect(!main.contains(.action(.init(
-            kind: .rerunPreSessionHook, title: RowActionMenu.rerunPreSessionLabel
-        ))))
+        #expect(kinds(scratchWith).contains(.rerunPreSessionHook))
+
+        let scratchWithout = RowActionMenu.items(context: .init(
+            hasRepoID: false, isScratch: true, hasPreSessionHook: false
+        ))
+        #expect(!kinds(scratchWithout).contains(.createPreSessionHook))
+        #expect(!kinds(scratchWithout).contains(.rerunPreSessionHook))
+        // The empty maintenance section must leave no doubled or dangling divider.
+        expectWellFormedDividers(scratchWithout)
+    }
+
+    @Test("main rows get neither maintenance item")
+    func maintenanceItemRowScopeMain() {
+        for hasHook in [true, false] {
+            let main = RowActionMenu.items(context: .init(
+                status: .main, hasPreSessionHook: hasHook
+            ))
+            #expect(!kinds(main).contains(.rerunPreSessionHook))
+            #expect(!kinds(main).contains(.createPreSessionHook))
+        }
     }
 
 }
@@ -205,6 +235,7 @@ struct RowActionMenuScratchTests {
                                         hasHibernatedClaude: true,
                                         hasUnpinnedClaude: true,
                                         hasKeepWarmClaude: true,
+                                        hasRepoID: false,
                                         isScratch: true,
                                         isPromoted: false,
                                         claudeSessions: [s])
@@ -232,7 +263,7 @@ struct RowActionMenuScratchTests {
         // No Claude sessions at all: hibernation and fork sections vanish, so
         // the menu is rename/archive | finder/copy | delete(+caption) with
         // exactly two dividers — never doubled.
-        let ctx = RowActionMenu.Context(isScratch: true, isPromoted: false)
+        let ctx = RowActionMenu.Context(hasRepoID: false, isScratch: true, isPromoted: false)
         let items = RowActionMenu.items(context: ctx)
         #expect(kinds(items) == [
             .rename,
@@ -258,7 +289,7 @@ struct RowActionMenuScratchTests {
         // Scratch spaces host Claude sessions too: the fork entries appear in
         // the middle section, same as the regular branch.
         let s = session("Claude 1")
-        let ctx = RowActionMenu.Context(isScratch: true, claudeSessions: [s])
+        let ctx = RowActionMenu.Context(hasRepoID: false, isScratch: true, claudeSessions: [s])
         let items = RowActionMenu.items(context: ctx)
         #expect(kinds(items) == [
             .rename,

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -278,11 +278,15 @@ struct RowActionMenuScratchTests {
     }
 
     @Test func promoteHintOmittedWhenAlreadyPromoted() {
-        let ctx = RowActionMenu.Context(isScratch: true, isPromoted: true)
+        let ctx = RowActionMenu.Context(hasRepoID: false, isScratch: true, isPromoted: true)
         let items = RowActionMenu.items(context: ctx)
         #expect(!items.contains(.caption(RowActionMenu.promoteHint)))
         // Delete then becomes the literal last item.
         #expect(items.last?.actionKind == .deleteScratch)
+        // A scratch row has no repo hooks editor to reveal: neither
+        // maintenance item should ever appear.
+        #expect(!kinds(items).contains(.createPreSessionHook))
+        #expect(!kinds(items).contains(.rerunPreSessionHook))
     }
 
     @Test func scratchWithClaudeSessionCarriesForkEntries() {
@@ -303,10 +307,15 @@ struct RowActionMenuScratchTests {
     }
 
     @Test func scratchArchiveAndDeleteAreDestructive() {
-        let ctx = RowActionMenu.Context(isScratch: true)
-        let actions = RowActionMenu.items(context: ctx).compactMap(\.action)
+        let ctx = RowActionMenu.Context(hasRepoID: false, isScratch: true)
+        let items = RowActionMenu.items(context: ctx)
+        let actions = items.compactMap(\.action)
         #expect(actions.first { $0.kind == .archiveScratch }?.role == .destructive)
         #expect(actions.first { $0.kind == .deleteScratch }?.role == .destructive)
+        // A scratch row has no repo hooks editor to reveal: neither
+        // maintenance item should ever appear.
+        #expect(!kinds(items).contains(.createPreSessionHook))
+        #expect(!kinds(items).contains(.rerunPreSessionHook))
     }
 }
 

--- a/Tests/TBDDaemonTests/PreSessionRerunTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionRerunTests.swift
@@ -158,7 +158,7 @@ struct PreSessionRerunTests {
         #expect(first.error == nil)
 
         let second = try await router.handleWorktreeRerunPreSession(params)
-        #expect(second.error == "Setup hook is already running for this worktree.")
+        #expect(second.error == "Pre-session hook is already running for this worktree.")
     }
 }
 }

--- a/docs/superpowers/specs/2026-07-09-presession-hook-menu-naming-design.md
+++ b/docs/superpowers/specs/2026-07-09-presession-hook-menu-naming-design.md
@@ -1,0 +1,237 @@
+# Pre-session hook: correct the menu naming, offer to create a missing hook
+
+Date: 2026-07-09
+Follows: `2026-07-08-rerun-presession-hook-design.md` (shipped as PR #405, merged as `2181073a`)
+
+## Problem
+
+Two independent defects in the context-menu entry shipped by #405.
+
+**1. The label names the wrong hook.** TBD has five hook events, two of which fire on
+worktree creation and are routinely confused:
+
+| Settings heading | `HookEvent` case | Behavior |
+| --- | --- | --- |
+| Pre-session hook | `preSession` | Runs in a visible terminal; **blocks** the agent from starting |
+| Setup hook | `setup` | Runs in parallel alongside the agent; does **not** block |
+
+The context-menu item reads **"Re-run setup hook"** but resolves and runs `HookEvent.preSession`.
+So it names one real hook while running a different real hook. Four daemon-side strings inherit
+the same mistake. The behavior is correct throughout — `rerunPreSessionHook`, the
+`worktree.rerunPreSession` RPC, and the app's `hasPreSessionHook` gate all key off
+`HookEvent.preSession`. Only the user-visible text is wrong, and all five strings were
+introduced by #405 (commit `5b094015`), so no pre-existing prose is in scope.
+
+**2. A missing hook is invisible.** When no `preSession` hook resolves, the entry is hidden
+entirely. A user who wants one has no affordance and must know to look in
+Settings → repo → Settings tab → scroll past the model-profile picker and env overrides.
+
+## Goals
+
+- The menu, the daemon's error, and the daemon's notifications all say *pre-session hook*.
+- A regular worktree with no `preSession` hook offers **Create pre-session hook…**, which
+  reveals the editor that authors it.
+- No change to what any hook does, when it runs, or which file resolves.
+
+## Non-goals
+
+- **The main-repo row.** `mainItems` has no maintenance section and does not gain one, even
+  though a repo-scoped "create a hook" arguably belongs there. Out of scope by request.
+- **A global-hooks editor.** `~/tbd/hooks/default/preSession` is the fallback for *every* repo
+  that has no per-repo hook. Nothing in this change authors it.
+- **`.worktree-hooks/preSession` authoring.** Nothing in the app writes that rung of the
+  resolution chain today, and this change does not start.
+- Renaming the `setup` event, its Settings heading, or the `setup`-hook comments in
+  `WorktreeLifecycle+Create.swift` — those are correct as written.
+
+## Behavior
+
+### Menu states
+
+`isScratch` is *defined* as `repoID == nil` (`Models.swift:156`), so a regular row always has a
+repo and a scratch row never does. That makes the matrix total without a new `Context` field:
+
+| Row | `preSession` hook resolves | No hook resolves |
+| --- | --- | --- |
+| Regular | `Re-run pre-session hook` | `Create pre-session hook…` |
+| Scratch | `Re-run pre-session hook` | *(section collapses — no entry, no divider)* |
+| Main / creating | *(unchanged — `mainItems` has no maintenance section)* |
+
+The scratch/no-hook cell is empty because a scratch space has nowhere repo-scoped to route:
+`ScratchDetailView`'s Settings tab holds only global scratch config and has no hooks editor.
+Its hook, if any, comes from the scratch dir's `.worktree-hooks/` or the global default — both
+non-goals above. So scratch keeps exactly today's behavior.
+
+The trailing ellipsis on **Create pre-session hook…** follows the macOS convention: the item
+opens further UI rather than acting immediately.
+
+### Create → reveal
+
+Clicking **Create pre-session hook…** selects the worktree's repo, switches its detail pane to
+the **Settings** tab, scrolls to the **Pre-session hook** section, and focuses its `TextEditor`.
+It does not write a file — the user types the hook and the existing save path in
+`RepoHooksSettingsView` persists it to `~/tbd/repos/<uuid>/hooks/preSession`.
+
+Once saved, the same menu entry becomes **Re-run pre-session hook** on the next right-click,
+because `hasPreSessionHook` re-resolves from disk each time the menu is built.
+
+## Design
+
+### 1. Strings
+
+Five strings change. All are the only occurrence of their text.
+
+| Location | From | To |
+| --- | --- | --- |
+| `RowActionMenu.swift:174` (`rerunPreSessionLabel`) | `Re-run setup hook` | `Re-run pre-session hook` |
+| `WorktreeLifecycle+PreSession.swift:460` (`.alreadyRunning`) | `Setup hook is already running for this worktree.` | `Pre-session hook is already running for this worktree.` |
+| `WorktreeLifecycle+PreSession.swift:462` (`.worktreeBusy`) | `…its setup hook is already running.` | `…its pre-session hook is already running.` |
+| `WorktreeLifecycle+PreSession.swift:546` (failure notification) | `Setup hook failed (exit N) — …` | `Pre-session hook failed (exit N) — …` |
+| `WorktreeLifecycle+PreSession.swift:551` (timeout notification) | `Setup hook timed out after Ns` | `Pre-session hook timed out after Ns` |
+
+Prose to match: the `RowActionMenu.items` doc comment (§4 "Maintenance") and the two lines in
+`docs/worktree-hooks.md` (`:32`, `:34`). The `.alreadyRunning` description remains the single
+source of that sentence — the app surfaces it verbatim via `showAlert`, so no app-side copy exists.
+
+`AppState+Worktrees.swift:296,298` log lines say "setup hook" too; they are `os.Logger` output,
+not user-facing, but they change with the rest so `log stream` reads consistently.
+
+### 2. Menu model (`RowActionMenu.swift`)
+
+`Kind` gains a payload-free case, and a label constant joins `rerunPreSessionLabel`:
+
+```swift
+case createPreSessionHook
+
+static let createPreSessionLabel = "Create pre-session hook…"  // U+2026, not "..."
+```
+
+`maintenanceActions(context:)` grows the third state. It already receives `isScratch` and
+`hasPreSessionHook`; no new `Context` field is required, and `items()` stays a pure function
+of `Context`:
+
+```swift
+static func maintenanceActions(context: Context) -> [Action] {
+    if context.hasPreSessionHook {
+        return [Action(kind: .rerunPreSessionHook, title: rerunPreSessionLabel)]
+    }
+    // A scratch space (repoID == nil) has no repo hooks editor to reveal.
+    guard !context.isScratch else { return [] }
+    return [Action(kind: .createPreSessionHook, title: createPreSessionLabel)]
+}
+```
+
+Both call sites (`regularItems`, `scratchItems`) already route through `maintenanceActions`, so
+the section placement — its own section between spawning and the filesystem section, above
+`Open in Finder` — is unchanged. The empty return keeps `joined(...)` collapsing the section,
+so a hookless scratch row still renders no dangling divider.
+
+### 3. Dispatch (`RowActionMenuActions.swift`)
+
+The new kind carries no payload; the dispatcher reads the repo from the worktree it already
+holds. A regular row always has a `repoID`, so the `guard` is a total-function formality:
+
+```swift
+case .createPreSessionHook:
+    guard let repoID = worktree.repoID else { return }
+    appState.revealPreSessionHookEditor(repoID: repoID)
+```
+
+`hasPreSessionHook` — the private computed property doing the `HookResolver` filesystem walk —
+is unchanged.
+
+### 4. Reveal plumbing (`AppState`, `RepoDetailView`, `RepoHooksSettingsView`)
+
+A one-shot published request, consumed by the view. This mirrors how `selectedRepoID` and
+`selectedScratchSection` already drive the detail pane.
+
+```swift
+// AppState.swift, beside selectedRepoID
+/// One-shot request to reveal a section of a repo's detail pane. Set by
+/// `revealPreSessionHookEditor`, cleared by `RepoDetailView` once applied.
+@Published var repoDetailReveal: RepoDetailReveal?
+
+enum RepoDetailReveal: Equatable {
+    case preSessionHook(repoID: UUID)
+}
+```
+
+```swift
+// AppState+Worktrees.swift, beside selectRepo(id:)
+func revealPreSessionHookEditor(repoID: UUID) {
+    selectRepo(id: repoID)
+    repoDetailReveal = .preSessionHook(repoID: repoID)
+}
+```
+
+`selectRepo(id:)` already clears `selectedWorktreeIDs` and `selectedScratchSection` and records
+a navigation entry, so `ContentView` swaps in `RepoDetailView(repoID:)` on the next render.
+
+**`RepoDetailView` must consume the reveal in both `onAppear` and `onChange`.** It is not
+`.id(repoID)`-keyed — only its `RepoInstructionsView` / `RepoSettingsView` children are — so
+SwiftUI reuses one instance across repo switches:
+
+- Pane not yet mounted (no repo was selected): `onAppear` fires, `onChange` does not.
+- Pane already mounted (another repo, or this repo on the Archived tab): the instance is
+  reused, `onAppear` does not fire again, `onChange` does.
+
+Handling only one of the two leaves a dead menu item in the other case. On match, the view sets
+`selectedTab = .settings` and sets `appState.repoDetailReveal = nil` so the reveal is not
+replayed when the user later navigates back. It ignores a reveal whose `repoID` is not its own.
+
+`RepoSettingsView` wraps its existing `ScrollView` in a `ScrollViewReader` and, on the same
+signal, scrolls to an anchor `.id(...)` placed on `RepoHooksSettingsView`'s pre-session section.
+`RepoHooksSettingsView` takes an optional `FocusState<...>.Binding` so the pre-session
+`TextEditor` receives focus; the `setup` and `archive` sections are untouched.
+
+## Error handling
+
+There is no new failure mode. The reveal is pure local navigation — no RPC, no filesystem
+write, nothing to fail. A reveal naming an unknown or since-removed repo simply matches no
+mounted `RepoDetailView` and is dropped; `selectRepo(id:)` on a stale ID already no-ops in the
+same way today.
+
+The `guard let repoID = worktree.repoID` in the dispatcher cannot fire for a regular row (that
+is what `isScratch` means), and the menu never offers the action to a scratch row. It returns
+silently rather than asserting, because a context menu is not a place to crash.
+
+## Testing
+
+`Tests/TBDAppTests/RowActionMenuTests.swift`
+- regular + no hook → `.createPreSessionHook`, titled `Create pre-session hook…`
+- regular + hook → `.rerunPreSessionHook`, titled `Re-run pre-session hook`
+- scratch + no hook → neither kind present, **and** no doubled/dangling divider (assert the
+  full `[Item]` sequence around the collapse point, not just the absence of the action)
+- scratch + hook → `.rerunPreSessionHook`
+- main → neither kind present
+
+`Tests/TBDAppTests/PreSessionAppStateTests.swift` (exists)
+- `revealPreSessionHookEditor(repoID:)` sets `selectedRepoID` and
+  `repoDetailReveal == .preSessionHook(repoID:)`
+- construct via `AppState(userDefaults: UserDefaults(suiteName:))` and tear down with
+  `removePersistentDomain(forName:)` — `UserDefaults.standard` on this unbundled executable is
+  the developer's real `TBDApp.plist`
+
+`Tests/TBDDaemonTests/PreSessionRerunTests.swift`
+- `rpcReportsAlreadyRunning` asserts the new sentence
+
+**Live-only, requires the user:** the scroll-to-section and editor focus. SwiftUI context menus
+do not respond to synthetic clicks, and scroll position/focus are not observable from a headless
+harness. Verify by right-clicking a hookless worktree and confirming the Settings tab opens
+scrolled to Pre-session hook with the editor focused.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `Sources/TBDApp/Helpers/RowActionMenu.swift` | `createPreSessionHook` kind, `createPreSessionLabel`, three-state `maintenanceActions`, renamed `rerunPreSessionLabel`, doc comment |
+| `Sources/TBDApp/Sidebar/RowActionMenuActions.swift` | dispatch the new kind |
+| `Sources/TBDApp/AppState.swift` | `RepoDetailReveal` enum, `repoDetailReveal` published property |
+| `Sources/TBDApp/AppState+Worktrees.swift` | `revealPreSessionHookEditor(repoID:)`; log-line wording |
+| `Sources/TBDApp/RepoDetailView.swift` | consume reveal in `onAppear` + `onChange`; `ScrollViewReader` in `RepoSettingsView` |
+| `Sources/TBDApp/Settings/RepoHooksSettingsView.swift` | scroll anchor + optional focus binding on the pre-session section |
+| `Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift` | four strings |
+| `docs/worktree-hooks.md` | prose at `:32`, `:34` |
+| `Tests/TBDAppTests/RowActionMenuTests.swift` | five cases above |
+| `Tests/TBDAppTests/PreSessionAppStateTests.swift` | reveal test |
+| `Tests/TBDDaemonTests/PreSessionRerunTests.swift` | updated assertion |

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -29,9 +29,11 @@ The split is your repo's choice; the rule of thumb is *preSession = "the agent m
 
 ## Re-running `preSession`
 
-You can re-run a worktree's `preSession` hook at any time, without recreating the worktree: right-click it in the sidebar and choose **Re-run setup hook**. It runs in a fresh background tab that does not steal focus, and it does not disturb anything already running — no restart, no hibernation, no status change. The menu item only appears when a `preSession` hook actually resolves for that worktree; where none does, it's simply absent from the menu.
+You can re-run a worktree's `preSession` hook at any time, without recreating the worktree: right-click it in the sidebar and choose **Re-run pre-session hook**. It runs in a fresh background tab that does not steal focus, and it does not disturb anything already running — no restart, no hibernation, no status change.
 
-Only one run is allowed per worktree at a time. Triggering a second one while the first is still in flight is refused with: `Setup hook is already running for this worktree.`
+When no `preSession` hook resolves for that worktree, the entry instead reads **Create pre-session hook…** and opens the repo's hook editor (Settings tab), scrolled to the Pre-session hook section. Scratch spaces have no repo, and therefore no hooks editor — for them the entry is simply absent when no hook resolves.
+
+Only one run is allowed per worktree at a time. Triggering a second one while the first is still in flight is refused with: `Pre-session hook is already running for this worktree.`
 
 Scratch spaces can run a `preSession` hook too. Previously they couldn't, because hook spawning required a backing repo. A scratch space has no repo, so for it `TBD_REPO_PATH` (see below) falls back to the worktree's own path.
 


### PR DESCRIPTION
## Summary

TBD has **two** worktree hook events that fire on creation, and Settings already names them apart:

| Settings heading | Event | Behavior |
| --- | --- | --- |
| Pre-session hook | `preSession` | Runs in a visible terminal, **blocks** the agent from starting |
| Setup hook | `setup` | Runs in parallel alongside the agent, does **not** block |

The context-menu item added by #405 read **"Re-run setup hook"** but resolved and ran `HookEvent.preSession` — naming one real hook while running a different real hook. Six user-facing strings inherited the mistake (the menu label, the "already running" refusal, the no-hook refusal, the failure and timeout notifications, and a comment describing the blocking hook as "setup"). All six were introduced by #405, so no pre-existing prose is touched. **Behavior is unchanged** — every layer already resolved `preSession` correctly.

While in there, this also fixes a discoverability gap. Previously, a worktree with no `preSession` hook simply hid the entry, leaving no affordance to create one. Now:

| Row | Hook resolves | No hook |
| --- | --- | --- |
| Regular | Re-run pre-session hook | **Create pre-session hook…** |
| Scratch | Re-run pre-session hook | *(section collapses)* |
| Main / creating | *(unchanged — no maintenance section)* |

**Create pre-session hook…** selects the worktree's repo, opens its Settings tab, scrolls to the Pre-session hook section, and focuses the editor. Scratch spaces have no repo — hence no hooks editor to reveal — so they keep today's behavior.

### Notes for reviewers

- The reveal is **two chained one-shots**: `AppState.repoDetailReveal` (cleared by `RepoDetailView`) → `RepoDetailView.pendingHookReveal` (cleared by `RepoSettingsView` before it scrolls). `RepoDetailView` is not `.id(repoID)`-keyed, so it is reused across repo switches and its `@State` persists. An earlier draft used a monotonic nonce; because it never reset, returning to a previously-revealed repo — or just tabbing away and back — re-scrolled and stole keyboard focus. Modeling it as a one-shot consumed by the acting view removes that class of bug at the root.
- The reveal is consumed in **both** `onAppear` and `onChange`, at both levels. A fresh mount fires only `onAppear`; a reused instance fires only `onChange`. Wiring one leaves the menu item dead in the other case.
- `RowActionMenu.items(context:)` stays a pure function of `Context`. The Create entry gates on `context.hasRepoID` (the actual precondition — the reveal needs a repo to navigate to), which also matches the dispatcher's `guard let repoID = worktree.repoID`.
- Two scratch test fixtures were constructing `Context(isScratch: true)` while leaving `hasRepoID` at its default `true` — impossible in production, since `Worktree.isScratch` **is** `repoID == nil`. That was silently letting a phantom `.createPreSessionHook` item into scratch menus without any test noticing. Fixed, and the assertions strengthened so it would have failed loudly.

### Known, out of scope

`RepoDetailView.selectedTab` is `@State` on that same unkeyed view, so after a reveal, clicking a different repo shows it on Settings rather than its `.archived` default. Pre-existing; the reveal makes it easier to reach. One-line fix (`.id(repoID)` in `ContentView`), deliberately left out of this diff.

## Test plan

- [x] Full suite: 3256 tests / 399 suites pass
- [x] `swiftlint --strict`: 0 violations across 515 files
- [x] Menu model: three-state matrix (re-run / create / collapsed), section placement, and no dangling divider for a hookless scratch row
- [x] `AppState.revealPreSessionHookEditor` selects the repo and posts the reveal
- [x] Daemon: `worktree.rerunPreSession` reports the new "already running" string
- [x] Re-run path verified live against the running daemon
- [ ] **Live GUI** (needs a human — scroll position, focus, and SwiftUI context menus aren't observable headlessly):
  - [ ] Right-click a worktree in a repo with no hook → **Create pre-session hook…** in its own section above Open in Finder; click it → Settings opens scrolled to Pre-session hook, editor focused
  - [ ] Reveal repo A → click repo B → click repo A again: must **not** re-scroll or steal focus. Same for A → Archived tab → Settings tab
  - [ ] Save a hook, right-click again → entry flips to **Re-run pre-session hook**
  - [ ] Scratch space with no hook → neither entry, no dangling divider

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=94854A36-B61C-4E47-8459-BC632BAA76DA)