### PR TITLE
feat(hibernation): Settings toggle for the pending-input veto soak flag (#421)

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -264,6 +264,19 @@ extension AppState {
         }
     }
 
+    /// Persist the pending-input veto for auto-hibernate, then re-fetch
+    /// capabilities so the Settings toggle reflects the daemon's EFFECTIVE
+    /// state. Applies on the next hibernation sweep.
+    func setHibernateInputVetoEnabled(_ enabled: Bool) async {
+        do {
+            try await hibernateInputVetoSetter(enabled)
+            await refreshDaemonCapabilities()
+        } catch {
+            logger.error("Failed to set pending-input veto: \(error, privacy: .public)")
+            showAlert("Failed to set pending-input veto: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Set or clear a per-repo model profile override.
     func setRepoProfileOverride(repoID: UUID, profileID: UUID?) async {
         do {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -629,6 +629,10 @@ final class AppState: ObservableObject {
     /// protocol), so the Settings-toggle tests can exercise the success branch.
     lazy var controlModeSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setControlMode(enabled: enabled) }
+    /// How `setHibernateInputVetoEnabled` persists the flag — injectable for
+    /// the same reason as `controlModeSetter`.
+    lazy var hibernateInputVetoSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in try await daemonClient.setHibernateInputVeto(enabled: enabled) }
 
     /// Best-effort re-fetch of `daemonCapabilities` (R7-minor). Used by the
     /// `.modelProfilesChanged` delta handler so a control-mode toggle from

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -817,6 +817,15 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the pending-input veto for auto-hibernate (machine-interface
+    /// guard that prevents hibernation of sessions with typed-but-unsent input).
+    /// Applies on the next hibernation sweep.
+    func setHibernateInputVeto(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetHibernateInputVeto,
+            params: ConfigSetHibernateInputVetoParams(enabled: enabled)
+        )
+    }
 
     /// Set or clear a repo's free-form env overrides.
     func setRepoEnvOverrides(repoID: UUID, overrides: [String: String]) async throws {

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -221,6 +221,7 @@ struct GeneralSettingsTab: View {
                     make prod/access calls yourself.
                     """)
                 controlModeToggle
+                hibernateInputVetoToggle
             }
         }
         .formStyle(.grouped)
@@ -250,6 +251,19 @@ struct GeneralSettingsTab: View {
             .font(.caption)
             .foregroundStyle(.secondary)
         }
+    }
+
+    /// Pending-input veto for auto-hibernate. Reads the persisted flag from
+    /// `daemon.capabilities` and writes via `config.setHibernateInputVeto`.
+    /// Off by default (soaking).
+    @ViewBuilder
+    private var hibernateInputVetoToggle: some View {
+        let capabilities = appState.daemonCapabilities
+        Toggle("Pending-input veto for auto-hibernate", isOn: Binding(
+            get: { capabilities?.hibernateInputVetoEnabled ?? false },
+            set: { newValue in Task { await appState.setHibernateInputVetoEnabled(newValue) } }
+        ))
+        .help("Guard that prevents hibernation of sessions with typed-but-unsent input (machine-interface input detector). Off by default (soaking). Independent of the auto-hibernate idle sweep, which is also off by default.")
     }
 
     private var primaryAgentPreferenceBinding: Binding<PrimaryAgentPreference> {

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -243,4 +243,17 @@ public struct ConfigStore: Sendable {
             )
         }
     }
+
+    /// Persist the pending-input veto for auto-hibernate (machine-interface
+    /// guard that prevents hibernation of sessions with typed-but-unsent input).
+    /// The hibernation sweep re-reads this per decision, so no daemon restart
+    /// is required — changes take effect on the next sweep cycle.
+    public func setHibernateInputVeto(enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET hibernate_input_veto_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -96,4 +96,16 @@ extension RPCRouter {
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()
     }
+
+    /// Persist the pending-input veto for auto-hibernate (machine-interface
+    /// guard that prevents hibernation of sessions with typed-but-unsent input).
+    /// The hibernation sweep re-reads the flag per cycle, so this applies on
+    /// the next sweep immediately — existing hibernated sessions are unaffected.
+    func handleConfigSetHibernateInputVeto(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetHibernateInputVetoParams.self, from: paramsData)
+        try await db.config.setHibernateInputVeto(enabled: params.enabled)
+        // Broadcast so the app reloads daemon capabilities.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -354,6 +354,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetAutoHibernate(request.paramsData)
             case RPCMethod.configSetControlMode:
                 return try await handleConfigSetControlMode(request.paramsData)
+            case RPCMethod.configSetHibernateInputVeto:
+                return try await handleConfigSetHibernateInputVeto(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }
@@ -378,10 +380,12 @@ public final class RPCRouter: Sendable {
             enabled = false
         }
         let version = controlMode?.tmuxVersion
+        let config = try await db.config.get()
         return try RPCResponse(result: DaemonCapabilitiesResult(
             controlModeEnabled: enabled,
             tmuxVersion: version?.description,
-            controlModeSupported: version.map { $0 >= TmuxVersion.controlModeMinimum } ?? false))
+            controlModeSupported: version.map { $0 >= TmuxVersion.controlModeMinimum } ?? false,
+            hibernateInputVetoEnabled: config.hibernateInputVetoEnabled))
     }
 
     // MARK: - PR Status

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -187,6 +187,7 @@ public enum RPCMethod {
     public static let nightwatchReport = "nightwatch.report"
     public static let terminalCancelScheduledResume = "terminal.cancelScheduledResume"
     public static let configSetControlMode = "config.setControlMode"
+    public static let configSetHibernateInputVeto = "config.setHibernateInputVeto"
 }
 
 // MARK: - Branch Listing
@@ -1174,6 +1175,15 @@ public struct ConfigSetControlModeParams: Codable, Sendable {
     public init(enabled: Bool) { self.enabled = enabled }
 }
 
+/// Params for `config.setHibernateInputVeto` — persist the pending-input veto
+/// for auto-hibernate (machine-interface guard that prevents hibernation of
+/// sessions with typed-but-unsent input). The change applies on the next
+/// hibernation sweep; no daemon restart required.
+public struct ConfigSetHibernateInputVetoParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
 /// Params for `repo.setEnvOverrides` — per-repo free-form env overrides.
 public struct SetRepoEnvOverridesParams: Codable, Sendable, Equatable {
     public let repoID: UUID
@@ -1305,13 +1315,19 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// Whether the detected tmux meets the control-mode minimum (>= 3.2).
     /// Computed daemon-side so the app never parses version strings.
     public let controlModeSupported: Bool
+    /// Whether the pending-input veto for auto-hibernate is enabled. Guards
+    /// against hibernating sessions with typed-but-unsent input. Re-evaluated
+    /// by the daemon on every call.
+    public let hibernateInputVetoEnabled: Bool
 
     public init(controlModeEnabled: Bool,
                 tmuxVersion: String? = nil,
-                controlModeSupported: Bool = false) {
+                controlModeSupported: Bool = false,
+                hibernateInputVetoEnabled: Bool = false) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
+        self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1321,6 +1337,8 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         // conservative "unsupported / unknown version".
         tmuxVersion = try c.decodeIfPresent(String.self, forKey: .tmuxVersion)
         controlModeSupported = try c.decodeIfPresent(Bool.self, forKey: .controlModeSupported) ?? false
+        // New field for pending-input veto; absent from older daemons defaults to false (soaking).
+        hibernateInputVetoEnabled = try c.decodeIfPresent(Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
     }
 }
 

--- a/Tests/TBDAppTests/ModelProfileAppStateTests.swift
+++ b/Tests/TBDAppTests/ModelProfileAppStateTests.swift
@@ -119,6 +119,37 @@ import TBDShared
             "a transient refresh failure after a successful set must not snap the toggle off")
 }
 
+// R8-M1 for hibernateInputVeto: these tests mirror the controlMode pair and
+// cover the same keep-last-known-value refresh path (transient failure safety).
+@MainActor
+@Test func appState_setHibernateInputVetoEnabledRefreshesCapabilitiesOnSuccess() async {
+    let state = AppState()
+    state.hibernateInputVetoSetter = { _ in }  // set RPC succeeds
+    state.daemonCapabilitiesFetcher = {
+        DaemonCapabilitiesResult(controlModeEnabled: false, hibernateInputVetoEnabled: true)
+    }
+    #expect(state.daemonCapabilities == nil)
+
+    await state.setHibernateInputVetoEnabled(true)
+
+    #expect(state.daemonCapabilities?.hibernateInputVetoEnabled == true,
+            "a successful toggle must re-fetch the daemon's effective state")
+}
+
+@MainActor
+@Test func appState_setHibernateInputVetoEnabledKeepsLastKnownCapabilitiesOnRefreshFailure() async {
+    let state = AppState()
+    state.hibernateInputVetoSetter = { _ in }  // set RPC succeeds...
+    state.daemonCapabilitiesFetcher = { nil }  // ...but the re-fetch transiently fails
+    state.daemonCapabilities = DaemonCapabilitiesResult(
+        controlModeEnabled: false, hibernateInputVetoEnabled: true)
+
+    await state.setHibernateInputVetoEnabled(true)
+
+    #expect(state.daemonCapabilities?.hibernateInputVetoEnabled == true,
+            "a transient refresh failure after a successful set must not snap the toggle off")
+}
+
 @MainActor
 @Test func appState_dismissedProxyWarningsStartsEmptyAndAcceptsInsertions() {
     // The banner dismissal logic in TerminalPanelView writes to this set so a

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -177,4 +177,25 @@ struct ConfigStoreTests {
         cfg = try await db.config.get()
         #expect(cfg.nightwatchMode == .off)
     }
+
+    @Test func hibernateInputVetoDefaultsToFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.hibernateInputVetoEnabled == false)
+    }
+
+    @Test func setAndGetHibernateInputVetoEnabled() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHibernateInputVeto(enabled: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.hibernateInputVetoEnabled == true)
+    }
+
+    @Test func setHibernateInputVetoToFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setHibernateInputVeto(enabled: true)
+        try await db.config.setHibernateInputVeto(enabled: false)
+        let cfg = try await db.config.get()
+        #expect(cfg.hibernateInputVetoEnabled == false)
+    }
 }

--- a/Tests/TBDDaemonTests/HibernateInputVetoRPCTests.swift
+++ b/Tests/TBDDaemonTests/HibernateInputVetoRPCTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Pending-input veto for auto-hibernate RPC tests. Covers the
+/// `config.setHibernateInputVeto` RPC and the extended `daemon.capabilities`
+/// response carrying the hibernateInputVetoEnabled flag.
+@Suite("Pending-input veto RPC")
+struct HibernateInputVetoRPCTests {
+
+    private func makeRouterAndDB() throws -> (RPCRouter, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+        return (router, db)
+    }
+
+    private func setHibernateInputVeto(_ router: RPCRouter, enabled: Bool) async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetHibernateInputVeto,
+            params: ConfigSetHibernateInputVetoParams(enabled: enabled))
+        let response = await router.handle(request)
+        #expect(response.success)
+    }
+
+    // MARK: - config.setHibernateInputVeto
+
+    @Test("config.setHibernateInputVeto persists the flag to true")
+    func setVetoEnabledPersists() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setHibernateInputVeto(router, enabled: true)
+        #expect(try await db.config.get().hibernateInputVetoEnabled == true)
+    }
+
+    @Test("config.setHibernateInputVeto persists the flag to false")
+    func setVetoDisabledPersists() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setHibernateInputVeto(router, enabled: true)
+        try await setHibernateInputVeto(router, enabled: false)
+        #expect(try await db.config.get().hibernateInputVetoEnabled == false)
+    }
+
+    // MARK: - daemon.capabilities
+
+    @Test("capabilities carries hibernateInputVetoEnabled")
+    func capabilitiesCarriesVetoFlag() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setHibernateInputVeto(router, enabled: true)
+        let response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        let result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.hibernateInputVetoEnabled == true)
+    }
+
+    @Test("capabilities re-evaluates the veto flag without a daemon restart")
+    func capabilitiesReEvaluatesVetoFlag() async throws {
+        let (router, db) = try makeRouterAndDB()
+
+        var response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        var result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.hibernateInputVetoEnabled == false)
+
+        try await setHibernateInputVeto(router, enabled: true)
+        response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.hibernateInputVetoEnabled == true)
+
+        try await setHibernateInputVeto(router, enabled: false)
+        response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.hibernateInputVetoEnabled == false)
+    }
+
+    /// Codable back-compat: capabilities JSON from a daemon without the new
+    /// hibernateInputVetoEnabled key must still decode with a safe default.
+    @Test("capabilities JSON without hibernateInputVetoEnabled decodes with default false")
+    func capabilitiesDecodeBackCompat() throws {
+        let json = Data(#"{"controlModeEnabled":true,"controlModeSupported":false}"#.utf8)
+        let result = try JSONDecoder().decode(DaemonCapabilitiesResult.self, from: json)
+        #expect(result.controlModeEnabled == true)
+        #expect(result.hibernateInputVetoEnabled == false)
+    }
+}


### PR DESCRIPTION
Follow-up to #426 (pending-input detection for #421).

## What
#426 added the pending-input veto (`config.hibernateInputVetoEnabled`) but left it flippable only via manual SQL. This wires a real toggle end-to-end so the soak can be started from the app, mirroring the existing `controlModeEnabled` plumbing exactly:

`ConfigStore.setHibernateInputVeto` → `config.setHibernateInputVeto` RPC → `DaemonCapabilitiesResult.hibernateInputVetoEnabled` → `DaemonClient` → `AppState.setHibernateInputVetoEnabled` → a Toggle in Settings → **Experimental**.

## Soak defaults OFF — enable path
The flag **stays default OFF** (it's a soak flag; the auto-hibernate idle sweep it feeds is also still off by default from `v50`). Nothing changes for users until the toggle is flipped.

**To enable the soak:** Settings → General → Experimental → **"Pending-input veto for auto-hibernate"**. (The old manual path — `UPDATE config SET hibernate_input_veto_enabled=1` — still works and is now equivalent.) The hibernation idle sweep re-reads config each pass, so toggling takes effect on the **next sweep — no daemon restart**.

## Scope
- Toggle plumbing only. The detector/sweep/gate logic from #426 is untouched.
- `DaemonCapabilitiesResult` gains `hibernateInputVetoEnabled` with a `?? false` default decode, so an older daemon's payload still decodes.

## Tests
- `ConfigStore`: `setHibernateInputVeto` round-trip, both branches (true then false).
- `HibernateInputVetoRPCTests`: the RPC handler persists the flag and it surfaces through `daemon.capabilities` in both states.
- `swift build`, filtered `swift test` (34 tests), and `swiftlint --strict` all green.

## Bigger picture (#421)
This unblocks the soak. The post-soak PR (separate) then removes the TUI scrape + its lint exclusion and reverts `v50` so auto-idle-hibernate returns to default-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)