### PR TITLE
Fix: Stop a glance back at the tab from defeating the deep-link auto-return

### DIFF
--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -58,12 +58,16 @@
       var manual = document.getElementById('manual');
       var link = document.getElementById('link');
 
+      console.log('[tbd-open] script start; worktree param:', JSON.stringify(raw));
+
       if (!ok) {
+        console.log('[tbd-open] worktree param missing or invalid — aborting');
         status.textContent = 'Missing or invalid ?worktree= parameter.';
         return;
       }
 
       var target = 'tbd://open?worktree=' + encodeURIComponent(raw);
+      console.log('[tbd-open] computed target:', target);
       link.href = target;
       manual.hidden = false;
       status.innerHTML = 'Opening TBD for worktree <code>' + raw.replace(/[<&]/g, function (c) {
@@ -82,51 +86,71 @@
       var RETURN_DELAY_MS = 600;
       var armedUntil = 0;
       var returned = false;
-      var returnTimer = null;
-      var fallbackStatusHTML = status.innerHTML;
 
       function arm() {
         armedUntil = Date.now() + DETECT_WINDOW_MS;
+        console.log('[tbd-open] arm(): detection window open until', armedUntil,
+          '(' + DETECT_WINDOW_MS + 'ms from now)');
       }
 
       function onOpened() {
         if (returned) return; // guard against double-fire
         returned = true;
         var canGoBack = history.length > 1;
+        console.log('[tbd-open] onOpened(): history.length =', history.length,
+          '— will', canGoBack ? 'history.back()' : 'window.close()',
+          'in', RETURN_DELAY_MS + 'ms');
         status.textContent = canGoBack
           ? 'Opened in TBD — taking you back…'
           : 'TBD opened — you can close this tab.';
         // Short delay so the scheme launch isn't interrupted by navigating
         // away; the tab is backgrounded at this point, so it's seamless.
-        returnTimer = setTimeout(function () {
-          returnTimer = null;
+        setTimeout(function () {
           if (canGoBack) {
+            console.log('[tbd-open] calling history.back() now');
             history.back();
           } else {
             // Works for script/link-opened tabs; silently no-ops otherwise,
             // in which case the status text above already tells the user.
+            console.log('[tbd-open] calling window.close() now');
             window.close();
+            setTimeout(function () {
+              // If this runs, the tab is still alive — the browser refused
+              // the scripted close (tab wasn't script/link-opened).
+              console.log('[tbd-open] window.close() was ignored by the browser — tab still alive');
+            }, 500);
           }
         }, RETURN_DELAY_MS);
       }
 
       document.addEventListener('visibilitychange', function () {
+        var now = Date.now();
+        var inWindow = now <= armedUntil;
+        console.log('[tbd-open] visibilitychange: document.hidden =', document.hidden,
+          '; inside armed window =', inWindow);
         if (document.hidden) {
-          if (Date.now() <= armedUntil) onOpened();
-        } else if (returnTimer !== null) {
-          // Tab became visible again before the return fired — the hide was
-          // incidental (alt-tab, a notification), not TBD activating. Cancel
-          // the pending navigation and restore the fallback UI intact.
-          clearTimeout(returnTimer);
-          returnTimer = null;
-          returned = false;
-          status.innerHTML = fallbackStatusHTML;
+          if (inWindow) {
+            onOpened();
+          } else if (armedUntil > 0) {
+            // Hidden arrived after the window expired — classic symptom of the
+            // user taking >3s on the "Open TBD.app?" permission dialog.
+            console.log('[tbd-open] hidden arrived', now - armedUntil,
+              'ms after the detection window expired — no auto-return');
+          }
+        } else if (returned) {
+          // Tab became visible again while the return is pending. We no longer
+          // cancel here — once onOpened() has fired, the auto-return proceeds
+          // regardless (glancing back at the tab must not defeat the return).
+          console.log('[tbd-open] tab visible again while return pending — continuing anyway');
         }
       });
 
       // The manual button fires the same tbd:// URL — arm the same
       // success-detection/auto-return logic on click.
-      link.addEventListener('click', arm);
+      link.addEventListener('click', function () {
+        console.log('[tbd-open] manual fallback button clicked');
+        arm();
+      });
 
       // Trigger the custom scheme. location.replace avoids a back-button trap.
       // Browsers handle the unknown scheme silently if the handler isn't installed,
@@ -134,6 +158,7 @@
       // detected, the status message, button, and install hint stay as-is.
       setTimeout(function () {
         arm();
+        console.log('[tbd-open] auto-redirect: calling location.replace(), armed until', armedUntil);
         location.replace(target);
       }, 50);
     })();

--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -94,6 +94,7 @@
       var RETURN_DELAY_MS = 600;
       var armedUntil = 0;
       var returned = false;
+      var returnTimer = null;
 
       function arm() {
         armedUntil = Date.now() + DETECT_WINDOW_MS;
@@ -114,7 +115,8 @@
         // Short delay so the scheme launch isn't interrupted by navigating
         // away. (The tab is usually backgrounded here, but not guaranteed —
         // the return proceeds even if it's visible again by then.)
-        setTimeout(function () {
+        returnTimer = setTimeout(function () {
+          returnTimer = null;
           if (canGoBack) {
             console.log('[tbd-open] calling history.back() now');
             history.back();
@@ -155,9 +157,17 @@
       });
 
       // The manual button fires the same tbd:// URL — arm the same
-      // success-detection/auto-return logic on click.
+      // success-detection/auto-return logic on click. A manual retry
+      // explicitly supersedes any in-flight auto-return: cancel the pending
+      // return timer so the new cycle's own success detection drives the
+      // (single) return, rather than a stale timer double-firing.
       link.addEventListener('click', function () {
         console.log('[tbd-open] manual fallback button clicked — re-arming, resetting returned flag');
+        if (returnTimer !== null) {
+          console.log('[tbd-open] pending return timer cancelled by manual click');
+          clearTimeout(returnTimer);
+          returnTimer = null;
+        }
         // Reset so a retry after a false positive (whose window.close() was
         // ignored) can trigger the status update and auto-return again.
         returned = false;

--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -82,6 +82,14 @@
       // false-positive signal — the browser's "Open TBD.app?" confirmation
       // dialog blurs the window even if the user cancels — but that dialog
       // does not hide the document, so visibilitychange is safe.
+      //
+      // Accepted trade-off: document.hidden is the ONLY success signal we
+      // have, so if TBD is NOT installed, an incidental hide within the 3s
+      // window (alt-tab, clicking a notification) is a false positive and
+      // will navigate the user away from this fallback/install page. We
+      // accept that: cancelling the return when the tab became visible
+      // again defeated the auto-return in the real-success case, which is
+      // why the cancel path was removed.
       var DETECT_WINDOW_MS = 3000;
       var RETURN_DELAY_MS = 600;
       var armedUntil = 0;
@@ -104,7 +112,8 @@
           ? 'Opened in TBD — taking you back…'
           : 'TBD opened — you can close this tab.';
         // Short delay so the scheme launch isn't interrupted by navigating
-        // away; the tab is backgrounded at this point, so it's seamless.
+        // away. (The tab is usually backgrounded here, but not guaranteed —
+        // the return proceeds even if it's visible again by then.)
         setTimeout(function () {
           if (canGoBack) {
             console.log('[tbd-open] calling history.back() now');
@@ -148,7 +157,10 @@
       // The manual button fires the same tbd:// URL — arm the same
       // success-detection/auto-return logic on click.
       link.addEventListener('click', function () {
-        console.log('[tbd-open] manual fallback button clicked');
+        console.log('[tbd-open] manual fallback button clicked — re-arming, resetting returned flag');
+        // Reset so a retry after a false positive (whose window.close() was
+        // ignored) can trigger the status update and auto-return again.
+        returned = false;
         arm();
       });
 


### PR DESCRIPTION
## Summary
- **What's broken:** after the tbd:// redirect page detects TBD opened, it schedules `history.back()` — but if the user glances back at the tab within the 600ms delay, the `visibilitychange` handler cancelled the pending return and restored the fallback UI. Checking whether it worked is exactly what users do, so the auto-return (PR #416) frequently defeated itself.
- **Fix:** once success detection fires, the return is uncancelable — it proceeds even if the tab becomes visible again. Accepted trade-off (documented in-file): with TBD *not installed*, an incidental hide within the 3s window now false-positives into a navigation; the manual button resets the `returned` flag so retries stay live after an ignored `window.close()`.
- **Diagnostics:** every decision point now logs with a `[tbd-open]` console prefix — including the two known silent-failure modes: a visibility flip arriving *after* the 3s window logs how many ms late it was (the >3s "Open TBD.app?" dialog case), and an ignored `window.close()` announces itself 500ms later. Next time the return doesn't fire, the devtools console says why.

## Test plan
- [ ] With TBD installed: click a redirector link from a PR page → TBD opens → immediately click back to the browser tab → the tab still returns to the PR (previously this cancelled the return)
- [ ] Same flow without touching anything → returns as before
- [ ] Console shows the `[tbd-open]` trail for each step; taking >3s on the "Open TBD.app?" dialog logs the late-arrival diagnostic
- [ ] Without TBD installed, invalid/missing `?worktree=` still shows the error; manual button still fires and re-arms

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=61966922-0E69-4FD6-9CF0-4FC4612C73EF)