### PR TITLE
feat(hibernation): profile pre-wake check + bounded "wake all parked" (#421)

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -91,6 +91,57 @@ extension AppState {
         return "Couldn't wake \(failures.count) sessions: \(first)"
     }
 
+    /// Concurrency bound for the explicit "Wake all parked" fan-out. Small on
+    /// purpose: full parallelism caused the #367 spawn storm (N simultaneous
+    /// heavy `claude --resume` respawns → RPC-timeout hang), so this caps
+    /// in-flight respawns at 3 while still beating a fully-sequential walk on a
+    /// 20-session worktree. The focus path stays ONE-at-a-time (see
+    /// `wakeHibernatedTerminalsOnFocus`) — this bound is ONLY for the explicit
+    /// user action.
+    static let wakeAllBatchSize = 3
+
+    /// Split parked-terminal ids into sequential batches of at most
+    /// `batchSize`. Pure + static so the batching is unit-tested without a live
+    /// `DaemonClient` (same pattern as `coalescedWakeFailureMessage`).
+    static func wakeAllBatches(_ ids: [UUID], batchSize: Int = wakeAllBatchSize) -> [[UUID]] {
+        guard batchSize > 0 else { return ids.isEmpty ? [] : [ids] }
+        return stride(from: 0, to: ids.count, by: batchSize).map {
+            Array(ids[$0 ..< min($0 + batchSize, ids.count)])
+        }
+    }
+
+    /// Explicit "Wake all parked in this worktree" action: wake EVERY parked
+    /// (hibernated or legacy-suspended) Claude session in `worktreeID`, in
+    /// bounded-concurrency batches (`wakeAllBatchSize` in flight, sequential
+    /// batches). Deliberately NOT the focus default (one-per-focus) — this is
+    /// the explicit fan-out users sometimes want. Folds all failures into ONE
+    /// coalesced alert (never a modal per terminal).
+    func wakeAllParkedInWorktree(worktreeID: UUID) async {
+        let ids = (terminals[worktreeID] ?? []).filter { $0.isParked }.map { $0.id }
+        var failures: [String] = []
+        for batch in Self.wakeAllBatches(ids) {
+            // Each batch's wakes run concurrently: wakeTerminal suspends at its
+            // RPC await, so up to wakeAllBatchSize respawns are in flight at once;
+            // the loop only starts the next batch after this one fully drains.
+            let batchFailures = await withTaskGroup(of: String?.self) { group in
+                for id in batch {
+                    group.addTask {
+                        await self.wakeTerminal(terminalID: id, worktreeID: worktreeID, userInitiated: true)
+                    }
+                }
+                var collected: [String] = []
+                for await failure in group where failure != nil {
+                    collected.append(failure!)
+                }
+                return collected
+            }
+            failures.append(contentsOf: batchFailures)
+        }
+        if let message = Self.coalescedWakeFailureMessage(failures: failures) {
+            showAlert(message, isError: true)
+        }
+    }
+
     /// Toggle a terminal's keep-warm pin (exempts it from auto-hibernation).
     func setTerminalKeepWarm(terminalID: UUID, keepWarm: Bool, worktreeID: UUID) async {
         do {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -966,10 +966,10 @@ actor DaemonClient {
 
     /// Wake a hibernated terminal: respawn `claude --resume` in its window.
     /// Idempotent — a double-call collapses to one respawn daemon-side.
-    func terminalWake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) async throws {
+    func terminalWake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, fallbackToDefaultProfile: Bool = false) async throws {
         try await callVoidAsync(
             method: RPCMethod.terminalWake,
-            params: TerminalWakeParams(terminalID: terminalID, cols: cols, rows: rows)
+            params: TerminalWakeParams(terminalID: terminalID, cols: cols, rows: rows, fallbackToDefaultProfile: fallbackToDefaultProfile)
         )
     }
 

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -126,24 +126,11 @@ struct RowActionMenuActions {
 
         case .wakeHibernated:
             let wtID = worktree.id
-            // Wake every PARKED session (hibernated or legacy-suspended).
-            let ids = terminals.filter { $0.isParked }.map { $0.id }
-            Task {
-                // Collect failures and show ONE coalesced alert after the
-                // loop — never a modal per terminal (post-reboot every window
-                // is dead, and a per-terminal alert becomes a modal storm).
-                var failures: [String] = []
-                for id in ids {
-                    if let failure = await appState.wakeTerminal(
-                        terminalID: id, worktreeID: wtID, userInitiated: true
-                    ) {
-                        failures.append(failure)
-                    }
-                }
-                if let message = AppState.coalescedWakeFailureMessage(failures: failures) {
-                    appState.showAlert(message, isError: true)
-                }
-            }
+            // Wake every PARKED session (hibernated or legacy-suspended) in
+            // bounded-concurrency batches — NOT a full fan-out (that caused the
+            // #367 spawn storm) and NOT the one-per-focus default. One coalesced
+            // failure alert for the whole action.
+            Task { await appState.wakeAllParkedInWorktree(worktreeID: wtID) }
 
         case let .toggleKeepWarm(enable):
             let wtID = worktree.id

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -25,6 +25,13 @@ public enum WakeResult: Equatable, Sendable {
     /// would silently land in $HOME. Carries the missing path so callers can
     /// surface an actionable message instead of a generic "not found".
     case worktreeMissing(path: String)
+    /// The terminal was pinned to a model profile whose row (or, for an
+    /// .apiKey profile, its keychain secret) no longer resolves. Waking would
+    /// silently fall back to the ambient keychain login and resume on the WRONG
+    /// account. Refuse and surface this so the app can offer an explicit
+    /// default-profile fallback; the row stays parked and resumable. Carries
+    /// the missing profile id for the message.
+    case profileMissing(profileID: UUID)
 }
 
 /// Owns session PARKING — the single unified "park a Claude session" feature
@@ -406,7 +413,7 @@ public actor HibernationCoordinator {
     /// machine reboot), the window is recreated (ensureServer + createWindow)
     /// and the same resume command spawned there; the terminal row keeps its
     /// identity and gets the new window/pane ids persisted.
-    public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) async -> WakeResult {
+    public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, allowDefaultProfileFallback: Bool = false) async -> WakeResult {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
         }
@@ -446,11 +453,26 @@ public actor HibernationCoordinator {
 
         // Honor the exact profile persisted on the terminal (loadByID, not
         // re-resolve) so wake lands on the same account the session used.
+        //
+        // Pre-wake profile check: if the pinned profile no longer resolves (row
+        // deleted, or an .apiKey profile whose keychain secret is gone), the OLD
+        // behavior silently fell back to the ambient keychain login — resuming on
+        // the WRONG account, which reads to the user as "the session won't wake".
+        // Refuse and surface `.profileMissing` so the app can offer an explicit
+        // default-profile fallback (mirrors how `.worktreeMissing` fails loudly
+        // just above rather than resuming into $HOME). This is BEFORE the tmux
+        // mutation section, so a refusal never disturbs the pane. Pass
+        // `allowDefaultProfileFallback` to opt back into the ambient-login resume.
         var resolvedProfile: ResolvedModelProfile? = nil
         if let profileID = terminal.profileID, let resolver = modelProfileResolver {
             resolvedProfile = try? await resolver.loadByID(profileID)
             if resolvedProfile == nil {
-                logger.warning("wake: profile \(profileID, privacy: .public) missing for terminal \(terminal.id, privacy: .public); falling back to keychain login")
+                if allowDefaultProfileFallback {
+                    logger.warning("wake: profile \(profileID, privacy: .public) missing for terminal \(terminal.id, privacy: .public); explicit default-profile fallback → ambient keychain login")
+                } else {
+                    logger.error("wake: profile \(profileID, privacy: .public) no longer resolves for terminal \(terminal.id, privacy: .public); refusing wake — retry with the default-profile fallback to resume on the default account")
+                    return .profileMissing(profileID: profileID)
+                }
             }
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -29,7 +29,8 @@ extension RPCRouter {
     func handleTerminalWake(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalWakeParams.self, from: paramsData)
         let result = await hibernationCoordinator.wake(
-            terminalID: params.terminalID, cols: params.cols, rows: params.rows
+            terminalID: params.terminalID, cols: params.cols, rows: params.rows,
+            allowDefaultProfileFallback: params.fallbackToDefaultProfile ?? false
         )
         switch result {
         case .ok, .notHibernated, .inFlight:
@@ -45,6 +46,8 @@ extension RPCRouter {
             return RPCResponse(error: reason)
         case .worktreeMissing(let path):
             return RPCResponse(error: "Worktree directory missing on disk: \(path). Restore the directory (or relocate the repo), then retry — the session stays parked and resumable.")
+        case .profileMissing(let profileID):
+            return RPCResponse(error: "This session was pinned to an account profile (\(profileID.uuidString)) that no longer exists. It stays parked and resumable — retry with the default-profile fallback to wake it on your default account.")
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -54,6 +54,8 @@ extension RPCRouter {
             return RPCResponse(error: reason)
         case .worktreeMissing(let path):
             return RPCResponse(error: "Worktree directory missing on disk: \(path). Restore the directory (or relocate the repo), then retry — the session stays parked and resumable.")
+        case .profileMissing(let profileID):
+            return RPCResponse(error: "This session was pinned to an account profile (\(profileID.uuidString)) that no longer exists. It stays parked and resumable — retry with the default-profile fallback to wake it on your default account.")
         }
     }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1132,10 +1132,15 @@ public struct TerminalWakeParams: Codable, Sendable {
     /// Initial tmux window size in cells (see TerminalSwapProfileParams).
     public let cols: Int?
     public let rows: Int?
-    public init(terminalID: UUID, cols: Int? = nil, rows: Int? = nil) {
+    /// Opt-in: when the pinned profile no longer resolves, resume on the ambient
+    /// default login instead of failing with `.profileMissing`. nil == false ==
+    /// strict (the default). Set true only on an explicit user retry.
+    public let fallbackToDefaultProfile: Bool?
+    public init(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, fallbackToDefaultProfile: Bool? = nil) {
         self.terminalID = terminalID
         self.cols = cols
         self.rows = rows
+        self.fallbackToDefaultProfile = fallbackToDefaultProfile
     }
 }
 

--- a/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
+++ b/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
@@ -181,4 +181,79 @@ struct WakeOnFocusDecisionTests {
         )
         #expect(message == "Couldn't wake 3 sessions: window @1 gone")
     }
+
+    // MARK: - Wake-all batching (bounded concurrency)
+    //
+    // The explicit "Wake all parked" menu action uses bounded-concurrency
+    // batches (at most wakeAllBatchSize in flight at once) to prevent the #367
+    // spawn storm. The focus path stays one-per-focus (see
+    // `terminalIDToWakeOnFocus` — covered by existing tests). Tests verify the
+    // batching pure function's branches and the batch-size constant.
+
+    /// Empty input → empty batches.
+    @Test func wakeAllBatchesEmptyIsEmpty() {
+        let result = AppState.wakeAllBatches([])
+        #expect(result == [])
+    }
+
+    /// Input smaller than batch size → single batch containing all ids.
+    @Test func wakeAllBatchesUnderSizeIsSingleBatch() {
+        let ids = [UUID(), UUID()]
+        let result = AppState.wakeAllBatches(ids)
+        #expect(result.count == 1)
+        #expect(result[0] == ids)
+    }
+
+    /// Input exactly a multiple of batch size → exact batches with no remainder.
+    @Test func wakeAllBatchesExactMultiple() {
+        let ids = (0..<6).map { _ in UUID() }
+        let result = AppState.wakeAllBatches(ids, batchSize: 3)
+        #expect(result.count == 2)
+        #expect(result[0].count == 3)
+        #expect(result[1].count == 3)
+    }
+
+    /// Input with remainder → last batch smaller than batch size.
+    @Test func wakeAllBatchesWithRemainder() {
+        let ids = (0..<7).map { _ in UUID() }
+        let result = AppState.wakeAllBatches(ids, batchSize: 3)
+        #expect(result.count == 3)
+        #expect(result[0].count == 3)
+        #expect(result[1].count == 3)
+        #expect(result[2].count == 1)
+        // Verify order is preserved (flattened = original).
+        let flattened = result.flatMap { $0 }
+        #expect(flattened == ids)
+    }
+
+    /// Verify the constant batch size and default argument behavior.
+    @Test func wakeAllBatchesDefaultSizeIsThree() {
+        #expect(AppState.wakeAllBatchSize == 3)
+        let ids = (0..<4).map { _ in UUID() }
+        let result = AppState.wakeAllBatches(ids)
+        #expect(result.count == 2)
+        #expect(result[0].count == 3)
+        #expect(result[1].count == 1)
+    }
+
+    /// The focus path default stays one-per-focus. `terminalIDToWakeOnFocus`
+    /// returns exactly one terminal (from existing tests). Pin that the bounded
+    /// method is ONLY for the explicit user action, not the background focus path.
+    @Test func focusPathStaysOneAtATime() {
+        let state = AppState()
+        let wt = UUID()
+        let ids = (0..<5).map { _ in UUID() }
+        state.terminals[wt] = ids.map { id in
+            Terminal(id: id, worktreeID: wt, tmuxWindowID: "@1", tmuxPaneID: "%1",
+                     hibernatedAt: Date())
+        }
+        // Focus the first parked terminal.
+        state.tabs[wt] = [Tab(id: UUID(), content: .terminal(terminalID: ids[0]), label: nil)]
+        state.activeTabIndices[wt] = 0
+
+        // terminalIDToWakeOnFocus returns exactly one, never a batch.
+        let focused = state.terminalIDToWakeOnFocus(worktreeID: wt)
+        #expect(focused == ids[0],
+                "focus wake must return exactly one terminal, not a batch")
+    }
 }

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -694,6 +694,94 @@ struct HibernationCoordinatorTests {
                 "wake must mirror the parked transcript into the derived dir under the injected projects root")
     }
 
+    // MARK: - Profile pre-wake check
+    //
+    // When a terminal is pinned to a profile that no longer resolves (row
+    // deleted or keychain secret missing for .apiKey), the OLD behavior silently
+    // fell back to ambient keychain login — resuming on the WRONG account. The
+    // new behavior refuses and surfaces `.profileMissing` so the app can offer
+    // an explicit default-profile fallback. Both branches covered: missing
+    // profile (strict mode) and opt-in fallback (lax mode). Also test that the
+    // check only fires when a resolver is present (no regression for daemon
+    // without a resolver).
+
+    private func coordinatorWithResolver(_ db: TBDDatabase) -> HibernationCoordinator {
+        HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            modelProfileResolver: ModelProfileResolver(
+                profiles: db.modelProfiles, repos: db.repos, config: db.config,
+                keychain: { _ in nil }),
+            configDirManager: isolatedConfigDirManager())
+    }
+
+    /// Wake refuses when the pinned profile ID no longer exists, returning
+    /// `.profileMissing` with the profile id. The row stays parked, retryable.
+    @Test func wakeRefusesWhenPinnedProfileMissing() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let bogusProfileID = UUID()
+        try await db.terminals.setProfileID(id: terminalID, profileID: bogusProfileID)
+
+        let coord = coordinatorWithResolver(db)
+        let wake = await coord.wake(terminalID: terminalID)
+
+        #expect(wake == .profileMissing(profileID: bogusProfileID))
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt != nil, "row must stay parked and retryable")
+    }
+
+    /// Wake succeeds when `allowDefaultProfileFallback: true` is passed, even
+    /// if the pinned profile is missing. The row is un-parked.
+    @Test func wakeWithFallbackResumesDespiteMissingProfile() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let bogusProfileID = UUID()
+        try await db.terminals.setProfileID(id: terminalID, profileID: bogusProfileID)
+
+        let coord = coordinatorWithResolver(db)
+        let wake = await coord.wake(terminalID: terminalID, allowDefaultProfileFallback: true)
+
+        #expect(wake == .ok)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt == nil, "row must be un-parked")
+    }
+
+    /// Wake succeeds (and doesn't return `.profileMissing`) when the pinned
+    /// profile actually resolves. Tests the happy path isn't broken by the check.
+    @Test func wakeSucceedsWhenPinnedProfileResolves() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+
+        // Create a real oauth profile (oauth resolves without a keychain secret).
+        let profile = try await db.modelProfiles.create(name: "test", kind: .oauth)
+        try await db.terminals.setProfileID(id: terminalID, profileID: profile.id)
+
+        let coord = coordinatorWithResolver(db)
+        let wake = await coord.wake(terminalID: terminalID)
+
+        #expect(wake == .ok)
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt == nil, "row must be un-parked")
+    }
+
+    /// When no resolver is injected, the profile check doesn't fire — even if a
+    /// profileID is pinned. This pins that the plain `coordinator(db)` (used by
+    /// other tests) is unaffected.
+    @Test func wakeIgnoresProfileCheckWhenNoResolverInjected() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let bogusProfileID = UUID()
+        try await db.terminals.setProfileID(id: terminalID, profileID: bogusProfileID)
+
+        // Plain coordinator with no resolver.
+        let coord = coordinator(db)
+        let wake = await coord.wake(terminalID: terminalID)
+
+        #expect(wake == .ok, "without a resolver, no profile check fires")
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.hibernatedAt == nil)
+    }
+
     // MARK: - Startup reconciliation
 
     /// `reconcileOnStartup` clears a stale parked timestamp for a terminal whose


