### PR TITLE
Feat: Create a new worktree straight from the repo-name header dropdown

### DIFF
--- a/Sources/TBDApp/Notes/WorktreeTitleView.swift
+++ b/Sources/TBDApp/Notes/WorktreeTitleView.swift
@@ -30,13 +30,17 @@ struct WorktreeTitleView: View {
         }
     }
 
-    // Repo name → dropdown linking to the repo's detail tabs.
+    // Repo name → dropdown linking to the repo's detail tabs, plus repo
+    // actions (New Worktree).
     private var repoMenu: some View {
         Menu {
             if let repoID = worktree.repoID {
                 Button("Archived Worktrees") { openRepoTab(repoID, .archived) }
                 Button("Default Prompts") { openRepoTab(repoID, .instructions) }
                 Button("Hooks & Settings") { openRepoTab(repoID, .settings) }
+                Divider()
+                Button("New Worktree") { appState.createWorktree(repoID: repoID) }
+                    .keyboardShortcut("n", modifiers: .command)
             }
         } label: {
             Text(repoName ?? "")


### PR DESCRIPTION
## Summary
- Adds a "New Worktree" action (with the native ⌘N hint) as a new section in the repo-name dropdown in the app header, so a worktree can be created without reaching for the sidebar's + button or the menu bar.
- Calls `appState.createWorktree(repoID:)` with the dropdown's own repo ID — the same path the global ⌘N (`newWorktreeInFocusedRepo()`) takes.

## Notes from local review
- The `.keyboardShortcut("n", .command)` on the menu item registers a key equivalent alongside the global `CommandMenu` ⌘N. Both resolve to the same repo whenever this title view is visible (the displayed worktree's repo is the focused repo), so behavior is identical either way; the modifier is kept for the native menu hint.
- No `.missing`-repo guard on the button: the daemon already rejects creation for missing repos safely, and a status-gated branch here would risk stale toolbar-menu materialization.

## Test plan
- [ ] `swift build` passes (verified locally)
- [ ] Click the repo name in the app header → dropdown shows a divider and "New Worktree ⌘N" under the three detail-tab links
- [ ] Clicking it creates a worktree in that repo (same as ⌘N)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=828A2012-F29C-4250-BA82-FC3A4971603B)