### PR TITLE
feat(hibernation): "Wake on default account" fallback for a parked session with a missing profile (#421)

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -1,9 +1,20 @@
 import Foundation
+import AppKit
 import os
+import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.app", category: "Hibernation")
 
 extension AppState {
+    /// Outcome of one wake attempt, for EXPLICIT paths that can offer a
+    /// follow-up. The focus path keeps using `wakeTerminal` (String?) and stays
+    /// silent.
+    enum WakeAttemptOutcome: Equatable {
+        case ok
+        case failed(message: String)
+        /// The pinned profile is gone; carries what a fallback retry needs.
+        case profileMissing(terminalID: UUID, worktreeID: UUID, message: String)
+    }
     /// Load the auto-hibernate config (master switch + idle minutes) from the
     /// daemon `Config`. Called on launch and whenever a config-change delta
     /// arrives. Silent on failure — the Settings toggle just shows stale
@@ -44,6 +55,42 @@ extension AppState {
         }
     }
 
+    /// Core explicit/implicit wake returning the structured outcome. `wakeTerminal`
+    /// wraps this. `fallbackToDefaultProfile` opts into the ambient default login
+    /// when the pinned profile is gone (used by the fallback retry).
+    func wakeTerminalOutcome(terminalID: UUID, worktreeID: UUID, userInitiated: Bool,
+                             fallbackToDefaultProfile: Bool) async -> WakeAttemptOutcome {
+        guard !wakeInFlight.contains(terminalID) else { return .ok }  // in-flight dedupe = benign no-op
+        wakeInFlight.insert(terminalID)
+        defer { wakeInFlight.remove(terminalID) }
+        do {
+            let size = mainAreaTerminalSize()
+            try await daemonClient.terminalWake(
+                terminalID: terminalID, cols: size.cols, rows: size.rows,
+                fallbackToDefaultProfile: fallbackToDefaultProfile)
+            await refreshTerminals(worktreeID: worktreeID)
+            return .ok
+        } catch {
+            let outcome = Self.wakeOutcome(
+                forErrorCode: (error as? DaemonClientError)?.rpcCode,
+                alreadyFallback: fallbackToDefaultProfile,
+                terminalID: terminalID, worktreeID: worktreeID,
+                message: error.localizedDescription)
+            switch outcome {
+            case .profileMissing:
+                logger.warning("Wake refused (profile missing) for terminal \(terminalID, privacy: .public); offering default-account fallback")
+            case .failed:
+                if userInitiated {
+                    logger.error("Failed to wake terminal \(terminalID, privacy: .public): \(error, privacy: .public)")
+                } else {
+                    logger.warning("Automatic wake failed for terminal \(terminalID, privacy: .public) (alert suppressed): \(error, privacy: .public)")
+                }
+            case .ok: break
+            }
+            return outcome
+        }
+    }
+
     /// Wake a hibernated terminal (respawn `claude --resume`). Idempotent and
     /// singleflighted on the app side: a second call while one is in flight is
     /// dropped, so double-focus never fires two respawns.
@@ -57,24 +104,23 @@ extension AppState {
     /// failure log level (explicit action → error; background → warning).
     @discardableResult
     func wakeTerminal(terminalID: UUID, worktreeID: UUID, userInitiated: Bool) async -> String? {
-        guard !wakeInFlight.contains(terminalID) else { return nil }
-        wakeInFlight.insert(terminalID)
-        defer { wakeInFlight.remove(terminalID) }
-        do {
-            let size = mainAreaTerminalSize()
-            try await daemonClient.terminalWake(
-                terminalID: terminalID, cols: size.cols, rows: size.rows
-            )
-            await refreshTerminals(worktreeID: worktreeID)
-            return nil
-        } catch {
-            if userInitiated {
-                logger.error("Failed to wake terminal \(terminalID, privacy: .public): \(error, privacy: .public)")
-            } else {
-                logger.warning("Automatic wake failed for terminal \(terminalID, privacy: .public) (alert suppressed): \(error, privacy: .public)")
-            }
-            return error.localizedDescription
+        switch await wakeTerminalOutcome(terminalID: terminalID, worktreeID: worktreeID,
+                                         userInitiated: userInitiated, fallbackToDefaultProfile: false) {
+        case .ok: return nil
+        case .failed(let m): return m
+        case .profileMissing(_, _, let m): return m
         }
+    }
+
+    /// Classify a wake error. A `.profileMissing`-coded RPC failure becomes the
+    /// structured outcome ONLY when this wasn't already a fallback retry, so the
+    /// offer can never loop. Everything else is a plain `.failed`.
+    static func wakeOutcome(forErrorCode code: String?, alreadyFallback: Bool,
+                            terminalID: UUID, worktreeID: UUID, message: String) -> WakeAttemptOutcome {
+        if !alreadyFallback, code == RPCErrorCode.profileMissing.rawValue {
+            return .profileMissing(terminalID: terminalID, worktreeID: worktreeID, message: message)
+        }
+        return .failed(message: message)
     }
 
     /// Pure decision/formatting seam behind the explicit Wake menu action's
@@ -91,6 +137,32 @@ extension AppState {
         return "Couldn't wake \(failures.count) sessions: \(first)"
     }
 
+    /// Copy for the default-account fallback confirm. Pure so the wording is
+    /// unit-tested; the actual modal is `confirmDefaultAccountFallback`.
+    static func defaultAccountFallbackPrompt(count: Int) -> (message: String, informative: String, confirm: String) {
+        let noun = count == 1 ? "This session was" : "\(count) sessions were"
+        return (
+            message: count == 1 ? "Wake this session on your default account?"
+                                 : "Wake \(count) sessions on your default account?",
+            informative: "\(noun) pinned to an account profile that no longer exists. You can wake on your default login instead, or cancel and restore the profile first.",
+            confirm: count == 1 ? "Wake on Default Account" : "Wake \(count) on Default Account"
+        )
+    }
+
+    /// Present the default-account fallback confirm. Returns true if the user
+    /// chose to wake on the default account. Modal (mirrors CLIInstallerCoordinator).
+    @MainActor
+    func confirmDefaultAccountFallback(count: Int) -> Bool {
+        let prompt = Self.defaultAccountFallbackPrompt(count: count)
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = prompt.message
+        alert.informativeText = prompt.informative
+        alert.addButton(withTitle: prompt.confirm)
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
     /// Concurrency bound for the explicit "Wake all parked" fan-out. Small on
     /// purpose: full parallelism caused the #367 spawn storm (N simultaneous
     /// heavy `claude --resume` respawns → RPC-timeout hang), so this caps
@@ -99,6 +171,33 @@ extension AppState {
     /// `wakeHibernatedTerminalsOnFocus`) — this bound is ONLY for the explicit
     /// user action.
     static let wakeAllBatchSize = 3
+
+    /// Explicit user-initiated wake of ONE parked terminal, with the
+    /// default-account fallback offer. On `.profileMissing`, confirm and retry
+    /// with fallback. Surfaces any final failure as a coalesced alert. Focus
+    /// path does NOT use this.
+    func wakeParkedTerminalUserInitiated(terminalID: UUID, worktreeID: UUID) async {
+        let outcome = await wakeTerminalOutcome(terminalID: terminalID, worktreeID: worktreeID,
+                                                userInitiated: true, fallbackToDefaultProfile: false)
+        var failure: String?
+        switch outcome {
+        case .ok: failure = nil
+        case .failed(let m): failure = m
+        case .profileMissing(let tid, let wid, let m):
+            if confirmDefaultAccountFallback(count: 1) {
+                switch await wakeTerminalOutcome(terminalID: tid, worktreeID: wid,
+                                                 userInitiated: true, fallbackToDefaultProfile: true) {
+                case .ok: failure = nil
+                case .failed(let m2), .profileMissing(_, _, let m2): failure = m2
+                }
+            } else {
+                failure = m  // declined → still show why it didn't wake
+            }
+        }
+        if let failure, let message = Self.coalescedWakeFailureMessage(failures: [failure]) {
+            showAlert(message, isError: true)
+        }
+    }
 
     /// Split parked-terminal ids into sequential batches of at most
     /// `batchSize`. Pure + static so the batching is unit-tested without a live
@@ -110,6 +209,28 @@ extension AppState {
         }
     }
 
+    /// Wake `ids` in bounded-concurrency batches (`wakeAllBatchSize` in flight,
+    /// sequential batches), returning each outcome. Shared by the initial pass
+    /// and the fallback retry.
+    private func wakeBatched(_ ids: [UUID], worktreeID: UUID, fallbackToDefaultProfile: Bool) async -> [WakeAttemptOutcome] {
+        var out: [WakeAttemptOutcome] = []
+        for batch in Self.wakeAllBatches(ids) {
+            let batchOutcomes = await withTaskGroup(of: WakeAttemptOutcome.self) { group in
+                for id in batch {
+                    group.addTask {
+                        await self.wakeTerminalOutcome(terminalID: id, worktreeID: worktreeID,
+                                                       userInitiated: true, fallbackToDefaultProfile: fallbackToDefaultProfile)
+                    }
+                }
+                var collected: [WakeAttemptOutcome] = []
+                for await o in group { collected.append(o) }
+                return collected
+            }
+            out += batchOutcomes
+        }
+        return out
+    }
+
     /// Explicit "Wake all parked in this worktree" action: wake EVERY parked
     /// (hibernated or legacy-suspended) Claude session in `worktreeID`, in
     /// bounded-concurrency batches (`wakeAllBatchSize` in flight, sequential
@@ -118,24 +239,16 @@ extension AppState {
     /// coalesced alert (never a modal per terminal).
     func wakeAllParkedInWorktree(worktreeID: UUID) async {
         let ids = (terminals[worktreeID] ?? []).filter { $0.isParked }.map { $0.id }
-        var failures: [String] = []
-        for batch in Self.wakeAllBatches(ids) {
-            // Each batch's wakes run concurrently: wakeTerminal suspends at its
-            // RPC await, so up to wakeAllBatchSize respawns are in flight at once;
-            // the loop only starts the next batch after this one fully drains.
-            let batchFailures = await withTaskGroup(of: String?.self) { group in
-                for id in batch {
-                    group.addTask {
-                        await self.wakeTerminal(terminalID: id, worktreeID: worktreeID, userInitiated: true)
-                    }
-                }
-                var collected: [String] = []
-                for await failure in group where failure != nil {
-                    collected.append(failure!)
-                }
-                return collected
+        let outcomes = await wakeBatched(ids, worktreeID: worktreeID, fallbackToDefaultProfile: false)
+        var failures = outcomes.compactMap(\.failureMessage)
+        let missing = outcomes.compactMap(\.profileMissingTerminalID)
+        if !missing.isEmpty {
+            if confirmDefaultAccountFallback(count: missing.count) {
+                let retried = await wakeBatched(missing, worktreeID: worktreeID, fallbackToDefaultProfile: true)
+                failures += retried.compactMap(\.anyFailureMessage)
+            } else {
+                failures += outcomes.compactMap(\.profileMissingMessage)  // declined → surface why
             }
-            failures.append(contentsOf: batchFailures)
         }
         if let message = Self.coalescedWakeFailureMessage(failures: failures) {
             showAlert(message, isError: true)
@@ -203,4 +316,21 @@ extension AppState {
         }
         return parked.first?.id
     }
+}
+
+extension AppState.WakeAttemptOutcome {
+    /// `.failed` message only (nil otherwise).
+    var failureMessage: String? { if case .failed(let m) = self { return m }; return nil }
+    /// Any terminal failure message — `.failed` OR `.profileMissing` (used
+    /// after a fallback retry, where `.profileMissing` shouldn't recur but is
+    /// still a failure to report).
+    var anyFailureMessage: String? {
+        switch self {
+        case .ok: return nil
+        case .failed(let m): return m
+        case .profileMissing(_, _, let m): return m
+        }
+    }
+    var profileMissingTerminalID: UUID? { if case .profileMissing(let t, _, _) = self { return t }; return nil }
+    var profileMissingMessage: String? { if case .profileMissing(_, _, let m) = self { return m }; return nil }
 }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -17,7 +17,7 @@ enum DaemonClientError: Error, CustomStringConvertible, LocalizedError, Sendable
     case sendFailed(String)
     case receiveFailed(String)
     case invalidResponse
-    case rpcError(String)
+    case rpcError(String, code: String?)
     case attachUnavailable(String)
 
     var description: String {
@@ -32,7 +32,7 @@ enum DaemonClientError: Error, CustomStringConvertible, LocalizedError, Sendable
             return "Receive failed: \(msg)"
         case .invalidResponse:
             return "Invalid response from daemon"
-        case .rpcError(let msg):
+        case .rpcError(let msg, _):
             return "RPC error: \(msg)"
         case .attachUnavailable(let status):
             return "Control-mode attach unavailable (status: \(status))"
@@ -40,6 +40,12 @@ enum DaemonClientError: Error, CustomStringConvertible, LocalizedError, Sendable
     }
 
     var errorDescription: String? { description }
+
+    /// The daemon-attached `RPCErrorCode` raw value, when present.
+    var rpcCode: String? {
+        if case .rpcError(_, let code) = self { return code }
+        return nil
+    }
 }
 
 /// `openAttach` failed AFTER `attach.request` succeeded — the daemon minted
@@ -317,7 +323,7 @@ actor DaemonClient {
         let request = try RPCRequest(method: method, params: params)
         let response = try sendRaw(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
         return try response.decodeResult(resultType)
     }
@@ -327,7 +333,7 @@ actor DaemonClient {
         let request = try RPCRequest(method: method, params: params)
         let response = try sendRaw(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
     }
 
@@ -336,7 +342,7 @@ actor DaemonClient {
         let request = RPCRequest(method: method)
         let response = try sendRaw(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
         return try response.decodeResult(resultType)
     }
@@ -354,7 +360,7 @@ actor DaemonClient {
         let request = try RPCRequest(method: method, params: params)
         let response = try await sendRawAsync(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
     }
 
@@ -364,7 +370,7 @@ actor DaemonClient {
         let request = try RPCRequest(method: method, params: params)
         let response = try await sendRawAsync(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
         return try response.decodeResult(resultType)
     }
@@ -373,7 +379,7 @@ actor DaemonClient {
         let request = RPCRequest(method: method)
         let response = try await sendRawAsync(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
         return try response.decodeResult(resultType)
     }
@@ -1386,7 +1392,7 @@ actor DaemonClient {
         )
         let response = try await sendRawAsync(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
         let bytes = response.result?.utf8.count ?? 0
         let decodeStart = ContinuousClock.now
@@ -1411,7 +1417,7 @@ actor DaemonClient {
         )
         let response = try await sendRawAsync(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
         let bytes = response.result?.utf8.count ?? 0
         let decodeStart = ContinuousClock.now
@@ -1458,7 +1464,7 @@ actor DaemonClient {
         let request = RPCRequest(method: RPCMethod.daemonRemoveLegacyGlobalHooks)
         let response = try await sendRawAsync(request)
         guard response.success else {
-            throw DaemonClientError.rpcError(response.error ?? "Unknown error")
+            throw DaemonClientError.rpcError(response.error ?? "Unknown error", code: response.errorCode)
         }
         return try response.decodeResult(RemoveLegacyGlobalHooksResult.self)
     }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -394,18 +394,7 @@ struct PanePlaceholder: View {
                     // only consumes Cmd+clicks that resolve a file path.
                     if ParkedPaneWakeModel.showsWakeOverlay(for: terminal) {
                         Button {
-                            Task {
-                                // Wake is the single resume path for parked
-                                // sessions (hibernated or legacy-suspended).
-                                // Singleflighted in AppState; explicit user
-                                // action → surface the failure (single wake,
-                                // so the coalescer yields the bare message).
-                                if let failure = await appState.wakeTerminal(
-                                    terminalID: terminal.id, worktreeID: worktree.id, userInitiated: true
-                                ), let message = AppState.coalescedWakeFailureMessage(failures: [failure]) {
-                                    appState.showAlert(message, isError: true)
-                                }
-                            }
+                            Task { await appState.wakeParkedTerminalUserInitiated(terminalID: terminal.id, worktreeID: worktree.id) }
                         } label: {
                             Color.clear
                                 .contentShape(Rectangle())

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -881,15 +881,7 @@ private struct TabBarItem: View {
             case .wake:
                 Button {
                     guard let terminalID = terminal?.id else { return }
-                    Task {
-                        // Explicit user action → surface the failure (single
-                        // wake, so the coalescer yields the bare message).
-                        if let failure = await appState.wakeTerminal(
-                            terminalID: terminalID, worktreeID: worktreeID, userInitiated: true
-                        ), let message = AppState.coalescedWakeFailureMessage(failures: [failure]) {
-                            appState.showAlert(message, isError: true)
-                        }
-                    }
+                    Task { await appState.wakeParkedTerminalUserInitiated(terminalID: terminalID, worktreeID: worktreeID) }
                 } label: {
                     Label("Wake", systemImage: "sun.max")
                 }

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -47,7 +47,9 @@ extension RPCRouter {
         case .worktreeMissing(let path):
             return RPCResponse(error: "Worktree directory missing on disk: \(path). Restore the directory (or relocate the repo), then retry — the session stays parked and resumable.")
         case .profileMissing(let profileID):
-            return RPCResponse(error: "This session was pinned to an account profile (\(profileID.uuidString)) that no longer exists. It stays parked and resumable — retry with the default-profile fallback to wake it on your default account.")
+            return RPCResponse(
+                error: "This session was pinned to an account profile (\(profileID.uuidString)) that no longer exists. It stays parked and resumable — wake it on your default account, or restore the profile and retry.",
+                code: RPCErrorCode.profileMissing.rawValue)
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -55,7 +55,9 @@ extension RPCRouter {
         case .worktreeMissing(let path):
             return RPCResponse(error: "Worktree directory missing on disk: \(path). Restore the directory (or relocate the repo), then retry — the session stays parked and resumable.")
         case .profileMissing(let profileID):
-            return RPCResponse(error: "This session was pinned to an account profile (\(profileID.uuidString)) that no longer exists. It stays parked and resumable — retry with the default-profile fallback to wake it on your default account.")
+            return RPCResponse(
+                error: "This session was pinned to an account profile (\(profileID.uuidString)) that no longer exists. It stays parked and resumable — wake it on your default account, or restore the profile and retry.",
+                code: RPCErrorCode.profileMissing.rawValue)
         }
     }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -34,18 +34,24 @@ public struct RPCResponse: Codable, Sendable {
     public let success: Bool
     public let result: String?
     public let error: String?
+    /// Machine-readable code carried alongside `error`'s human string,
+    /// so the app can branch on a specific failure without matching message text.
+    /// Optional on the wire — nil for errors that carry no code.
+    public let errorCode: String?
 
     public init<R: Encodable>(result: R) throws {
         self.success = true
         let data = try JSONEncoder().encode(result)
         self.result = String(data: data, encoding: .utf8)
         self.error = nil
+        self.errorCode = nil
     }
 
-    public init(error: String) {
+    public init(error: String, code: String? = nil) {
         self.success = false
         self.result = nil
         self.error = error
+        self.errorCode = code
     }
 
     /// Convenience for success responses with no meaningful result payload.
@@ -57,6 +63,7 @@ public struct RPCResponse: Codable, Sendable {
         self.success = true
         self.result = nil
         self.error = nil
+        self.errorCode = nil
     }
 
     /// Decode the result payload into the expected type.
@@ -71,6 +78,16 @@ public struct RPCResponse: Codable, Sendable {
 
 public enum RPCError: Error, Sendable {
     case noResultData
+}
+
+/// Machine-readable code carried alongside `RPCResponse.error`'s human string,
+/// so the app can branch on a specific failure (e.g. offer a fallback) without
+/// matching message text. Optional on the wire — nil for errors that carry no code.
+public enum RPCErrorCode: String, Sendable {
+    /// A parked terminal's pinned model profile no longer resolves; the wake was
+    /// refused. The app offers a default-account fallback retry
+    /// (`TerminalWakeParams.fallbackToDefaultProfile`).
+    case profileMissing
 }
 
 // MARK: - RPC Method Names

--- a/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
+++ b/Tests/TBDAppTests/WakeOnFocusDecisionTests.swift
@@ -256,4 +256,125 @@ struct WakeOnFocusDecisionTests {
         #expect(focused == ids[0],
                 "focus wake must return exactly one terminal, not a batch")
     }
+
+    // MARK: - Wake outcome classification (fallback-offer logic)
+    //
+    // When an explicit wake fails with profileMissing, the app offers a
+    // default-account fallback retry. The classifier detects the code and
+    // structured outcome, avoiding loops (a fallback retry that also fails
+    // with the same code becomes `.failed`, never `.profileMissing` again).
+    // All branches tested.
+
+    /// Profile-missing code on first attempt → structured `.profileMissing`
+    /// outcome so the app can offer a retry.
+    @Test func wakeOutcomeProfileMissingCodeNotFallback() {
+        let tid = UUID()
+        let wid = UUID()
+        let msg = "Profile gone"
+        let outcome = AppState.wakeOutcome(
+            forErrorCode: RPCErrorCode.profileMissing.rawValue,
+            alreadyFallback: false,
+            terminalID: tid, worktreeID: wid, message: msg)
+        #expect(outcome == .profileMissing(terminalID: tid, worktreeID: wid, message: msg))
+    }
+
+    /// Profile-missing code but `alreadyFallback: true` → `.failed`, not
+    /// `.profileMissing` again. Prevents the offer loop.
+    @Test func wakeOutcomeProfileMissingCodeDuringFallbackIsFailed() {
+        let tid = UUID()
+        let wid = UUID()
+        let msg = "Still missing"
+        let outcome = AppState.wakeOutcome(
+            forErrorCode: RPCErrorCode.profileMissing.rawValue,
+            alreadyFallback: true,
+            terminalID: tid, worktreeID: wid, message: msg)
+        #expect(outcome == .failed(message: msg))
+    }
+
+    /// Different error code → `.failed`.
+    @Test func wakeOutcomeOtherCodeIsFailed() {
+        let tid = UUID()
+        let wid = UUID()
+        let msg = "Some other error"
+        let outcome = AppState.wakeOutcome(
+            forErrorCode: "someOtherCode",
+            alreadyFallback: false,
+            terminalID: tid, worktreeID: wid, message: msg)
+        #expect(outcome == .failed(message: msg))
+    }
+
+    /// Nil code → `.failed`.
+    @Test func wakeOutcomeNilCodeIsFailed() {
+        let tid = UUID()
+        let wid = UUID()
+        let msg = "Unknown error"
+        let outcome = AppState.wakeOutcome(
+            forErrorCode: nil,
+            alreadyFallback: false,
+            terminalID: tid, worktreeID: wid, message: msg)
+        #expect(outcome == .failed(message: msg))
+    }
+
+    // MARK: - Default-account fallback prompt copy
+    //
+    // The confirmation dialog copy is pure and testable so the wording is
+    // pinned and can be audited.
+
+    /// Singular case: one session.
+    @Test func defaultAccountFallbackPromptSingular() {
+        let (message, informative, confirm) = AppState.defaultAccountFallbackPrompt(count: 1)
+        #expect(message == "Wake this session on your default account?")
+        #expect(informative.contains("This session was"))
+        #expect(informative.contains("pinned to an account profile"))
+        #expect(confirm == "Wake on Default Account")
+    }
+
+    /// Plural case: multiple sessions.
+    @Test func defaultAccountFallbackPromptPlural() {
+        let (message, informative, confirm) = AppState.defaultAccountFallbackPrompt(count: 3)
+        #expect(message == "Wake 3 sessions on your default account?")
+        #expect(informative.contains("3 sessions were"))
+        #expect(informative.contains("pinned to an account profile"))
+        #expect(confirm == "Wake 3 on Default Account")
+    }
+
+    // MARK: - Wake outcome accessors
+    //
+    // Computed properties on `.WakeAttemptOutcome` extract fields for coalescing
+    // failures and detecting profile-missing terminals. All branches tested.
+
+    /// `.ok` outcome: all accessors return nil.
+    @Test func wakeOutcomeAccessorsOkIsNil() {
+        let outcome = AppState.WakeAttemptOutcome.ok
+        #expect(outcome.failureMessage == nil)
+        #expect(outcome.anyFailureMessage == nil)
+        #expect(outcome.profileMissingTerminalID == nil)
+        #expect(outcome.profileMissingMessage == nil)
+    }
+
+    /// `.failed` outcome: `failureMessage` and `anyFailureMessage` carry the
+    /// message; profile accessors return nil.
+    @Test func wakeOutcomeAccessorsFailed() {
+        let msg = "Wake failed"
+        let outcome = AppState.WakeAttemptOutcome.failed(message: msg)
+        #expect(outcome.failureMessage == msg)
+        #expect(outcome.anyFailureMessage == msg)
+        #expect(outcome.profileMissingTerminalID == nil)
+        #expect(outcome.profileMissingMessage == nil)
+    }
+
+    /// `.profileMissing` outcome: all accessors return their fields.
+    @Test func wakeOutcomeAccessorsProfileMissing() {
+        let tid = UUID()
+        let wid = UUID()
+        let msg = "Profile gone"
+        let outcome = AppState.WakeAttemptOutcome.profileMissing(
+            terminalID: tid, worktreeID: wid, message: msg)
+        #expect(outcome.failureMessage == nil,
+                "`failureMessage` is nil for `.profileMissing` (only `.failed` carries it)")
+        #expect(outcome.anyFailureMessage == msg,
+                "`anyFailureMessage` captures both `.failed` and `.profileMissing`")
+        #expect(outcome.profileMissingTerminalID == tid)
+        #expect(outcome.profileMissingMessage == msg)
+    }
 }


### PR DESCRIPTION
Follow-up to #424 (which shipped the daemon-side profile pre-wake check). That PR made `wake()` refuse with `WakeResult.profileMissing` when a parked terminal's pinned model profile no longer resolves, and plumbed an opt-in ambient-login fallback (`fallbackToDefaultProfile`) all the way through the RPC — but the app only surfaced the failure as an error string. This PR wires the one-click **"Wake on Default Account"** affordance the #421 inventory called for.

## What's new

**Structured RPC error code.** `RPCResponse` gains an optional `errorCode`, backed by a shared `RPCErrorCode` enum (first case: `profileMissing`). The wake/resume handlers tag the profile-missing failure with it, and `DaemonClientError.rpcError` carries it through (`rpcCode`). The app branches on the **code**, never on message text.

**Typed wake outcome.** New `wakeTerminalOutcome` returns `.ok` / `.failed` / `.profileMissing`; `wakeTerminal(...) -> String?` is now a thin adapter over it, so the focus path (`wakeHibernatedTerminalsOnFocus`) and every existing caller/test are unchanged and stay **silent** — the offer is explicit-action-only.

**The fallback offer.** On an explicit user-initiated wake that hits `.profileMissing`, an `NSAlert` confirm (mirroring `CLIInstallerCoordinator`'s modal idiom) offers to wake on the default account; on confirm, the wake retries with `fallbackToDefaultProfile: true`. An `!alreadyFallback` guard ensures the offer can never loop. Wired into all three explicit affordances:
- the worktree-row **Wake** fan-out — one *consolidated* confirm for N missing-profile sessions, then a bounded-concurrency retry of just those;
- the **parked-pane click** (`PanePlaceholder`);
- the **tab Wake button** (`TabBar`).

No feature flag: this is small additive UI reacting to an explicit user gesture (not autonomous/destructive), per the repo's flag-gating rule.

## Tests

`WakeOnFocusDecisionTests` gains 9 tests covering each branch: the classifier (`profileMissing` on first attempt → offer; the same code *during* a fallback retry → plain `.failed`, proving no loop; other/nil code → `.failed`), the singular vs plural confirm copy, and the outcome accessors (`failureMessage` / `anyFailureMessage` / `profileMissingTerminalID` / `profileMissingMessage`). The `NSAlert` modal and live `daemonClient` wake aren't unit-tested (not testable here — same as the existing CLI-installer modal).

`swift build` clean (incl. `TBDCLI`, which also decodes `RPCResponse`); `swiftlint --strict` clean on all changed files; full `swift test` green except the one pre-existing environment-only failure (`refreshGitStatusesChecksUnconditionallyWhenTipsUnresolvable`, git shell exit 128 in a temp repo), confirmed failing on the pristine base.

Refs #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)