### PR TITLE
feat: make entire Nightwatch/Daywatch banner clickable

### DIFF
--- a/Sources/TBDApp/Sidebar/NightwatchDeskStatusBanner.swift
+++ b/Sources/TBDApp/Sidebar/NightwatchDeskStatusBanner.swift
@@ -42,32 +42,32 @@ struct NightwatchDeskStatusBanner: View {
 
     var body: some View {
         if let content = bannerContent {
-            HStack(spacing: 8) {
-                Text(content.glyph)
-                    .font(.system(size: 14, weight: .semibold))
-                Text(content.text)
-                    .font(.caption)
-                Spacer()
-                Button(action: focusDeskSession) {
+            Button(action: focusDeskSession) {
+                HStack(spacing: 8) {
+                    Text(content.glyph)
+                        .font(.system(size: 14, weight: .semibold))
+                    Text(content.text)
+                        .font(.caption)
+                    Spacer()
                     Image(systemName: "arrow.up.left")
                         .font(.system(size: 10))
                 }
-                .buttonStyle(.plain)
-                .help("Focus Watch Desk session")
+                .padding(8)
+                .background(
+                    (tintColor(for: appState.nightwatchMode) ?? .gray)
+                        .opacity(0.15)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .strokeBorder(
+                            (tintColor(for: appState.nightwatchMode) ?? .gray)
+                                .opacity(0.3),
+                            lineWidth: 1
+                        )
+                )
             }
-            .padding(8)
-            .background(
-                (tintColor(for: appState.nightwatchMode) ?? .gray)
-                    .opacity(0.15)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .strokeBorder(
-                        (tintColor(for: appState.nightwatchMode) ?? .gray)
-                            .opacity(0.3),
-                        lineWidth: 1
-                    )
-            )
+            .buttonStyle(.plain)
+            .help("Focus Watch Desk session")
             .onAppear {
                 // Only update desk worktree lookup when mode is active (not .off)
                 if appState.nightwatchMode != .off {


### PR DESCRIPTION
## Summary
Make the entire Nightwatch/Daywatch desk status banner a single clickable target to jump to the Watch Desk session, instead of requiring a precise click on the small arrow button.

## Changes
- Wrapped the banner HStack in a Button with action `focusDeskSession`
- Demoted the inner arrow from a nested Button to a plain Image (visual affordance only)
- Applied `.buttonStyle(.plain)` and `.help()` to the outer Button
- The entire banner area with padding, background, and border is now the tap target

## Testing
- `swift build` passes
- NightwatchDeskStatusBanner tests pass (5/5 tests)
- Existing behavior preserved: banner only appears when mode != .off

🤖 Generated with Claude Code