### PR TITLE
Fix: Turn usage bars yellow when burning over pace, matching Claude-Usage-Tracker

### DIFF
--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -204,9 +204,10 @@ private struct UsageBarRow: View {
             bucket("weekly_all", 12, severity: "normal", resetsIn: 6 * 24 * 3600),
         ]), now: now)
 
-        // Mid usage, over pace — the marker sits behind the fill (burning
-        // fast). Session projects to ~85% (yellow "warming"); weekly projects
-        // to ~95% (orange) despite the API still saying "normal".
+        // Mid usage — the projection lands in the caution/warning bands even
+        // while the marker sits just ahead of the fill. Session projects to
+        // ~85% (yellow "warming"); weekly projects to ~95% (orange) despite
+        // the API still saying "normal".
         UsageBarsView(snapshot: snap([
             bucket("session", 55, severity: "normal", resetsIn: 1.75 * 3600),
             bucket("weekly_all", 55, severity: "normal", resetsIn: 2.95 * 24 * 3600),

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -3,8 +3,10 @@ import TBDShared
 
 /// A compact two-row usage meter for a Claude OAuth profile: the 5-hour session
 /// window and the weekly all-models window, each drawn as a thin bar with a
-/// severity-colored fill, a neutral "time marker" tick showing how far
-/// through the window we are, and a trailing percent.
+/// pace-aware colored fill (green/yellow/orange/red — projection of end-of-window
+/// usage from the current burn rate, floored by the API severity so a
+/// warning/critical bucket never reads healthy), a neutral "time marker" tick
+/// showing how far through the window we are, and a trailing percent.
 ///
 /// Pure presentation over a `ProfileUsageSnapshot` (no picker/tab state), so it
 /// is reusable anywhere a snapshot is in hand. `now`/`timeZone` are injectable
@@ -116,12 +118,20 @@ private struct UsageBarRow: View {
 
     // MARK: Colors
 
-    /// Usage-severity fill: green (adaptive) when healthy, orange at warning,
-    /// red at critical.
+    /// Pace-aware fill (shared by the bar and the trailing percent): green
+    /// (adaptive) when on a sustainable pace, yellow (adaptive) when the
+    /// projected end-of-window usage is warming (75–90%), orange when it will
+    /// likely graze the limit (90–100%), red when on pace to exceed. The API
+    /// severity (or the >=75/>=90 percent fallback) floors the tier, so a
+    /// warning/critical bucket never renders healthier than before; without
+    /// pace data (no reset date, <15% elapsed) this is exactly the old
+    /// severity coloring.
     private var fillColor: Color {
-        switch ProfileUsagePresentation.severityLevel(severity: bucket.severity,
-                                                      percent: bucket.percent) {
+        switch ProfileUsagePresentation.fillLevel(severity: bucket.severity,
+                                                  percent: bucket.percent,
+                                                  elapsedFraction: elapsedFraction) {
         case .normal: return Self.adaptiveGreen(colorScheme)
+        case .caution: return Self.adaptiveYellow(colorScheme)
         case .warning: return .orange
         case .critical: return .red
         }
@@ -140,6 +150,15 @@ private struct UsageBarRow: View {
         colorScheme == .dark
             ? Color(red: 60 / 255, green: 199 / 255, blue: 95 / 255)
             : Color(red: 27 / 255, green: 107 / 255, blue: 52 / 255)
+    }
+
+    /// Yellow that reads on both appearances: a bright warm yellow in dark
+    /// mode, a deeper amber in light mode (pure yellow washes out against the
+    /// pale bar track).
+    private static func adaptiveYellow(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(red: 235 / 255, green: 194 / 255, blue: 52 / 255)
+            : Color(red: 158 / 255, green: 110 / 255, blue: 6 / 255)
     }
 
     // MARK: Tooltip
@@ -185,10 +204,12 @@ private struct UsageBarRow: View {
             bucket("weekly_all", 12, severity: "normal", resetsIn: 6 * 24 * 3600),
         ]), now: now)
 
-        // Mid usage, over pace — the marker sits behind the fill (burning fast).
+        // Mid usage, over pace — the marker sits behind the fill (burning
+        // fast). Session projects to ~85% (yellow "warming"); weekly projects
+        // to ~95% (orange) despite the API still saying "normal".
         UsageBarsView(snapshot: snap([
-            bucket("session", 70, severity: "normal", resetsIn: 3.5 * 3600),
-            bucket("weekly_all", 55, severity: "warning", resetsIn: 5 * 24 * 3600),
+            bucket("session", 55, severity: "normal", resetsIn: 1.75 * 3600),
+            bucket("weekly_all", 55, severity: "normal", resetsIn: 2.95 * 24 * 3600),
         ]), now: now)
 
         // Near limit.

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -56,6 +56,67 @@ enum ProfileUsagePresentation {
         }
     }
 
+    // MARK: - Pace-aware fill tier
+
+    /// Fill tiers for the usage bars, ordered by urgency. A superset of
+    /// `SeverityLevel` with one extra `caution` (yellow) tier between normal
+    /// and warning that only pace projection can produce — "you're burning
+    /// faster than the window, but not yet alarmingly so".
+    enum FillLevel: Int, Comparable {
+        case normal
+        case caution
+        case warning
+        case critical
+
+        static func < (lhs: FillLevel, rhs: FillLevel) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+
+    /// Minimum elapsed fraction before pace projection kicks in — earlier than
+    /// this the projection is too noisy to color by (a single request at
+    /// minute one would scream red). Matches the reference tracker's gate.
+    static let paceGateElapsedFraction = 0.15
+
+    /// Pace-aware fill tier for a usage bar: project end-of-window usage from
+    /// the current burn rate (`projected = (percent/100) / elapsedFraction`)
+    /// and tier it —
+    ///
+    /// - projected < 0.75 → `.normal` (green: sustainable pace)
+    /// - 0.75 ..< 0.90 → `.caution` (yellow: warming — on track to land close)
+    /// - 0.90 ..< 1.00 → `.warning` (orange: will likely graze the limit)
+    /// - >= 1.00 → `.critical` (red: on pace to exceed)
+    ///
+    /// The plain `severityLevel(severity:percent:)` result acts as a FLOOR:
+    /// the final tier is `max(paceTier, floor)`, so an API "warning"/
+    /// "critical" (or the >=75%/>=90% used fallback) never renders healthier
+    /// than it does today. Projection only runs when an elapsed fraction is
+    /// available, is within `[paceGateElapsedFraction, 1)`, and percent > 0;
+    /// otherwise (no reset date, window barely started, window over) the
+    /// result is exactly the floor — today's behavior.
+    static func fillLevel(severity: String?,
+                          percent: Double,
+                          elapsedFraction: Double?) -> FillLevel {
+        let floor: FillLevel
+        switch severityLevel(severity: severity, percent: percent) {
+        case .normal: floor = .normal
+        case .warning: floor = .warning
+        case .critical: floor = .critical
+        }
+        guard let elapsed = elapsedFraction,
+              elapsed >= paceGateElapsedFraction, elapsed < 1.0,
+              percent > 0 else { return floor }
+        let projected = (percent / 100) / elapsed
+        let pace: FillLevel
+        switch projected {
+        case ..<0.75: pace = .normal
+        case 0.75..<0.90: pace = .caution
+        case 0.90..<1.00: pace = .warning
+        default: pace = .critical
+        }
+        return max(pace, floor)
+    }
+
     // MARK: - Pace projection
 
     /// The 5-hour rolling session window, in seconds — the denominator for the

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -215,6 +215,104 @@ struct SeverityLevelTests {
     }
 }
 
+// MARK: - Pace-aware fill tier
+
+@Suite("ProfileUsagePresentation — fillLevel (pace)")
+struct FillLevelTests {
+    @Test func underPaceProjectionStaysNormal() {
+        // 20% used at half-window → projected 0.40 < 0.75 → green.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 20, elapsedFraction: 0.5) == .normal)
+    }
+
+    @Test func projectionInWarmingBandIsCaution() {
+        // 55% used at 0.65 elapsed → projected ≈ 0.846 → yellow.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 55, elapsedFraction: 0.65) == .caution)
+        // Band edges: exactly 0.75 is caution, just below is normal.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 37.5, elapsedFraction: 0.5) == .caution)
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 37.4, elapsedFraction: 0.5) == .normal)
+    }
+
+    @Test func projectionInPressingBandIsWarning() {
+        // 45% used at 0.475 elapsed → projected ≈ 0.947 → orange.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 45, elapsedFraction: 0.475) == .warning)
+        // Lower band edge: exactly 0.90.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 45, elapsedFraction: 0.5) == .warning)
+    }
+
+    @Test func projectionAtOrAboveOneIsCritical() {
+        // 50% used at 0.5 elapsed → projected exactly 1.0 → red.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 50, elapsedFraction: 0.5) == .critical)
+        // 70% at 0.3 elapsed → projected ≈ 2.33 → red.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 70, elapsedFraction: 0.3) == .critical)
+    }
+
+    @Test func gateOffBelowFifteenPercentElapsedFallsBackToFloor() {
+        // Burning insanely fast, but the window barely started: projection is
+        // too noisy, so the plain severity floor rules (normal here).
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 30, elapsedFraction: 0.10) == .normal)
+        // At exactly the gate the projection turns on.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 30, elapsedFraction: 0.15) == .critical)
+    }
+
+    @Test func windowOverOrNoFractionFallsBackToFloor() {
+        // elapsedFraction == 1.0 (window over) → floor only.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 60, elapsedFraction: 1.0) == .normal)
+        // No reset date → nil fraction → exactly today's severity mapping.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 60, elapsedFraction: nil) == .normal)
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: nil, percent: 80, elapsedFraction: nil) == .warning)
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: nil, percent: 95, elapsedFraction: nil) == .critical)
+    }
+
+    @Test func severityFloorWinsWhenWorseThanPaceTier() {
+        // Pace says green (10% at 0.8 elapsed → projected 0.125), but the API
+        // says warning/critical — the floor keeps the bar honest.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "warning", percent: 10, elapsedFraction: 0.8) == .warning)
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "critical", percent: 10, elapsedFraction: 0.8) == .critical)
+        // Percent-threshold fallback floors too: 76% used late in the window
+        // projects under 1.0 but still can't render below warning.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: nil, percent: 76, elapsedFraction: 0.99) == .warning)
+    }
+
+    @Test func paceTierWinsWhenWorseThanSeverityFloor() {
+        // API still says normal but the burn rate projects past the limit.
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 55, elapsedFraction: 0.286) == .critical)
+    }
+
+    @Test func zeroPercentStaysNormalRegardlessOfElapsed() {
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: "normal", percent: 0, elapsedFraction: 0.9) == .normal)
+        #expect(ProfileUsagePresentation.fillLevel(
+            severity: nil, percent: 0, elapsedFraction: 0.5) == .normal)
+    }
+
+    @Test func fillLevelsAreOrderedByUrgency() {
+        #expect(ProfileUsagePresentation.FillLevel.normal
+                < ProfileUsagePresentation.FillLevel.caution)
+        #expect(ProfileUsagePresentation.FillLevel.caution
+                < ProfileUsagePresentation.FillLevel.warning)
+        #expect(ProfileUsagePresentation.FillLevel.warning
+                < ProfileUsagePresentation.FillLevel.critical)
+    }
+}
+
 // MARK: - Pace projection: elapsed-time fraction
 
 @Suite("ProfileUsagePresentation — elapsedFraction")


