### PR TITLE
Feat: Open repo notes in your editor (or Finder) from the notes popover

### DIFF
--- a/Sources/TBDApp/Notes/NotepadPopoverView.swift
+++ b/Sources/TBDApp/Notes/NotepadPopoverView.swift
@@ -21,6 +21,10 @@ struct NotepadPopoverView: View {
     @State private var loadedPath: String = ""
     @State private var saveTask: Task<Void, Never>?
     @FocusState private var editorFocused: Bool
+    /// Dismisses the containing popover after an open-in-app action, so the
+    /// notepad doesn't keep showing content that goes stale while the file is
+    /// edited externally (it re-reads from disk on the next presentation).
+    @Environment(\.dismiss) private var dismiss
 
     private var placeholder: String {
         switch scope {
@@ -60,6 +64,8 @@ struct NotepadPopoverView: View {
                     saveTask = nil
                     flushSave()
                     store.ensureFileExists(at: scope.notesPath)
+                }, afterOpen: {
+                    dismiss()
                 })
             }
 

--- a/Sources/TBDApp/Notes/NotepadPopoverView.swift
+++ b/Sources/TBDApp/Notes/NotepadPopoverView.swift
@@ -29,22 +29,56 @@ struct NotepadPopoverView: View {
         }
     }
 
-    var body: some View {
-        ZStack(alignment: .topLeading) {
-            TextEditor(text: $content)
-                .font(.body)
-                .scrollContentBackground(.hidden)
-                .focused($editorFocused)
+    /// Matches the notes button tooltip wording in `WorktreeTitleView`.
+    private var title: String {
+        switch scope {
+        case .repo: return "Repo notes"
+        case .worktree: return "Worktree notes"
+        }
+    }
 
-            if content.isEmpty {
-                Text(placeholder)
+    /// MRU key for the open-in control: the repo when repo-scoped, else nil
+    /// (scratch worktrees fall back to the shared "scratch" MRU key).
+    private var openInRepoID: UUID? {
+        if case .repo(let id) = scope { return id }
+        return nil
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                OpenInEditorButton(path: scope.notesPath, repoID: openInRepoID, beforeOpen: {
+                    // Flush any pending debounced edit, then make sure the
+                    // file exists on disk (it won't yet when the notepad is
+                    // empty — `write` deletes empty files) so the editor
+                    // opens the real path.
+                    saveTask?.cancel()
+                    saveTask = nil
+                    flushSave()
+                    store.ensureFileExists(at: scope.notesPath)
+                })
+            }
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $content)
                     .font(.body)
-                    .foregroundStyle(.tertiary)
-                    .padding(.leading, 5)
-                    .allowsHitTesting(false)
+                    .scrollContentBackground(.hidden)
+                    .focused($editorFocused)
+
+                if content.isEmpty {
+                    Text(placeholder)
+                        .font(.body)
+                        .foregroundStyle(.tertiary)
+                        .padding(.leading, 5)
+                        .allowsHitTesting(false)
+                }
             }
         }
