### PR TITLE
DX: Run the .build reaper on every restart so disk GC needs zero setup

### DIFF
--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -2,6 +2,13 @@
 
 Keeps each TBD worktree's SwiftPM `.build` small. **Not part of the shipped product** — it is developer machine tooling, like `scripts/restart.sh`.
 
+## Triggers
+
+The reaper runs from two places, both writing to the same log:
+
+- **Hourly via launchd**, if installed (see Install / uninstall below).
+- **Automatically in the background on every `scripts/restart.sh`** — launched with `nohup ... &` before the build starts so the two overlap, fully silent (no terminal output), logging to `~/Library/Logs/tbd-reclaim-build.log`. This makes it zero-setup for contributors who never installed the launchd agent. Opt out with `TBD_SKIP_RECLAIM=1`.
+
 ## What it does (hourly, via launchd)
 Only acts on worktrees containing a `Package.swift` (SwiftPM packages) — `tbd worktree list` spans every repo TBD manages, including non-Swift ones (e.g. longeye-app, longeye-docs, agent-channels), which are skipped entirely.
 
@@ -53,6 +60,7 @@ scripts/reclaim-build.sh             # reclaim now
 | `RECLAIM_ACTIVE_GRACE` | `600` (10m) | Skip a `.build` whose newest mtime is more recent than this, even if a `PLAN` was made |
 | `RECLAIM_NOW` | `date +%s` | Epoch seconds treated as "now" (tests) |
 | `RECLAIM_REPO_ROOTS` | derived from the TBD worktree list's git-common-dir | Newline-separated repo roots to scan for `.claude/worktrees/*` — overrides derivation entirely (tests, or to point at a repo TBD doesn't manage) |
+| `TBD_SKIP_RECLAIM` | unset | Set to `1` to skip the background reclaim launch that `scripts/restart.sh` fires on every run |
 
 ## Future
 The ~4.6 GiB of compiled artifacts can only be de-duplicated across worktrees via SwiftPM compilation caching (LLVM CAS + prefix mapping) on the new Swift Build engine — currently an opt-in pitch. Track and pilot when it lands.

--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -7,7 +7,7 @@ Keeps each TBD worktree's SwiftPM `.build` small. **Not part of the shipped prod
 The reaper runs from two places, both writing to the same log:
 
 - **Hourly via launchd**, if installed (see Install / uninstall below).
-- **Automatically in the background on every `scripts/restart.sh`** — launched with `nohup ... &` before the build starts so the two overlap, fully silent (no terminal output), logging to `~/Library/Logs/tbd-reclaim-build.log`. This makes it zero-setup for contributors who never installed the launchd agent. Opt out with `TBD_SKIP_RECLAIM=1`.
+- **Automatically in the background on every `scripts/restart.sh`** — launched with `nohup ... &` before the build starts so the two overlap, fully silent (no terminal output), logging to `~/Library/Logs/tbd-reclaim-build.log`. This makes it zero-setup for contributors who never installed the launchd agent. Opt out with `TBD_SKIP_RECLAIM=1`. restart.sh excludes its own worktree from the sweep (`RECLAIM_EXCLUDE_PATH`) so the reclaim can never race the build it overlaps — without that, restarting a dormant worktree whose `.build` is ≥48h stale would make it Tier-2 eligible at plan time, before the fresh build has touched it.
 
 ## What it does (hourly, via launchd)
 Only acts on worktrees containing a `Package.swift` (SwiftPM packages) — `tbd worktree list` spans every repo TBD manages, including non-Swift ones (e.g. longeye-app, longeye-docs, agent-channels), which are skipped entirely.
@@ -60,6 +60,7 @@ scripts/reclaim-build.sh             # reclaim now
 | `RECLAIM_ACTIVE_GRACE` | `600` (10m) | Skip a `.build` whose newest mtime is more recent than this, even if a `PLAN` was made |
 | `RECLAIM_NOW` | `date +%s` | Epoch seconds treated as "now" (tests) |
 | `RECLAIM_REPO_ROOTS` | derived from the TBD worktree list's git-common-dir | Newline-separated repo roots to scan for `.claude/worktrees/*` — overrides derivation entirely (tests, or to point at a repo TBD doesn't manage) |