### PR DESCRIPTION
Implements the two "quick wins" from the wake-reliability inventory in #421 (gaps 2 and 3). Both are aimed at making hibernation trustworthy enough to re-enable auto-idle across a large fleet.

## 1. Profile pre-wake check (daemon)

**Problem.** When a parked terminal was pinned to a model profile that no longer resolves (row deleted, or an `.apiKey` profile whose keychain secret is gone), `HibernationCoordinator.wake()` silently fell back to the ambient keychain login — resuming on the **wrong account**, which reads to the user as "the session won't wake / woke weird."

**Fix.** `wake()` now validates the pinned profile *before* any tmux mutation and refuses with a new `WakeResult.profileMissing(profileID:)`, surfaced through the RPC layer with an actionable message (same shape as the existing `.worktreeMissing` rail). The row stays parked and resumable. An explicit opt-in — `allowDefaultProfileFallback` on the coordinator, plumbed through `TerminalWakeParams.fallbackToDefaultProfile` and `DaemonClient.terminalWake(fallbackToDefaultProfile:)` — preserves the old ambient-login resume for a deliberate user retry.

- `WakeResult.profileMissing` handled in both wake handlers (`terminal.wake` and the legacy `terminal.resume`).
- `TerminalWakeParams.fallbackToDefaultProfile` is optional (nil == false == strict) so existing encoded params still decode.

