### PR TITLE
DX: Make backgroundIndexing-off the committed default so every worktree stops wasting 2.6 GiB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@ docs/plans/
 
 # Mock harness screenshot artifacts
 artifacts/
-
-# Local SourceKit-LSP suppression config seeded by scripts/reclaim-build.sh (never commit)
-.sourcekit-lsp/

--- a/.sourcekit-lsp/config.json
+++ b/.sourcekit-lsp/config.json
@@ -1,0 +1,3 @@
+{
+  "backgroundIndexing": false
+}

--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -4,11 +4,20 @@ Keeps each TBD worktree's SwiftPM `.build` small. **Not part of the shipped prod
 
 ## What it does (hourly, via launchd)
 Only acts on worktrees containing a `Package.swift` (SwiftPM packages) — `tbd worktree list` spans every repo TBD manages, including non-Swift ones (e.g. longeye-app, longeye-docs, agent-channels), which are skipped entirely.
-1. Seeds a **gitignored** `.sourcekit-lsp/config.json` (`"backgroundIndexing": false`) into every active worktree, so SourceKit-LSP never builds the ~2.6 GiB `index-build/`. Trade-off: cross-file LSP (workspace symbols, global find-references, cross-module go-to-definition) is disabled on TBD worktrees; live single-file diagnostics still work. Reversible — delete the `.sourcekit-lsp/` dirs.
-2. Deletes stale build artifacts from **active, idle** worktrees:
-   - **Tier 1** — `index-build/` idle > 6h → deleted (regenerates on demand).
-   - **Tier 2** — whole `.build` idle > 48h AND no live Claude session → deleted (one cold rebuild next time).
-   Worktrees with a running `swift-*` build process are never touched. Archived worktrees are already reclaimed by `git worktree remove`.
+
+SourceKit-LSP background-indexing suppression is a **committed** `.sourcekit-lsp/config.json` (`"backgroundIndexing": false`) at the repo root, present in every worktree the moment it's checked out — the script no longer seeds it. Trade-off: cross-file LSP (workspace symbols, global find-references, cross-module go-to-definition) is disabled on TBD worktrees; live single-file diagnostics still work.
+
+The script itself only reclaims disk from **active, idle** worktrees:
+- **Tier 1** — `index-build/` idle > 6h → deleted (regenerates on demand).
+- **Tier 2** — whole `.build` idle > 48h AND no live Claude session → deleted (one cold rebuild next time).
+
+Worktrees with a running `swift-*` build process are never touched. Archived worktrees are already reclaimed by `git worktree remove`.
+
+### Re-enabling background indexing
+A project-local `.sourcekit-lsp/config.json` takes precedence over user-global SourceKit-LSP config. To get cross-file LSP back on your machine without affecting the committed default: set `"backgroundIndexing": true` in the file locally, then run `git update-index --skip-worktree .sourcekit-lsp/config.json` so the flip is never committed. Alternatively, just delete the file locally.
+
+### Migration note
+Worktrees created before this change may have an untracked `.sourcekit-lsp/config.json` left over from the old per-worktree seeding, which git will flag as colliding with the newly-tracked file on pull. Remove it (`rm .sourcekit-lsp/config.json`) and re-checkout, or leave it — its contents are identical to the committed version.
 
 ## Install / uninstall
 ```sh

--- a/scripts/reclaim-build.sh
+++ b/scripts/reclaim-build.sh
@@ -40,20 +40,6 @@ has_active_build() {
   _ps_lines | grep -Ei 'swift-build|swift-frontend|swiftc|swift-driver' | grep -Fq -- "$wt"
 }
 
-# ensure_lsp_config WORKTREE_PATH DRY -> seed backgroundIndexing:false if absent
-ensure_lsp_config() {
-  local wt="$1" dry="$2"
-  local cfg="$wt/.sourcekit-lsp/config.json"
-  if [[ -f "$cfg" ]]; then
-    echo "SKIP lsp-config-exists $wt"
-    return 0
-  fi
-  echo "SEED lsp-config $wt"
-  [[ "$dry" == "true" ]] && return 0
-  mkdir -p "$wt/.sourcekit-lsp"
-  printf '{\n  "backgroundIndexing": false\n}\n' > "$cfg"
-}
-
 # list_worktrees_tsv -> "<path>\t<liveSessions>" for each active worktree
 list_worktrees_tsv() {
   _worktree_json | jq -r '.[] | select(.status == "active") | [.path, (.liveClaudeSessionCount // 0)] | @tsv'
@@ -108,7 +94,6 @@ main() {
   while IFS=$'\t' read -r wt sessions; do
     [[ -n "$wt" ]] || continue
     [[ -f "$wt/Package.swift" ]] || continue   # only SwiftPM-package worktrees produce .build/index-build
-    ensure_lsp_config "$wt" "$dry"
     plan_worktree "$wt" "$sessions"
   done < <(list_worktrees_tsv) | tee "$plan_file" >&2
 

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -61,33 +61,6 @@ test_has_active_build_false_when_swift_proc_other_worktree() {
   fi
 }
 
-test_ensure_lsp_config_seeds_when_absent() {
-  local wt; wt="$(mktmpd)"
-  local out; out="$(ensure_lsp_config "$wt" false)"
-  assert_contains "seeds when absent (output)" "$out" "SEED lsp-config"
-  assert_eq "config file written" "true" "$([[ -f "$wt/.sourcekit-lsp/config.json" ]] && echo true || echo false)"
-  assert_contains "config disables bg indexing" "$(cat "$wt/.sourcekit-lsp/config.json")" '"backgroundIndexing": false'
-  rm -rf "$wt"
-}
-
-test_ensure_lsp_config_dry_run_writes_nothing() {
-  local wt; wt="$(mktmpd)"
-  local out; out="$(ensure_lsp_config "$wt" true)"
-  assert_contains "dry-run still reports SEED" "$out" "SEED lsp-config"
-  assert_eq "dry-run writes no file" "false" "$([[ -f "$wt/.sourcekit-lsp/config.json" ]] && echo true || echo false)"
-  rm -rf "$wt"
-}
-
-test_ensure_lsp_config_noop_when_present() {
-  local wt; wt="$(mktmpd)"
-  mkdir -p "$wt/.sourcekit-lsp"
-  printf '{ "someOtherKey": true }\n' > "$wt/.sourcekit-lsp/config.json"
-  local out; out="$(ensure_lsp_config "$wt" false)"
-  assert_contains "no-op when present (output)" "$out" "SKIP lsp-config-exists"
-  assert_contains "existing config untouched" "$(cat "$wt/.sourcekit-lsp/config.json")" '"someOtherKey": true'
-  rm -rf "$wt"
-}
-
 # helper: build a fake worktree with index-build + debug build files aged relative to NOW
 _mk_worktree() { # dir now index_age debug_age
   local d="$1" now="$2" iage="$3" dage="$4"
@@ -180,11 +153,10 @@ JSON
   assert_contains "dry-run plans tier1 for b" "$out" "PLAN tier1 $b"
   assert_eq "dry-run keeps a/.build" "true" "$([[ -d "$a/.build" ]] && echo true || echo false)"
   assert_eq "dry-run keeps b/index-build" "true" "$([[ -d "$b/.build/index-build" ]] && echo true || echo false)"
-  assert_eq "dry-run seeds no lsp config" "false" "$([[ -f "$a/.sourcekit-lsp/config.json" ]] && echo true || echo false)"
   rm -rf "$root"
 }
 
-test_main_real_run_reclaims_and_seeds() {
+test_main_real_run_reclaims() {
   local root; root="$(mktmpd)"; local now=2000000000
   local a="$root/active-a" b="$root/active-b"
   _mk_worktree "$a" "$now" 200000 200000   # tier2 -> whole .build deleted
@@ -200,8 +172,6 @@ JSON
   assert_eq "tier2 removed a/.build"          "false" "$([[ -d "$a/.build" ]] && echo true || echo false)"
   assert_eq "tier1 removed b/index-build"     "false" "$([[ -d "$b/.build/index-build" ]] && echo true || echo false)"
   assert_eq "tier1 kept b debug build"        "true"  "$([[ -d "$b/.build/arm64-apple-macosx" ]] && echo true || echo false)"
-  assert_eq "seeded lsp config in a"          "true"  "$([[ -f "$a/.sourcekit-lsp/config.json" ]] && echo true || echo false)"
-  assert_eq "seeded lsp config in b"          "true"  "$([[ -f "$b/.sourcekit-lsp/config.json" ]] && echo true || echo false)"
   rm -rf "$root"
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #388. That PR suppressed SourceKit-LSP's 2.6 GiB `index-build` by having the hourly reaper **seed** a gitignored `.sourcekit-lsp/config.json` per worktree. But multi-worktree development is TBD's whole model, so *every* worktree paying for a background index nobody asked for is a project-wide default worth fixing — not a per-machine workaround.

This **commits** `.sourcekit-lsp/config.json` (`backgroundIndexing: false`) at the repo root, so the default lands the instant a worktree is checked out — no seeding, no hourly lag (the lag is why some worktrees still showed a 2.6 GiB `index-build` under the old approach), and no reliance on a script running for suppression.

- **Commit** `.sourcekit-lsp/config.json` (`backgroundIndexing: false`) + un-ignore it in `.gitignore`.
- **Remove** the now-redundant `ensure_lsp_config` seeding from `scripts/reclaim-build.sh` (+ its tests). The reaper is now **pure GC** — it still reclaims stale `.build`/`index-build`; it just no longer manages the config.

## Behavior + how to opt back in

Background indexing (cross-file LSP: workspace symbols, global find-references, cross-module go-to-definition) is now **off by default in every checkout**. Live single-file diagnostics are unaffected. Because a project-local `.sourcekit-lsp/config.json` has **higher precedence** than user-global sourcekit-lsp config, a developer who wants indexing back sets `"backgroundIndexing": true` locally and runs `git update-index --skip-worktree .sourcekit-lsp/config.json` (so the flip isn't committed), or deletes the file. Documented in `docs/reclaim-build.md`.

**Migration note:** worktrees created before this change hold an *untracked* `.sourcekit-lsp/config.json` (from the old seeding) that git will flag as colliding on pull — `rm` it and re-checkout the identical committed one.

## Test plan

- [x] `bash scripts/reclaim-build.test.sh` — all pass (3 `ensure_lsp_config` unit tests removed; GC + integration coverage intact).
- [x] `shellcheck scripts/reclaim-build.sh scripts/reclaim-build.test.sh scripts/install-reclaim-agent.sh` — clean.
- [x] `.sourcekit-lsp/config.json` is tracked; `.gitignore` no longer ignores it; reaper has zero `ensure_lsp_config`/`sourcekit-lsp` references.
- [x] Verified live in #388: a worktree with the config + active LSP generates **zero** `index-build`; the one worktree *without* it carried the full 2.4 GiB — so the config is genuinely honored.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B95A348F-9277-4B2D-BBD9-1655E91E1B61)