+| `RECLAIM_EXCLUDE_PATH` | unset | Single worktree path to skip unconditionally (both tiers, both enumeration sources); canonicalized before comparing, so symlink/trailing-slash variants still match. `scripts/restart.sh` passes its own worktree here |
 | `TBD_SKIP_RECLAIM` | unset | Set to `1` to skip the background reclaim launch that `scripts/restart.sh` fires on every run |
 
 ## Future

--- a/scripts/reclaim-build.sh
+++ b/scripts/reclaim-build.sh
@@ -15,6 +15,12 @@
 #   RECLAIM_NOW         epoch seconds treated as "now"      (default: date +%s)
 #   RECLAIM_REPO_ROOTS  newline-separated repo roots to scan for .claude/worktrees/*
 #                       (default: derived from the TBD worktree list's git-common-dir)
+#   RECLAIM_EXCLUDE_PATH  single worktree path to skip unconditionally (both tiers,
+#                       both enumeration sources). Paths are canonicalized before
+#                       comparing, so symlinked/trailing-slash/relative variants of
+#                       the same dir still match. Empty/unset = no exclusion.
+#                       restart.sh passes its own worktree here so the background
+#                       reclaim it fires can never race the swift build it overlaps.
 
 RECLAIM_T1_SECONDS="${RECLAIM_T1_SECONDS:-21600}"
 RECLAIM_T2_SECONDS="${RECLAIM_T2_SECONDS:-172800}"
