### PR TITLE
Fix: Remove the + tooltip that overlaps the new hover worktree menu

### DIFF
--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -137,13 +137,12 @@ struct RepoSectionView: View {
 
             Group {
                 if HoverMenuModel.shouldShowPlus(hovered: isSectionHovered, menuOpen: newWorktreeMenu.isOpen) {
-                    SectionHeaderPlusButton(
-                        // Hover opens the unified profile picker; its "Choose a
-                        // branch…" row drills into the branch list. ⌥-click opens
-                        // it immediately.
-                        help: "New worktree (hover to pick a model profile, or \u{2325}-click)",
-                        action: handlePlusButton
-                    )
+                    // Hover opens the unified profile picker; its "Choose a
+                    // branch…" row drills into the branch list. ⌥-click opens
+                    // it immediately. No tooltip — it would render on top of
+                    // the hover menu.
+                    SectionHeaderPlusButton(action: handlePlusButton)
+                    .accessibilityLabel("New worktree")
                     .disabled(repo.status == .missing)
                     // `.disabled` blocks the click path but NOT `.onHover`
                     // tracking-area events, so gate the hover-open explicitly —

--- a/Sources/TBDApp/Sidebar/SectionHeaderPlusButton.swift
+++ b/Sources/TBDApp/Sidebar/SectionHeaderPlusButton.swift
@@ -5,16 +5,24 @@ import SwiftUI
 /// caption-sized glyph in a 20x20 hit target — so every section header gets
 /// the same tap/hover target size.
 struct SectionHeaderPlusButton: View {
-    let help: String
+    /// Tooltip text. Pass `nil` for buttons that open a hover menu — a
+    /// tooltip would render on top of the menu.
+    var help: String? = nil
     let action: () -> Void
 
+    @ViewBuilder
     var body: some View {
-        Button(action: action) {
+        let button = Button(action: action) {
             Image(systemName: "plus")
                 .font(.caption)
                 .frame(width: 20, height: 20)
         }
         .buttonStyle(HoverPressButtonStyle())
-        .help(help)
+
+        if let help {
+            button.help(help)
+        } else {
+            button
+        }
     }
 }

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -49,10 +49,10 @@ struct WorktreeRowView: View {
 
     @ViewBuilder
     private func nestedPlusButton(repoID: UUID) -> some View {
-        SectionHeaderPlusButton(
-            help: "New nested worktree under \(worktree.displayName) (hover to pick a model profile, or \u{2325}-click)",
-            action: { handleNestedPlus(repoID: repoID) }
-        )
+        // No tooltip — hover opens the profile picker menu, which a tooltip
+        // would render on top of.
+        SectionHeaderPlusButton(action: { handleNestedPlus(repoID: repoID) })
+        .accessibilityLabel("New nested worktree under \(worktree.displayName)")
         .onHover { newChildMenu.triggerHover($0) }
         .background(
             FloatingMenuAnchor(


### PR DESCRIPTION
## Summary
- PR #408 made the sidebar `+` buttons open the new-worktree profile picker on hover, but the repo and nested `+` buttons kept their macOS `.help(...)` tooltips — so hovering rendered the tooltip on top of / overlapping the freshly opened menu.
- `SectionHeaderPlusButton.help` is now optional and the `.help(...)` modifier is applied only when non-nil; the two menu-opening call sites (repo `+`, nested `+`) drop the tooltip and gain `.accessibilityLabel(...)` so VoiceOver naming survives.
- The scratch `+` doesn't open a hover menu, so it keeps its "New scratch space" tooltip unchanged.

## Test plan
- [x] `swift build` and `swiftlint --strict` clean
- [x] `swift test --filter TBDAppTests` — 1197 tests passing
- [x] Live: hovering the repo `+` and a nested `+` opens the profile menu with no overlapping tooltip; scratch `+` still shows its tooltip (confirmed by Chang)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E022CA47-9D3F-47E5-9411-FD5E56DBD14F)