### PR TITLE
Fix: Return users to where they came from after the deep-link redirect page opens TBD

### DIFF
--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -82,6 +82,8 @@
       var RETURN_DELAY_MS = 600;
       var armedUntil = 0;
       var returned = false;
+      var returnTimer = null;
+      var fallbackStatusHTML = status.innerHTML;
 
       function arm() {
         armedUntil = Date.now() + DETECT_WINDOW_MS;
@@ -96,7 +98,8 @@
           : 'TBD opened — you can close this tab.';
         // Short delay so the scheme launch isn't interrupted by navigating
         // away; the tab is backgrounded at this point, so it's seamless.
-        setTimeout(function () {
+        returnTimer = setTimeout(function () {
+          returnTimer = null;
           if (canGoBack) {
             history.back();
           } else {
@@ -108,7 +111,17 @@
       }
 
       document.addEventListener('visibilitychange', function () {
-        if (document.hidden && Date.now() <= armedUntil) onOpened();
+        if (document.hidden) {
+          if (Date.now() <= armedUntil) onOpened();
+        } else if (returnTimer !== null) {
+          // Tab became visible again before the return fired — the hide was
+          // incidental (alt-tab, a notification), not TBD activating. Cancel
+          // the pending navigation and restore the fallback UI intact.
+          clearTimeout(returnTimer);
+          returnTimer = null;
+          returned = false;
+          status.innerHTML = fallbackStatusHTML;
+        }
       });
 
       // The manual button fires the same tbd:// URL — arm the same

--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -70,10 +70,59 @@
         return c === '<' ? '&lt;' : '&amp;';
       }) + '</code>…';
 
+      // Success detection: navigating to a custom scheme does NOT unload this
+      // page — the tab stays here. We can't observe the handler directly, but
+      // when TBD activates, macOS brings it frontmost and the tab becomes
+      // hidden. So: document.hidden flipping true within a short window of
+      // firing the redirect means the handler opened. window.blur alone is a
+      // false-positive signal — the browser's "Open TBD.app?" confirmation
+      // dialog blurs the window even if the user cancels — but that dialog
+      // does not hide the document, so visibilitychange is safe.
+      var DETECT_WINDOW_MS = 3000;
+      var RETURN_DELAY_MS = 600;
+      var armedUntil = 0;
+      var returned = false;
+
+      function arm() {
+        armedUntil = Date.now() + DETECT_WINDOW_MS;
+      }
+
+      function onOpened() {
+        if (returned) return; // guard against double-fire
+        returned = true;
+        var canGoBack = history.length > 1;
+        status.textContent = canGoBack
+          ? 'Opened in TBD — taking you back…'
+          : 'TBD opened — you can close this tab.';
+        // Short delay so the scheme launch isn't interrupted by navigating
+        // away; the tab is backgrounded at this point, so it's seamless.
+        setTimeout(function () {
+          if (canGoBack) {
+            history.back();
+          } else {
+            // Works for script/link-opened tabs; silently no-ops otherwise,
+            // in which case the status text above already tells the user.
+            window.close();
+          }
+        }, RETURN_DELAY_MS);
+      }
+
+      document.addEventListener('visibilitychange', function () {
+        if (document.hidden && Date.now() <= armedUntil) onOpened();
+      });
+
+      // The manual button fires the same tbd:// URL — arm the same
+      // success-detection/auto-return logic on click.
+      link.addEventListener('click', arm);
+
       // Trigger the custom scheme. location.replace avoids a back-button trap.
       // Browsers handle the unknown scheme silently if the handler isn't installed,
-      // so we leave the manual button visible as a fallback.
-      setTimeout(function () { location.replace(target); }, 50);
+      // so we leave the manual button visible as a fallback: if success is never
+      // detected, the status message, button, and install hint stay as-is.
+      setTimeout(function () {
+        arm();
+        location.replace(target);
+      }, 50);
     })();
   </script>
 </body>


### PR DESCRIPTION
## Summary

**What's broken:** clicking an `open in tbd` link (e.g. from a PR body) lands on the GitHub Pages redirector at `/tbd/open/`, which fires the `tbd://` custom scheme — and then strands the user on the redirect page. They have to navigate back by hand every time.

**Why it happens:** navigating to a custom scheme doesn't unload the page; the tab just stays put with the static "Opening TBD…" message.

**What this PR does:** once the handler demonstrably opened — TBD activating makes the tab hidden, so `document.hidden` flipping true within 3s of firing the redirect is the success signal — the page waits 600ms (the tab is already backgrounded, so it's invisible) and then returns the user to where they came from:

- `history.length > 1` → `history.back()`
- fresh tab → `window.close()`, with a "you can close this tab" status as the no-op fallback

Guardrails:
- `window.blur` is deliberately **not** used as a signal — the browser's "Open TBD.app?" confirmation dialog blurs the window even when the user cancels; it doesn't hide the document.
- If the tab becomes visible again before the delayed return fires (incidental alt-tab with no handler installed), the pending navigation is cancelled and the fallback UI — manual button + install hint — is restored intact.
- No handler installed and no incidental hide → existing fallback UX is unchanged.

## Test plan

- [ ] From a PR body's `open in tbd` link (same-tab navigation): page opens TBD, then automatically returns to the PR
- [ ] Open the redirect URL in a fresh tab: TBD opens, tab closes (or shows "you can close this tab")
- [ ] With TBD not installed: page stays on the fallback message with the manual button and install hint
- [ ] With TBD not installed, alt-tab away within 3s and come back: page is still intact (no back-navigation fired)
- [ ] Cancel the "Open TBD.app?" browser dialog: page does not navigate away

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A8181D93-88D0-4863-ABF2-6ABEE9C868E3)