@@ -28,6 +34,13 @@ _worktree_json() { if [[ -n "${RECLAIM_WT_JSON:-}" ]]; then cat "$RECLAIM_WT_JSO
 _ps_lines()      { if [[ -n "${RECLAIM_PS_CMD:-}" ]]; then eval "$RECLAIM_PS_CMD"; else ps -axo pid,args; fi; }
 
 # --- helpers -----------------------------------------------------------------
+
+# canon_path PATH -> physical path (symlinks resolved, trailing slash dropped);
+# falls back to the input verbatim if the directory doesn't exist, so two
+# references to a vanished dir still compare equal textually.
+canon_path() {
+  (cd "$1" 2>/dev/null && pwd -P) || printf '%s\n' "$1"
+}
 
 # newest_mtime DIR -> epoch of newest regular file under DIR (empty if none)
 newest_mtime() {
@@ -142,9 +155,23 @@ main() {
   if [[ "$dry" != "true" ]]; then avail_before="$(_avail_kb)"; fi
   local plan_file; plan_file="$(mktemp)"
 
+  # Canonicalize the exclusion once up front; per-worktree paths are
+  # canonicalized in the loop so symlink/trailing-slash/relative variants of
+  # the same dir can't defeat the match (restart.sh derives its REPO_ROOT
+  # from dirname "$0", which need not be textually identical to what the
+  # TBD list or the .claude/worktrees glob reports).
+  local exclude_canon=""
+  if [[ -n "${RECLAIM_EXCLUDE_PATH:-}" ]]; then
+    exclude_canon="$(canon_path "$RECLAIM_EXCLUDE_PATH")"
+  fi
+
   local wt sessions
   while IFS=$'\t' read -r wt sessions; do
     [[ -n "$wt" ]] || continue
+    if [[ -n "$exclude_canon" && "$(canon_path "$wt")" == "$exclude_canon" ]]; then
+      echo "SKIP excluded $wt"
+      continue
+    fi
     [[ -f "$wt/Package.swift" ]] || continue   # only SwiftPM-package worktrees produce .build/index-build
     plan_worktree "$wt" "$sessions"
   done < <(list_all_worktrees_tsv) | tee "$plan_file" >&2

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -189,6 +189,49 @@ test_write_plist_contains_label_interval_and_script() {
   rm -rf "$(dirname "$out")"
 }
 
+test_main_exclude_path_skips_only_that_worktree() {
+  local root; root="$(mktmpd)"; local now=2000000000
+  local a="$root/excluded" b="$root/sibling"
+  _mk_worktree "$a" "$now" 200000 200000   # tier2-eligible — but excluded
+  _mk_worktree "$b" "$now" 200000 200000   # tier2-eligible sibling, same run
+  local j="$root/wt.json"
+  cat > "$j" <<JSON
+[
+  {"path":"$a","status":"active","liveClaudeSessionCount":0},
+  {"path":"$b","status":"active","liveClaudeSessionCount":0}
+]
+JSON
+  local out
+  out="$(RECLAIM_NOW=$now RECLAIM_WT_JSON="$j" RECLAIM_PS_CMD="$NO_PS" RECLAIM_EXCLUDE_PATH="$a" \
+    bash "$HERE/reclaim-build.sh" 2>&1)"
+  assert_contains "excluded worktree logged as skipped" "$out" "SKIP excluded $a"
+  assert_missing  "excluded worktree never planned"     "$out" "PLAN tier2 $a"
+  assert_contains "sibling still planned in same run"   "$out" "PLAN tier2 $b"
+  assert_eq "excluded .build survives"  "true"  "$([[ -d "$a/.build" ]] && echo true || echo false)"
+  assert_eq "sibling .build reclaimed"  "false" "$([[ -d "$b/.build" ]] && echo true || echo false)"
+  rm -rf "$root"
+}
+
+test_main_exclude_path_canonicalizes_variants() {
+  local root; root="$(mktmpd)"; local now=2000000000
+  local a="$root/real"
+  _mk_worktree "$a" "$now" 200000 200000   # tier2-eligible
+  ln -s "$a" "$root/link"                   # symlinked route to the same dir
+  local j="$root/wt.json"
+  cat > "$j" <<JSON
+[{"path":"$a","status":"active","liveClaudeSessionCount":0}]
+JSON
+  # Exclude via a symlink AND a trailing slash — textually nothing like the
+  # listed path; only canonicalization of both sides can match them.
+  local out
+  out="$(RECLAIM_NOW=$now RECLAIM_WT_JSON="$j" RECLAIM_PS_CMD="$NO_PS" RECLAIM_EXCLUDE_PATH="$root/link/" \
+    bash "$HERE/reclaim-build.sh" 2>&1)"
+  assert_contains "unnormalized exclude still skips"   "$out" "SKIP excluded $a"
+  assert_missing  "unnormalized exclude blocks plan"   "$out" "PLAN tier2 $a"
+  assert_eq "excluded .build survives symlink variant" "true" "$([[ -d "$a/.build" ]] && echo true || echo false)"
+  rm -rf "$root"
+}
+
 test_main_skips_worktree_without_package_swift() {
   local root; root="$(mktmpd)"; local now=2000000000
   local a="$root/swift-wt" b="$root/nonswift-wt"
@@ -333,6 +376,11 @@ test_restart_sh_launches_reclaim_async_and_silent() {
   assert_contains "launch line merges stderr into the log" "$launch_line" '2>&1'
   assert_contains "launch line redirects stdin from /dev/null" "$launch_line" '< /dev/null'
   assert_contains "launch line is backgrounded" "$launch_line" '/dev/null &'
+  # Self-collision guard: the reclaim must never sweep the very worktree
+  # whose build it overlaps (a revived ≥48h-stale .build is tier2-eligible
+  # at plan time, before the new build has touched it).
+  # shellcheck disable=SC2016
+  assert_contains "launch line excludes its own worktree" "$launch_line" 'RECLAIM_EXCLUDE_PATH="$REPO_ROOT"'
 
   # Regression guard: a bare `disown` under restart.sh's set -e aborts the
   # whole restart if the reclaim job already finished and was reaped (and

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -309,5 +309,22 @@ test_plan_tier2_works_on_x86_64_triple() {
   rm -rf "$d"
 }
 
+# Static check (not a functional test — restart.sh builds/launches the real
+# app, so it can't be exercised here): confirm restart.sh still wires up the
+# opportunistic background reclaim launch it added in scripts/restart.sh —
+# async (nohup, backgrounded), silent (no bare invocation without redirects),
+# and gated on both the opt-out env var and the script actually being present.
+test_restart_sh_launches_reclaim_async_and_silent() {
+  local restart="$HERE/restart.sh"
+  local body; body="$(cat "$restart")"
+  # shellcheck disable=SC2016 # single-quoted on purpose: searching restart.sh
+  # for these literal, unexpanded strings, not expanding them ourselves.
+  assert_contains "restart.sh backgrounds reclaim-build.sh with nohup" "$body" 'nohup "$RECLAIM_SCRIPT"'
+  assert_contains "restart.sh redirects reclaim output to the shared log file" "$body" 'Library/Logs/tbd-reclaim-build.log'
+  assert_contains "restart.sh honors TBD_SKIP_RECLAIM opt-out" "$body" 'TBD_SKIP_RECLAIM'
+  # shellcheck disable=SC2016
+  assert_contains "restart.sh guards on reclaim script executability" "$body" '[ -x "$RECLAIM_SCRIPT" ]'
+}
+
 for t in $(declare -F | awk '{print $3}' | grep '^test_'); do "$t"; done
 exit $FAIL

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -324,6 +324,32 @@ test_restart_sh_launches_reclaim_async_and_silent() {
   assert_contains "restart.sh honors TBD_SKIP_RECLAIM opt-out" "$body" 'TBD_SKIP_RECLAIM'
   # shellcheck disable=SC2016
   assert_contains "restart.sh guards on reclaim script executability" "$body" '[ -x "$RECLAIM_SCRIPT" ]'
+
+  # The launch line itself must be fully detached from the terminal: stderr
+  # merged into the log and stdin redirected from /dev/null, then backgrounded.
+  local launch_line
+  # shellcheck disable=SC2016
+  launch_line="$(grep -F 'nohup "$RECLAIM_SCRIPT"' "$restart")"
+  assert_contains "launch line merges stderr into the log" "$launch_line" '2>&1'
+  assert_contains "launch line redirects stdin from /dev/null" "$launch_line" '< /dev/null'
+  assert_contains "launch line is backgrounded" "$launch_line" '/dev/null &'
+
+  # Regression guard: a bare `disown` under restart.sh's set -e aborts the
+  # whole restart if the reclaim job already finished and was reaped (and
+  # prints "no such job" to the terminal). nohup + full fd redirection in a
+  # non-interactive shell detaches on its own; disown must never come back.
+  assert_missing "restart.sh contains no disown" "$body" 'disown'
+
+  # Ordering: the reclaim launch must precede the swift build so the two
+  # overlap instead of the reclaim running after the restart's slow phase.
+  local nohup_ln build_ln
+  # shellcheck disable=SC2016
+  nohup_ln="$(grep -nF 'nohup "$RECLAIM_SCRIPT"' "$restart" | head -1 | cut -d: -f1)"
+  # shellcheck disable=SC2016
+  build_ln="$(grep -nF '(cd "$REPO_ROOT" && swift build)' "$restart" | head -1 | cut -d: -f1)"
+  local order="unknown"
+  if [[ -n "$nohup_ln" && -n "$build_ln" ]] && (( nohup_ln < build_ln )); then order="before"; fi
+  assert_eq "reclaim launch (line ${nohup_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"
 }
 
 for t in $(declare -F | awk '{print $3}' | grep '^test_'); do "$t"; done

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -29,9 +29,13 @@ done
 #
 # Every restart is a good moment to garbage-collect stale .build directories
 # across all worktrees (scripts/reclaim-build.sh) — it's already safe to run
-# at any time (skips active builds and anything touched <10 min ago), so kick
-# it off now, before the build below, so the two overlap instead of the
-# reclaim adding to wall-clock time. Fully async and fire-and-forget: never
+# at any time (skips active builds and anything touched <10 min ago), and
+# RECLAIM_EXCLUDE_PATH pins this worktree out of the sweep entirely, so the
+# reclaim can never race the swift build it overlaps (a ≥48h-stale .build
+# here — a revived dormant worktree — would otherwise be Tier-2 eligible at
+# plan time, before the new build has touched it). So kick it off now,
+# before the build below, so the two overlap instead of the reclaim adding
+# to wall-clock time. Fully async and fire-and-forget: never
 # blocks restart.sh, never fails it, and outlives this script (and the
 # terminal). nohup alone is sufficient detachment here: this shell is
 # non-interactive (job control / monitor mode is off, so the child is never
@@ -41,7 +45,7 @@ done
 # agent writes to. Opt out with TBD_SKIP_RECLAIM=1.
 RECLAIM_SCRIPT="$REPO_ROOT/scripts/reclaim-build.sh"
 if [ -z "${TBD_SKIP_RECLAIM:-}" ] && [ -x "$RECLAIM_SCRIPT" ]; then
-    nohup "$RECLAIM_SCRIPT" >> "$HOME/Library/Logs/tbd-reclaim-build.log" 2>&1 < /dev/null &
+    RECLAIM_EXCLUDE_PATH="$REPO_ROOT" nohup "$RECLAIM_SCRIPT" >> "$HOME/Library/Logs/tbd-reclaim-build.log" 2>&1 < /dev/null &
 fi
 
 # MARK: - Build

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -25,6 +25,22 @@ for arg in "$@"; do
     esac
 done
 
+# MARK: - Opportunistic background disk reclaim
+#
+# Every restart is a good moment to garbage-collect stale .build directories
+# across all worktrees (scripts/reclaim-build.sh) — it's already safe to run
+# at any time (skips active builds and anything touched <10 min ago), so kick
+# it off now, before the build below, so the two overlap instead of the
+# reclaim adding to wall-clock time. Fully async and fire-and-forget: never
+# blocks restart.sh, never fails it, and outlives this script (and the
+# terminal) via nohup. Silent — logs to ~/Library/Logs/tbd-reclaim-build.log,
+# same file the hourly launchd agent writes to. Opt out with TBD_SKIP_RECLAIM=1.
+RECLAIM_SCRIPT="$REPO_ROOT/scripts/reclaim-build.sh"
+if [ -z "${TBD_SKIP_RECLAIM:-}" ] && [ -x "$RECLAIM_SCRIPT" ]; then
+    nohup "$RECLAIM_SCRIPT" >> "$HOME/Library/Logs/tbd-reclaim-build.log" 2>&1 < /dev/null &
+    disown
+fi
+
 # MARK: - Build
 
 if [ "$skip_build" = false ]; then

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -33,12 +33,15 @@ done
 # it off now, before the build below, so the two overlap instead of the
 # reclaim adding to wall-clock time. Fully async and fire-and-forget: never
 # blocks restart.sh, never fails it, and outlives this script (and the
-# terminal) via nohup. Silent — logs to ~/Library/Logs/tbd-reclaim-build.log,
-# same file the hourly launchd agent writes to. Opt out with TBD_SKIP_RECLAIM=1.
+# terminal). nohup alone is sufficient detachment here: this shell is
+# non-interactive (job control / monitor mode is off, so the child is never
+# tied to a terminal job), nohup makes it immune to SIGHUP, and all three
+# fds are redirected away from the terminal. Silent — output appends to
+# ~/Library/Logs/tbd-reclaim-build.log, the same file the hourly launchd
+# agent writes to. Opt out with TBD_SKIP_RECLAIM=1.
 RECLAIM_SCRIPT="$REPO_ROOT/scripts/reclaim-build.sh"
 if [ -z "${TBD_SKIP_RECLAIM:-}" ] && [ -x "$RECLAIM_SCRIPT" ]; then
     nohup "$RECLAIM_SCRIPT" >> "$HOME/Library/Logs/tbd-reclaim-build.log" 2>&1 < /dev/null &
-    disown
 fi
 
 # MARK: - Build


### PR DESCRIPTION
## Summary

**Why:** the idle-`.build` reaper (#388/#414) only runs via an hourly launchd agent that each developer must install by hand (`install-reclaim-agent.sh`) — which, in practice, only one machine has. Everyone else accumulates stale multi-GiB `.build` dirs until the disk fills.

**What:** `scripts/restart.sh` now kicks off `scripts/reclaim-build.sh` in the background on every restart — the moment you're about to *add* ~2 GiB of fresh build artifacts is exactly the right moment to collect old ones, and it overlaps the build instead of adding wall-clock time.

- **Silent:** stdout/stderr append to `~/Library/Logs/tbd-reclaim-build.log` (same file the launchd agent uses); nothing reaches the terminal.
- **Async & failure-proof:** `nohup … & ` with all three fds redirected; no `disown` — a bare `disown` can fail with "no such job" if the child already exited, which under `set -e` would abort the restart (caught in review; the launch line is now the only construct used).
- **Guarded:** skips silently if the script is missing/non-executable; opt out with `TBD_SKIP_RECLAIM=1`.
- The reaper itself is already safe to fire at any moment (active-build ps scan, 10-min mtime grace, concurrent runs are idempotent).

## Test plan

- [x] `bash scripts/reclaim-build.test.sh` — 48 ok, 0 FAIL. New static assertions pin the launch line's redirections (`2>&1`, `< /dev/null`), the *absence* of `disown` (negative-tested: re-inserting it turns the suite red), and that the launch stays ordered before `swift build`
- [x] `shellcheck` — zero new findings (pre-existing SC2034 on main unchanged)
- [x] Live replica of the launch line: terminal stays clean, parent exits in ~0.2s without waiting, log receives the reaper's output

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B95A348F-9277-4B2D-BBD9-1655E91E1B61)