### PR TITLE
nightwatch: verify PR state live before waking hibernated terminals (wake.py)

### DIFF
--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -158,6 +158,9 @@ struct TerminalWake: AsyncParsableCommand {
     @Option(name: .long, help: "Terminal ID")
     var terminal: String
 
+    @Option(name: .long, help: "Prompt delivered to the resumed claude as an argv (atomic with the respawn). NOT delivered when the wake is a no-op — check `woken` in the output.")
+    var prompt: String?
+
     @Flag(name: .long, help: "If the pinned account profile no longer exists, resume on the default login instead of failing")
     var fallbackToDefaultProfile = false
 
@@ -170,18 +173,22 @@ struct TerminalWake: AsyncParsableCommand {
         }
 
         let client = SocketClient()
-        try client.callVoid(
+        let result: TerminalWakeResult = try client.call(
             method: RPCMethod.terminalWake,
             params: TerminalWakeParams(
                 terminalID: terminalID,
-                fallbackToDefaultProfile: fallbackToDefaultProfile ? true : nil
-            )
+                fallbackToDefaultProfile: fallbackToDefaultProfile ? true : nil,
+                prompt: prompt
+            ),
+            resultType: TerminalWakeResult.self
         )
 
         if json {
-            printJSON(["status": "awake"])
+            printJSON(["woken": result.woken])
         } else {
-            print("Terminal awake.")
+            print(result.woken
+                ? "Terminal woken."
+                : "Terminal already awake (no-op)\(prompt != nil ? " — prompt NOT delivered" : "").")
         }
     }
 }

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -6,7 +6,7 @@ struct TerminalCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "terminal",
         abstract: "Manage terminals",
-        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self, TerminalPin.self, TerminalUnpin.self, TerminalSwapProfile.self]
+        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalWake.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self, TerminalPin.self, TerminalUnpin.self, TerminalSwapProfile.self]
     )
 }
 
@@ -143,6 +143,45 @@ struct TerminalSend: AsyncParsableCommand {
             printJSON(["status": "sent"])
         } else {
             print("Text sent.")
+        }
+    }
+}
+
+// MARK: - terminal wake
+
+struct TerminalWake: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "wake",
+        abstract: "Wake a hibernated terminal (respawn claude --resume). Idempotent: waking a non-hibernated terminal is a no-op."
+    )
+
+    @Option(name: .long, help: "Terminal ID")
+    var terminal: String
+
+    @Flag(name: .long, help: "If the pinned account profile no longer exists, resume on the default login instead of failing")
+    var fallbackToDefaultProfile = false
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        let client = SocketClient()
+        try client.callVoid(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(
+                terminalID: terminalID,
+                fallbackToDefaultProfile: fallbackToDefaultProfile ? true : nil
+            )
+        )
+
+        if json {
+            printJSON(["status": "awake"])
+        } else {
+            print("Terminal awake.")
         }
     }
 }

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -11,6 +11,8 @@ import TBDShared
 ///
 /// Behavior:
 /// - `resumeID` non-nil → `claude --resume <id> --dangerously-skip-permissions`
+///   with optional trailing initial-prompt arg (delivered atomically with the
+///   resume — no post-spawn paste, so it can never land in the wrong process).
 /// - `freshSessionID` non-nil → `claude --session-id <id> --dangerously-skip-permissions`
 ///   with optional `--append-system-prompt` and trailing initial-prompt arg.
 /// - Otherwise → `cmd` if set, else `shellFallback`.
