### PR TITLE
docs: add nightwatch operating rules and worktree display-name invariant

### DIFF
--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -50,6 +50,16 @@ Only when `tick.py` exits 10 (or on the 2-hour deep-review window): read `queue/
 
 A PR may only be enqueued when **claude-review = APPROVED on the current SHA + checks clean**. Human approval never substitutes. `gh pr merge` is NOT a safe-wedge — it always escalates. nightwatch's job is to get PRs *ready*; the human merges.
 
+## Operating rules (hard-won via incidents)
+
+**REBALANCE FIRST on saturation** — A capacity crunch is usually too many sessions piled on ONE rate-capped account, not global scarcity. Swap stuck (STRANDED/RATE/ERROR) sessions onto an emptier account via `tbd terminal swap-profile --terminal <tid> --profile <name>` (parked=cold/cheap, awake=respawn). Passive holding just freezes them. *(Incident 2026-07-10: 14 of 19 stuck sessions were piled on one account; the watcher held instead of rebalancing and the whole fleet stalled overnight until rebalanced.)*
+
+**READ context before nudging** — Capture the worker's actual conversation (`tbd terminal conversation --terminal <tid>` or the pane) and give a SPECIFIC next step, not a blanket "continue" (which just makes agents re-idle).
+
+**FOLLOW UP in ~90s** — After nudging (background sleep), re-check in ~90 seconds rather than waiting for the next tick. Catches agents mid-action at confirm/permission prompts that would otherwise hang the whole cycle.
+
+**ALWAYS SIGN commits** — Never use `gpgsign=false`; some repos (longeye-ai/monorepo) silently reject unsigned commits.
+
 ## Config (`config/`)
 - `priorities.txt` — must-keep-moving worktrees (flagged ★, reported first)
 - `safe_wedges.txt` — permission-wedge prefixes the daemon may auto-approve (never `gh pr merge`)

--- a/docs/worktree-display-name-invariant.md
+++ b/docs/worktree-display-name-invariant.md
@@ -1,0 +1,42 @@
+# Worktree display-name invariant: `name == displayName`
+
+## The rule
+
+On default worktree creation, keep the internal folder slug (`name`) equal to the user-visible tab label (`displayName`). Both should derive from a single source: the daemon-generated slug.
+
+```
+✓ CORRECT
+  createWorktree() → daemon auto-generates name
+  name = "eager-squirrel"
+  displayName = "eager-squirrel"  (defaulted to name in daemon)
+
+✗ BROKEN
+  createWorktree() → explicit displayName without folder
+  name = "eager-squirrel"        (daemon-generated)
+  displayName = "Custom Label"   (app-specified)
+  → worktree appears "already renamed" → stop-rename-check hook never fires
+```
+
+## Why it matters
+
+The `stop-rename-check` hook only fires when `hasDefaultDisplayName == true`, defined as:
+
+```swift
+public var hasDefaultDisplayName: Bool { displayName == name }
+```
+
+If a worktree is born with diverged `name` and `displayName`, it looks "already renamed" and the hook skips, leaving the tab title unchanged. This breaks the auto-title UX that normalizes poorly-chosen daemon-generated names on first use.
+
+## Implementation rule
+
+When calling `daemonClient.createWorktree()`:
+- Pass **neither** `folder` nor `displayName` to the daemon
+- Let the daemon default `displayName ?? name`, ensuring they're equal
+- The local optimistic placeholder still gets `displayName: placeholderName` for instant UI feedback; this is reconciled at swap time
+
+## Regression history
+
+- **PR #378** broke it: set `displayName` without `folder` → two independent slugs
+- **PR #419** fixed it: pass neither → daemon defaults both to same value
+
+See `Sources/TBDApp/AppState+Worktrees.swift` lines 55–63 for the current correct pattern.


### PR DESCRIPTION
Add hard-won nightwatch fleet-babysitter operating rules from incident analysis:
- **Rebalance first on saturation**: Swap stuck sessions to emptier accounts via `tbd terminal swap-profile` instead of passive holding (incident 2026-07-10)
- **Read context before nudging**: Capture the worker's actual conversation and give specific next steps
- **Follow up in ~90s**: Check progress after nudging to catch agents at confirmation prompts
- **Always sign commits**: Some repos silently reject unsigned commits

Also document the worktree `name == displayName` invariant and its implications for the `stop-rename-check` hook.