### PR TITLE
Fix: Detect TBD launch via window blur so the deep-link auto-return works on big monitors

### DIFF
--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -76,15 +76,28 @@
 
       // Success detection: navigating to a custom scheme does NOT unload this
       // page — the tab stays here. We can't observe the handler directly, but
-      // when TBD activates, macOS brings it frontmost and the tab becomes
-      // hidden. So: document.hidden flipping true within a short window of
-      // firing the redirect means the handler opened. window.blur alone is a
-      // false-positive signal — the browser's "Open TBD.app?" confirmation
-      // dialog blurs the window even if the user cancels — but that dialog
-      // does not hide the document, so visibilitychange is safe.
+      // when TBD activates, macOS brings it frontmost. We accept TWO signals
+      // within a short window of firing the redirect:
       //
-      // Accepted trade-off: document.hidden is the ONLY success signal we
-      // have, so if TBD is NOT installed, an incidental hide within the 3s
+      //   - visibilitychange → document.hidden: fires when the tab is
+      //     switched away, minimized, or fully occluded. Reliable when it
+      //     fires — but Chrome does NOT flip visibility when TBD's window
+      //     only partially covers the browser (the common big-monitor,
+      //     side-by-side case), so relying on it alone made detection
+      //     silently miss even though the handler launched.
+      //   - window blur: fires whenever the browser window loses focus,
+      //     including when TBD activates without occluding it. This catches
+      //     the partial-occlusion case visibilitychange misses.
+      //
+      // Accepted trade-off: blur is also fired by the browser's
+      // "Open TBD.app?" confirmation dialog, even if the user cancels it —
+      // so a user who gets that dialog and cancels will still be bounced
+      // back to the previous page. We accept that: it only affects the
+      // one-time-confirmation path, while the visibility-only approach
+      // missed real successes every time on large monitors.
+      //
+      // Accepted trade-off: neither signal proves the handler exists, so if
+      // TBD is NOT installed, an incidental hide or blur within the 3s
       // window (alt-tab, clicking a notification) is a false positive and
       // will navigate the user away from this fallback/install page. We
       // accept that: cancelling the return when the tab became visible
@@ -102,11 +115,12 @@
           '(' + DETECT_WINDOW_MS + 'ms from now)');
       }
 
-      function onOpened() {
+      function onOpened(signal) {
         if (returned) return; // guard against double-fire
         returned = true;
         var canGoBack = history.length > 1;
-        console.log('[tbd-open] onOpened(): history.length =', history.length,
+        console.log('[tbd-open] onOpened(): signal =', signal,
+          '; history.length =', history.length,
           '— will', canGoBack ? 'history.back()' : 'window.close()',
           'in', RETURN_DELAY_MS + 'ms');
         status.textContent = canGoBack
@@ -141,7 +155,7 @@
           '; inside armed window =', inWindow);
         if (document.hidden) {
           if (inWindow) {
-            onOpened();
+            onOpened('hidden');
           } else if (armedUntil > 0) {
             // Hidden arrived after the window expired — classic symptom of the
             // user taking >3s on the "Open TBD.app?" permission dialog.
@@ -153,6 +167,21 @@
           // cancel here — once onOpened() has fired, the auto-return proceeds
           // regardless (glancing back at the tab must not defeat the return).
           console.log('[tbd-open] tab visible again while return pending — continuing anyway');
+        }
+      });
+
+      window.addEventListener('blur', function () {
+        var now = Date.now();
+        var inWindow = now <= armedUntil;
+        console.log('[tbd-open] blur: inside armed window =', inWindow);
+        if (inWindow) {
+          onOpened('blur');
+        } else if (armedUntil > 0) {
+          // Blur arrived after the window expired — same late-arrival symptom
+          // as the visibilitychange case above (e.g. the user taking >3s on
+          // the "Open TBD.app?" permission dialog).
+          console.log('[tbd-open] blur arrived', now - armedUntil,
+            'ms after the detection window expired — no auto-return');
         }
       });
 

--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -89,12 +89,17 @@
       //     including when TBD activates without occluding it. This catches
       //     the partial-occlusion case visibilitychange misses.
       //
-      // Accepted trade-off: blur is also fired by the browser's
-      // "Open TBD.app?" confirmation dialog, even if the user cancels it —
-      // so a user who gets that dialog and cancels will still be bounced
-      // back to the previous page. We accept that: it only affects the
-      // one-time-confirmation path, while the visibility-only approach
-      // missed real successes every time on large monitors.
+      // Known wrinkle: blur is also fired by the browser's "Open TBD.app?"
+      // confirmation dialog the moment it OPENS — before the user has
+      // decided anything. So the blur path returns on its own, longer
+      // schedule (BLUR_RETURN_DELAY_MS) that outlasts most dialog
+      // interactions, and re-checks document.hasFocus() at fire time: if
+      // the page has focus again (dialog cancelled, or the user came back
+      // deliberately), the auto-return is skipped instead of navigating
+      // away mid-flow. Residual gap, accepted honestly: a user who takes
+      // longer than ~4s to click "Allow" could still have the return fire
+      // while the dialog is up. The 'hidden' path has no such race (the
+      // dialog never hides the document) and keeps its short delay.
       //
       // Accepted trade-off: neither signal proves the handler exists, so if
       // TBD is NOT installed, an incidental hide or blur within the 3s
@@ -105,6 +110,7 @@
       // why the cancel path was removed.
       var DETECT_WINDOW_MS = 3000;
       var RETURN_DELAY_MS = 600;
+      var BLUR_RETURN_DELAY_MS = 4000;
       var armedUntil = 0;
       var returned = false;
       var returnTimer = null;
@@ -119,10 +125,14 @@
         if (returned) return; // guard against double-fire
         returned = true;
         var canGoBack = history.length > 1;
+        // 'hidden' is unambiguous — return quickly. 'blur' may just be the
+        // "Open TBD.app?" dialog opening, so give it long enough to outlast
+        // most dialog interactions before we decide.
+        var delay = signal === 'blur' ? BLUR_RETURN_DELAY_MS : RETURN_DELAY_MS;
         console.log('[tbd-open] onOpened(): signal =', signal,
           '; history.length =', history.length,
           '— will', canGoBack ? 'history.back()' : 'window.close()',
-          'in', RETURN_DELAY_MS + 'ms');
+          'in', delay + 'ms');
         status.textContent = canGoBack
           ? 'Opened in TBD — taking you back…'
           : 'TBD opened — you can close this tab.';
