### PR TITLE
DX: Share one clang module cache across worktrees (~640 MB saved per worktree)

### DIFF
--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -63,5 +63,46 @@ scripts/reclaim-build.sh             # reclaim now
 | `RECLAIM_EXCLUDE_PATH` | unset | Single worktree path to skip unconditionally (both tiers, both enumeration sources); canonicalized before comparing, so symlink/trailing-slash variants still match. `scripts/restart.sh` passes its own worktree here |
 | `TBD_SKIP_RECLAIM` | unset | Set to `1` to skip the background reclaim launch that `scripts/restart.sh` fires on every run |
 
+## Shared module cache
+
+`scripts/restart.sh` passes every `swift build` through a **shared clang/Swift
+module cache** at `$HOME/Library/Caches/tbd/swift-module-cache`:
+
+```sh
+swift build -Xswiftc -module-cache-path -Xswiftc "$SHARED" -Xcc -fmodules-cache-path="$SHARED"
+```
+
+Without it, every worktree's `.build` accumulates its own ~640 MB
+`ModuleCache` with near-identical contents (precompiled clang modules for
+Foundation, AppKit, SwiftUI, the NIO C shims, …). With it there is **one
+~610–690 MB copy total, regardless of worktree count**, and the per-worktree
+`.build` carries no ModuleCache at all (measured: clean build's `.build`
+drops ~2.1 GB → ~1.4 GB; local `ModuleCache` 707 MB → 0 MB). The `-Xcc
+-fmodules-cache-path=` piece is what reaches the C-language dependency shim
+targets (e.g. CNIOAtomics) that `-Xswiftc -module-cache-path` alone misses
+(~70 MB residual otherwise).
+
+Notes:
+
+- **Concurrency-safe.** clang's module cache is designed for concurrent
+  writers; parallel builds from multiple worktrees against the shared cache
+  were tested with zero lock errors.
+- **Stickiness (expected, not a bug).** SwiftPM bakes the cache path into
+  `.build/debug.yaml` at plan time. A plain `swift build` after a flagged one
+  silently keeps using the shared cache — and conversely, the first build
+  after a manifest re-plan only picks the shared cache up if it runs with the
+  flags (i.e. via `restart.sh`). Flag alternation does not trigger
+  recompilation; worst case is a ~14 s re-plan.
+- **Why not `Package.swift` `swiftSettings`?** Measured dead end:
+  `.unsafeFlags(["-module-cache-path", …])` on every root target still left
+  a 591 MB local ModuleCache — manifest settings don't apply to dependency
+  targets (SwiftNIO, GRDB, SwiftTerm…), which are the bulk of it.
+- **Not swept by the reaper.** The shared cache sits outside every `.build`,
+  so Tier 1/2 above never touch it. It stays a constant single-copy size and
+  is safe to delete manually at any time — the next build regenerates it.
+- **CI is unchanged.** Runners are ephemeral (one worktree per VM), so a
+  shared cache buys nothing there, and the `actions/cache`d `.build` interacts
+  with plan-time stickiness in non-obvious ways. Deliberately not wired up.
+
 ## Future
 The ~4.6 GiB of compiled artifacts can only be de-duplicated across worktrees via SwiftPM compilation caching (LLVM CAS + prefix mapping) on the new Swift Build engine — currently an opt-in pitch. Track and pilot when it lands.

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -394,10 +394,43 @@ test_restart_sh_launches_reclaim_async_and_silent() {
   # shellcheck disable=SC2016
   nohup_ln="$(grep -nF 'nohup "$RECLAIM_SCRIPT"' "$restart" | head -1 | cut -d: -f1)"
   # shellcheck disable=SC2016
-  build_ln="$(grep -nF '(cd "$REPO_ROOT" && swift build)' "$restart" | head -1 | cut -d: -f1)"
+  build_ln="$(grep -nF '(cd "$REPO_ROOT" && swift build' "$restart" | head -1 | cut -d: -f1)"
   local order="unknown"
   if [[ -n "$nohup_ln" && -n "$build_ln" ]] && (( nohup_ln < build_ln )); then order="before"; fi
   assert_eq "reclaim launch (line ${nohup_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"
+}
+
+# Static check: restart.sh's swift build must route the clang/Swift module
+# cache to the shared per-user directory (single ~610 MB copy for ALL
+# worktrees instead of ~640 MB inside each .build) — both the Swift frontend
+# flag and the clang flag (which reaches C-shim dependency targets like
+# CNIOAtomics), and the cache dir must be created before the build runs.
+test_restart_sh_uses_shared_module_cache() {
+  local restart="$HERE/restart.sh"
+  local body; body="$(cat "$restart")"
+  assert_contains "restart.sh points at the shared per-user module cache" "$body" 'Library/Caches/tbd/swift-module-cache'
+  # shellcheck disable=SC2016 # literal, unexpanded strings searched in restart.sh
+  assert_contains "restart.sh creates the shared cache dir" "$body" 'mkdir -p "$SHARED_MODULE_CACHE"'
+  assert_contains "flags include the Swift frontend module-cache-path" "$body" '-Xswiftc -module-cache-path'
+  assert_contains "flags include the clang modules cache path" "$body" '-Xcc -fmodules-cache-path='
+
+  # The build line itself must carry the flags.
+  local build_line
+  # shellcheck disable=SC2016
+  build_line="$(grep -F '(cd "$REPO_ROOT" && swift build' "$restart")"
+  # shellcheck disable=SC2016
+  assert_contains "build line passes the module-cache flags" "$build_line" 'swift build "${MODULE_CACHE_FLAGS[@]}"'
+
+  # mkdir must precede the build so the first flagged build never races a
+  # missing parent directory.
+  local mkdir_ln build_ln
+  # shellcheck disable=SC2016
+  mkdir_ln="$(grep -nF 'mkdir -p "$SHARED_MODULE_CACHE"' "$restart" | head -1 | cut -d: -f1)"
+  # shellcheck disable=SC2016
+  build_ln="$(grep -nF '(cd "$REPO_ROOT" && swift build' "$restart" | head -1 | cut -d: -f1)"
+  local order="unknown"
+  if [[ -n "$mkdir_ln" && -n "$build_ln" ]] && (( mkdir_ln < build_ln )); then order="before"; fi
+  assert_eq "shared cache mkdir (line ${mkdir_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"
 }
 
 for t in $(declare -F | awk '{print $3}' | grep '^test_'); do "$t"; done

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -49,11 +49,30 @@ if [ -z "${TBD_SKIP_RECLAIM:-}" ] && [ -x "$RECLAIM_SCRIPT" ]; then
 fi
 
 # MARK: - Build
