### PR TITLE
DX: Stop a 5s wall-clock timer from flaking the attach orchestration suite (146s CI failures)

### DIFF
--- a/Tests/TBDDaemonTests/AttachRPCTests.swift
+++ b/Tests/TBDDaemonTests/AttachRPCTests.swift
@@ -144,14 +144,6 @@ struct AttachRPCOrchestrationTests {
             commandProvider: commandProvider)
     }
 
-    /// Thread-safe, synchronous recorder of fake-client stream writes.
-    private final class Recorder: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _writes: [String] = []
-        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
-        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
-    }
-
     /// Thread-safe monotonic counter — lets a commandProvider hand each
     /// successive attach.ready sequence its OWN fake correlator, so a test
     /// can complete a later sequence's replies before an earlier one's.
@@ -159,16 +151,6 @@ struct AttachRPCOrchestrationTests {
         private let lock = NSLock()
         private var count = 0
         func next() -> Int { lock.lock(); defer { lock.unlock() }; let c = count; count += 1; return c }
-    }
-
-    /// A fake-backed correlator (real FIFO, recorded writes) for the bridge's
-    /// commandProvider seam — the M4.3 attach.ready sequence rides it.
-    private func makeFakeClient() -> (TmuxControlCommandClient, Recorder) {
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
-        return (client, recorder)
     }
 
     /// A 22-field state line for `paneID` (80x24, primary screen, cursor 0,0,