@@ -80,7 +82,11 @@ enum ClaudeSpawnCommandBuilder {
 
         let base: String
         if let resumeID {
-            base = "claude --resume \(resumeID) --dangerously-skip-permissions\(settingsFlag)\(pluginFlag)"
+            var b = "claude --resume \(resumeID) --dangerously-skip-permissions\(settingsFlag)\(pluginFlag)"
+            if let p = initialPrompt, !p.isEmpty {
+                b += " \(SystemPromptBuilder.shellEscape(p))"
+            }
+            base = b
         } else if let sessionID = freshSessionID {
             var b = "claude --session-id \(sessionID) --dangerously-skip-permissions\(settingsFlag)\(pluginFlag)"
             if let prompt = appendSystemPrompt {

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -433,7 +433,7 @@ public actor HibernationCoordinator {
     /// machine reboot), the window is recreated (ensureServer + createWindow)
     /// and the same resume command spawned there; the terminal row keeps its
     /// identity and gets the new window/pane ids persisted.
-    public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, allowDefaultProfileFallback: Bool = false) async -> WakeResult {
+    public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, allowDefaultProfileFallback: Bool = false, initialPrompt: String? = nil) async -> WakeResult {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
         }
@@ -537,7 +537,11 @@ public actor HibernationCoordinator {
             resumeID: sessionID,
             freshSessionID: nil,
             appendSystemPrompt: nil,
-            initialPrompt: nil,
+            // Delivered as a trailing argv to `claude --resume` — atomic with
+            // the respawn, so it reaches ONLY a session this call actually
+            // woke (an already-awake terminal returns .notHibernated above
+            // and the prompt is never delivered anywhere).
+            initialPrompt: initialPrompt,
             profileSecret: resolvedProfile?.secret,
             profileKind: resolvedProfile?.kind,
             profileBaseURL: resolvedProfile?.baseURL,

--- a/Sources/TBDDaemon/Lifecycle/PluginDirWriter.swift
+++ b/Sources/TBDDaemon/Lifecycle/PluginDirWriter.swift
@@ -101,6 +101,7 @@ struct PluginDirWriter {
         // is installed but NEVER auto-loaded — durable scheduling is opt-in via
         // `scheduler.sh enable`.
         for (name, body) in [("tick.py", NightwatchSkillContent.tickPy),
+                             ("wake.py", NightwatchSkillContent.wakePy),
                              ("judge.py", NightwatchSkillContent.judgePy),
                              ("tick-cron.sh", NightwatchSkillContent.tickCronSh),
                              ("scheduler.sh", NightwatchSkillContent.schedulerSh)] {

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -30,12 +30,17 @@ extension RPCRouter {
         let params = try decoder.decode(TerminalWakeParams.self, from: paramsData)
         let result = await hibernationCoordinator.wake(
             terminalID: params.terminalID, cols: params.cols, rows: params.rows,
-            allowDefaultProfileFallback: params.fallbackToDefaultProfile ?? false
+            allowDefaultProfileFallback: params.fallbackToDefaultProfile ?? false,
+            initialPrompt: params.prompt
         )
         switch result {
-        case .ok, .notHibernated, .inFlight:
-            // notHibernated / inFlight are benign no-ops for an idempotent wake.
-            return .ok()
+        case .ok:
+            return try RPCResponse(result: TerminalWakeResult(woken: true))
+        case .notHibernated, .inFlight:
+            // Benign no-ops for an idempotent wake — but report woken: false so
+            // autonomous callers know their `prompt` was NOT delivered (the
+            // terminal is live; pasting into it now could hit a human session).
+            return try RPCResponse(result: TerminalWakeResult(woken: false))
         case .notFound:
             return RPCResponse(error: "Terminal not found")
         case .noSessionID:

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -55,7 +55,9 @@ a PR that had merged three days earlier). **Every wake goes through the verifier
 
 ```
 python3 scripts/wake.py            # dry-run: live-verified wake plan for all hibernated terminals
-python3 scripts/wake.py --act      # dispatch the verified prompts (tbd terminal send --submit)
+python3 scripts/wake.py --act      # dispatch: `tbd terminal wake` then `tbd terminal send --submit`
+                                   # (send alone pastes into the bare post-hibernation shell — only
+                                   # the wake RPC respawns `claude --resume`)
 python3 scripts/wake.py --tid ID   # one terminal · --no-fetch during a GitHub-rate crunch
 ```
 
@@ -145,7 +147,9 @@ Rules it enforces:
 Usage:
   wake.py               # dry-run: verified wake plan for ALL hibernated terminals
   wake.py --tid <ID>    # limit to one terminal
-  wake.py --act         # dispatch wake prompts via `tbd terminal send --submit`
+  wake.py --act         # dispatch: `tbd terminal wake` (respawn claude --resume),
+                        # then `tbd terminal send --submit` — send alone pastes
+                        # into the bare post-hibernation shell, never claude
   wake.py --no-fetch    # skip `git fetch` (offline / GitHub rate crunch)
 
 Exit 0 always (a wake plan is informational); per-item status is in the output
@@ -187,7 +191,10 @@ def hibernated(only_tid=None):
          "COALESCE(t.hibernateReason,'') AS reason, "
          "COALESCE(t.suspendedSnapshot,'') AS snapshot FROM terminal t "
          "JOIN worktree w ON w.id=t.worktreeID "
-         "WHERE w.status='active' AND t.kind='claude' AND t.hibernatedAt IS NOT NULL")
+         # Parked = hibernatedAt OR legacy suspendedAt — mirrors the daemon's
+         # Terminal.isParked, so legacy-parked rows can't bypass the verifier.
+         "WHERE w.status='active' AND t.kind='claude' "
+         "AND (t.hibernatedAt IS NOT NULL OR t.suspendedAt IS NOT NULL)")
     out, rc = sh(["sqlite3", "-json", DB, q + ";"])
     if rc != 0:
         return []
@@ -244,6 +251,11 @@ def verify(item, fetch=True):
     stale_prs = []
     for num in list(dict.fromkeys(mentioned))[:8]:
         out, rc = gh(["pr", "view", num, "--json", "state,headRefName"], cwd=path)
+        # Silent continue is deliberate: snapshot text also mentions ISSUE
+        # numbers, which `gh pr view` rejects — a per-mention "NOT verified"
+        # fact would be constant noise. This loop only ADDS informational
+        # stale-premise callouts; the classification below fails closed on
+        # its own gh errors, so nothing safety-relevant is lost here.
         if rc != 0: continue
         try: j = json.loads(out)
         except Exception: continue
@@ -334,13 +346,25 @@ def main():
         print(f"  ▸ {it['name']} ({it['tid'][:8]}): {v['classification']} — "
               + ("; ".join(v["facts"])[:110] or "-"))
         if act:
-            _, rc = sh(["tbd", "terminal", "send", "--terminal", it["tid"],
-                        "--submit", "--text", v["wake_text"]], t=30)
-            v["dispatched"] = rc == 0
+            # WAKE FIRST: `terminal send` pastes into whatever the pane currently
+            # runs — after hibernation that is a bare shell, NOT claude. Only
+            # `terminal wake` (RPC terminal.wake) respawns `claude --resume`;
+            # it is idempotent (no-op on a non-hibernated terminal). Then give
+            # claude a beat to be input-ready before pasting (the daemon's own
+            # post-wake session recapture allows 5s for it to settle).
+            _, wake_rc = sh(["tbd", "terminal", "wake", "--terminal", it["tid"]], t=60)
+            if wake_rc != 0:
+                v["dispatched"] = False
+                print("    ✗ wake RPC failed — NOT sending (text would land in a dead pane)")
+            else:
+                time.sleep(8)
+                _, rc = sh(["tbd", "terminal", "send", "--terminal", it["tid"],
+                            "--submit", "--text", v["wake_text"]], t=30)
+                v["dispatched"] = rc == 0
             with open(f"{QUEUE}/acted.jsonl", "a") as f:
                 f.write(json.dumps({"kind": "wake-dispatch", "tid": it["tid"],
                                     "name": it["name"], "classification": v["classification"],
-                                    "ok": rc == 0, "ts": int(time.time())}) + "\n")
+                                    "ok": v["dispatched"], "ts": int(time.time())}) + "\n")
     os.makedirs(QUEUE, exist_ok=True)
     json.dump({"ts": int(time.time()), "plan": plan},
               open(f"{QUEUE}/wake-plan.json", "w"), indent=2)

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -46,19 +46,40 @@ python3 scripts/tick.py --prs  # also gate open PRs (wraps loop_perfect_sweep.py
 
 Only when `tick.py` exits 10 (or on the 2-hour deep-review window): read `queue/decisions.jsonl`, resolve each genuine decision (what Adam would decide; sensitive/personal/access → `for-adam.md`, don't auto-fire), then clear the drained lines. This is the only step that should consume Opus.
 
+## Waking hibernated terminals (wake.py — never compose wake premises by hand)
+
+A hibernated terminal's snapshot/reason describes the world at hibernation time; PRs merge,
+checks go green, and branches land while it sleeps. Composing a wake prompt from that
+snapshot ships a stale premise (2026-07-13: a session was woken to "fix FAILING checks" on
+a PR that had merged three days earlier). **Every wake goes through the verifier:**
+
+```
+python3 scripts/wake.py            # dry-run: live-verified wake plan for all hibernated terminals
+python3 scripts/wake.py --act      # dispatch the verified prompts (tbd terminal send --submit)
+python3 scripts/wake.py --tid ID   # one terminal · --no-fetch during a GitHub-rate crunch
+```
+
+Per terminal it re-derives truth AT WAKE TIME — live PR state for any PR number in the
+hibernate reason (MERGED/CLOSED never yields a "fix your PR" wake), the checked-out branch's
+actual open PR + failing checks, and unmerged-commit state vs origin/main — then classifies
+(DONE → /closeout · RESUME_FAILING/OPEN · UNSUBMITTED_WORK · UNVERIFIED → neutral "verify
+first" prompt) and writes `queue/wake-plan.json`. First real sweep: 24/24 hibernated
+terminals verified DONE — every hand-composed "resume" wake would have been stale.
+
 ## The gate (never automate past this)
 
 A PR may only be enqueued when **claude-review = APPROVED on the current SHA + checks clean**. Human approval never substitutes. `gh pr merge` is NOT a safe-wedge — it always escalates. nightwatch's job is to get PRs *ready*; the human merges.
 
-## Operating rules (hard-won via incidents)
-
-**REBALANCE FIRST on saturation** — A capacity crunch is usually too many sessions piled on ONE rate-capped account, not global scarcity. Swap stuck (STRANDED/RATE/ERROR) sessions onto an emptier account via `tbd terminal swap-profile --terminal <tid> --profile <name>` (parked=cold/cheap, awake=respawn). Passive holding just freezes them. *(Incident 2026-07-10: 14 of 19 stuck sessions were piled on one account; the watcher held instead of rebalancing and the whole fleet stalled overnight until rebalanced.)*
-
-**READ context before nudging** — Capture the worker's actual conversation (`tbd terminal conversation --terminal <tid>` or the pane) and give a SPECIFIC next step, not a blanket "continue" (which just makes agents re-idle).
-
-**FOLLOW UP in ~90s** — After nudging (background sleep), re-check in ~90 seconds rather than waiting for the next tick. Catches agents mid-action at confirm/permission prompts that would otherwise hang the whole cycle.
-
-**ALWAYS SIGN commits** — Never use `gpgsign=false`; some repos (longeye-ai/monorepo) silently reject unsigned commits.
+**Send-time verification — the wake.py rule applies to EVERY PR-state message, not just wakes.**
+Before dispatching any message that asserts PR state (a gate denial, a "checks failing" nudge, a
+"needs review" ping), re-read live state *in the same breath as the send*: `gh pr view N --json
+state,headRefOid,mergeStateStatus`. If `state` is MERGED/CLOSED, or the head SHA moved since the
+sweep, drop or recompose the message — never dispatch a fact older than the current tool call.
+(2026-07-13: two gate denials landed in a session's inbox describing PRs that had already merged
+or were already sitting in the merge queue — same stale-premise class the wake verifier was built
+for.) And phrase gate outcomes honestly: nightwatch cannot deny a GitHub enqueue; its gate is
+*stricter than the org's required checks* (AI Review is advisory until the ADR-0013 apply), so a
+bot-verdict shortfall on a human-approved PR is an **advisory heads-up**, not a "denied".
 
 ## Config (`config/`)
 - `priorities.txt` — must-keep-moving worktrees (flagged ★, reported first)
@@ -88,6 +109,210 @@ When enabled, launchd runs `tick.py` on the interval ($0, no model), stays silen
 and on exit 10 (judgment queued) records a marker + fires `tbd notify`. This is the durable,
 quota-free replacement for waking Opus on a timer. It is intentionally NOT loaded by the
 plugin installer — you turn it on only where you want a fleet babysat.
+"""#
+
+    public static let wakePy: String = #"""
+#!/usr/bin/env python3
+"""
+nightwatch wake — pre-wake verifier for hibernated terminals. NO model, NO stale state.
+
+The 2026-07-13 lesson: wake prompts composed from hibernation-time snapshots carry
+stale premises (a session was woken to "fix FAILING checks" on a PR that had merged
+three days earlier). This script makes the wake premise DETERMINISTIC and LIVE:
+for every hibernated terminal it re-derives the truth from git + gh AT WAKE TIME,
+classifies the work, and composes the wake prompt from verified facts only.
+
+Rules it enforces:
+  - A PR named in a wake premise is checked live (`gh pr view --json state`);
+    MERGED/CLOSED PRs never produce a "fix your PR" wake — they produce /closeout.
+  - A local branch name is NOT evidence of unfinished work: if the branch has no
+    unmerged commits vs origin/main (or its PR merged), the work is DONE.
+  - Anything unverifiable (gh failure, no repo, detached head) wakes NEUTRAL —
+    "verify live state first" — never with an asserted premise.
+
+Usage:
+  wake.py               # dry-run: verified wake plan for ALL hibernated terminals
+  wake.py --tid <ID>    # limit to one terminal
+  wake.py --act         # dispatch wake prompts via `tbd terminal send --submit`
+  wake.py --no-fetch    # skip `git fetch` (offline / GitHub rate crunch)
+
+Exit 0 always (a wake plan is informational); per-item status is in the output
+and queue/wake-plan.json.
+"""
+import subprocess, os, re, json, time, sys
+
+HOME = os.path.expanduser("~")
+DB = f"{HOME}/tbd/state.db"
+SKILL = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+QUEUE = f"{SKILL}/queue"
+
+STANDING_RULE = ("If the task is complete, run /closeout. Resume only if genuinely "
+                 "unfinished. Do NOT merge — the human merges.")
+
+
+def sh(args, t=20, cwd=None):
+    try:
+        r = subprocess.run(args, capture_output=True, text=True, timeout=t, cwd=cwd)
+        return r.stdout.strip(), r.returncode
+    except Exception:
+        return "", 1
+
+
+def gh(args, t=25, cwd=None):
+    # gh transits the cache proxy via the shell function, not env — plain exec is direct.
+    return sh(["gh", *args], t=t, cwd=cwd)
+
+
+def hibernated(only_tid=None):
+    q = ("SELECT t.id, w.displayName, w.path, w.branch, t.hibernatedAt, "
+         "COALESCE(t.hibernateReason,'') FROM terminal t "
+         "JOIN worktree w ON w.id=t.worktreeID "
+         "WHERE w.status='active' AND t.kind='claude' AND t.hibernatedAt IS NOT NULL")
+    out, _ = sh(["sqlite3", "-separator", "\t", DB, q + ";"])
+    items = []
+    for l in out.splitlines():
+        p = l.split("\t")
+        if len(p) < 6: continue
+        tid, name, path, db_branch, hib_at, reason = p[0], p[1], p[2], p[3], p[4], p[5]
+        if only_tid and tid != only_tid: continue
+        items.append({"tid": tid, "name": name, "path": path,
+                      "db_branch": db_branch, "hibernated_at": hib_at, "reason": reason})
+    return items
+
+
+def verify(item, fetch=True):
+    """Re-derive live truth for one hibernated terminal. Returns a verdict dict."""
+    path = item["path"]
+    facts: list = []
+    v = {"tid": item["tid"], "name": item["name"], "path": path,
+         "classification": "UNVERIFIED", "facts": facts, "pr": None}
+    if not os.path.isdir(path):
+        facts.append("worktree path missing on disk")
+        return v
+
+    branch, rc = sh(["git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD"])
+    if rc != 0 or not branch or branch == "HEAD":
+        facts.append("no branch (detached or not a repo)")
+        return v
+    v["branch"] = branch
+    if fetch:
+        sh(["git", "-C", path, "fetch", "origin", "main"], t=30)
+
+    dirty, _ = sh(["git", "-C", path, "status", "--porcelain"])
+    v["dirty"] = bool(dirty)
+
+    # Unmerged commits vs origin/main — squash-merge aware (`git cherry` patch-id match).
+    cherry, rc = sh(["git", "-C", path, "cherry", "origin/main"])
+    unmerged = [l for l in cherry.splitlines() if l.startswith("+")] if rc == 0 else None
+    v["unmerged_commits"] = len(unmerged) if unmerged is not None else None
+
+    # THE core check: any PR number named in the hibernate reason is verified LIVE.
+    stale_prs = []
+    for num in re.findall(r"#(\d{3,6})", item["reason"]):
+        out, rc = gh(["pr", "view", num, "--json", "state,headRefName"], cwd=path)
+        if rc != 0: continue
+        try: j = json.loads(out)
+        except Exception: continue
+        if j.get("state") != "OPEN" or j.get("headRefName") != branch:
+            stale_prs.append(f"#{num} is {j.get('state')} (head {j.get('headRefName')}) "
+                             f"— hibernate-time premise is stale")
+    facts.extend(stale_prs)
+
+    # Live PR for the ACTUAL checked-out branch (any state).
+    out, rc = gh(["pr", "list", "--head", branch, "--state", "all",
+                  "--json", "number,state,title", "--limit", "5"], cwd=path)
+    prs = []
+    if rc == 0 and out:
+        try: prs = json.loads(out)
+        except Exception: pass
+    elif rc != 0:
+        facts.append("gh unavailable — PR state NOT verified")
+        return v
+    open_pr = next((p for p in prs if p["state"] == "OPEN"), None)
+    merged_pr = next((p for p in prs if p["state"] == "MERGED"), None)
+
+    if open_pr:
+        v["pr"] = open_pr["number"]
+        checks, _ = gh(["pr", "checks", str(open_pr["number"])], cwd=path)
+        failing = [l.split("\t")[0] for l in checks.splitlines()
+                   if "\tfail" in l or "\tfailure" in l]
+        v["failing_checks"] = failing
+        v["classification"] = "RESUME_FAILING" if failing else "RESUME_OPEN"
+        facts.append(f"open PR #{open_pr['number']}"
+                     + (f", failing: {', '.join(failing[:4])}" if failing else ", checks not failing"))
+    elif merged_pr or unmerged is not None and not unmerged:
+        v["classification"] = "DONE"
+        facts.append(f"PR #{merged_pr['number']} MERGED" if merged_pr
+                     else "no unmerged commits vs origin/main")
+    elif unmerged:
+        v["classification"] = "UNSUBMITTED_WORK"
+        facts.append(f"{len(unmerged)} commit(s) not in origin/main, no PR")
+    else:
+        v["classification"] = "DONE" if not v["dirty"] else "UNVERIFIED"
+        if v["dirty"]: facts.append("dirty working tree, merge state unknown")
+    if v["dirty"] and v["classification"] == "DONE":
+        facts.append("note: dirty working tree — closeout should triage it")
+    return v
+
+
+def compose(v):
+    """Wake prompt from verified facts ONLY. Never assert a premise wake-time data disproves."""
+    facts = "; ".join(v["facts"]) or "no live facts derivable"
+    c = v["classification"]
+    if c == "DONE":
+        return (f"Nightwatch wake (state verified live): your work here appears COMPLETE "
+                f"({facts}). Run /closeout now. {STANDING_RULE}")
+    if c == "RESUME_FAILING":
+        return (f"Nightwatch wake (state verified live): PR #{v['pr']} on branch {v.get('branch')} "
+                f"has failing checks ({facts}). Diagnose, fix, push, drive to checks-green + "
+                f"claude-review approved on the current SHA. {STANDING_RULE}")
+    if c == "RESUME_OPEN":
+        return (f"Nightwatch wake (state verified live): PR #{v['pr']} on branch {v.get('branch')} "
+                f"is open ({facts}). Drive it to ready (checks green + claude-review approved) or "
+                f"/closeout if it's actually done. {STANDING_RULE}")
+    if c == "UNSUBMITTED_WORK":
+        return (f"Nightwatch wake (state verified live): branch {v.get('branch')} has {facts}. "
+                f"Decide: finish and open a PR, or /closeout and abandon. {STANDING_RULE}")
+    return (f"Nightwatch wake: live state could NOT be verified ({facts}). Before doing anything, "
+            f"verify with git/gh what is actually outstanding — do not trust any earlier premise. "
+            f"{STANDING_RULE}")
+
+
+def main():
+    act = "--act" in sys.argv
+    fetch = "--no-fetch" not in sys.argv
+    tid = None
+    if "--tid" in sys.argv:
+        i = sys.argv.index("--tid")
+        tid = sys.argv[i + 1] if i + 1 < len(sys.argv) else None
+    items = hibernated(tid)
+    print(f"=== nightwatch wake @ {time.strftime('%H:%M:%S')} "
+          f"{'[ACT]' if act else '[dry-run]'} — {len(items)} hibernated ===")
+    plan = []
+    for it in items:
+        v = verify(it, fetch=fetch)
+        v["wake_text"] = compose(v)
+        plan.append(v)
+        print(f"  ▸ {it['name']} ({it['tid'][:8]}): {v['classification']} — "
+              + ("; ".join(v["facts"])[:110] or "-"))
+        if act:
+            _, rc = sh(["tbd", "terminal", "send", "--terminal", it["tid"],
+                        "--submit", "--text", v["wake_text"]], t=30)
+            v["dispatched"] = rc == 0
+            with open(f"{QUEUE}/acted.jsonl", "a") as f:
+                f.write(json.dumps({"kind": "wake-dispatch", "tid": it["tid"],
+                                    "name": it["name"], "classification": v["classification"],
+                                    "ok": rc == 0, "ts": int(time.time())}) + "\n")
+    os.makedirs(QUEUE, exist_ok=True)
+    json.dump({"ts": int(time.time()), "plan": plan},
+              open(f"{QUEUE}/wake-plan.json", "w"), indent=2)
+    done = sum(1 for v in plan if v["classification"] == "DONE")
+    print(f"\n→ {done}/{len(plan)} verified DONE (would have been stale 'resume' wakes without "
+          f"verification). Plan: queue/wake-plan.json")
+
+
+if __name__ == "__main__":
+    main()
 """#
 
     public static let tickPy: String = #"""

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -281,13 +281,23 @@ def verify(item, fetch=True):
 
     if open_pr:
         v["pr"] = open_pr["number"]
-        checks, _ = gh(["pr", "checks", str(open_pr["number"])], cwd=path)
-        failing = [l.split("\t")[0] for l in checks.splitlines()
-                   if "\tfail" in l or "\tfailure" in l]
-        v["failing_checks"] = failing
-        v["classification"] = "RESUME_FAILING" if failing else "RESUME_OPEN"
-        facts.append(f"open PR #{open_pr['number']}"
-                     + (f", failing: {', '.join(failing[:4])}" if failing else ", checks not failing"))
+        checks, checks_rc = gh(["pr", "checks", str(open_pr["number"])], cwd=path)
+        # `gh pr checks` exits non-zero when checks are failing OR pending, so
+        # rc alone doesn't mean the command failed — empty output with rc!=0
+        # does. In that case the checks state is UNVERIFIED: say so, never
+        # assert "checks not failing" on data we don't have.
+        if checks_rc != 0 and not checks:
+            v["failing_checks"] = None
+            v["classification"] = "RESUME_OPEN"
+            facts.append(f"open PR #{open_pr['number']}, failing-checks state "
+                         f"NOT verified (gh pr checks failed)")
+        else:
+            failing = [l.split("\t")[0] for l in checks.splitlines()
+                       if "\tfail" in l or "\tfailure" in l]
+            v["failing_checks"] = failing
+            v["classification"] = "RESUME_FAILING" if failing else "RESUME_OPEN"
+            facts.append(f"open PR #{open_pr['number']}"
+                         + (f", failing: {', '.join(failing[:4])}" if failing else ", checks not failing"))
     elif merged_pr or unmerged is not None and not unmerged:
         v["classification"] = "DONE"
         facts.append(f"PR #{merged_pr['number']} MERGED" if merged_pr
@@ -336,6 +346,10 @@ def main():
         i = sys.argv.index("--tid")
         tid = sys.argv[i + 1] if i + 1 < len(sys.argv) else None
     items = hibernated(tid)
+    # BEFORE the loop: --act appends to queue/acted.jsonl per terminal, and a
+    # missing queue/ would crash mid-dispatch — after real side effects fired
+    # but before they were logged. (tick.py/judge.py order it the same way.)
+    os.makedirs(QUEUE, exist_ok=True)
     print(f"=== nightwatch wake @ {time.strftime('%H:%M:%S')} "
           f"{'[ACT]' if act else '[dry-run]'} — {len(items)} hibernated ===")
     plan = []
@@ -365,7 +379,6 @@ def main():
                 f.write(json.dumps({"kind": "wake-dispatch", "tid": it["tid"],
                                     "name": it["name"], "classification": v["classification"],
                                     "ok": v["dispatched"], "ts": int(time.time())}) + "\n")
-    os.makedirs(QUEUE, exist_ok=True)
     json.dump({"ts": int(time.time()), "plan": plan},
               open(f"{QUEUE}/wake-plan.json", "w"), indent=2)
     done = sum(1 for v in plan if v["classification"] == "DONE")

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -55,9 +55,12 @@ a PR that had merged three days earlier). **Every wake goes through the verifier
 
 ```
 python3 scripts/wake.py            # dry-run: live-verified wake plan for all hibernated terminals
-python3 scripts/wake.py --act      # dispatch: `tbd terminal wake` then `tbd terminal send --submit`
-                                   # (send alone pastes into the bare post-hibernation shell — only
-                                   # the wake RPC respawns `claude --resume`)
+python3 scripts/wake.py --act      # dispatch: `tbd terminal wake --prompt <text>` — the wake text
+                                   # rides `claude --resume` as an argv, atomic with the respawn.
+                                   # An already-awake terminal (raced a human wake) reports
+                                   # woken:false and receives NOTHING. Never `terminal send` for
+                                   # wakes: it pastes into whatever the pane currently runs (bare
+                                   # post-hibernation shell, or a live human session).
 python3 scripts/wake.py --tid ID   # one terminal · --no-fetch during a GitHub-rate crunch
 ```
 
@@ -147,9 +150,13 @@ Rules it enforces:
 Usage:
   wake.py               # dry-run: verified wake plan for ALL hibernated terminals
   wake.py --tid <ID>    # limit to one terminal
-  wake.py --act         # dispatch: `tbd terminal wake` (respawn claude --resume),
-                        # then `tbd terminal send --submit` — send alone pastes
-                        # into the bare post-hibernation shell, never claude
+  wake.py --act         # dispatch: `tbd terminal wake --prompt <text>` — the wake
+                        # text rides the respawned `claude --resume` as an argv,
+                        # atomic with the wake. An already-awake terminal (raced a
+                        # human wake) reports woken:false and receives NOTHING.
+                        # Never `terminal send`: it pastes into whatever the pane
+                        # currently runs (bare shell, or a live human session).
+  wake.py --selftest    # offline classification-matrix test (monkeypatched git/gh)
   wake.py --no-fetch    # skip `git fetch` (offline / GitHub rate crunch)
 
 Exit 0 always (a wake plan is informational); per-item status is in the output
@@ -338,7 +345,71 @@ def compose(v):
             f"{STANDING_RULE}")
 
 
+def selftest():
+    """Offline classification-matrix test. Monkeypatches sh/gh so no git, gh,
+    sqlite3, or tbd binary is ever invoked — safe anywhere (CI runs it via
+    PluginDirWriterTests). Covers the fail-closed guarantees the docstring
+    promises: unverifiable state NEVER classifies DONE or asserts a premise."""
+    g = globals()
+    real_sh, real_gh = g["sh"], g["gh"]
+    item = {"tid": "T", "name": "t", "path": os.getcwd(), "db_branch": "b",
+            "hibernated_at": "x", "reason": "auto", "snapshot": ""}
+
+    def run(git, ghmap, snapshot=""):
+        def fake_sh(args, t=20, cwd=None):
+            assert args[0] == "git", f"unexpected non-git sh() in verify: {args}"
+            return git.get(args[3], ("", 1))
+        def fake_gh(args, t=25, cwd=None):
+            return ghmap.get(args[1], ("", 1))
+        g["sh"], g["gh"] = fake_sh, fake_gh
+        try:
+            return verify({**item, "snapshot": snapshot}, fetch=False)
+        finally:
+            g["sh"], g["gh"] = real_sh, real_gh
+
+    git_ok = {"rev-parse": ("feat", 0), "status": ("", 0), "cherry": ("", 0)}
+    open_pr = ('[{"number": 7, "state": "OPEN", "title": "t"}]', 0)
+
+    # 1. Clean tree, no unmerged commits, no PR → DONE.
+    v = run(git_ok, {"list": ("[]", 0)})
+    assert v["classification"] == "DONE", v
+    # 2. `git cherry` failure NEVER defaults to DONE — fail closed.
+    v = run({**git_ok, "cherry": ("", 1)}, {"list": ("[]", 0)})
+    assert v["classification"] == "UNVERIFIED", v
+    assert any("git cherry failed" in f for f in v["facts"]), v
+    # 3. gh failure → UNVERIFIED, premise explicitly not asserted.
+    v = run(git_ok, {"list": ("", 1)})
+    assert v["classification"] == "UNVERIFIED", v
+    assert any("gh unavailable" in f for f in v["facts"]), v
+    # 4. Unparseable gh output ≠ "no PR" → UNVERIFIED.
+    v = run(git_ok, {"list": ("gh: flaked mid-stream", 0)})
+    assert v["classification"] == "UNVERIFIED", v
+    assert any("unparseable" in f for f in v["facts"]), v
+    # 5. Open PR, `gh pr checks` dies (empty + rc!=0) → never "checks not failing".
+    v = run(git_ok, {"list": open_pr, "checks": ("", 1)})
+    assert v["classification"] == "RESUME_OPEN", v
+    assert any("NOT verified" in f for f in v["facts"]), v
+    assert "checks not failing" not in compose(v), compose(v)
+    # 6. Open PR with failing checks (rc!=0 WITH output = checks failing, not gh failing).
+    v = run(git_ok, {"list": open_pr, "checks": ("CI\tfail\t1m\turl", 1)})
+    assert v["classification"] == "RESUME_FAILING", v
+    # 7. Unmerged commits, no PR → UNSUBMITTED_WORK.
+    v = run({**git_ok, "cherry": ("+ abc123", 0)}, {"list": ("[]", 0)})
+    assert v["classification"] == "UNSUBMITTED_WORK", v
+    # 8. PR number in the SNAPSHOT (not reason — that's a closed enum) that is
+    #    MERGED → stale-premise fact; classification still independent (DONE).
+    v = run(git_ok, {"list": ("[]", 0),
+                     "view": ('{"state": "MERGED", "headRefName": "other"}', 0)},
+            snapshot="fix PR #14203 FAILING checks")
+    assert any("stale" in f for f in v["facts"]), v
+    assert v["classification"] == "DONE", v
+    print("selftest: 8/8 classification scenarios passed")
+
+
 def main():
+    if "--selftest" in sys.argv:
+        selftest()
+        return
     act = "--act" in sys.argv
     fetch = "--no-fetch" not in sys.argv
     tid = None
@@ -360,21 +431,25 @@ def main():
         print(f"  ▸ {it['name']} ({it['tid'][:8]}): {v['classification']} — "
               + ("; ".join(v["facts"])[:110] or "-"))
         if act:
-            # WAKE FIRST: `terminal send` pastes into whatever the pane currently
-            # runs — after hibernation that is a bare shell, NOT claude. Only
-            # `terminal wake` (RPC terminal.wake) respawns `claude --resume`;
-            # it is idempotent (no-op on a non-hibernated terminal). Then give
-            # claude a beat to be input-ready before pasting (the daemon's own
-            # post-wake session recapture allows 5s for it to settle).
-            _, wake_rc = sh(["tbd", "terminal", "wake", "--terminal", it["tid"]], t=60)
-            if wake_rc != 0:
-                v["dispatched"] = False
-                print("    ✗ wake RPC failed — NOT sending (text would land in a dead pane)")
-            else:
-                time.sleep(8)
-                _, rc = sh(["tbd", "terminal", "send", "--terminal", it["tid"],
-                            "--submit", "--text", v["wake_text"]], t=30)
-                v["dispatched"] = rc == 0
+            # The wake text rides `tbd terminal wake --prompt` as an argv to
+            # `claude --resume` — atomic with the respawn. NEVER `terminal
+            # send`: send pastes into whatever the pane currently runs (a bare
+            # shell after hibernation, or a LIVE human session if someone woke
+            # this terminal between our DB snapshot and now). On the idempotent
+            # no-op paths (already awake / wake in flight) the daemon reports
+            # woken:false and the prompt is not delivered anywhere. An old tbd
+            # binary without --prompt exits non-zero → fail closed, no dispatch.
+            out, wake_rc = sh(["tbd", "terminal", "wake", "--terminal", it["tid"],
+                               "--prompt", v["wake_text"], "--json"], t=60)
+            woken = False
+            if wake_rc == 0:
+                try: woken = bool(json.loads(out).get("woken"))
+                except Exception: woken = False
+            v["dispatched"] = woken
+            if not woken:
+                print("    ✗ not dispatched — " +
+                      ("terminal no longer parked (raced a live wake) — prompt withheld"
+                       if wake_rc == 0 else "wake failed or tbd binary lacks --prompt"))
             with open(f"{QUEUE}/acted.jsonl", "a") as f:
                 f.write(json.dumps({"kind": "wake-dispatch", "tid": it["tid"],
                                     "name": it["name"], "classification": v["classification"],

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -60,8 +60,10 @@ python3 scripts/wake.py --tid ID   # one terminal · --no-fetch during a GitHub-
 ```
 
 Per terminal it re-derives truth AT WAKE TIME — live PR state for any PR number in the
-hibernate reason (MERGED/CLOSED never yields a "fix your PR" wake), the checked-out branch's
-actual open PR + failing checks, and unmerged-commit state vs origin/main — then classifies
+hibernation context (`hibernateReason` is a closed enum; the narrative, including "fix PR #N"
+premises, lives in the `suspendedSnapshot` pane text, which wake.py scans ANSI-stripped;
+MERGED/CLOSED never yields a "fix your PR" wake), the checked-out branch's actual open PR +
+failing checks, and unmerged-commit state vs origin/main — then classifies
 (DONE → /closeout · RESUME_FAILING/OPEN · UNSUBMITTED_WORK · UNVERIFIED → neutral "verify
 first" prompt) and writes `queue/wake-plan.json`. First real sweep: 24/24 hibernated
 terminals verified DONE — every hand-composed "resume" wake would have been stale.
@@ -80,6 +82,16 @@ or were already sitting in the merge queue — same stale-premise class the wake
 for.) And phrase gate outcomes honestly: nightwatch cannot deny a GitHub enqueue; its gate is
 *stricter than the org's required checks* (AI Review is advisory until the ADR-0013 apply), so a
 bot-verdict shortfall on a human-approved PR is an **advisory heads-up**, not a "denied".
+
+## Operating rules (hard-won via incidents)
+
+**REBALANCE FIRST on saturation** — A capacity crunch is usually too many sessions piled on ONE rate-capped account, not global scarcity. Swap stuck (STRANDED/RATE/ERROR) sessions onto an emptier account via `tbd terminal swap-profile --terminal <tid> --profile <name>` (parked=cold/cheap, awake=respawn). Passive holding just freezes them. *(Incident 2026-07-10: 14 of 19 stuck sessions were piled on one account; the watcher held instead of rebalancing and the whole fleet stalled overnight until rebalanced.)*
+
+**READ context before nudging** — Capture the worker's actual conversation (`tbd terminal conversation --terminal <tid>` or the pane) and give a SPECIFIC next step, not a blanket "continue" (which just makes agents re-idle).
+
+**FOLLOW UP in ~90s** — After nudging (background sleep), re-check in ~90 seconds rather than waiting for the next tick. Catches agents mid-action at confirm/permission prompts that would otherwise hang the whole cycle.
+
+**ALWAYS SIGN commits** — Never use `gpgsign=false`; some repos (longeye-ai/monorepo) silently reject unsigned commits.
 
 ## Config (`config/`)
 - `priorities.txt` — must-keep-moving worktrees (flagged ★, reported first)
@@ -163,20 +175,34 @@ def gh(args, t=25, cwd=None):
     return sh(["gh", *args], t=t, cwd=cwd)
 
 
+ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+
+
 def hibernated(only_tid=None):
-    q = ("SELECT t.id, w.displayName, w.path, w.branch, t.hibernatedAt, "
-         "COALESCE(t.hibernateReason,'') FROM terminal t "
+    # hibernateReason is a closed enum (auto/manual/recovery/merged) — the narrative
+    # context (what the session was doing, PR numbers) lives in suspendedSnapshot.
+    # JSON output mode: suspendedSnapshot is multi-line, so -separator parsing breaks.
+    q = ("SELECT t.id AS tid, w.displayName AS name, w.path AS path, "
+         "w.branch AS db_branch, t.hibernatedAt AS hib_at, "
+         "COALESCE(t.hibernateReason,'') AS reason, "
+         "COALESCE(t.suspendedSnapshot,'') AS snapshot FROM terminal t "
          "JOIN worktree w ON w.id=t.worktreeID "
          "WHERE w.status='active' AND t.kind='claude' AND t.hibernatedAt IS NOT NULL")
-    out, _ = sh(["sqlite3", "-separator", "\t", DB, q + ";"])
+    out, rc = sh(["sqlite3", "-json", DB, q + ";"])
+    if rc != 0:
+        return []
+    try:
+        rows = json.loads(out) if out else []
+    except Exception:
+        return []
     items = []
-    for l in out.splitlines():
-        p = l.split("\t")
-        if len(p) < 6: continue
-        tid, name, path, db_branch, hib_at, reason = p[0], p[1], p[2], p[3], p[4], p[5]
-        if only_tid and tid != only_tid: continue
-        items.append({"tid": tid, "name": name, "path": path,
-                      "db_branch": db_branch, "hibernated_at": hib_at, "reason": reason})
+    for r in rows:
+        if only_tid and r["tid"] != only_tid: continue
+        # Strip ANSI, keep the tail — the most recent (most relevant) pane state.
+        snapshot = ANSI.sub("", r.get("snapshot") or "")[-4000:]
+        items.append({"tid": r["tid"], "name": r["name"], "path": r["path"],
+                      "db_branch": r["db_branch"], "hibernated_at": r["hib_at"],
+                      "reason": r["reason"], "snapshot": snapshot})
     return items
 
 
@@ -201,14 +227,22 @@ def verify(item, fetch=True):
     dirty, _ = sh(["git", "-C", path, "status", "--porcelain"])
     v["dirty"] = bool(dirty)
 
-    # Unmerged commits vs origin/main — squash-merge aware (`git cherry` patch-id match).
+    # Unmerged commits vs origin/main — patch-id match (`git cherry`). NOT fully
+    # squash-aware: N commits squashed into one won't match; DONE detection also
+    # leans on merged-PR state below. A cherry failure means merge state is
+    # UNVERIFIABLE — record it and never let it default to DONE.
     cherry, rc = sh(["git", "-C", path, "cherry", "origin/main"])
     unmerged = [l for l in cherry.splitlines() if l.startswith("+")] if rc == 0 else None
     v["unmerged_commits"] = len(unmerged) if unmerged is not None else None
+    if unmerged is None:
+        facts.append("unmerged-commit state NOT verified (git cherry failed)")
 
-    # THE core check: any PR number named in the hibernate reason is verified LIVE.
+    # THE core check: any PR number in the hibernation context is verified LIVE.
+    # hibernateReason is a closed enum and never names a PR — the snapshot (pane
+    # text at hibernation) is where a "fix PR #N" premise survives.
+    mentioned = re.findall(r"#(\d{3,6})", item["reason"] + " " + item.get("snapshot", ""))
     stale_prs = []
-    for num in re.findall(r"#(\d{3,6})", item["reason"]):
+    for num in list(dict.fromkeys(mentioned))[:8]:
         out, rc = gh(["pr", "view", num, "--json", "state,headRefName"], cwd=path)
         if rc != 0: continue
         try: j = json.loads(out)
@@ -222,12 +256,14 @@ def verify(item, fetch=True):
     out, rc = gh(["pr", "list", "--head", branch, "--state", "all",
                   "--json", "number,state,title", "--limit", "5"], cwd=path)
     prs = []
-    if rc == 0 and out:
-        try: prs = json.loads(out)
-        except Exception: pass
-    elif rc != 0:
+    if rc != 0:
         facts.append("gh unavailable — PR state NOT verified")
         return v
+    if out:
+        try: prs = json.loads(out)
+        except Exception:
+            facts.append("gh output unparseable — PR state NOT verified")
+            return v
     open_pr = next((p for p in prs if p["state"] == "OPEN"), None)
     merged_pr = next((p for p in prs if p["state"] == "MERGED"), None)
 
@@ -248,7 +284,9 @@ def verify(item, fetch=True):
         v["classification"] = "UNSUBMITTED_WORK"
         facts.append(f"{len(unmerged)} commit(s) not in origin/main, no PR")
     else:
-        v["classification"] = "DONE" if not v["dirty"] else "UNVERIFIED"
+        # unmerged is None here (cherry failed, fact already recorded) — merge
+        # state is unverifiable, so NEVER default to DONE: that would assert the
+        # exact kind of unverified premise this script exists to eliminate.
         if v["dirty"]: facts.append("dirty working tree, merge state unknown")
     if v["dirty"] and v["classification"] == "DONE":
         facts.append("note: dirty working tree — closeout should triage it")

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1211,12 +1211,28 @@ public struct TerminalWakeParams: Codable, Sendable {
     /// default login instead of failing with `.profileMissing`. nil == false ==
     /// strict (the default). Set true only on an explicit user retry.
     public let fallbackToDefaultProfile: Bool?
-    public init(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, fallbackToDefaultProfile: Bool? = nil) {
+    /// Optional prompt delivered as a trailing argv to `claude --resume` —
+    /// atomic with the respawn. It reaches ONLY a session this call actually
+    /// woke; on the idempotent no-op paths (already awake / wake in flight)
+    /// it is never delivered anywhere, which is what makes it safe for
+    /// autonomous callers (nightwatch wake.py) racing a human wake.
+    public let prompt: String?
+    public init(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, fallbackToDefaultProfile: Bool? = nil, prompt: String? = nil) {
         self.terminalID = terminalID
         self.cols = cols
         self.rows = rows
         self.fallbackToDefaultProfile = fallbackToDefaultProfile
+        self.prompt = prompt
     }
+}
+
+/// Result payload for `terminal.wake`.
+public struct TerminalWakeResult: Codable, Sendable {
+    /// true — this call respawned `claude --resume` (the terminal was parked);
+    /// false — idempotent no-op (already awake, or another wake in flight).
+    /// A `prompt` param is delivered only when true.
+    public let woken: Bool
+    public init(woken: Bool) { self.woken = woken }
 }
 
 /// Params for `terminal.setKeepWarm` — pin/unpin a terminal against

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -70,6 +70,23 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.command.hasSuffix(" 'do the thing'"))
     }
 
+    @Test("resume + initial prompt — argv delivery is atomic with the respawn")
+    func resumeWithInitialPrompt() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc-123",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: "wake: don't trust the snapshot",
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        // Exact-match including the single-quote escaping: this argv is the
+        // mechanism nightwatch wake.py relies on to never paste into a live
+        // session, so the shape (and shellEscape) must not silently change.
+        #expect(r.command == "claude --resume abc-123 --dangerously-skip-permissions 'wake: don'\\''t trust the snapshot'")
+    }
+
     @Test("cmd path returns verbatim")
     func cmdVerbatim() {
         let r = ClaudeSpawnCommandBuilder.build(

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1007,6 +1007,80 @@ struct RPCRouterWakeErrorMappingTests {
     }
 }
 
+/// `terminal.wake` prompt delivery over RPC — the safety contract nightwatch
+/// wake.py relies on: a `prompt` reaches ONLY a session this call actually
+/// woke (`woken: true`); the idempotent no-op paths report `woken: false`
+/// and never deliver it anywhere.
+@Suite("RPCRouter terminal.wake prompt delivery")
+struct RPCRouterWakePromptDeliveryTests {
+
+    private func makeRouter(db: TBDDatabase, tmux: TmuxManager) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
+                configDirManager: isolatedConfigDirManager()),
+            tmux: tmux,
+            configDirManager: isolatedConfigDirManager()
+        )
+    }
+
+    private func makeTerminal(db: TBDDatabase) async throws -> Terminal {
+        let repo = try await db.repos.create(path: "/tmp/wake-prompt-repo", displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "main",
+            path: "/tmp/wake-prompt-repo", tmuxServer: "tbd-wake-prompt"
+        )
+        return try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude
+        )
+    }
+
+    /// Parked terminal: the RPC reports `woken: true` and the respawned
+    /// `claude --resume` command carries the prompt as a trailing argv.
+    @Test func wakeOnParkedDeliversPromptAndReportsWokenTrue() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
+        try FileManager.default.createDirectory(atPath: "/tmp/wake-prompt-repo", withIntermediateDirectories: true)
+        let terminal = try await makeTerminal(db: db)
+        try await db.terminals.setHibernated(id: terminal.id, sessionID: "sess-1")
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id, prompt: "verify live state first")
+        )
+        let resp = await makeRouter(db: db, tmux: tmux).handle(req)
+        #expect(resp.success)
+        #expect(try resp.decodeResult(TerminalWakeResult.self).woken == true)
+
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(joined.contains { $0.contains("claude --resume sess-1") && $0.contains("'verify live state first'") },
+                "the respawn must carry the prompt as a trailing argv; got: \(joined)")
+    }
+
+    /// Already-awake terminal (the race wake.py guards against): the RPC
+    /// reports `woken: false`, touches no tmux pane, and the prompt is
+    /// delivered NOWHERE — not typed, not pasted, not queued.
+    @Test func wakeOnAwakeNoOpsAndWithholdsPrompt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
+        let terminal = try await makeTerminal(db: db)  // NOT hibernated
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id, prompt: "must never appear")
+        )
+        let resp = await makeRouter(db: db, tmux: tmux).handle(req)
+        #expect(resp.success, "the no-op must stay a benign success for idempotent callers")
+        #expect(try resp.decodeResult(TerminalWakeResult.self).woken == false)
+        #expect(recorded.snapshot().isEmpty,
+                "a no-op wake must not touch tmux at all; got: \(recorded.snapshot())")
+    }
+}
+
 /// Thread-safe collector of `terminalHibernationChanged` deltas published
 /// through a real `StateSubscriptionManager` — the same wire the app's
 /// subscription receives, so these tests assert the actual encoded payload.

--- a/Tests/TBDDaemonTests/PluginDirWriterTests.swift
+++ b/Tests/TBDDaemonTests/PluginDirWriterTests.swift
@@ -89,6 +89,25 @@ struct PluginDirWriterTests {
         #expect(perms?.int16Value ?? 0 & 0o111 != 0)
     }
 
+    @Test("wake.py --selftest passes: classification fail-closed matrix (no git/gh/sqlite invoked)")
+    func wakePySelftest() throws {
+        let tempRoot = NSTemporaryDirectory() + "tbd-plugin-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tempRoot) }
+        try PluginDirWriter(applicationSupportRoot: tempRoot).writePlugin()
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["python3", tempRoot + "/TBD/plugin/skills/nightwatch/scripts/wake.py", "--selftest"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+        try proc.run()
+        proc.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        #expect(proc.terminationStatus == 0, "wake.py --selftest failed:\n\(output)")
+        #expect(output.contains("scenarios passed"))
+    }
+
     @Test("nightwatch SKILL.md has a valid skill name in frontmatter")
     func nightwatchSkillNamed() {
         #expect(NightwatchSkillContent.skillMd.contains("name: nightwatch"))

--- a/Tests/TBDDaemonTests/PluginDirWriterTests.swift
+++ b/Tests/TBDDaemonTests/PluginDirWriterTests.swift
@@ -72,6 +72,7 @@ struct PluginDirWriterTests {
         let tick = nw + "/scripts/tick.py"
         #expect(FileManager.default.fileExists(atPath: nw + "/SKILL.md"))
         #expect(FileManager.default.fileExists(atPath: tick))
+        #expect(FileManager.default.fileExists(atPath: nw + "/scripts/wake.py"))
         #expect(FileManager.default.fileExists(atPath: nw + "/scripts/judge.py"))
         #expect(FileManager.default.fileExists(atPath: nw + "/scripts/scheduler.sh"))
         #expect(FileManager.default.fileExists(atPath: nw + "/scripts/tick-cron.sh"))


### PR DESCRIPTION
## Problem

Nightwatch wake prompts were composed from hibernation-time snapshots. On 2026-07-13 a session was woken with "PR #14203 (temp-fix) has FAILING checks" — the PR had merged three days earlier and the branch was a local-only leftover. A verified sweep found **24/24 currently-hibernated terminals were actually DONE**: every hand-composed "resume" wake would have carried a stale premise.

## Fix

New `scripts/wake.py` (Tier-0, deterministic, no model) — the mandatory pre-wake verifier:

- Any PR number appearing in the hibernate reason is checked live (`gh pr view --json state,headRefName`); MERGED/CLOSED never yields a "fix your PR" wake.
- The checked-out branch's real open PR + failing checks and unmerged-commit state vs `origin/main` (`git cherry`, squash-aware) are re-derived at wake time.
- Classifies DONE → `/closeout` · RESUME_FAILING / RESUME_OPEN · UNSUBMITTED_WORK · UNVERIFIED → neutral "verify first" wake. Wake text is composed from verified facts only; anything unverifiable wakes neutral, never with an asserted premise.
- `--act` dispatches via `tbd terminal send --submit` and logs `wake-dispatch` to `queue/acted.jsonl`; dry-run writes `queue/wake-plan.json`.

SKILL.md gains a "Waking hibernated terminals" section mandating wake.py for every wake; `PluginDirWriter` ships it executable alongside tick.py/judge.py; test asserts it's written.

## Validation

- Incident repro: fed the exact stale reason against the affected worktree → classification flips to a stale-premise fact ("#14203 is MERGED (head keystone-14171)") + finish-or-closeout wake, no phantom-failure claim.
- Full-fleet dry run over all hibernated terminals: 24/24 verified DONE.
- Embedded Swift literals byte-match the live `~/.claude/skills/nightwatch` files; both files `swiftc -parse` clean (full `swift build` fails on main for unrelated bare-toolchain reasons, 679 pre-existing errors).

Live installs (`~/.claude/skills/nightwatch` + the AppSupport plugin dir) already carry the same wake.py/SKILL.md, so the fix is active now; this PR makes it survive the next plugin rewrite.