### PR TITLE
Fix: Reap .build in Claude agent worktrees — 36 GiB blind spot in the disk reaper

### DIFF
--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -13,6 +13,14 @@ The script itself only reclaims disk from **active, idle** worktrees:
 
 Worktrees with a running `swift-*` build process are never touched. Archived worktrees are already reclaimed by `git worktree remove`.
 
+### Claude agent worktrees
+
+`isolation: "worktree"` subagents and Workflow runs make Claude Code create their own git worktrees under `<repo-root>/.claude/worktrees/agent-*` and `<repo-root>/.claude/worktrees/wf_*`. These are real git worktrees — visible in `git worktree list` — but they are **not** TBD-managed, so `tbd worktree list` never sees them and the reaper used to skip them entirely.
+
+They accumulate because Claude Code only auto-removes an agent worktree if it ends up unchanged; the moment an agent commits, the worktree persists (by design, so the commit/branch survives), and its gitignored `.build` persists with it. Nothing else ever cleans these up. One incident: 17 such worktrees, all idle 6+ days, had accumulated 36 GiB before being hand-deleted.
+
+The reaper now finds them too: for each repo root derived from the TBD worktree list (via `git -C <wt> rev-parse --path-format=absolute --git-common-dir`, deduped), it globs `<root>/.claude/worktrees/*/`, applies the same `Package.swift` gate, and feeds the results through the identical tier logic. They have no TBD session concept, so they're always treated as "no live session" — Tier 2 eligible on idleness alone. All the same safety rails (`has_active_build`, `RECLAIM_ACTIVE_GRACE`) still apply.
+
 ### Re-enabling background indexing
 A project-local `.sourcekit-lsp/config.json` takes precedence over user-global SourceKit-LSP config. To get cross-file LSP back on your machine without affecting the committed default: set `"backgroundIndexing": true` in the file locally, then run `git update-index --skip-worktree .sourcekit-lsp/config.json` so the flip is never committed. Alternatively, just delete the file locally.
 
@@ -34,6 +42,17 @@ scripts/reclaim-build.sh             # reclaim now
 
 ## Tuning
 `RECLAIM_T1_SECONDS` (default 21600) and `RECLAIM_T2_SECONDS` (default 172800) override the thresholds.
+
+## Env vars
+| Var | Default | Purpose |
+|---|---|---|
+| `RECLAIM_WT_JSON` | run `tbd worktree list --json` | Fixture file for the TBD worktree list (tests) |
+| `RECLAIM_PS_CMD` | `ps -axo pid,args` | Fixture command for the active-build-process scan (tests) |
+| `RECLAIM_T1_SECONDS` | `21600` (6h) | Tier-1 (`index-build/`) idle threshold |
+| `RECLAIM_T2_SECONDS` | `172800` (48h) | Tier-2 (whole `.build`) idle threshold |
+| `RECLAIM_ACTIVE_GRACE` | `600` (10m) | Skip a `.build` whose newest mtime is more recent than this, even if a `PLAN` was made |
+| `RECLAIM_NOW` | `date +%s` | Epoch seconds treated as "now" (tests) |
+| `RECLAIM_REPO_ROOTS` | derived from the TBD worktree list's git-common-dir | Newline-separated repo roots to scan for `.claude/worktrees/*` — overrides derivation entirely (tests, or to point at a repo TBD doesn't manage) |
 
 ## Future
 The ~4.6 GiB of compiled artifacts can only be de-duplicated across worktrees via SwiftPM compilation caching (LLVM CAS + prefix mapping) on the new Swift Build engine — currently an opt-in pitch. Track and pilot when it lands.

--- a/scripts/reclaim-build.sh
+++ b/scripts/reclaim-build.sh
@@ -13,6 +13,8 @@
 #   RECLAIM_T1_SECONDS  Tier-1 (index-build) idle threshold (default 21600 = 6h)
 #   RECLAIM_T2_SECONDS  Tier-2 (whole .build) idle threshold (default 172800 = 48h)
 #   RECLAIM_NOW         epoch seconds treated as "now"      (default: date +%s)
+#   RECLAIM_REPO_ROOTS  newline-separated repo roots to scan for .claude/worktrees/*
+#                       (default: derived from the TBD worktree list's git-common-dir)
 
 RECLAIM_T1_SECONDS="${RECLAIM_T1_SECONDS:-21600}"
 RECLAIM_T2_SECONDS="${RECLAIM_T2_SECONDS:-172800}"
