### PR TITLE
DX: Deflake ThemeStore watcher test — 5s deadline loses to MainActor contention under parallel suites

### DIFF
--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -192,7 +192,18 @@ struct ThemeStoreTests {
         try JSONEncoder().encode(theme)
             .write(to: themesDir.appendingPathComponent("ext.json"))
 
-        let deadline = Date().addingTimeInterval(5)
+        // Generous positive-wait deadline that only elapses on failure. Both
+        // this polling loop and the FSEvents callback's `Task { @MainActor in
+        // ... }` bounce must acquire a turn on the single serial MainActor
+        // executor (bound to the process's one main thread); under a
+        // full-suite `swift test --parallel -j 2` run, hundreds of other
+        // @MainActor suites queue for that same executor and can stretch
+        // delivery well past a 5s window (reproduced locally: reload landed
+        // at ~12s wall-clock). Same root cause as the cooperative-pool
+        // starvation documented for `ciSafeDeadline` in
+        // Tests/TBDDaemonTests/ControlModeTestSupport.swift (PR #379).
+        // Passing runs still complete in ~0.1s.
+        let deadline = Date().addingTimeInterval(30)
         while store.userThemes.isEmpty && Date() < deadline {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }


### PR DESCRIPTION
## Summary
- `ThemeStoreTests` "external file additions trigger a reload via the watcher" fails intermittently under full-suite `swift test --parallel -j 2`: the FSEvents callback's `@MainActor` hop and the test's polling loop both queue behind hundreds of concurrent `@MainActor` suites on the single main-thread executor, stretching delivery past the test's 5s deadline (observed ~12s under load; passes in ~0.1s isolated).
- Fix: raise the deadline to 30s with a comment explaining the contention mechanism, citing the identical precedent (`ciSafeDeadline` in `ControlModeTestSupport`, PR #379).

## Test plan
- [x] Reproduced the failure under a real full-suite parallel run before the fix (11.95s vs 5s deadline)
- [x] After: filtered 5/5 green; full suite green with the test at ~11.8s, comfortably inside 30s
- [x] `swiftlint --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)