### PR TITLE
Reliability: Default the auto-hibernate idle sweep to OFF so a TUI rendering change can't eat typed input

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -429,7 +429,7 @@ final class AppState: ObservableObject {
     @Published var nightwatchMode: NightwatchMode = .off
     /// Auto-hibernate master switch. Loaded from the daemon `Config` via
     /// `loadHibernationConfig()`.
-    @Published var autoHibernateEnabled: Bool = true
+    @Published var autoHibernateEnabled: Bool = false
     /// Auto-hibernate idle timeout in minutes. Loaded from `Config`.
     @Published var hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes
     /// Daemon-persisted gate for session-limit auto-resume (default OFF).

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -44,7 +44,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             scratchProfileOverrideID: scratch_profile_override_id.flatMap(UUID.init(uuidString:)),
             nightwatchMode: nightwatch_mode
                 .flatMap(NightwatchMode.init(rawValue:)) ?? .off,
-            autoHibernateEnabled: auto_hibernate_enabled ?? true,
+            autoHibernateEnabled: auto_hibernate_enabled ?? false,
             hibernateIdleMinutes: hibernate_idle_minutes ?? Config.defaultHibernateIdleMinutes,
             controlModeEnabled: control_mode_enabled ?? false,
             autoResumeOnApiError: auto_resume_on_api_error ?? false

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -833,6 +833,27 @@ public final class TBDDatabase: Sendable {
                 type: .boolean, defaults: false)
         }
 
