### PR TITLE
Compound: Make TUI screen-scraping structurally hard to reintroduce

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -129,6 +129,8 @@ jobs:
 
             Do not read or review changes in generated files like graphql codegen output.
 
+            TUI screen-scraping is a High-severity defect. REJECT any PR that adds logic parsing captured terminal screen text (tmux capture-pane output, pane text, composer lines) to infer agent state — e.g. matching TUI glyphs like ❯, prompts, placeholder or status strings. Agent state must come from machine interfaces (Claude Code hooks, transcript JSONL, control mode, exit codes). Likewise treat as High severity any file added to the `excluded:` lists of the `no_tui_scraping_literals` or `capture_pane_allowlist` rules in .swiftlint.yml without a compelling justification in the PR description. See the CLAUDE.md section "No TUI screen-scraping".
+
             IMPORTANT: You are to execute in three phases. Do not write the review content to your text response during Phases 1 and 2 — save that for Phase 3. Tool calls and brief phase transitions are fine.
 
             Phase 1: Write out your feedback and comments on the changes in a local txt file in the current working directory (not to GitHub). Use the Write tool to create the file, not shell redirection. Do not write to /tmp/.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -97,3 +97,46 @@ custom_rules:
       - string
     message: "setenv(\"TBD_HOME\") is only allowed in TBDDaemonTests under TBDHomeSerialized — it races concurrent suites in other targets (see CLAUDE.md, ConstantsTests flake)."
     severity: error