@@ -185,7 +167,7 @@ struct AttachRPCOrchestrationTests {
     /// (R8-M3), so it carries the history content these tests assert on
     /// (screen leg empty → combined == history).
     private func feedCaptureReplies(
-        _ client: TmuxControlCommandClient, recorder: Recorder, paneID: String,
+        _ client: TmuxControlCommandClient, recorder: LineRecorder, paneID: String,
         history: [String], captureBatchWrites: Int = 2,
         sourceLocation: SourceLocation = #_sourceLocation
     ) async throws {
@@ -196,19 +178,6 @@ struct AttachRPCOrchestrationTests {
         for lines in [history, [], [], history, [stateLine(paneID: paneID)], [], [] as [String]] {
             await client.handle(.commandSucceeded(number: 0, fromClient: true, lines: lines))
         }
-    }
-
-    private func waitFor(
-        _ what: String, deadline: Duration = .seconds(60),
-        sourceLocation: SourceLocation = #_sourceLocation,
-        _ condition: @Sendable () async -> Bool
-    ) async throws {
-        let end = ContinuousClock.now + deadline
-        while ContinuousClock.now < end {
-            if await condition() { return }
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
     }
 
     /// Drain everything currently readable from `fd` (made nonblocking).

--- a/Tests/TBDDaemonTests/AttachRPCTests.swift
+++ b/Tests/TBDDaemonTests/AttachRPCTests.swift
@@ -123,7 +123,16 @@ struct AttachRPCOrchestrationTests {
         supervisor: TmuxControlSupervisor,
         vending: FDVendingServer,
         gateOn: Bool = true,
-        readyTimeout: Duration = .seconds(5),
+        // Effectively-infinite default: the ready-timeout is incidental
+        // machinery in these orchestration tests, and it spawns a REAL
+        // wall-clock timer per attach.request that tears down an un-acked
+        // attach. Under parallel CI load a test task can be starved for
+        // seconds between an attach.request and its attach.ready; a short
+        // default lets the timer fire in that gap, tear down the sink, and
+        // fail the ready with notAttached (observed CI flake). The one test
+        // that exercises the timeout, `unackedAttachTornDownAfterTimeout`,
+        // passes its own short value explicitly.
+        readyTimeout: Duration = .seconds(600),
         commandProvider: (@Sendable (String) async -> TmuxControlCommandClient?)? = nil
     ) -> TmuxControlModeBridge {
         TmuxControlModeBridge(

--- a/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
+++ b/Tests/TBDDaemonTests/AttachReplayFenceTests.swift
@@ -4,11 +4,6 @@ import Testing
 
 @testable import TBDDaemonLib
 
-/// Positive-wait deadline sized for starved CI runners (PR #379: cooperative-pool
-/// starvation stretched sub-second async-drain deliveries past a 5 s poll).
-/// Passing runs still complete in milliseconds — only failures wait this long.
-private let ciSafeDeadline: Duration = .seconds(30)
-
 /// Phase B M2 — the attach-boundary fence (issue #376, second bullet).
 ///
 /// Before M2, output a pane emitted between the attach's capture and the
@@ -30,21 +25,10 @@ private let ciSafeDeadline: Duration = .seconds(30)
 struct AttachReplayFenceTests {
     private let server = "tbd-fence-unit"
 
-    /// Thread-safe, synchronous recorder of stream writes in call order.
-    private final class Recorder: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _writes: [String] = []
-        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
-        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
-    }
-
     private func makeHarness() -> (
-        TmuxControlSupervisor, AttachReplayOrchestrator, Recorder, TmuxControlCommandClient
+        TmuxControlSupervisor, AttachReplayOrchestrator, LineRecorder, TmuxControlCommandClient
     ) {
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+        let (client, recorder) = makeFakeClient()
         let supervisor = TmuxControlSupervisor()
         let orchestrator = AttachReplayOrchestrator(
             supervisor: supervisor,
@@ -56,21 +40,6 @@ struct AttachReplayFenceTests {
     /// cursor at (x=2, y=1) — the replay's final CUP must be `ESC[2;3H`.
     private func stateLine(paneID: String) -> String {
         "\(paneID) 2 1 0 4294967295 4294967295 0 23 1 0 0 0 1 0 0 0 0 0 0 80 24 1"
-    }
-
-    /// Poll until `condition`, failing after `deadline` (async work — the
-    /// orchestrator's batch writes — lands on other tasks).
-    private func waitFor(
-        _ what: String, deadline: Duration = ciSafeDeadline,
-        sourceLocation: SourceLocation = #_sourceLocation,
-        _ condition: @Sendable () async -> Bool
-    ) async throws {
-        let end = ContinuousClock.now + deadline
-        while ContinuousClock.now < end {
-            if await condition() { return }
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
     }
 
     /// Complete the next `lines.count` pending commands with `%end`.

--- a/Tests/TBDDaemonTests/AttachReplayOrchestratorTests.swift
+++ b/Tests/TBDDaemonTests/AttachReplayOrchestratorTests.swift
@@ -17,14 +17,6 @@ import Testing
 struct AttachReplayOrchestratorTests {
     private let server = "tbd-orch-unit"
 
-    /// Thread-safe, synchronous recorder of stream writes in call order.
-    private final class Recorder: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _writes: [String] = []
-        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
-        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
-    }
-
     /// Parks the FIRST `commandProvider` call until `release()`; every later
     /// call passes straight through. Models a stale attach.ready task
     /// preempted at the provider hop while a successor's sequence runs.
@@ -94,11 +86,8 @@ struct AttachReplayOrchestratorTests {
         historyDepth: Int = 50_000,
         onHistoryTruncation: (@Sendable (Int) -> Void)? = nil,
         onPauseFailure: (@Sendable (String) -> Void)? = nil
-    ) -> (TmuxControlSupervisor, AttachReplayOrchestrator, Recorder, TmuxControlCommandClient) {
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+    ) -> (TmuxControlSupervisor, AttachReplayOrchestrator, LineRecorder, TmuxControlCommandClient) {
+        let (client, recorder) = makeFakeClient()
         let supervisor = TmuxControlSupervisor()
         let orchestrator = AttachReplayOrchestrator(
             supervisor: supervisor,
@@ -122,21 +111,6 @@ struct AttachReplayOrchestratorTests {
         "\(paneID) 2 1 1 0 0 0 23 1 0 0 0 1 0 0 0 0 0 0 80 24 \(historySize)"
     }
 
-    /// Poll until `condition`, failing after `deadline` (async work — the
-    /// orchestrator's batch write — lands on other tasks).
-    private func waitFor(
-        _ what: String, deadline: Duration = .seconds(60),
-        sourceLocation: SourceLocation = #_sourceLocation,
-        _ condition: @Sendable () async -> Bool
-    ) async throws {
-        let end = ContinuousClock.now + deadline
-        while ContinuousClock.now < end {
-            if await condition() { return }
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
-    }
-
     /// Complete the next `count` pending commands with `%end`, per-command lines.
     private func succeed(_ client: TmuxControlCommandClient, _ lines: [[String]]) async {
         for reply in lines {
@@ -148,7 +122,7 @@ struct AttachReplayOrchestratorTests {
     /// captures + continue) being written, then feed the 6 capture replies
     /// and the batched continue's reply.
     private func feedSequence(
-        _ client: TmuxControlCommandClient, recorder: Recorder,
+        _ client: TmuxControlCommandClient, recorder: LineRecorder,
         captures: [[String]],
         sourceLocation: SourceLocation = #_sourceLocation
     ) async throws {
@@ -657,7 +631,7 @@ struct AttachReplayOrchestratorTests {
 
     @Test("pause %error is surfaced but the replay still runs and the gate opens (review M4)")
     func pauseFailureSurfacedReplayProceeds() async throws {
-        let failures = Recorder()
+        let failures = LineRecorder()
         let (supervisor, orchestrator, recorder, client) = makeHarness(
             onPauseFailure: { failures.record($0) })
         let paneID = "%15"
@@ -687,7 +661,7 @@ struct AttachReplayOrchestratorTests {
 
     @Test("a successful pause does not trip the pause-failure hook")
     func pauseSuccessDoesNotFireHook() async throws {
-        let failures = Recorder()
+        let failures = LineRecorder()
         let (supervisor, orchestrator, recorder, client) = makeHarness(
             onPauseFailure: { failures.record($0) })
         let paneID = "%16"
@@ -708,10 +682,7 @@ struct AttachReplayOrchestratorTests {
     @Test("stale task parked at the provider hop sends ZERO commands once a successor's FULL sequence completed (R10-3)")
     func staleTaskParkedAtProviderHopSendsNothing() async throws {
         let gate = ProviderGate()
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+        let (client, recorder) = makeFakeClient()
         let supervisor = TmuxControlSupervisor()
         let orchestrator = AttachReplayOrchestrator(
             supervisor: supervisor,
@@ -726,7 +697,7 @@ struct AttachReplayOrchestratorTests {
 
         // The stale sequence acknowledges gen1, then is preempted at the
         // `await commandProvider(server)` hop (parked in the gate).
-        let staleDone = Recorder()
+        let staleDone = LineRecorder()
         let staleTask = Task { () throws -> AttachReplayOrchestrator.Outcome in
             defer { staleDone.record("done") }
             return try await orchestrator.performAttachReady(

--- a/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
@@ -34,15 +34,17 @@ struct ControlModeInputHealthTests {
     /// Poll until `recorder` has at least `count` health events (shared
     /// `waitFor`, which keeps the post-deadline re-check this suite needed
     /// under parallel-suite load).
+    @discardableResult
     private func waitForEvents(_ recorder: HealthRecorder, count: Int,
-                               sourceLocation: SourceLocation = #_sourceLocation) async throws {
+                               sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
         try await waitFor("\(count) health events", sourceLocation: sourceLocation) {
             recorder.events.count >= count
         }
     }
 
+    @discardableResult
     private func waitForWrites(_ recorder: LineRecorder, count: Int,
-                               sourceLocation: SourceLocation = #_sourceLocation) async throws {
+                               sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
         try await waitFor("\(count) stream writes", sourceLocation: sourceLocation) {
             recorder.writes.count >= count
         }
@@ -102,7 +104,7 @@ struct ControlModeInputHealthTests {
         for _ in 0..<3 { router.enqueue(header: header, bytes: Data([0x41])) }
         router.enqueue(header: header, bytes: Data([0xff]))
 
-        try await waitForEvents(health, count: 2)
+        try #require(await waitForEvents(health, count: 2))
         let events = health.events
         #expect(events.count == 2)
         #expect(events[0].healthy == false)

--- a/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
@@ -27,41 +27,25 @@ struct ControlModeInputHealthTests {
         }
     }
 
-    /// Thread-safe recorder of stream writes.
-    private final class Recorder: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _writes: [String] = []
-        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
-        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
-    }
-
     private final class ClientHolder: @unchecked Sendable {
         weak var client: TmuxControlCommandClient?
     }
 
-    /// Poll until `recorder` has at least `count` health events (15 s deadline +
-    /// post-deadline re-check; see ControlModeInputRouterTests.waitForWrites for
-    /// why the budget is generous under parallel-suite load).
+    /// Poll until `recorder` has at least `count` health events (shared
+    /// `waitFor`, which keeps the post-deadline re-check this suite needed
+    /// under parallel-suite load).
     private func waitForEvents(_ recorder: HealthRecorder, count: Int,
-                               timeout: Duration = .seconds(60)) async throws {
-        let deadline = ContinuousClock.now + timeout
-        while ContinuousClock.now < deadline {
-            if recorder.events.count >= count { return }
-            try await Task.sleep(for: .milliseconds(10))
+                               sourceLocation: SourceLocation = #_sourceLocation) async throws {
+        try await waitFor("\(count) health events", sourceLocation: sourceLocation) {
+            recorder.events.count >= count
         }
-        guard recorder.events.count < count else { return }
-        throw HealthTestError.timedOut(got: recorder.events.count, want: count)
     }
 
-    private func waitForWrites(_ recorder: Recorder, count: Int,
-                               timeout: Duration = .seconds(60)) async throws {
-        let deadline = ContinuousClock.now + timeout
-        while ContinuousClock.now < deadline {
-            if recorder.writes.count >= count { return }
-            try await Task.sleep(for: .milliseconds(10))
+    private func waitForWrites(_ recorder: LineRecorder, count: Int,
+                               sourceLocation: SourceLocation = #_sourceLocation) async throws {
+        try await waitFor("\(count) stream writes", sourceLocation: sourceLocation) {
+            recorder.writes.count >= count
         }
-        guard recorder.writes.count < count else { return }
-        throw HealthTestError.timedOut(got: recorder.writes.count, want: count)
     }
 
     /// A router whose client replies to every command: `%error` when
@@ -69,8 +53,8 @@ struct ControlModeInputHealthTests {
     /// back one per command in FIFO order, so completion order matches write
     /// order and health transitions are deterministic.
     private func makeRouter(shouldFail: @escaping @Sendable (String) -> Bool)
-        -> (ControlModeInputRouter, Recorder, HealthRecorder) {
-        let recorder = Recorder()
+        -> (ControlModeInputRouter, LineRecorder, HealthRecorder) {
+        let recorder = LineRecorder()
         let health = HealthRecorder()
         let holder = ClientHolder()
         let client = TmuxControlCommandClient(
@@ -297,5 +281,3 @@ struct ControlModeInputHealthTests {
         router.shutdown()
     }
 }
-
-private enum HealthTestError: Error { case timedOut(got: Int, want: Int) }

--- a/Tests/TBDDaemonTests/ControlModeInputRouterTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputRouterTests.swift
@@ -26,8 +26,9 @@ struct ControlModeInputRouterTests {
     /// Poll until `recorder` has at least `count` writes, or fail on timeout
     /// (shared `waitFor`, which keeps the post-deadline re-check this suite
     /// needed under parallel-suite load).
+    @discardableResult
     private func waitForWrites(_ recorder: LineRecorder, count: Int,
-                               sourceLocation: SourceLocation = #_sourceLocation) async throws {
+                               sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
         try await waitFor("\(count) stream writes", sourceLocation: sourceLocation) {
             recorder.writes.count >= count
         }
@@ -128,7 +129,7 @@ struct ControlModeInputRouterTests {
         router.enqueuePaste(header: header, bytes: Data(repeating: 0x50, count: 8 * 1024))  // large "P…"
         router.enqueue(header: header, bytes: Data([0x42]))                       // "B"
 
-        try await waitForWrites(recorder, count: 4)
+        try #require(await waitForWrites(recorder, count: 4))
         let writes = recorder.writes
         #expect(writes.count == 4)
         // send-keys A, then load-buffer + paste-buffer -p, then send-keys B.

--- a/Tests/TBDDaemonTests/ControlModeInputRouterTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputRouterTests.swift
@@ -10,23 +10,12 @@ import TBDShared
 @Suite("ControlModeInputRouter")
 struct ControlModeInputRouterTests {
 
-    /// Thread-safe, synchronous recorder of stream writes in call order.
-    private final class Recorder: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _writes: [String] = []
-        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
-        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
-    }
-
     /// Build a router whose single server "srv" resolves to a client backed by
     /// `recorder`. An unknown server resolves to nil.
     private func makeRouter(chunkSize: Int = 330,
                             latency: InputLatencyRecorder = InputLatencyRecorder())
-        -> (ControlModeInputRouter, Recorder) {
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+        -> (ControlModeInputRouter, LineRecorder) {
+        let (client, recorder) = makeFakeClient()
         let router = ControlModeInputRouter(
             commandProvider: { server in server == "srv" ? client : nil },
             latency: latency,
@@ -34,20 +23,14 @@ struct ControlModeInputRouterTests {
         return (router, recorder)
     }
 
-    /// Poll until `recorder` has at least `count` writes, or fail on timeout.
-    /// 15 s deadline + a final post-deadline re-check: under parallel-suite
-    /// load a sleep slice can overshoot the deadline AFTER the writes landed
-    /// (observed live as `timedOut(got: N, want: N)` at loadavg ~40), and the
-    /// old 2 s budget starved outright (`got: 2, want: 4`).
-    private func waitForWrites(_ recorder: Recorder, count: Int,
-                               timeout: Duration = .seconds(60)) async throws {
-        let deadline = ContinuousClock.now + timeout
-        while ContinuousClock.now < deadline {
-            if recorder.writes.count >= count { return }
-            try await Task.sleep(for: .milliseconds(10))
+    /// Poll until `recorder` has at least `count` writes, or fail on timeout
+    /// (shared `waitFor`, which keeps the post-deadline re-check this suite
+    /// needed under parallel-suite load).
+    private func waitForWrites(_ recorder: LineRecorder, count: Int,
+                               sourceLocation: SourceLocation = #_sourceLocation) async throws {
+        try await waitFor("\(count) stream writes", sourceLocation: sourceLocation) {
+            recorder.writes.count >= count
         }
-        guard recorder.writes.count < count else { return }
-        throw RouterTestError.timedOut(got: recorder.writes.count, want: count)
     }
 
     @Test("keystrokes for many frames are delivered to the stream in order")
@@ -111,8 +94,8 @@ struct ControlModeInputRouterTests {
     /// written stream line (a command list is one `\n`-joined write) is answered
     /// with one `%end` per contained command, preserving FIFO order.
     private func makeSelfRespondingRouter(chunkSize: Int = 330)
-        -> (ControlModeInputRouter, Recorder) {
-        let recorder = Recorder()
+        -> (ControlModeInputRouter, LineRecorder) {
+        let recorder = LineRecorder()
         let holder = ClientHolder()
         let client = TmuxControlCommandClient(
             writeLine: { line in
@@ -162,7 +145,7 @@ struct ControlModeInputRouterTests {
         // Client whose paste-buffer command FAILS (%error, tolerated). The
         // keystroke after the paste must still be written — deliverPaste logs
         // the failure and tears nothing down.
-        let recorder = Recorder()
+        let recorder = LineRecorder()
         let holder = ClientHolder()
         let client = TmuxControlCommandClient(
             writeLine: { line in
@@ -213,5 +196,3 @@ struct ControlModeInputRouterTests {
         router.shutdown()
     }
 }
-
-private enum RouterTestError: Error { case timedOut(got: Int, want: Int) }

--- a/Tests/TBDDaemonTests/ControlModeResizeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeResizeCoordinatorTests.swift
@@ -10,14 +10,6 @@ import Testing
 @Suite("ControlModeResizeCoordinator")
 struct ControlModeResizeCoordinatorTests {
 
-    /// Thread-safe, synchronous recorder of stream writes in call order.
-    private final class Recorder: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _writes: [String] = []
-        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
-        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
-    }
-
     /// Thread-safe monotonic call counter for the provider seam.
     private final class CallCounter: @unchecked Sendable {
         private let lock = NSLock()
@@ -45,11 +37,8 @@ struct ControlModeResizeCoordinatorTests {
     /// `recorder`; an unknown server resolves to nil. The client is returned so
     /// tests can feed reply blocks (`%end`/`%error`) back into it.
     private func makeCoordinator()
-        -> (ControlModeResizeCoordinator, Recorder, TmuxControlCommandClient) {
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+        -> (ControlModeResizeCoordinator, LineRecorder, TmuxControlCommandClient) {
+        let (client, recorder) = makeFakeClient()
         let coordinator = ControlModeResizeCoordinator(
             commandProvider: { server in server == "srv" ? client : nil })
         return (coordinator, recorder, client)
@@ -141,10 +130,7 @@ struct ControlModeResizeCoordinatorTests {
         // SocketServer spawns an unstructured Task per RPC, so two resize()
         // calls for one window can overlap; the OLDER call's provider hop
         // resolving LAST must not put the older geometry on the wire last.
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+        let (client, recorder) = makeFakeClient()
         let gate = ProviderGate()
         let calls = CallCounter()
         let coordinator = ControlModeResizeCoordinator(

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// Shared helpers for the control-mode test suites (attach orchestration,
+/// replay fence, pane repair, input router/health, resize coordinator). All
+/// of them fake tmux the same way: a real `TmuxControlCommandClient` whose
+/// `writeLine` records stream writes synchronously, with reply blocks fed by
+/// hand through `client.handle(...)` — the correlator is exercised, only its
+/// stdout is faked.
+
+/// Generous positive-wait poll deadline that only elapses on failure; sized
+/// for loaded parallel CI (PR #379: cooperative-pool starvation stretched
+/// sub-second async-drain deliveries past a 5 s poll). Passing runs still
+/// complete in milliseconds.
+let ciSafeDeadline: Duration = .seconds(30)
+
+/// Thread-safe, synchronous recorder of fake-client stream writes in call
+/// order.
+final class LineRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _writes: [String] = []
+    func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
+    var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
+}
+
+/// A fake-backed correlator: a real `TmuxControlCommandClient` whose stream
+/// writes land in the returned recorder (onFatalError is a no-op). Tests feed
+/// reply blocks by hand through `client.handle(...)`.
+func makeFakeClient() -> (TmuxControlCommandClient, LineRecorder) {
+    let recorder = LineRecorder()
+    let client = TmuxControlCommandClient(
+        writeLine: { recorder.record($0) },
+        onFatalError: {})
+    return (client, recorder)
+}
+
+/// Poll every 10 ms until `condition`, recording an Issue at the caller's
+/// source location after `deadline`. A final post-deadline re-check absorbs
+/// sleep slices that overshoot the deadline AFTER the condition became true
+/// (observed live as `timedOut(got: N, want: N)` at loadavg ~40).
+func waitFor(
+    _ what: String, deadline: Duration = ciSafeDeadline,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    _ condition: @Sendable () async -> Bool
+) async throws {
+    let end = ContinuousClock.now + deadline
+    while ContinuousClock.now < end {
+        if await condition() { return }
+        try await Task.sleep(for: .milliseconds(10))
+    }
+    if await condition() { return }
+    Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
+}

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -40,16 +40,22 @@ func makeFakeClient() -> (TmuxControlCommandClient, LineRecorder) {
 /// source location after `deadline`. A final post-deadline re-check absorbs
 /// sleep slices that overshoot the deadline AFTER the condition became true
 /// (observed live as `timedOut(got: N, want: N)` at loadavg ~40).
+///
+/// Returns whether the condition was met (false on timeout) so callers that
+/// index into results afterwards can abort via `#require` instead of trapping
+/// out of range; count/equality-checking callers may ignore the result.
+@discardableResult
 func waitFor(
     _ what: String, deadline: Duration = ciSafeDeadline,
     sourceLocation: SourceLocation = #_sourceLocation,
     _ condition: @Sendable () async -> Bool
-) async throws {
+) async throws -> Bool {
     let end = ContinuousClock.now + deadline
     while ContinuousClock.now < end {
-        if await condition() { return }
+        if await condition() { return true }
         try await Task.sleep(for: .milliseconds(10))
     }
-    if await condition() { return }
+    if await condition() { return true }
     Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
+    return false
 }

--- a/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
+++ b/Tests/TBDDaemonTests/PaneFanoutFlowControlTests.swift
@@ -4,11 +4,6 @@ import Testing
 
 @testable import TBDDaemonLib
 
-/// Positive-wait deadline sized for starved CI runners (PR #379: cooperative-pool
-/// starvation stretched sub-second async-drain deliveries past a 5 s poll).
-/// Passing runs still complete in milliseconds — only failures wait this long.
-private let ciSafeDeadline: TimeInterval = 30
-
 /// Phase B M1 — `PaneFanout.route` backpressure: instead of dropping the
 /// unwritten remainder on EAGAIN (issue #376's corruption source), the
 /// remainder is queued per (key, generation) and an async drain task delivers
@@ -17,6 +12,14 @@ private let ciSafeDeadline: TimeInterval = 30
 @Suite("PaneFanout flow control")
 struct PaneFanoutFlowControlTests {
     private let server = "tbd-test-server"
+
+    /// Positive-wait deadline sized for starved CI runners (PR #379:
+    /// cooperative-pool starvation stretched sub-second async-drain deliveries
+    /// past a 5 s poll). Passing runs complete in milliseconds — only failures
+    /// wait this long. Scoped inside the suite (TimeInterval idiom) so it
+    /// cannot collide with the shared Duration `ciSafeDeadline` in
+    /// ControlModeTestSupport.swift.
+    private static let ciSafeDeadline: TimeInterval = 30
 
     /// Darwin pipes buffer at most 64 KB; chunks are routed in 32 KB slices.
     private static let chunkSize = 32 * 1024
@@ -128,7 +131,7 @@ struct PaneFanoutFlowControlTests {
         #expect(received == total, "stream must arrive intact and in order across backpressure")
 
         // Queue must eventually report empty.
-        let deadline = Date().addingTimeInterval(ciSafeDeadline)
+        let deadline = Date().addingTimeInterval(Self.ciSafeDeadline)
         while Date() < deadline, (fanout.flowStats(key: key)?.queuedBytes ?? 0) > 0 {
             usleep(5_000)
         }
@@ -415,7 +418,7 @@ struct PaneFanoutFlowControlTests {
         let received = readAll(fd: readFD, expected: fenced.count)
         #expect(received == fenced, "markReady must flush the fence queue intact and in order")
 
-        let deadline = Date().addingTimeInterval(ciSafeDeadline)
+        let deadline = Date().addingTimeInterval(Self.ciSafeDeadline)
         while Date() < deadline, (fanout.flowStats(key: key)?.queuedBytes ?? 0) > 0 {
             usleep(5_000)
         }

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -4,11 +4,6 @@ import Testing
 
 @testable import TBDDaemonLib
 
-/// Positive-wait deadline sized for starved CI runners (PR #379: cooperative-pool
-/// starvation stretched sub-second async-drain deliveries past a 5 s poll).
-/// Passing runs still complete in milliseconds — only failures wait this long.
-private let ciSafeDeadline: Duration = .seconds(30)
-
 /// Phase B M3 — the overflow repair cycle (issue #376, the queue-overflow
 /// residual M1/M2 left behind). When a ready, unfenced pane's backpressure
 /// queue overflows, the fanout clears the queue, marks the sink `repairing`,
@@ -26,14 +21,6 @@ private let ciSafeDeadline: Duration = .seconds(30)
 struct PaneRepairCoordinatorTests {
     private let server = "tbd-repair-unit"
 
-    /// Thread-safe, synchronous recorder of stream writes in call order.
-    private final class Recorder: @unchecked Sendable {
-        private let lock = NSLock()
-        private var _writes: [String] = []
-        func record(_ line: String) { lock.lock(); _writes.append(line); lock.unlock() }
-        var writes: [String] { lock.lock(); defer { lock.unlock() }; return _writes }
-    }
-
     /// Thread-safe overflow-signal counter.
     private final class SignalCounter: @unchecked Sendable {
         private let lock = NSLock()
@@ -46,11 +33,8 @@ struct PaneRepairCoordinatorTests {
         writableCheckInterval: Duration = .milliseconds(10),
         writableSlowInterval: Duration = .milliseconds(25),
         writableEscalationThreshold: Duration = .milliseconds(50)
-    ) -> (TmuxControlSupervisor, PaneRepairCoordinator, Recorder, TmuxControlCommandClient, SignalCounter) {
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+    ) -> (TmuxControlSupervisor, PaneRepairCoordinator, LineRecorder, TmuxControlCommandClient, SignalCounter) {
+        let (client, recorder) = makeFakeClient()
         let supervisor = TmuxControlSupervisor()
         let coordinator = PaneRepairCoordinator(
             supervisor: supervisor,
@@ -106,20 +90,6 @@ struct PaneRepairCoordinatorTests {
             let n = buffer.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
             if n <= 0 { break }
         }
-    }
-
-    /// Poll until `condition`, failing after `deadline`.
-    private func waitFor(
-        _ what: String, deadline: Duration = ciSafeDeadline,
-        sourceLocation: SourceLocation = #_sourceLocation,
-        _ condition: @Sendable () async -> Bool
-    ) async throws {
-        let end = ContinuousClock.now + deadline
-        while ContinuousClock.now < end {
-            if await condition() { return }
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
     }
 
     /// Complete the next `lines.count` pending commands with `%end`.
@@ -515,10 +485,7 @@ struct PaneRepairCoordinatorTests {
         // returning the client, superseding the repair generation exactly
         // inside the provider hop — the entry guard has already passed, so
         // this pins the post-hop ownership re-check (R10-3).
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+        let (client, recorder) = makeFakeClient()
         let supervisor = TmuxControlSupervisor()
         let paneID = "%10"
         let key = PaneKey(server: server, paneID: paneID)
@@ -604,10 +571,7 @@ struct PaneRepairCoordinatorTests {
         // A REAL TmuxControlModeBridge with its DEFAULT repair coordinator:
         // only the command provider is faked. This drives the production
         // `onOverflowRepair` closure installed in the bridge's init.
-        let recorder = Recorder()
-        let client = TmuxControlCommandClient(
-            writeLine: { recorder.record($0) },
-            onFatalError: {})
+        let (client, recorder) = makeFakeClient()
         let supervisor = TmuxControlSupervisor()
         let bridge = TmuxControlModeBridge(
             supervisor: supervisor,

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -153,6 +153,7 @@ struct PaneRepairCoordinatorTests {
         // The app catches up — the pipe becomes writable.
         drainPipe(readFD)
         try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+        try #require(recorder.writes.count >= 2, "the captures+continue batch was never sent")
         #expect(recorder.writes[1] == """
             capture-pane -peqJN -S -50000 -E -1 -q -t %1
             capture-pane -peqJN -t %1
@@ -332,6 +333,7 @@ struct PaneRepairCoordinatorTests {
         // endRepair, streaming resumed. No new attach needed.
         drainPipe(readFD)
         try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
+        try #require(recorder.writes.count >= 2, "the captures+continue batch was never sent")
         #expect(recorder.writes[1].hasSuffix("refresh-client -A '%4:continue'"),
                 "the same repair must send batch 2 once the reader drains")
         await succeed(client, captureAndContinueReplies(paneID: paneID))


### PR DESCRIPTION
## Summary

**What's broken.** The "Attach RPC orchestration" suite intermittently fails in CI (surfaced on #408's rerun-clean run, a UI-only diff — pre-existing flake, not a regression). Failing runs burn ~146s and record 6 issues around the mid-sequence supersession test: `ready2` returns an error, no `continue` is ever written, and both 60s `waitFor` polls time out.

**Why it happens.** The suite's `bridge()` helper defaulted `readyTimeout` to a real 5-second wall-clock timer. Every `attach.request` arms `Task.sleep(readyTimeout) → detachIfNotReady`. All test targets share one process and one cooperative pool, so under parallel CI load a test task can be starved >5s between an attach and its `attach.ready`; the timer fires, tears down the un-acked sink, and the ready fails with `notAttached`. Confirmed by exact local reproduction: starving only that window reproduces the identical 6-issue signature (~126s locally vs 146s in CI). All five supersession tests in the suite carried the same latent race.

**What this PR does.**
- `fix(tests)`: the helper default becomes an un-hittable 600s, with a comment explaining the race. The ready-timeout is incidental machinery in these tests; the one test that exercises it (`unackedAttachTornDownAfterTimeout`) already passes its own explicit 100ms and is unchanged.
- `refactor(tests)`: extracts `ControlModeTestSupport` (canonical `waitFor` with a single 30s `ciSafeDeadline`, `LineRecorder`, `makeFakeClient`) and de-duplicates the ~8 hand-copied variants across the control-mode test files — the copy-paste drift (60s vs 30s deadlines, three private `ciSafeDeadline` declarations) that let this class of flake hide. Pure mechanical extraction; no test logic changed. `LoginSessionCoordinatorTests` and `TmuxControlCommandClientTests` keep their genuinely different-shaped local helpers.

## Test plan
- [x] Root cause proven before fixing: a 6s starve of the gen-2 window reproduced the exact CI failure signature locally
- [x] Previously flaky test looped 10x post-fix: 10/10 pass
- [x] Affected families green after rebase on main: 145 tests / 17 suites via `swift test --filter "AttachRPC|AttachReplay|ControlModeInput|ControlModeResize|PaneRepair|PaneFanout"`
- [x] `swift build --build-tests` and `swiftlint --strict` clean

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=2EFA4D7B-1A1D-4C7E-8826-0365E2236741)