+        // One-time forced opt-out of the auto-hibernate idle sweep.
+        //
+        // The idle sweep drives `HibernationSafetyChecks.hasPendingInput`, a
+        // sanctioned TUI screen-scrape whose failure direction is asymmetric:
+        // if Claude Code changes its `>` composer rendering, typed-but-unsent
+        // input goes unrecognized and gets EATEN by the park. Defaulting the
+        // sweep off shrinks the default-on scraping surface to zero.
+        //
+        // A forcing UPDATE (not just a Swift default flip) is required: v39
+        // added `auto_hibernate_enabled` with `DEFAULT 1`, and SQLite's
+        // `ADD COLUMN ... DEFAULT 1` backfills every pre-existing row to `1`
+        // rather than NULL — so an explicit-true is byte-identical to a
+        // never-touched-true, and `auto_hibernate_enabled ?? true` never fires.
+        // The only way to move existing installs off the sweep is to rewrite
+        // the column. This deliberately clears an explicit `true` too; that is
+        // the approved one-time opt-out. Naturally idempotent, and a later user
+        // opt-in (`setAutoHibernate(enabled: true, ...)`) is not fought.
+        migrator.registerMigration("v50_auto_hibernate_idle_sweep_off_by_default") { db in
+            try db.execute(sql: "UPDATE config SET auto_hibernate_enabled = 0")
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -731,9 +731,13 @@ public struct Config: Codable, Sendable, Equatable {
     /// Nightwatch mode flag: off, daywatch, or nightwatch.
     public var nightwatchMode: NightwatchMode
     /// Master switch for the daemon-side auto-hibernate idle timer. Default
-    /// ON: idle Claude sessions are auto-hibernated to reclaim memory (their
-    /// prompt cache has already expired, so resume is cheap). When false, only
-    /// manual "Hibernate now" hibernates.
+    /// OFF: the idle sweep drives a sanctioned TUI screen-scrape
+    /// (`HibernationSafetyChecks.hasPendingInput`) whose failure direction is
+    /// asymmetric — a composer-rendering change in Claude Code could let the
+    /// park eat typed-but-unsent input — so it is opt-in. When true, idle
+    /// Claude sessions are auto-hibernated to reclaim memory (their prompt
+    /// cache has already expired, so resume is cheap). When false, only manual
+    /// "Hibernate now" hibernates.
     public var autoHibernateEnabled: Bool
     /// Minutes a Claude session must sit idle-at-rest before the auto-hibernate
     /// timer terminates its process. Clamped to a sane floor by the daemon.
@@ -762,7 +766,7 @@ public struct Config: Codable, Sendable, Equatable {
                 scratchRenamePrompt: String? = nil,
                 scratchProfileOverrideID: UUID? = nil,
                 nightwatchMode: NightwatchMode = .off,
-                autoHibernateEnabled: Bool = true,
+                autoHibernateEnabled: Bool = false,
                 hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes,
                 controlModeEnabled: Bool = false,
                 autoResumeOnApiError: Bool = false) {
@@ -805,7 +809,7 @@ public struct Config: Codable, Sendable, Equatable {
         scratchProfileOverrideID = try c.decodeIfPresent(UUID.self, forKey: .scratchProfileOverrideID)
         nightwatchMode = try c.decodeIfPresent(
             NightwatchMode.self, forKey: .nightwatchMode) ?? .off
-        autoHibernateEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoHibernateEnabled) ?? true
+        autoHibernateEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoHibernateEnabled) ?? false
         hibernateIdleMinutes = try c.decodeIfPresent(Int.self, forKey: .hibernateIdleMinutes)
             ?? Config.defaultHibernateIdleMinutes
         controlModeEnabled = try c.decodeIfPresent(

--- a/Tests/TBDDaemonTests/MigrationV39HibernationTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV39HibernationTests.swift
@@ -86,6 +86,14 @@ import GRDB
         try await db.config.setAutoHibernate(
             enabled: true, idleMinutes: Config.defaultHibernateIdleMinutes)
         #expect(try await db.config.get().autoHibernateEnabled == true)
+
+        // ...and opting back out persists too. This is the only direct
+        // config-level assertion of the false write path now that
+        // `configHibernationDefaultsAndRoundTrip` was repointed at the true
+        // case — the toggle's off-branch must round-trip through `get()`.
+        try await db.config.setAutoHibernate(
+            enabled: false, idleMinutes: Config.defaultHibernateIdleMinutes)
+        #expect(try await db.config.get().autoHibernateEnabled == false)
     }
 
     @Test func configIdleMinutesFlooredAtOne() async throws {

--- a/Tests/TBDDaemonTests/MigrationV39HibernationTests.swift
+++ b/Tests/TBDDaemonTests/MigrationV39HibernationTests.swift
@@ -63,15 +63,29 @@ import GRDB
 
     @Test func configHibernationDefaultsAndRoundTrip() async throws {
         let db = try TBDDatabase(inMemory: true)
-        // Defaults: ON, 30 min.
+        // Defaults: idle sweep OFF (forced off by migration v50), 30 min.
         let initial = try await db.config.get()
-        #expect(initial.autoHibernateEnabled == true)
+        #expect(initial.autoHibernateEnabled == false)
         #expect(initial.hibernateIdleMinutes == Config.defaultHibernateIdleMinutes)
 
-        try await db.config.setAutoHibernate(enabled: false, idleMinutes: 45)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 45)
         let updated = try await db.config.get()
-        #expect(updated.autoHibernateEnabled == false)
+        #expect(updated.autoHibernateEnabled == true)
         #expect(updated.hibernateIdleMinutes == 45)
+    }
+
+    /// Migration v50 forces the idle-sweep master switch off on a fresh DB, and
+    /// a subsequent user opt-in must round-trip (the migration must not fight a
+    /// later `setAutoHibernate(enabled: true, ...)`).
+    @Test func migrationV50ForcesIdleSweepOffButAllowsOptIn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        // A fresh DB runs every migration through v50 → sweep off.
+        #expect(try await db.config.get().autoHibernateEnabled == false)
+
+        // User opts back in; the value must stick.
+        try await db.config.setAutoHibernate(
+            enabled: true, idleMinutes: Config.defaultHibernateIdleMinutes)
+        #expect(try await db.config.get().autoHibernateEnabled == true)
     }
 
     @Test func configIdleMinutesFlooredAtOne() async throws {

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -311,10 +311,11 @@ import Testing
 }
 
 @Test func testConfigDecodesWithoutHibernationFields() throws {
-    // Config JSON from before v39 must decode with feature ON, 30 min.
+    // Config JSON with no hibernation fields must decode with the idle sweep
+    // OFF (opt-in) and 30 min.
     let json = "{}".data(using: .utf8)!
     let decoded = try JSONDecoder().decode(Config.self, from: json)
-    #expect(decoded.autoHibernateEnabled == true)
+    #expect(decoded.autoHibernateEnabled == false)
     #expect(decoded.hibernateIdleMinutes == Config.defaultHibernateIdleMinutes)
 }
 


### PR DESCRIPTION
## Summary

- The auto-hibernate **idle sweep** now defaults to **OFF**. Manual "Hibernate now" and the rest of the hibernation machinery are unchanged — only the idle sweep's default gate flips.
- This required a migration, not just a Swift default change. Details below.
- **This is a one-time forced opt-out.** If you use auto-hibernate, you will need to re-enable it once.

## Why

The idle sweep runs `HibernationSafetyChecks.hasPendingInput(paneCapture:)`, a sanctioned TUI screen-scrape (see the "No TUI screen-scraping" section of `CLAUDE.md`). Its failure direction is asymmetric: if Claude Code ever changes its `>` composer/box rendering, typed-but-unsent input goes **unrecognized and gets eaten by the park**. Silent data loss, triggered by an upstream cosmetic change we don't control.

Defaulting the sweep off shrinks the default-on scraping surface to zero. Anyone who wants the memory reclamation can opt in and accept the tradeoff knowingly.

## A migration was required — the Swift default flip alone would have been a no-op

The obvious change is `autoHibernateEnabled: Bool = true` → `false` plus `auto_hibernate_enabled ?? true` → `?? false`. That would have changed nothing for anyone:

- Migration `v1` inserts a `config` singleton row on **every** install (`INSERT OR IGNORE INTO config (id, ...) VALUES ('singleton', NULL)`).
- Migration `v39` added `auto_hibernate_enabled` with SQLite `DEFAULT 1`.
- `ALTER TABLE ... ADD COLUMN ... DEFAULT 1` **backfills pre-existing rows to `1`, not NULL** — verified empirically against a scratch DB and a live `state.db`.

So the column is never NULL, `auto_hibernate_enabled ?? true` in `ConfigStore.swift` never fired, and the **SQL column default was the real default** all along. The Swift fallbacks are still flipped here (they govern the missing-row and old-JSON decode paths), but the behavior change comes from a new migration:

```
v50_auto_hibernate_idle_sweep_off_by_default
  → UPDATE config SET auto_hibernate_enabled = 0
```

No schema change. Naturally idempotent, and GRDB runs it exactly once.

## Behavior change, stated plainly

Because an explicit `true` and a never-touched `true` are **byte-identical** in that column, the migration clears both. There is no way to distinguish them after the fact.

- Everyone who had the sweep on — deliberately or by default — gets it off, once.
- Re-enable in Settings if you want it back. A later opt-in **sticks across restarts** (covered by a test).
- `hibernate_idle_minutes` is preserved. Your timeout survives.

## Scope: this is a global switch, not per-worktree

Worth stating because the naming invites the opposite assumption:

- `config.auto_hibernate_enabled` is **global** — the `config` table holds exactly one row (`id = 'singleton'`). Re-enabling is **a single toggle in Settings, once** — not once per worktree.
- The genuinely per-worktree `worktree.autoHibernateOnMerge` and its global default `config.auto_hibernate_on_merge_default` drive the **separate** hibernate-on-PR-merge feature. Those already default to off and are **untouched** here.

## Heads up @zionts

Auto-hibernate now defaults to OFF — you're the only known user. **Re-enable it in Settings if you rely on it.**

To be straight with you: we initially thought an explicit existing "on" setting would be preserved. It isn't. The v39 column default made an explicit `true` indistinguishable from never having touched the toggle, so the migration clears both. You'll need to flip it back on once, **globally** (not per worktree). Your idle-timeout minutes are preserved.

## Test plan

- [x] `swift build` — clean
- [x] `swiftlint --strict` — 0 violations across 518 files
- [x] Full suite: `swift test --parallel -j 2` → **3288 tests / 401 suites pass**
- [x] Both gate branches covered: the sweep hibernates when enabled, returns `.featureDisabled` when not
- [x] New migration test: a fresh DB reads `false`; an opt-in (`true`) round-trips; an opt-back-out (`false`) round-trips
- [x] Manual "Hibernate now" while auto is off remains covered (`manualHibernateWorksWhileAutoOff`)

[20260709-rigid-pike](https://cheapsteak.github.io/tbd/open/?worktree=B02F266F-76F9-4F99-A750-8098F62EA3F9)