+
+  no_tui_scraping_literals:
+    name: "No agent-TUI literals in Sources/"
+    # included/excluded HERE take REGEX (not glob), matched against file path.
+    included:
+      - "Sources/.*\\.swift"
+    excluded:
+      # Sanctioned scrapers, exempt with refactor-later intent — see CLAUDE.md "No TUI screen-scraping".
+      # Drives the interactive `claude /login` TUI; no machine interface exists pre-login.
+      - "Sources/TBDDaemon/Claude/LoginSessionCoordinator\\.swift"
+      # Typed-but-unsent-input hibernation safety rail; no machine signal for composer state.
+      - "Sources/TBDDaemon/Lifecycle/HibernationSafetyChecks\\.swift"
+      # Embedded Nightwatch Python: fleet babysitting via screen classification is its purpose;
+      # belongs outside TBD once a plugin/extensibility surface exists.
+      - "Sources/TBDShared/NightwatchSkillContent\\.swift"
+    regex: '❯|\[Pasted text|esc to interrupt|Do you want to proceed|Enter to select|Tab/Arrow keys|Ready to submit|Select login method|Ask Claude|Type a message|context used|until auto-compact|bypass permissions'
+    match_kinds:
+      - string
+    message: "Don't infer agent state from rendered screen text — use hooks, transcript JSONL, control mode, or exit codes. See CLAUDE.md 'No TUI screen-scraping'."
+    severity: error
+
+  capture_pane_allowlist:
+    name: "capture-pane use outside allowlisted files"
+    # included/excluded HERE take REGEX (not glob), matched against file path.
+    included:
+      - "Sources/.*\\.swift"
+    excluded:
+      # The allowlist. Capturing pane text is legitimate ONLY as verbatim pass-through
+      # (display / transport / snapshot). Adding a file here draws High-severity review
+      # scrutiny — see CLAUDE.md "No TUI screen-scraping".
+      - "Sources/TBDDaemon/Tmux/TmuxManager\\.swift"                     # defines the capture API
+      - "Sources/TBDDaemon/Server/RPCRouter\\+TerminalHandlers\\.swift"  # terminal.read returns text verbatim
+      - "Sources/TBDDaemon/Lifecycle/HibernationCoordinator\\.swift"     # ANSI display snapshot + safety-rail feed
+      # Capture-for-replay: rebuilds a pane's display state verbatim for control-mode
+      # attach/repair (replay bytes); never parses captured content for agent state.
+      - "Sources/TBDDaemon/Tmux/ControlMode/PaneCaptureReplay\\.swift"
+      - "Sources/TBDShared/NightwatchSkillContent\\.swift"               # embedded Python babysitter (see rule above)
+    regex: 'capturePane\w*\s*\(|capture-pane'
+    match_kinds:
+      - identifier
+      - string
+    message: "capture-pane text may only be passed through verbatim (display/transport/snapshot) from allowlisted files — never parsed for agent state. See CLAUDE.md 'No TUI screen-scraping'."
+    severity: error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,12 @@ Use `os.Logger` (`import os`) with one of the established subsystems (`com.tbd.a
 
 This rule is enforced mechanically by SwiftLint (custom rule `no_print_in_sources`) in the dedicated `lint` CI job and the pre-push git hook, both invoking a Homebrew-installed `swiftlint --strict` directly. To lint manually: `swiftlint --strict`. Prerequisite: `brew install swiftlint`. See `.swiftlint.yml`.
 
+### No TUI screen-scraping
+
+Never infer an agent's state by parsing its rendered terminal screen — tmux `capture-pane` text, composer glyphs like `❯`, placeholder or status strings. Screen text is a display surface, not an API: scraping breaks *silently* when the TUI changes copy or rendering, couples TBD to one agent version, and sits at the wrong layer. Get agent state from machine interfaces instead: Claude Code hooks, transcript JSONL, tmux control-mode events, process exit codes, or TBD's own DB/RPC state. (Cautionary tale: PR #398 verified submits by scanning the composer line for `[Pasted text` — it defended an unreachable state and was removed as dead code.)
+
+Enforced mechanically by two SwiftLint custom rules in `.swiftlint.yml` (`no_tui_scraping_literals`, `capture_pane_allowlist`), which run in the `lint` CI job and the pre-push hook. Three sanctioned scrapers predate this rule and are excluded with comments (interactive `/login` driving, the pending-input hibernation rail, the embedded Nightwatch babysitter) — they should eventually migrate off screen text. Adding a **new** exclusion requires a compelling justification in the PR description; the PR review gate treats unjustified additions as High severity.
+
 ### Changing the PR-review merge gate
 `claude-review` is a required check on `main`, produced by `.github/workflows/claude-code-review.yml`. Before touching that workflow or its `claude-review-hooks/`, read [`docs/pr-review-gate.md`](docs/pr-review-gate.md). Two traps it documents: the workflow runs on `pull_request_target` and **must** pass `github_token` (the OIDC app-token exchange 401s on that trigger), and changing the workflow's *trigger event* requires a one-time **admin merge** (such a PR matches neither the old nor new event, so no review runs and the required check never reports).
 

--- a/docs/superpowers/specs/2026-07-09-no-tui-scraping-guard-design.md
+++ b/docs/superpowers/specs/2026-07-09-no-tui-scraping-guard-design.md
@@ -1,0 +1,166 @@
+# No TUI screen-scraping — structural guard design
+
+**Date:** 2026-07-09
+**Status:** Approved
+**Branch:** `tbd/no-tui-scraping-guard`
+
+## Problem
+
+PR #398 added a "verify-and-retry submit" layer to `tbd terminal send --submit` that
+decided whether a submit succeeded by running `tmux capture-pane` and parsing the
+rendered screen: it found the bottom-most line starting with Claude's composer glyph
+`❯` and checked it for the literal `[Pasted text`. A live investigation later proved
+the state it defended is unreachable (Claude pins bracketed-paste mode on), and the
+layer is being removed as dead code in a sibling branch.
+
+The durable lesson: **inferring agent state by scraping the rendered TUI screen is an
+anti-pattern in TBD.** It is (a) brittle — it breaks *silently* when the TUI changes a
+glyph, placeholder string, or its rendering; (b) coupled to a specific TUI and version;
+(c) at the wrong layer — agent state should come from machine interfaces (hooks,
+transcript JSONL, control mode, exit codes), not from pixels-as-text.
+
+This design makes it structurally hard to reintroduce the pattern.
+
+## Definition
+
+Capturing pane text is **fine** when the text is passed through verbatim — display,
+transport (`terminal.read`), or snapshotting. It becomes **scraping** when code
+*branches on the captured content* by matching UI-specific strings or glyphs to infer
+agent state.
+
+A deterministic guard cannot do that dataflow analysis, so the design approximates it
+with layered mechanical checks plus visible, commented escape hatches.
+
+## Current inventory (audited 2026-07-09)
+
+Legitimate capture (verbatim pass-through):
+
+- `RPCRouter+TerminalHandlers.swift:402,646` — `terminal.read` RPC returns pane text
+  to the caller unparsed.
+- `HibernationCoordinator.swift:269` — ANSI screen snapshot before hibernation
+  (capture-for-display).
+
+Sanctioned scrapers (exempt now, refactor later):
+
+- `LoginSessionCoordinator.swift:95-99` — classifies pane text (`"Run /login"`, `❯`,
+  `"Select login method"`) to drive the interactive `claude /login` flow. The login
+  TUI exposes no machine interface (no hooks fire pre-login).
+- `HibernationSafetyChecks.swift:28-48` — `hasPendingInput(paneCapture:)` detects
+  typed-but-unsent composer text (placeholders `"Ask Claude"`, `"Type a message"`,
+  `"Try \""`) as a hibernation safety rail. No machine signal exists for "composer
+  has pending input".
+- `NightwatchSkillContent.swift` — embedded Python (`DECISION_PAT`, `RATE_PAT`, …)
+  classifies fleet panes by UI strings; runs `tmux capture-pane` from Python inside a
+  Swift string literal. Screen classification is its entire purpose. Longer term this
+  arguably shouldn't live inside TBD at all, but TBD lacks a plugin/extensibility
+  surface for custom workflows today.
+
+The anti-pattern itself (`verifyAndRetrySubmit`, `RPCRouter+TerminalHandlers.swift:1383`)
+still exists on this branch; its removal is in flight on a sibling branch. See
+Sequencing.
+
+## Design — four layers
+
+### Layer 1: SwiftLint rule `no_tui_scraping_literals` (Rule A)
+
+Custom rule in `.swiftlint.yml`, following the `no_print_in_sources` pattern
+(severity `error`, enforced by the existing `lint` CI job and pre-push hook via
+`swiftlint --strict` — zero new plumbing).
+
+- `included`: `Sources/.*\.swift`
+- `match_kinds`: `string` only. Custom-rule regexes run over raw file text, then
+  filter the matched region by syntax kind: this catches literals inside ordinary
+  strings *and* inside `#"""…"""#` raw heredocs (the embedded-Python case — same
+  mechanism the existing `migration_use_helpers` rule uses to catch DDL in SQL
+  strings), while leaving doc comments that merely *mention* a glyph legal (e.g.
+  `TmuxManager.swift:303`).
+- `regex`: alternation of high-signal agent-UI strings:
+  `❯`, `[Pasted text`, `esc to interrupt`, `Do you want to proceed`,
+  `Enter to select`, `Tab/Arrow keys`, `Select login method`, `Run /login`,
+  `Ask Claude`, `Type a message`, `context used`, `until auto-compact`,
+  `bypass permissions`.
+- `excluded` (each with a why-comment and refactor-later note): the three sanctioned
+  scrapers listed above.
+- `message`: infer agent state from hooks, transcript JSONL, control mode, or exit
+  codes — never from rendered screen text; see CLAUDE.md.
+
+Rationale: the tell of a scraper is the UI strings it matches against, which must
+appear as literals *somewhere*, regardless of how the pane text reaches the matching
+code (direct capture, injected closure, plain `String` parameter). This is what
+catches `classifyPane`-style scrapers that never call a capture API.
+
+### Layer 2: SwiftLint rule `capture_pane_allowlist` (Rule B)
+
+Same shape. Any new file touching the capture surface trips lint; the only path
+through is a visible `.swiftlint.yml` exclusion diff that Layer 3 tells the reviewer
+to scrutinize.
+
+- `included`: `Sources/.*\.swift`
+- `regex`: `capturePane\w*\s*\(` (kind `identifier`) and `capture-pane`
+  (kind `string`), as one alternation with `match_kinds: [identifier, string]`.
+- `excluded`: `TmuxManager.swift` (defines the API), `RPCRouter+TerminalHandlers.swift`
+  (verbatim `terminal.read`), `HibernationCoordinator.swift` (display snapshot),
+  `NightwatchSkillContent.swift` (embedded Python).
+
+### Layer 3: PR-review gate instruction
+
+One concise paragraph added to the `Additional review instructions` block of the
+`prompt` in `.github/workflows/claude-code-review.yml`. **Prompt content only — the
+trigger is untouched**, so no admin merge is needed (see `docs/pr-review-gate.md`).
+
+Content: treat as **High severity** (→ REJECT) any new logic that parses captured
+terminal/screen text to infer agent state (matching TUI glyphs, prompts, placeholder
+or status strings), *and* any new exclusion added to the `no_tui_scraping_literals` /
+`capture_pane_allowlist` rules without strong justification. Point to the CLAUDE.md
+policy section.
+
+This layer covers what the deterministic rules cannot: structural scrapers with no
+recognizable literals (e.g. matching a bare `>` prompt prefix), novel TUI strings not
+yet in the denylist, and social-engineering of the allowlist.
+
+### Layer 4: Policy doc
+
+A short "No TUI screen-scraping" section in the repo `CLAUDE.md` — the single thing
+the lint messages and the review instruction cite. States the rule, the why (brittle /
+silent / wrong layer; PR #398 story in one line), the correct layers to use instead,
+and the exemption process (add a commented exclusion; expect review scrutiny).
+
+## Known residual gap
+
+A scraper that branches only on structural features (line counts, bare `>` prefixes,
+box-drawing characters) with zero denylisted literals escapes both rules. Accepted:
+Layer 3 exists precisely for this; tightening Rule A's regex to catch structure would
+drown in false positives.
+
+## Sequencing
+
+This branch still contains `verifyAndRetrySubmit`, whose `❯` / `[Pasted text` literals
+correctly fail Rule A. No temporary exclusion (it would defeat the point). Instead:
+
+1. Implement everything; run `swiftlint --strict` and confirm Rule A fires on
+   `verifyAndRetrySubmit` — this is the positive acceptance test.
+2. Wait for the sibling removal branch to merge to `main`, rebase, confirm zero
+   violations, then open/land the PR.
+
+## Testing
+
+Mechanical verification via `swiftlint --strict` (or `swiftlint lint` scoped runs):
+
+- (a) Pre-rebase tree → Rule A fires on `verifyAndRetrySubmit` (proof the rule works).
+- (b) Scratch fixture files (outside the repo, linted with a copied config) exercising
+  each rule and each exclusion → fire / not-fire as expected. Fixtures include: UI
+  literal in a plain string; UI literal inside a raw `#"""…"""#` heredoc; glyph in a
+  doc comment (must NOT fire); `capturePane…(` call in a non-allowlisted file;
+  `capture-pane` argv string in a non-allowlisted file.
+- (c) Post-rebase tree → zero violations.
+
+No Swift tests: lint config is not runtime branching (CLAUDE.md's
+branch-coverage-for-conditionals rule doesn't apply), and the `no_print_in_sources`
+precedent ships without tests.
+
+## Out of scope
+
+- Refactoring the three sanctioned scrapers off screen text.
+- A plugin/extensibility surface that would let Nightwatch live outside TBD.
+- Guarding `Tests/` — live-tmux tests legitimately assert pane content to verify
+  delivery/rendering.

--- a/docs/superpowers/specs/2026-07-09-no-tui-scraping-guard-design.md
+++ b/docs/superpowers/specs/2026-07-09-no-tui-scraping-guard-design.md
@@ -39,6 +39,9 @@ Legitimate capture (verbatim pass-through):
   to the caller unparsed.
 - `HibernationCoordinator.swift:269` — ANSI screen snapshot before hibernation
   (capture-for-display).
+- `PaneCaptureReplay.swift` — control-mode attach/repair capture batch; reassembles
+  captured lines into replay bytes verbatim for display reconstruction (post-audit
+  addition, found by the rule itself during implementation).
 
 Sanctioned scrapers (exempt now, refactor later):
 
@@ -100,7 +103,8 @@ to scrutinize.
   (kind `string`), as one alternation with `match_kinds: [identifier, string]`.
 - `excluded`: `TmuxManager.swift` (defines the API), `RPCRouter+TerminalHandlers.swift`
   (verbatim `terminal.read`), `HibernationCoordinator.swift` (display snapshot),
-  `NightwatchSkillContent.swift` (embedded Python).
+  `PaneCaptureReplay.swift` (capture-for-replay), `NightwatchSkillContent.swift`
+  (embedded Python).
 
 ### Layer 3: PR-review gate instruction
 

--- a/docs/superpowers/specs/2026-07-09-no-tui-scraping-guard-design.md
+++ b/docs/superpowers/specs/2026-07-09-no-tui-scraping-guard-design.md
@@ -79,9 +79,11 @@ Custom rule in `.swiftlint.yml`, following the `no_print_in_sources` pattern
   `TmuxManager.swift:303`).
 - `regex`: alternation of high-signal agent-UI strings:
   `❯`, `[Pasted text`, `esc to interrupt`, `Do you want to proceed`,
-  `Enter to select`, `Tab/Arrow keys`, `Select login method`, `Run /login`,
+  `Enter to select`, `Tab/Arrow keys`, `Ready to submit`, `Select login method`,
   `Ask Claude`, `Type a message`, `context used`, `until auto-compact`,
-  `bypass permissions`.
+  `bypass permissions`. (`Run /login` is deliberately absent: it false-positives
+  on TBD's own UI caption `"Run /login once"` in `Models.swift`; the login
+  scraper file is excluded wholesale anyway.)
 - `excluded` (each with a why-comment and refactor-later note): the three sanctioned
   scrapers listed above.
 - `message`: infer agent state from hooks, transcript JSONL, control mode, or exit


### PR DESCRIPTION
## Summary

PR #398 inferred submit success by parsing the rendered Claude TUI (`tmux capture-pane` → find the `❯` composer line → check for `[Pasted text`). It defended an unreachable state and was removed as dead code in #407 — but the durable lesson is that screen-scraping an agent's rendered UI breaks *silently* when the TUI changes copy or rendering, couples TBD to one agent version, and sits at the wrong layer. This PR encodes that lesson mechanically, in four layers:

- **Two deterministic SwiftLint rules** (ride the existing `lint` CI job + pre-push hook, zero new plumbing):
  - `no_tui_scraping_literals` — errors on agent-UI literals (`❯`, `[Pasted text`, `esc to interrupt`, `Do you want to proceed`, …) in `Sources/` string literals. `match_kinds: [string]` catches them inside raw `#"""…"""#` heredocs (embedded scripts) while leaving doc comments legal. Catches classifiers no matter how pane text reaches them (injected closure, plain `String` param) — the tell is the literals they match against.
  - `capture_pane_allowlist` — errors on any `capturePane*(` call or `capture-pane` string outside five allowlisted files; new capture-surface users need a visible, commented `.swiftlint.yml` diff.
- **PR review gate**: the `claude-review` prompt now treats screen-scraping — and unjustified additions to the two rules' exclusion lists — as High severity → REJECT. Prompt content only; the `pull_request_target` trigger is untouched.
- **CLAUDE.md policy section** ("No TUI screen-scraping") that the lint messages and review instruction cite, plus the committed design spec.

Three pre-existing sanctioned scrapers are excluded with why-comments and refactor-later intent: `LoginSessionCoordinator` (the `/login` TUI has no machine interface), `HibernationSafetyChecks` (pending-input safety rail), and the embedded Nightwatch babysitter (screen classification is its purpose; belongs outside TBD once a plugin surface exists).

## Test plan

- [x] Positive acceptance test: pre-rebase, `no_tui_scraping_literals` fired on exactly the 4 `verifyAndRetrySubmit` literals (the #407 dead code) and nothing else; post-rebase `swiftlint --strict` exits 0
- [x] Fixture matrix (scratchpad, copied config): UI literal in plain string ✓ fires; UI literal in raw heredoc ✓ fires; `capturePane*(` identifier and `capture-pane` argv string in non-allowlisted file ✓ fire; glyph in doc comment and TBD's own `"Run /login once"` caption ✓ stay clean
- [x] Grep sweep of every denylist term across `Sources/`: no false positives outside excluded files
- [x] Rule B already caught a real post-audit file during implementation (`PaneCaptureReplay.swift`, verified legitimate capture-for-replay and allowlisted with justification)
- [x] Workflow YAML parses; trigger diff empty (no admin merge needed per `docs/pr-review-gate.md`)
- [x] `swift build` clean; pre-push hook (which runs the new rules) passed on push

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=31AFCDCA-E5C6-4014-A584-7B816FB9076D)