> Scope note: the daemon + RPC plumbing for the default-profile fallback is complete and reachable via RPC, but this PR does **not** add a dedicated in-app confirm dialog to offer it on a one-click retry — the fallback is currently surfaced as the actionable error text. A follow-up can wire a "Wake on default account" button that sets `fallbackToDefaultProfile: true`.

## 2. "Wake all parked in this worktree" — bounded concurrency (app)

The explicit worktree-row **Wake** action already woke every parked session, but strictly sequentially. It now fans out in bounded-concurrency batches — `wakeAllBatchSize` = 3 in flight, batches strictly sequential — via `AppState.wakeAllParkedInWorktree`. This beats a sequential walk on a 20-session worktree while capping concurrent `claude --resume` respawns.

The one-terminal-per-focus default (`wakeHibernatedTerminalsOnFocus`, the #367 spawn-storm fix) is **deliberately unchanged** — this bounded fan-out is only the explicit user action.

## Tests

Per the repo's gated-conditional rule, each branch is covered:

- **Daemon** (`HibernationCoordinatorTests`): `wakeRefusesWhenPinnedProfileMissing` (strict → `.profileMissing`, row stays parked), `wakeWithFallbackResumesDespiteMissingProfile` (opt-in → `.ok`), `wakeSucceedsWhenPinnedProfileResolves` (happy path), `wakeIgnoresProfileCheckWhenNoResolverInjected` (no-resolver no-op).
- **App** (`WakeOnFocusDecisionTests`): `wakeAllBatches` edges (empty / under-size / exact multiple / remainder / default-size-is-three) and `focusPathStaysOneAtATime` pinning the untouched focus default.

`swift build` clean; full `swift test` green except two pre-existing environment-only failures unrelated to this change (`agentExecutableAvailability_detectsHomeLocalBinFallback` — depends on a local `~/.local/bin/claude`; `refreshGitStatusesChecksUnconditionallyWhenTipsUnresolvable` — git shell exit 128 in a temp repo), both confirmed failing on the pristine base. `swiftlint --strict` clean on all changed files.

Refs #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)