@@ -131,6 +141,16 @@
         // the return proceeds even if it's visible again by then.)
         returnTimer = setTimeout(function () {
           returnTimer = null;
+          if (signal === 'blur' && document.hasFocus()) {
+            // The blur was likely the confirmation dialog opening and the
+            // user cancelled — or they deliberately came back to this page.
+            // Navigating now would yank them away (and, mid-dialog, kill
+            // the launch), so stay put and let them retry manually.
+            console.log('[tbd-open] skipping auto-return: page has focus at fire time (dialog cancelled or user returned)');
+            returned = false; // allow the manual button / a later signal to retry cleanly
+            status.textContent = 'TBD may not have opened — use the button below.';
+            return;
+          }
           if (canGoBack) {
             console.log('[tbd-open] calling history.back() now');
             history.back();
@@ -145,7 +165,7 @@
               console.log('[tbd-open] window.close() was ignored by the browser — tab still alive');
             }, 500);
           }
-        }, RETURN_DELAY_MS);
+        }, delay);
       }
 
       document.addEventListener('visibilitychange', function () {

--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -87,7 +87,12 @@
       //     silently miss even though the handler launched.
       //   - window blur: fires whenever the browser window loses focus,
       //     including when TBD activates without occluding it. This catches
-      //     the partial-occlusion case visibilitychange misses.
+      //     the partial-occlusion case visibilitychange misses. Note blur
+      //     fires BEFORE hidden even in the full-occlusion/minimize case
+      //     (OS focus loss precedes the browser's occlusion recompute), so
+      //     the first signal to arrive is almost always blur — a later
+      //     'hidden' therefore upgrades a pending blur-scheduled return to
+      //     the fast path instead of being ignored (see onOpened()).
       //
       // Known wrinkle: blur is also fired by the browser's "Open TBD.app?"
       // confirmation dialog the moment it OPENS — before the user has
@@ -114,6 +119,9 @@
       var armedUntil = 0;
       var returned = false;
       var returnTimer = null;
+      // Which signal scheduled the currently pending returnTimer — lets a
+      // later 'hidden' recognize (and upgrade) a blur-scheduled return.
+      var pendingSignal = null;
 
       function arm() {
         armedUntil = Date.now() + DETECT_WINDOW_MS;
@@ -121,21 +129,15 @@
           '(' + DETECT_WINDOW_MS + 'ms from now)');
       }
 
-      function onOpened(signal) {
-        if (returned) return; // guard against double-fire
-        returned = true;
-        var canGoBack = history.length > 1;
+      function scheduleReturn(signal, canGoBack) {
         // 'hidden' is unambiguous — return quickly. 'blur' may just be the
         // "Open TBD.app?" dialog opening, so give it long enough to outlast
         // most dialog interactions before we decide.
         var delay = signal === 'blur' ? BLUR_RETURN_DELAY_MS : RETURN_DELAY_MS;
-        console.log('[tbd-open] onOpened(): signal =', signal,
-          '; history.length =', history.length,
+        console.log('[tbd-open] scheduleReturn(): signal =', signal,
           '— will', canGoBack ? 'history.back()' : 'window.close()',
           'in', delay + 'ms');
-        status.textContent = canGoBack
-          ? 'Opened in TBD — taking you back…'
-          : 'TBD opened — you can close this tab.';
+        pendingSignal = signal;
         // Short delay so the scheme launch isn't interrupted by navigating
         // away. (The tab is usually backgrounded here, but not guaranteed —
         // the return proceeds even if the tab is visible again by then,
@@ -143,6 +145,7 @@
         // has regained focus.)
         returnTimer = setTimeout(function () {
           returnTimer = null;
+          pendingSignal = null;
           if (signal === 'blur' && document.hasFocus()) {
             // The blur was likely the confirmation dialog opening and the
             // user cancelled — or they deliberately came back to this page.
@@ -168,6 +171,34 @@
             }, 500);
           }
         }, delay);
+      }
+
+      function onOpened(signal) {
+        if (returned) {
+          // blur fires before hidden even in the full-occlusion/minimize
+          // case, so a blur-scheduled return is usually already pending when
+          // 'hidden' arrives. 'hidden' is the unambiguous signal (the
+          // confirmation dialog never hides the document), so let it preempt
+          // the slow blur path and upgrade to the fast unconditional return.
+          if (signal === 'hidden' && pendingSignal === 'blur' && returnTimer !== null) {
+            console.log('[tbd-open] hidden signal upgrading pending blur return to the fast unconditional path');
+            clearTimeout(returnTimer);
+            returnTimer = null;
+            pendingSignal = null;
+            // Status text was already set by the first onOpened — no need
+            // to set it again here.
+            scheduleReturn('hidden', history.length > 1);
+          }
+          return; // guard against double-fire
+        }
+        returned = true;
+        var canGoBack = history.length > 1;
+        console.log('[tbd-open] onOpened(): signal =', signal,
+          '; history.length =', history.length);
+        status.textContent = canGoBack
+          ? 'Opened in TBD — taking you back…'
+          : 'TBD opened — you can close this tab.';
+        scheduleReturn(signal, canGoBack);
       }
 
       document.addEventListener('visibilitychange', function () {
@@ -218,6 +249,7 @@
           console.log('[tbd-open] pending return timer cancelled by manual click');
           clearTimeout(returnTimer);
           returnTimer = null;
+          pendingSignal = null;
         }
         // Reset so a retry after a false positive (whose window.close() was
         // ignored) can trigger the status update and auto-return again.

--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -138,7 +138,9 @@
           : 'TBD opened — you can close this tab.';
         // Short delay so the scheme launch isn't interrupted by navigating
         // away. (The tab is usually backgrounded here, but not guaranteed —
-        // the return proceeds even if it's visible again by then.)
+        // the return proceeds even if the tab is visible again by then,
+        // except on the blur path, which skips at fire time when the page
+        // has regained focus.)
         returnTimer = setTimeout(function () {
           returnTimer = null;
           if (signal === 'blur' && document.hasFocus()) {


### PR DESCRIPTION
## Summary
- **What's broken:** the redirect page's auto-return (#416, #436) never fired for real launches. Field `[tbd-open]` diagnostics showed Chrome logging `Launched external handler for 'tbd://…'` while `visibilitychange` never fired: Chrome only flips `document.hidden` on tab-switch, minimize, or *full* occlusion, so when TBD's window doesn't completely cover the browser (large monitor, side-by-side), the visibility-only success detection silently missed every launch.
- **Fix:** accept `window.blur` as a second success signal — it fires when TBD takes app focus regardless of window geometry. `visibilitychange` stays. Blur fires before hidden even under full occlusion (focus loss precedes the occlusion recompute), so a later `hidden` inside the armed window *upgrades* a pending blur-scheduled return to the fast unconditional path rather than being ignored; `onOpened()` logs which signal drove the return.
- **Dialog-race hardening (from code review):** the "Open TBD.app?" confirmation dialog fires blur the moment it *opens*, so a fast return could execute mid-dialog and kill the launch. Blur-triggered returns therefore wait 4s (vs 600ms for `hidden`) and re-check `document.hasFocus()` at fire time — focus back on the page means the dialog was cancelled or the user deliberately returned, so the navigation is skipped, `returned` resets for a clean manual retry, and the status points at the button. Residual gap documented in-file: taking >4s to click "Allow" can still fire the return mid-dialog.

## Test plan
- [ ] Big-monitor / side-by-side setup with "always allow" ticked: click a redirector link from a PR page → TBD opens without covering Chrome → console shows `onOpened(): signal = blur` → tab returns to the PR ~4s later (previously: nothing)
- [ ] Full-occlusion / minimized case: `signal = hidden` still returns after 600ms as before
- [ ] First-run dialog path: cancel the "Open TBD.app?" dialog → no navigation; status offers the manual button; clicking it retries cleanly
- [ ] Console `[tbd-open]` trail names the winning signal and logs any skipped return

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=61966922-0E69-4FD6-9CF0-4FC4612C73EF)
