### PR TITLE
feat(hibernation): TUI-independent pending-input veto for auto-idle (#421)

### DIFF
--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -320,6 +320,10 @@ public final class Daemon: Sendable {
         // gated control connection through a single supervisor. When the gate
         // is off (the default), `enableIfGated` is a no-op.
         let tmuxVersion = await TmuxVersion.detect()
+        // Input activity tracker: records the timestamp of the last keystroke
+        // routed to each pane so the idle sweep can veto a park if input arrived
+        // after the session went idle (pending-input detection).
+        let inputActivity = InputActivityTracker()
         // Input router with the health sink wired to the state-delta broadcast
         // (#318 polish): edge-triggered per-pane input-delivery transitions
         // ride the same subscription channel the app already listens on.
@@ -331,6 +335,9 @@ public final class Daemon: Sendable {
                 subs.broadcast(delta: .controlModeInputHealthChanged(ControlModeInputHealthDelta(
                     worktreeID: worktreeID, paneID: paneID, healthy: healthy,
                     generation: generation)))
+            },
+            onInput: { [inputActivity] paneID in
+                inputActivity.recordInput(paneID: paneID)
             }
         )
         let controlModeBridge = TmuxControlModeBridge(
@@ -431,6 +438,8 @@ public final class Daemon: Sendable {
             modelProfileResolver: modelProfileResolver,
             pendingQuestions: pendingQuestions
         )
+        // Wire the shared input activity tracker to the coordinator
+        await rpcRouter.hibernationCoordinator.setInputActivity(inputActivity)
         rpcRouter.controlMode = controlModeBridge
         // The wake path recreates a terminal's tmux server/window when the
         // window is gone (e.g. post-reboot); give the recreated server the

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -28,6 +28,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var hibernate_idle_minutes: Int?
     var control_mode_enabled: Bool?
     var auto_resume_on_api_error: Bool?
+    var hibernate_input_veto_enabled: Bool?
 
     func toModel() -> Config {
         Config(
@@ -47,7 +48,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             autoHibernateEnabled: auto_hibernate_enabled ?? false,
             hibernateIdleMinutes: hibernate_idle_minutes ?? Config.defaultHibernateIdleMinutes,
             controlModeEnabled: control_mode_enabled ?? false,
-            autoResumeOnApiError: auto_resume_on_api_error ?? false
+            autoResumeOnApiError: auto_resume_on_api_error ?? false,
+            hibernateInputVetoEnabled: hibernate_input_veto_enabled ?? false
         )
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -854,6 +854,17 @@ public final class TBDDatabase: Sendable {
             try db.execute(sql: "UPDATE config SET auto_hibernate_enabled = 0")
         }
 
+        // Soak flag for the input-pipeline pending-input veto (design
+        // 2026-07-09-pending-input-detection-design). Default false: the veto is
+        // opt-in until it soaks; when on it's the primary machine-interface guard
+        // against parking a pane with typed-but-unsent input, demoting the TUI
+        // scrape to a backup.
+        migrator.registerMigration("v51_config_hibernate_input_veto") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "hibernate_input_veto_enabled",
+                type: .boolean, defaults: false)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -75,6 +75,9 @@ public actor HibernationCoordinator {
     /// sync — injectable (mirroring `RPCRouter.configDirManager`) so tests
     /// point it at a temp dir instead of falling back to the real `~/.claude`.
     private let configDirManager: ClaudeProfileConfigDirManager
+    /// Default input activity tracker. Wired post-construction by Daemon.swift
+    /// to the shared instance from the input router so both use the same tracker.
+    private var inputActivity: InputActivityTracker
     private let now: @Sendable () -> Date
 
     /// Per-terminal "first time we observed it idle-at-rest" marker, maintained
@@ -144,6 +147,7 @@ public actor HibernationCoordinator {
         self.modelProfileResolver = modelProfileResolver
         self.subscriptions = subscriptions
         self.configDirManager = configDirManager
+        self.inputActivity = InputActivityTracker()
         self.now = now
     }
 
@@ -167,6 +171,15 @@ public actor HibernationCoordinator {
     /// `controlMode` is wired post-construction.
     public func setOnServerCreated(_ hook: (@Sendable (String) async -> Void)?) {
         onServerCreated = hook
+    }
+
+    /// Wire the input activity tracker so the sweep can veto parks based on
+    /// pending typed input. Set once by Daemon.swift after construction so the
+    /// shared tracker is used across the input router and coordinator.
+    func setInputActivity(_ tracker: InputActivityTracker) {
+        // Replace the default tracker with the shared one from the input router.
+        // This is safe because nothing has accessed inputActivity yet at wiring time.
+        self.inputActivity = tracker
     }
 
     // MARK: - Keep-warm
@@ -235,7 +248,7 @@ public actor HibernationCoordinator {
         case .keepWarm: return "Terminal is pinned keep-warm"
         case .running: return "Session is actively running"
         case .waitingForUser: return "Session is waiting on a permission prompt"
-        case .eligible, .featureDisabled, .notIdleLongEnough: return "Not hibernatable"
+        case .eligible, .featureDisabled, .notIdleLongEnough, .pendingTypedInput: return "Not hibernatable"
         }
     }
 
@@ -329,6 +342,13 @@ public actor HibernationCoordinator {
         // orphaned claude child processes (#43944, #25188) are logged but not
         // killed in v1 — surfacing them is enough.
         await verifyHibernationTookEffect(server: server, paneID: paneID, terminalID: terminal.id)
+
+        // Clear the recorded input timestamp for this pane. The paneID may be
+        // reused in a future respawn, so clearing prevents a stale veto from the
+        // old session's final keystrokes. (A paneID reused with residual input
+        // would only add a stale veto, never drop a real one — the safe direction
+        // — but clearing is cleaner.)
+        inputActivity.forget(paneID: paneID)
 
         do {
             // setHibernated also cancels any scheduled auto-resume in the
@@ -749,15 +769,20 @@ public actor HibernationCoordinator {
 
         // Prune markers for terminals that vanished.
         let liveIDs = Set(terminals.map { $0.id })
+        let livePaneIDs = Set(terminals.compactMap { $0.tmuxPaneID })
         idleSince = idleSince.filter { liveIDs.contains($0.key) }
         pendingKillSince = pendingKillSince.filter { liveIDs.contains($0.key) }
+        inputActivity.prune(keeping: livePaneIDs)
 
         for terminal in terminals {
+            let lastInputAt = inputActivity.lastInput(paneID: terminal.tmuxPaneID)
             let decision = HibernationGate.decide(
                 terminal: terminal,
                 autoHibernateEnabled: config.autoHibernateEnabled,
+                inputVetoEnabled: config.hibernateInputVetoEnabled,
                 idleTimeout: timeout,
                 idleSince: idleSince[terminal.id],
+                lastInputAt: lastInputAt,
                 now: reference
             )
 
@@ -786,6 +811,14 @@ public actor HibernationCoordinator {
                 if idleSince[terminal.id] == nil {
                     idleSince[terminal.id] = reference
                 }
+                pendingKillSince[terminal.id] = nil
+
+            case .pendingTypedInput:
+                // Idle long enough but input arrived after it went idle: keep the
+                // idle marker (session IS at rest) but clear the armed debounce so
+                // the veto persists across sweeps until input is consumed (sending
+                // advances idleSince past lastInputAt).
+                logger.debug("hibernate: skipping \(terminal.id, privacy: .public) — pending typed input")
                 pendingKillSince[terminal.id] = nil
 
             case .featureDisabled, .notClaudeResumable, .alreadyHibernated,

--- a/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationGate.swift
@@ -25,6 +25,7 @@ public enum HibernationGate {
         case running            // actively running a turn — never eat an in-flight generation
         case waitingForUser     // a raised permission hand — hibernating would eat it
         case notIdleLongEnough  // idle, but not past the timeout yet
+        case pendingTypedInput  // idle, but input arrived after it went to rest
     }
 
     /// Evaluate the auto-hibernate decision for `terminal`.
@@ -32,16 +33,22 @@ public enum HibernationGate {
     /// - Parameters:
     ///   - terminal: the candidate.
     ///   - autoHibernateEnabled: the global master switch.
+    ///   - inputVetoEnabled: soak flag for the input-pipeline pending-input veto.
     ///   - idleTimeout: how long a terminal must be idle before it qualifies.
     ///   - idleSince: when the terminal last went idle (its `hibernationIdleSince`
     ///     marker). `nil` means "no idle marker yet" — treated as not-yet-idle,
     ///     since we can't prove it has been at rest long enough.
+    ///   - lastInputAt: the timestamp of the last keystroke/paste routed to this
+    ///     terminal's pane (from InputActivityTracker). `nil` means "no input
+    ///     recorded" (e.g. post-restart, or a pane never typed into).
     ///   - now: the reference time (injectable for tests).
     public static func decide(
         terminal: Terminal,
         autoHibernateEnabled: Bool,
+        inputVetoEnabled: Bool = false,
         idleTimeout: TimeInterval,
         idleSince: Date?,
+        lastInputAt: Date? = nil,
         now: Date
     ) -> Decision {
         guard autoHibernateEnabled else { return .featureDisabled }
@@ -51,6 +58,11 @@ public enum HibernationGate {
         // Idle-duration rail: needs a marker and enough elapsed time.
         guard let idleSince, now.timeIntervalSince(idleSince) >= idleTimeout else {
             return .notIdleLongEnough
+        }
+        // Input veto: if the soak flag is on and input arrived at or after the
+        // session went idle, block the park — pending typed input should not be eaten.
+        if inputVetoEnabled, let lastInputAt, lastInputAt >= idleSince {
+            return .pendingTypedInput
         }
         return .eligible
     }

--- a/Sources/TBDDaemon/Tmux/ControlMode/ControlModeInputRouter.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/ControlModeInputRouter.swift
@@ -57,6 +57,11 @@ final class ControlModeInputRouter: @unchecked Sendable {
     /// a `StateDelta.controlModeInputHealthChanged` broadcast; tests inject
     /// a recorder; the default is a no-op.
     private let onHealthChange: @Sendable (UUID, String, Bool, UInt64?) -> Void
+    /// Sink for input-activity recording: called with paneID whenever input
+    /// (keystroke or paste) is delivered to a pane. Wired to InputActivityTracker
+    /// in production so the idle sweep can veto a park if input arrived after
+    /// the session went idle. Tests inject a no-op.
+    private let onInput: @Sendable (String) -> Void
     private let latency: InputLatencyRecorder
     private let chunkSize: Int
 
@@ -78,11 +83,13 @@ final class ControlModeInputRouter: @unchecked Sendable {
     init(commandProvider: @escaping @Sendable (String) async -> TmuxControlCommandClient?,
          latency: InputLatencyRecorder = InputLatencyRecorder(),
          chunkSize: Int = 330,
-         onHealthChange: @escaping @Sendable (UUID, String, Bool, UInt64?) -> Void = { _, _, _, _ in }) {
+         onHealthChange: @escaping @Sendable (UUID, String, Bool, UInt64?) -> Void = { _, _, _, _ in },
+         onInput: @escaping @Sendable (String) -> Void = { _ in }) {
         self.commandProvider = commandProvider
         self.latency = latency
         self.chunkSize = chunkSize
         self.onHealthChange = onHealthChange
+        self.onInput = onInput
 
         var escapedContinuation: AsyncStream<Item>.Continuation!
         let stream = AsyncStream<Item>(bufferingPolicy: .unbounded) { escapedContinuation = $0 }
@@ -195,6 +202,8 @@ final class ControlModeInputRouter: @unchecked Sendable {
     /// missing paste — but tears NOTHING down; no latency sample (keystroke
     /// telemetry only).
     private func deliverPaste(_ item: Item, client: TmuxControlCommandClient) async {
+        // Record input attempt regardless of send success — the user DID paste it.
+        onInput(item.header.paneID)
         do {
             try await PasteExecutor.paste(client: client, paneID: item.header.paneID, bytes: item.bytes)
             reportDelivery(header: item.header, success: true)
@@ -208,6 +217,8 @@ final class ControlModeInputRouter: @unchecked Sendable {
     }
 
     private func deliverInput(_ item: Item, client: TmuxControlCommandClient) async {
+        // Record input attempt regardless of send success — the user DID type it.
+        onInput(item.header.paneID)
         let commandTexts = SendKeysEncoder.commands(
             paneID: item.header.paneID, bytes: item.bytes, maxBytesPerCommand: chunkSize)
         guard !commandTexts.isEmpty else { return }

--- a/Sources/TBDDaemon/Tmux/InputActivityTracker.swift
+++ b/Sources/TBDDaemon/Tmux/InputActivityTracker.swift
@@ -1,0 +1,60 @@
+import Foundation
+import os
+
+/// Tracks the timestamp of the last keystroke recorded for each tmux pane,
+/// enabling a daemon-side pending-input veto for auto-idle-hibernate that does
+/// not depend on parsing the Claude TUI.
+///
+/// In-memory only, mirroring the coordinator's `idleSince` map. Keyed by
+/// paneID (not terminal UUID) because the input router speaks paneIDs; a paneID
+/// reused after respawn can only ADD a stale veto, never drop a real one —
+/// the safe direction.
+///
+/// Lock-protected so the router's consumer can `recordInput` while nothing else
+/// contends. The `now` seam lets tests drive time without real time.
+final class InputActivityTracker: @unchecked Sendable {
+    private let logger = Logger(subsystem: "com.tbd.daemon", category: "InputActivityTracker")
+    private let lock = NSLock()
+    private let now: @Sendable () -> Date
+
+    /// Maps paneID → last input timestamp (wall-clock Date, comparable to idleSince).
+    private var lastInputByPane: [String: Date] = [:]
+
+    init(now: @escaping @Sendable () -> Date = { Date() }) {
+        self.now = now
+    }
+
+    /// Record that `paneID` received input at the current time.
+    func recordInput(paneID: String) {
+        lock.lock()
+        lastInputByPane[paneID] = now()
+        lock.unlock()
+    }
+
+    /// Return the timestamp of the last input recorded for `paneID`, or `nil`
+    /// if no input has been recorded (e.g. post-restart, or a pane that has
+    /// never received input).
+    func lastInput(paneID: String) -> Date? {
+        lock.lock()
+        defer { lock.unlock() }
+        return lastInputByPane[paneID]
+    }
+
+    /// Clear the recorded input timestamp for `paneID`. Called when a pane is
+    /// respawned or closed.
+    func forget(paneID: String) {
+        lock.lock()
+        lastInputByPane.removeValue(forKey: paneID)
+        lock.unlock()
+    }
+
+    /// Drop recorded entries for panes not in `livePaneIDs`. Called during the
+    /// idle sweep to prune stale entries alongside the coordinator's existing
+    /// idleSince prune. Safe to call on any pane ID whether or not it has ever
+    /// received input.
+    func prune(keeping livePaneIDs: Set<String>) {
+        lock.lock()
+        lastInputByPane = lastInputByPane.filter { livePaneIDs.contains($0.key) }
+        lock.unlock()
+    }
+}

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -751,6 +751,14 @@ public struct Config: Codable, Sendable, Equatable {
     /// classified as `ScheduledResume.apiErrorLimitType` rather than a hard
     /// usage-limit hit. Default OFF.
     public var autoResumeOnApiError: Bool
+    /// Soak flag for the input-pipeline pending-input veto (design spec
+    /// 2026-07-09). When true, the auto-hibernate idle sweep includes a
+    /// machine-interface guard against parking a pane with typed-but-unsent
+    /// input: if any keystroke arrived at or after the session went idle, the
+    /// park is vetoed. When false (the default), only the TUI scrape veto
+    /// applies. The input veto is opt-in until it soaks and the v50 master
+    /// default is reverted.
+    public var hibernateInputVetoEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -769,7 +777,8 @@ public struct Config: Codable, Sendable, Equatable {
                 autoHibernateEnabled: Bool = false,
                 hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes,
                 controlModeEnabled: Bool = false,
-                autoResumeOnApiError: Bool = false) {
+                autoResumeOnApiError: Bool = false,
+                hibernateInputVetoEnabled: Bool = false) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -785,6 +794,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.hibernateIdleMinutes = hibernateIdleMinutes
         self.controlModeEnabled = controlModeEnabled
         self.autoResumeOnApiError = autoResumeOnApiError
+        self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -816,6 +826,8 @@ public struct Config: Codable, Sendable, Equatable {
             Bool.self, forKey: .controlModeEnabled) ?? false
         autoResumeOnApiError = try c.decodeIfPresent(
             Bool.self, forKey: .autoResumeOnApiError) ?? false
+        hibernateInputVetoEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
     }
 }
 

--- a/Tests/TBDDaemonTests/HibernationGateTests.swift
+++ b/Tests/TBDDaemonTests/HibernationGateTests.swift
@@ -31,12 +31,15 @@ struct HibernationGateTests {
     private func decide(
         _ terminal: Terminal,
         enabled: Bool = true,
+        inputVetoEnabled: Bool = false,
         timeout: TimeInterval = 30 * 60,
-        idleSince: Date?
+        idleSince: Date?,
+        lastInputAt: Date? = nil
     ) -> HibernationGate.Decision {
         HibernationGate.decide(
             terminal: terminal, autoHibernateEnabled: enabled,
-            idleTimeout: timeout, idleSince: idleSince, now: now
+            inputVetoEnabled: inputVetoEnabled,
+            idleTimeout: timeout, idleSince: idleSince, lastInputAt: lastInputAt, now: now
         )
     }
 
@@ -139,5 +142,98 @@ struct HibernationGateTests {
         let t = claudeTerminal(activityState: .working)
         let idleSince = now.addingTimeInterval(-60 * 60)
         #expect(decide(t, idleSince: idleSince) == .running)
+    }
+
+    // MARK: - Rail: pending typed input (input veto)
+
+    @Test func pendingTypedInputBlocksWhenVetoEnabled() {
+        // Input veto on + lastInputAt >= idleSince + idle long enough →
+        // `.pendingTypedInput`. This is the headline guarantee: pending typed
+        // input is never eaten by the park.
+        let t = claudeTerminal()
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        let lastInputAt = now.addingTimeInterval(-10 * 60) // input 10m after idle
+        #expect(decide(t, inputVetoEnabled: true, idleSince: idleSince, lastInputAt: lastInputAt) == .pendingTypedInput)
+    }
+
+    @Test func vetoDisabledProvesFlagIsGated() {
+        // Flag OFF + same inputs (input after idle, idle long enough) →
+        // `.eligible`. Proves the veto is truly gated; regression-guards
+        // today's behavior (scrape-only guard).
+        let t = claudeTerminal()
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        let lastInputAt = now.addingTimeInterval(-10 * 60) // input 10m after idle
+        #expect(decide(t, inputVetoEnabled: false, idleSince: idleSince, lastInputAt: lastInputAt) == .eligible)
+    }
+
+    @Test func inputBeforeIdleIsEligible() {
+        // Input veto on + lastInputAt < idleSince (input consumed by last turn) →
+        // `.eligible`. The session DID see the input (it was processed in a turn),
+        // so it's safe to park.
+        let t = claudeTerminal()
+        let idleSince = now.addingTimeInterval(-30 * 60)
+        let lastInputAt = now.addingTimeInterval(-35 * 60) // input 35m ago, before idle
+        #expect(decide(t, inputVetoEnabled: true, idleSince: idleSince, lastInputAt: lastInputAt) == .eligible)
+    }
+
+    @Test func noRecordedInputIsEligible() {
+        // Input veto on + lastInputAt == nil (no input recorded, e.g. post-restart,
+        // or a pane never typed into) → `.eligible` from the gate. The scrape veto
+        // in performHibernate covers this branch.
+        let t = claudeTerminal()
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        #expect(decide(t, inputVetoEnabled: true, idleSince: idleSince, lastInputAt: nil) == .eligible)
+    }
+
+    @Test func inputVetoLosesToRunning() {
+        // Precedence: `.running` wins over the input veto. A session that
+        // received input AND is actively running is reported as running, not
+        // pending-input.
+        let t = claudeTerminal(activityState: .working)
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        let lastInputAt = now.addingTimeInterval(-10 * 60) // input after idle
+        #expect(decide(t, inputVetoEnabled: true, idleSince: idleSince, lastInputAt: lastInputAt) == .running)
+    }
+
+    @Test func inputVetoLosesToWaitingForUser() {
+        // Precedence: `.waitingForUser` wins over the input veto.
+        let t = claudeTerminal(activityState: .waitingForUser)
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        let lastInputAt = now.addingTimeInterval(-10 * 60) // input after idle
+        #expect(decide(t, inputVetoEnabled: true, idleSince: idleSince, lastInputAt: lastInputAt) == .waitingForUser)
+    }
+
+    @Test func inputVetoLosesToNotIdleLongEnough() {
+        // Precedence: `.notIdleLongEnough` wins over the input veto — the
+        // timeout check comes before the input check.
+        let t = claudeTerminal()
+        let idleSince = now.addingTimeInterval(-5 * 60) // only 5m idle, not 30m
+        let lastInputAt = now.addingTimeInterval(-2 * 60) // input 2m after idle
+        #expect(decide(t, inputVetoEnabled: true, idleSince: idleSince, lastInputAt: lastInputAt) == .notIdleLongEnough)
+    }
+
+    @Test func inputAtExactIdleTimestampIsBlocked() {
+        // Edge case: input at exactly idleSince → input >= idleSince is true →
+        // blocked. Conservative: the comparison is >=, so input at the idle moment
+        // is treated as "after idle".
+        let t = claudeTerminal()
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        let lastInputAt = idleSince // input exactly when idle was marked
+        #expect(decide(t, inputVetoEnabled: true, idleSince: idleSince, lastInputAt: lastInputAt) == .pendingTypedInput)
+    }
+
+    @Test func tuiBreakSimulation() {
+        // Headline guarantee (fail-safe test): a simulated Claude Code composer
+        // redesign where the scraper is blind (would return false for pending input)
+        // cannot eat typed-but-unsent input because the input veto catches it at
+        // the gate level. This terminal received input AFTER going idle, and while
+        // the gate passes only the decision (the scrape logic is separate), the
+        // input veto alone suffices to block the park.
+        let t = claudeTerminal()
+        let idleSince = now.addingTimeInterval(-31 * 60)
+        let lastInputAt = now.addingTimeInterval(-5 * 60) // typed something 5m after idle
+        let decision = decide(t, inputVetoEnabled: true, idleSince: idleSince, lastInputAt: lastInputAt)
+        #expect(decision == .pendingTypedInput)
+        // The gate alone blocks, so even if the scrape is broken the park is safe.
     }
 }

--- a/Tests/TBDDaemonTests/InputActivityTrackerTests.swift
+++ b/Tests/TBDDaemonTests/InputActivityTrackerTests.swift
@@ -1,0 +1,123 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+
+/// Tests for the InputActivityTracker: timestamp recording, query, forget, and
+/// pruning. Pure: no DB, no tmux, no actor. One test per method/path.
+@Suite("InputActivityTracker")
+struct InputActivityTrackerTests {
+    private let pane1 = "pane-1"
+    private let pane2 = "pane-2"
+    private let pane3 = "pane-3"
+
+    @Test func recordInputThenLastInputReturnsTimestamp() {
+        let tracker = InputActivityTracker()
+
+        tracker.recordInput(paneID: pane1)
+        // Capture the first recorded time
+        let recorded = tracker.lastInput(paneID: pane1)
+        #expect(recorded != nil)
+
+        // Record again after a small delay
+        usleep(100)
+        tracker.recordInput(paneID: pane1)
+        let recorded2 = tracker.lastInput(paneID: pane1)
+        #expect(recorded2 != nil)
+        // Second time should be >= first (likely strictly greater due to delay)
+        #expect(recorded2! >= recorded!)
+    }
+
+    @Test func recordInputRecordsCurrentTime() {
+        let tracker = InputActivityTracker()
+        let beforeRecord = Date()
+
+        tracker.recordInput(paneID: pane1)
+
+        let recorded = tracker.lastInput(paneID: pane1)
+        let afterRecord = Date()
+
+        #expect(recorded != nil)
+        #expect(recorded! >= beforeRecord)
+        #expect(recorded! <= afterRecord)
+    }
+
+    @Test func lastInputReturnsNilForUnknownPane() {
+        let tracker = InputActivityTracker()
+        #expect(tracker.lastInput(paneID: pane1) == nil)
+    }
+
+    @Test func forgetClearsRecordedTimestamp() {
+        let tracker = InputActivityTracker()
+        tracker.recordInput(paneID: pane1)
+        #expect(tracker.lastInput(paneID: pane1) != nil)
+
+        tracker.forget(paneID: pane1)
+        #expect(tracker.lastInput(paneID: pane1) == nil)
+    }
+
+    @Test func forgetOnUnknownPaneIsIdempotent() {
+        let tracker = InputActivityTracker()
+        // Should not crash
+        tracker.forget(paneID: pane1)
+        #expect(tracker.lastInput(paneID: pane1) == nil)
+    }
+
+    @Test func pruneDropsAbsentPanes() {
+        let tracker = InputActivityTracker()
+        tracker.recordInput(paneID: pane1)
+        tracker.recordInput(paneID: pane2)
+        tracker.recordInput(paneID: pane3)
+
+        #expect(tracker.lastInput(paneID: pane1) != nil)
+        #expect(tracker.lastInput(paneID: pane2) != nil)
+        #expect(tracker.lastInput(paneID: pane3) != nil)
+
+        // Prune: keep only pane1 and pane2
+        tracker.prune(keeping: Set([pane1, pane2]))
+
+        #expect(tracker.lastInput(paneID: pane1) != nil)
+        #expect(tracker.lastInput(paneID: pane2) != nil)
+        #expect(tracker.lastInput(paneID: pane3) == nil)
+    }
+
+    @Test func pruneWithEmptySetClearsAll() {
+        let tracker = InputActivityTracker()
+        tracker.recordInput(paneID: pane1)
+        tracker.recordInput(paneID: pane2)
+
+        tracker.prune(keeping: Set())
+
+        #expect(tracker.lastInput(paneID: pane1) == nil)
+        #expect(tracker.lastInput(paneID: pane2) == nil)
+    }
+
+    @Test func pruneIsIdempotent() {
+        let tracker = InputActivityTracker()
+        tracker.recordInput(paneID: pane1)
+
+        tracker.prune(keeping: Set([pane1]))
+        let after1 = tracker.lastInput(paneID: pane1)
+
+        tracker.prune(keeping: Set([pane1]))
+        let after2 = tracker.lastInput(paneID: pane1)
+
+        #expect(after1 == after2)
+    }
+
+    @Test func multiplepanesTrackedIndependently() {
+        let tracker = InputActivityTracker()
+
+        tracker.recordInput(paneID: pane1)
+        let time1 = tracker.lastInput(paneID: pane1)!
+
+        // Small delay to ensure time advances
+        usleep(100)
+
+        tracker.recordInput(paneID: pane2)
+        let time2 = tracker.lastInput(paneID: pane2)!
+
+        #expect(time2 >= time1)
+        // pane1's time should not have changed
+        #expect(tracker.lastInput(paneID: pane1) == time1)
+    }
+}

--- a/docs/superpowers/specs/2026-07-09-pending-input-detection-design.md
+++ b/docs/superpowers/specs/2026-07-09-pending-input-detection-design.md
@@ -1,0 +1,316 @@
+# Design: Pending-typed-input detection without TUI scraping
+
+*2026-07-09. Grounded in a read of the live hibernation stack on `upstream/main`
+(`HibernationSafetyChecks.swift`, `HibernationGate.swift`,
+`HibernationCoordinator.swift`, the v39/v50 migrations), the Claude-hook overlay
+(`ClaudeHookOverlay.swift`), and the tmux input pipeline
+(`ControlModeInputRouter.swift`). Addresses gap #1 of issue #421.*
+
+## Problem
+
+Auto-idle-hibernate is the lever that keeps a 40-worktree fleet out of swap
+(live Claude session ≈ 70 MB RSS → parked ≈ 0). It was **forced off by default**
+in migration `v50_auto_hibernate_idle_sweep_off_by_default` for one reason,
+spelled out in that migration's own comment:
+
+> The idle sweep drives `HibernationSafetyChecks.hasPendingInput`, a sanctioned
+> TUI screen-scrape whose failure direction is asymmetric: if Claude Code
+> changes its `>` composer rendering, typed-but-unsent input goes unrecognized
+> and gets EATEN by the park.
+
+Today the *sole* guard against eating half-typed input is
+`HibernationSafetyChecks.hasPendingInput(paneCapture:)` — a `capture-pane`
+snapshot scanned bottom-up for a `>` prompt line with non-placeholder content.
+It is a good heuristic, but it is coupled 1:1 to Claude Code's TUI. The moment
+Anthropic reshapes the composer (a different prompt glyph, a full-width box, a
+status line below the input, a theme that recolors the gutter), the scraper
+silently returns `false` ("no pending input") and the sweep parks a pane with a
+half-composed prompt. That is the single worst failure this feature can have —
+the Chrome "discarding lost my typed text" backlash the code comments already
+cite — and it is why the default is off.
+
+**Goal:** add a pending-input signal that does **not** depend on parsing the
+Claude TUI, so a Claude Code UI change fails *safe* (blocks the park) instead of
+silently eating input. Once that signal exists and has soaked, the `v50`
+default-off can be reverted in a later change. This design delivers the
+detector, flag-gated and default-off; **it deliberately does not flip the
+sweep's master default back on** (that is the post-soak follow-up, and keeps
+this diff scoped to the detection layer while another session lands the
+`HibernationCoordinator` wake-path changes for the same issue).
+
+This is also exactly the direction the CLAUDE.md **"No TUI screen-scraping"**
+rule now mandates: get agent state from machine interfaces — Claude Code hooks,
+transcript JSONL, **tmux control-mode events** — not rendered screen text.
+`HibernationSafetyChecks.hasPendingInput` is one of three *sanctioned legacy
+scrapers* the rule explicitly excludes "with refactor-later intent … [it] should
+eventually migrate off screen text." This design is that migration: the
+control-mode input pipeline becomes the primary machine-interface signal, and
+the scrape is demoted to a soak-window backup on a path to removal (see Future
+work #1).
+
+## Investigation findings (verified against `upstream/main`, not assumed)
+
+1. **Every user keystroke already flows through the daemon.** The app does not
+   write to the PTY directly. `TBDTerminalView` → `FDSidecarClient.sendInput`
+   → the daemon's `ControlModeInputRouter`, whose `deliverInput` /
+   `deliverPaste` emit `send-keys -H` on the pane. There is a single daemon-side
+   chokepoint through which *all* typed input passes — a place to stamp "last
+   input at" that owes nothing to how the TUI looks.
+
+2. **Claude Code emits no composer-level event.** The hook overlay
+   (`ClaudeHookOverlay`) registers `SessionStart`, `Stop`, `StopFailure`,
+   `UserPromptSubmit`, and `PreToolUse/PostToolUse:AskUserQuestion`. These are
+   **turn-boundary** events: `UserPromptSubmit`→`working`, `Stop`→`idle`, etc.
+   The finest-grained "user did something" signal Claude Code exposes is
+   *prompt submitted* — i.e. after the user pressed Enter. Nothing fires while
+   the user is *typing* into the composer. So "composer state via session
+   instrumentation" (option b below) cannot be built on today's hook surface.
+
+3. **`activityState` already gates the coarse states.** `HibernationGate.blockingRail`
+   already blocks `.working` and `.waitingForUser`. The residual danger is
+   exactly the state hooks *can't* distinguish: **idle, but with unsent text in
+   the composer.** That is the gap this design fills.
+
+4. **The idle marker is in-memory and resets on restart.** `idleSince` is a
+   `[UUID: Date]` map on the coordinator, seeded during the sweep and cleared on
+   any activity transition; it is not persisted. After a daemon restart every
+   terminal re-seeds `idleSince = now`, so nothing is "idle long enough" for a
+   full `hibernateIdleMinutes` window post-restart. That existing behavior gives
+   any in-memory input tracker a natural grace period to repopulate before the
+   sweep can act (relevant to fail-safe below).
+
+## Options evaluated
+
+### (a) Keystroke tracking at the input pipeline — **chosen as primary**
+
+Stamp a per-pane `lastInputAt` timestamp at the daemon-side input chokepoint
+(`deliverInput` / `deliverPaste`), then veto the park if input arrived **at or
+after** the moment the session went idle (`lastInputAt >= idleSince`).
+
+- **TUI-independent.** It observes bytes entering the pane, not pixels leaving
+  it. A Claude Code composer redesign cannot break it.
+- **Conservative by construction.** *Any* input byte since idle vetoes — a bare
+  Enter, Ctrl-C, an arrow key, or real text. All false positives are in the
+  safe direction (skip one park this sweep; the issue explicitly accepts that
+  cost). The only *permanent* veto is type-then-never-send-never-clear, which is
+  precisely the case we must protect.
+- **Self-clearing.** When the user finally sends (`Enter`→`working`→`Stop`→a
+  new, later `idleSince`), `idleSince` advances past `lastInputAt` and the veto
+  releases with no extra bookkeeping.
+- **Cheap.** One dictionary write per input frame (already the granularity of
+  `InputLatencyRecorder`), one comparison per sweep. No pane capture.
+
+Weakness: in-memory, so a daemon restart forgets pre-restart typing. Covered by
+(c) below and by finding #4's post-restart grace window.
+
+### (b) Composer state via Claude Code session instrumentation — **rejected**
+
+Finding #2 is decisive: Claude Code exposes no composer/keystroke hook. The only
+session signal is turn-boundary state, which TBD already consumes and which by
+definition cannot see "idle with half-typed text." Building (b) would require an
+upstream Claude Code change (a new hook or a queryable composer-dirty bit) that
+does not exist today. Recorded as a future possibility, not a current option.
+
+### (c) Keep the scrape as a second, independent veto — **retained for the soak window only**
+
+`hasPendingInput(paneCapture:)` stays exactly where it is, in
+`performHibernate`, as a second veto re-checked at the kill instant. It covers
+(a)'s one weakness — after a daemon restart the in-memory `lastInputAt` is empty,
+but the scrape still reads the live pane. The two vetoes are independent (one
+reads the input pipeline, one reads the rendered pane) and a park proceeds only
+when **both** agree there is no pending input. Neither is load-bearing alone.
+
+This is a *transitional* retention, not a permanent backup. The "No
+TUI screen-scraping" rule wants this sanctioned scraper gone; keeping it while
+the input veto soaks is the safe way to get there (two independent vetoes during
+the risky window), and removing it once the input veto is trusted is tracked as
+Future work #1 — that removal is what actually discharges the rule's
+migrate-off-screen-text intent and deletes the `HibernationSafetyChecks.swift`
+lint exclusion.
+
+## Recommendation
+
+**(a) as the new primary veto + (c) retained as the second veto; (b) rejected as
+infeasible on today's hook surface.** This is the layered defense the issue asks
+for: the primary signal is now TUI-independent, and the scrape degrades from
+"sole guard" to "backup." A Claude Code UI change now costs *at most* the loss of
+the backup veto, with the primary still blocking the park — the failure mode is
+"we skip an eligible park," never "we eat typed input."
+
+## Design
+
+### Component A: `InputActivityTracker` (new, `Sources/TBDDaemon/Tmux/`)
+
+A small `Sendable` actor (or lock-guarded final class, mirroring
+`InputLatencyRecorder`) keyed by tmux `paneID`:
+
+```swift
+func recordInput(paneID: String, at: ContinuousClock.Instant /* + wall Date */)
+func lastInput(paneID: String) -> Date?
+func forget(paneID: String)   // called when a pane is respawned/closed
+```
+
+- Written from `ControlModeInputRouter.deliverInput` **and** `deliverPaste`
+  (paste into the composer is pending input too) — the single chokepoint.
+- Read by `HibernationCoordinator` during the sweep, translating
+  `terminal.tmuxPaneID` → `lastInput(paneID:)`.
+- In-memory only, matching `idleSince`. Keyed by paneID (not terminal UUID)
+  because the router speaks paneIDs; a paneID reused after respawn can only
+  *add* a stale veto, never drop a real one — the safe direction. Pruned
+  alongside the coordinator's existing `idleSince` prune, plus a `forget` on
+  respawn.
+
+Storing a wall-clock `Date` (comparable to `idleSince`) as well as the
+`ContinuousClock.Instant` the latency path uses; the sweep compares against
+`idleSince`, which is a `Date`.
+
+### Component B: the veto in `HibernationGate.decide` (pure, unit-testable)
+
+Add two parameters and one `Decision` case, consistent with how
+`autoHibernateEnabled` is already threaded into the gate:
+
+```swift
+public enum Decision {
+    ...
+    case pendingTypedInput   // idle, but input arrived after it went to rest
+}
+
+public static func decide(
+    terminal: Terminal,
+    autoHibernateEnabled: Bool,
+    inputVetoEnabled: Bool,        // NEW — the soak flag
+    idleTimeout: TimeInterval,
+    idleSince: Date?,
+    lastInputAt: Date?,            // NEW — from InputActivityTracker
+    now: Date
+) -> Decision {
+    guard autoHibernateEnabled else { return .featureDisabled }
+    if let blocked = blockingRail(terminal: terminal) { return blocked }
+    guard let idleSince, now.timeIntervalSince(idleSince) >= idleTimeout else {
+        return .notIdleLongEnough
+    }
+    if inputVetoEnabled, let lastInputAt, lastInputAt >= idleSince {
+        return .pendingTypedInput
+    }
+    return .eligible
+}
+```
+
+Placed *after* the idle-duration check: we only consult the input veto for an
+otherwise-eligible terminal. The gate stays pure and actor-free — both flag
+branches and the veto boundary are testable with plain values. `sweep()` treats
+`.pendingTypedInput` like the other non-go cases (reset `pendingKillSince`, keep
+the `idleSince` marker so the clock isn't punished, log the precise reason).
+
+`decideForMerge` is left untouched: merge-park is a distinct trigger and keeps
+its own rails; adding the input veto there is a possible follow-up but out of
+scope here.
+
+### Component C: scrape unchanged
+
+`performHibernate` keeps its `hasPendingInput(paneCapture:)` re-check verbatim.
+No change — it is now the *second* veto rather than the only one.
+
+### Component D: the soak flag
+
+A new config column, `hibernate_input_veto_enabled`, added in the next migration
+(`v51_…`), **default `false`** — following the CLAUDE.md migration rules (add
+column with a default, update the GRDB record, update the `Config` model in
+`TBDShared/Models.swift`, all in one commit; new field optional/defaulted so
+existing rows decode). The coordinator reads it and passes `inputVetoEnabled`
+into the gate.
+
+Flag semantics:
+- **OFF (default, today's behavior):** the input veto is never consulted; the
+  scrape alone guards, exactly as on `main`. The `v50` sweep default also stays
+  off, so nothing changes for users until they opt in.
+- **ON (soak):** the input veto is the primary guard; the scrape is the backup.
+  Dogfooded on the author's fleet to measure veto rate (how often real input is
+  correctly caught vs. how often benign input needlessly skips a park) before
+  proposing the `v50` revert.
+
+Deliberately **not in this change:** flipping `autoHibernateEnabled`'s default
+back on. That is the payoff, but it waits until the detector has soaked — and it
+touches the same master-switch surface the concurrent `HibernationCoordinator`
+work is on.
+
+### Data flow
+
+```
+user types  ─▶ TBDTerminalView ─▶ FDSidecarClient.sendInput
+            ─▶ ControlModeInputRouter.deliverInput/deliverPaste
+                   ├─ send-keys -H  (unchanged)
+                   └─ InputActivityTracker.recordInput(paneID, now)   ← NEW
+
+sweep()  ─▶ for each Claude terminal:
+             lastInputAt = InputActivityTracker.lastInput(terminal.tmuxPaneID)
+             HibernationGate.decide(..., inputVetoEnabled, lastInputAt, ...)
+               ├─ .pendingTypedInput ─▶ skip (primary veto)          ← NEW
+               └─ .eligible ─▶ performHibernate
+                                 └─ hasPendingInput(capture) ─▶ skip (backup veto)
+```
+
+## Testing
+
+Both flag branches and the fail-safe path get explicit coverage (per CLAUDE.md's
+"add a test for each branch of a gating conditional"):
+
+**`HibernationGate` unit tests (pure):**
+- Flag ON + `lastInputAt >= idleSince` + idle long enough → `.pendingTypedInput`.
+- Flag OFF + same inputs → `.eligible` (proves the veto is truly gated;
+  regression-guards today's behavior).
+- Flag ON + `lastInputAt < idleSince` (input was consumed by the last turn) →
+  `.eligible`.
+- Flag ON + `lastInputAt == nil` (no input recorded, e.g. post-restart) →
+  `.eligible` from the gate — the scrape is what covers this branch (below).
+- Precedence: `.running` / `.waitingForUser` / `.notIdleLongEnough` still win
+  over the input veto where they should.
+
+**`InputActivityTracker` unit tests:**
+- `recordInput` then `lastInput` returns the stamp; `forget` clears it; unknown
+  pane returns `nil`.
+
+**Fail-safe / belt-and-suspenders (the headline guarantee):**
+- **TUI-break simulation:** feed `performHibernate`'s path a `paneCapture` the
+  scraper does *not* recognize (`hasPendingInput` returns `false`, mimicking a
+  composer redesign) **while** `lastInputAt > idleSince`. Assert the overall
+  decision blocks via `.pendingTypedInput` — i.e. the input veto catches what
+  the scrape misses. This is the test that proves "a Claude Code UI change fails
+  safe."
+- **Restart simulation:** `lastInputAt == nil` but the live pane shows composer
+  text → the scrape veto in `performHibernate` still blocks. Proves the backup
+  covers (a)'s one gap.
+
+**Integration (coordinator sweep):**
+- With the flag ON, a terminal that receives an input frame after going idle is
+  not parked on the next sweep; after it "sends" (idle marker advances past the
+  input), it becomes eligible again.
+
+## Future work (fast-follow, tracked after soak)
+
+1. **Remove the scrape + revert `v50`.** The payoff, in one post-soak PR: once
+   the input veto's veto rate is acceptable, delete `hasPendingInput` and its
+   `HibernationSafetyChecks.swift` lint exclusion (discharging the "No TUI
+   screen-scraping" migrate-off intent), and flip the sweep's master default
+   back on. Coordinated with the wake-path work.
+2. **Reduce benign false positives.** If the soak shows the veto skipping too
+   many parks, refine "any input" → "any input that isn't a lone submit/cancel"
+   (reset the marker on a bare Enter or Ctrl-C, which submit or clear the
+   composer). Kept out of v1 to stay maximally conservative.
+3. **Upstream composer-dirty signal (option b).** If Claude Code ever adds a
+   hook or queryable "composer non-empty" bit, promote it to the primary — an
+   even cleaner machine interface than the input pipeline.
+4. **Extend the veto to `decideForMerge`** if merge-park ever eats input in
+   practice.
+
+## Success criteria
+
+- A simulated Claude Code composer redesign (scraper blind) **cannot** cause a
+  park that eats typed input, as long as the input arrived after the session
+  went idle — proven by the TUI-break test.
+- Flag OFF reproduces today's behavior byte-for-byte (regression test green).
+- The detector is purely additive to safety: it can only *add* vetoes, never
+  remove an existing one.
+- Diff is scoped to the detection layer (input router, tracker, gate, config
+  flag, migration) — no changes to the wake path or the master default that the
+  concurrent `HibernationCoordinator` work owns.


### PR DESCRIPTION
Closes gap #1 of #421 ("pending-input detection without TUI scraping").

## Why
Auto-idle-hibernate was forced OFF by default in `v50` because its only guard against eating half-typed input is `HibernationSafetyChecks.hasPendingInput` — a `capture-pane` scrape of Claude's `>` composer. A Claude Code TUI change silently breaks that scrape and the park eats typed-but-unsent input. This adds a **machine-interface** signal so the failure mode becomes "skip an eligible park" instead of "eat input".

## How
Every keystroke already flows daemon-side through `ControlModeInputRouter` → `send-keys`. New `InputActivityTracker` stamps a per-pane "last input at" there (wired via an `onInput` callback at the `Daemon` composition root, mirroring the existing `onHealthChange` pattern). `HibernationGate.decide` gains a `.pendingTypedInput` case: **veto when `lastInputAt >= idleSince`** — input arrived at/after the session went idle. Conservative (any input since idle vetoes) and self-clearing (sending advances `idleSince` past the input).

This is the migration the new "No TUI screen-scraping" rule asks for: the tmux control-mode input event is the primary signal. The existing scrape is **retained as a second, independent veto** for the soak window (covers the post-restart gap where the in-memory stamp is empty) — a park proceeds only when both agree.

## Scope / safety
- **Flag-gated behind `config.hibernateInputVetoEnabled` (migration `v51`, default OFF).** The `v50` auto-hibernate master default stays OFF. No behavior change for users until the flag is flipped.
- Enable the soak via SQL for now (no RPC/UI toggle, to keep this scoped to the detection layer): `UPDATE config SET hibernate_input_veto_enabled=1`.
- **Detection layer only** — no wake-path changes. Rebased on top of #424 (profile pre-wake + wake-all); the two coexist cleanly.
- **Rejected option (b)** composer-state-via-hooks: Claude Code emits no composer/keystroke event, only turn-boundary hooks (already consumed).

## Tests
- `HibernationGate`: both flag branches, veto precedence (`.running`/`.waitingForUser`/`.notIdleLongEnough` still win), the idle-timestamp boundary, and **`tuiBreakSimulation`** — scraper blind + input stamp → still blocks (proves a Claude Code UI change fails safe).
- `InputActivityTracker`: record/lastInput/forget/prune, multi-pane isolation.
- `swift build`, targeted `swift test` (40 tests), and `swiftlint --strict` all green.

## Follow-up (post-soak, separate PR)
Once the veto rate is acceptable: delete the scrape + its `HibernationSafetyChecks.swift` lint exclusion (discharging the migrate-off-screen-text intent) **and** revert `v50` so auto-idle-hibernate is default-on.

Design doc: `docs/superpowers/specs/2026-07-09-pending-input-detection-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)