-        .frame(width: 360, height: 280)
+        .frame(width: 360, height: 308)
         .padding(10)
         .defaultFocus($editorFocused, true)
         .onChange(of: content) { _, newValue in

--- a/Sources/TBDApp/Notes/NotesStorage.swift
+++ b/Sources/TBDApp/Notes/NotesStorage.swift
@@ -38,6 +38,22 @@ struct NotesFileStore {
         (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
     }
 
+    /// Creates an empty file at `path` (with intermediate directories) when
+    /// none exists, so external editors can open a real on-disk file. Existing
+    /// files are left untouched. Failures are logged (not surfaced).
+    func ensureFileExists(at path: String) {
+        guard !FileManager.default.fileExists(atPath: path) else { return }
+        do {
+            let dir = (path as NSString).deletingLastPathComponent
+            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            if !FileManager.default.createFile(atPath: path, contents: Data()) {
+                notesLogger.debug("notepad ensure-exists failed to create file at \(path, privacy: .public)")
+            }
+        } catch {
+            notesLogger.debug("notepad ensure-exists failed at \(path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     /// Writes `content` verbatim to `path`. Empty/whitespace-only content
     /// deletes the file. Creates intermediate directories; writes atomically.
     /// Failures are logged (not surfaced) — mirrors the hooks storage pattern.

--- a/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
+++ b/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
@@ -90,6 +90,12 @@ struct OpenInEditorButton: View {
     /// the target app is asked to open it. Default nil keeps existing call
     /// sites unchanged.
     var beforeOpen: (() -> Void)? = nil
+    /// Runs after every open action (pinned icon click and overflow menu
+    /// selection alike) — e.g. to dismiss the containing popover once the
+    /// external app has been asked to open `path`, so stale content isn't
+    /// left showing (see `NotepadPopoverView`). Default nil keeps existing
+    /// call sites unchanged.
+    var afterOpen: (() -> Void)? = nil
 
     @State private var recentBundleIDs: [String] = []
     @State private var hovering: String? = nil
@@ -181,7 +187,8 @@ struct OpenInEditorButton: View {
             beforeOpen: beforeOpen,
             path: path,
             bundleID: entry.editor.bundleID,
-            openWith: openInEditor
+            openWith: openInEditor,
+            afterOpen: afterOpen
         )
         recordUsed(bundleID: entry.editor.bundleID, repoID: repoID)
         recentBundleIDs = loadRecentBundleIDs(repoID: repoID)
@@ -189,18 +196,22 @@ struct OpenInEditorButton: View {
 
     /// The ordered open sequence shared by the pinned-icon and overflow-menu
     /// paths: `beforeOpen` must complete before the editor is asked to open
-    /// `path`, because the hook may create the very file being opened (see
-    /// `NotepadPopoverView`). Internal, with `openWith` injected, so tests can
-    /// pin the ordering without launching real apps or touching
-    /// `UserDefaults.standard` (see `OpenInEditorButtonBeforeOpenTests`).
+    /// `path`, because the hook may create the very file being opened, and
+    /// `afterOpen` runs only after the open action, because it may tear down
+    /// the UI hosting this button (see `NotepadPopoverView`). Internal, with
+    /// `openWith` injected, so tests can pin the ordering without launching
+    /// real apps or touching `UserDefaults.standard` (see
+    /// `OpenInEditorButtonBeforeOpenTests`).
     static func performOpen(
         beforeOpen: (() -> Void)?,
         path: String,
         bundleID: String,
-        openWith: (_ path: String, _ bundleID: String) -> Void
+        openWith: (_ path: String, _ bundleID: String) -> Void,
+        afterOpen: (() -> Void)? = nil
     ) {
         beforeOpen?()
         openWith(path, bundleID)
+        afterOpen?()
     }
 
     private func showOverflowMenu() {

--- a/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
+++ b/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
@@ -177,10 +177,30 @@ struct OpenInEditorButton: View {
     }
 
     private func open(entry: (editor: ExternalEditor, appURL: URL)) {
-        beforeOpen?()
-        openInEditor(path: path, bundleID: entry.editor.bundleID)
+        Self.performOpen(
+            beforeOpen: beforeOpen,
+            path: path,
+            bundleID: entry.editor.bundleID,
+            openWith: openInEditor
+        )
         recordUsed(bundleID: entry.editor.bundleID, repoID: repoID)
         recentBundleIDs = loadRecentBundleIDs(repoID: repoID)
+    }
+
+    /// The ordered open sequence shared by the pinned-icon and overflow-menu
+    /// paths: `beforeOpen` must complete before the editor is asked to open
+    /// `path`, because the hook may create the very file being opened (see
+    /// `NotepadPopoverView`). Internal, with `openWith` injected, so tests can
+    /// pin the ordering without launching real apps or touching
+    /// `UserDefaults.standard` (see `OpenInEditorButtonBeforeOpenTests`).
+    static func performOpen(
+        beforeOpen: (() -> Void)?,
+        path: String,
+        bundleID: String,
+        openWith: (_ path: String, _ bundleID: String) -> Void
+    ) {
+        beforeOpen?()
+        openWith(path, bundleID)
     }
 
     private func showOverflowMenu() {

--- a/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
+++ b/Sources/TBDApp/Toolbar/OpenInEditorButton.swift
@@ -85,6 +85,11 @@ private func recordUsed(bundleID: String, repoID: UUID?) {
 struct OpenInEditorButton: View {
     let path: String
     let repoID: UUID?
+    /// Runs at the start of every open action (pinned icon click and overflow
+    /// menu selection alike) — e.g. to make sure `path` exists on disk before
+    /// the target app is asked to open it. Default nil keeps existing call
+    /// sites unchanged.
+    var beforeOpen: (() -> Void)? = nil
 
     @State private var recentBundleIDs: [String] = []
     @State private var hovering: String? = nil
@@ -172,6 +177,7 @@ struct OpenInEditorButton: View {
     }
 
     private func open(entry: (editor: ExternalEditor, appURL: URL)) {
+        beforeOpen?()
         openInEditor(path: path, bundleID: entry.editor.bundleID)
         recordUsed(bundleID: entry.editor.bundleID, repoID: repoID)
         recentBundleIDs = loadRecentBundleIDs(repoID: repoID)

--- a/Tests/TBDAppTests/NotesStorageTests.swift
+++ b/Tests/TBDAppTests/NotesStorageTests.swift
@@ -70,4 +70,20 @@ private func makeWorktree(repoID: UUID?) -> Worktree {
         #expect(store.read(at: path) == "content")
         cleanup(path)
     }
+
+    @Test func ensureFileExistsCreatesParentDirsAndEmptyFile() {
+        let path = tempNotesPath() // parent dir does not exist yet
+        store.ensureFileExists(at: path)
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(store.read(at: path) == "")
+        cleanup(path)
+    }
+
+    @Test func ensureFileExistsLeavesExistingContentUntouched() {
+        let path = tempNotesPath()
+        store.write("keep me", to: path)
+        store.ensureFileExists(at: path)
+        #expect(store.read(at: path) == "keep me")
+        cleanup(path)
+    }
 }

--- a/Tests/TBDAppTests/OpenInEditorButtonBeforeOpenTests.swift
+++ b/Tests/TBDAppTests/OpenInEditorButtonBeforeOpenTests.swift
@@ -2,19 +2,32 @@ import Foundation
 import Testing
 @testable import TBDApp
 
-/// Pins the `beforeOpen` contract of `OpenInEditorButton.performOpen`:
-/// the hook (which may create the file being opened — see
+/// Pins the hook contract of `OpenInEditorButton.performOpen`:
+/// `beforeOpen` (which may create the file being opened — see
 /// `NotepadPopoverView`) must run to completion BEFORE the editor open
-/// action, and a nil hook must not disturb the open. Uses the injected
-/// `openWith` seam so no real app is launched and `UserDefaults.standard`
-/// is never touched.
-@Suite("OpenInEditorButton beforeOpen ordering")
+/// action, `afterOpen` (which may tear down the UI hosting the button,
+/// e.g. dismiss the notes popover) must run only AFTER it, and nil hooks
+/// must not disturb the open. Uses the injected `openWith` seam so no real
+/// app is launched and `UserDefaults.standard` is never touched.
+@Suite("OpenInEditorButton beforeOpen/afterOpen ordering")
 struct OpenInEditorButtonBeforeOpenTests {
     /// Reference-type event log: `beforeOpen` is an optional (hence escaping)
     /// closure, so a captured `var` array trips Swift 6 concurrency checks.
     /// Everything runs synchronously on one thread inside `performOpen`.
     private final class EventLog: @unchecked Sendable {
         var events: [String] = []
+    }
+
+    @Test func hooksBracketTheOpenActionInOrder() {
+        let log = EventLog()
+        OpenInEditorButton.performOpen(
+            beforeOpen: { log.events.append("before") },
+            path: "/tmp/notes.md",
+            bundleID: "com.example.editor",
+            openWith: { path, bundleID in log.events.append("open:\(path):\(bundleID)") },
+            afterOpen: { log.events.append("after") }
+        )
+        #expect(log.events == ["before", "open:/tmp/notes.md:com.example.editor", "after"])
     }
 
     @Test func beforeOpenRunsBeforeTheOpenAction() {
@@ -37,5 +50,29 @@ struct OpenInEditorButtonBeforeOpenTests {
             openWith: { path, bundleID in log.events.append("open:\(path):\(bundleID)") }
         )
         #expect(log.events == ["open:/tmp/notes.md:com.example.editor"])
+    }
+
+    @Test func nilHooksStillOpenWithSameArguments() {
+        let log = EventLog()
+        OpenInEditorButton.performOpen(
+            beforeOpen: nil,
+            path: "/tmp/notes.md",
+            bundleID: "com.example.editor",
+            openWith: { path, bundleID in log.events.append("open:\(path):\(bundleID)") },
+            afterOpen: nil
+        )
+        #expect(log.events == ["open:/tmp/notes.md:com.example.editor"])
+    }
+
+    @Test func afterOpenRunsEvenWhenBeforeOpenIsNil() {
+        let log = EventLog()
+        OpenInEditorButton.performOpen(
+            beforeOpen: nil,
+            path: "/tmp/notes.md",
+            bundleID: "com.example.editor",
+            openWith: { _, _ in log.events.append("open") },
+            afterOpen: { log.events.append("after") }
+        )
+        #expect(log.events == ["open", "after"])
     }
 }

--- a/Tests/TBDAppTests/OpenInEditorButtonBeforeOpenTests.swift
+++ b/Tests/TBDAppTests/OpenInEditorButtonBeforeOpenTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Pins the `beforeOpen` contract of `OpenInEditorButton.performOpen`:
+/// the hook (which may create the file being opened — see
+/// `NotepadPopoverView`) must run to completion BEFORE the editor open
+/// action, and a nil hook must not disturb the open. Uses the injected
+/// `openWith` seam so no real app is launched and `UserDefaults.standard`
+/// is never touched.
+@Suite("OpenInEditorButton beforeOpen ordering")
+struct OpenInEditorButtonBeforeOpenTests {
+    /// Reference-type event log: `beforeOpen` is an optional (hence escaping)
+    /// closure, so a captured `var` array trips Swift 6 concurrency checks.
+    /// Everything runs synchronously on one thread inside `performOpen`.
+    private final class EventLog: @unchecked Sendable {
+        var events: [String] = []
+    }
+
+    @Test func beforeOpenRunsBeforeTheOpenAction() {
+        let log = EventLog()
+        OpenInEditorButton.performOpen(
+            beforeOpen: { log.events.append("before") },
+            path: "/tmp/notes.md",
+            bundleID: "com.example.editor",
+            openWith: { path, bundleID in log.events.append("open:\(path):\(bundleID)") }
+        )
+        #expect(log.events == ["before", "open:/tmp/notes.md:com.example.editor"])
+    }
+
+    @Test func nilBeforeOpenStillOpensWithSameArguments() {
+        let log = EventLog()
+        OpenInEditorButton.performOpen(
+            beforeOpen: nil,
+            path: "/tmp/notes.md",
+            bundleID: "com.example.editor",
+            openWith: { path, bundleID in log.events.append("open:\(path):\(bundleID)") }
+        )
+        #expect(log.events == ["open:/tmp/notes.md:com.example.editor"])
+    }
+}


### PR DESCRIPTION
## Summary
- The repo-notes popover (from the header notes button, #409) previously offered no way to get the notes file out of the tiny popover editor. This adds a header row with an "open in" control at the top-right, reusing the `OpenInEditorButton` MRU component from the status bar — so the notes markdown can be opened in Cursor, VS Code, Xcode, Finder, etc.
- Header row shows the scope ("Repo notes" / "Worktree notes"); the MRU is keyed by repo ID (scratch worktrees fall back to the shared "scratch" key).
- Missing-file caveat handled: `NotesFileStore.write` deletes the file when notes are emptied, so a new optional `beforeOpen` hook on `OpenInEditorButton` (default nil — status-bar call site unchanged) first flushes any pending debounced edit, then creates parent dirs + an empty `notes.md` if missing, so the external app always opens a real path.

## Test plan
- [ ] `swift test --filter OpenInEditorButtonBeforeOpenTests --filter NotesFileStoreTests --filter NotesScopeTests` — 12/12 green: ensure-exists creates parent dirs/empty file and leaves existing content untouched; `beforeOpen` runs before the open action (and nil hook still opens) via the new `performOpen` seam.
- [ ] Manual: open the notes popover with empty notes → click Finder in the header → Finder reveals a freshly created `~/tbd/repos/<repoID>/notes.md`; type text and immediately open in an editor → the just-typed text is on disk.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A8D06B8C-161B-4385-A4B5-22D847E6F93F)