+#
+# Shared clang/Swift module cache across ALL TBD worktrees. By default every
+# worktree's `.build` accumulates its own ~640 MB ModuleCache with near-
+# identical contents; pointing both the Swift frontend (-module-cache-path)
+# and clang (-fmodules-cache-path, reaches the C-shim dependency targets like
+# CNIOAtomics) at one $HOME-level directory keeps a single ~610 MB copy total,
+# concurrency-safe across parallel builds. Verified empirically (Swift 6.2.4):
+# local ModuleCache drops to ~0 MB with this flag combo.
+#
+# Stickiness note: SwiftPM bakes the cache path into .build/debug.yaml at plan
+# time, so a later plain `swift build` in this worktree silently keeps using
+# the shared cache until a manifest re-plan — expected, not a bug. See
+# docs/reclaim-build.md ("Shared module cache").
+SHARED_MODULE_CACHE="$HOME/Library/Caches/tbd/swift-module-cache"
+mkdir -p "$SHARED_MODULE_CACHE"
+MODULE_CACHE_FLAGS=(
+    -Xswiftc -module-cache-path -Xswiftc "$SHARED_MODULE_CACHE"
+    -Xcc -fmodules-cache-path="$SHARED_MODULE_CACHE"
+)
 
 if [ "$skip_build" = false ]; then
     echo "Building..."
     t0=$SECONDS
-    (cd "$REPO_ROOT" && swift build) 2>&1 | tail -3
+    (cd "$REPO_ROOT" && swift build "${MODULE_CACHE_FLAGS[@]}") 2>&1 | tail -3
     echo "  Build: $((SECONDS - t0))s"
 fi
 


### PR DESCRIPTION
## Summary

**Why:** every worktree's debug `.build` carries a ~700 MB clang `ModuleCache` — compiled SDK modules that are near-identical across all worktrees. With ~10 active worktrees that's ~7 GB of pure duplication. (This is the same thing Xcode dedups globally with its shared `ModuleCache.noindex`.)

**What:** `scripts/restart.sh` now passes `-Xswiftc -module-cache-path -Xswiftc ~/Library/Caches/tbd/swift-module-cache -Xcc -fmodules-cache-path=<same>` to its `swift build`, so all worktrees populate and share a single module cache.

Measured (controlled experiment on throwaway clones, then verified live):
- Local `.build/**/ModuleCache` drops to **zero** (the `-Xcc` half also catches the C-shim targets a `-Xswiftc`-only approach leaves behind); `.build` shrinks ~2.1 GB → ~1.1–1.4 GB.
- The shared cache stays a **single ~675 MB copy** no matter how many worktrees use it, and survives two simultaneous clean builds with zero lock errors (clang's module cache is designed for concurrent access).
- Flag alternation is safe: SwiftPM bakes the path into its build manifest and keeps it, so a raw `swift build` after a flagged one continues using the shared cache with **no rebuild** (worst case a 14s manifest-only re-plan). Documented so the stickiness isn't mistaken for a bug.
- Clean builds got slightly *faster* (61–84s vs 107s baseline).

**Deliberately not touched:** CI (ephemeral single-worktree runners gain nothing, and moving ModuleCache out of the `actions/cache`d `.build` has non-obvious interactions) and `Package.swift` (`unsafeFlags` in the manifest was measured and rejected — it can't reach dependency targets, leaving 591 MB local).

**Known limits (documented):** a fresh worktree joins the shared cache on its first `restart.sh` build (raw first builds stay local until then — the reaper collects those), and toolchain upgrades accrete a new module generation in the shared cache; it's safe to delete manually anytime and regenerates.

## Test plan

- [x] `bash scripts/reclaim-build.test.sh` — 63 ok, 0 FAIL; new static test pins both flags on the build line and the `mkdir -p` before-build ordering
- [x] `shellcheck` — no new findings (pre-existing SC2034 unchanged)
- [x] Live in this worktree: clean flagged build 61s, `.build` = 1115 MB with no ModuleCache dir, shared cache = 675 MB

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B95A348F-9277-4B2D-BBD9-1655E91E1B61)