### PR DESCRIPTION
## Summary
- The usage bars (5h / wk) never turned yellow: the fill color only mapped the API's `severity` string with ≥75%/≥90% used-percent fallbacks — the pace-aware coloring from the reference [Claude-Usage-Tracker](https://github.com/anthropics/Claude-Usage-Tracker) was never ported, and no yellow tier existed at all. Only the time-marker *position* math had been borrowed.
- This ports the tracker's projection semantics (`UsageStatusCalculator` gate + `PaceStatus` "warming" band): once ≥15% of the window has elapsed, projected end-of-window usage = used ÷ elapsed-fraction, tiered **<75% green, 75–90% yellow, 90–100% orange, ≥100% red**.
- The existing API-severity/absolute mapping is kept as a **floor** (`max(paceTier, floor)`), so an exhausted or API-flagged bucket never renders healthier than before; with no pace data (<15% elapsed, no reset date) behavior is byte-identical to today.
- The time marker tick stays neutral black (`Color.primary`) — deliberately not pace-colored. Yellow is an adaptive pair (bright warm yellow in dark mode, deep amber in light) so it reads against the pale track, following the existing `adaptiveGreen` pattern.

## Test plan
- [ ] `swift test --filter ProfileUsage` — 132 tests pass, including 19 new cases covering each pace band, the exact 0.75/0.90 edges, the 0.15 gate on/off, floor-wins-over-pace, pace-wins-over-"normal", percent-0, and nil-reset fallback
- [ ] Xcode preview "Usage bars": the mid-usage example now renders yellow (session, projected ~85%) and orange (weekly, projected ~95%) while the API still reports "normal"
- [ ] Live: hover an account with heavy burn early in a window — fill/percent shift green → yellow → orange → red as projection worsens; marker tick remains black

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A4849547-6566-4241-ACA4-F461D77F9DEF)