### PR TITLE
Feat: Orphan GC — reap dead agent worktrees & scratchpads, snapshot-first, restorable from History

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -180,6 +180,7 @@ extension AppState {
             await refreshWorktrees()
             if let repoID = snapshot.repoID {
                 await refreshArchivedWorktrees(repoID: repoID)
+                await refreshReapRecords(repoID: repoID)
             }
         } catch {
             revivingArchived.removeValue(forKey: worktreeID)

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -201,7 +201,7 @@ extension AppState {
             gcEnabled = enabled
         } catch {
             logger.error("Failed to set gcEnabled: \(error, privacy: .public)")
-            showAlert("Failed to set default: \(error.localizedDescription)", isError: true)
+            showAlert("Failed to update GC setting: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -35,6 +35,9 @@ extension AppState {
             if result.autoHibernateOnMergeDefault != autoHibernateOnMergeDefault {
                 autoHibernateOnMergeDefault = result.autoHibernateOnMergeDefault
             }
+            if result.gcEnabled != gcEnabled {
+                gcEnabled = result.gcEnabled
+            }
             if result.nightwatchMode != nightwatchMode {
                 nightwatchMode = result.nightwatchMode
             }
@@ -187,6 +190,17 @@ extension AppState {
             autoHibernateOnMergeDefault = enabled
         } catch {
             logger.error("Failed to set auto-hibernate default: \(error, privacy: .public)")
+            showAlert("Failed to set default: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Set the orphan-GC master switch.
+    func setGCEnabled(_ enabled: Bool) async {
+        do {
+            try await daemonClient.setGCEnabled(enabled)
+            gcEnabled = enabled
+        } catch {
+            logger.error("Failed to set gcEnabled: \(error, privacy: .public)")
             showAlert("Failed to set default: \(error.localizedDescription)", isError: true)
         }
     }

--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -212,6 +212,7 @@ extension AppState {
             selectedRepoID = id
             selectedScratchSection = false
             Task { await refreshArchivedWorktrees(repoID: id) }
+            Task { await refreshReapRecords(repoID: id) }
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -644,7 +644,15 @@ extension AppState {
     /// actually exists in the archived list (or in `revivingArchived` for that
     /// repo). If unset or stale, set it to the most-recently-archived row.
     /// Also kicks off the session fetch for the newly-selected worktree.
-    private func ensureArchivedSelectionValid(repoID: UUID) {
+    ///
+    /// A deliberate Reclaimed-row selection (`selectedReapRecordIDs[repoID]`)
+    /// must not be stolen by this fallback maintenance — see
+    /// `ArchivedWorktreesView`/`ReclaimedSectionView` for the UI side of the
+    /// mutual-exclusivity contract. `internal` (not `private`) so tests can
+    /// drive it directly.
+    func ensureArchivedSelectionValid(repoID: UUID) {
+        guard selectedReapRecordIDs[repoID] == nil else { return }
+
         let archived = (archivedWorktrees[repoID] ?? [])
         let lingering = revivingArchived.values
             .map(\.snapshot)
@@ -659,11 +667,35 @@ extension AppState {
             .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
             .first
         if let pick = mostRecent {
-            selectedArchivedWorktreeIDs[repoID] = pick.id
+            selectArchivedWorktree(pick.id, repoID: repoID)
             Task { await fetchSessions(worktreeID: pick.id) }
+        } else {
+            selectArchivedWorktree(nil, repoID: repoID)
+        }
+    }
+
+    /// Select an archived-worktree row for `repoID`, clearing any Reclaimed
+    /// (reap-record) selection for the same repo — the two are mutually
+    /// exclusive per repo. Pass `nil` to clear the archived selection.
+    func selectArchivedWorktree(_ id: UUID?, repoID: UUID) {
+        if let id {
+            selectedArchivedWorktreeIDs[repoID] = id
         } else {
             selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
         }
+        selectedReapRecordIDs.removeValue(forKey: repoID)
+    }
+
+    /// Select a Reclaimed (reap-record) row for `repoID`, clearing any
+    /// archived-worktree selection for the same repo. Mirrors
+    /// `selectArchivedWorktree(_:repoID:)`. Pass `nil` to clear the reap selection.
+    func selectReapRecord(_ id: UUID?, repoID: UUID) {
+        if let id {
+            selectedReapRecordIDs[repoID] = id
+        } else {
+            selectedReapRecordIDs.removeValue(forKey: repoID)
+        }
+        selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
     }
 
     // MARK: - Reorder top-level

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -332,6 +332,7 @@ extension AppState {
             // same as createWorktree relies on its delta.
             if let repoID = snapshot.repoID {
                 await refreshArchivedWorktrees(repoID: repoID)
+                await refreshReapRecords(repoID: repoID)
             }
         } catch {
             revivingArchived.removeValue(forKey: id)
@@ -591,6 +592,29 @@ extension AppState {
             ensureArchivedSelectionValid(repoID: repoID)
         } catch {
             logger.error("Failed to list archived worktrees: \(error)")
+        }
+    }
+
+    /// Fetch orphan-GC reap records for a repo (History → Reclaimed).
+    func refreshReapRecords(repoID: UUID) async {
+        guard let repoPath = repos.first(where: { $0.id == repoID })?.path else { return }
+        do {
+            reapRecords[repoID] = try await daemonClient.listReapRecords(repoPath: repoPath)
+        } catch {
+            logger.error("Failed to list reap records: \(error)")
+        }
+    }
+
+    /// Restore a swept `ReapRecord` (agent worktrees only) and refresh the
+    /// repo's list so the row disappears from Reclaimed once restored.
+    func restoreReap(_ record: ReapRecord, repoID: UUID) async {
+        do {
+            try await daemonClient.restoreReap(recordID: record.id)
+            await refreshReapRecords(repoID: repoID)
+            await refreshWorktrees()
+        } catch {
+            logger.error("Failed to restore reap record \(record.id, privacy: .public): \(error)")
+            showAlert("Couldn't restore worktree: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -615,6 +615,7 @@ extension AppState {
         } catch {
             logger.error("Failed to restore reap record \(record.id, privacy: .public): \(error)")
             showAlert("Couldn't restore worktree: \(error.localizedDescription)", isError: true)
+            handleConnectionError(error)
         }
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -205,6 +205,10 @@ final class AppState: ObservableObject {
     /// Guards against concurrent loadMoreArchivedWorktrees calls (double-tap, race with refresh).
     @Published var isLoadingMoreArchived: [UUID: Bool] = [:]
 
+    /// Orphan-GC reap records (History → Reclaimed), keyed by repo ID and
+    /// fetched on demand alongside `archivedWorktrees`.
+    @Published var reapRecords: [UUID: [ReapRecord]] = [:]
+
     /// Set briefly when a deep link lands on an archived worktree. The
     /// ArchivedWorktreesView observes this and scrolls/flashes the matching
     /// row, then clears the value after the flash animation completes.
@@ -430,6 +434,10 @@ final class AppState: ObservableObject {
     /// Global default for auto-hibernate-on-PR-merge. Loaded from the daemon
     /// alongside `autoArchiveOnMergeDefault` via `loadModelProfiles()`.
     @Published var autoHibernateOnMergeDefault: Bool = false
+    /// Orphan-GC master switch (Config mirror, default true to match
+    /// `Config.gcEnabled`). Loaded from the daemon alongside
+    /// `autoArchiveOnMergeDefault` via `loadModelProfiles()`.
+    @Published var gcEnabled: Bool = true
     @Published var nightwatchMode: NightwatchMode = .off
     /// Auto-hibernate master switch. Loaded from the daemon `Config` via
     /// `loadHibernationConfig()`.
@@ -965,6 +973,10 @@ final class AppState: ObservableObject {
             Task { [weak self] in await self?.refreshWorktrees() }
         case .controlModeInputHealthChanged(let d):
             applyControlModeInputHealthDelta(d)
+        case .reapRecordsChanged:
+            if let repoID = selectedRepoID {
+                Task { [weak self] in await self?.refreshReapRecords(repoID: repoID) }
+            }
         default:
             break
         }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -600,6 +600,14 @@ final class AppState: ObservableObject {
     /// Selected archived worktree per repo (left rail of the archived view's nested master-detail).
     @Published var selectedArchivedWorktreeIDs: [UUID: UUID] = [:]
 
+    /// Selected "Reclaimed" (orphan-GC reap record) row per repo, in the same
+    /// left rail as `selectedArchivedWorktreeIDs`. The two are mutually
+    /// exclusive per repo — use `selectArchivedWorktree(_:repoID:)` /
+    /// `selectReapRecord(_:repoID:)` (AppState+Worktrees.swift) to change
+    /// either, which keep that invariant instead of mutating these
+    /// dictionaries directly.
+    @Published var selectedReapRecordIDs: [UUID: UUID] = [:]
+
     /// Worktrees the user just revived from the archived view. Keeps the row
     /// visible with a status indicator until the user navigates away from the
     /// archived section. Cleared by `AppState+Navigation` when the active

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -178,6 +178,10 @@ struct ArchivedWorktreesView: View {
         }
         .onAppear { reconcileSelection() }
         .onChange(of: hideEmpty) { _, _ in reconcileSelection() }
+        // This view isn't .id(repoID)-keyed, so @State survives repo switches
+        // (see RepoDetailView note) — a reap selection must not leak into
+        // another repo's Reclaimed section.
+        .onChange(of: repoID) { _, _ in selectedReapRecordID = nil }
     }
 
     /// Make sure `selectedArchivedWorktreeIDs[repoID]` points to a row that
@@ -185,6 +189,9 @@ struct ArchivedWorktreesView: View {
     /// unset or stale; clears when nothing is visible. Triggers a session
     /// fetch for any newly-selected row.
     private func reconcileSelection() {
+        // A deliberate Reclaimed-row selection must not be stolen by the
+        // archived auto-select (mutual exclusivity with selectedReapRecordID).
+        if selectedReapRecordID != nil { return }
         let visibleIDs = Set(rows.map(\.id))
         if let current = selectedID, visibleIDs.contains(current) { return }
         if let first = rows.first(where: { $0.reviveState == nil })?.worktree {

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -8,11 +8,6 @@ struct ArchivedWorktreesView: View {
     @State private var listWidth: CGFloat = 280
     @State private var dragStartWidth: CGFloat? = nil
     @AppStorage("archived.hideEmpty") private var hideEmpty: Bool = true
-    /// Selection for the "Reclaimed" section (Task 12), mutually exclusive
-    /// with `appState.selectedArchivedWorktreeIDs[repoID]` — selecting a reap
-    /// row clears the archived-row selection and vice versa (see `select(_:)`
-    /// and `ReclaimedSectionView.select(_:)`).
-    @State private var selectedReapRecordID: UUID?
 
     /// All archived rows for this repo (∪ lingering revive snapshots), unfiltered.
     /// Used for the unfiltered count and to back the filter visibility decision.
@@ -44,6 +39,13 @@ struct ArchivedWorktreesView: View {
 
     private var selectedID: UUID? {
         appState.selectedArchivedWorktreeIDs[repoID]
+    }
+
+    /// "Reclaimed" section selection, mutually exclusive with `selectedID`
+    /// (see `AppState.selectArchivedWorktree(_:repoID:)` /
+    /// `selectReapRecord(_:repoID:)`).
+    private var selectedReapID: UUID? {
+        appState.selectedReapRecordIDs[repoID]
     }
 
     private var hasMore: Bool {
@@ -173,15 +175,11 @@ struct ArchivedWorktreesView: View {
             }
 
             if appState.reapRecords[repoID]?.isEmpty == false {
-                ReclaimedSectionView(repoID: repoID, selectedReapRecordID: $selectedReapRecordID)
+                ReclaimedSectionView(repoID: repoID)
             }
         }
         .onAppear { reconcileSelection() }
         .onChange(of: hideEmpty) { _, _ in reconcileSelection() }
-        // This view isn't .id(repoID)-keyed, so @State survives repo switches
-        // (see RepoDetailView note) — a reap selection must not leak into
-        // another repo's Reclaimed section.
-        .onChange(of: repoID) { _, _ in selectedReapRecordID = nil }
     }
 
     /// Make sure `selectedArchivedWorktreeIDs[repoID]` points to a row that
@@ -190,15 +188,15 @@ struct ArchivedWorktreesView: View {
     /// fetch for any newly-selected row.
     private func reconcileSelection() {
         // A deliberate Reclaimed-row selection must not be stolen by the
-        // archived auto-select (mutual exclusivity with selectedReapRecordID).
-        if selectedReapRecordID != nil { return }
+        // archived auto-select (mutual exclusivity with selectedReapID).
+        if selectedReapID != nil { return }
         let visibleIDs = Set(rows.map(\.id))
         if let current = selectedID, visibleIDs.contains(current) { return }
         if let first = rows.first(where: { $0.reviveState == nil })?.worktree {
-            appState.selectedArchivedWorktreeIDs[repoID] = first.id
+            appState.selectArchivedWorktree(first.id, repoID: repoID)
             Task { await appState.fetchSessions(worktreeID: first.id) }
         } else {
-            appState.selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
+            appState.selectArchivedWorktree(nil, repoID: repoID)
         }
     }
 
@@ -223,7 +221,7 @@ struct ArchivedWorktreesView: View {
 
     @ViewBuilder
     private var rightPane: some View {
-        if let reapID = selectedReapRecordID,
+        if let reapID = selectedReapID,
            let record = (appState.reapRecords[repoID] ?? []).first(where: { $0.id == reapID }) {
             ReclaimedDetailView(record: record, repoID: repoID)
         } else if let id = selectedID,
@@ -279,8 +277,7 @@ struct ArchivedWorktreesView: View {
     private func select(_ row: ArchivedRow) {
         // In-flight revives are non-selectable; .done rows are fine to browse.
         if case .inFlight = row.reviveState { return }
-        selectedReapRecordID = nil
-        appState.selectedArchivedWorktreeIDs[repoID] = row.id
+        appState.selectArchivedWorktree(row.id, repoID: repoID)
         Task { await appState.fetchSessions(worktreeID: row.id) }
     }
 

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -8,6 +8,11 @@ struct ArchivedWorktreesView: View {
     @State private var listWidth: CGFloat = 280
     @State private var dragStartWidth: CGFloat? = nil
     @AppStorage("archived.hideEmpty") private var hideEmpty: Bool = true
+    /// Selection for the "Reclaimed" section (Task 12), mutually exclusive
+    /// with `appState.selectedArchivedWorktreeIDs[repoID]` — selecting a reap
+    /// row clears the archived-row selection and vice versa (see `select(_:)`
+    /// and `ReclaimedSectionView.select(_:)`).
+    @State private var selectedReapRecordID: UUID?
 
     /// All archived rows for this repo (∪ lingering revive snapshots), unfiltered.
     /// Used for the unfiltered count and to back the filter visibility decision.
@@ -166,6 +171,10 @@ struct ArchivedWorktreesView: View {
                     }
                 }
             }
+
+            if appState.reapRecords[repoID]?.isEmpty == false {
+                ReclaimedSectionView(repoID: repoID, selectedReapRecordID: $selectedReapRecordID)
+            }
         }
         .onAppear { reconcileSelection() }
         .onChange(of: hideEmpty) { _, _ in reconcileSelection() }
@@ -207,7 +216,10 @@ struct ArchivedWorktreesView: View {
 
     @ViewBuilder
     private var rightPane: some View {
-        if let id = selectedID,
+        if let reapID = selectedReapRecordID,
+           let record = (appState.reapRecords[repoID] ?? []).first(where: { $0.id == reapID }) {
+            ReclaimedDetailView(record: record, repoID: repoID)
+        } else if let id = selectedID,
            let row = rows.first(where: { $0.id == id }) {
             if row.effectiveSessionCount == 0 {
                 noSessionsState(for: row.worktree)
@@ -260,6 +272,7 @@ struct ArchivedWorktreesView: View {
     private func select(_ row: ArchivedRow) {
         // In-flight revives are non-selectable; .done rows are fine to browse.
         if case .inFlight = row.reviveState { return }
+        selectedReapRecordID = nil
         appState.selectedArchivedWorktreeIDs[repoID] = row.id
         Task { await appState.fetchSessions(worktreeID: row.id) }
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -807,6 +807,32 @@ actor DaemonClient {
         try await callNoParamsAsync(method: RPCMethod.configGet, resultType: Config.self)
     }
 
+    /// List reaped `ReapRecord`s from the orphan GC, optionally scoped to one
+    /// repo's path (`nil` == every repo, including scratch reap records).
+    func listReapRecords(repoPath: String?) async throws -> [ReapRecord] {
+        try await callAsync(
+            method: RPCMethod.gcList,
+            params: GCListParams(repoPath: repoPath),
+            resultType: [ReapRecord].self
+        )
+    }
+
+    /// Restore a swept `ReapRecord` (agent worktrees only — snapshot-first).
+    func restoreReap(recordID: UUID) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.gcRestore,
+            params: GCRestoreParams(recordID: recordID)
+        )
+    }
+
+    /// Set the orphan-GC master switch.
+    func setGCEnabled(_ enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetGCEnabled,
+            params: ConfigSetGCEnabledParams(enabled: enabled)
+        )
+    }
+
     /// Persist the tmux control-mode opt-in (M5). Applies to newly created
     /// panes; a truthy TBD_TMUX_CONTROL_MODE in the daemon's env still forces
     /// the gate on regardless of this flag.

--- a/Sources/TBDApp/ReclaimedSectionView.swift
+++ b/Sources/TBDApp/ReclaimedSectionView.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+import TBDShared
+
+/// "Reclaimed" collapsed section rendered at the bottom of
+/// `ArchivedWorktreesView`'s leftRail, below the archived-worktree List.
+/// Shows orphan-GC's reap history for the repo (Task 12) — hand-rolled
+/// disclosure per `FileStatusSection` (FileViewer/FileViewerPanel.swift
+/// ~259-301), collapsed by default. Caller renders this only when
+/// `appState.reapRecords[repoID]` is non-empty.
+struct ReclaimedSectionView: View {
+    let repoID: UUID
+    @Binding var selectedReapRecordID: UUID?
+    @EnvironmentObject var appState: AppState
+
+    @State private var isExpanded = false
+
+    /// Single SF Symbol used everywhere GC/reclaim needs a glyph — header,
+    /// row icon, scratchpad rollup row. Keep this the only place it's picked.
+    static let glyph = "arrow.3.trianglepath"
+
+    private var summary: ReclaimedSummary {
+        ReclaimedSummary(records: appState.reapRecords[repoID] ?? [])
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Divider()
+            header
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(summary.agentRecords) { record in
+                        ReclaimedRow(record: record, isSelected: selectedReapRecordID == record.id)
+                            .contentShape(Rectangle())
+                            .onTapGesture { select(record) }
+                    }
+                    if let rollup = summary.scratchpadRollup {
+                        scratchpadRow(rollup)
+                    }
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) { isExpanded.toggle() }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Image(systemName: Self.glyph)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text("RECLAIMED")
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                let unrestored = summary.unrestored
+                Text("(\(unrestored.count) · \(Self.byteString(unrestored.totalApparentBytes)))")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func scratchpadRow(_ rollup: (count: Int, bytes: Int64)) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: Self.glyph)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("\(rollup.count) scratchpad\(rollup.count == 1 ? "" : "s") cleaned · \(Self.byteString(rollup.bytes))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+    }
+
+    /// Selecting a reap row is mutually exclusive with the archived-row
+    /// selection above it — clear the archived selection so the right pane
+    /// unambiguously shows this record's detail.
+    private func select(_ record: ReapRecord) {
+        selectedReapRecordID = record.id
+        appState.selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
+    }
+
+    static func byteString(_ bytes: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+}
+
+// MARK: - Row
+
+private struct ReclaimedRow: View {
+    let record: ReapRecord
+    let isSelected: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: ReclaimedSectionView.glyph)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .padding(.top, 2)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(basename)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    if let branch = record.branch {
+                        Text("branch \(branch) kept")
+                        separator
+                    }
+                    Text("\(ReclaimedSectionView.byteString(record.apparentBytes ?? 0)) (apparent)")
+                    if record.snapshotRef != nil {
+                        separator
+                        Text("snapshot ✓")
+                    }
+                    Spacer(minLength: 6)
+                    Text(record.reapedAt, format: .relative(presentation: .named))
+                        .lineLimit(1)
+                }
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
+    }
+
+    private var separator: some View {
+        Text("·").foregroundStyle(.quaternary).font(.caption2)
+    }
+
+    private var basename: String {
+        URL(fileURLWithPath: record.worktreePath).lastPathComponent
+    }
+}
+
+// MARK: - Detail pane
+
+/// Right-pane detail for a selected reap record — mirrors the "select an
+/// archived worktree" detail shell but for a `ReapRecord`. Restore button
+/// mirrors the revive-button error handling (`AppState.restoreReap` already
+/// catches and calls `showAlert`, per `AppState+Worktrees.swift:608-619`).
+struct ReclaimedDetailView: View {
+    let record: ReapRecord
+    let repoID: UUID
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 6) {
+                Image(systemName: ReclaimedSectionView.glyph)
+                    .foregroundStyle(.secondary)
+                Text(basename)
+                    .font(.title3)
+                    .fontWeight(.medium)
+            }
+
+            detailRow("Path", record.worktreePath)
+            if let branch = record.branch {
+                detailRow("Branch", branch)
+            }
+            detailRow("Reaped", record.reapedAt.formatted(.relative(presentation: .named)))
+            detailRow("Size", "\(ReclaimedSectionView.byteString(record.apparentBytes ?? 0)) (apparent)")
+            detailRow("Snapshot", record.snapshotRef != nil ? "✓ captured" : "clean (no snapshot)")
+
+            Spacer(minLength: 0)
+
+            if let restoredAt = record.restoredAt {
+                Text("Restored \(restoredAt, format: .relative(presentation: .named))")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            } else {
+                Button("Restore") {
+                    Task { await appState.restoreReap(record, repoID: repoID) }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func detailRow(_ label: String, _ value: String) -> some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text(label)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(width: 70, alignment: .leading)
+            Text(value)
+                .font(.callout)
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+        }
+    }
+
+    private var basename: String {
+        URL(fileURLWithPath: record.worktreePath).lastPathComponent
+    }
+}

--- a/Sources/TBDApp/ReclaimedSectionView.swift
+++ b/Sources/TBDApp/ReclaimedSectionView.swift
@@ -103,16 +103,21 @@ private struct ReclaimedRow: View {
     let record: ReapRecord
     let isSelected: Bool
 
+    /// Restored records stay in the list (audit trail) but are no longer
+    /// reclaimed disk — dim the row a step and swap the reaped-at date for
+    /// a "Restored <date>" label so they're visually distinct.
+    private var isRestored: Bool { record.restoredAt != nil }
+
     var body: some View {
         HStack(alignment: .top, spacing: 6) {
             Image(systemName: ReclaimedSectionView.glyph)
                 .font(.caption2)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(isRestored ? .tertiary : .secondary)
                 .padding(.top, 2)
             VStack(alignment: .leading, spacing: 2) {
                 Text(basename)
                     .font(.callout)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(isRestored ? .tertiary : .secondary)
                     .lineLimit(1)
                 HStack(spacing: 4) {
                     if let branch = record.branch {
@@ -125,11 +130,16 @@ private struct ReclaimedRow: View {
                         Text("snapshot ✓")
                     }
                     Spacer(minLength: 6)
-                    Text(record.reapedAt, format: .relative(presentation: .named))
-                        .lineLimit(1)
+                    if let restoredAt = record.restoredAt {
+                        Text("Restored \(restoredAt, format: .relative(presentation: .named))")
+                            .lineLimit(1)
+                    } else {
+                        Text(record.reapedAt, format: .relative(presentation: .named))
+                            .lineLimit(1)
+                    }
                 }
                 .font(.caption2)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(isRestored ? .quaternary : .tertiary)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/TBDApp/ReclaimedSectionView.swift
+++ b/Sources/TBDApp/ReclaimedSectionView.swift
@@ -9,7 +9,6 @@ import TBDShared
 /// `appState.reapRecords[repoID]` is non-empty.
 struct ReclaimedSectionView: View {
     let repoID: UUID
-    @Binding var selectedReapRecordID: UUID?
     @EnvironmentObject var appState: AppState
 
     @State private var isExpanded = false
@@ -20,6 +19,10 @@ struct ReclaimedSectionView: View {
 
     private var summary: ReclaimedSummary {
         ReclaimedSummary(records: appState.reapRecords[repoID] ?? [])
+    }
+
+    private var selectedReapRecordID: UUID? {
+        appState.selectedReapRecordIDs[repoID]
     }
 
     var body: some View {
@@ -88,8 +91,7 @@ struct ReclaimedSectionView: View {
     /// selection above it — clear the archived selection so the right pane
     /// unambiguously shows this record's detail.
     private func select(_ record: ReapRecord) {
-        selectedReapRecordID = record.id
-        appState.selectedArchivedWorktreeIDs.removeValue(forKey: repoID)
+        appState.selectReapRecord(record.id, repoID: repoID)
     }
 
     static func byteString(_ bytes: Int64) -> String {

--- a/Sources/TBDApp/ReclaimedSummary.swift
+++ b/Sources/TBDApp/ReclaimedSummary.swift
@@ -48,4 +48,13 @@ struct ReclaimedSummary {
         let bytes = scratch.reduce(Int64(0)) { $0 + ($1.apparentBytes ?? 0) }
         return (scratch.count, bytes)
     }
+
+    /// Subset excluding already-restored records — a restored agent worktree
+    /// is no longer reclaimed disk. This is what the "Reclaimed (N · X GB)"
+    /// header counts; the expanded row list still shows every `agentRecords`
+    /// entry (restored ones render "Restored <date>" instead of a Restore
+    /// button, via `ReapRecord.restoredAt`).
+    var unrestored: ReclaimedSummary {
+        ReclaimedSummary(records: records.filter { $0.restoredAt == nil })
+    }
 }

--- a/Sources/TBDApp/ReclaimedSummary.swift
+++ b/Sources/TBDApp/ReclaimedSummary.swift
@@ -1,0 +1,51 @@
+import Foundation
+import TBDShared
+
+/// Pure aggregation over a repo's `[ReapRecord]` (as fetched into
+/// `AppState.reapRecords[repoID]`). UI-free on purpose: the "Reclaimed"
+/// section (History → Reclaimed, Task 12) renders exactly these fields, and
+/// keeping the arithmetic/sorting out of any View makes it trivially
+/// testable.
+///
+/// Callers decide whether to exclude already-restored records before
+/// constructing this (e.g. `records.filter { $0.restoredAt == nil }`) —
+/// `ReclaimedSummary` itself does no restoredAt filtering, it just summarizes
+/// whatever list it's handed.
+struct ReclaimedSummary {
+    let records: [ReapRecord]
+
+    init(records: [ReapRecord]) {
+        self.records = records
+    }
+
+    /// Total number of records in this summary.
+    var count: Int {
+        records.count
+    }
+
+    /// Sum of `apparentBytes` across all records. A nil `apparentBytes`
+    /// (e.g. `du` failed or was never run) contributes 0, not a crash.
+    var totalApparentBytes: Int64 {
+        records.reduce(0) { $0 + ($1.apparentBytes ?? 0) }
+    }
+
+    /// Agent-worktree records, most-recently-reaped first — these render as
+    /// individual restorable rows.
+    var agentRecords: [ReapRecord] {
+        records
+            .filter { $0.kind == .agentWorktree }
+            .sorted { $0.reapedAt > $1.reapedAt }
+    }
+
+    /// Scratchpad records rolled up into a single (count, bytes) pair —
+    /// scratchpad volume can be high and scratchpads aren't individually
+    /// restorable (`OrphanGC.restore` only accepts `.agentWorktree`), so the
+    /// UI shows one summary line instead of a row per scratchpad. `nil` when
+    /// there are no scratchpad records to summarize.
+    var scratchpadRollup: (count: Int, bytes: Int64)? {
+        let scratch = records.filter { $0.kind == .scratchpad }
+        guard !scratch.isEmpty else { return nil }
+        let bytes = scratch.reduce(Int64(0)) { $0 + ($1.apparentBytes ?? 0) }
+        return (scratch.count, bytes)
+    }
+}

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -144,6 +144,12 @@ struct GeneralSettingsTab: View {
 
                 Toggle("Show Scratch section", isOn: $showScratchSection)
                     .help("Hide the repo-less Scratch section. Existing scratch spaces and their terminals keep running.")
+
+                Toggle("Automatically clean up orphaned agent worktrees", isOn: Binding(
+                    get: { appState.gcEnabled },
+                    set: { newValue in Task { await appState.setGCEnabled(newValue) } }
+                ))
+                .help("Reaps Claude agent worktrees whose run has ended, snapshot-first. Restore from History → Reclaimed.")
             }
 
             Section("Claude") {

--- a/Sources/TBDCLI/Commands/GCCommands.swift
+++ b/Sources/TBDCLI/Commands/GCCommands.swift
@@ -1,0 +1,53 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct GCCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "gc",
+        abstract: "Orphan GC: list reaps, restore a reaped agent worktree, trigger a sweep",
+        subcommands: [GCList.self, GCRestore.self, GCSweep.self]
+    )
+}
+
+struct GCList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List reap records")
+    @Option(name: .long, help: "Filter by repo root path") var repo: String?
+    @Flag(name: .long, help: "Output JSON") var json = false
+    mutating func run() async throws {
+        let client = SocketClient()
+        let records: [ReapRecord] = try client.call(method: RPCMethod.gcList,
+                                                    params: GCListParams(repoPath: repo),
+                                                    resultType: [ReapRecord].self)
+        if json { printJSON(records); return }
+        if records.isEmpty { print("No reap records."); return }
+        for r in records {
+            let size = r.apparentBytes.map { ByteCountFormatter.string(fromByteCount: $0, countStyle: .file) } ?? "?"
+            let snap = r.snapshotRef != nil ? "snapshot ✓" : "clean"
+            let restored = r.restoredAt != nil ? " (restored)" : ""
+            print("\(r.id)  \(r.kind.rawValue)  \(r.worktreePath)  \(size)  \(snap)\(restored)")
+        }
+    }
+}
+
+struct GCRestore: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "restore", abstract: "Restore a reaped agent worktree")
+    @Argument(help: "Reap record ID (from 'tbd gc list')") var id: String
+    mutating func run() async throws {
+        guard let uuid = UUID(uuidString: id) else { throw ValidationError("Not a UUID: \(id)") }
+        try SocketClient().callVoid(method: RPCMethod.gcRestore, params: GCRestoreParams(recordID: uuid))
+        print("Restored.")
+    }
+}
+
+struct GCSweep: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "sweep", abstract: "Run an orphan-GC sweep now")
+    @Flag(name: .long, help: "Print the plan without deleting anything") var dryRun = false
+    mutating func run() async throws {
+        let result: GCSweepResult = try SocketClient().call(method: RPCMethod.gcSweepNow,
+                                                            params: GCSweepNowParams(dryRun: dryRun),
+                                                            resultType: GCSweepResult.self)
+        for line in result.planned { print(line) }
+        print(dryRun ? "(dry run — nothing deleted)" : "Reaped \(result.reaped) item(s).")
+    }
+}

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -25,6 +25,7 @@ struct TBDCommand: AsyncParsableCommand {
             LinkCommand.self,
             DoctorCommand.self,
             NightwatchCommand.self,
+            GCCommand.self,
         ]
     )
 }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -378,8 +378,8 @@ public final class Daemon: Sendable {
         if mockMode == nil {
             let gc = OrphanGC(db: database, git: git, broadcast: { [subs] delta in subs.broadcast(delta: delta) })
             self.orphanGC = gc
-            lifecycle.onWorktreeRemoved = { [gc] path in
-                await gc.scratchpadCleanup(forRemovedWorktreePath: path)
+            lifecycle.onWorktreeRemoved = { [gc] path, repoPath in
+                await gc.scratchpadCleanup(forRemovedWorktreePath: path, repoPath: repoPath)
             }
         }
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -496,6 +496,11 @@ public final class Daemon: Sendable {
         }
 
         self.router = rpcRouter
+        // Post-construction wiring, same shape as `claudeUsagePoller` below:
+        // `orphanGC` was constructed earlier (before `lifecycle`) so the
+        // archive-event callback could reach it; the `gc.*` handlers reach it
+        // through the router the same way they reach `hibernationCoordinator`.
+        rpcRouter.orphanGC = orphanGC
 
         // Shared foreground gate: the app reports its active/inactive state via
         // `app.setForegroundState`; the periodic git tasks below slow their

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -61,6 +61,13 @@ public final class Daemon: Sendable {
     public nonisolated(unsafe) var gitStatusTask: Task<Void, Never>?
     public nonisolated(unsafe) var reaperTask: Task<Void, Never>?
     public nonisolated(unsafe) var hibernationSweepTask: Task<Void, Never>?
+    /// Orphan-GC hourly sweep task (agent worktrees + scratchpads). `nil` in
+    /// mock mode. See `orphanGC` for the actor it drives.
+    public nonisolated(unsafe) var gcTask: Task<Void, Never>?
+    /// Orphan-GC actor. Owned here so `gc.*` RPC handlers (Task 9) can reach
+    /// it the same way they reach `rpcRouter.hibernationCoordinator`. `nil`
+    /// in mock mode (never constructed).
+    public nonisolated(unsafe) var orphanGC: OrphanGC?
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
     public nonisolated(unsafe) var oauthUsagePoller: OAuthProfileUsagePoller?
     /// Session-limit auto-resume scheduler. Owned here so it can be stopped
@@ -360,6 +367,22 @@ public final class Daemon: Sendable {
             pendingQuestions: pendingQuestions
         )
         lifecycle.controlMode = controlModeBridge
+
+        // Orphan-GC: constructed here — before `lifecycle` gets copied into
+        // the RPC router / auto-archive coordinator below (both take a
+        // value-type snapshot at their own init) — so the archive-event
+        // callback reaches every consumer of `lifecycle`. `nil` in mock mode,
+        // mirroring every other background-task guard in this method; the
+        // periodic sweep task itself is started later, alongside the reaper,
+        // inside the main `if mockMode == nil` block.
+        if mockMode == nil {
+            let gc = OrphanGC(db: database, git: git, broadcast: { [subs] delta in subs.broadcast(delta: delta) })
+            self.orphanGC = gc
+            lifecycle.onWorktreeRemoved = { [gc] path in
+                await gc.scratchpadCleanup(forRemovedWorktreePath: path)
+            }
+        }
+
         let prManager = PRStatusManager()
 
         // Hydrate PR status cache from the DB so PR icons survive restart, then
@@ -542,6 +565,24 @@ public final class Daemon: Sendable {
                     try? await Task.sleep(for: .seconds(60))
                     guard !Task.isCancelled else { break }
                     await reaper.sweep(servers: await ownedServers())
+                }
+            }
+
+            // 11a-gc. Orphan-GC: reap abandoned agent worktrees + scratchpads
+            // (event-driven cleanup already runs via `lifecycle.onWorktreeRemoved`
+            // above; this periodic sweep catches everything else — worktrees
+            // orphaned outside a TBD-initiated remove, e.g. manual `rm -rf`).
+            // Constructed above (guarded the same `mockMode == nil` check), so
+            // `orphanGC` is always non-nil here.
+            if let orphanGC {
+                self.gcTask = Task {
+                    // Sweep once immediately (cold recovery), then every hour.
+                    _ = await orphanGC.sweep()
+                    while !Task.isCancelled {
+                        try? await Task.sleep(for: .seconds(3600))
+                        guard !Task.isCancelled else { break }
+                        _ = await orphanGC.sweep()
+                    }
                 }
             }
 
@@ -779,6 +820,7 @@ public final class Daemon: Sendable {
         gitStatusTask?.cancel()
         reaperTask?.cancel()
         hibernationSweepTask?.cancel()
+        gcTask?.cancel()
 
         // Stop servers
         if let sock = socketServer {

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -29,6 +29,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var control_mode_enabled: Bool?
     var auto_resume_on_api_error: Bool?
     var hibernate_input_veto_enabled: Bool?
+    var gc_enabled: Bool?
+    var gc_grace_seconds: Int?
+    var gc_snapshot_retention_days: Int?
 
     func toModel() -> Config {
         Config(
@@ -49,7 +52,10 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             hibernateIdleMinutes: hibernate_idle_minutes ?? Config.defaultHibernateIdleMinutes,
             controlModeEnabled: control_mode_enabled ?? false,
             autoResumeOnApiError: auto_resume_on_api_error ?? false,
-            hibernateInputVetoEnabled: hibernate_input_veto_enabled ?? false
+            hibernateInputVetoEnabled: hibernate_input_veto_enabled ?? false,
+            gcEnabled: gc_enabled ?? true,
+            gcGraceSeconds: gc_grace_seconds ?? Config.defaultGCGraceSeconds,
+            gcSnapshotRetentionDays: gc_snapshot_retention_days ?? Config.defaultGCSnapshotRetentionDays
         )
     }
 }
@@ -252,6 +258,16 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET hibernate_input_veto_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the orphan-GC master switch (default ON).
+    public func setGCEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET gc_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -24,6 +24,7 @@ public final class TBDDatabase: Sendable {
     public let clearance: ClearanceStore
     public let audit: AuditStore
     public let scheduledResumes: ScheduledResumeStore
+    public let reapRecords: ReapRecordStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
@@ -56,6 +57,7 @@ public final class TBDDatabase: Sendable {
         self.clearance = ClearanceStore(writer: pool)
         self.audit = AuditStore(writer: pool)
         self.scheduledResumes = ScheduledResumeStore(writer: pool)
+        self.reapRecords = ReapRecordStore(writer: pool)
 
         let migrator = Self.buildMigrator()
         if fileExisted {
@@ -88,6 +90,7 @@ public final class TBDDatabase: Sendable {
         self.clearance = ClearanceStore(writer: queue)
         self.audit = AuditStore(writer: queue)
         self.scheduledResumes = ScheduledResumeStore(writer: queue)
+        self.reapRecords = ReapRecordStore(writer: queue)
         try Self.buildMigrator().migrate(queue)
     }
 
@@ -863,6 +866,29 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(
                 table: "config", column: "hibernate_input_veto_enabled",
                 type: .boolean, defaults: false)
+        }
+
+        // Orphan GC: persisted record of every agent-worktree/scratchpad the
+        // daemon-owned GC swept (and optionally snapshotted) before removal,
+        // plus the config knobs that gate the sweep (default ON, 1h grace,
+        // 30-day snapshot retention).
+        migrator.registerMigration("v52_reap_records_and_gc_config") { db in
+            try db.createTableIfNotExists("reap_records") { t in
+                t.column("id", .text).primaryKey()
+                t.column("kind", .text).notNull()
+                t.column("repoPath", .text).notNull()
+                t.column("worktreePath", .text).notNull()
+                t.column("branch", .text)
+                t.column("headSHA", .text)
+                t.column("snapshotRef", .text)
+                t.column("apparentBytes", .integer)
+                t.column("reapedAt", .datetime).notNull()
+                t.column("restoredAt", .datetime)
+            }
+            try db.addIndexIfMissing("idx_reap_records_repo", on: "reap_records", columns: ["repoPath"])
+            try db.addColumnIfMissing(table: "config", column: "gc_enabled", type: .boolean, defaults: true)
+            try db.addColumnIfMissing(table: "config", column: "gc_grace_seconds", type: .integer, defaults: 3600)
+            try db.addColumnIfMissing(table: "config", column: "gc_snapshot_retention_days", type: .integer, defaults: 30)
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/ReapRecordStore.swift
+++ b/Sources/TBDDaemon/Database/ReapRecordStore.swift
@@ -1,0 +1,122 @@
+import Foundation
+import GRDB
+import os
+import TBDShared
+
+private let reapDecodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
+
+/// GRDB Record type for the `reap_records` table.
+struct ReapRecordRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "reap_records"
+
+    var id: String
+    var kind: String
+    var repoPath: String
+    var worktreePath: String
+    var branch: String?
+    var headSHA: String?
+    var snapshotRef: String?
+    var apparentBytes: Int64?
+    var reapedAt: Date
+    var restoredAt: Date?
+
+    init(from record: ReapRecord) {
+        self.id = record.id.uuidString
+        self.kind = record.kind.rawValue
+        self.repoPath = record.repoPath
+        self.worktreePath = record.worktreePath
+        self.branch = record.branch
+        self.headSHA = record.headSHA
+        self.snapshotRef = record.snapshotRef
+        self.apparentBytes = record.apparentBytes
+        self.reapedAt = record.reapedAt
+        self.restoredAt = record.restoredAt
+    }
+
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when a required UUID or the reap kind fails to parse.
+    /// A single malformed row must not take down the whole `reapRecords.list`
+    /// fetch — and thus the daemon — on startup.
+    func toModel() -> ReapRecord? {
+        guard let uuid = UUID(uuidString: id) else {
+            reapDecodeLogger.warning("Skipping reap_records row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        guard let reapKind = ReapKind(rawValue: kind) else {
+            reapDecodeLogger.warning("Skipping reap_records row \(id, privacy: .public): unknown kind \(kind, privacy: .public)")
+            return nil
+        }
+        return ReapRecord(
+            id: uuid,
+            kind: reapKind,
+            repoPath: repoPath,
+            worktreePath: worktreePath,
+            branch: branch,
+            headSHA: headSHA,
+            snapshotRef: snapshotRef,
+            apparentBytes: apparentBytes,
+            reapedAt: reapedAt,
+            restoredAt: restoredAt
+        )
+    }
+}
+
+/// Provides CRUD operations for orphan-GC reap records.
+public struct ReapRecordStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Persist a new reap record.
+    public func insert(_ record: ReapRecord) async throws {
+        let dbRecord = ReapRecordRecord(from: record)
+        try await writer.write { db in
+            try dbRecord.insert(db)
+        }
+    }
+
+    /// All reap records, newest first. `repoPath` nil returns every repo.
+    public func list(repoPath: String?) async throws -> [ReapRecord] {
+        try await writer.read { db in
+            var request = ReapRecordRecord.order(Column("reapedAt").desc)
+            if let repoPath {
+                request = request.filter(Column("repoPath") == repoPath)
+            }
+            return try request.fetchAll(db).compactMap { $0.toModel() }
+        }
+    }
+
+    /// Fetch a single reap record by id.
+    public func get(id: UUID) async throws -> ReapRecord? {
+        try await writer.read { db in
+            try ReapRecordRecord.fetchOne(db, key: id.uuidString)?.toModel()
+        }
+    }
+
+    /// Mark a reap record as restored at the given date.
+    public func markRestored(id: UUID, at date: Date) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE reap_records SET restoredAt = ? WHERE id = ?",
+                arguments: [date, id.uuidString]
+            )
+        }
+    }
+
+    /// Reap records that are still un-restored, were reaped before `date`,
+    /// and captured a snapshot ref — the candidate set for snapshot-retention
+    /// GC (expired-snapshot pruning).
+    public func unrestoredOlderThan(_ date: Date) async throws -> [ReapRecord] {
+        try await writer.read { db in
+            try ReapRecordRecord
+                .filter(Column("restoredAt") == nil)
+                .filter(Column("reapedAt") < date)
+                .filter(Column("snapshotRef") != nil)
+                .order(Column("reapedAt").desc)
+                .fetchAll(db)
+                .compactMap { $0.toModel() }
+        }
+    }
+}

--- a/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
+++ b/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
@@ -86,7 +86,12 @@ public struct AgentWorktreeCollector: Sendable {
         let base = repoPath + "/.claude/worktrees"
         guard let names = try? FileManager.default.contentsOfDirectory(atPath: base) else { return [] }
         guard let entries = try? await git.worktreeListDetailed(repoPath: repoPath) else { return [] }
-        let byPath = Dictionary(uniqueKeysWithValues: entries.map { (Self.canon($0.path), $0) })
+        // `uniquingKeysWith:` rather than `uniqueKeysWithValues:` — this is
+        // fail-soft, best-effort GC code, so a duplicate canonicalized path
+        // (e.g. two `git worktree list` entries somehow resolving to the
+        // same realpath) must never crash the sweep; keep the first entry
+        // seen and move on.
+        let byPath = Dictionary(entries.map { (Self.canon($0.path), $0) }, uniquingKeysWith: { first, _ in first })
         var out: [AgentWorktreeCandidate] = []
         for name in names {
             let p = Self.canon(base + "/" + name)
@@ -119,7 +124,8 @@ public struct AgentWorktreeCollector: Sendable {
             logger.debug("gc: keep \(c.path, privacy: .public) — live cwd")
             return .keep(reason: "live-cwd")
         }
-        let age = now().timeIntervalSince(Self.lastActivity(worktreePath: wt))
+        let nowDate = now()
+        let age = nowDate.timeIntervalSince(Self.lastActivity(worktreePath: wt, now: nowDate))
         if age < Double(graceSeconds) {
             logger.debug("gc: keep \(c.path, privacy: .public) — within grace (age=\(age, privacy: .public)s)")
             return .keep(reason: "grace")
@@ -188,22 +194,35 @@ public struct AgentWorktreeCollector: Sendable {
     /// actually used: the `<worktreePath>/.git` file itself (rewritten by
     /// some git operations) and the admin gitdir's `index` file (rewritten by
     /// almost every git operation that touches the working tree — status,
-    /// add, commit, checkout). Either file missing contributes
-    /// `Date.distantPast` rather than failing the whole computation.
-    static func lastActivity(worktreePath: String) -> Date {
+    /// add, commit, checkout). Either file missing (but not both) still
+    /// contributes what's readable via `max`.
+    ///
+    /// If NEITHER mtime is readable at all (both the `.git` file and the
+    /// admin index are unreadable/missing), this returns `now` rather than
+    /// `Date.distantPast`. `Date.distantPast` would make `decide(_:)`'s age
+    /// computation enormous, making an unreadable worktree immediately
+    /// grace-*eligible* for reap — exactly backwards for keep-biased GC.
+    /// Returning `now` instead makes age ≈ 0, so an unreadable worktree is
+    /// treated the same as one just touched: kept by the grace window like
+    /// everything else uncertain, not silently fast-tracked for deletion.
+    static func lastActivity(worktreePath: String, now: Date) -> Date {
         let gitFile = worktreePath + "/.git"
-        let gitFileMtime = mtime(gitFile) ?? .distantPast
+        let gitFileMtime = mtime(gitFile)
 
-        var indexMtime = Date.distantPast
+        var indexMtime: Date?
         if let contents = try? String(contentsOfFile: gitFile, encoding: .utf8) {
             let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
             let prefix = "gitdir: "
             if trimmed.hasPrefix(prefix) {
                 let gitdir = String(trimmed.dropFirst(prefix.count))
-                indexMtime = mtime(gitdir + "/index") ?? .distantPast
+                indexMtime = mtime(gitdir + "/index")
             }
         }
-        return max(gitFileMtime, indexMtime)
+
+        guard gitFileMtime != nil || indexMtime != nil else {
+            return now
+        }
+        return max(gitFileMtime ?? .distantPast, indexMtime ?? .distantPast)
     }
 
     private static func mtime(_ path: String) -> Date? {

--- a/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
+++ b/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
@@ -119,13 +119,12 @@ public struct AgentWorktreeCollector: Sendable {
             logger.debug("gc: keep \(c.path, privacy: .public) — locked")
             return .keep(reason: "locked")
         }
-        let wt = c.path
-        if liveCWDs.contains(where: { $0 == wt || $0.hasPrefix(wt + "/") }) {
+        if Self.liveCWDsContain(liveCWDs, path: c.path) {
             logger.debug("gc: keep \(c.path, privacy: .public) — live cwd")
             return .keep(reason: "live-cwd")
         }
         let nowDate = now()
-        let age = nowDate.timeIntervalSince(Self.lastActivity(worktreePath: wt, now: nowDate))
+        let age = nowDate.timeIntervalSince(Self.lastActivity(worktreePath: c.path, now: nowDate))
         if age < Double(graceSeconds) {
             logger.debug("gc: keep \(c.path, privacy: .public) — within grace (age=\(age, privacy: .public)s)")
             return .keep(reason: "grace")
@@ -134,15 +133,51 @@ public struct AgentWorktreeCollector: Sendable {
         return .reap(c)
     }
 
-    /// Executes one reap: snapshot-first (any throw here means "keep, don't
-    /// touch the directory"), then measure, then delete, then verify the
-    /// delete actually took, and only then prune git's stale registration.
+    /// Executes one reap: a final pre-rm re-check (fresh lock/listed state +
+    /// fresh live-cwd), then snapshot-first (any throw here means "keep,
+    /// don't touch the directory"), then measure, then delete, then verify
+    /// the delete actually took, and only then prune git's stale
+    /// registration.
     ///
-    /// Returns the `ReapRecord` for the caller to persist, or `nil` if a late
-    /// gate refused — either the snapshot step threw (kept, nothing was
-    /// deleted) or the removal didn't actually take (kept for a retry on the
-    /// next sweep).
-    public func reap(_ c: AgentWorktreeCandidate) async -> ReapRecord? {
+    /// `decide(_:liveCWDs:graceSeconds:)` gates on lock/lsof data captured at
+    /// sweep start, which can be minutes stale by the time a given
+    /// candidate's turn to reap comes up on a large sweep (TOCTOU). The
+    /// re-check here re-fetches both right before anything destructive
+    /// happens, closing that window down to the instant between the
+    /// re-check and the `removeItem` call below. It runs BEFORE the
+    /// snapshot step (not after) because `snapshotIfNeeded` itself can write
+    /// into the doomed worktree's git index — nothing should mutate the
+    /// candidate until the re-check has cleared.
+    ///
+    /// `freshLiveCWDs` mirrors `OrphanGC`'s sweep-level live-cwd provider:
+    /// `nil` means "live cwds could not be determined this instant", which
+    /// keeps (same sentinel semantics as a sweep-wide lsof failure) rather
+    /// than being treated as "no live processes".
+    ///
+    /// Returns the `ReapRecord` for the caller to persist, or `nil` if any
+    /// gate — the re-check, the snapshot step, or the post-delete
+    /// verification — refused.
+    public func reap(_ c: AgentWorktreeCandidate, freshLiveCWDs: @Sendable () async -> [String]?) async -> ReapRecord? {
+        guard let freshEntries = try? await git.worktreeListDetailed(repoPath: c.repoPath) else {
+            logger.debug("gc: kept \(c.path, privacy: .public) — re-check locked/missing")
+            return nil
+        }
+        let freshByPath = Dictionary(
+            freshEntries.map { (Self.canon($0.path), $0) }, uniquingKeysWith: { first, _ in first }
+        )
+        guard let freshEntry = freshByPath[c.path], !freshEntry.locked else {
+            logger.debug("gc: kept \(c.path, privacy: .public) — re-check locked/missing")
+            return nil
+        }
+        guard let freshLive = await freshLiveCWDs() else {
+            logger.debug("gc: kept \(c.path, privacy: .public) — re-check lsof unavailable")
+            return nil
+        }
+        guard !Self.liveCWDsContain(freshLive, path: c.path) else {
+            logger.debug("gc: kept \(c.path, privacy: .public) — re-check live-cwd")
+            return nil
+        }
+
         let name = (c.path as NSString).lastPathComponent
         let ref: String?
         do {
@@ -178,6 +213,15 @@ public struct AgentWorktreeCollector: Sendable {
     }
 
     // MARK: - Helpers
+
+    /// True when `liveCWDs` contains `path` itself or any path strictly below
+    /// it (prefix-boundary match on `path + "/"`, not a bare string prefix —
+    /// so `/tmp/wt-2` does not false-positive against a candidate `/tmp/wt`).
+    /// Shared by `decide(_:liveCWDs:graceSeconds:)` and `reap(_:freshLiveCWDs:)`'s
+    /// pre-rm re-check so both use identical matching semantics.
+    static func liveCWDsContain(_ liveCWDs: [String], path: String) -> Bool {
+        liveCWDs.contains { $0 == path || $0.hasPrefix(path + "/") }
+    }
 
     /// Resolves `path` through POSIX `realpath()`, following every symlink
     /// component (including macOS's `/var` -> `/private/var`, which

--- a/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
+++ b/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
@@ -1,0 +1,237 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
+
+/// A Claude Code agent worktree (`<repo>/.claude/worktrees/<name>`) proven —
+/// via `GitManager.isLinkedWorktree` — to be a bona fide linked worktree of
+/// `repoPath`, and cross-referenced against `git worktree list --porcelain`
+/// for its HEAD/branch/lock state.
+public struct AgentWorktreeCandidate: Sendable, Equatable {
+    public var path: String
+    public var repoPath: String
+    public var branch: String?
+    public var headSHA: String
+    public var locked: Bool
+
+    public init(path: String, repoPath: String, branch: String?, headSHA: String, locked: Bool) {
+        self.path = path
+        self.repoPath = repoPath
+        self.branch = branch
+        self.headSHA = headSHA
+        self.locked = locked
+    }
+}
+
+/// The outcome of gating a single `AgentWorktreeCandidate`. Every `.keep`
+/// reason below is a spec invariant with a dedicated test: the gate order
+/// (locked -> live-cwd -> grace -> reap) always fails toward keeping, and a
+/// snapshot failure during `reap(_:)` is reported the same way even though it
+/// happens after `decide(_:liveCWDs:graceSeconds:)` already said `.reap`.
+public enum GCDecision: Sendable, Equatable {
+    /// `reason` is one of: `"locked"` | `"live-cwd"` | `"grace"` |
+    /// `"not-linked"` | `"snapshot-failed"`. Only the first three are
+    /// produced by `decide(_:liveCWDs:graceSeconds:)` itself — `"not-linked"`
+    /// describes directories `candidates(repoPath:)` silently drops, and
+    /// `"snapshot-failed"` describes a `reap(_:)` that returned `nil`; both
+    /// are surfaced as this same reason vocabulary by callers (Task 7) that
+    /// log/persist a decision for every directory they looked at.
+    case keep(reason: String)
+    case reap(AgentWorktreeCandidate)
+}
+
+/// Enumerates, gates, and reaps Claude Code agent worktrees
+/// (`<repo>/.claude/worktrees/<name>`) that TBD's orphan-GC sweep may safely
+/// delete.
+///
+/// Every gate in `decide(_:liveCWDs:graceSeconds:)` and every failure path in
+/// `reap(_:)` fails toward KEEPING the worktree — this type never deletes
+/// anything it isn't certain about. `candidates(repoPath:)` never touches the
+/// DB; the caller (Task 7's `OrphanGC` actor) persists whatever `reap(_:)`
+/// returns.
+public struct AgentWorktreeCollector: Sendable {
+    let git: GitManager
+    let snapshot: ReapSnapshot
+    /// Canonicalized (realpath'd) cwds of currently-running processes, as a
+    /// live-cwd provider would report them (built in Task 7 from `lsof`).
+    /// Injected so tests never shell out to `lsof`.
+    let liveCWDs: @Sendable () async -> [String]
+    let now: @Sendable () -> Date
+
+    public init(
+        git: GitManager,
+        snapshot: ReapSnapshot,
+        liveCWDs: @escaping @Sendable () async -> [String],
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
+        self.git = git
+        self.snapshot = snapshot
+        self.liveCWDs = liveCWDs
+        self.now = now
+    }
+
+    /// Lists every directory under `<repoPath>/.claude/worktrees/` that is
+    /// proven — via `GitManager.isLinkedWorktree` — to be a linked git
+    /// worktree of `repoPath`, cross-referenced against
+    /// `git worktree list --porcelain` for its HEAD/branch/lock state.
+    ///
+    /// A directory that fails the linkage proof (plain `mkdir`'d decoy, a
+    /// symlink to the repo root itself, anything without a `gitdir:`-style
+    /// `.git` file resolving under `<repoPath>/.git/worktrees/`) is silently
+    /// skipped — never touched, never returned. A directory that passes
+    /// linkage but isn't in git's own worktree list (already
+    /// `git worktree prune`-eligible) is likewise skipped: that's `git
+    /// worktree prune`'s job, not this sweep's.
+    ///
+    /// Both sides of every path comparison go through `canon(_:)` so a
+    /// `repoPath` argument built from a symlinked parent (e.g. macOS's
+    /// `/var` -> `/private/var`) still lines up with git's own
+    /// already-canonical worktree-list output.
+    public func candidates(repoPath: String) async -> [AgentWorktreeCandidate] {
+        let base = repoPath + "/.claude/worktrees"
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: base) else { return [] }
+        guard let entries = try? await git.worktreeListDetailed(repoPath: repoPath) else { return [] }
+        let byPath = Dictionary(uniqueKeysWithValues: entries.map { (Self.canon($0.path), $0) })
+        var out: [AgentWorktreeCandidate] = []
+        for name in names {
+            let p = Self.canon(base + "/" + name)
+            guard await git.isLinkedWorktree(candidatePath: p, repoPath: repoPath) else {
+                logger.debug("gc: skip \(p, privacy: .public) — not a proven linked worktree")
+                continue
+            }
+            guard let entry = byPath[p] else {
+                logger.debug("gc: skip \(p, privacy: .public) — linked but not in worktree list (prune territory)")
+                continue
+            }
+            out.append(AgentWorktreeCandidate(
+                path: p, repoPath: repoPath, branch: entry.branch, headSHA: entry.headSHA, locked: entry.locked
+            ))
+        }
+        return out
+    }
+
+    /// Gates a single candidate through the five keep-biased checks, in
+    /// order, each one short-circuiting the rest: `locked` -> `live-cwd`
+    /// (exact match or any path strictly below it) -> `grace` (recent HEAD or
+    /// index activity) -> `reap`.
+    public func decide(_ c: AgentWorktreeCandidate, liveCWDs: [String], graceSeconds: Int) async -> GCDecision {
+        if c.locked {
+            logger.debug("gc: keep \(c.path, privacy: .public) — locked")
+            return .keep(reason: "locked")
+        }
+        let wt = c.path
+        if liveCWDs.contains(where: { $0 == wt || $0.hasPrefix(wt + "/") }) {
+            logger.debug("gc: keep \(c.path, privacy: .public) — live cwd")
+            return .keep(reason: "live-cwd")
+        }
+        let age = now().timeIntervalSince(Self.lastActivity(worktreePath: wt))
+        if age < Double(graceSeconds) {
+            logger.debug("gc: keep \(c.path, privacy: .public) — within grace (age=\(age, privacy: .public)s)")
+            return .keep(reason: "grace")
+        }
+        logger.info("gc: \(c.path, privacy: .public) eligible for reap")
+        return .reap(c)
+    }
+
+    /// Executes one reap: snapshot-first (any throw here means "keep, don't
+    /// touch the directory"), then measure, then delete, then verify the
+    /// delete actually took, then prune git's stale registration.
+    ///
+    /// Returns the `ReapRecord` for the caller to persist, or `nil` if a late
+    /// gate refused — either the snapshot step threw (kept, nothing was
+    /// deleted) or the removal didn't actually take (kept for a retry on the
+    /// next sweep).
+    public func reap(_ c: AgentWorktreeCandidate) async -> ReapRecord? {
+        let name = (c.path as NSString).lastPathComponent
+        let ref: String?
+        do {
+            ref = try await snapshot.snapshotIfNeeded(
+                worktreePath: c.path, repoPath: c.repoPath, headSHA: c.headSHA, worktreeName: name, now: now()
+            )
+        } catch {
+            logger.warning(
+                "gc: kept \(c.path, privacy: .public) — snapshot failed: \(String(describing: error), privacy: .public)"
+            )
+            return nil
+        }
+
+        let bytes = await Self.apparentBytes(path: c.path)
+        try? FileManager.default.removeItem(atPath: c.path)
+        try? await git.worktreePrune(repoPath: c.repoPath)
+
+        guard !FileManager.default.fileExists(atPath: c.path) else {
+            logger.warning("gc: rm failed for \(c.path, privacy: .public), will retry next sweep")
+            return nil
+        }
+
+        logger.info("gc: reaped \(c.path, privacy: .public), snapshotRef=\(ref ?? "none", privacy: .public)")
+        return ReapRecord(
+            kind: .agentWorktree, repoPath: c.repoPath, worktreePath: c.path,
+            branch: c.branch, headSHA: c.headSHA, snapshotRef: ref,
+            apparentBytes: bytes, reapedAt: now()
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Resolves `path` through POSIX `realpath()`, following every symlink
+    /// component (including macOS's `/var` -> `/private/var`, which
+    /// `URL.resolvingSymlinksInPath()` does not follow). Falls back to the
+    /// original `path` when `realpath()` fails (e.g. the path doesn't exist
+    /// yet) so callers always get a usable string rather than `nil`.
+    static func canon(_ path: String) -> String {
+        guard let cString = realpath(path, nil) else { return path }
+        defer { free(cString) }
+        return String(cString: cString)
+    }
+
+    /// The most recent of two mtimes that change whenever the worktree is
+    /// actually used: the `<worktreePath>/.git` file itself (rewritten by
+    /// some git operations) and the admin gitdir's `index` file (rewritten by
+    /// almost every git operation that touches the working tree — status,
+    /// add, commit, checkout). Either file missing contributes
+    /// `Date.distantPast` rather than failing the whole computation.
+    static func lastActivity(worktreePath: String) -> Date {
+        let gitFile = worktreePath + "/.git"
+        let gitFileMtime = mtime(gitFile) ?? .distantPast
+
+        var indexMtime = Date.distantPast
+        if let contents = try? String(contentsOfFile: gitFile, encoding: .utf8) {
+            let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+            let prefix = "gitdir: "
+            if trimmed.hasPrefix(prefix) {
+                let gitdir = String(trimmed.dropFirst(prefix.count))
+                indexMtime = mtime(gitdir + "/index") ?? .distantPast
+            }
+        }
+        return max(gitFileMtime, indexMtime)
+    }
+
+    private static func mtime(_ path: String) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
+    }
+
+    /// `du -sk`'s apparent-size measurement for `path`, in bytes (the
+    /// reported KB * 1024). `nil` on any failure — spawn error, non-zero
+    /// exit, timeout, or unparseable output — since a missing byte count is
+    /// never worth blocking or retrying a reap over.
+    static func apparentBytes(path: String) async -> Int64? {
+        guard let outcome = try? await runBoundedProcess(
+            executable: "/usr/bin/du", arguments: ["-sk", path], currentDirectory: nil, timeout: .seconds(60)
+        ) else {
+            return nil
+        }
+        guard case .completed(let status, let stdout, _) = outcome, status == 0 else { return nil }
+        guard let text = String(data: stdout, encoding: .utf8) else { return nil }
+        guard let firstToken = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0.isWhitespace })
+            .first,
+            let kilobytes = Int64(firstToken)
+        else {
+            return nil
+        }
+        return kilobytes * 1024
+    }
+}

--- a/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
+++ b/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
@@ -53,21 +53,15 @@ public enum GCDecision: Sendable, Equatable {
 public struct AgentWorktreeCollector: Sendable {
     let git: GitManager
     let snapshot: ReapSnapshot
-    /// Canonicalized (realpath'd) cwds of currently-running processes, as a
-    /// live-cwd provider would report them (built in Task 7 from `lsof`).
-    /// Injected so tests never shell out to `lsof`.
-    let liveCWDs: @Sendable () async -> [String]
     let now: @Sendable () -> Date
 
     public init(
         git: GitManager,
         snapshot: ReapSnapshot,
-        liveCWDs: @escaping @Sendable () async -> [String],
         now: @escaping @Sendable () -> Date = Date.init
     ) {
         self.git = git
         self.snapshot = snapshot
-        self.liveCWDs = liveCWDs
         self.now = now
     }
 

--- a/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
+++ b/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
@@ -156,7 +156,7 @@ public struct AgentWorktreeCollector: Sendable {
             return nil
         }
 
-        let bytes = await Self.apparentBytes(path: c.path)
+        let bytes = await GCDiskUsage.apparentBytes(path: c.path)
         try? FileManager.default.removeItem(atPath: c.path)
 
         // Verify the removal actually took BEFORE pruning: if the directory
@@ -214,28 +214,5 @@ public struct AgentWorktreeCollector: Sendable {
 
     private static func mtime(_ path: String) -> Date? {
         (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
-    }
-
-    /// `du -sk`'s apparent-size measurement for `path`, in bytes (the
-    /// reported KB * 1024). `nil` on any failure — spawn error, non-zero
-    /// exit, timeout, or unparseable output — since a missing byte count is
-    /// never worth blocking or retrying a reap over.
-    static func apparentBytes(path: String) async -> Int64? {
-        guard let outcome = try? await runBoundedProcess(
-            executable: "/usr/bin/du", arguments: ["-sk", path], currentDirectory: nil, timeout: .seconds(60)
-        ) else {
-            return nil
-        }
-        guard case .completed(let status, let stdout, _) = outcome, status == 0 else { return nil }
-        guard let text = String(data: stdout, encoding: .utf8) else { return nil }
-        guard let firstToken = text
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(whereSeparator: { $0.isWhitespace })
-            .first,
-            let kilobytes = Int64(firstToken)
-        else {
-            return nil
-        }
-        return kilobytes * 1024
     }
 }

--- a/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
+++ b/Sources/TBDDaemon/GC/AgentWorktreeCollector.swift
@@ -136,7 +136,7 @@ public struct AgentWorktreeCollector: Sendable {
 
     /// Executes one reap: snapshot-first (any throw here means "keep, don't
     /// touch the directory"), then measure, then delete, then verify the
-    /// delete actually took, then prune git's stale registration.
+    /// delete actually took, and only then prune git's stale registration.
     ///
     /// Returns the `ReapRecord` for the caller to persist, or `nil` if a late
     /// gate refused — either the snapshot step threw (kept, nothing was
@@ -158,12 +158,16 @@ public struct AgentWorktreeCollector: Sendable {
 
         let bytes = await Self.apparentBytes(path: c.path)
         try? FileManager.default.removeItem(atPath: c.path)
-        try? await git.worktreePrune(repoPath: c.repoPath)
 
+        // Verify the removal actually took BEFORE pruning: if the directory
+        // is still there, git's worktree registration must stay intact too,
+        // so the retry on the next sweep starts from a consistent state.
         guard !FileManager.default.fileExists(atPath: c.path) else {
             logger.warning("gc: rm failed for \(c.path, privacy: .public), will retry next sweep")
             return nil
         }
+
+        try? await git.worktreePrune(repoPath: c.repoPath)
 
         logger.info("gc: reaped \(c.path, privacy: .public), snapshotRef=\(ref ?? "none", privacy: .public)")
         return ReapRecord(

--- a/Sources/TBDDaemon/GC/GCDiskUsage.swift
+++ b/Sources/TBDDaemon/GC/GCDiskUsage.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Shared disk-usage measurement for the orphan-GC collectors.
+enum GCDiskUsage {
+    /// `du -sk`'s apparent-size measurement for `path`, in bytes (the
+    /// reported KB * 1024). `nil` on any failure — spawn error, non-zero
+    /// exit, timeout, or unparseable output — since a missing byte count is
+    /// never worth blocking or retrying a reap over.
+    static func apparentBytes(path: String) async -> Int64? {
+        guard let outcome = try? await runBoundedProcess(
+            executable: "/usr/bin/du", arguments: ["-sk", path], currentDirectory: nil, timeout: .seconds(60)
+        ) else {
+            return nil
+        }
+        guard case .completed(let status, let stdout, _) = outcome, status == 0 else { return nil }
+        guard let text = String(data: stdout, encoding: .utf8) else { return nil }
+        guard let firstToken = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0.isWhitespace })
+            .first,
+            let kilobytes = Int64(firstToken)
+        else {
+            return nil
+        }
+        return kilobytes * 1024
+    }
+}

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -137,7 +137,7 @@ public actor OrphanGC {
                     // The outer `gcEnabled || dryRun` guard means a non-dry
                     // run here always has gcEnabled == true.
                     guard !dryRun else { continue }
-                    if let record = await agentCollector.reap(candidate) {
+                    if let record = await agentCollector.reap(candidate, freshLiveCWDs: { await self.liveCWDs() }) {
                         await insertReapRecord(record)
                         reaped += 1
                         logger.info("""

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -138,7 +138,7 @@ public actor OrphanGC {
                     // run here always has gcEnabled == true.
                     guard !dryRun else { continue }
                     if let record = await agentCollector.reap(candidate) {
-                        try? await db.reapRecords.insert(record)
+                        await insertReapRecord(record)
                         reaped += 1
                         logger.info("""
                         gc: reaped agent worktree \(candidate.path, privacy: .public) \
@@ -149,7 +149,7 @@ public actor OrphanGC {
                         if let scratchRecord = await scratchpadCollector.cleanUp(
                             forRemovedWorktreePath: candidate.path, repoPath: candidate.repoPath, now: now()
                         ) {
-                            try? await db.reapRecords.insert(scratchRecord)
+                            await insertReapRecord(scratchRecord)
                             reaped += 1
                             planned.append("REAP scratchpad \(scratchRecord.worktreePath)")
                         }
@@ -181,6 +181,13 @@ public actor OrphanGC {
     /// DB round trip; a row with no resolvable repo (deleted repo, no
     /// `repoID`) stamps `""` — fails toward the previous behavior rather than
     /// dropping the record.
+    ///
+    /// The mutating work is delegated to `ScratchpadCollector.reconcile` (the
+    /// same entry point `reconcileScratchpadsBeforeRepoRemoval` uses) so
+    /// there is exactly one implementation of "delete a scratchpad whose
+    /// worktree is gone". `dryRun` short-circuits before calling it —
+    /// `reconcile` always mutates, so dry-run planning recomputes the
+    /// candidate list read-only instead.
     private func reconcileScratchpads(
         repos: [Repo], dryRun: Bool, planned: inout [String], reaped: inout Int
     ) async {
@@ -189,21 +196,58 @@ public actor OrphanGC {
         let gone = archived
             .filter { !FileManager.default.fileExists(atPath: $0.path) }
             .map { (worktreePath: $0.path, repoPath: $0.repoID.flatMap { repoPathByID[$0] } ?? "") }
-        for entry in gone {
-            let slug = ScratchpadCollector.slug(forWorktreePath: entry.worktreePath)
-            let dir = scratchpadBase.appendingPathComponent(slug)
-            guard FileManager.default.fileExists(atPath: dir.path) else { continue }
-            planned.append("REAP scratchpad \(dir.path)")
-            // The outer `gcEnabled || dryRun` guard means a non-dry run here
-            // always has gcEnabled == true.
-            guard !dryRun else { continue }
-            if let record = await scratchpadCollector.cleanUp(
-                forRemovedWorktreePath: entry.worktreePath, repoPath: entry.repoPath, now: now()
-            ) {
-                try? await db.reapRecords.insert(record)
-                reaped += 1
-                logger.info("gc: reaped scratchpad \(record.worktreePath, privacy: .public)")
+
+        guard !dryRun else {
+            for entry in gone {
+                let slug = ScratchpadCollector.slug(forWorktreePath: entry.worktreePath)
+                let dir = scratchpadBase.appendingPathComponent(slug)
+                guard FileManager.default.fileExists(atPath: dir.path) else { continue }
+                planned.append("REAP scratchpad \(dir.path)")
             }
+            return
+        }
+
+        // The outer `gcEnabled || dryRun` guard means a non-dry run here
+        // always has gcEnabled == true.
+        let records = await scratchpadCollector.reconcile(knownPaths: gone, now: now())
+        for record in records {
+            await insertReapRecord(record)
+            reaped += 1
+            planned.append("REAP scratchpad \(record.worktreePath)")
+            logger.info("gc: reaped scratchpad \(record.worktreePath, privacy: .public)")
+        }
+    }
+
+    /// Entry point for `repo.remove` (review Medium 2): `db.worktrees.deleteForRepo`
+    /// deletes EVERY worktree row for `repoID` — every status, including
+    /// archived — with no further chance for the sweep's own reconciliation
+    /// to catch up: once the rows are gone, nothing can resolve their paths
+    /// to a scratchpad slug again. Fetches every row up front and runs them
+    /// through the same `ScratchpadCollector.reconcile` the sweep's own
+    /// reconciliation uses, stamped with `repoPath` (the caller already has
+    /// the `Repo` in scope) so reclaimed scratchpads still surface in that
+    /// repo's History UI even after the repo itself is gone. Call this
+    /// BEFORE `db.worktrees.deleteForRepo`.
+    ///
+    /// Gated by `gcEnabled`, same as every other GC deletion path; a config
+    /// read failure fails toward keeping (skip), and a worktree-list read
+    /// failure likewise skips rather than risking a partial reconciliation.
+    public func reconcileScratchpadsBeforeRepoRemoval(repoID: UUID, repoPath: String) async {
+        guard let config = try? await db.config.get(), config.gcEnabled else {
+            logger.debug("""
+            gc: repo-removal scratchpad reconciliation skipped for \(repoPath, privacy: .public) — gc disabled
+            """)
+            return
+        }
+        guard let rows = try? await db.worktrees.list(repoID: repoID) else { return }
+        let pairs = rows.map { (worktreePath: $0.path, repoPath: repoPath) }
+        let records = await scratchpadCollector.reconcile(knownPaths: pairs, now: now())
+        for record in records {
+            await insertReapRecord(record)
+            logger.info("gc: reaped scratchpad (repo removal) \(record.worktreePath, privacy: .public)")
+        }
+        if !records.isEmpty {
+            broadcast(.reapRecordsChanged)
         }
     }
 
@@ -297,9 +341,26 @@ public actor OrphanGC {
         ) else {
             return
         }
-        try? await db.reapRecords.insert(record)
+        await insertReapRecord(record)
         logger.info("gc: reaped scratchpad (event) \(record.worktreePath, privacy: .public)")
         broadcast(.reapRecordsChanged)
+    }
+
+    /// Persists a `ReapRecord`, never failing the caller: by the time this is
+    /// called the disk reclaim already happened, so there is nothing left to
+    /// roll back. A failure here only loses the *record* of what was
+    /// reclaimed (and, for agent worktrees, the restorability pointer) — bad
+    /// enough to log at `.error`, not bad enough to undo a deletion that
+    /// already succeeded.
+    private func insertReapRecord(_ record: ReapRecord) async {
+        do {
+            try await db.reapRecords.insert(record)
+        } catch {
+            logger.error("""
+            gc: failed to persist reap record for \(record.worktreePath, privacy: .public) \
+            (kind=\(record.kind.rawValue, privacy: .public)): \(String(describing: error), privacy: .public)
+            """)
+        }
     }
 
     // MARK: - Live cwds (one lsof pass per sweep)

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -1,0 +1,305 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
+
+/// Errors thrown by `OrphanGC.restore(recordID:)`.
+public enum OrphanGCError: Error, CustomStringConvertible, Equatable {
+    /// No `ReapRecord` exists with the given id.
+    case recordNotFound(UUID)
+    /// `restore(recordID:)` only supports `.agentWorktree` records — scratchpads
+    /// have no restore path (there's nothing to recreate a bare tmp dir from).
+    case unsupportedKind(ReapKind)
+    /// The record was already restored once; restoring twice would attempt to
+    /// recreate a worktree that (probably) already exists on disk.
+    case alreadyRestored(UUID)
+
+    public var description: String {
+        switch self {
+        case .recordNotFound(let id):
+            return "OrphanGC: no reap record with id \(id)"
+        case .unsupportedKind(let kind):
+            return "OrphanGC: restore is only supported for .agentWorktree records, got .\(kind.rawValue)"
+        case .alreadyRestored(let id):
+            return "OrphanGC: reap record \(id) was already restored"
+        }
+    }
+}
+
+/// Result of one `OrphanGC.sweep(dryRun:)` pass: a human-readable log of every
+/// decision made (`KEEP <reason> <path>` / `REAP <kind> <path>`) and a count
+/// of directories actually removed (always `0` when `dryRun` is `true`).
+public struct GCSweepResult: Sendable, Equatable {
+    public var planned: [String]
+    public var reaped: Int
+
+    public init(planned: [String], reaped: Int) {
+        self.planned = planned
+        self.reaped = reaped
+    }
+}
+
+/// Orchestrates one orphan-GC sweep: enumerates agent-worktree and scratchpad
+/// candidates via the Task 5/6 collectors, gates them through the
+/// `gcEnabled` master switch, reaps what's eligible, persists a `ReapRecord`
+/// per reap, deletes expired snapshot refs whose branch anchor still exists,
+/// and broadcasts `.reapRecordsChanged` whenever anything actually changed.
+///
+/// Every failure direction here is toward keeping/no-op: a DB read failure
+/// short-circuits the whole sweep, an `lsof` timeout skips the whole sweep
+/// (never treated as "no live processes"), and `dryRun` never touches disk or
+/// the DB regardless of `gcEnabled`.
+public actor OrphanGC {
+    private let db: TBDDatabase
+    private let git: GitManager
+    private let broadcast: @Sendable (StateDelta) -> Void
+    private let lsofProvider: (@Sendable () async -> [String])?
+    private let scratchpadBase: URL
+    private let now: @Sendable () -> Date
+
+    private let snapshot: ReapSnapshot
+    private let agentCollector: AgentWorktreeCollector
+    private let scratchpadCollector: ScratchpadCollector
+
+    public init(
+        db: TBDDatabase,
+        git: GitManager,
+        broadcast: @escaping @Sendable (StateDelta) -> Void,
+        lsofProvider: (@Sendable () async -> [String])? = nil,
+        scratchpadBase: URL? = nil,
+        now: (@Sendable () -> Date)? = nil
+    ) {
+        let resolvedNow = now ?? Date.init
+        let resolvedScratchpadBase = scratchpadBase ?? TBDConstants.claudeScratchpadBase
+        let snap = ReapSnapshot(git: git)
+
+        self.db = db
+        self.git = git
+        self.broadcast = broadcast
+        self.lsofProvider = lsofProvider
+        self.scratchpadBase = resolvedScratchpadBase
+        self.now = resolvedNow
+        self.snapshot = snap
+        // OrphanGC always passes live cwds explicitly to `decide(_:liveCWDs:graceSeconds:)`
+        // per sweep (one lsof pass), so the collector's own stored closure is
+        // never consulted here — it's a harmless placeholder.
+        self.agentCollector = AgentWorktreeCollector(git: git, snapshot: snap, liveCWDs: { [] }, now: resolvedNow)
+        self.scratchpadCollector = ScratchpadCollector(base: resolvedScratchpadBase)
+    }
+
+    // MARK: - Sweep
+
+    /// Runs one full orphan-GC pass. `dryRun` computes and returns `planned`
+    /// without touching disk or the DB, regardless of `gcEnabled`. When
+    /// `gcEnabled` is `false` and `dryRun` is also `false`, the sweep does
+    /// nothing at all — not even the `lsof` pass.
+    public func sweep(dryRun: Bool = false) async -> GCSweepResult {
+        var planned: [String] = []
+        var reaped = 0
+
+        guard let config = try? await db.config.get() else { return .init(planned: [], reaped: 0) }
+        guard config.gcEnabled || dryRun else { return .init(planned: ["gc disabled"], reaped: 0) }
+
+        guard let live = await liveCWDs() else {
+            logger.error("gc: lsof unavailable this sweep (timeout or spawn failure) — skipping entirely")
+            return .init(planned: ["lsof unavailable - sweep skipped"], reaped: 0)
+        }
+
+        let repos = (try? await db.repos.list()) ?? []
+        for repo in repos {
+            let candidates = await agentCollector.candidates(repoPath: repo.path)
+            for candidate in candidates {
+                switch await agentCollector.decide(candidate, liveCWDs: live, graceSeconds: config.gcGraceSeconds) {
+                case .keep(let reason):
+                    planned.append("KEEP \(reason) \(candidate.path)")
+                    logger.debug("gc: keep \(reason, privacy: .public) \(candidate.path, privacy: .public)")
+                case .reap:
+                    planned.append("REAP agent-worktree \(candidate.path)")
+                    guard !dryRun, config.gcEnabled else { continue }
+                    if let record = await agentCollector.reap(candidate) {
+                        try? await db.reapRecords.insert(record)
+                        reaped += 1
+                        logger.info("""
+                        gc: reaped agent worktree \(candidate.path, privacy: .public) \
+                        snapshot=\(record.snapshotRef ?? "none", privacy: .public)
+                        """)
+                        // The reaped worktree may have had its own Claude Code
+                        // scratchpad; clean that up too.
+                        if let scratchRecord = await scratchpadCollector.cleanUp(
+                            forRemovedWorktreePath: candidate.path, now: now()
+                        ) {
+                            try? await db.reapRecords.insert(scratchRecord)
+                            reaped += 1
+                            planned.append("REAP scratchpad \(scratchRecord.worktreePath)")
+                        }
+                    } else {
+                        planned.append("KEEP snapshot-failed \(candidate.path)")
+                        logger.warning("gc: reap refused (late gate) for \(candidate.path, privacy: .public)")
+                    }
+                }
+            }
+        }
+
+        await reconcileScratchpads(dryRun: dryRun, config: config, planned: &planned, reaped: &reaped)
+
+        if !dryRun, config.gcEnabled {
+            await gcOldSnapshots(retentionDays: config.gcSnapshotRetentionDays)
+        }
+
+        if reaped > 0 { broadcast(.reapRecordsChanged) }
+        return .init(planned: planned, reaped: reaped)
+    }
+
+    /// Scratchpad reconciliation: archived TBD worktrees whose directory is
+    /// already gone but whose Claude Code scratchpad survives. Mirrors the
+    /// same keep-biased `dryRun`/`gcEnabled` gate as the agent-worktree loop.
+    private func reconcileScratchpads(
+        dryRun: Bool, config: Config, planned: inout [String], reaped: inout Int
+    ) async {
+        let knownPaths = ((try? await db.worktrees.list(status: .archived)) ?? []).map(\.path)
+        let gonePaths = knownPaths.filter { !FileManager.default.fileExists(atPath: $0) }
+        for path in gonePaths {
+            let slug = ScratchpadCollector.slug(forWorktreePath: path)
+            let dir = scratchpadBase.appendingPathComponent(slug)
+            guard FileManager.default.fileExists(atPath: dir.path) else { continue }
+            planned.append("REAP scratchpad \(dir.path)")
+            guard !dryRun, config.gcEnabled else { continue }
+            if let record = await scratchpadCollector.cleanUp(forRemovedWorktreePath: path, now: now()) {
+                try? await db.reapRecords.insert(record)
+                reaped += 1
+                logger.info("gc: reaped scratchpad \(record.worktreePath, privacy: .public)")
+            }
+        }
+    }
+
+    // MARK: - Snapshot retention
+
+    /// Deletes expired snapshot refs — never-restored records reaped before
+    /// the retention window — but ONLY when the record's branch still exists.
+    /// A record whose branch is gone keeps its ref forever: the ref is the
+    /// only thing anchoring that commit reachable, so deleting it would make
+    /// the snapshot unrecoverable garbage-collectable by git itself. Never
+    /// called in `dryRun`.
+    private func gcOldSnapshots(retentionDays: Int) async {
+        let cutoff = now().addingTimeInterval(-Double(retentionDays) * 86400)
+        guard let records = try? await db.reapRecords.unrestoredOlderThan(cutoff) else { return }
+        for record in records {
+            guard let snapshotRef = record.snapshotRef else { continue }
+            guard let branch = record.branch else {
+                logger.debug("""
+                gc: keeping snapshot \(snapshotRef, privacy: .public) — no branch on record, ref is sole guardian
+                """)
+                continue
+            }
+            guard await git.refExists(repoPath: record.repoPath, ref: "refs/heads/\(branch)") else {
+                logger.debug("""
+                gc: keeping snapshot \(snapshotRef, privacy: .public) — branch \(branch, privacy: .public) is gone
+                """)
+                continue
+            }
+            do {
+                try await git.deleteRef(repoPath: record.repoPath, ref: snapshotRef)
+                logger.info("gc: deleted expired snapshot ref \(snapshotRef, privacy: .public)")
+            } catch {
+                logger.warning("""
+                gc: failed to delete expired snapshot ref \(snapshotRef, privacy: .public): \
+                \(String(describing: error), privacy: .public)
+                """)
+            }
+        }
+    }
+
+    // MARK: - Restore
+
+    /// Restores a reaped agent worktree. Only valid for `.agentWorktree`
+    /// records that haven't already been restored — scratchpads have no
+    /// restore path, and restoring twice would try to recreate a worktree
+    /// that (very likely) already exists on disk.
+    public func restore(recordID: UUID) async throws {
+        guard let record = try await db.reapRecords.get(id: recordID) else {
+            throw OrphanGCError.recordNotFound(recordID)
+        }
+        guard record.kind == .agentWorktree else {
+            throw OrphanGCError.unsupportedKind(record.kind)
+        }
+        guard record.restoredAt == nil else {
+            throw OrphanGCError.alreadyRestored(recordID)
+        }
+
+        try await snapshot.restore(record: record)
+        try await db.reapRecords.markRestored(id: recordID, at: now())
+        logger.info("gc: restored \(record.worktreePath, privacy: .public)")
+        broadcast(.reapRecordsChanged)
+    }
+
+    // MARK: - Event-driven scratchpad cleanup
+
+    /// Entry point for the archive hook (Task 8): a TBD worktree at `path`
+    /// was just removed, so its Claude Code scratchpad (if any) is cleaned up
+    /// immediately rather than waiting for the next sweep's reconciliation.
+    public func scratchpadCleanup(forRemovedWorktreePath path: String) async {
+        guard let record = await scratchpadCollector.cleanUp(forRemovedWorktreePath: path, now: now()) else {
+            return
+        }
+        try? await db.reapRecords.insert(record)
+        logger.info("gc: reaped scratchpad (event) \(record.worktreePath, privacy: .public)")
+        broadcast(.reapRecordsChanged)
+    }
+
+    // MARK: - Live cwds (one lsof pass per sweep)
+
+    /// Returns the canonicalized cwds of every currently-running process, or
+    /// `nil` when that can't be determined reliably (lsof timed out or failed
+    /// to spawn) — callers MUST treat `nil` as "skip the sweep", never as
+    /// "no live processes".
+    private func liveCWDs() async -> [String]? {
+        if let lsofProvider {
+            return await lsofProvider()
+        }
+        return await Self.realLiveCWDs()
+    }
+
+    /// Real `lsof`-backed live-cwd provider: `lsof -d cwd -Fn` prints one
+    /// `p<pid>` header line per process followed by an `n<path>` line for its
+    /// cwd. Lines are filtered to the `n`-prefixed ones, canonicalized (so
+    /// they compare equal to git's always-canonical worktree paths), and
+    /// deduped.
+    private static func realLiveCWDs() async -> [String]? {
+        let outcome: BoundedProcessOutcome
+        do {
+            outcome = try await runBoundedProcess(
+                executable: "/usr/sbin/lsof",
+                arguments: ["-d", "cwd", "-Fn"],
+                currentDirectory: nil,
+                timeout: .seconds(60)
+            )
+        } catch {
+            logger.error("gc: lsof spawn failed: \(String(describing: error), privacy: .public)")
+            return nil
+        }
+
+        switch outcome {
+        case .timedOut:
+            logger.error("gc: lsof timed out after 60s")
+            return nil
+        case .completed(_, let stdout, _):
+            guard let text = String(data: stdout, encoding: .utf8) else {
+                logger.error("gc: lsof output was not valid UTF-8")
+                return nil
+            }
+            var seen = Set<String>()
+            var result: [String] = []
+            for line in text.split(separator: "\n") {
+                guard line.hasPrefix("n") else { continue }
+                let raw = String(line.dropFirst())
+                guard !raw.isEmpty else { continue }
+                let canonical = AgentWorktreeCollector.canon(raw)
+                if seen.insert(canonical).inserted {
+                    result.append(canonical)
+                }
+            }
+            return result
+        }
+    }
+}

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -102,10 +102,7 @@ public actor OrphanGC {
         self.scratchpadBase = resolvedScratchpadBase
         self.now = resolvedNow
         self.snapshot = snap
-        // OrphanGC always passes live cwds explicitly to `decide(_:liveCWDs:graceSeconds:)`
-        // per sweep (one lsof pass), so the collector's own stored closure is
-        // never consulted here — it's a harmless placeholder.
-        self.agentCollector = AgentWorktreeCollector(git: git, snapshot: snap, liveCWDs: { [] }, now: resolvedNow)
+        self.agentCollector = AgentWorktreeCollector(git: git, snapshot: snap, now: resolvedNow)
         self.scratchpadCollector = ScratchpadCollector(base: resolvedScratchpadBase)
     }
 
@@ -150,7 +147,7 @@ public actor OrphanGC {
                         // The reaped worktree may have had its own Claude Code
                         // scratchpad; clean that up too.
                         if let scratchRecord = await scratchpadCollector.cleanUp(
-                            forRemovedWorktreePath: candidate.path, now: now()
+                            forRemovedWorktreePath: candidate.path, repoPath: candidate.repoPath, now: now()
                         ) {
                             try? await db.reapRecords.insert(scratchRecord)
                             reaped += 1
@@ -164,7 +161,7 @@ public actor OrphanGC {
             }
         }
 
-        await reconcileScratchpads(dryRun: dryRun, planned: &planned, reaped: &reaped)
+        await reconcileScratchpads(repos: repos, dryRun: dryRun, planned: &planned, reaped: &reaped)
 
         // Snapshot retention never runs in dryRun; the outer guard already
         // establishes gcEnabled for any non-dry run.
@@ -179,20 +176,30 @@ public actor OrphanGC {
     /// Scratchpad reconciliation: archived TBD worktrees whose directory is
     /// already gone but whose Claude Code scratchpad survives. Mirrors the
     /// same keep-biased `dryRun`/`gcEnabled` gate as the agent-worktree loop.
+    /// `repos` is the sweep's own already-loaded repo list, reused here to
+    /// resolve each archived row's `repoID` to a `repo.path` without a second
+    /// DB round trip; a row with no resolvable repo (deleted repo, no
+    /// `repoID`) stamps `""` — fails toward the previous behavior rather than
+    /// dropping the record.
     private func reconcileScratchpads(
-        dryRun: Bool, planned: inout [String], reaped: inout Int
+        repos: [Repo], dryRun: Bool, planned: inout [String], reaped: inout Int
     ) async {
-        let knownPaths = ((try? await db.worktrees.list(status: .archived)) ?? []).map(\.path)
-        let gonePaths = knownPaths.filter { !FileManager.default.fileExists(atPath: $0) }
-        for path in gonePaths {
-            let slug = ScratchpadCollector.slug(forWorktreePath: path)
+        let repoPathByID = Dictionary(uniqueKeysWithValues: repos.map { ($0.id, $0.path) })
+        let archived = (try? await db.worktrees.list(status: .archived)) ?? []
+        let gone = archived
+            .filter { !FileManager.default.fileExists(atPath: $0.path) }
+            .map { (worktreePath: $0.path, repoPath: $0.repoID.flatMap { repoPathByID[$0] } ?? "") }
+        for entry in gone {
+            let slug = ScratchpadCollector.slug(forWorktreePath: entry.worktreePath)
             let dir = scratchpadBase.appendingPathComponent(slug)
             guard FileManager.default.fileExists(atPath: dir.path) else { continue }
             planned.append("REAP scratchpad \(dir.path)")
             // The outer `gcEnabled || dryRun` guard means a non-dry run here
             // always has gcEnabled == true.
             guard !dryRun else { continue }
-            if let record = await scratchpadCollector.cleanUp(forRemovedWorktreePath: path, now: now()) {
+            if let record = await scratchpadCollector.cleanUp(
+                forRemovedWorktreePath: entry.worktreePath, repoPath: entry.repoPath, now: now()
+            ) {
                 try? await db.reapRecords.insert(record)
                 reaped += 1
                 logger.info("gc: reaped scratchpad \(record.worktreePath, privacy: .public)")
@@ -265,16 +272,29 @@ public actor OrphanGC {
     /// Entry point for the archive hook (Task 8): a TBD worktree at `path`
     /// was just removed, so its Claude Code scratchpad (if any) is cleaned up
     /// immediately rather than waiting for the next sweep's reconciliation.
+    /// `repoPath` is the owning repo's root (the archive caller has `repo` in
+    /// scope), stamped onto the resulting record; pass `""` when unknown.
+    ///
+    /// Verifies the worktree directory is actually gone before doing
+    /// anything else: `completeArchiveWorktree` fires this callback after a
+    /// `try?`-swallowed `git.worktreeRemove`, so a failed removal must not
+    /// orphan-classify (and delete) a scratchpad that's still in active use.
     ///
     /// The `gcEnabled` master switch governs ALL GC deletion, including this
     /// event-driven path — one toggle covers both collectors. A config read
     /// failure also skips (fail toward keeping).
-    public func scratchpadCleanup(forRemovedWorktreePath path: String) async {
+    public func scratchpadCleanup(forRemovedWorktreePath path: String, repoPath: String) async {
+        guard !FileManager.default.fileExists(atPath: path) else {
+            logger.debug("gc: scratchpad cleanup skipped for \(path, privacy: .public) — worktree dir still exists")
+            return
+        }
         guard let config = try? await db.config.get(), config.gcEnabled else {
             logger.debug("gc: scratchpad cleanup skipped for \(path, privacy: .public) — gc disabled")
             return
         }
-        guard let record = await scratchpadCollector.cleanUp(forRemovedWorktreePath: path, now: now()) else {
+        guard let record = await scratchpadCollector.cleanUp(
+            forRemovedWorktreePath: path, repoPath: repoPath, now: now()
+        ) else {
             return
         }
         try? await db.reapRecords.insert(record)

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -27,18 +27,10 @@ public enum OrphanGCError: Error, CustomStringConvertible, Equatable {
     }
 }
 
-/// Result of one `OrphanGC.sweep(dryRun:)` pass: a human-readable log of every
-/// decision made (`KEEP <reason> <path>` / `REAP <kind> <path>`) and a count
-/// of directories actually removed (always `0` when `dryRun` is `true`).
-public struct GCSweepResult: Sendable, Equatable {
-    public var planned: [String]
-    public var reaped: Int
-
-    public init(planned: [String], reaped: Int) {
-        self.planned = planned
-        self.reaped = reaped
-    }
-}
+// `OrphanGC.sweep` returns `TBDShared.GCSweepResult` (the Codable RPC wire
+// type, RPCProtocol.swift) directly — a same-shaped local mirror type used to
+// live here and silently module-shadow the shared one; it was consolidated
+// away so the RPC handler needs no conversion.
 
 /// Orchestrates one orphan-GC sweep: enumerates agent-worktree and scratchpad
 /// candidates via the Task 5/6 collectors, gates them through the

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -54,7 +54,10 @@ public actor OrphanGC {
     private let db: TBDDatabase
     private let git: GitManager
     private let broadcast: @Sendable (StateDelta) -> Void
-    private let lsofProvider: (@Sendable () async -> [String])?
+    /// Optional-returning live-cwd provider. The provider returning `nil`
+    /// means "live cwds could not be determined" and makes `sweep` skip
+    /// entirely; the property itself being `nil` means "use the real lsof".
+    private let liveCWDsProvider: (@Sendable () async -> [String]?)?
     private let scratchpadBase: URL
     private let now: @Sendable () -> Date
 
@@ -62,11 +65,37 @@ public actor OrphanGC {
     private let agentCollector: AgentWorktreeCollector
     private let scratchpadCollector: ScratchpadCollector
 
+    /// Production seam: an injected `lsofProvider` returns a non-optional
+    /// `[String]` — by definition authoritative, it can't signal
+    /// "unavailable". Wraps into the internal optional-returning provider.
     public init(
         db: TBDDatabase,
         git: GitManager,
         broadcast: @escaping @Sendable (StateDelta) -> Void,
         lsofProvider: (@Sendable () async -> [String])? = nil,
+        scratchpadBase: URL? = nil,
+        now: (@Sendable () -> Date)? = nil
+    ) {
+        var wrapped: (@Sendable () async -> [String]?)?
+        if let lsofProvider {
+            wrapped = { await lsofProvider() }
+        }
+        self.init(
+            db: db, git: git, broadcast: broadcast, liveCWDsProvider: wrapped,
+            scratchpadBase: scratchpadBase, now: now
+        )
+    }
+
+    /// Internal seam (tests): the provider may return `nil` to simulate the
+    /// real lsof path's "unavailable" sentinel (timeout / spawn failure /
+    /// non-zero exit), which must make `sweep` skip entirely rather than be
+    /// treated as "no live processes". `liveCWDsProvider` has no default so
+    /// this never collides with the public init's defaulted overload.
+    init(
+        db: TBDDatabase,
+        git: GitManager,
+        broadcast: @escaping @Sendable (StateDelta) -> Void,
+        liveCWDsProvider: (@Sendable () async -> [String]?)?,
         scratchpadBase: URL? = nil,
         now: (@Sendable () -> Date)? = nil
     ) {
@@ -77,7 +106,7 @@ public actor OrphanGC {
         self.db = db
         self.git = git
         self.broadcast = broadcast
-        self.lsofProvider = lsofProvider
+        self.liveCWDsProvider = liveCWDsProvider
         self.scratchpadBase = resolvedScratchpadBase
         self.now = resolvedNow
         self.snapshot = snap
@@ -116,7 +145,9 @@ public actor OrphanGC {
                     logger.debug("gc: keep \(reason, privacy: .public) \(candidate.path, privacy: .public)")
                 case .reap:
                     planned.append("REAP agent-worktree \(candidate.path)")
-                    guard !dryRun, config.gcEnabled else { continue }
+                    // The outer `gcEnabled || dryRun` guard means a non-dry
+                    // run here always has gcEnabled == true.
+                    guard !dryRun else { continue }
                     if let record = await agentCollector.reap(candidate) {
                         try? await db.reapRecords.insert(record)
                         reaped += 1
@@ -141,9 +172,11 @@ public actor OrphanGC {
             }
         }
 
-        await reconcileScratchpads(dryRun: dryRun, config: config, planned: &planned, reaped: &reaped)
+        await reconcileScratchpads(dryRun: dryRun, planned: &planned, reaped: &reaped)
 
-        if !dryRun, config.gcEnabled {
+        // Snapshot retention never runs in dryRun; the outer guard already
+        // establishes gcEnabled for any non-dry run.
+        if !dryRun {
             await gcOldSnapshots(retentionDays: config.gcSnapshotRetentionDays)
         }
 
@@ -155,7 +188,7 @@ public actor OrphanGC {
     /// already gone but whose Claude Code scratchpad survives. Mirrors the
     /// same keep-biased `dryRun`/`gcEnabled` gate as the agent-worktree loop.
     private func reconcileScratchpads(
-        dryRun: Bool, config: Config, planned: inout [String], reaped: inout Int
+        dryRun: Bool, planned: inout [String], reaped: inout Int
     ) async {
         let knownPaths = ((try? await db.worktrees.list(status: .archived)) ?? []).map(\.path)
         let gonePaths = knownPaths.filter { !FileManager.default.fileExists(atPath: $0) }
@@ -164,7 +197,9 @@ public actor OrphanGC {
             let dir = scratchpadBase.appendingPathComponent(slug)
             guard FileManager.default.fileExists(atPath: dir.path) else { continue }
             planned.append("REAP scratchpad \(dir.path)")
-            guard !dryRun, config.gcEnabled else { continue }
+            // The outer `gcEnabled || dryRun` guard means a non-dry run here
+            // always has gcEnabled == true.
+            guard !dryRun else { continue }
             if let record = await scratchpadCollector.cleanUp(forRemovedWorktreePath: path, now: now()) {
                 try? await db.reapRecords.insert(record)
                 reaped += 1
@@ -238,7 +273,15 @@ public actor OrphanGC {
     /// Entry point for the archive hook (Task 8): a TBD worktree at `path`
     /// was just removed, so its Claude Code scratchpad (if any) is cleaned up
     /// immediately rather than waiting for the next sweep's reconciliation.
+    ///
+    /// The `gcEnabled` master switch governs ALL GC deletion, including this
+    /// event-driven path — one toggle covers both collectors. A config read
+    /// failure also skips (fail toward keeping).
     public func scratchpadCleanup(forRemovedWorktreePath path: String) async {
+        guard let config = try? await db.config.get(), config.gcEnabled else {
+            logger.debug("gc: scratchpad cleanup skipped for \(path, privacy: .public) — gc disabled")
+            return
+        }
         guard let record = await scratchpadCollector.cleanUp(forRemovedWorktreePath: path, now: now()) else {
             return
         }
@@ -254,17 +297,15 @@ public actor OrphanGC {
     /// to spawn) — callers MUST treat `nil` as "skip the sweep", never as
     /// "no live processes".
     private func liveCWDs() async -> [String]? {
-        if let lsofProvider {
-            return await lsofProvider()
+        if let liveCWDsProvider {
+            return await liveCWDsProvider()
         }
         return await Self.realLiveCWDs()
     }
 
-    /// Real `lsof`-backed live-cwd provider: `lsof -d cwd -Fn` prints one
-    /// `p<pid>` header line per process followed by an `n<path>` line for its
-    /// cwd. Lines are filtered to the `n`-prefixed ones, canonicalized (so
-    /// they compare equal to git's always-canonical worktree paths), and
-    /// deduped.
+    /// Real `lsof`-backed live-cwd provider: runs `lsof -d cwd -Fn` under a
+    /// 60s deadline and hands the outcome to `parseLiveCWDs`. A spawn failure
+    /// is the same "unavailable" sentinel as a timeout: `nil`, skip the sweep.
     private static func realLiveCWDs() async -> [String]? {
         let outcome: BoundedProcessOutcome
         do {
@@ -278,12 +319,33 @@ public actor OrphanGC {
             logger.error("gc: lsof spawn failed: \(String(describing: error), privacy: .public)")
             return nil
         }
+        return parseLiveCWDs(outcome)
+    }
 
+    /// Pure parser for the lsof outcome — extracted so the safety-relevant
+    /// "unavailable ⇒ skip sweep" direction is directly unit-testable.
+    ///
+    /// `lsof -d cwd -Fn` prints one `p<pid>` header line per process followed
+    /// by an `n<path>` line for its cwd. Lines are filtered to the
+    /// `n`-prefixed ones, the prefix is stripped, each path is canonicalized
+    /// (so it compares equal to git's always-canonical worktree paths), and
+    /// the result is deduped preserving first-seen order.
+    ///
+    /// Returns `nil` — the "skip the entire sweep" sentinel — for:
+    /// - `.timedOut`: a partial listing must never read as "no live processes".
+    /// - non-zero exit: lsof's output on failure is not a complete cwd
+    ///   picture, so it gets the same keep-biased treatment as a timeout.
+    /// - non-UTF-8 stdout: unparseable output is no picture at all.
+    static func parseLiveCWDs(_ outcome: BoundedProcessOutcome) -> [String]? {
         switch outcome {
         case .timedOut:
             logger.error("gc: lsof timed out after 60s")
             return nil
-        case .completed(_, let stdout, _):
+        case .completed(let status, let stdout, _):
+            guard status == 0 else {
+                logger.error("gc: lsof exited \(status, privacy: .public) — treating live cwds as unavailable")
+                return nil
+            }
             guard let text = String(data: stdout, encoding: .utf8) else {
                 logger.error("gc: lsof output was not valid UTF-8")
                 return nil

--- a/Sources/TBDDaemon/GC/ReapSnapshot.swift
+++ b/Sources/TBDDaemon/GC/ReapSnapshot.swift
@@ -1,0 +1,117 @@
+import Foundation
+import TBDShared
+
+/// Errors thrown by `ReapSnapshot`'s snapshot/restore orchestration.
+public enum ReapSnapshotError: Error, CustomStringConvertible, Equatable {
+    /// The snapshot ref was written but a subsequent `listRefs` read didn't
+    /// find it — the caller must keep the worktree rather than delete it.
+    case verificationFailed(String)
+    /// `restore(record:)` was asked to recreate a worktree at a path that
+    /// already exists on disk.
+    case targetExists(String)
+    /// `restore(record:)` had neither a live branch nor a `headSHA` to
+    /// recreate the worktree from.
+    case nothingToRestore
+
+    public var description: String {
+        switch self {
+        case .verificationFailed(let ref):
+            return "ReapSnapshot: wrote ref \(ref) but could not verify it via listRefs"
+        case .targetExists(let path):
+            return "ReapSnapshot: restore target already exists: \(path)"
+        case .nothingToRestore:
+            return "ReapSnapshot: record has neither a live branch nor a headSHA to restore from"
+        }
+    }
+}
+
+/// Orchestrates the orphan-GC "snapshot before delete, restore on demand"
+/// lifecycle on top of the `GitManager` primitives from Task 3.
+///
+/// `snapshotIfNeeded` is the pre-delete safety gate: the spec invariant is
+/// that the snapshot ref (when one is needed) is written AND verified
+/// present via `listRefs` before returning — any thrown error anywhere in
+/// the sequence means the caller must keep the worktree rather than reap it.
+public struct ReapSnapshot: Sendable {
+    let git: GitManager
+
+    /// Snapshots `worktreePath` if it's dirty or its HEAD isn't reachable
+    /// from any branch, returning the created ref name — or `nil` when the
+    /// worktree was clean AND `headSHA` was branch-reachable (no snapshot
+    /// needed, safe to reap with nothing to restore).
+    ///
+    /// Throws on any git failure. The caller must treat a throw as "keep the
+    /// worktree" — this function never returns having deleted anything.
+    public func snapshotIfNeeded(
+        worktreePath: String, repoPath: String, headSHA: String, worktreeName: String, now: Date
+    ) async throws -> String? {
+        let dirty = await git.isDirty(worktreePath: worktreePath)
+        let reachable = await git.isReachableFromAnyBranch(repoPath: repoPath, sha: headSHA)
+        if !dirty && reachable {
+            return nil
+        }
+
+        let stamp = Self.refTimestamp(now)
+        let ref = "refs/tbd/snapshots/\(worktreeName)-\(stamp)"
+
+        if dirty {
+            let tree = try await git.stageAllAndWriteTree(worktreePath: worktreePath)
+            let commit = try await git.commitTree(
+                repoPath: repoPath, tree: tree, parent: headSHA,
+                message: "TBD reap snapshot: \(worktreePath) @ \(stamp)"
+            )
+            try await git.updateRef(repoPath: repoPath, ref: ref, sha: commit)
+        } else {
+            // Clean but unreachable from any branch: anchor the ref directly
+            // at headSHA — a pure `update-ref`, no new commit object.
+            try await git.updateRef(repoPath: repoPath, ref: ref, sha: headSHA)
+        }
+
+        // VERIFY before the caller may delete anything (spec invariant).
+        guard try await git.listRefs(repoPath: repoPath, prefix: ref).contains(ref) else {
+            throw ReapSnapshotError.verificationFailed(ref)
+        }
+        return ref
+    }
+
+    /// Recreates the worktree described by `record` (on its branch if the
+    /// branch still exists, detached at `record.headSHA` otherwise) and, if
+    /// a snapshot was captured, restores that snapshot's content over it.
+    public func restore(record: ReapRecord) async throws {
+        guard !FileManager.default.fileExists(atPath: record.worktreePath) else {
+            throw ReapSnapshotError.targetExists(record.worktreePath)
+        }
+
+        var branchArg: String?
+        if let branch = record.branch,
+           await git.refExists(repoPath: record.repoPath, ref: "refs/heads/\(branch)") {
+            branchArg = branch
+        }
+        guard branchArg != nil || record.headSHA != nil else {
+            throw ReapSnapshotError.nothingToRestore
+        }
+
+        try await git.worktreeAdd(
+            repoPath: record.repoPath,
+            path: record.worktreePath,
+            branch: branchArg,
+            detachAt: branchArg == nil ? record.headSHA : nil
+        )
+
+        if let snapshotRef = record.snapshotRef {
+            try await git.restoreFromRef(worktreePath: record.worktreePath, ref: snapshotRef)
+        }
+    }
+
+    /// Formats `date` as `yyyyMMdd-HHmmss` in UTC with a fixed POSIX locale,
+    /// so ref names are deterministic regardless of the host's locale/TZ.
+    /// `date` is always caller-supplied — never the ambient `Date()` — so
+    /// this function (and everything above it) stays reproducible in tests.
+    static func refTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter.string(from: date)
+    }
+}

--- a/Sources/TBDDaemon/GC/ScratchpadCollector.swift
+++ b/Sources/TBDDaemon/GC/ScratchpadCollector.swift
@@ -39,6 +39,22 @@ public struct ScratchpadCollector: Sendable {
             return nil
         }
 
+        // Defensive anchor guard, right before the recursive delete below:
+        // `dir` must resolve to a path strictly *under* `base`. Normally
+        // this is guaranteed by `slug` collapsing every `/` in `path` to
+        // `-`, so `dir` is always exactly one path component below `base` —
+        // but a degenerate input (e.g. an empty `path`) collapses to an
+        // empty slug, making `appendingPathComponent` a no-op and `dir ==
+        // base` itself. Never trust that invariant blindly this close to
+        // `removeItem`; fail toward keeping instead.
+        guard dir.path.hasPrefix(base.path + "/") else {
+            logger.warning("""
+            gc: refusing to remove \(dir.path, privacy: .public) — not strictly under scratchpad base \
+            \(base.path, privacy: .public)
+            """)
+            return nil
+        }
+
         let bytes = await GCDiskUsage.apparentBytes(path: dir.path)
 
         do {

--- a/Sources/TBDDaemon/GC/ScratchpadCollector.swift
+++ b/Sources/TBDDaemon/GC/ScratchpadCollector.swift
@@ -1,0 +1,108 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
+
+/// Enumerates, gates, and reaps Claude Code scratchpad directories
+/// (`/private/tmp/claude-<uid>/<slug>`) that TBD's orphan-GC sweep may safely
+/// delete.
+///
+/// Every failure path fails toward KEEPING the scratchpad — this type never
+/// deletes anything it isn't certain about. The caller (Task 7's `OrphanGC`
+/// actor) persists whatever `cleanUp(_:)` and `reconcile(_:)` return.
+public struct ScratchpadCollector: Sendable {
+    let base: URL
+
+    public init(base: URL) {
+        self.base = base
+    }
+
+    /// Computes the slug for a worktree path by replacing all forward slashes
+    /// with hyphens. For example: `/Users/chang/tbd` → `-Users-chang-tbd`.
+    public static func slug(forWorktreePath path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "-")
+    }
+
+    /// Event-driven: delete the scratchpad for one known, just-removed worktree
+    /// path. Returns a `ReapRecord` on success, or `nil` if the scratchpad did
+    /// not exist, or if removal failed (directory still exists).
+    public func cleanUp(forRemovedWorktreePath path: String, now: Date) async -> ReapRecord? {
+        let slug = Self.slug(forWorktreePath: path)
+        let dir = base.appendingPathComponent(slug)
+
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            return nil
+        }
+
+        let bytes = await Self.apparentBytes(path: dir.path)
+
+        do {
+            try FileManager.default.removeItem(at: dir)
+        } catch {
+            logger.warning(
+                "gc: rm failed for \(dir.path, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+            return nil
+        }
+
+        // Verify the removal actually took. If the directory is still there,
+        // fail toward keeping so the retry on the next sweep starts from a
+        // consistent state.
+        guard !FileManager.default.fileExists(atPath: dir.path) else {
+            logger.warning("gc: rm failed for \(dir.path, privacy: .public), will retry next sweep")
+            return nil
+        }
+
+        logger.info("gc: reaped scratchpad \(dir.path, privacy: .public)")
+        return ReapRecord(
+            kind: .scratchpad, repoPath: "", worktreePath: dir.path,
+            apparentBytes: bytes, reapedAt: now
+        )
+    }
+
+    /// Reconciliation: for each known path whose directory no longer exists,
+    /// delete its scratchpad. Unrelated directories in the base are untouched.
+    /// Returns an array of `ReapRecord` for paths that were successfully cleaned.
+    ///
+    /// If the base directory does not exist, this is a no-op (returns empty array).
+    public func reconcile(knownPaths: [String], now: Date) async -> [ReapRecord] {
+        guard FileManager.default.fileExists(atPath: base.path) else {
+            return []
+        }
+
+        let gonePaths = knownPaths.filter { !FileManager.default.fileExists(atPath: $0) }
+        var records: [ReapRecord] = []
+        for path in gonePaths {
+            if let record = await cleanUp(forRemovedWorktreePath: path, now: now) {
+                records.append(record)
+            }
+        }
+        return records
+    }
+
+    // MARK: - Helpers
+
+    /// `du -sk`'s apparent-size measurement for `path`, in bytes (the
+    /// reported KB * 1024). `nil` on any failure — spawn error, non-zero
+    /// exit, timeout, or unparseable output — since a missing byte count is
+    /// never worth blocking or retrying a reap over.
+    private static func apparentBytes(path: String) async -> Int64? {
+        guard let outcome = try? await runBoundedProcess(
+            executable: "/usr/bin/du", arguments: ["-sk", path], currentDirectory: nil, timeout: .seconds(60)
+        ) else {
+            return nil
+        }
+        guard case .completed(let status, let stdout, _) = outcome, status == 0 else { return nil }
+        guard let text = String(data: stdout, encoding: .utf8) else { return nil }
+        guard let firstToken = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0.isWhitespace })
+            .first,
+            let kilobytes = Int64(firstToken)
+        else {
+            return nil
+        }
+        return kilobytes * 1024
+    }
+}

--- a/Sources/TBDDaemon/GC/ScratchpadCollector.swift
+++ b/Sources/TBDDaemon/GC/ScratchpadCollector.swift
@@ -35,7 +35,7 @@ public struct ScratchpadCollector: Sendable {
             return nil
         }
 
-        let bytes = await Self.apparentBytes(path: dir.path)
+        let bytes = await GCDiskUsage.apparentBytes(path: dir.path)
 
         do {
             try FileManager.default.removeItem(at: dir)
@@ -79,30 +79,5 @@ public struct ScratchpadCollector: Sendable {
             }
         }
         return records
-    }
-
-    // MARK: - Helpers
-
-    /// `du -sk`'s apparent-size measurement for `path`, in bytes (the
-    /// reported KB * 1024). `nil` on any failure — spawn error, non-zero
-    /// exit, timeout, or unparseable output — since a missing byte count is
-    /// never worth blocking or retrying a reap over.
-    private static func apparentBytes(path: String) async -> Int64? {
-        guard let outcome = try? await runBoundedProcess(
-            executable: "/usr/bin/du", arguments: ["-sk", path], currentDirectory: nil, timeout: .seconds(60)
-        ) else {
-            return nil
-        }
-        guard case .completed(let status, let stdout, _) = outcome, status == 0 else { return nil }
-        guard let text = String(data: stdout, encoding: .utf8) else { return nil }
-        guard let firstToken = text
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(whereSeparator: { $0.isWhitespace })
-            .first,
-            let kilobytes = Int64(firstToken)
-        else {
-            return nil
-        }
-        return kilobytes * 1024
     }
 }

--- a/Sources/TBDDaemon/GC/ScratchpadCollector.swift
+++ b/Sources/TBDDaemon/GC/ScratchpadCollector.swift
@@ -25,9 +25,13 @@ public struct ScratchpadCollector: Sendable {
     }
 
     /// Event-driven: delete the scratchpad for one known, just-removed worktree
-    /// path. Returns a `ReapRecord` on success, or `nil` if the scratchpad did
+    /// path. `repoPath` is the owning repo's root, stamped onto the resulting
+    /// record so it surfaces in the per-repo History UI (`gc.list(repoPath:)`);
+    /// pass `""` when the owning repo can't be resolved (fails toward the
+    /// record simply not appearing per-repo rather than dropping it).
+    /// Returns a `ReapRecord` on success, or `nil` if the scratchpad did
     /// not exist, or if removal failed (directory still exists).
-    public func cleanUp(forRemovedWorktreePath path: String, now: Date) async -> ReapRecord? {
+    public func cleanUp(forRemovedWorktreePath path: String, repoPath: String, now: Date) async -> ReapRecord? {
         let slug = Self.slug(forWorktreePath: path)
         let dir = base.appendingPathComponent(slug)
 
@@ -56,25 +60,31 @@ public struct ScratchpadCollector: Sendable {
 
         logger.info("gc: reaped scratchpad \(dir.path, privacy: .public)")
         return ReapRecord(
-            kind: .scratchpad, repoPath: "", worktreePath: dir.path,
+            kind: .scratchpad, repoPath: repoPath, worktreePath: dir.path,
             apparentBytes: bytes, reapedAt: now
         )
     }
 
-    /// Reconciliation: for each known path whose directory no longer exists,
-    /// delete its scratchpad. Unrelated directories in the base are untouched.
-    /// Returns an array of `ReapRecord` for paths that were successfully cleaned.
+    /// Reconciliation: for each known `(worktreePath, repoPath)` pair whose
+    /// worktree directory no longer exists, delete its scratchpad. Unrelated
+    /// directories in the base are untouched. Returns an array of `ReapRecord`
+    /// for paths that were successfully cleaned, each stamped with the
+    /// `repoPath` of its own pair.
     ///
     /// If the base directory does not exist, this is a no-op (returns empty array).
-    public func reconcile(knownPaths: [String], now: Date) async -> [ReapRecord] {
+    public func reconcile(
+        knownPaths: [(worktreePath: String, repoPath: String)], now: Date
+    ) async -> [ReapRecord] {
         guard FileManager.default.fileExists(atPath: base.path) else {
             return []
         }
 
-        let gonePaths = knownPaths.filter { !FileManager.default.fileExists(atPath: $0) }
+        let gone = knownPaths.filter { !FileManager.default.fileExists(atPath: $0.worktreePath) }
         var records: [ReapRecord] = []
-        for path in gonePaths {
-            if let record = await cleanUp(forRemovedWorktreePath: path, now: now) {
+        for entry in gone {
+            if let record = await cleanUp(
+                forRemovedWorktreePath: entry.worktreePath, repoPath: entry.repoPath, now: now
+            ) {
                 records.append(record)
             }
         }

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -14,6 +14,27 @@ public struct GitTimeoutError: Error, CustomStringConvertible {
     }
 }
 
+/// A single entry from `git worktree list --porcelain`, parsed with full
+/// detail (lock state, detached-HEAD detection) for the orphan-GC sweep.
+/// Bare-repository entries (no `HEAD` line) are dropped by the parser since
+/// they aren't worktrees a GC pass would ever act on.
+public struct WorktreeListEntry: Sendable, Equatable {
+    /// Canonical path as git reports it (git itself `realpath()`s worktree
+    /// paths when recording them, so no extra resolution is needed here).
+    public var path: String
+    public var headSHA: String
+    /// `nil` when the worktree's HEAD is detached.
+    public var branch: String?
+    public var locked: Bool
+
+    public init(path: String, headSHA: String, branch: String?, locked: Bool) {
+        self.path = path
+        self.headSHA = headSHA
+        self.branch = branch
+        self.locked = locked
+    }
+}
+
 /// A branch reference returned by `GitManager.listBranches`.
 ///
 /// Includes both `refs/heads/*` (local) and `refs/remotes/origin/*` (remote
@@ -423,6 +444,153 @@ public struct GitManager: Sendable {
         }
     }
 
+    // MARK: - Orphan-GC primitives
+
+    /// Lists all worktrees with full detail (HEAD SHA, branch or detached,
+    /// lock state) for the orphan-GC sweep. Unlike `worktreeList`, this
+    /// parses the `HEAD`, `detached`, and `locked[ reason]` lines that the
+    /// legacy parser ignores.
+    public func worktreeListDetailed(repoPath: String) async throws -> [WorktreeListEntry] {
+        let output = try await run(arguments: ["worktree", "list", "--porcelain"], at: repoPath)
+        return parseWorktreeListDetailed(output)
+    }
+
+    /// Returns `true` iff `candidatePath` is a bona fide linked worktree of
+    /// the repo at `repoPath` — i.e. `<candidatePath>/.git` is a *file*
+    /// (not the repo root's `.git` directory) containing a `gitdir:` pointer
+    /// that resolves under `<repoPath>/.git/worktrees/`.
+    ///
+    /// This is the proof-of-linkage check the orphan-GC sweep uses before
+    /// ever touching a directory: any read/parse failure returns `false`
+    /// (not proven linked → untouchable), which is the safe direction since
+    /// callers only act on directories proven to be linked worktrees.
+    ///
+    /// Foundation's `URL.resolvingSymlinksInPath()` does NOT follow macOS's
+    /// `/var` → `/private/var` symlink; POSIX `realpath()` does (see the
+    /// same trap documented in `WorktreeCommands.swift`), so resolution here
+    /// goes through `realpath()` directly.
+    public func isLinkedWorktree(candidatePath: String, repoPath: String) async -> Bool {
+        let gitFilePath = candidatePath + "/.git"
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: gitFilePath, isDirectory: &isDirectory),
+              !isDirectory.boolValue else {
+            return false
+        }
+        guard let contents = try? String(contentsOfFile: gitFilePath, encoding: .utf8) else {
+            return false
+        }
+        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = "gitdir: "
+        guard trimmed.hasPrefix(prefix) else {
+            return false
+        }
+        let gitdirPath = String(trimmed.dropFirst(prefix.count))
+        guard let resolvedGitdir = Self.resolveRealPath(gitdirPath),
+              let resolvedWorktreesDir = Self.resolveRealPath(repoPath + "/.git/worktrees") else {
+            return false
+        }
+        return resolvedGitdir.hasPrefix(resolvedWorktreesDir + "/")
+    }
+
+    /// Returns `true` if `git status --porcelain` reports any changes
+    /// (tracked or untracked) in the worktree. A thrown error (e.g. the path
+    /// isn't a git worktree at all) is treated as `true` — fail toward
+    /// keeping the worktree rather than reaping something we couldn't
+    /// actually verify was clean.
+    public func isDirty(worktreePath: String) async -> Bool {
+        guard let output = try? await run(arguments: ["status", "--porcelain"], at: worktreePath) else {
+            return true
+        }
+        return !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Returns `true` if `sha` is an ancestor of (contained in) any local
+    /// branch. A thrown error is treated as `false` — the orphan-GC caller
+    /// treats `false` as "no branch protects this commit, create an anchor
+    /// ref", so failing to `false` here fails toward MORE protection, not
+    /// less.
+    public func isReachableFromAnyBranch(repoPath: String, sha: String) async -> Bool {
+        guard let output = try? await run(
+            arguments: ["branch", "--contains", sha, "--format=%(refname)"],
+            at: repoPath
+        ) else {
+            return false
+        }
+        return !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Stages every change in the worktree (`git add -A`) and writes the
+    /// resulting index as a tree object, returning its SHA.
+    ///
+    /// This intentionally mutates the worktree's real index rather than
+    /// using a scratch `GIT_INDEX_FILE` — the worktree is orphaned and about
+    /// to be deleted by the GC sweep, so there's no working state left to
+    /// preserve.
+    public func stageAllAndWriteTree(worktreePath: String) async throws -> String {
+        _ = try await run(arguments: ["add", "-A"], at: worktreePath)
+        let output = try await run(arguments: ["write-tree"], at: worktreePath)
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Creates a commit object from an existing tree with a single parent,
+    /// without touching any ref. Returns the new commit's SHA.
+    public func commitTree(repoPath: String, tree: String, parent: String, message: String) async throws -> String {
+        let output = try await run(
+            arguments: ["commit-tree", tree, "-p", parent, "-m", message],
+            at: repoPath
+        )
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Points `ref` at `sha`, creating it if it doesn't exist.
+    public func updateRef(repoPath: String, ref: String, sha: String) async throws {
+        _ = try await run(arguments: ["update-ref", ref, sha], at: repoPath)
+    }
+
+    /// Deletes `ref`.
+    public func deleteRef(repoPath: String, ref: String) async throws {
+        _ = try await run(arguments: ["update-ref", "-d", ref], at: repoPath)
+    }
+
+    /// Lists all ref names under `prefix` (e.g. `refs/tbd/snapshots`).
+    public func listRefs(repoPath: String, prefix: String) async throws -> [String] {
+        let output = try await run(
+            arguments: ["for-each-ref", "--format=%(refname)", prefix],
+            at: repoPath
+        )
+        return output
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// Restores every path in the worktree to its content in `ref`.
+    ///
+    /// Known limitation: this only restores content present in the ref's
+    /// tree — files that were *deleted* in the pre-snapshot dirty state are
+    /// not re-deleted (git's `restore` doesn't replay deletions for paths it
+    /// wasn't asked about). Acceptable for the GC use case, where the goal
+    /// is recovering lost work, not exact working-tree reconstruction.
+    public func restoreFromRef(worktreePath: String, ref: String) async throws {
+        _ = try await run(arguments: ["restore", "--source", ref, "--worktree", "--", "."], at: worktreePath)
+    }
+
+    /// Adds a worktree either on an existing `branch` or detached at `sha`.
+    /// Exactly one of `branch`/`sha` must be non-nil.
+    public func worktreeAdd(repoPath: String, path: String, branch: String?, detachAt sha: String?) async throws {
+        if let branch {
+            _ = try await run(arguments: ["worktree", "add", path, branch], at: repoPath)
+        } else if let sha {
+            _ = try await run(arguments: ["worktree", "add", "--detach", path, sha], at: repoPath)
+        } else {
+            throw GitError(
+                command: "git worktree add \(path)",
+                exitCode: -1,
+                stderr: "worktreeAdd requires either a branch or a detachAt sha"
+            )
+        }
+    }
+
     // MARK: - Private
 
     /// Runs a git command with the given arguments at the given directory and returns stdout.
@@ -511,6 +679,73 @@ public struct GitManager: Sendable {
         }
 
         return results
+    }
+
+    /// Parses the porcelain output of `git worktree list --porcelain` into
+    /// full-detail entries (HEAD SHA, detached vs. branch, lock state).
+    ///
+    /// Format (blank-line-separated blocks):
+    /// ```
+    /// worktree /path/to/worktree
+    /// HEAD abc123
+    /// branch refs/heads/main
+    /// locked optional reason
+    ///
+    /// worktree /path/to/other
+    /// HEAD def456
+    /// detached
+    /// ```
+    /// Entries with no `HEAD` line (bare-repository entries, which report a
+    /// `bare` line instead) are dropped — a GC sweep never acts on the bare
+    /// source repo itself.
+    private func parseWorktreeListDetailed(_ output: String) -> [WorktreeListEntry] {
+        var results: [WorktreeListEntry] = []
+        var currentPath: String?
+        var currentHeadSHA: String?
+        var currentBranch: String?
+        var currentLocked = false
+
+        func flush() {
+            if let path = currentPath, let headSHA = currentHeadSHA {
+                results.append(WorktreeListEntry(path: path, headSHA: headSHA, branch: currentBranch, locked: currentLocked))
+            }
+        }
+
+        for line in output.components(separatedBy: "\n") {
+            if line.hasPrefix("worktree ") {
+                flush()
+                currentPath = String(line.dropFirst("worktree ".count))
+                currentHeadSHA = nil
+                currentBranch = nil
+                currentLocked = false
+            } else if line.hasPrefix("HEAD ") {
+                currentHeadSHA = String(line.dropFirst("HEAD ".count))
+            } else if line.hasPrefix("branch ") {
+                let ref = String(line.dropFirst("branch ".count))
+                if ref.hasPrefix("refs/heads/") {
+                    currentBranch = String(ref.dropFirst("refs/heads/".count))
+                } else {
+                    currentBranch = ref
+                }
+            } else if line == "detached" {
+                currentBranch = nil
+            } else if line == "locked" || line.hasPrefix("locked ") {
+                currentLocked = true
+            }
+        }
+
+        flush()
+        return results
+    }
+
+    /// Resolves `path` through POSIX `realpath()`, following every symlink
+    /// component including macOS's `/var` → `/private/var`, which
+    /// `URL.resolvingSymlinksInPath()` does not follow. Returns `nil` if any
+    /// path component doesn't exist.
+    private static func resolveRealPath(_ path: String) -> String? {
+        guard let cString = realpath(path, nil) else { return nil }
+        defer { free(cString) }
+        return String(cString: cString)
     }
 }
 

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -576,7 +576,8 @@ public struct GitManager: Sendable {
     }
 
     /// Adds a worktree either on an existing `branch` or detached at `sha`.
-    /// Exactly one of `branch`/`sha` must be non-nil.
+    /// At least one of `branch`/`sha` must be non-nil (both nil throws
+    /// `GitError`); when both are given, `branch` wins and `sha` is ignored.
     public func worktreeAdd(repoPath: String, path: String, branch: String?, detachAt sha: String?) async throws {
         if let branch {
             _ = try await run(arguments: ["worktree", "add", path, branch], at: repoPath)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -170,7 +170,7 @@ extension WorktreeLifecycle {
         // The directory is gone from disk — fire the event-driven scratchpad
         // cleanup hook (Task 8) rather than waiting for the next hourly sweep.
         if let onWorktreeRemoved {
-            await onWorktreeRemoved(worktree.path)
+            await onWorktreeRemoved(worktree.path, repo.path)
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -166,6 +166,12 @@ extension WorktreeLifecycle {
             repoPath: repo.path,
             worktreePath: worktree.path
         )
+
+        // The directory is gone from disk — fire the event-driven scratchpad
+        // cleanup hook (Task 8) rather than waiting for the next hourly sweep.
+        if let onWorktreeRemoved {
+            await onWorktreeRemoved(worktree.path)
+        }
     }
 
     /// Legacy all-in-one archive (used by CLI).

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -84,12 +84,15 @@ public struct WorktreeLifecycle: Sendable {
 
     /// Fired immediately after a worktree's directory is actually removed
     /// from disk (`completeArchiveWorktree`'s `git.worktreeRemove`), with the
-    /// removed worktree's path. `nil` by default (tests, older callers).
-    /// `Daemon` wires this to `OrphanGC.scratchpadCleanup(forRemovedWorktreePath:)`
-    /// so the worktree's Claude Code scratchpad is reclaimed event-driven
-    /// instead of waiting for the next hourly sweep. Deliberately NOT fired by
+    /// removed worktree's path and its owning repo's path (the archive
+    /// caller has `repo` in scope). `nil` by default (tests, older callers).
+    /// `Daemon` wires this to
+    /// `OrphanGC.scratchpadCleanup(forRemovedWorktreePath:repoPath:)` so the
+    /// worktree's Claude Code scratchpad is reclaimed event-driven instead of
+    /// waiting for the next hourly sweep, stamped with the repo path so it
+    /// surfaces in that repo's History UI. Deliberately NOT fired by
     /// `forgetWorktree` — forget leaves the directory in place.
-    public var onWorktreeRemoved: (@Sendable (String) async -> Void)?
+    public var onWorktreeRemoved: (@Sendable (_ worktreePath: String, _ repoPath: String) async -> Void)?
 
     /// Opt-in tmux control-mode wiring. `nil` when the daemon did not provide
     /// one (tests, older callers); when present, lifecycle paths open a gated

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -82,6 +82,15 @@ public struct WorktreeLifecycle: Sendable {
     /// Default `preSession` hook timeout (production value).
     public static let defaultPreSessionTimeout: TimeInterval = 600
 
+    /// Fired immediately after a worktree's directory is actually removed
+    /// from disk (`completeArchiveWorktree`'s `git.worktreeRemove`), with the
+    /// removed worktree's path. `nil` by default (tests, older callers).
+    /// `Daemon` wires this to `OrphanGC.scratchpadCleanup(forRemovedWorktreePath:)`
+    /// so the worktree's Claude Code scratchpad is reclaimed event-driven
+    /// instead of waiting for the next hourly sweep. Deliberately NOT fired by
+    /// `forgetWorktree` — forget leaves the directory in place.
+    public var onWorktreeRemoved: (@Sendable (String) async -> Void)?
+
     /// Opt-in tmux control-mode wiring. `nil` when the daemon did not provide
     /// one (tests, older callers); when present, lifecycle paths open a gated
     /// logging-only `tmux -CC` connection after each `ensureServer()`.

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -108,4 +108,15 @@ extension RPCRouter {
         subscriptions.broadcast(delta: .modelProfilesChanged)
         return .ok()
     }
+
+    /// Persist the orphan-GC master switch. Turning it off does not cancel or
+    /// undo any in-progress sweep — `OrphanGC.sweep` re-reads the flag itself
+    /// on its next pass — this just flips the persisted gate.
+    func handleConfigSetGCEnabled(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetGCEnabledParams.self, from: paramsData)
+        try await db.config.setGCEnabled(params.enabled)
+        // Reuse the existing config-change channel so the app reloads Config.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+GCHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+GCHandlers.swift
@@ -1,0 +1,36 @@
+import Foundation
+import TBDShared
+
+/// RPC handlers for orphan-GC (Task 9): `gc.list` / `gc.restore` /
+/// `gc.sweepNow`. `gc.list` only needs the DB (reap records are readable
+/// even when GC itself is disabled or unwired); `gc.restore` and
+/// `gc.sweepNow` need the `OrphanGC` actor and return an error response
+/// (never crash) when it's `nil` — mock mode / a daemon that hasn't finished
+/// booting it yet.
+extension RPCRouter {
+    func handleGCList(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(GCListParams.self, from: paramsData)
+        let records = try await db.reapRecords.list(repoPath: params.repoPath)
+        return try RPCResponse(result: records)
+    }
+
+    func handleGCRestore(_ paramsData: Data) async throws -> RPCResponse {
+        guard let orphanGC else {
+            return RPCResponse(error: "gc unavailable")
+        }
+        let params = try decoder.decode(GCRestoreParams.self, from: paramsData)
+        try await orphanGC.restore(recordID: params.recordID)
+        return .ok()
+    }
+
+    func handleGCSweepNow(_ paramsData: Data) async throws -> RPCResponse {
+        guard let orphanGC else {
+            return RPCResponse(error: "gc unavailable")
+        }
+        let params = try decoder.decode(GCSweepNowParams.self, from: paramsData)
+        let result = await orphanGC.sweep(dryRun: params.dryRun)
+        // `OrphanGC.sweep` returns TBDDaemon's own (non-Codable) GCSweepResult;
+        // convert to TBDShared's Codable mirror for RPC serialization.
+        return try RPCResponse(result: TBDShared.GCSweepResult(planned: result.planned, reaped: result.reaped))
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+GCHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+GCHandlers.swift
@@ -29,8 +29,6 @@ extension RPCRouter {
         }
         let params = try decoder.decode(GCSweepNowParams.self, from: paramsData)
         let result = await orphanGC.sweep(dryRun: params.dryRun)
-        // `OrphanGC.sweep` returns TBDDaemon's own (non-Codable) GCSweepResult;
-        // convert to TBDShared's Codable mirror for RPC serialization.
-        return try RPCResponse(result: TBDShared.GCSweepResult(planned: result.planned, reaped: result.reaped))
+        return try RPCResponse(result: result)
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -60,7 +60,8 @@ extension RPCRouter {
             autoHibernateOnMergeDefault: config.autoHibernateOnMergeDefault,
             nightwatchMode: config.nightwatchMode,
             autoResumeOnLimitReset: config.autoResumeOnLimitReset,
-            autoResumeOnApiError: config.autoResumeOnApiError
+            autoResumeOnApiError: config.autoResumeOnApiError,
+            gcEnabled: config.gcEnabled
         ))
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -86,6 +86,13 @@ extension RPCRouter {
             }
         }
 
+        // Reclaim scratchpads for EVERY worktree row this repo owns (every
+        // status, including archived) before the rows below vanish — once
+        // they're gone, reconciliation has no path left to resolve them by.
+        if let orphanGC {
+            await orphanGC.reconcileScratchpadsBeforeRepoRemoval(repoID: repo.id, repoPath: repo.path)
+        }
+
         // Delete any remaining worktrees (e.g. main worktree) for this repo
         try await db.worktrees.deleteForRepo(repoID: params.repoID)
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -114,6 +114,20 @@ extension RPCRouter {
             }
         }
 
+        // The folder at `wt.path` is now gone — trashed just above, already
+        // relocated by promotion (skip-trash branch), or never existed — so
+        // this is the last moment anything can attribute a leftover Claude
+        // Code scratchpad to this row: once it's deleted below, the sweep's
+        // reconciliation has no path left to resolve it by. Scratch spaces
+        // have no owning repo, so repoPath is "" — the same
+        // unresolvable-repo convention `OrphanGC`'s own reconciliation uses.
+        // `scratchpadCleanup` re-verifies the directory is gone and is
+        // gated by `gcEnabled` internally, so this is safe to call
+        // unconditionally.
+        if let orphanGC {
+            await orphanGC.scratchpadCleanup(forRemovedWorktreePath: wt.path, repoPath: "")
+        }
+
         try await db.worktrees.delete(id: wt.id)
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -19,6 +19,11 @@ public final class RPCRouter: Sendable {
     public let modelProfileResolver: ModelProfileResolver
     public nonisolated(unsafe) var daywatchRunner: DaywatchRunner?
     public nonisolated(unsafe) var claudeUsagePoller: ClaudeUsagePoller?
+    /// Orphan-GC actor. `nil` in mock mode / unit tests that don't need it;
+    /// set post-construction by `Daemon.swift` (mirrors `claudeUsagePoller`).
+    /// The `gc.*` handlers return an error response rather than crashing when
+    /// this is nil.
+    public nonisolated(unsafe) var orphanGC: OrphanGC?
     /// In-memory per-profile OAuth usage poller. Wired post-construction by
     /// Daemon.swift (mirrors `claudeUsagePoller`); nil in unit tests / mock
     /// mode, where usage snapshots are simply absent.
@@ -356,6 +361,14 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetControlMode(request.paramsData)
             case RPCMethod.configSetHibernateInputVeto:
                 return try await handleConfigSetHibernateInputVeto(request.paramsData)
+            case RPCMethod.configSetGCEnabled:
+                return try await handleConfigSetGCEnabled(request.paramsData)
+            case RPCMethod.gcList:
+                return try await handleGCList(request.paramsData)
+            case RPCMethod.gcRestore:
+                return try await handleGCRestore(request.paramsData)
+            case RPCMethod.gcSweepNow:
+                return try await handleGCSweepNow(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -71,6 +71,23 @@ public enum TBDConstants {
     }
     public static var scratchDir: URL { scratchDir(environment: ProcessInfo.processInfo.environment) }
 
+    /// Base directory for Claude Code scratchpads resolved from the given environment dictionary.
+    /// Honors `TBD_CLAUDE_SCRATCH_BASE`; falls back to `/private/tmp/claude-<uid>` when the key
+    /// is absent or empty.
+    public static func claudeScratchpadBase(environment: [String: String]) -> URL {
+        if let override = environment["TBD_CLAUDE_SCRATCH_BASE"], !override.isEmpty {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        let uid = getuid()
+        return URL(fileURLWithPath: "/private/tmp/claude-\(uid)", isDirectory: true)
+    }
+
+    /// Base directory for Claude Code scratchpads. Resolves `TBD_CLAUDE_SCRATCH_BASE` env var
+    /// on every access so a process that sets the env after first read (e.g. a SwiftTesting
+    /// suite trait) gets the new value. Falls back to `/private/tmp/claude-<uid>` when the env
+    /// is unset or empty, preserving production behavior.
+    public static var claudeScratchpadBase: URL { claudeScratchpadBase(environment: ProcessInfo.processInfo.environment) }
+
     public static func hookPath(repoID: UUID, eventName: String, environment: [String: String]) -> String {
         reposDir(environment: environment)
             .appendingPathComponent(repoID.uuidString)

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -759,9 +759,21 @@ public struct Config: Codable, Sendable, Equatable {
     /// applies. The input veto is opt-in until it soaks and the v50 master
     /// default is reverted.
     public var hibernateInputVetoEnabled: Bool
+    /// Master switch for the daemon-owned orphan GC sweep. Default ON.
+    public var gcEnabled: Bool
+    /// Minimum age (seconds) an orphaned worktree/scratchpad must reach
+    /// before the sweep reaps it, so a directory mid-teardown isn't raced.
+    public var gcGraceSeconds: Int
+    /// Days a reap snapshot (`refs/tbd/snapshots/...`) is retained before
+    /// being pruned.
+    public var gcSnapshotRetentionDays: Int
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
+    /// Default grace period before the orphan-GC sweep reaps a directory.
+    public static let defaultGCGraceSeconds = 3600
+    /// Default retention window for reap snapshots.
+    public static let defaultGCSnapshotRetentionDays = 30
 
     public init(defaultProfileID: UUID? = nil,
                 primaryAgentPreference: PrimaryAgentPreference = .defaultValue,
@@ -778,7 +790,10 @@ public struct Config: Codable, Sendable, Equatable {
                 hibernateIdleMinutes: Int = Config.defaultHibernateIdleMinutes,
                 controlModeEnabled: Bool = false,
                 autoResumeOnApiError: Bool = false,
-                hibernateInputVetoEnabled: Bool = false) {
+                hibernateInputVetoEnabled: Bool = false,
+                gcEnabled: Bool = true,
+                gcGraceSeconds: Int = Config.defaultGCGraceSeconds,
+                gcSnapshotRetentionDays: Int = Config.defaultGCSnapshotRetentionDays) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -795,6 +810,9 @@ public struct Config: Codable, Sendable, Equatable {
         self.controlModeEnabled = controlModeEnabled
         self.autoResumeOnApiError = autoResumeOnApiError
         self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
+        self.gcEnabled = gcEnabled
+        self.gcGraceSeconds = gcGraceSeconds
+        self.gcSnapshotRetentionDays = gcSnapshotRetentionDays
     }
 
     public init(from decoder: Decoder) throws {
@@ -828,6 +846,11 @@ public struct Config: Codable, Sendable, Equatable {
             Bool.self, forKey: .autoResumeOnApiError) ?? false
         hibernateInputVetoEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
+        gcEnabled = try c.decodeIfPresent(Bool.self, forKey: .gcEnabled) ?? true
+        gcGraceSeconds = try c.decodeIfPresent(Int.self, forKey: .gcGraceSeconds)
+            ?? Config.defaultGCGraceSeconds
+        gcSnapshotRetentionDays = try c.decodeIfPresent(Int.self, forKey: .gcSnapshotRetentionDays)
+            ?? Config.defaultGCSnapshotRetentionDays
     }
 }
 
@@ -907,6 +930,46 @@ public struct Note: Codable, Sendable, Identifiable, Equatable {
         self.content = content
         self.createdAt = createdAt
         self.updatedAt = updatedAt
+    }
+}
+
+/// Kind of reaped directory a `ReapRecord` describes.
+public enum ReapKind: String, Codable, Sendable { case agentWorktree, scratchpad }
+
+/// Record of a directory the daemon-owned orphan GC swept and (optionally)
+/// snapshotted before removal. Persisted so a swept worktree/scratchpad can
+/// be listed and restored later.
+public struct ReapRecord: Codable, Sendable, Identifiable, Equatable {
+    public let id: UUID
+    public var kind: ReapKind
+    /// Main repo root ("" for scratchpads with no repo).
+    public var repoPath: String
+    /// Reaped dir (agent worktree path, or scratchpad path).
+    public var worktreePath: String
+    /// `agentWorktree` only.
+    public var branch: String?
+    /// `agentWorktree` only.
+    public var headSHA: String?
+    /// `refs/tbd/snapshots/...` when dirty state was captured.
+    public var snapshotRef: String?
+    /// `du -sk` * 1024 at reap time.
+    public var apparentBytes: Int64?
+    public var reapedAt: Date
+    public var restoredAt: Date?
+
+    public init(id: UUID = UUID(), kind: ReapKind, repoPath: String, worktreePath: String,
+                branch: String? = nil, headSHA: String? = nil, snapshotRef: String? = nil,
+                apparentBytes: Int64? = nil, reapedAt: Date = Date(), restoredAt: Date? = nil) {
+        self.id = id
+        self.kind = kind
+        self.repoPath = repoPath
+        self.worktreePath = worktreePath
+        self.branch = branch
+        self.headSHA = headSHA
+        self.snapshotRef = snapshotRef
+        self.apparentBytes = apparentBytes
+        self.reapedAt = reapedAt
+        self.restoredAt = restoredAt
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -512,6 +512,8 @@ public struct ModelProfileListResult: Codable, Sendable {
     public let nightwatchMode: NightwatchMode
     public let autoResumeOnLimitReset: Bool
     public let autoResumeOnApiError: Bool
+    /// The orphan-GC master switch (config mirror, default true).
+    public let gcEnabled: Bool
     public init(
         profiles: [ModelProfileWithUsage],
         defaultID: UUID? = nil,
@@ -521,7 +523,8 @@ public struct ModelProfileListResult: Codable, Sendable {
         autoHibernateOnMergeDefault: Bool = false,
         nightwatchMode: NightwatchMode = .off,
         autoResumeOnLimitReset: Bool = false,
-        autoResumeOnApiError: Bool = false
+        autoResumeOnApiError: Bool = false,
+        gcEnabled: Bool = true
     ) {
         self.profiles = profiles
         self.defaultID = defaultID
@@ -532,6 +535,7 @@ public struct ModelProfileListResult: Codable, Sendable {
         self.nightwatchMode = nightwatchMode
         self.autoResumeOnLimitReset = autoResumeOnLimitReset
         self.autoResumeOnApiError = autoResumeOnApiError
+        self.gcEnabled = gcEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -556,6 +560,7 @@ public struct ModelProfileListResult: Codable, Sendable {
             Bool.self, forKey: .autoResumeOnLimitReset) ?? false
         autoResumeOnApiError = try c.decodeIfPresent(
             Bool.self, forKey: .autoResumeOnApiError) ?? false
+        gcEnabled = try c.decodeIfPresent(Bool.self, forKey: .gcEnabled) ?? true
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -188,6 +188,9 @@ public enum RPCMethod {
     public static let terminalCancelScheduledResume = "terminal.cancelScheduledResume"
     public static let configSetControlMode = "config.setControlMode"
     public static let configSetHibernateInputVeto = "config.setHibernateInputVeto"
+    public static let gcList = "gc.list"
+    public static let gcRestore = "gc.restore"
+    public static let gcSweepNow = "gc.sweepNow"
 }
 
 // MARK: - Branch Listing
@@ -845,6 +848,43 @@ public struct WorktreeArchiveParams: Codable, Sendable {
     public let force: Bool
     public init(worktreeID: UUID, force: Bool = false) {
         self.worktreeID = worktreeID; self.force = force
+    }
+}
+
+/// Params for `gc.list` — lists reaped `ReapRecord`s, optionally scoped to
+/// one repo (`nil` == every repo, including scratch reap records).
+public struct GCListParams: Codable, Sendable {
+    public var repoPath: String?
+    public init(repoPath: String? = nil) {
+        self.repoPath = repoPath
+    }
+}
+
+/// Params for `gc.restore` — restores a swept `ReapRecord` by id.
+public struct GCRestoreParams: Codable, Sendable {
+    public var recordID: UUID
+    public init(recordID: UUID) {
+        self.recordID = recordID
+    }
+}
+
+/// Params for `gc.sweepNow` — triggers an out-of-band sweep. `dryRun: true`
+/// plans without reaping.
+public struct GCSweepNowParams: Codable, Sendable {
+    public var dryRun: Bool
+    public init(dryRun: Bool = false) {
+        self.dryRun = dryRun
+    }
+}
+
+/// Result of a `gc.sweepNow` sweep (dry-run or real).
+public struct GCSweepResult: Codable, Sendable {
+    /// Human-readable plan lines, e.g. "REAP agent-worktree /path …", "KEEP locked /path".
+    public var planned: [String]
+    public var reaped: Int
+    public init(planned: [String], reaped: Int) {
+        self.planned = planned
+        self.reaped = reaped
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -878,8 +878,10 @@ public struct GCSweepNowParams: Codable, Sendable {
     }
 }
 
-/// Result of a `gc.sweepNow` sweep (dry-run or real).
-public struct GCSweepResult: Codable, Sendable {
+/// Result of a `gc.sweepNow` sweep (dry-run or real). Also the direct return
+/// type of `OrphanGC.sweep(dryRun:)` in TBDDaemon — one type, no daemon-side
+/// mirror.
+public struct GCSweepResult: Codable, Sendable, Equatable {
     /// Human-readable plan lines, e.g. "REAP agent-worktree /path …", "KEEP locked /path".
     public var planned: [String]
     public var reaped: Int

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -191,6 +191,7 @@ public enum RPCMethod {
     public static let gcList = "gc.list"
     public static let gcRestore = "gc.restore"
     public static let gcSweepNow = "gc.sweepNow"
+    public static let configSetGCEnabled = "config.setGCEnabled"
 }
 
 // MARK: - Branch Listing
@@ -1221,6 +1222,12 @@ public struct ConfigSetControlModeParams: Codable, Sendable {
 /// hibernation sweep; no daemon restart required.
 public struct ConfigSetHibernateInputVetoParams: Codable, Sendable {
     public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
+/// Params for `config.setGCEnabled` — the orphan-GC master switch.
+public struct ConfigSetGCEnabledParams: Codable, Sendable {
+    public var enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }
 }
 

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -27,6 +27,10 @@ public enum StateDelta: Codable, Sendable {
     case worktreeMoved(WorktreeMovedDelta)
     case terminalHibernationChanged(TerminalHibernationDelta)
     case controlModeInputHealthChanged(ControlModeInputHealthDelta)
+    /// Fired when the orphan GC sweep reaps or restores a `ReapRecord`. No
+    /// payload (mirrors `.modelProfilesChanged`) — subscribers refetch via
+    /// `gc.list`.
+    case reapRecordsChanged
 }
 
 /// Delta payload for a terminal's hibernation state change (hibernate / wake)

--- a/Tests/TBDAppTests/ReapRecordsStateTests.swift
+++ b/Tests/TBDAppTests/ReapRecordsStateTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for the orphan-GC app plumbing: the `ReclaimedSummary` pure
+/// view-model helpers, and the `AppState.reapRecords` / `gcEnabled` mirror.
+///
+/// Every AppState-touching test constructs `AppState(userDefaults:)` against
+/// a unique throwaway suite — TBDApp ships as an unbundled SPM executable, so
+/// `UserDefaults.standard` is the running developer's real `TBDApp.plist`
+/// (mirrors `EffectiveAutoArchiveTests.swift:14-35`).
+@MainActor
+@Suite("ReapRecordsState")
+struct ReapRecordsStateTests {
+
+    private func withAppState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.ReapRecordsState.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func record(
+        kind: ReapKind,
+        worktreePath: String = "/tmp/wt",
+        apparentBytes: Int64? = nil,
+        reapedAt: Date = Date(),
+        restoredAt: Date? = nil
+    ) -> ReapRecord {
+        ReapRecord(
+            kind: kind,
+            repoPath: "/tmp/repo",
+            worktreePath: worktreePath,
+            apparentBytes: apparentBytes,
+            reapedAt: reapedAt,
+            restoredAt: restoredAt
+        )
+    }
+
+    // MARK: - ReclaimedSummary
+
+    @Test func emptyRecordsYieldZeroedSummary() {
+        let summary = ReclaimedSummary(records: [])
+        #expect(summary.count == 0)
+        #expect(summary.totalApparentBytes == 0)
+        #expect(summary.agentRecords.isEmpty)
+        #expect(summary.scratchpadRollup == nil)
+    }
+
+    @Test func countAndBytesSumAcrossMixedKinds() {
+        let records = [
+            record(kind: .agentWorktree, apparentBytes: 1_000),
+            record(kind: .scratchpad, apparentBytes: 500),
+            record(kind: .agentWorktree, apparentBytes: 2_000),
+        ]
+        let summary = ReclaimedSummary(records: records)
+        #expect(summary.count == 3)
+        #expect(summary.totalApparentBytes == 3_500)
+    }
+
+    @Test func nilApparentBytesTreatedAsZero() {
+        let records = [
+            record(kind: .agentWorktree, apparentBytes: nil),
+            record(kind: .agentWorktree, apparentBytes: 100),
+        ]
+        let summary = ReclaimedSummary(records: records)
+        #expect(summary.totalApparentBytes == 100)
+    }
+
+    @Test func agentRecordsExcludesScratchpadsAndSortsDescending() {
+        let now = Date()
+        let oldest = record(kind: .agentWorktree, worktreePath: "/tmp/oldest", reapedAt: now.addingTimeInterval(-200))
+        let middle = record(kind: .agentWorktree, worktreePath: "/tmp/middle", reapedAt: now.addingTimeInterval(-100))
+        let newest = record(kind: .agentWorktree, worktreePath: "/tmp/newest", reapedAt: now)
+        let scratch = record(kind: .scratchpad, worktreePath: "/tmp/scratch", reapedAt: now)
+
+        let summary = ReclaimedSummary(records: [oldest, newest, scratch, middle])
+        #expect(summary.agentRecords.map(\.worktreePath) == ["/tmp/newest", "/tmp/middle", "/tmp/oldest"])
+    }
+
+    @Test func scratchpadRollupNilWhenNoScratchpads() {
+        let summary = ReclaimedSummary(records: [record(kind: .agentWorktree, apparentBytes: 10)])
+        #expect(summary.scratchpadRollup == nil)
+    }
+
+    @Test func scratchpadRollupAggregatesCountAndBytes() {
+        let records = [
+            record(kind: .scratchpad, apparentBytes: 300),
+            record(kind: .scratchpad, apparentBytes: nil),
+            record(kind: .scratchpad, apparentBytes: 200),
+            record(kind: .agentWorktree, apparentBytes: 9_999),
+        ]
+        let summary = ReclaimedSummary(records: records)
+        let rollup = summary.scratchpadRollup
+        #expect(rollup?.count == 3)
+        #expect(rollup?.bytes == 500)
+    }
+
+    // MARK: - AppState mirror
+
+    @Test func gcEnabledDefaultsToTrue() {
+        withAppState { app in
+            #expect(app.gcEnabled == true)
+        }
+    }
+
+    @Test func reapRecordsDefaultsToEmpty() {
+        withAppState { app in
+            #expect(app.reapRecords.isEmpty)
+        }
+    }
+
+    @Test func reapRecordsKeyedByRepoID() {
+        withAppState { app in
+            let repoA = UUID()
+            let repoB = UUID()
+            app.reapRecords[repoA] = [record(kind: .agentWorktree)]
+            app.reapRecords[repoB] = []
+            #expect(app.reapRecords[repoA]?.count == 1)
+            #expect(app.reapRecords[repoB]?.isEmpty == true)
+            #expect(app.reapRecords[UUID()] == nil)
+        }
+    }
+}

--- a/Tests/TBDAppTests/ReapRecordsStateTests.swift
+++ b/Tests/TBDAppTests/ReapRecordsStateTests.swift
@@ -21,6 +21,20 @@ struct ReapRecordsStateTests {
         body(AppState(userDefaults: defaults))
     }
 
+    private func archivedWorktree(id: UUID, repoID: UUID, archivedAt: Date) -> Worktree {
+        Worktree(
+            id: id,
+            repoID: repoID,
+            name: "test-\(id.uuidString.prefix(8))",
+            displayName: "Test \(id.uuidString.prefix(8))",
+            branch: "main",
+            path: "/tmp/test",
+            status: .archived,
+            archivedAt: archivedAt,
+            tmuxServer: "test-server"
+        )
+    }
+
     private func record(
         kind: ReapKind,
         worktreePath: String = "/tmp/wt",
@@ -141,6 +155,97 @@ struct ReapRecordsStateTests {
             #expect(app.reapRecords[repoA]?.count == 1)
             #expect(app.reapRecords[repoB]?.isEmpty == true)
             #expect(app.reapRecords[UUID()] == nil)
+        }
+    }
+
+    // MARK: - Archived/Reclaimed selection exclusivity
+    //
+    // ArchivedWorktreesView's "Reclaimed" section used to hold its selection
+    // in view-local @State, documented as mutually exclusive with
+    // `selectedArchivedWorktreeIDs[repoID]` but with no way to enforce that
+    // from `ensureArchivedSelectionValid`'s fallback auto-pick, which could
+    // steal the highlight out from under a deliberate Reclaimed selection.
+    // The fix lifts both selections into AppState (`selectedReapRecordIDs` +
+    // `selectedArchivedWorktreeIDs`) so every entry point can respect the
+    // invariant. These tests cover that invariant directly.
+
+    @Test func ensureArchivedSelectionValidDoesNotAutoPickWhenReapSelectionExists() {
+        withAppState { app in
+            let repoID = UUID()
+            let worktreeID = UUID()
+            app.archivedWorktrees[repoID] = [
+                archivedWorktree(id: worktreeID, repoID: repoID, archivedAt: Date())
+            ]
+            app.selectedReapRecordIDs[repoID] = UUID()
+
+            app.ensureArchivedSelectionValid(repoID: repoID)
+
+            #expect(app.selectedArchivedWorktreeIDs[repoID] == nil)
+            #expect(app.selectedReapRecordIDs[repoID] != nil)
+        }
+    }
+
+    @Test func ensureArchivedSelectionValidStillAutoPicksWhenNoReapSelection() {
+        withAppState { app in
+            let repoID = UUID()
+            let older = archivedWorktree(id: UUID(), repoID: repoID, archivedAt: Date().addingTimeInterval(-100))
+            let newer = archivedWorktree(id: UUID(), repoID: repoID, archivedAt: Date())
+            app.archivedWorktrees[repoID] = [older, newer]
+
+            app.ensureArchivedSelectionValid(repoID: repoID)
+
+            #expect(app.selectedArchivedWorktreeIDs[repoID] == newer.id)
+        }
+    }
+
+    @Test func ensureArchivedSelectionValidClearsWhenNothingArchivedAndNoReapSelection() {
+        withAppState { app in
+            let repoID = UUID()
+            app.archivedWorktrees[repoID] = []
+
+            app.ensureArchivedSelectionValid(repoID: repoID)
+
+            #expect(app.selectedArchivedWorktreeIDs[repoID] == nil)
+        }
+    }
+
+    @Test func selectArchivedWorktreeClearsReapSelectionForSameRepo() {
+        withAppState { app in
+            let repoID = UUID()
+            let worktreeID = UUID()
+            app.selectedReapRecordIDs[repoID] = UUID()
+
+            app.selectArchivedWorktree(worktreeID, repoID: repoID)
+
+            #expect(app.selectedArchivedWorktreeIDs[repoID] == worktreeID)
+            #expect(app.selectedReapRecordIDs[repoID] == nil)
+        }
+    }
+
+    @Test func selectReapRecordClearsArchivedSelectionForSameRepo() {
+        withAppState { app in
+            let repoID = UUID()
+            let recordID = UUID()
+            app.selectedArchivedWorktreeIDs[repoID] = UUID()
+
+            app.selectReapRecord(recordID, repoID: repoID)
+
+            #expect(app.selectedReapRecordIDs[repoID] == recordID)
+            #expect(app.selectedArchivedWorktreeIDs[repoID] == nil)
+        }
+    }
+
+    @Test func selectionHelpersScopeToTheirOwnRepoOnly() {
+        withAppState { app in
+            let repoA = UUID()
+            let repoB = UUID()
+            app.selectedReapRecordIDs[repoB] = UUID()
+
+            app.selectArchivedWorktree(UUID(), repoID: repoA)
+
+            // Selecting an archived row in repoA must not disturb repoB's
+            // independent reap selection.
+            #expect(app.selectedReapRecordIDs[repoB] != nil)
         }
     }
 }

--- a/Tests/TBDAppTests/ReapRecordsStateTests.swift
+++ b/Tests/TBDAppTests/ReapRecordsStateTests.swift
@@ -97,6 +97,27 @@ struct ReapRecordsStateTests {
         #expect(rollup?.bytes == 500)
     }
 
+    @Test func unrestoredExcludesRestoredRecordsFromCountAndBytes() {
+        let restored = record(kind: .agentWorktree, apparentBytes: 1_000, restoredAt: Date())
+        let live = record(kind: .agentWorktree, apparentBytes: 500)
+        let scratch = record(kind: .scratchpad, apparentBytes: 250)
+        let summary = ReclaimedSummary(records: [restored, live, scratch])
+
+        #expect(summary.count == 3) // unfiltered — the expanded list still shows everything
+        #expect(summary.unrestored.count == 2)
+        #expect(summary.unrestored.totalApparentBytes == 750)
+    }
+
+    @Test func unrestoredIsIdentityWhenNothingRestored() {
+        let records = [
+            record(kind: .agentWorktree, apparentBytes: 100),
+            record(kind: .scratchpad, apparentBytes: 200),
+        ]
+        let summary = ReclaimedSummary(records: records)
+        #expect(summary.unrestored.count == summary.count)
+        #expect(summary.unrestored.totalApparentBytes == summary.totalApparentBytes)
+    }
+
     // MARK: - AppState mirror
 
     @Test func gcEnabledDefaultsToTrue() {

--- a/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
+++ b/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
@@ -1,0 +1,270 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+import TestSupport
+
+/// Resolves symlinks in a path the same way git's `worktree list --porcelain`
+/// does: `URL.resolvingSymlinksInPath()` does NOT follow macOS's
+/// `/var` -> `/private/var` symlink, but C `realpath()` does. Test fixtures
+/// must canonicalize before comparing against collector output — mirrors
+/// `AgentWorktreeCollector.canon(_:)` exactly (and `GitManagerGCTests`'
+/// private helper of the same shape).
+private func canon(_ path: String) -> String {
+    guard let cReal = realpath(path, nil) else { return path }
+    defer { free(cReal) }
+    return String(cString: cReal)
+}
+
+@Suite("AgentWorktreeCollector")
+struct AgentWorktreeCollectorTests {
+    // MARK: - Helpers
+
+    private func makeCollector(
+        liveCWDs: @escaping @Sendable () async -> [String] = { [] },
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) -> AgentWorktreeCollector {
+        let git = GitManager()
+        return AgentWorktreeCollector(git: git, snapshot: ReapSnapshot(git: git), liveCWDs: liveCWDs, now: now)
+    }
+
+    /// Builds `<repo>/.claude/worktrees/<name>` as a real linked git
+    /// worktree on its own branch (named after `name` unless `branch` is
+    /// given) and returns its canonicalized path.
+    @discardableResult
+    private func makeAgentWorktree(repo: URL, name: String, branch: String? = nil) async throws -> String {
+        try await shell("mkdir -p .claude/worktrees", at: repo)
+        try await shell("git worktree add .claude/worktrees/\(name) -b \(branch ?? name)", at: repo)
+        return canon(repo.path + "/.claude/worktrees/" + name)
+    }
+
+    // MARK: - candidates(repoPath:)
+
+    @Test func candidatesEnumeratesOnlyLinkedDirsUnderClaudeWorktrees() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await shell("mkdir -p .claude/worktrees", at: repo)
+        // Decoy 1: plain `mkdir`'d dir, no `.git` at all — fails linkage proof.
+        try await shell("mkdir -p .claude/worktrees/decoy", at: repo)
+        // Decoy 2: a symlink to the repo root itself — its `.git` resolves to
+        // a *directory*, not a `gitdir:`-pointer file, so linkage proof
+        // rejects it too (the "repo root" exclusion case).
+        try await shell("ln -s '\(repo.path)' .claude/worktrees/reporoot", at: repo)
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-t1")
+
+        let collector = makeCollector()
+        let candidates = await collector.candidates(repoPath: repo.path)
+
+        #expect(candidates.count == 1)
+        let c = try #require(candidates.first)
+        #expect(c.path == wtPath)
+        #expect(c.repoPath == repo.path)
+        #expect(c.branch == "agent-t1")
+        #expect(c.headSHA.count == 40)
+        #expect(c.locked == false)
+    }
+
+    // MARK: - Gate 1: locked
+
+    @Test func lockedIsKept() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await makeAgentWorktree(repo: repo, name: "agent-t1")
+        try await shell("git worktree lock .claude/worktrees/agent-t1", at: repo)
+
+        let collector = makeCollector()
+        let c = try #require(await collector.candidates(repoPath: repo.path).first)
+        #expect(c.locked == true)
+
+        let decision = await collector.decide(c, liveCWDs: [], graceSeconds: 0)
+        #expect(decision == .keep(reason: "locked"))
+    }
+
+    // MARK: - Gate 2: live-cwd (exact, subdir, and sibling-prefix negative)
+
+    @Test func liveCwdIsKept() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await makeAgentWorktree(repo: repo, name: "agent-t1")
+        try await makeAgentWorktree(repo: repo, name: "agent-t1x")
+
+        let collector = makeCollector()
+        let candidates = await collector.candidates(repoPath: repo.path)
+        let c1 = try #require(candidates.first { $0.path.hasSuffix("agent-t1") })
+        let c1x = try #require(candidates.first { $0.path.hasSuffix("agent-t1x") })
+
+        // Exact match keeps.
+        let exact = await collector.decide(c1, liveCWDs: [c1.path], graceSeconds: 0)
+        #expect(exact == .keep(reason: "live-cwd"))
+
+        // A cwd strictly below the worktree root also keeps.
+        let subdir = await collector.decide(c1, liveCWDs: [c1.path + "/subdir"], graceSeconds: 0)
+        #expect(subdir == .keep(reason: "live-cwd"))
+
+        // The sibling `agent-t1x`'s cwd must NOT match `agent-t1` via a bare
+        // prefix check (the #41010 prefix-collision case: `agent-t1x` starts
+        // with `agent-t1` as a *string*, but is not a path strictly below
+        // it once the `/` separator is required).
+        let siblingDecision = await collector.decide(c1, liveCWDs: [c1x.path], graceSeconds: 0)
+        guard case .reap = siblingDecision else {
+            Issue.record("expected .reap when only a sibling worktree's cwd is live, got \(siblingDecision)")
+            return
+        }
+    }
+
+    // MARK: - Gate 3: grace (HEAD/index activity)
+
+    @Test func graceKeepsRecentlyTouched() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-t1")
+        let git = GitManager()
+        let snap = ReapSnapshot(git: git)
+
+        let entries = try await git.worktreeListDetailed(repoPath: repo.path)
+        let entry = try #require(entries.first { $0.path == wtPath })
+        let candidate = AgentWorktreeCandidate(
+            path: wtPath, repoPath: repo.path, branch: entry.branch, headSHA: entry.headSHA, locked: entry.locked
+        )
+
+        let baseline = AgentWorktreeCollector.lastActivity(worktreePath: wtPath)
+
+        // Well within a 1-hour grace window: kept.
+        let recentCollector = AgentWorktreeCollector(
+            git: git, snapshot: snap, liveCWDs: { [] }, now: { baseline.addingTimeInterval(100) }
+        )
+        let keepDecision = await recentCollector.decide(candidate, liveCWDs: [], graceSeconds: 3600)
+        #expect(keepDecision == .keep(reason: "grace"))
+
+        // Well past a 1-hour grace window: reaps.
+        let staleCollector = AgentWorktreeCollector(
+            git: git, snapshot: snap, liveCWDs: { [] }, now: { baseline.addingTimeInterval(7200) }
+        )
+        let reapDecision = await staleCollector.decide(candidate, liveCWDs: [], graceSeconds: 3600)
+        guard case .reap = reapDecision else {
+            Issue.record("expected .reap once past the grace window, got \(reapDecision)")
+            return
+        }
+    }
+
+    // MARK: - Reap: clean orphan
+
+    @Test func cleanOrphanReaped() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await makeAgentWorktree(repo: repo, name: "agent-t1")
+
+        let collector = makeCollector()
+        let c = try #require(await collector.candidates(repoPath: repo.path).first)
+
+        let decision = await collector.decide(c, liveCWDs: [], graceSeconds: 0)
+        guard case .reap(let reapCandidate) = decision else {
+            Issue.record("expected .reap for a clean, unlocked, non-live, out-of-grace worktree, got \(decision)")
+            return
+        }
+
+        let record = try #require(await collector.reap(reapCandidate))
+        #expect(record.kind == .agentWorktree)
+        #expect(record.snapshotRef == nil)
+        #expect(record.worktreePath == c.path)
+        #expect(!FileManager.default.fileExists(atPath: c.path))
+
+        let git = GitManager()
+        let remaining = try await git.worktreeListDetailed(repoPath: repo.path)
+        #expect(!remaining.contains { $0.path == c.path })
+
+        // The branch itself must survive — only the worktree dir + its git
+        // registration are removed, never the branch/history.
+        try await shell("git rev-parse --verify refs/heads/agent-t1", at: repo)
+    }
+
+    // MARK: - Reap: dirty orphan snapshots first
+
+    @Test func dirtyOrphanSnapshotThenReaped() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-t1")
+        try await shell("echo dirty > untracked.txt", at: URL(fileURLWithPath: wtPath))
+
+        let collector = makeCollector()
+        let c = try #require(await collector.candidates(repoPath: repo.path).first)
+
+        let decision = await collector.decide(c, liveCWDs: [], graceSeconds: 0)
+        guard case .reap(let reapCandidate) = decision else {
+            Issue.record("expected .reap for a dirty-but-idle worktree, got \(decision)")
+            return
+        }
+
+        let record = try #require(await collector.reap(reapCandidate))
+        let ref = try #require(record.snapshotRef)
+        #expect(!FileManager.default.fileExists(atPath: c.path))
+
+        let git = GitManager()
+        let refs = try await git.listRefs(repoPath: repo.path, prefix: "refs/tbd/snapshots")
+        #expect(refs.contains(ref))
+    }
+
+    // MARK: - Reap: snapshot failure keeps
+
+    @Test func snapshotFailureKeeps() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await makeAgentWorktree(repo: repo, name: "agent-t1")
+        // Dirty, so snapshotIfNeeded takes the commit-tree path, which uses
+        // headSHA as the new commit's parent.
+        let entriesBefore = try await GitManager().worktreeListDetailed(repoPath: repo.path)
+        let realEntry = try #require(entriesBefore.first { $0.path.hasSuffix("agent-t1") })
+        try await shell("echo dirty > untracked.txt", at: URL(fileURLWithPath: realEntry.path))
+
+        let collector = makeCollector()
+        let real = try #require(await collector.candidates(repoPath: repo.path).first)
+
+        // A candidate identical to the real one except for a headSHA that
+        // names no object in the repo — forces `commit-tree -p <bogus>` to
+        // fail *inside* `snapshotIfNeeded`, proving the failure happens there
+        // and not earlier in `candidates()` (which already succeeded above).
+        let bogusSHA = String(repeating: "0", count: 39) + "1"
+        let bogus = AgentWorktreeCandidate(
+            path: real.path, repoPath: real.repoPath, branch: real.branch, headSHA: bogusSHA, locked: real.locked
+        )
+
+        let record = await collector.reap(bogus)
+        #expect(record == nil)
+        #expect(FileManager.default.fileExists(atPath: real.path))
+    }
+
+    // MARK: - Symlinked parent path robustness
+
+    @Test func symlinkedPathsStillMatch() async throws {
+        // Deliberately the RAW (non-realpath'd) temp dir — on macOS this sits
+        // under `/var/folders/...`, itself a symlink to `/private/var/folders/...`.
+        let (tmp, repo) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await makeAgentWorktree(repo: repo, name: "agent-t1")
+
+        let collector = makeCollector()
+        // Pass the unresolved `repo.path` straight through — linkage proof
+        // and the byPath cross-reference must still line up even though the
+        // directory listing side and git's own (always-canonical) worktree
+        // list only meet in the middle via `canon(_:)`.
+        let candidates = await collector.candidates(repoPath: repo.path)
+        #expect(candidates.count == 1)
+        let c = try #require(candidates.first)
+
+        // `candidates()` always returns an already-canonicalized path (git
+        // itself realpath()s worktree paths when recording them), matching
+        // what a real `lsof`-based live-cwd provider reports. A liveCWDs
+        // entry built from that same canonical path must still keep it.
+        let decision = await collector.decide(c, liveCWDs: [c.path], graceSeconds: 0)
+        #expect(decision == .keep(reason: "live-cwd"))
+    }
+}

--- a/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
+++ b/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
@@ -195,7 +195,7 @@ struct AgentWorktreeCollectorTests {
             return
         }
 
-        let record = try #require(await collector.reap(reapCandidate))
+        let record = try #require(await collector.reap(reapCandidate, freshLiveCWDs: { [] }))
         #expect(record.kind == .agentWorktree)
         #expect(record.snapshotRef == nil)
         #expect(record.worktreePath == c.path)
@@ -228,7 +228,7 @@ struct AgentWorktreeCollectorTests {
             return
         }
 
-        let record = try #require(await collector.reap(reapCandidate))
+        let record = try #require(await collector.reap(reapCandidate, freshLiveCWDs: { [] }))
         let ref = try #require(record.snapshotRef)
         #expect(!FileManager.default.fileExists(atPath: c.path))
 
@@ -262,9 +262,92 @@ struct AgentWorktreeCollectorTests {
             path: real.path, repoPath: real.repoPath, branch: real.branch, headSHA: bogusSHA, locked: real.locked
         )
 
-        let record = await collector.reap(bogus)
+        let record = await collector.reap(bogus, freshLiveCWDs: { [] })
         #expect(record == nil)
         #expect(FileManager.default.fileExists(atPath: real.path))
+    }
+
+    // MARK: - Reap: pre-rm TOCTOU re-check (Medium review finding)
+    //
+    // `decide(_:liveCWDs:graceSeconds:)` gates on lock/lsof data captured at
+    // sweep start, which can go stale by the time a candidate's turn to reap
+    // comes up on a large sweep. `reap(_:freshLiveCWDs:)` re-checks both
+    // right before doing anything destructive (and before the snapshot step,
+    // which itself mutates the doomed worktree's git index). These tests
+    // drive `reap(_:freshLiveCWDs:)` directly with a candidate that already
+    // cleared `decide`, then falsify the re-check to prove it still keeps.
+
+    @Test func reapKeepsWhenCandidateBecameLockedSinceDecide() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await makeAgentWorktree(repo: repo, name: "agent-t1")
+
+        let collector = makeCollector()
+        let c = try #require(await collector.candidates(repoPath: repo.path).first)
+
+        let decision = await collector.decide(c, liveCWDs: [], graceSeconds: 0)
+        guard case .reap(let reapCandidate) = decision else {
+            Issue.record("expected .reap for a clean, unlocked, non-live, out-of-grace worktree, got \(decision)")
+            return
+        }
+
+        // Simulate the TOCTOU window: something locked the worktree after
+        // `decide` ran but before `reap` got to it.
+        try await shell("git worktree lock .claude/worktrees/agent-t1", at: repo)
+
+        let record = await collector.reap(reapCandidate, freshLiveCWDs: { [] })
+        #expect(record == nil)
+        #expect(FileManager.default.fileExists(atPath: c.path))
+
+        let git = GitManager()
+        let remaining = try await git.worktreeListDetailed(repoPath: repo.path)
+        #expect(remaining.contains { $0.path == c.path })
+    }
+
+    @Test func reapKeepsWhenFreshLiveCWDsFindsCwdInsideWorktree() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await makeAgentWorktree(repo: repo, name: "agent-t1")
+
+        let collector = makeCollector()
+        let c = try #require(await collector.candidates(repoPath: repo.path).first)
+
+        let decision = await collector.decide(c, liveCWDs: [], graceSeconds: 0)
+        guard case .reap(let reapCandidate) = decision else {
+            Issue.record("expected .reap for a clean, unlocked, non-live, out-of-grace worktree, got \(decision)")
+            return
+        }
+
+        // Simulate the TOCTOU window: an agent attached a live cwd under the
+        // worktree between `decide` and `reap`.
+        let record = await collector.reap(reapCandidate, freshLiveCWDs: { [c.path + "/subdir"] })
+        #expect(record == nil)
+        #expect(FileManager.default.fileExists(atPath: c.path))
+    }
+
+    @Test func reapKeepsWhenFreshLiveCWDsUnavailable() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await makeAgentWorktree(repo: repo, name: "agent-t1")
+
+        let collector = makeCollector()
+        let c = try #require(await collector.candidates(repoPath: repo.path).first)
+
+        let decision = await collector.decide(c, liveCWDs: [], graceSeconds: 0)
+        guard case .reap(let reapCandidate) = decision else {
+            Issue.record("expected .reap for a clean, unlocked, non-live, out-of-grace worktree, got \(decision)")
+            return
+        }
+
+        // `nil` means the re-check's lsof pass couldn't determine live cwds
+        // this instant — same fail-toward-keep sentinel as a sweep-wide lsof
+        // failure, not "no live processes".
+        let record = await collector.reap(reapCandidate, freshLiveCWDs: { nil })
+        #expect(record == nil)
+        #expect(FileManager.default.fileExists(atPath: c.path))
     }
 
     // MARK: - Symlinked parent path robustness

--- a/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
+++ b/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
@@ -4,16 +4,12 @@ import Foundation
 import TBDShared
 import TestSupport
 
-/// Resolves symlinks in a path the same way git's `worktree list --porcelain`
-/// does: `URL.resolvingSymlinksInPath()` does NOT follow macOS's
-/// `/var` -> `/private/var` symlink, but C `realpath()` does. Test fixtures
-/// must canonicalize before comparing against collector output — mirrors
-/// `AgentWorktreeCollector.canon(_:)` exactly (and `GitManagerGCTests`'
-/// private helper of the same shape).
+/// Test fixtures must canonicalize paths before comparing against collector
+/// output (git's `worktree list --porcelain` paths are always realpath'd).
+/// Uses the collector's own `canon(_:)` — reachable via `@testable import` —
+/// so both sides of every comparison share one resolution implementation.
 private func canon(_ path: String) -> String {
-    guard let cReal = realpath(path, nil) else { return path }
-    defer { free(cReal) }
-    return String(cString: cReal)
+    AgentWorktreeCollector.canon(path)
 }
 
 @Suite("AgentWorktreeCollector")

--- a/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
+++ b/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
@@ -127,7 +127,7 @@ struct AgentWorktreeCollectorTests {
             path: wtPath, repoPath: repo.path, branch: entry.branch, headSHA: entry.headSHA, locked: entry.locked
         )
 
-        let baseline = AgentWorktreeCollector.lastActivity(worktreePath: wtPath)
+        let baseline = AgentWorktreeCollector.lastActivity(worktreePath: wtPath, now: Date())
 
         // Well within a 1-hour grace window: kept.
         let recentCollector = AgentWorktreeCollector(
@@ -145,6 +145,37 @@ struct AgentWorktreeCollectorTests {
             Issue.record("expected .reap once past the grace window, got \(reapDecision)")
             return
         }
+    }
+
+    // MARK: - lastActivity fail-toward-keep (Minor-g review finding)
+
+    @Test func lastActivityReturnsNowWhenNeitherMtimeIsReadable() {
+        // A path with no `.git` file at all (and therefore no gitdir/index
+        // to read either) — both mtime lookups fail.
+        let unreadablePath = "/nonexistent/gc-lastactivity-test-\(UUID().uuidString)"
+        let now = Date()
+
+        let activity = AgentWorktreeCollector.lastActivity(worktreePath: unreadablePath, now: now)
+
+        // Must be `now`, not `Date.distantPast`: distantPast would make the
+        // grace-window age computation enormous, fast-tracking an
+        // unreadable worktree for reap instead of keeping it like every
+        // other uncertain case.
+        #expect(activity == now)
+    }
+
+    @Test func lastActivityFailureKeepsWithinGraceWindow() async throws {
+        // End-to-end through `decide(_:liveCWDs:graceSeconds:)`: an
+        // unreadable candidate path must be kept by the grace gate, not
+        // treated as ancient/stale and reaped.
+        let unreadablePath = "/nonexistent/gc-lastactivity-decide-test-\(UUID().uuidString)"
+        let candidate = AgentWorktreeCandidate(
+            path: unreadablePath, repoPath: "/nonexistent/gc-lastactivity-repo",
+            branch: "b", headSHA: String(repeating: "0", count: 40), locked: false
+        )
+        let collector = makeCollector()
+        let decision = await collector.decide(candidate, liveCWDs: [], graceSeconds: 3600)
+        #expect(decision == .keep(reason: "grace"))
     }
 
     // MARK: - Reap: clean orphan

--- a/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
+++ b/Tests/TBDDaemonTests/AgentWorktreeCollectorTests.swift
@@ -17,11 +17,10 @@ struct AgentWorktreeCollectorTests {
     // MARK: - Helpers
 
     private func makeCollector(
-        liveCWDs: @escaping @Sendable () async -> [String] = { [] },
         now: @escaping @Sendable () -> Date = { Date() }
     ) -> AgentWorktreeCollector {
         let git = GitManager()
-        return AgentWorktreeCollector(git: git, snapshot: ReapSnapshot(git: git), liveCWDs: liveCWDs, now: now)
+        return AgentWorktreeCollector(git: git, snapshot: ReapSnapshot(git: git), now: now)
     }
 
     /// Builds `<repo>/.claude/worktrees/<name>` as a real linked git
@@ -132,14 +131,14 @@ struct AgentWorktreeCollectorTests {
 
         // Well within a 1-hour grace window: kept.
         let recentCollector = AgentWorktreeCollector(
-            git: git, snapshot: snap, liveCWDs: { [] }, now: { baseline.addingTimeInterval(100) }
+            git: git, snapshot: snap, now: { baseline.addingTimeInterval(100) }
         )
         let keepDecision = await recentCollector.decide(candidate, liveCWDs: [], graceSeconds: 3600)
         #expect(keepDecision == .keep(reason: "grace"))
 
         // Well past a 1-hour grace window: reaps.
         let staleCollector = AgentWorktreeCollector(
-            git: git, snapshot: snap, liveCWDs: { [] }, now: { baseline.addingTimeInterval(7200) }
+            git: git, snapshot: snap, now: { baseline.addingTimeInterval(7200) }
         )
         let reapDecision = await staleCollector.decide(candidate, liveCWDs: [], graceSeconds: 3600)
         guard case .reap = reapDecision else {

--- a/Tests/TBDDaemonTests/ArchiveScratchpadCleanupTests.swift
+++ b/Tests/TBDDaemonTests/ArchiveScratchpadCleanupTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Task 8: `WorktreeLifecycle.onWorktreeRemoved` fires whenever a worktree's
+/// directory is actually removed from disk, so `OrphanGC.scratchpadCleanup`
+/// can run event-driven instead of waiting for the next hourly sweep.
+@Suite struct ArchiveScratchpadCleanupTests {
+    @Test func archiveWorktreeFiresOnWorktreeRemovedWithThePath() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        var lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver()
+        )
+        let box = RemovedPathBox()
+        lifecycle.onWorktreeRemoved = { path in await box.record(path) }
+
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+        #expect(FileManager.default.fileExists(atPath: wt.path))
+
+        try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+        #expect(!FileManager.default.fileExists(atPath: wt.path))
+        #expect(await box.paths == [wt.path])
+    }
+
+    @Test func archiveWorktreeWithoutCallbackStillArchives() async throws {
+        // No `onWorktreeRemoved` set (nil default) — archive must not crash
+        // or otherwise depend on the callback being present.
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver()
+        )
+
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+        try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+
+        let archived = try await db.worktrees.get(id: wt.id)
+        #expect(archived?.status == .archived)
+    }
+
+    @Test func forgetWorktreeDoesNotFireOnWorktreeRemoved() async throws {
+        // `forget` deliberately leaves the directory on disk (no git worktree
+        // remove), so it must NOT trigger scratchpad cleanup.
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        var lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver()
+        )
+        let box = RemovedPathBox()
+        lifecycle.onWorktreeRemoved = { path in await box.record(path) }
+
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+        try await lifecycle.forgetWorktree(worktreeID: wt.id)
+
+        #expect(await box.paths.isEmpty)
+    }
+}
+
+actor RemovedPathBox {
+    private(set) var paths: [String] = []
+    func record(_ path: String) { paths.append(path) }
+}

--- a/Tests/TBDDaemonTests/ArchiveScratchpadCleanupTests.swift
+++ b/Tests/TBDDaemonTests/ArchiveScratchpadCleanupTests.swift
@@ -20,7 +20,7 @@ import Testing
             hooks: HookResolver()
         )
         let box = RemovedPathBox()
-        lifecycle.onWorktreeRemoved = { path in await box.record(path) }
+        lifecycle.onWorktreeRemoved = { path, repoPath in await box.record(path, repoPath) }
 
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
@@ -30,6 +30,7 @@ import Testing
 
         #expect(!FileManager.default.fileExists(atPath: wt.path))
         #expect(await box.paths == [wt.path])
+        #expect(await box.repoPaths == [repo.path], "must thread the owning repo's path alongside the worktree path")
     }
 
     @Test func archiveWorktreeWithoutCallbackStillArchives() async throws {
@@ -69,7 +70,7 @@ import Testing
             hooks: HookResolver()
         )
         let box = RemovedPathBox()
-        lifecycle.onWorktreeRemoved = { path in await box.record(path) }
+        lifecycle.onWorktreeRemoved = { path, repoPath in await box.record(path, repoPath) }
 
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
@@ -82,5 +83,9 @@ import Testing
 
 actor RemovedPathBox {
     private(set) var paths: [String] = []
-    func record(_ path: String) { paths.append(path) }
+    private(set) var repoPaths: [String] = []
+    func record(_ path: String, _ repoPath: String) {
+        paths.append(path)
+        repoPaths.append(repoPath)
+    }
 }

--- a/Tests/TBDDaemonTests/GCHandlersTests.swift
+++ b/Tests/TBDDaemonTests/GCHandlersTests.swift
@@ -1,0 +1,233 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Thread-safe collector for broadcast StateDeltas, mirroring the pattern in
+/// `RPCRouterWorktreeCreateBroadcastTests` / `OrphanGCTests`.
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+}
+
+/// Router-level coverage for Task 9: `gc.list` / `gc.restore` / `gc.sweepNow`
+/// / `config.setGCEnabled`.
+@Suite("GC RPC handlers")
+struct GCHandlersTests {
+    /// Router construction mirrors `RPCRouterTests` / `ControlModeSettingsRPCTests`
+    /// (in-memory DB, dry-run tmux). Callers that need `orphanGC` wired set
+    /// `router.orphanGC` afterward, the same post-construction seam
+    /// `Daemon.swift` uses for `claudeUsagePoller`.
+    private func makeRouter(db: TBDDatabase, subscriptions: StateSubscriptionManager = StateSubscriptionManager())
+        -> RPCRouter
+    {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subscriptions
+        )
+    }
+
+    private func makeGC(db: TBDDatabase, broadcaster: BroadcastDeltas, now: @escaping @Sendable () -> Date = Date.init) -> OrphanGC {
+        OrphanGC(
+            db: db,
+            git: GitManager(),
+            broadcast: { broadcaster.append($0) },
+            lsofProvider: { [] },
+            now: now
+        )
+    }
+
+    @discardableResult
+    private func makeAgentWorktree(repo: URL, name: String, branch: String? = nil) async throws -> String {
+        try await shell("mkdir -p .claude/worktrees", at: repo)
+        try await shell("git worktree add .claude/worktrees/\(name) -b \(branch ?? name)", at: repo)
+        guard let cReal = realpath(repo.path + "/.claude/worktrees/" + name, nil) else {
+            return repo.path + "/.claude/worktrees/" + name
+        }
+        defer { free(cReal) }
+        return String(cString: cReal)
+    }
+
+    // MARK: - gc.list
+
+    @Test("gc.list returns inserted records")
+    func listReturnsInsertedRecords() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db)
+
+        let record = ReapRecord(
+            kind: .agentWorktree, repoPath: "/tmp/gc-list-repo", worktreePath: "/tmp/gc-list-repo/wt-a"
+        )
+        try await db.reapRecords.insert(record)
+
+        let request = try RPCRequest(method: RPCMethod.gcList, params: GCListParams())
+        let response = await router.handle(request)
+        #expect(response.success)
+        let records = try response.decodeResult([ReapRecord].self)
+        #expect(records.count == 1)
+        #expect(records.first?.id == record.id)
+    }
+
+    @Test("gc.list honors the repoPath filter")
+    func listHonorsRepoPathFilter() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db)
+
+        let matching = ReapRecord(
+            kind: .agentWorktree, repoPath: "/tmp/gc-filter-a", worktreePath: "/tmp/gc-filter-a/wt-a"
+        )
+        let other = ReapRecord(
+            kind: .agentWorktree, repoPath: "/tmp/gc-filter-b", worktreePath: "/tmp/gc-filter-b/wt-b"
+        )
+        try await db.reapRecords.insert(matching)
+        try await db.reapRecords.insert(other)
+
+        let request = try RPCRequest(method: RPCMethod.gcList, params: GCListParams(repoPath: "/tmp/gc-filter-a"))
+        let response = await router.handle(request)
+        #expect(response.success)
+        let records = try response.decodeResult([ReapRecord].self)
+        #expect(records.count == 1)
+        #expect(records.first?.id == matching.id)
+    }
+
+    // MARK: - gc.sweepNow
+
+    @Test("gc.sweepNow dryRun=true returns non-empty planned and mutates nothing")
+    func sweepNowDryRunPlansWithoutMutating() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.repos.create(path: repo.path, displayName: "acme", defaultBranch: "main")
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-x")
+
+        let router = makeRouter(db: db)
+        let broadcaster = BroadcastDeltas()
+        // Far-future `now` clears the default grace window so the freshly
+        // created worktree above is immediately eligible.
+        router.orphanGC = makeGC(db: db, broadcaster: broadcaster, now: { Date().addingTimeInterval(3 * 3600) })
+
+        let request = try RPCRequest(method: RPCMethod.gcSweepNow, params: GCSweepNowParams(dryRun: true))
+        let response = await router.handle(request)
+        #expect(response.success)
+        let result = try response.decodeResult(GCSweepResult.self)
+
+        #expect(!result.planned.isEmpty)
+        #expect(result.planned.contains { $0.contains("REAP agent-worktree") && $0.contains(wtPath) })
+        #expect(result.reaped == 0)
+        #expect(FileManager.default.fileExists(atPath: wtPath), "dry run must not touch disk")
+
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty, "dry run must not mutate the DB")
+    }
+
+    @Test("gc.sweepNow returns an error when orphanGC is unavailable (mock mode)")
+    func sweepNowUnavailableWhenOrphanGCNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db)
+        // router.orphanGC left nil, mirroring mock mode.
+
+        let request = try RPCRequest(method: RPCMethod.gcSweepNow, params: GCSweepNowParams(dryRun: true))
+        let response = await router.handle(request)
+        #expect(!response.success)
+        #expect(response.error != nil)
+    }
+
+    // MARK: - gc.restore
+
+    @Test("gc.restore round-trips a reaped record")
+    func restoreRoundTrips() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.repos.create(path: repo.path, displayName: "acme", defaultBranch: "main")
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-x")
+
+        let router = makeRouter(db: db)
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, broadcaster: broadcaster, now: { Date().addingTimeInterval(3 * 3600) })
+        router.orphanGC = gc
+
+        // Reap for real via the actor directly (not via RPC — sweepNow's own
+        // reap path is covered by OrphanGCTests) so restore has a record to
+        // round-trip.
+        let sweepResult = await gc.sweep()
+        #expect(sweepResult.reaped == 1)
+        #expect(!FileManager.default.fileExists(atPath: wtPath))
+
+        let record = try #require(try await db.reapRecords.list(repoPath: nil).first)
+
+        let request = try RPCRequest(method: RPCMethod.gcRestore, params: GCRestoreParams(recordID: record.id))
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        #expect(FileManager.default.fileExists(atPath: wtPath))
+        let restored = try await db.reapRecords.get(id: record.id)
+        #expect(restored?.restoredAt != nil)
+    }
+
+    @Test("gc.restore returns an error when orphanGC is unavailable (mock mode)")
+    func restoreUnavailableWhenOrphanGCNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db)
+
+        let request = try RPCRequest(method: RPCMethod.gcRestore, params: GCRestoreParams(recordID: UUID()))
+        let response = await router.handle(request)
+        #expect(!response.success)
+        #expect(response.error != nil)
+    }
+
+    // MARK: - config.setGCEnabled
+
+    @Test("config.setGCEnabled flips the config and broadcasts")
+    func setGCEnabledFlipsConfigAndBroadcasts() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let subs = StateSubscriptionManager()
+        let deltas = BroadcastDeltas()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let router = makeRouter(db: db, subscriptions: subs)
+
+        #expect(try await db.config.get().gcEnabled == true, "default is enabled")
+
+        let request = try RPCRequest(method: RPCMethod.configSetGCEnabled, params: ConfigSetGCEnabledParams(enabled: false))
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        #expect(try await db.config.get().gcEnabled == false)
+        let modelProfilesChangedCount = deltas.snapshot().filter {
+            if case .modelProfilesChanged = $0 { return true }; return false
+        }.count
+        #expect(modelProfilesChangedCount == 1)
+
+        // Flip back on to also exercise the true branch end-to-end.
+        let request2 = try RPCRequest(method: RPCMethod.configSetGCEnabled, params: ConfigSetGCEnabledParams(enabled: true))
+        let response2 = await router.handle(request2)
+        #expect(response2.success)
+        #expect(try await db.config.get().gcEnabled == true)
+    }
+}

--- a/Tests/TBDDaemonTests/GitManagerGCTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerGCTests.swift
@@ -65,6 +65,28 @@ struct GitManagerGCTests {
         #expect(plainLinked == false)
     }
 
+    @Test func linkageProofRejectsGitdirOutsideRepoWorktreesDir() async throws {
+        let (tmp, repo, _, _) = try await makeRepoWithExternalWorktree(branch: "feat4", folder: "wt4")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // A `.git` FILE whose gitdir points somewhere other than
+        // <repo>/.git/worktrees/ (submodule-style modules dir): rejected.
+        // The target directory must actually exist — realpath() fails on
+        // missing paths and that guard alone would mask a broken prefix
+        // check — so create it for real to force the prefix comparison.
+        let modulesGitdir = repo.appendingPathComponent(".git/modules/sub")
+        try FileManager.default.createDirectory(at: modulesGitdir, withIntermediateDirectories: true)
+        let fakeWt = tmp.appendingPathComponent("fake-submodule")
+        try FileManager.default.createDirectory(at: fakeWt, withIntermediateDirectories: true)
+        try "gitdir: \(modulesGitdir.path)\n".write(
+            to: fakeWt.appendingPathComponent(".git"), atomically: true, encoding: .utf8
+        )
+
+        let git = GitManager()
+        let linked = await git.isLinkedWorktree(candidatePath: fakeWt.path, repoPath: repo.path)
+        #expect(linked == false)
+    }
+
     @Test func dirtyDetectsUntrackedAndErrorsAreDirty() async throws {
         let (tmp, repo) = try await createTestRepoResolvingSymlinks()
         defer { try? FileManager.default.removeItem(at: tmp) }
@@ -148,6 +170,24 @@ struct GitManagerGCTests {
         try await shell("git reset --hard HEAD~1", at: repo)
 
         #expect(await git.isReachableFromAnyBranch(repoPath: repo.path, sha: orphanSHA) == false)
+    }
+
+    @Test func reachabilityErrorsAreUnreachable() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let git = GitManager()
+
+        // Malformed SHA: `git branch --contains` exits non-zero. The error
+        // direction is load-bearing — error => false makes the caller create
+        // a protective anchor ref (more protection), never less.
+        #expect(await git.isReachableFromAnyBranch(repoPath: repo.path, sha: "not-a-sha") == false)
+
+        // Not a git repo at all: also an error, also false.
+        let notARepo = tmp.appendingPathComponent("not-a-repo")
+        try FileManager.default.createDirectory(at: notARepo, withIntermediateDirectories: true)
+        let headSHA = try await git.headSHA(repoPath: repo.path)
+        #expect(await git.isReachableFromAnyBranch(repoPath: notARepo.path, sha: headSHA) == false)
     }
 
     // MARK: - Helpers

--- a/Tests/TBDDaemonTests/GitManagerGCTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerGCTests.swift
@@ -1,0 +1,176 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TestSupport
+
+/// Resolves symlinks in a path the same way git's `worktree list --porcelain`
+/// does: `URL.resolvingSymlinksInPath()` does NOT follow macOS's
+/// `/var` → `/private/var` symlink, but C `realpath()` does. Test fixtures
+/// must canonicalize before comparing against GitManager output.
+private func canonicalPath(_ path: String) -> String {
+    guard let cReal = realpath(path, nil) else { return path }
+    defer { free(cReal) }
+    return String(cString: cReal)
+}
+
+@Suite("GitManager GC primitives")
+struct GitManagerGCTests {
+    @Test func detailedListParsesLockAndDetached() async throws {
+        let (tmp, repo, wt, branch) = try await makeRepoWithExternalWorktree(branch: "feat", folder: "wt1")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await shell("git worktree lock '\(wt)'", at: repo)
+
+        let entries = try await GitManager().worktreeListDetailed(repoPath: repo.path)
+        let entry = try #require(entries.first { $0.path == wt })
+        #expect(entry.locked == true)
+        #expect(entry.branch == branch)
+        #expect(entry.headSHA.count == 40)
+
+        // The main worktree (repo root) should be present, unlocked, not detached.
+        let mainEntry = try #require(entries.first { $0.path == canonicalPath(repo.path) })
+        #expect(mainEntry.locked == false)
+    }
+
+    @Test func detailedListParsesDetachedHead() async throws {
+        let (tmp, repo, wt, _) = try await makeRepoWithExternalWorktree(branch: "feat2", folder: "wt2")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        try await shell("git checkout --detach", at: URL(fileURLWithPath: wt))
+
+        let entries = try await GitManager().worktreeListDetailed(repoPath: repo.path)
+        let entry = try #require(entries.first { $0.path == wt })
+        #expect(entry.branch == nil)
+        #expect(entry.locked == false)
+    }
+
+    @Test func linkageProofAcceptsRealWorktreeRejectsRepoRootAndPlainDir() async throws {
+        let (tmp, repo, wt, _) = try await makeRepoWithExternalWorktree(branch: "feat3", folder: "wt3")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let git = GitManager()
+
+        // Real linked worktree: accepted.
+        let linked = await git.isLinkedWorktree(candidatePath: wt, repoPath: repo.path)
+        #expect(linked == true)
+
+        // Repo root itself (its .git is a directory, not a gitdir-file): rejected.
+        let repoRootLinked = await git.isLinkedWorktree(candidatePath: repo.path, repoPath: repo.path)
+        #expect(repoRootLinked == false)
+
+        // Plain directory with no .git at all: rejected.
+        let plainDir = tmp.appendingPathComponent("plain-dir")
+        try FileManager.default.createDirectory(at: plainDir, withIntermediateDirectories: true)
+        let plainLinked = await git.isLinkedWorktree(candidatePath: plainDir.path, repoPath: repo.path)
+        #expect(plainLinked == false)
+    }
+
+    @Test func dirtyDetectsUntrackedAndErrorsAreDirty() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let git = GitManager()
+
+        // Clean repo right after init: not dirty.
+        #expect(await git.isDirty(worktreePath: repo.path) == false)
+
+        // Untracked file makes it dirty.
+        try await shell("echo dirty > untracked.txt", at: repo)
+        #expect(await git.isDirty(worktreePath: repo.path) == true)
+
+        // A path that isn't a git repo at all => `status --porcelain` errors => dirty (fail toward keep).
+        let notARepo = tmp.appendingPathComponent("not-a-repo")
+        try FileManager.default.createDirectory(at: notARepo, withIntermediateDirectories: true)
+        #expect(await git.isDirty(worktreePath: notARepo.path) == true)
+    }
+
+    @Test func snapshotPlumbingRoundTrip() async throws {
+        let (tmp, repo, wt, _) = try await makeRepoWithExternalWorktree(branch: "snap", folder: "snapwt")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let git = GitManager()
+        let wtURL = URL(fileURLWithPath: wt)
+
+        // Tracked change.
+        try await shell("echo tracked-change > tracked.txt && git add tracked.txt && git commit -m 'add tracked'", at: wtURL)
+        try await shell("echo tracked-modified > tracked.txt", at: wtURL)
+        // Untracked file that should be captured by `add -A`.
+        try await shell("echo untracked-content > untracked.txt", at: wtURL)
+        // Gitignored file that should NOT be captured.
+        try await shell("echo ignored-content > ignored.txt && echo ignored.txt > .gitignore", at: wtURL)
+
+        let parent = try await git.headSHA(worktreePath: wt)
+        let tree = try await git.stageAllAndWriteTree(worktreePath: wt)
+        let commitSHA = try await git.commitTree(repoPath: repo.path, tree: tree, parent: parent, message: "tbd-snapshot")
+
+        let ref = "refs/tbd/snapshots/t1"
+        try await git.updateRef(repoPath: repo.path, ref: ref, sha: commitSHA)
+
+        let refs = try await git.listRefs(repoPath: repo.path, prefix: "refs/tbd/snapshots")
+        #expect(refs.contains(ref))
+
+        // ls-tree the snapshot ref: untracked file present, ignored file absent.
+        let lsTreeOutput = try await runGit(["ls-tree", "-r", "--name-only", ref], at: repo)
+        #expect(lsTreeOutput.contains("untracked.txt"))
+        #expect(lsTreeOutput.contains("tracked.txt"))
+        #expect(!lsTreeOutput.contains("ignored.txt"))
+
+        // Restore into a fresh worktree from main and verify contents.
+        let freshWt = tmp.appendingPathComponent("fresh-wt").path
+        try await git.worktreeAdd(repoPath: repo.path, path: freshWt, branch: nil, detachAt: parent)
+        try await git.restoreFromRef(worktreePath: freshWt, ref: ref)
+
+        let restoredTracked = try String(contentsOfFile: freshWt + "/tracked.txt", encoding: .utf8)
+        let restoredUntracked = try String(contentsOfFile: freshWt + "/untracked.txt", encoding: .utf8)
+        #expect(restoredTracked.trimmingCharacters(in: .whitespacesAndNewlines) == "tracked-modified")
+        #expect(restoredUntracked.trimmingCharacters(in: .whitespacesAndNewlines) == "untracked-content")
+        #expect(!FileManager.default.fileExists(atPath: freshWt + "/ignored.txt"))
+
+        try await git.deleteRef(repoPath: repo.path, ref: ref)
+        let refsAfterDelete = try await git.listRefs(repoPath: repo.path, prefix: "refs/tbd/snapshots")
+        #expect(!refsAfterDelete.contains(ref))
+    }
+
+    @Test func reachability() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let git = GitManager()
+
+        // HEAD on the default branch: reachable.
+        let headSHA = try await git.headSHA(repoPath: repo.path)
+        #expect(await git.isReachableFromAnyBranch(repoPath: repo.path, sha: headSHA) == true)
+
+        // A commit reachable only via a detached-HEAD commit (no branch points at it): not reachable.
+        try await shell("echo orphan > orphan.txt && git add orphan.txt && git commit -m orphan", at: repo)
+        let orphanSHA = try await git.headSHA(repoPath: repo.path)
+        // Reset the branch back so orphanSHA is no longer reachable from any branch tip.
+        try await shell("git reset --hard HEAD~1", at: repo)
+
+        #expect(await git.isReachableFromAnyBranch(repoPath: repo.path, sha: orphanSHA) == false)
+    }
+
+    // MARK: - Helpers
+
+    /// Runs a raw git command and returns trimmed stdout — used only to assert
+    /// on plumbing state (`ls-tree`) that GitManager itself doesn't expose.
+    private func runGit(_ arguments: [String], at dir: URL) async throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = dir
+        process.environment = [
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
+            "HOME": NSHomeDirectory(),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+        ]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -1,0 +1,247 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+import TestSupport
+
+/// Thread-safe collector for broadcast `StateDelta`s, mirroring the pattern
+/// in `RPCRouterWorktreeCreateBroadcastTests`.
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+}
+
+@Suite("OrphanGC")
+struct OrphanGCTests {
+    // MARK: - Helpers
+
+    /// Well past the default 3600s grace window relative to a worktree just
+    /// created by this test process.
+    private static let farFuture: @Sendable () -> Date = { Date().addingTimeInterval(3 * 3600) }
+
+    @discardableResult
+    private func makeAgentWorktree(repo: URL, name: String, branch: String? = nil) async throws -> String {
+        try await shell("mkdir -p .claude/worktrees", at: repo)
+        try await shell("git worktree add .claude/worktrees/\(name) -b \(branch ?? name)", at: repo)
+        guard let cReal = realpath(repo.path + "/.claude/worktrees/" + name, nil) else {
+            return repo.path + "/.claude/worktrees/" + name
+        }
+        defer { free(cReal) }
+        return String(cString: cReal)
+    }
+
+    private func makeGC(
+        db: TBDDatabase,
+        git: GitManager,
+        broadcaster: BroadcastDeltas,
+        scratchpadBase: URL? = nil,
+        now: @escaping @Sendable () -> Date = OrphanGCTests.farFuture
+    ) -> OrphanGC {
+        OrphanGC(
+            db: db,
+            git: git,
+            broadcast: { broadcaster.append($0) },
+            lsofProvider: { [] },
+            scratchpadBase: scratchpadBase,
+            now: now
+        )
+    }
+
+    // MARK: - gcEnabled gate
+
+    @Test func sweepDisabledDoesNothing() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        _ = try await db.repos.create(path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-x")
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster)
+
+        let result = await gc.sweep()
+
+        #expect(result.reaped == 0)
+        #expect(FileManager.default.fileExists(atPath: wtPath))
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+        #expect(broadcaster.snapshot().isEmpty)
+    }
+
+    // MARK: - Enabled sweep reaps + records + broadcasts
+
+    @Test func sweepEnabledReapsAndRecordsAndBroadcasts() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.repos.create(path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-x")
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster)
+
+        let result = await gc.sweep()
+
+        #expect(result.reaped == 1)
+        #expect(!FileManager.default.fileExists(atPath: wtPath))
+
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.count == 1)
+        #expect(records.first?.kind == .agentWorktree)
+        #expect(records.first?.worktreePath == wtPath)
+
+        let deltas = broadcaster.snapshot()
+        #expect(deltas.contains { if case .reapRecordsChanged = $0 { return true }; return false })
+    }
+
+    // MARK: - Dry run plans without mutating
+
+    @Test func sweepDryRunPlansWithoutMutating() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.repos.create(path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-x")
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster)
+
+        let result = await gc.sweep(dryRun: true)
+
+        #expect(!result.planned.isEmpty)
+        #expect(result.planned.contains { $0.contains("REAP agent-worktree") && $0.contains(wtPath) })
+        #expect(result.reaped == 0)
+        #expect(FileManager.default.fileExists(atPath: wtPath))
+
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+        #expect(broadcaster.snapshot().isEmpty)
+    }
+
+    // MARK: - Restore round trip
+
+    @Test func restoreRoundTrip() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.repos.create(path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-x")
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster)
+
+        let sweepResult = await gc.sweep()
+        #expect(sweepResult.reaped == 1)
+        #expect(!FileManager.default.fileExists(atPath: wtPath))
+
+        let record = try #require(try await db.reapRecords.list(repoPath: nil).first)
+
+        try await gc.restore(recordID: record.id)
+
+        #expect(FileManager.default.fileExists(atPath: wtPath))
+        let restored = try await db.reapRecords.get(id: record.id)
+        #expect(restored?.restoredAt != nil)
+
+        let deltas = broadcaster.snapshot()
+        let changedCount = deltas.filter { if case .reapRecordsChanged = $0 { return true }; return false }.count
+        #expect(changedCount == 2, "expected one broadcast from sweep + one from restore")
+    }
+
+    // MARK: - Snapshot retention (anchor rule)
+
+    @Test func snapshotRetentionDeletesOldRefs() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let git = GitManager()
+        try await shell("git branch alive-branch", at: repo)
+        let sha = try await resolvedHeadSHA(repo: repo)
+
+        let aliveRef = "refs/tbd/snapshots/alive-1"
+        let goneRef = "refs/tbd/snapshots/gone-1"
+        try await git.updateRef(repoPath: repo.path, ref: aliveRef, sha: sha)
+        try await git.updateRef(repoPath: repo.path, ref: goneRef, sha: sha)
+
+        let db = try TBDDatabase(inMemory: true)
+        let fixedNow = Date()
+        let oldReapedAt = fixedNow.addingTimeInterval(-40 * 86400)
+
+        let aliveRecord = ReapRecord(
+            kind: .agentWorktree, repoPath: repo.path, worktreePath: repo.path + "/nonexistent-alive",
+            branch: "alive-branch", headSHA: sha, snapshotRef: aliveRef, reapedAt: oldReapedAt
+        )
+        let goneRecord = ReapRecord(
+            kind: .agentWorktree, repoPath: repo.path, worktreePath: repo.path + "/nonexistent-gone",
+            branch: "deleted-branch", headSHA: sha, snapshotRef: goneRef, reapedAt: oldReapedAt
+        )
+        try await db.reapRecords.insert(aliveRecord)
+        try await db.reapRecords.insert(goneRecord)
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: git, broadcaster: broadcaster, now: { fixedNow })
+
+        _ = await gc.sweep()
+
+        let remainingRefs = try await git.listRefs(repoPath: repo.path, prefix: "refs/tbd/snapshots")
+        #expect(!remainingRefs.contains(aliveRef), "ref anchored by a still-existing branch must be deleted")
+        #expect(remainingRefs.contains(goneRef), "ref whose branch is gone must be kept forever (anchor rule)")
+    }
+
+    private func resolvedHeadSHA(repo: URL) async throws -> String {
+        let git = GitManager()
+        let entries = try await git.worktreeListDetailed(repoPath: repo.path)
+        if let entry = entries.first { return entry.headSHA }
+        // Fresh repo, no worktrees registered besides the main checkout —
+        // `worktreeListDetailed` always includes the main worktree itself.
+        throw NSError(domain: "OrphanGCTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "no HEAD found"])
+    }
+
+    // MARK: - Event-driven scratchpad cleanup
+
+    @Test func scratchpadEventCleanup() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-scratch-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let worktreePath = "/Users/chang/tbd/worktrees/removed-wt"
+        let slug = ScratchpadCollector.slug(forWorktreePath: worktreePath)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        try "hi".write(to: scratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+
+        let db = try TBDDatabase(inMemory: true)
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
+
+        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreePath)
+
+        #expect(!FileManager.default.fileExists(atPath: scratchDir.path))
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.count == 1)
+        #expect(records.first?.kind == .scratchpad)
+
+        let deltas = broadcaster.snapshot()
+        #expect(deltas.contains { if case .reapRecordsChanged = $0 { return true }; return false })
+    }
+}

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -109,6 +109,48 @@ struct OrphanGCTests {
         #expect(deltas.contains { if case .reapRecordsChanged = $0 { return true }; return false })
     }
 
+    // MARK: - Sweep-companion scratchpad reap stamps the agent worktree's own repoPath
+
+    @Test func sweepReapsCompanionScratchpadStampedWithAgentWorktreeRepoPath() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-companion-repopath-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.repos.create(path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-x")
+
+        // The agent worktree's own Claude Code scratchpad, planted so the
+        // sweep's reap-then-clean-companion-scratchpad path (OrphanGC.swift
+        // ~149-155) has something to find.
+        let slug = ScratchpadCollector.slug(forWorktreePath: wtPath)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        try "hi".write(to: scratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
+
+        let result = await gc.sweep()
+
+        #expect(result.reaped == 2, "one agent-worktree reap + one companion scratchpad reap")
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.count == 2)
+
+        let agentRecord = try #require(records.first { $0.kind == .agentWorktree })
+        #expect(agentRecord.repoPath == repo.path)
+
+        let scratchRecord = try #require(records.first { $0.kind == .scratchpad })
+        #expect(scratchRecord.worktreePath == scratchDir.path)
+        #expect(scratchRecord.repoPath == repo.path, "companion scratchpad must carry the same repoPath as its agent worktree")
+    }
+
     // MARK: - Dry run plans without mutating
 
     @Test func sweepDryRunPlansWithoutMutating() async throws {
@@ -328,6 +370,44 @@ struct OrphanGCTests {
         #expect(broadcaster.snapshot().isEmpty)
     }
 
+    @Test func sweepReconciliationStampsArchivedWorktreesOwningRepoPath() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-reconcile-repopath-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        // Repo path deliberately nonexistent: candidates() returns [] and the
+        // sweep's agent-worktree loop is a no-op, isolating reconciliation.
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path, displayName: "acme", defaultBranch: "main"
+        )
+        let goneWorktreePath = sandbox.appendingPathComponent("gone-wt").path
+        let row = try await db.worktrees.create(
+            repoID: repo.id, name: "gone-wt", branch: "gone-wt",
+            path: goneWorktreePath, tmuxServer: "test-server"
+        )
+        try await db.worktrees.archive(id: row.id)
+
+        let slug = ScratchpadCollector.slug(forWorktreePath: goneWorktreePath)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        try "hi".write(to: scratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
+
+        let result = await gc.sweep()
+
+        #expect(result.reaped == 1)
+        #expect(!FileManager.default.fileExists(atPath: scratchDir.path))
+        let records = try await db.reapRecords.list(repoPath: nil)
+        let record = try #require(records.first)
+        #expect(record.kind == .scratchpad)
+        #expect(record.repoPath == repo.path, "reconcile must resolve the archived row's repoID to its repo.path")
+    }
+
     // MARK: - Event-driven scratchpad cleanup
 
     @Test func scratchpadEventCleanup() async throws {
@@ -347,15 +427,48 @@ struct OrphanGCTests {
         let broadcaster = BroadcastDeltas()
         let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
 
-        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreePath)
+        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreePath, repoPath: "/Users/chang/tbd")
 
         #expect(!FileManager.default.fileExists(atPath: scratchDir.path))
         let records = try await db.reapRecords.list(repoPath: nil)
         #expect(records.count == 1)
         #expect(records.first?.kind == .scratchpad)
+        #expect(records.first?.repoPath == "/Users/chang/tbd", "event path must stamp the caller's repoPath")
 
         let deltas = broadcaster.snapshot()
         #expect(deltas.contains { if case .reapRecordsChanged = $0 { return true }; return false })
+    }
+
+    @Test func scratchpadEventCleanupKeepsWhenWorktreeDirStillExists() async throws {
+        // Guards against the case where `completeArchiveWorktree`'s
+        // `try?`-swallowed `git.worktreeRemove` actually failed: the
+        // worktree directory is still there, so the scratchpad must not be
+        // orphan-classified (and deleted) out from under a live session.
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-scratch-dir-still-exists-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let worktreeDir = sandbox.appendingPathComponent("still-here-wt")
+        try FileManager.default.createDirectory(at: worktreeDir, withIntermediateDirectories: true)
+
+        let slug = ScratchpadCollector.slug(forWorktreePath: worktreeDir.path)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        try "hi".write(to: scratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+
+        let db = try TBDDatabase(inMemory: true)
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
+
+        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreeDir.path, repoPath: "/Users/chang/tbd")
+
+        #expect(FileManager.default.fileExists(atPath: scratchDir.path),
+                "worktree dir still on disk — the removal must have failed, so the scratchpad stays intact")
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+        #expect(broadcaster.snapshot().isEmpty)
     }
 
     @Test func scratchpadEventCleanupDisabledDoesNothing() async throws {
@@ -376,7 +489,7 @@ struct OrphanGCTests {
         let broadcaster = BroadcastDeltas()
         let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
 
-        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreePath)
+        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreePath, repoPath: "/Users/chang/tbd")
 
         #expect(FileManager.default.fileExists(atPath: scratchDir.path),
                 "the gcEnabled master switch must suppress event-driven deletion too")

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -215,6 +215,119 @@ struct OrphanGCTests {
         throw NSError(domain: "OrphanGCTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "no HEAD found"])
     }
 
+    // MARK: - lsof outcome parsing (parseLiveCWDs)
+
+    @Test func parseLiveCWDsTimedOutReturnsNil() {
+        #expect(OrphanGC.parseLiveCWDs(.timedOut) == nil,
+                "a timed-out lsof must be 'unavailable', never 'no live processes'")
+    }
+
+    @Test func parseLiveCWDsNonZeroExitReturnsNil() {
+        let outcome = BoundedProcessOutcome.completed(
+            status: 1, stdout: Data("p123\nn/some/path\n".utf8), stderr: Data()
+        )
+        #expect(OrphanGC.parseLiveCWDs(outcome) == nil,
+                "partial output from a failed lsof is not a complete cwd picture — fail toward keep")
+    }
+
+    @Test func parseLiveCWDsParsesCompletedOutput() {
+        // Nonexistent paths pass through canon() unchanged (realpath fallback),
+        // so expectations are deterministic. Mixed lines: p-prefixed pid
+        // headers are dropped, n-prefixed cwds are kept (prefix stripped),
+        // duplicates are deduped preserving first-seen order, and a bare "n"
+        // (empty path) is dropped.
+        let stdout = """
+        p101
+        n/nonexistent/gc-test/wt-a
+        p102
+        n/nonexistent/gc-test/wt-b
+        p103
+        n/nonexistent/gc-test/wt-a
+        p104
+        n
+        """
+        let outcome = BoundedProcessOutcome.completed(status: 0, stdout: Data(stdout.utf8), stderr: Data())
+        let parsed = OrphanGC.parseLiveCWDs(outcome)
+        #expect(parsed == ["/nonexistent/gc-test/wt-a", "/nonexistent/gc-test/wt-b"])
+    }
+
+    // MARK: - lsof unavailable skips the entire sweep
+
+    @Test func sweepSkipsEntirelyWhenLiveCWDsUnavailable() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        _ = try await db.repos.create(path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        let wtPath = try await makeAgentWorktree(repo: repo, name: "agent-x")
+
+        let broadcaster = BroadcastDeltas()
+        // Internal seam: a nil-returning provider simulates the real lsof
+        // path's timeout/spawn-failure/non-zero-exit sentinel.
+        let gc = OrphanGC(
+            db: db,
+            git: GitManager(),
+            broadcast: { broadcaster.append($0) },
+            liveCWDsProvider: { nil },
+            scratchpadBase: nil,
+            now: OrphanGCTests.farFuture
+        )
+
+        let result = await gc.sweep()
+
+        #expect(result.reaped == 0)
+        #expect(result.planned.contains { $0.contains("lsof unavailable") })
+        #expect(FileManager.default.fileExists(atPath: wtPath),
+                "an lsof outage must never be treated as 'no live processes'")
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+        #expect(broadcaster.snapshot().isEmpty)
+    }
+
+    // MARK: - Dry-run scratchpad reconciliation
+
+    @Test func sweepDryRunPlansScratchpadReconciliationWithoutMutating() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-reconcile-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        // Repo path deliberately nonexistent: candidates() returns [] and the
+        // sweep's agent-worktree loop is a no-op, isolating reconciliation.
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path, displayName: "acme", defaultBranch: "main"
+        )
+        // Archived worktree row whose directory never existed on disk.
+        let goneWorktreePath = sandbox.appendingPathComponent("gone-wt").path
+        let row = try await db.worktrees.create(
+            repoID: repo.id, name: "gone-wt", branch: "gone-wt",
+            path: goneWorktreePath, tmuxServer: "test-server"
+        )
+        try await db.worktrees.archive(id: row.id)
+
+        // Its scratchpad, however, survives in the injected base.
+        let slug = ScratchpadCollector.slug(forWorktreePath: goneWorktreePath)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        try "hi".write(to: scratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
+
+        let result = await gc.sweep(dryRun: true)
+
+        #expect(result.planned.contains { $0.contains("REAP scratchpad") && $0.contains(scratchDir.path) })
+        #expect(result.reaped == 0)
+        #expect(FileManager.default.fileExists(atPath: scratchDir.path),
+                "dry run must not remove the scratchpad")
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+        #expect(broadcaster.snapshot().isEmpty)
+    }
+
     // MARK: - Event-driven scratchpad cleanup
 
     @Test func scratchpadEventCleanup() async throws {
@@ -243,5 +356,32 @@ struct OrphanGCTests {
 
         let deltas = broadcaster.snapshot()
         #expect(deltas.contains { if case .reapRecordsChanged = $0 { return true }; return false })
+    }
+
+    @Test func scratchpadEventCleanupDisabledDoesNothing() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-scratch-disabled-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let worktreePath = "/Users/chang/tbd/worktrees/removed-wt"
+        let slug = ScratchpadCollector.slug(forWorktreePath: worktreePath)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+        try "hi".write(to: scratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
+
+        await gc.scratchpadCleanup(forRemovedWorktreePath: worktreePath)
+
+        #expect(FileManager.default.fileExists(atPath: scratchDir.path),
+                "the gcEnabled master switch must suppress event-driven deletion too")
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+        #expect(broadcaster.snapshot().isEmpty)
     }
 }

--- a/Tests/TBDDaemonTests/OrphanGCTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCTests.swift
@@ -471,6 +471,107 @@ struct OrphanGCTests {
         #expect(broadcaster.snapshot().isEmpty)
     }
 
+    // MARK: - Repo-removal scratchpad reconciliation
+
+    /// Medium-2 review finding: `repo.remove` deletes ALL worktree rows for
+    /// a repo (every status, incl. archived) via `deleteForRepo`, with no
+    /// chance for the sweep's own reconciliation to catch up afterward.
+    /// `reconcileScratchpadsBeforeRepoRemoval` must be called first and
+    /// reclaim every row's scratchpad while the rows still resolve to a path.
+    @Test func reconcileScratchpadsBeforeRepoRemovalReapsGoneRowsAcrossStatuses() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-repo-removal-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path, displayName: "acme", defaultBranch: "main"
+        )
+
+        // Archived row whose worktree dir is gone — its scratchpad survives.
+        let archivedPath = sandbox.appendingPathComponent("archived-wt").path
+        let archivedRow = try await db.worktrees.create(
+            repoID: repo.id, name: "archived-wt", branch: "archived-wt",
+            path: archivedPath, tmuxServer: "test-server"
+        )
+        try await db.worktrees.archive(id: archivedRow.id)
+
+        // Active row whose worktree dir still exists on disk — its
+        // scratchpad must be left alone (mirrors `reconcile`'s own
+        // gone-only filter).
+        let activePath = sandbox.appendingPathComponent("active-wt").path
+        try FileManager.default.createDirectory(at: URL(fileURLWithPath: activePath), withIntermediateDirectories: true)
+        _ = try await db.worktrees.create(
+            repoID: repo.id, name: "active-wt", branch: "active-wt",
+            path: activePath, tmuxServer: "test-server"
+        )
+
+        let archivedSlug = ScratchpadCollector.slug(forWorktreePath: archivedPath)
+        let archivedScratchDir = base.appendingPathComponent(archivedSlug)
+        try FileManager.default.createDirectory(at: archivedScratchDir, withIntermediateDirectories: true)
+        try "hi".write(to: archivedScratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+
+        let activeSlug = ScratchpadCollector.slug(forWorktreePath: activePath)
+        let activeScratchDir = base.appendingPathComponent(activeSlug)
+        try FileManager.default.createDirectory(at: activeScratchDir, withIntermediateDirectories: true)
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
+
+        await gc.reconcileScratchpadsBeforeRepoRemoval(repoID: repo.id, repoPath: repo.path)
+
+        #expect(!FileManager.default.fileExists(atPath: archivedScratchDir.path),
+                "the archived row's gone-worktree scratchpad must be reclaimed before the row disappears")
+        #expect(FileManager.default.fileExists(atPath: activeScratchDir.path),
+                "a scratchpad whose worktree dir still exists must be left alone")
+
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.count == 1)
+        #expect(records.first?.kind == .scratchpad)
+        #expect(records.first?.worktreePath == archivedScratchDir.path)
+        #expect(records.first?.repoPath == repo.path, "must stamp the caller's repoPath, not a resolved one")
+
+        let deltas = broadcaster.snapshot()
+        #expect(deltas.contains { if case .reapRecordsChanged = $0 { return true }; return false })
+    }
+
+    @Test func reconcileScratchpadsBeforeRepoRemovalDisabledDoesNothing() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("orphan-gc-repo-removal-disabled-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path, displayName: "acme", defaultBranch: "main"
+        )
+        let goneWorktreePath = sandbox.appendingPathComponent("gone-wt").path
+        let row = try await db.worktrees.create(
+            repoID: repo.id, name: "gone-wt", branch: "gone-wt",
+            path: goneWorktreePath, tmuxServer: "test-server"
+        )
+        try await db.worktrees.archive(id: row.id)
+
+        let slug = ScratchpadCollector.slug(forWorktreePath: goneWorktreePath)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+
+        let broadcaster = BroadcastDeltas()
+        let gc = makeGC(db: db, git: GitManager(), broadcaster: broadcaster, scratchpadBase: base)
+
+        await gc.reconcileScratchpadsBeforeRepoRemoval(repoID: repo.id, repoPath: repo.path)
+
+        #expect(FileManager.default.fileExists(atPath: scratchDir.path),
+                "the gcEnabled master switch must suppress repo-removal reconciliation too")
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+        #expect(broadcaster.snapshot().isEmpty)
+    }
+
     @Test func scratchpadEventCleanupDisabledDoesNothing() async throws {
         let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("orphan-gc-scratch-disabled-test-\(UUID().uuidString)")

--- a/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
@@ -102,6 +102,91 @@ extension RPCRouterTests {
         #expect(response.error?.contains("active worktree") == true)
     }
 
+    /// Medium-2 review finding: `repo.remove` hard-deletes every worktree
+    /// row for the repo (`deleteForRepo`, all statuses) with no chance for
+    /// the sweep's own reconciliation to catch up afterward — the rows are
+    /// gone. Verifies the RPC path reclaims an archived row's scratchpad
+    /// before the delete, wired through a real `OrphanGC` with an injected
+    /// scratchpad base (mirrors `GCHandlersTests.makeGC`).
+    @Test("repo.remove reclaims scratchpads for gone worktree rows before deleting them")
+    func repoRemoveReclaimsScratchpadsBeforeDeletingRows() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("repo-remove-scratchpad-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+        router.orphanGC = OrphanGC(
+            db: db, git: GitManager(), broadcast: { _ in }, lsofProvider: { [] }, scratchpadBase: base)
+
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path, displayName: "acme", defaultBranch: "main"
+        )
+        let goneWorktreePath = sandbox.appendingPathComponent("gone-wt").path
+        let row = try await db.worktrees.create(
+            repoID: repo.id, name: "gone-wt", branch: "gone-wt",
+            path: goneWorktreePath, tmuxServer: "test-server"
+        )
+        try await db.worktrees.archive(id: row.id)
+
+        let slug = ScratchpadCollector.slug(forWorktreePath: goneWorktreePath)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+
+        let request = try RPCRequest(method: RPCMethod.repoRemove, params: RepoRemoveParams(repoID: repo.id, force: true))
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        #expect(!FileManager.default.fileExists(atPath: scratchDir.path),
+                "the archived row's scratchpad must be reclaimed before its row disappears")
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.contains { $0.kind == .scratchpad && $0.worktreePath == scratchDir.path && $0.repoPath == repo.path })
+    }
+
+    @Test("repo.remove with gcEnabled=false leaves scratchpads untouched")
+    func repoRemoveLeavesScratchpadsWhenGCDisabled() async throws {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("repo-remove-scratchpad-disabled-test-\(UUID().uuidString)")
+        let base = sandbox.appendingPathComponent("base")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+        router.orphanGC = OrphanGC(
+            db: db, git: GitManager(), broadcast: { _ in }, lsofProvider: { [] }, scratchpadBase: base)
+
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path, displayName: "acme", defaultBranch: "main"
+        )
+        let goneWorktreePath = sandbox.appendingPathComponent("gone-wt").path
+        let row = try await db.worktrees.create(
+            repoID: repo.id, name: "gone-wt", branch: "gone-wt",
+            path: goneWorktreePath, tmuxServer: "test-server"
+        )
+        try await db.worktrees.archive(id: row.id)
+
+        let slug = ScratchpadCollector.slug(forWorktreePath: goneWorktreePath)
+        let scratchDir = base.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: scratchDir, withIntermediateDirectories: true)
+
+        let request = try RPCRequest(method: RPCMethod.repoRemove, params: RepoRemoveParams(repoID: repo.id, force: true))
+        let response = await router.handle(request)
+        #expect(response.success)
+
+        #expect(FileManager.default.fileExists(atPath: scratchDir.path),
+                "gcEnabled=false must suppress repo-removal scratchpad reconciliation too")
+    }
+
     // MARK: - Repo Instructions Tests
 
     @Test("repo.updateInstructions stores and retrieves instructions")

--- a/Tests/TBDDaemonTests/ReapRecordStoreTests.swift
+++ b/Tests/TBDDaemonTests/ReapRecordStoreTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("ReapRecordStore")
+struct ReapRecordStoreTests {
+    @Test func insertListGetMarkRestored() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let rec = ReapRecord(kind: .agentWorktree, repoPath: "/r", worktreePath: "/r/.claude/worktrees/agent-x",
+                             branch: "b", headSHA: "abc", snapshotRef: "refs/tbd/snapshots/x", apparentBytes: 42)
+        try await db.reapRecords.insert(rec)
+        let listed = try await db.reapRecords.list(repoPath: "/r")
+        // GRDB persists Date as a "yyyy-MM-dd HH:mm:ss.SSS" string (millisecond
+        // precision), so a round-tripped Date() is never bit-identical to the
+        // in-memory value — compare every field exactly except reapedAt, which
+        // gets a millisecond tolerance.
+        #expect(listed.count == 1)
+        let got = try #require(listed.first)
+        #expect(got.id == rec.id)
+        #expect(got.kind == rec.kind)
+        #expect(got.repoPath == rec.repoPath)
+        #expect(got.worktreePath == rec.worktreePath)
+        #expect(got.branch == rec.branch)
+        #expect(got.headSHA == rec.headSHA)
+        #expect(got.snapshotRef == rec.snapshotRef)
+        #expect(got.apparentBytes == rec.apparentBytes)
+        #expect(abs(got.reapedAt.timeIntervalSince1970 - rec.reapedAt.timeIntervalSince1970) < 0.01)
+        #expect(got.restoredAt == nil)
+        #expect(try await db.reapRecords.list(repoPath: "/other").isEmpty)
+        try await db.reapRecords.markRestored(id: rec.id, at: Date(timeIntervalSince1970: 1_800_000_000))
+        #expect(try await db.reapRecords.get(id: rec.id)?.restoredAt != nil)
+    }
+    @Test func unrestoredOlderThanFiltersRestoredMissingSnapshotAndRecent() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cutoff = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let eligible = ReapRecord(
+            kind: .scratchpad, repoPath: "", worktreePath: "/scratch/old",
+            snapshotRef: "refs/tbd/snapshots/old",
+            reapedAt: cutoff.addingTimeInterval(-3600))
+        let alreadyRestored = ReapRecord(
+            kind: .scratchpad, repoPath: "", worktreePath: "/scratch/restored",
+            snapshotRef: "refs/tbd/snapshots/restored",
+            reapedAt: cutoff.addingTimeInterval(-3600),
+            restoredAt: cutoff.addingTimeInterval(-1800))
+        let noSnapshot = ReapRecord(
+            kind: .scratchpad, repoPath: "", worktreePath: "/scratch/no-snapshot",
+            reapedAt: cutoff.addingTimeInterval(-3600))
+        let tooRecent = ReapRecord(
+            kind: .scratchpad, repoPath: "", worktreePath: "/scratch/recent",
+            snapshotRef: "refs/tbd/snapshots/recent",
+            reapedAt: cutoff.addingTimeInterval(3600))
+
+        for rec in [eligible, alreadyRestored, noSnapshot, tooRecent] {
+            try await db.reapRecords.insert(rec)
+        }
+
+        let result = try await db.reapRecords.unrestoredOlderThan(cutoff)
+        #expect(result.map(\.id) == [eligible.id])
+    }
+
+    @Test func gcConfigDefaultsOnAndSetterFlips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().gcEnabled == true)
+        #expect(try await db.config.get().gcGraceSeconds == 3600)
+        try await db.config.setGCEnabled(false)
+        #expect(try await db.config.get().gcEnabled == false)
+    }
+}

--- a/Tests/TBDDaemonTests/ReapSnapshotTests.swift
+++ b/Tests/TBDDaemonTests/ReapSnapshotTests.swift
@@ -1,0 +1,189 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+import TestSupport
+
+/// A fixed, deterministic instant for all `now:` parameters in this suite —
+/// `ReapSnapshot` must never call the argless `Date()` internally, so tests
+/// always pass an explicit value and never assert on wall-clock timing.
+private let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+@Suite("ReapSnapshot")
+struct ReapSnapshotTests {
+    // MARK: (a) Dirty worktree -> ref exists, ls-tree shows untracked, ignored absent.
+
+    @Test func dirtyWorktreeCreatesVerifiedSnapshotRef() async throws {
+        let (tmp, repo, wt, _) = try await makeRepoWithExternalWorktree(branch: "dirty", folder: "dirtywt")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wtURL = URL(fileURLWithPath: wt)
+
+        try await shell("echo untracked-content > untracked.txt", at: wtURL)
+        try await shell("echo ignored-content > ignored.txt && echo ignored.txt > .gitignore", at: wtURL)
+
+        let git = GitManager()
+        let headSHA = try await git.headSHA(worktreePath: wt)
+        let snap = ReapSnapshot(git: git)
+
+        let ref = try await snap.snapshotIfNeeded(
+            worktreePath: wt, repoPath: repo.path, headSHA: headSHA, worktreeName: "dirty", now: fixedNow
+        )
+        let resolvedRef = try #require(ref)
+
+        let refs = try await git.listRefs(repoPath: repo.path, prefix: "refs/tbd/snapshots")
+        #expect(refs.contains(resolvedRef))
+
+        let lsTree = try await runGit(["ls-tree", "-r", "--name-only", resolvedRef], at: repo)
+        #expect(lsTree.contains("untracked.txt"))
+        #expect(!lsTree.contains("ignored.txt"))
+    }
+
+    // MARK: (b) Clean + branch-reachable -> nil, no ref.
+
+    @Test func cleanAndReachableReturnsNilAndWritesNoRef() async throws {
+        let (tmp, repo, wt, _) = try await makeRepoWithExternalWorktree(branch: "clean", folder: "cleanwt")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let git = GitManager()
+        let headSHA = try await git.headSHA(worktreePath: wt)
+        let snap = ReapSnapshot(git: git)
+
+        let ref = try await snap.snapshotIfNeeded(
+            worktreePath: wt, repoPath: repo.path, headSHA: headSHA, worktreeName: "clean", now: fixedNow
+        )
+        #expect(ref == nil)
+
+        let refs = try await git.listRefs(repoPath: repo.path, prefix: "refs/tbd/snapshots")
+        #expect(refs.isEmpty)
+    }
+
+    // MARK: (c) Clean but detached-unreachable HEAD -> anchor ref AT headSHA, no new commit.
+
+    @Test func cleanDetachedUnreachableHeadCreatesAnchorRef() async throws {
+        let (tmp, repo, wt, branch) = try await makeRepoWithExternalWorktree(branch: "det", folder: "detwt")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wtURL = URL(fileURLWithPath: wt)
+
+        // Commit an extra commit, then detach HEAD at it, then rewind the
+        // branch pointer so the detached commit is no longer reachable from
+        // any branch — mirrors GitManagerGCTests' reachability fixture but
+        // inside a worktree so isDirty/headSHA read from the worktree path.
+        try await shell("echo extra > extra.txt && git add extra.txt && git commit -m extra", at: wtURL)
+        let git = GitManager()
+        let orphanSHA = try await git.headSHA(worktreePath: wt)
+        try await shell("git checkout --detach", at: wtURL)
+        try await shell("git branch -f \(branch) HEAD~1", at: wtURL)
+
+        #expect(await git.isDirty(worktreePath: wt) == false)
+        #expect(await git.isReachableFromAnyBranch(repoPath: repo.path, sha: orphanSHA) == false)
+
+        let snap = ReapSnapshot(git: git)
+        let ref = try await snap.snapshotIfNeeded(
+            worktreePath: wt, repoPath: repo.path, headSHA: orphanSHA, worktreeName: "det", now: fixedNow
+        )
+        let resolvedRef = try #require(ref)
+
+        // The ref must point directly AT headSHA (a pure anchor, `update-ref`
+        // only) — not a new commit created via commit-tree.
+        let pointee = try await runGit(["rev-parse", resolvedRef], at: repo)
+        #expect(pointee.trimmingCharacters(in: .whitespacesAndNewlines) == orphanSHA)
+    }
+
+    // MARK: (d) Full round-trip: snapshot -> simulated reap -> restore.
+
+    @Test func fullRoundTripSnapshotReapRestore() async throws {
+        let (tmp, repo, wt, branch) = try await makeRepoWithExternalWorktree(branch: "round", folder: "roundwt")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wtURL = URL(fileURLWithPath: wt)
+
+        try await shell(
+            "echo tracked-change > tracked.txt && git add tracked.txt && git commit -m 'add tracked'", at: wtURL
+        )
+        try await shell("echo tracked-modified > tracked.txt", at: wtURL)
+        try await shell("echo untracked-content > untracked.txt", at: wtURL)
+
+        let git = GitManager()
+        let headSHA = try await git.headSHA(worktreePath: wt)
+        let snap = ReapSnapshot(git: git)
+
+        let ref = try await snap.snapshotIfNeeded(
+            worktreePath: wt, repoPath: repo.path, headSHA: headSHA, worktreeName: "round", now: fixedNow
+        )
+        let resolvedRef = try #require(ref)
+
+        // Simulate the GC sweep deleting the worktree.
+        try await shell("rm -rf '\(wt)'", at: repo)
+        try await shell("git worktree prune", at: repo)
+        #expect(!FileManager.default.fileExists(atPath: wt))
+
+        let record = ReapRecord(
+            kind: .agentWorktree, repoPath: repo.path, worktreePath: wt,
+            branch: branch, headSHA: headSHA, snapshotRef: resolvedRef
+        )
+        try await snap.restore(record: record)
+
+        let restoredBranch = try await runGit(["rev-parse", "--abbrev-ref", "HEAD"], at: URL(fileURLWithPath: wt))
+        #expect(restoredBranch.trimmingCharacters(in: .whitespacesAndNewlines) == branch)
+
+        let restoredTracked = try String(contentsOfFile: wt + "/tracked.txt", encoding: .utf8)
+        let restoredUntracked = try String(contentsOfFile: wt + "/untracked.txt", encoding: .utf8)
+        #expect(restoredTracked.trimmingCharacters(in: .whitespacesAndNewlines) == "tracked-modified")
+        #expect(restoredUntracked.trimmingCharacters(in: .whitespacesAndNewlines) == "untracked-content")
+    }
+
+    // MARK: (e) Restore refuses when the target path already exists.
+
+    @Test func restoreRefusesWhenTargetPathExists() async throws {
+        let (tmp, repo, wt, branch) = try await makeRepoWithExternalWorktree(branch: "exists", folder: "existswt")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let git = GitManager()
+        let headSHA = try await git.headSHA(worktreePath: wt)
+        let snap = ReapSnapshot(git: git)
+
+        // The worktree at `wt` was never reaped — it's still on disk.
+        let record = ReapRecord(
+            kind: .agentWorktree, repoPath: repo.path, worktreePath: wt,
+            branch: branch, headSHA: headSHA, snapshotRef: nil
+        )
+
+        try await #require(throws: ReapSnapshotError.self) {
+            try await snap.restore(record: record)
+        }
+    }
+
+    // MARK: - Bonus: timestamp determinism (never argless Date() inside)
+
+    @Test func refTimestampIsDeterministicUTCFormat() {
+        // 2023-11-14T22:13:20Z
+        #expect(ReapSnapshot.refTimestamp(fixedNow) == "20231114-221320")
+        // Calling again with the same instant must yield the identical string —
+        // guards against any hidden reliance on the ambient clock/locale/TZ.
+        #expect(ReapSnapshot.refTimestamp(fixedNow) == ReapSnapshot.refTimestamp(fixedNow))
+    }
+
+    // MARK: - Helpers
+
+    /// Runs a raw git command and returns trimmed stdout — used only to assert
+    /// on plumbing state (`ls-tree`, `rev-parse`) that GitManager itself
+    /// doesn't expose.
+    private func runGit(_ arguments: [String], at dir: URL) async throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = dir
+        process.environment = [
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin",
+            "HOME": NSHomeDirectory(),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+        ]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        try process.run()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
@@ -85,6 +85,77 @@ struct ScratchDeleteRPCTests {
         #expect(FileManager.default.fileExists(atPath: wt.path))  // folder untouched
     }
 
+    /// Medium-1 review finding: `scratch.delete` must reclaim the scratch
+    /// space's Claude Code scratchpad before the row disappears — once the
+    /// row is gone, reconciliation has no path left to resolve it by.
+    @Test func deletesAssociatedScratchpadWhenGCEnabled() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        let scratchpadBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-scratchdel-claudebase-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratchpadBase, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchpadBase) }
+        router.orphanGC = OrphanGC(
+            db: db, git: GitManager(), broadcast: { _ in }, lsofProvider: { [] }, scratchpadBase: scratchpadBase)
+
+        let created = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-claude-scratchpad")))
+        let wt = try created.decodeResult(Worktree.self)
+
+        let slug = ScratchpadCollector.slug(forWorktreePath: wt.path)
+        let claudeScratchDir = scratchpadBase.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: claudeScratchDir, withIntermediateDirectories: true)
+        try "hi".write(to: claudeScratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
+
+        let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
+        #expect(del.success)
+        #expect(
+            !FileManager.default.fileExists(atPath: claudeScratchDir.path),
+            "the Claude Code scratchpad must be reclaimed, not left orphaned once the row is gone"
+        )
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.contains { $0.kind == .scratchpad && $0.worktreePath == claudeScratchDir.path })
+    }
+
+    /// The `gcEnabled` master switch must suppress this event-driven cleanup
+    /// too, same as every other GC deletion path.
+    @Test func leavesScratchpadIntactWhenGCDisabled() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+
+        let scratchpadBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-scratchdel-claudebase-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: scratchpadBase, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchpadBase) }
+        router.orphanGC = OrphanGC(
+            db: db, git: GitManager(), broadcast: { _ in }, lsofProvider: { [] }, scratchpadBase: scratchpadBase)
+
+        let created = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-claude-scratchpad-disabled")))
+        let wt = try created.decodeResult(Worktree.self)
+
+        let slug = ScratchpadCollector.slug(forWorktreePath: wt.path)
+        let claudeScratchDir = scratchpadBase.appendingPathComponent(slug)
+        try FileManager.default.createDirectory(at: claudeScratchDir, withIntermediateDirectories: true)
+
+        let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
+        #expect(del.success)
+        #expect(
+            FileManager.default.fileExists(atPath: claudeScratchDir.path),
+            "gcEnabled=false must suppress the scratchpad cleanup too"
+        )
+    }
+
     @Test func rejectsNonScratchWorktree() async throws {
         let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/ScratchpadCollectorTests.swift
+++ b/Tests/TBDDaemonTests/ScratchpadCollectorTests.swift
@@ -83,6 +83,24 @@ struct ScratchpadCollectorTests: ~Copyable {
         #expect(record?.repoPath == "")
     }
 
+    @Test("cleanUp refuses to remove the base directory itself for a degenerate empty worktreePath")
+    func testCleanUpRefusesAnchorViolation() async {
+        let collector = ScratchpadCollector(base: tmpDir)
+        // A marker file proves `cleanUp` did not touch `tmpDir` itself: an
+        // empty `worktreePath` collapses (via `slug`) to an empty path
+        // component, so `base.appendingPathComponent("")` resolves to `base`
+        // — without the anchor guard this would `removeItem` the entire
+        // scratchpad base.
+        let marker = tmpDir.appendingPathComponent("marker.txt")
+        try? "keep".write(to: marker, atomically: true, encoding: .utf8)
+
+        let record = await collector.cleanUp(forRemovedWorktreePath: "", repoPath: "/repo", now: Date())
+
+        #expect(record == nil)
+        #expect(fm.fileExists(atPath: tmpDir.path), "the scratchpad base directory itself must never be removed")
+        #expect(fm.fileExists(atPath: marker.path), "the base directory's contents must be untouched")
+    }
+
     @Test("cleanUp returns nil when scratchpad does not exist")
     func testCleanUpNonExistent() async {
         let collector = ScratchpadCollector(base: tmpDir)

--- a/Tests/TBDDaemonTests/ScratchpadCollectorTests.swift
+++ b/Tests/TBDDaemonTests/ScratchpadCollectorTests.swift
@@ -6,16 +6,26 @@ import TBDShared
 @Suite("ScratchpadCollector")
 struct ScratchpadCollectorTests: ~Copyable {
     let fm = FileManager.default
+    /// Sandbox root for this test instance; everything lives under it.
+    let sandbox: URL
+    /// Injected scratchpad base (`ScratchpadCollector(base:)`).
     let tmpDir: URL
+    /// Parent for fixture "worktree" directories — inside the sandbox so
+    /// parallel test runs never collide on shared literal paths like
+    /// `/tmp/existing-wt`.
+    let wtParent: URL
 
     init() {
-        tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("scratchpad-test-\(UUID().uuidString)")
+        tmpDir = sandbox.appendingPathComponent("base")
+        wtParent = sandbox.appendingPathComponent("worktrees")
         try? fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: wtParent, withIntermediateDirectories: true)
     }
 
     deinit {
-        try? fm.removeItem(at: tmpDir)
+        try? fm.removeItem(at: sandbox)
     }
 
     @Test("slug replaces forward slashes with hyphens")
@@ -74,8 +84,8 @@ struct ScratchpadCollectorTests: ~Copyable {
     func testReconcileRemovesGoneWorktrees() async {
         let collector = ScratchpadCollector(base: tmpDir)
 
-        let existingWT = "/tmp/existing-wt"
-        let goneWT = "/tmp/gone-wt"
+        let existingWT = wtParent.appendingPathComponent("existing-wt").path
+        let goneWT = wtParent.appendingPathComponent("gone-wt").path
 
         // Create scratchpads for both
         let existingSlug = ScratchpadCollector.slug(forWorktreePath: existingWT)
@@ -95,9 +105,6 @@ struct ScratchpadCollectorTests: ~Copyable {
 
         let records = await collector.reconcile(knownPaths: [existingWT, goneWT], now: Date())
 
-        // Clean up the test worktree
-        try? fm.removeItem(atPath: existingWT)
-
         #expect(records.count == 1)
         #expect(records[0].kind == ReapKind.scratchpad)
         #expect(records[0].worktreePath == goneDir.path)
@@ -109,7 +116,7 @@ struct ScratchpadCollectorTests: ~Copyable {
     func testReconcilePreservesUnrelated() async {
         let collector = ScratchpadCollector(base: tmpDir)
 
-        let worktreePath = "/tmp/some-wt"
+        let worktreePath = wtParent.appendingPathComponent("some-wt").path
         let unrelatedDir = tmpDir.appendingPathComponent("unrelated-project")
 
         // Create the scratchpad
@@ -127,9 +134,6 @@ struct ScratchpadCollectorTests: ~Copyable {
 
         let records = await collector.reconcile(knownPaths: [worktreePath], now: Date())
 
-        // Clean up test worktree
-        try? fm.removeItem(atPath: worktreePath)
-
         // Scratchpad should still exist because worktree exists
         #expect(records.count == 0)
         #expect(fm.fileExists(atPath: scratchpadDir.path))
@@ -144,7 +148,9 @@ struct ScratchpadCollectorTests: ~Copyable {
 
         let collector = ScratchpadCollector(base: missingBase)
 
-        let records = await collector.reconcile(knownPaths: ["/tmp/some-wt"], now: Date())
+        let records = await collector.reconcile(
+            knownPaths: [wtParent.appendingPathComponent("gone-wt").path], now: Date()
+        )
 
         #expect(records.count == 0)
     }

--- a/Tests/TBDDaemonTests/ScratchpadCollectorTests.swift
+++ b/Tests/TBDDaemonTests/ScratchpadCollectorTests.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("ScratchpadCollector")
+struct ScratchpadCollectorTests: ~Copyable {
+    let fm = FileManager.default
+    let tmpDir: URL
+
+    init() {
+        tmpDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("scratchpad-test-\(UUID().uuidString)")
+        try? fm.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        try? fm.removeItem(at: tmpDir)
+    }
+
+    @Test("slug replaces forward slashes with hyphens")
+    func testSlugConversion() {
+        let slug = ScratchpadCollector.slug(forWorktreePath: "/Users/chang/tbd/worktrees/some-wt")
+        #expect(slug == "-Users-chang-tbd-worktrees-some-wt")
+    }
+
+    @Test("slug with single component")
+    func testSlugSingleComponent() {
+        let slug = ScratchpadCollector.slug(forWorktreePath: "somepath")
+        #expect(slug == "somepath")
+    }
+
+    @Test("slug with empty string")
+    func testSlugEmpty() {
+        let slug = ScratchpadCollector.slug(forWorktreePath: "")
+        #expect(slug == "")
+    }
+
+    @Test("cleanUp removes scratchpad dir and returns record")
+    func testCleanUpSuccess() async {
+        let collector = ScratchpadCollector(base: tmpDir)
+        let worktreePath = "/Users/chang/tbd/worktrees/test-wt"
+        let slug = ScratchpadCollector.slug(forWorktreePath: worktreePath)
+
+        let scratchpadDir = tmpDir.appendingPathComponent(slug)
+        try? fm.createDirectory(at: scratchpadDir, withIntermediateDirectories: true)
+
+        // Create some dummy files to measure
+        let file1 = scratchpadDir.appendingPathComponent("file1.txt")
+        try? "test content".write(to: file1, atomically: true, encoding: .utf8)
+
+        let now = Date()
+        let record = await collector.cleanUp(forRemovedWorktreePath: worktreePath, now: now)
+
+        #expect(record != nil)
+        #expect(record?.kind == ReapKind.scratchpad)
+        #expect(record?.repoPath == "")
+        #expect(record?.worktreePath == scratchpadDir.path)
+        #expect(record?.apparentBytes != nil)
+        #expect(!fm.fileExists(atPath: scratchpadDir.path))
+    }
+
+    @Test("cleanUp returns nil when scratchpad does not exist")
+    func testCleanUpNonExistent() async {
+        let collector = ScratchpadCollector(base: tmpDir)
+        let worktreePath = "/Users/chang/tbd/worktrees/nonexistent"
+
+        let record = await collector.cleanUp(forRemovedWorktreePath: worktreePath, now: Date())
+
+        #expect(record == nil)
+    }
+
+    @Test("reconcile removes only scratchpads for nonexistent worktrees")
+    func testReconcileRemovesGoneWorktrees() async {
+        let collector = ScratchpadCollector(base: tmpDir)
+
+        let existingWT = "/tmp/existing-wt"
+        let goneWT = "/tmp/gone-wt"
+
+        // Create scratchpads for both
+        let existingSlug = ScratchpadCollector.slug(forWorktreePath: existingWT)
+        let goneSlug = ScratchpadCollector.slug(forWorktreePath: goneWT)
+
+        let existingDir = tmpDir.appendingPathComponent(existingSlug)
+        let goneDir = tmpDir.appendingPathComponent(goneSlug)
+
+        try? fm.createDirectory(at: existingDir, withIntermediateDirectories: true)
+        try? fm.createDirectory(at: goneDir, withIntermediateDirectories: true)
+
+        // Add dummy file to measure
+        try? "test".write(to: goneDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+        // Create the existing worktree dir
+        try? fm.createDirectory(atPath: existingWT, withIntermediateDirectories: true)
+
+        let records = await collector.reconcile(knownPaths: [existingWT, goneWT], now: Date())
+
+        // Clean up the test worktree
+        try? fm.removeItem(atPath: existingWT)
+
+        #expect(records.count == 1)
+        #expect(records[0].kind == ReapKind.scratchpad)
+        #expect(records[0].worktreePath == goneDir.path)
+        #expect(!fm.fileExists(atPath: goneDir.path))
+        #expect(fm.fileExists(atPath: existingDir.path))
+    }
+
+    @Test("reconcile preserves unrelated dirs in base")
+    func testReconcilePreservesUnrelated() async {
+        let collector = ScratchpadCollector(base: tmpDir)
+
+        let worktreePath = "/tmp/some-wt"
+        let unrelatedDir = tmpDir.appendingPathComponent("unrelated-project")
+
+        // Create the scratchpad
+        let slug = ScratchpadCollector.slug(forWorktreePath: worktreePath)
+        let scratchpadDir = tmpDir.appendingPathComponent(slug)
+        try? fm.createDirectory(at: scratchpadDir, withIntermediateDirectories: true)
+        try? "test".write(to: scratchpadDir.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+
+        // Create unrelated directory
+        try? fm.createDirectory(at: unrelatedDir, withIntermediateDirectories: true)
+        try? "unrelated".write(to: unrelatedDir.appendingPathComponent("data.txt"), atomically: true, encoding: .utf8)
+
+        // Create the worktree so it won't be cleaned
+        try? fm.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
+
+        let records = await collector.reconcile(knownPaths: [worktreePath], now: Date())
+
+        // Clean up test worktree
+        try? fm.removeItem(atPath: worktreePath)
+
+        // Scratchpad should still exist because worktree exists
+        #expect(records.count == 0)
+        #expect(fm.fileExists(atPath: scratchpadDir.path))
+        // Unrelated directory should still exist
+        #expect(fm.fileExists(atPath: unrelatedDir.path))
+    }
+
+    @Test("reconcile is no-op when base dir missing")
+    func testReconcileMissingBase() async {
+        let missingBase = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("nonexistent-base-\(UUID().uuidString)")
+
+        let collector = ScratchpadCollector(base: missingBase)
+
+        let records = await collector.reconcile(knownPaths: ["/tmp/some-wt"], now: Date())
+
+        #expect(records.count == 0)
+    }
+}

--- a/Tests/TBDDaemonTests/ScratchpadCollectorTests.swift
+++ b/Tests/TBDDaemonTests/ScratchpadCollectorTests.swift
@@ -46,7 +46,7 @@ struct ScratchpadCollectorTests: ~Copyable {
         #expect(slug == "")
     }
 
-    @Test("cleanUp removes scratchpad dir and returns record")
+    @Test("cleanUp removes scratchpad dir and returns record stamped with repoPath")
     func testCleanUpSuccess() async {
         let collector = ScratchpadCollector(base: tmpDir)
         let worktreePath = "/Users/chang/tbd/worktrees/test-wt"
@@ -60,14 +60,27 @@ struct ScratchpadCollectorTests: ~Copyable {
         try? "test content".write(to: file1, atomically: true, encoding: .utf8)
 
         let now = Date()
-        let record = await collector.cleanUp(forRemovedWorktreePath: worktreePath, now: now)
+        let record = await collector.cleanUp(forRemovedWorktreePath: worktreePath, repoPath: "/Users/chang/tbd", now: now)
 
         #expect(record != nil)
         #expect(record?.kind == ReapKind.scratchpad)
-        #expect(record?.repoPath == "")
+        #expect(record?.repoPath == "/Users/chang/tbd")
         #expect(record?.worktreePath == scratchpadDir.path)
         #expect(record?.apparentBytes != nil)
         #expect(!fm.fileExists(atPath: scratchpadDir.path))
+    }
+
+    @Test("cleanUp stamps an empty repoPath when the caller has none to give")
+    func testCleanUpStampsEmptyRepoPathWhenUnknown() async {
+        let collector = ScratchpadCollector(base: tmpDir)
+        let worktreePath = "/Users/chang/tbd/worktrees/test-wt-2"
+        let slug = ScratchpadCollector.slug(forWorktreePath: worktreePath)
+        let scratchpadDir = tmpDir.appendingPathComponent(slug)
+        try? fm.createDirectory(at: scratchpadDir, withIntermediateDirectories: true)
+
+        let record = await collector.cleanUp(forRemovedWorktreePath: worktreePath, repoPath: "", now: Date())
+
+        #expect(record?.repoPath == "")
     }
 
     @Test("cleanUp returns nil when scratchpad does not exist")
@@ -75,12 +88,12 @@ struct ScratchpadCollectorTests: ~Copyable {
         let collector = ScratchpadCollector(base: tmpDir)
         let worktreePath = "/Users/chang/tbd/worktrees/nonexistent"
 
-        let record = await collector.cleanUp(forRemovedWorktreePath: worktreePath, now: Date())
+        let record = await collector.cleanUp(forRemovedWorktreePath: worktreePath, repoPath: "/Users/chang/tbd", now: Date())
 
         #expect(record == nil)
     }
 
-    @Test("reconcile removes only scratchpads for nonexistent worktrees")
+    @Test("reconcile removes only scratchpads for nonexistent worktrees, stamped with each pair's repoPath")
     func testReconcileRemovesGoneWorktrees() async {
         let collector = ScratchpadCollector(base: tmpDir)
 
@@ -103,11 +116,18 @@ struct ScratchpadCollectorTests: ~Copyable {
         // Create the existing worktree dir
         try? fm.createDirectory(atPath: existingWT, withIntermediateDirectories: true)
 
-        let records = await collector.reconcile(knownPaths: [existingWT, goneWT], now: Date())
+        let records = await collector.reconcile(
+            knownPaths: [
+                (worktreePath: existingWT, repoPath: "/repo/existing"),
+                (worktreePath: goneWT, repoPath: "/repo/gone"),
+            ],
+            now: Date()
+        )
 
         #expect(records.count == 1)
         #expect(records[0].kind == ReapKind.scratchpad)
         #expect(records[0].worktreePath == goneDir.path)
+        #expect(records[0].repoPath == "/repo/gone", "must stamp the repoPath from its own pair, not the survivor's")
         #expect(!fm.fileExists(atPath: goneDir.path))
         #expect(fm.fileExists(atPath: existingDir.path))
     }
@@ -132,7 +152,9 @@ struct ScratchpadCollectorTests: ~Copyable {
         // Create the worktree so it won't be cleaned
         try? fm.createDirectory(atPath: worktreePath, withIntermediateDirectories: true)
 
-        let records = await collector.reconcile(knownPaths: [worktreePath], now: Date())
+        let records = await collector.reconcile(
+            knownPaths: [(worktreePath: worktreePath, repoPath: "/repo/some")], now: Date()
+        )
 
         // Scratchpad should still exist because worktree exists
         #expect(records.count == 0)
@@ -149,7 +171,8 @@ struct ScratchpadCollectorTests: ~Copyable {
         let collector = ScratchpadCollector(base: missingBase)
 
         let records = await collector.reconcile(
-            knownPaths: [wtParent.appendingPathComponent("gone-wt").path], now: Date()
+            knownPaths: [(worktreePath: wtParent.appendingPathComponent("gone-wt").path, repoPath: "/repo/gone")],
+            now: Date()
         )
 
         #expect(records.count == 0)

--- a/Tests/TBDSharedTests/ConstantsTests.swift
+++ b/Tests/TBDSharedTests/ConstantsTests.swift
@@ -78,6 +78,23 @@ import Foundation
         let path = TBDConstants.scratchDir(environment: [:]).path
         #expect(path.hasSuffix("/tbd/scratch"))
     }
+
+    @Test func claudeScratchpadBaseDefaultsToPrivateTmpClaudeUID() {
+        let url = TBDConstants.claudeScratchpadBase(environment: [:])
+        #expect(url.path == "/private/tmp/claude-\(getuid())")
+    }
+
+    @Test func claudeScratchpadBaseHonorsOverride() {
+        let url = TBDConstants.claudeScratchpadBase(
+            environment: ["TBD_CLAUDE_SCRATCH_BASE": "/tmp/claude-scratch-test"]
+        )
+        #expect(url.path == "/tmp/claude-scratch-test")
+    }
+
+    @Test func emptyClaudeScratchpadBaseOverrideIsTreatedAsUnset() {
+        let url = TBDConstants.claudeScratchpadBase(environment: ["TBD_CLAUDE_SCRATCH_BASE": ""])
+        #expect(url.path == "/private/tmp/claude-\(getuid())")
+    }
 }
 
 /// Smoke-tests that the production computed vars are correctly wired to the

--- a/Tests/TBDSharedTests/ReapRecordTests.swift
+++ b/Tests/TBDSharedTests/ReapRecordTests.swift
@@ -1,0 +1,25 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("ReapRecord model")
+struct ReapRecordTests {
+    @Test func roundTrips() throws {
+        let rec = ReapRecord(kind: .agentWorktree, repoPath: "/r", worktreePath: "/r/.claude/worktrees/agent-x",
+                             branch: "b", headSHA: "abc", snapshotRef: "refs/tbd/snapshots/agent-x-20260710",
+                             apparentBytes: 1_200_000)
+        let data = try JSONEncoder().encode(rec)
+        let back = try JSONDecoder().decode(ReapRecord.self, from: data)
+        #expect(back == rec)
+    }
+    @Test func configDecodesGCDefaultsWhenFieldsAbsent() throws {
+        // Encode a current Config, strip the gc keys, decode — must apply defaults.
+        var obj = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Config())) as? [String: Any])
+        obj.removeValue(forKey: "gcEnabled"); obj.removeValue(forKey: "gcGraceSeconds"); obj.removeValue(forKey: "gcSnapshotRetentionDays")
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        let cfg = try JSONDecoder().decode(Config.self, from: data)
+        #expect(cfg.gcEnabled == true)
+        #expect(cfg.gcGraceSeconds == 3600)
+        #expect(cfg.gcSnapshotRetentionDays == 30)
+    }
+}

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -53,10 +53,21 @@ gate fails toward keeping** — a `nil`/error/timeout anywhere means "don't touc
 4. **Grace window** — HEAD/index mtime older than `gcGraceSeconds` (default 3600s /
    1h). A settling buffer for the gap between unlock and sweep, and for a human still
    poking around right after a run — not an idle policy.
-5. **Reap** — snapshot first if needed (see below), `du -sk` for the disk-usage
-   estimate, `rm -rf`, verify the removal actually took, then `git worktree prune`.
-   **The branch is never deleted** — branch cleanup stays a human / `clean_gone`
-   concern.
+5. **Reap** — a pre-rm re-check first (see below), then snapshot if needed (see
+   below), `du -sk` for the disk-usage estimate, `rm -rf`, verify the removal actually
+   took, then `git worktree prune`. **The branch is never deleted** — branch cleanup
+   stays a human / `clean_gone` concern.
+
+**TOCTOU: pre-rm re-check.** Gates 2–4 run once, against lock/`lsof` data captured at
+sweep start; on a large sweep a given candidate's turn to actually reap can come up
+minutes later, so that data can be stale by the time it matters. Immediately before
+anything destructive happens — before even the snapshot step, since snapshotting
+writes into the doomed worktree's git index — the reap step re-fetches both the lock
+state and a fresh `lsof` pass and re-applies the same lock/live-cwd checks. A `nil`
+from the fresh `lsof` pass fails toward keeping, same sentinel semantics as the
+sweep-level pass. This closes the staleness window down to the instant between the
+re-check and the `rm -rf`/`removeItem` call — a race an external process would have to
+land in to defeat it, not the minutes-wide window gates 2–4 alone left open.
 
 ## Snapshot & restore
 

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -126,7 +126,11 @@ The sweep itself runs:
 
 For an ad-hoc look without waiting for the clock, use `tbd gc sweep --dry-run` — it
 computes and prints the identical plan without touching disk or the DB, regardless of
-`gcEnabled`.
+`gcEnabled`. One under-report to know about: a companion scratchpad reap for an
+agent worktree that's only *planned* (not actually reaped) in a dry run isn't planned
+either, since it's only computed once the agent worktree itself has actually been
+removed — a real (non-dry) sweep will report more scratchpad reaps than the preceding
+dry run predicted.
 
 ## Config knobs
 

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -1,0 +1,183 @@
+# Orphan GC (product feature)
+
+Daemon-owned garbage collection for Claude Code agent worktrees and their scratchpads.
+**Shipped product**, unlike `scripts/reclaim-build.sh`/`sweep-scratchpads.sh` (see
+[`docs/reclaim-build.md`](reclaim-build.md) for the dev-script sibling and the boundary
+between the two). Design background:
+[`docs/superpowers/specs/2026-07-10-orphan-gc-design.md`](superpowers/specs/2026-07-10-orphan-gc-design.md),
+[`docs/research/2026-07-10-agent-worktree-gc/agent-deck-worktree-lifecycle.md`](research/2026-07-10-agent-worktree-gc/agent-deck-worktree-lifecycle.md),
+[`docs/research/2026-07-10-agent-worktree-gc/ecosystem-prior-art.md`](research/2026-07-10-agent-worktree-gc/ecosystem-prior-art.md).
+
+## What it reaps
+
+`isolation: "worktree"` subagents and Workflow runs make Claude Code create git
+worktrees under `<repo-root>/.claude/worktrees/{agent-*,wf_*}`. Claude Code only
+auto-removes one if it ended unchanged — the moment an agent commits, the worktree
+(and its gitignored `.build`/`node_modules`/`.venv`) persists forever, and Claude
+Code's own 30-day sweep permanently exempts anything with unpushed commits. Nothing
+else ever cleans these up.
+
+Two things get reaped:
+- **Agent worktrees** — `<repo>/.claude/worktrees/agent-*` and `wf_*` whose run has
+  ended (see gates below).
+- **Attributable scratchpads** — `/private/tmp/claude-<uid>/<slug>` directories TBD can
+  tie to a worktree path it knows about (its own, or an agent worktree it just reaped).
+
+## Philosophy: orphaned, not idle
+
+*Orphaned* = the owning entity is gone and nothing will programmatically return to it.
+*Idle* = the owner still exists and might come back — that needs a time-judgment
+policy, which stays out of the product and lives in the dev-script reaper instead. The
+branch and its commits always live in the repo's shared `.git`, not the checkout —
+removing the worktree directory never loses committed work. Only uncommitted/untracked
+state is at risk, and the snapshot step (below) covers exactly that.
+
+## Agent-worktree reap gates
+
+For each directory under `<repo>/.claude/worktrees/`, gates run in this order. **Every
+gate fails toward keeping** — a `nil`/error/timeout anywhere means "don't touch it":
+
+1. **Linkage proof** — the candidate's `.git` file must resolve (via `realpath`
+   canonicalization on both sides) into `<repo>/.git/worktrees/<id>`. Path shape alone
+   never qualifies a directory; a decoy `mkdir`, a symlink to the repo root, or
+   anything not backed by a real linked worktree is silently skipped.
+2. **Not locked** — `git worktree list --porcelain` reports no `locked` for the path.
+   Claude Code holds the lock for the whole live run, so this alone excludes in-flight
+   agents. A leaked stale lock means the worktree is kept forever (fail-safe, logged as
+   `kept: locked`).
+3. **No live process** — no `lsof -d cwd` entry at or below the canonicalized path.
+   **A non-zero `lsof` exit skips the entire sweep, not just this gate** — a failed or
+   partial process listing is never treated as "no live processes"; same treatment as
+   an `lsof` timeout. This is stricter than a per-candidate keep: one bad `lsof` run
+   means nothing in the whole sweep gets reaped that pass.
+4. **Grace window** — HEAD/index mtime older than `gcGraceSeconds` (default 3600s /
+   1h). A settling buffer for the gap between unlock and sweep, and for a human still
+   poking around right after a run — not an idle policy.
+5. **Reap** — snapshot first if needed (see below), `du -sk` for the disk-usage
+   estimate, `rm -rf`, verify the removal actually took, then `git worktree prune`.
+   **The branch is never deleted** — branch cleanup stays a human / `clean_gone`
+   concern.
+
+## Snapshot & restore
+
+**Snapshot** (only when the worktree is dirty, or its HEAD isn't reachable from any
+branch — e.g. a detached-HEAD agent): stage everything with a temp index, `git
+write-tree`, `git commit-tree` on top of HEAD, `git update-ref
+refs/tbd/snapshots/<worktree-name>-<timestamp>`, then **verify the ref is actually
+readable** before anything is deleted. A verification failure keeps the worktree
+untouched. `.gitignore`d content (so `node_modules`/`.venv`) never enters the snapshot
+— `git add -A` respects ignore rules. Nothing is stored outside the repo; content
+dedupes into the normal object store.
+
+**Anchor refs**: if HEAD is clean but unreachable from any branch, the ref is written
+straight at `headSHA` (no new commit) purely to keep the commit alive against git's own
+GC. Anchor refs for otherwise-unreachable commits are **kept indefinitely** — they're
+the only thing keeping that work alive, and refs are cheap.
+
+**Restore** (`tbd gc restore <id>` or the Reclaimed section's Restore button):
+recreates the worktree with `git worktree add` — on the original branch if it still
+exists, detached at the recorded HEAD SHA otherwise — then, if a snapshot ref exists,
+replays it into the working tree (`git restore --source=<ref> --worktree -- .` for
+tracked content, snapshot-tree files re-created for untracked content). Refuses with an
+error if the original path is already occupied.
+
+**Known limitation — deletions aren't replayed.** `git restore` re-creates files from
+the snapshot tree; it does not delete files. If the dirty state being snapshotted
+included files the agent had *deleted* (vs. modified or added), restore does not
+reproduce those deletions — the restored worktree can end up with files present that
+were gone at snapshot time. Only for `.agentWorktree` records — scratchpads have no
+restore path (nothing to recreate a bare tmp dir from); restoring twice, or restoring
+an already-restored record, is refused.
+
+**Snapshot retention**: the sweep deletes `refs/tbd/snapshots/*` older than
+`gcSnapshotRetentionDays` (default 30) **only** when the record was never restored
+*and* its branch still exists. A record whose branch is gone keeps its ref forever —
+deleting it would make the snapshot unrecoverable garbage to git itself.
+
+## Scratchpad cleanup
+
+A scratchpad is only ever cleaned when TBD can attribute it to a concrete worktree path
+it knows — there is no slug *decoding*, only exact slug *computation*
+(`path.replacingOccurrences(of: "/", with: "-")`) from paths TBD already has on hand:
+
+- **Event-driven** — the moment TBD archives/deletes one of its own worktrees, and the
+  moment an agent worktree is reaped, the exact slug's scratchpad is deleted
+  immediately. This path runs independent of the hourly sweep cadence, still gated by
+  `gcEnabled`.
+- **Reconciliation (part of the hourly sweep)** — for archived TBD worktree rows whose
+  `path` no longer exists on disk, compute the slug and remove the scratchpad. Catches
+  anything missed while the daemon was down.
+
+Non-goals: scratchpads of non-TBD projects, and scratchpads left behind by agent
+worktrees Claude Code itself removed before TBD ever swept them. That residue is
+`scripts/sweep-scratchpads.sh`'s territory (`docs/reclaim-build.md`).
+
+## Cadence and the `gcEnabled` gate
+
+`gcEnabled` (config-table boolean, **default on**) is the single master switch — it
+gates the hourly sweep **and** event-driven scratchpad cleanup. When off, a non-dry-run
+sweep does nothing at all — not even the `lsof` pass. Toggle it in Settings
+("Automatically clean up orphaned agent worktrees") or via the `config.setGCEnabled`
+RPC.
+
+The sweep itself runs:
+- **Once immediately at daemon boot** (cold-start recovery), then
+- **Every hour** thereafter, for as long as the daemon runs.
+
+For an ad-hoc look without waiting for the clock, use `tbd gc sweep --dry-run` — it
+computes and prints the identical plan without touching disk or the DB, regardless of
+`gcEnabled`.
+
+## Config knobs
+
+| Key | Default | Where |
+|---|---|---|
+| `gcEnabled` | `true` | Settings toggle + `config.setGCEnabled` RPC |
+| `gcGraceSeconds` | `3600` (1h) | config table only, no UI |
+| `gcSnapshotRetentionDays` | `30` | config table only, no UI |
+
+Deliberately **not** configurable, as safety invariants rather than knobs: whether a
+dirty worktree gets snapshotted before delete (always), the detection gates
+themselves, and sweep cadence.
+
+## History (Reclaimed section)
+
+Archived-worktrees view gets a collapsed-by-default "Reclaimed" disclosure section at
+the bottom, rendered only when the repo has reap records. Header reads e.g. *"RECLAIMED
+(12 · 9.4 GB)"* — the count/size covers **unrestored** records only. Rows:
+
+- **Agent-worktree rows** — one per record, muted/distinct styling from real archived
+  worktrees (no session-count or revive affordances). Shows path, branch, apparent
+  size, whether a snapshot exists. Restored rows are dimmed and show "Restored
+  `<date>`" instead of a Restore button.
+- **Scratchpad rows** — rolled up into a single aggregate row per repo (e.g. "23
+  scratchpads cleaned · 31 GB") — no restore action, so no per-row listing.
+
+Restore is available for `agentWorktree` records only.
+
+## CLI
+
+```sh
+tbd gc list [--repo <path>] [--json]   # list reap records (id, kind, path, size, snapshot state, restored)
+tbd gc restore <uuid>                  # restore a reaped agent worktree
+tbd gc sweep [--dry-run]               # run a sweep now; --dry-run prints the plan, mutates nothing
+```
+
+## Non-goals (from the design spec)
+
+| Out of scope | Why |
+|---|---|
+| Idle-based reaping of anything | Stays in dev scripts (`docs/reclaim-build.md`) — needs a time-judgment policy this feature deliberately avoids |
+| Deleting branches | Human / `clean_gone` concern |
+| Reaping installs (`node_modules`/`.venv`/`.terraform`) or `.build` inside living TBD worktrees | Never orphaned, only idle |
+| GC of non-attributable scratchpads or other Claude Code global state | No linkage to a known TBD/agent-worktree path |
+| Provenance capture via Claude Code hooks (`WorktreeCreate`/`SubagentStop`) | Possible future refinement for authoritative run-ended signals; not needed for orphan detection today |
+
+## Logging
+
+`os.Logger` subsystem `com.tbd.daemon`, category `gc` — `.debug` for per-candidate gate
+traces, `.info` for reaps/restores, with explicit `privacy:` on dynamic
+interpolations. Stream live:
+```sh
+log stream --level debug --predicate 'subsystem == "com.tbd.daemon" AND category == "gc"'
+```

--- a/docs/orphan-gc.md
+++ b/docs/orphan-gc.md
@@ -120,6 +120,29 @@ sweep does nothing at all — not even the `lsof` pass. Toggle it in Settings
 ("Automatically clean up orphaned agent worktrees") or via the `config.setGCEnabled`
 RPC.
 
+### Why default-on, despite the default-off house rule
+
+CLAUDE.md's "large or risky new behavior ships behind a default-off flag" rule names
+exactly this shape (background timer, deletes persisted state), and the
+`auto_hibernate_enabled` precedent (shipped on, force-disabled in v50) is the cautionary
+tale. This feature is judged exempt, deliberately, per the design spec's brainstorm
+decision (`docs/superpowers/specs/2026-07-10-orphan-gc-design.md` §Config):
+
+- **Deletion here is not lossy by construction.** Nothing is deleted without a
+  snapshot ref written *and verified* in the shared repo first; branches are never
+  deleted; every reap is restorable from History/CLI for `gcSnapshotRetentionDays`.
+  The un-gated failure mode of auto-hibernate (losing live session state) has no
+  analog: the worst outcome of a wrong reap is one click to restore.
+- **Orphan-only, never idle.** Every gate must *prove* the owner is gone (linkage,
+  lock, live-cwd, grace) and every gate/error direction fails toward keeping — each
+  direction carries a dedicated test, including the both-branch `gcEnabled` tests the
+  house rule requires.
+- **Default-off would un-ship the feature.** The entire point is unattended cleanup of
+  worktrees nothing else GCs; the population it protects against grows silently
+  (81-worktree incident). A soak already happened live during development: the first
+  boot sweep reaped 11 real orphaned agent worktrees on the dev machine, all
+  restorable, gates verifiably keeping every busy worktree.
+
 The sweep itself runs:
 - **Once immediately at daemon boot** (cold-start recovery), then
 - **Every hour** thereafter, for as long as the daemon runs.

--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -2,6 +2,29 @@
 
 Keeps each TBD worktree's SwiftPM `.build` small, reclaims idle dependency-install directories (`node_modules`, `.venv`, `.terraform`), and cleans up orphaned Claude Code per-worktree scratchpads. **Not part of the shipped product** — it is developer machine tooling, like `scripts/restart.sh`. Two sibling scripts share conventions: `scripts/reclaim-build.sh` (SwiftPM + installs), `scripts/sweep-scratchpads.sh` (orphaned scratchpads).
 
+## Product GC vs dev-script territory
+
+TBD also ships a **product** garbage collector — the daemon-owned orphan GC
+(`Sources/TBDDaemon/GC/`, [`docs/orphan-gc.md`](orphan-gc.md)) — which is a different
+thing from everything else in this file. The split is by construction, not overlap:
+
+| | Product GC (daemon) | This file's scripts |
+|---|---|---|
+| Owns | Orphaned Claude Code agent worktrees (`.claude/worktrees/agent-*`, `wf_*`) whose run has ended, + scratchpads TBD can attribute to a known worktree path | SwiftPM `.build` tiers, install dirs (`node_modules`/`.venv`/`.terraform`) in **living** TBD worktrees, and scratchpad residue TBD can't attribute |
+| Trigger | Orphan-only: the owning entity is provably gone (unlocked, no live process, linkage-proven) | Idle-only: the owner (a living worktree) still exists, reaped purely by elapsed time |
+| Surfacing | History "Reclaimed" section, `tbd gc` CLI, snapshot-first + restorable | Log file only, not restorable |
+| Runs via | Daemon sweep loop (boot + hourly) | `launchd` (hourly) + `scripts/restart.sh` background launch |
+
+They're non-overlapping populations: a living TBD worktree's `.build`/installs are
+never orphaned (only idle), so the daemon never touches them; an agent worktree that's
+been fully reaped by the daemon no longer exists for this file's scripts to consider.
+One overlap is now moot rather than active: the **"Claude agent worktrees" install-dir
+tier described below is redundant** wherever the daemon reaps the whole agent worktree
+first (whole-directory removal takes the installs with it) — but that tier's script
+behavior is intentionally left in place in this PR as a backstop for agent worktrees
+the daemon hasn't gotten to yet (still locked, within grace, or `gcEnabled` off), and
+for any repo the daemon doesn't manage.
+
 ## Triggers
 
 Both scripts write to the same log (`~/Library/Logs/tbd-reclaim-build.log`) and run from `scripts/restart.sh`; `reclaim-build.sh` additionally runs hourly via launchd:

--- a/docs/superpowers/specs/2026-07-10-orphan-gc-design.md
+++ b/docs/superpowers/specs/2026-07-10-orphan-gc-design.md
@@ -129,7 +129,10 @@ excludes `.gitignore`d content — so `node_modules`/`.venv` never enter the sna
 `git write-tree`, `git commit-tree <tree> -p HEAD -m "TBD reap snapshot: <path> @
 <iso-date>"`, `git update-ref refs/tbd/snapshots/<worktree-name>-<yyyymmdd-hhmmss>`.
 Nothing is stored outside the repo; content dedupes into the object store; power users
-can inspect with plain git.
+can inspect with plain git. (Shipped implementation note: `GitManager.stageAllAndWriteTree`
+stages directly against the orphaned worktree's own real index via a plain `git add -A`
+rather than a temp `GIT_INDEX_FILE` as sketched above — safe because the worktree is
+already orphaned and about to be deleted, so there is no live index state left to protect.)
 
 **Restore** (`tbd gc restore <id>` or the History button): `git worktree add
 <original-path> <branch>` (or `--detach <head-sha>` if the branch is gone), then if a


### PR DESCRIPTION
## Summary
- Implements the daemon-owned **orphan GC** designed in `docs/superpowers/specs/2026-07-10-orphan-gc-design.md` (research: `docs/research/2026-07-10-agent-worktree-gc/`): Claude agent worktrees (`.claude/worktrees/{agent-*,wf_*}`) are reaped when their run has provably ended — **orphan detection, never idle clocks**: git-linkage proof → not `git worktree lock`ed → no live process cwd (one lsof pass; timeout/non-zero exit skips the whole sweep) → 1h grace → snapshot-verified-before-delete (`refs/tbd/snapshots/*`, dirty state as a commit, anchor refs for unreachable HEADs kept forever). Branches are never deleted.
- Scratchpad cleanup is **attributable-only**: event-driven at archive/reap time plus a reconciliation sweep over TBD's own DB paths — exact slug computation, no decoding heuristics, non-TBD scratchpads untouched.
- Surfaces: `reap_records` (v52 migration), `gc.list/gc.restore/gc.sweepNow` RPC, `tbd gc list|restore|sweep [--dry-run]` CLI, a collapsed **Reclaimed** section in History (restored rows dim + show restored-at; header counts unrestored only; scratchpads roll up) with one-click Restore, and a Settings toggle (`gcEnabled`, default on; snapshot-before-delete and the detection gates are deliberately not configurable).
- Dev-script boundary documented in `docs/reclaim-build.md` + new `docs/orphan-gc.md`.

## Test plan
- [x] 30+ new unit/integration tests across the GC subsystem (gates each fail-toward-keep incl. forced-error directions, snapshot round-trip byte fidelity, retention anchor rule, gcEnabled both-branch house rule, RPC handlers, view-model helpers) — full suite 3432 green locally apart from a pre-existing ThemeStore watcher load-flake (passes 3/3 isolated; no theme/watcher code touched)
- [x] Live verification on a real machine: boot sweep reaped 11 real orphaned agent worktrees (restorable, snapshot refs verified); dry-run shows KEEP locked/live-cwd/grace for busy ones; CLI verified against the live daemon
- [ ] CI suite (this draft exists to run it)
- [ ] Live UI walkthrough of the Reclaimed section (pending unlocked screen): collapsed header, expand, selection exclusivity vs archived rows, restored-row dimming, Restore round-trip

Related: #420, #423 (dev-script reaper this complements), #429 (design docs).

Draft until the final whole-branch review completes.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=8B570B88-D2C0-4D64-9930-EA27F5481F5B)

## Why gcEnabled ships default-on (house-rule exemption rationale)

CLAUDE.md's default-off rule names this exact shape (background timer + deletes persisted state), with auto_hibernate_enabled as the cautionary precedent. This feature is judged exempt, deliberately (design spec §Config, decided at brainstorm time):

- **Deletion is not lossy by construction** — nothing is deleted without a snapshot ref written *and verified* first; branches are never deleted; every reap is restorable from History/CLI within the 30-day retention window. Auto-hibernate's un-gated failure mode (irrecoverably losing live state) has no analog here: a wrong reap costs one click.
- **Orphan-only, never idle** — every gate proves the owner is gone and every gate/error direction fails toward keeping, each with a dedicated test (incl. the both-branch gcEnabled tests the house rule requires).
- **Default-off would un-ship the feature** — unattended cleanup is its entire purpose; the target population grows silently (the 81-worktree incident). A live soak already ran during development: the first boot sweep reaped 11 real orphans on the dev machine, all restorable, with gates verifiably keeping every busy worktree.

Same rationale is committed in docs/orphan-gc.md §"Why default-on".