### PR TITLE
polish: add pointing-hand cursor to Nightwatch/Daywatch banner

### DIFF
--- a/Sources/TBDApp/Sidebar/NightwatchDeskStatusBanner.swift
+++ b/Sources/TBDApp/Sidebar/NightwatchDeskStatusBanner.swift
@@ -67,6 +67,7 @@ struct NightwatchDeskStatusBanner: View {
                 )
             }
             .buttonStyle(.plain)
+            .pointerStyle(.link)
             .help("Focus Watch Desk session")
             .onAppear {
                 // Only update desk worktree lookup when mode is active (not .off)


### PR DESCRIPTION
## Summary
Adds a pointing-hand hover cursor (`pointerStyle(.link)`) to the Nightwatch/Daywatch desk banner to make it clearly readable as clickable. The banner was made fully clickable in #428; this commit adds the missing cursor affordance.

## Test plan
- [x] `swift build` passes
- [x] `NightwatchDeskStatusBanner` tests pass (5 tests)
- [x] Hovering over the banner shows pointing-hand cursor

🤖 Generated with Claude Code