@@ -43,6 +45,56 @@ has_active_build() {
 # list_worktrees_tsv -> "<path>\t<liveSessions>" for each active worktree
 list_worktrees_tsv() {
   _worktree_json | jq -r '.[] | select(.status == "active") | [.path, (.liveClaudeSessionCount // 0)] | @tsv'
+}
+
+# repo_root_for_worktree WORKTREE_PATH -> absolute repo root (parent of the
+# common .git dir), or nonzero exit if the worktree is gone / not a git dir.
+# A TBD worktree may have been deleted between listing and probing; callers
+# guard with `|| continue`.
+repo_root_for_worktree() {
+  local wt="$1" common_git
+  common_git="$(git -C "$wt" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+  [[ -n "$common_git" ]] || return 1
+  dirname "$common_git"
+}
+
+# repo_roots -> unique repo roots to scan for Claude agent worktrees.
+# RECLAIM_REPO_ROOTS (newline-separated), when set, is used INSTEAD of
+# deriving roots from the TBD worktree list — the test injection seam.
+repo_roots() {
+  if [[ -n "${RECLAIM_REPO_ROOTS:-}" ]]; then
+    printf '%s\n' "$RECLAIM_REPO_ROOTS"
+  else
+    local wt sessions root
+    while IFS=$'\t' read -r wt sessions; do
+      [[ -n "$wt" ]] || continue
+      root="$(repo_root_for_worktree "$wt")" || continue
+      [[ -n "$root" ]] || continue
+      printf '%s\n' "$root"
+    done < <(list_worktrees_tsv)
+  fi | grep -v '^[[:space:]]*$' | sort -u
+}
+
+# claude_agent_worktrees_tsv -> "<path>\t0" for each .claude/worktrees/*/ dir
+# under every repo root. These have no TBD session concept, so they're always
+# reported with 0 live sessions (Tier-2 eligible on idleness alone). The
+# Package.swift gate is applied by the caller, same as TBD worktrees.
+claude_agent_worktrees_tsv() {
+  local root d
+  while IFS= read -r root; do
+    [[ -n "$root" ]] || continue
+    for d in "$root"/.claude/worktrees/*/; do
+      [[ -d "$d" ]] || continue
+      printf '%s\t0\n' "${d%/}"
+    done
+  done < <(repo_roots)
+}
+
+# list_all_worktrees_tsv -> combined TBD + Claude-agent worktrees, deduped by
+# path (first occurrence wins, so a TBD-list session count beats the
+# Claude-agent default of 0 if the same path somehow appears in both).
+list_all_worktrees_tsv() {
+  { list_worktrees_tsv; claude_agent_worktrees_tsv; } | awk -F'\t' '!seen[$1]++'
 }
 
 # plan_worktree WORKTREE_PATH LIVE_SESSIONS -> one decision line (or nothing if no .build)
@@ -95,7 +147,7 @@ main() {
     [[ -n "$wt" ]] || continue
     [[ -f "$wt/Package.swift" ]] || continue   # only SwiftPM-package worktrees produce .build/index-build
     plan_worktree "$wt" "$sessions"
-  done < <(list_worktrees_tsv) | tee "$plan_file" >&2
+  done < <(list_all_worktrees_tsv) | tee "$plan_file" >&2
 
   if [[ "$dry" != "true" ]]; then
     local action tier path

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -225,6 +225,81 @@ JSON
   rm -rf "$root"
 }
 
+test_repo_root_for_worktree_returns_parent_of_git_common_dir() {
+  local d; d="$(mktmpd)"
+  git init -q "$d"
+  # git canonicalizes symlinks (e.g. macOS /tmp -> /private/tmp) in its
+  # absolute-path output, so compare against the same resolution.
+  local expected; expected="$(cd "$d" && pwd -P)"
+  local out; out="$(repo_root_for_worktree "$d")"
+  assert_eq "repo root is parent of .git" "$expected" "$out"
+  rm -rf "$d"
+}
+
+test_repo_root_for_worktree_fails_for_non_git_dir() {
+  local d; d="$(mktmpd)"
+  local out rc=0
+  out="$(repo_root_for_worktree "$d")" || rc=$?
+  assert_eq "non-git dir yields nonzero exit" "1" "$rc"
+  assert_eq "non-git dir yields empty output" "" "$out"
+  rm -rf "$d"
+}
+
+test_claude_agent_worktree_tier2_reaped() {
+  local root; root="$(mktmpd)"; local now=2000000000
+  local agent="$root/.claude/worktrees/agent-abc123"
+  _mk_worktree "$agent" "$now" 200000 200000   # both stale -> tier2
+  local j="$root/wt.json"; printf '[]' > "$j"
+  RECLAIM_NOW=$now RECLAIM_WT_JSON="$j" RECLAIM_REPO_ROOTS="$root" RECLAIM_PS_CMD="$NO_PS" \
+    bash "$HERE/reclaim-build.sh" >/dev/null 2>&1
+  assert_eq "claude agent worktree .build reaped (tier2)" "false" "$([[ -d "$agent/.build" ]] && echo true || echo false)"
+  rm -rf "$root"
+}
+
+test_claude_agent_worktree_without_package_swift_skipped() {
+  local root; root="$(mktmpd)"; local now=2000000000
+  local agent="$root/.claude/worktrees/agent-nopkg"
+  mkdir -p "$agent/.build/arm64-apple-macosx/debug"
+  : > "$agent/.build/arm64-apple-macosx/debug/app.o"
+  touch_age "$agent/.build/arm64-apple-macosx/debug/app.o" "$now" 200000
+  # deliberately NO Package.swift
+  local j="$root/wt.json"; printf '[]' > "$j"
+  local out; out="$(RECLAIM_NOW=$now RECLAIM_WT_JSON="$j" RECLAIM_REPO_ROOTS="$root" RECLAIM_PS_CMD="$NO_PS" \
+    bash "$HERE/reclaim-build.sh" --dry-run 2>&1)"
+  assert_missing "non-swift claude agent worktree skipped entirely" "$out" "$agent"
+  rm -rf "$root"
+}
+
+test_claude_agent_worktree_fresh_build_skipped() {
+  local root; root="$(mktmpd)"; local now=2000000000
+  local agent="$root/.claude/worktrees/agent-fresh"
+  _mk_worktree "$agent" "$now" 60 60   # 1 min old — within grace, fresh
+  local j="$root/wt.json"; printf '[]' > "$j"
+  local out; out="$(RECLAIM_NOW=$now RECLAIM_WT_JSON="$j" RECLAIM_REPO_ROOTS="$root" RECLAIM_PS_CMD="$NO_PS" \
+    bash "$HERE/reclaim-build.sh" --dry-run 2>&1)"
+  assert_contains "fresh claude agent worktree skipped" "$out" "SKIP fresh $agent"
+  rm -rf "$root"
+}
+
+test_repo_roots_injection_dedups_against_tbd_list() {
+  local root; root="$(mktmpd)"; local now=2000000000
+  # Same path enumerated via BOTH the TBD list and RECLAIM_REPO_ROOTS-derived
+  # .claude/worktrees glob — dedup must keep exactly one line, using the TBD
+  # list's (nonzero) session count so tier2 (needs sessions==0) is blocked.
+  local dup="$root/.claude/worktrees/dup-agent"
+  _mk_worktree "$dup" "$now" 200000 200000   # both stale -> tier2 if sessions==0
+  local j="$root/wt.json"
+  cat > "$j" <<JSON
+[{"path":"$dup","status":"active","liveClaudeSessionCount":5}]
+JSON
+  local out; out="$(RECLAIM_NOW=$now RECLAIM_WT_JSON="$j" RECLAIM_REPO_ROOTS="$root" RECLAIM_PS_CMD="$NO_PS" \
+    bash "$HERE/reclaim-build.sh" --dry-run 2>&1)"
+  local count; count="$(grep -c -- "$dup" <<<"$out")"
+  assert_eq "dup path processed exactly once" "1" "$count"
+  assert_contains "dup path uses TBD session count -> tier1 not tier2" "$out" "PLAN tier1 $dup"
+  rm -rf "$root"
+}
+
 test_plan_tier2_works_on_x86_64_triple() {
   local d; d="$(mktmpd)"; local now=2000000000
   mkdir -p "$d/.build/x86_64-apple-macosx/debug"


### PR DESCRIPTION
## Summary

**What's broken:** the `.build` disk reaper (#388) only enumerates TBD-managed worktrees via `tbd worktree list`. Claude Code creates its *own* agent worktrees under `<repo-root>/.claude/worktrees/` (for `isolation: worktree` subagents and Workflow runs), and Claude auto-removes one only if it's *unchanged* — once an agent commits, the worktree persists along with the ~2.7 GiB gitignored `.build` its `swift build` produced. 17 of these had silently accumulated **36 GiB** (all idle 6+ days) before being found and hand-reaped today.

**What this PR does:** adds a second enumeration source to `scripts/reclaim-build.sh`:

- Derives unique repo roots from the TBD worktree list (`git rev-parse --git-common-dir` → parent dir), injectable via new `RECLAIM_REPO_ROOTS` env var for tests.
- Globs `<root>/.claude/worktrees/*/`, gated on `Package.swift` exactly like the existing source, so non-SwiftPM repos are never touched.
- Applies the same tier logic (Tier-1 `index-build` >6h idle, Tier-2 whole `.build` >48h idle) and the same safety rails (active-build ps scan, 10-min mtime grace). Agent worktrees have no TBD session concept, so Tier-2 gates on idleness alone — called out in the docs.
- Dedups the combined list by path; a worktree adopted into TBD (`import-claude-code-desktop.sh`) appears in both sources, and the TBD entry (with its real session count) wins.

## Test plan

- [x] `bash scripts/reclaim-build.test.sh` — 39 ok, 0 FAIL (9 new tests, incl. an end-to-end non-dry-run test asserting the agent worktree's `.build` is actually deleted, and a dedup test asserting exactly one plan line with the TBD session count winning)
- [x] `shellcheck scripts/reclaim-build.sh scripts/reclaim-build.test.sh` — clean
- [x] Live dry-run on the real machine: enumerates all 17 `/Users/chang/projects/tbd/.claude/worktrees/*` candidates, zero planned deletions in non-SwiftPM repos (`longeye-app` excluded correctly), exit 0

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B95A348F-9277-4B2D-BBD9-1655E91E1B61)