### PR TITLE
Feat: Show a toast while archived deep links resolve, then navigate instantly (was ~19s of silence)

### DIFF
--- a/Sources/TBDApp/AppState+Toast.swift
+++ b/Sources/TBDApp/AppState+Toast.swift
@@ -2,79 +2,45 @@ import Foundation
 
 // MARK: - Toast state machine
 //
-// One toast at a time. All transitions run on the main actor. The countdown
-// is owned here (not by the view) so expiry fires even if the overlay view
-// rebuilds. `toastTickDuration` is the injectable clock seam for tests.
+// One toast at a time. All transitions run on the main actor. Transient
+// toasts (notice/error) auto-dismiss after ~4 ticks; the dismiss task is
+// owned here (not by the view) so it fires even if the overlay view rebuilds.
+// `toastTickDuration` is the injectable clock seam for tests.
 extension AppState {
 
-    /// Show `toast`, replacing any current one and cancelling its countdown.
+    /// Show `toast`, replacing any current one and cancelling its dismiss task.
     @MainActor
     func showToast(_ toast: Toast) {
-        toastCountdownTask?.cancel()
-        toastCountdownTask = nil
-        toastCTAAction = nil
+        toastDismissTask?.cancel()
+        toastDismissTask = nil
         activeToast = toast
     }
 
     @MainActor
     func dismissToast() {
-        toastCountdownTask?.cancel()
-        toastCountdownTask = nil
-        toastCTAAction = nil
+        toastDismissTask?.cancel()
+        toastDismissTask = nil
         activeToast = nil
     }
 
-    /// Start a `seconds`→1 countdown on the active toast. When it reaches
-    /// zero the toast is dismissed and `onExpiry` runs. Cancelled by hover
-    /// (`toastHoverChanged`), dismissal, or a replacing toast.
-    @MainActor
-    func startToastCountdown(
-        seconds: Int = 5, onExpiry: @escaping @MainActor () -> Void
-    ) {
-        toastCountdownTask?.cancel()
-        guard var toast = activeToast else { return }
-        toast.style = .countdown(secondsRemaining: seconds)
-        activeToast = toast
-        let toastID = toast.id
-        let tick = toastTickDuration
-        toastCountdownTask = Task { @MainActor [weak self] in
-            for remaining in stride(from: seconds - 1, through: 0, by: -1) {
-                try? await Task.sleep(for: tick)
-                guard !Task.isCancelled,
-                      let self, self.activeToast?.id == toastID else { return }
-                if remaining > 0 {
-                    self.activeToast?.style = .countdown(secondsRemaining: remaining)
-                }
-            }
-            guard !Task.isCancelled, let self,
-                  self.activeToast?.id == toastID else { return }
-            self.dismissToast()
-            onExpiry()
-        }
-    }
-
-    /// Pointer entered/left the toast. Entering during a countdown cancels it
-    /// permanently (no resume on exit — decided in spec) and swaps in the CTA.
-    @MainActor
-    func toastHoverChanged(_ hovering: Bool) {
-        guard hovering, case .countdown = activeToast?.style else { return }
-        toastCountdownTask?.cancel()
-        toastCountdownTask = nil
-        activeToast?.style = .action(ctaLabel: "Go to archive entry")
-    }
-
-    /// Show an error toast that auto-dismisses after ~4 ticks
+    /// Show a transient toast that auto-dismisses after ~4 ticks
     /// (~4s in production, milliseconds under test).
     @MainActor
-    func showErrorToast(_ message: String) {
-        showToast(Toast(id: UUID(), message: message, style: .error))
+    func showTransientToast(_ message: String, style: Toast.Style) {
+        showToast(Toast(id: UUID(), message: message, style: style))
         let toastID = activeToast?.id
         let delay = toastTickDuration * 4
-        toastCountdownTask = Task { @MainActor [weak self] in
+        toastDismissTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: delay)
             guard !Task.isCancelled,
                   let self, self.activeToast?.id == toastID else { return }
             self.dismissToast()
         }
+    }
+
+    /// Show an error toast that auto-dismisses.
+    @MainActor
+    func showErrorToast(_ message: String) {
+        showTransientToast(message, style: .error)
     }
 }

--- a/Sources/TBDApp/AppState+Toast.swift
+++ b/Sources/TBDApp/AppState+Toast.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+// MARK: - Toast state machine
+//
+// One toast at a time. All transitions run on the main actor. The countdown
+// is owned here (not by the view) so expiry fires even if the overlay view
+// rebuilds. `toastTickDuration` is the injectable clock seam for tests.
+extension AppState {
+
+    /// Show `toast`, replacing any current one and cancelling its countdown.
+    @MainActor
+    func showToast(_ toast: Toast) {
+        toastCountdownTask?.cancel()
+        toastCountdownTask = nil
+        toastCTAAction = nil
+        activeToast = toast
+    }
+
+    @MainActor
+    func dismissToast() {
+        toastCountdownTask?.cancel()
+        toastCountdownTask = nil
+        toastCTAAction = nil
+        activeToast = nil
+    }
+
+    /// Start a `seconds`→1 countdown on the active toast. When it reaches
+    /// zero the toast is dismissed and `onExpiry` runs. Cancelled by hover
+    /// (`toastHoverChanged`), dismissal, or a replacing toast.
+    @MainActor
+    func startToastCountdown(
+        seconds: Int = 5, onExpiry: @escaping @MainActor () -> Void
+    ) {
+        toastCountdownTask?.cancel()
+        guard var toast = activeToast else { return }
+        toast.style = .countdown(secondsRemaining: seconds)
+        activeToast = toast
+        let toastID = toast.id
+        let tick = toastTickDuration
+        toastCountdownTask = Task { @MainActor [weak self] in
+            for remaining in stride(from: seconds - 1, through: 0, by: -1) {
+                try? await Task.sleep(for: tick)
+                guard !Task.isCancelled,
+                      let self, self.activeToast?.id == toastID else { return }
+                if remaining > 0 {
+                    self.activeToast?.style = .countdown(secondsRemaining: remaining)
+                }
+            }
+            guard !Task.isCancelled, let self,
+                  self.activeToast?.id == toastID else { return }
+            self.dismissToast()
+            onExpiry()
+        }
+    }
+
+    /// Pointer entered/left the toast. Entering during a countdown cancels it
+    /// permanently (no resume on exit — decided in spec) and swaps in the CTA.
+    @MainActor
+    func toastHoverChanged(_ hovering: Bool) {
+        guard hovering, case .countdown = activeToast?.style else { return }
+        toastCountdownTask?.cancel()
+        toastCountdownTask = nil
+        activeToast?.style = .action(ctaLabel: "Go to archive entry")
+    }
+
+    /// Show an error toast that auto-dismisses after ~4 ticks
+    /// (~4s in production, milliseconds under test).
+    @MainActor
+    func showErrorToast(_ message: String) {
+        showToast(Toast(id: UUID(), message: message, style: .error))
+        let toastID = activeToast?.id
+        let delay = toastTickDuration * 4
+        toastCountdownTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled,
+                  let self, self.activeToast?.id == toastID else { return }
+            self.dismissToast()
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -488,7 +488,7 @@ extension AppState {
         } else {
             do {
                 archived = try await daemonClient.listWorktrees(
-                    repoID: nil, status: .archived
+                    repoID: nil, status: .archived, includeSessionCounts: false
                 )
             } catch {
                 logger.error("Deep-link archived lookup failed: \(error.localizedDescription)")

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -474,8 +474,12 @@ extension AppState {
     }
 
     /// Archived-worktree path for deep-link navigation. Async — issues an RPC
-    /// to find the worktree across all archived ones, then opens the
-    /// archived pane and flashes the row.
+    /// to find the worktree across all archived ones, then announces the
+    /// upcoming navigation via a countdown toast instead of yanking the user
+    /// immediately (spec: 2026-07-13-deeplink-archived-toast-design.md).
+    /// Hovering the toast cancels the countdown permanently and leaves an
+    /// explicit "Go to archive entry" CTA. Lookup failures and unknown UUIDs
+    /// surface as error toasts (previously silent).
     @MainActor
     func navigateToArchivedWorktree(_ id: UUID) async {
         let archived: [Worktree]
@@ -488,26 +492,47 @@ extension AppState {
                 )
             } catch {
                 logger.error("Deep-link archived lookup failed: \(error.localizedDescription)")
+                showErrorToast("Couldn't look up the worktree: \(error.localizedDescription)")
                 return
             }
         }
 
         guard let wt = archived.first(where: { $0.id == id }) else {
             logger.warning("Deep link references unknown worktree \(id.uuidString, privacy: .public)")
+            showErrorToast("Worktree not found — it may have been deleted.")
             return
         }
         // Archived flows are repo-only — a scratch space has no archived view to deep-link into.
-        guard let rid = wt.repoID else { return }
-
-        selectedWorktreeIDs = []
-        selectedRepoID = rid
-        selectedScratchSection = false
-        archivedWorktrees[rid] = archived.filter { $0.repoID == rid }
-        archivedWorktreesHasMore[rid] = false
-        highlightedArchivedWorktreeID = id
-        if NSApplication.shared.isRunning {
-            NSApplication.shared.activate(ignoringOtherApps: true)
+        guard let rid = wt.repoID else {
+            dismissToast()
+            return
         }
+
+        showToast(Toast(
+            id: UUID(),
+            message: "“\(wt.displayName)” is archived — showing its archive entry",
+            style: .progress
+        ))
+        let navigate: @MainActor () -> Void = { [weak self] in
+            self?.performArchivedNavigation(worktreeID: id, repoID: rid, archived: archived)
+        }
+        toastCTAAction = { [weak self] in
+            self?.dismissToast()
+            navigate()
+        }
+        startToastCountdown(onExpiry: navigate)
+    }
+
+    /// The pre-toast navigation tail: select the repo, populate its archived
+    /// rows, and flash-highlight the target. Runs on countdown expiry or CTA.
+    @MainActor
+    private func performArchivedNavigation(worktreeID: UUID, repoID: UUID, archived: [Worktree]) {
+        selectedWorktreeIDs = []
+        selectedRepoID = repoID
+        selectedScratchSection = false
+        archivedWorktrees[repoID] = archived.filter { $0.repoID == repoID }
+        archivedWorktreesHasMore[repoID] = false
+        highlightedArchivedWorktreeID = worktreeID
     }
 
     /// Public entry point for deep-link navigation. Synchronous fast path
@@ -531,6 +556,12 @@ extension AppState {
         if activeMatch {
             navigateToActiveWorktree(id, terminalID: terminalID)
         } else {
+            // Foreground the app *before* the async lookup so the progress
+            // toast is actually visible (guarded: NSApp is nil under tests).
+            if NSApplication.shared.isRunning {
+                NSApplication.shared.activate(ignoringOtherApps: true)
+            }
+            showToast(Toast(id: UUID(), message: "Looking for worktree…", style: .progress))
             Task { await navigateToArchivedWorktree(id) }
         }
     }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -474,12 +474,12 @@ extension AppState {
     }
 
     /// Archived-worktree path for deep-link navigation. Async — issues an RPC
-    /// to find the worktree across all archived ones, then announces the
-    /// upcoming navigation via a countdown toast instead of yanking the user
-    /// immediately (spec: 2026-07-13-deeplink-archived-toast-design.md).
-    /// Hovering the toast cancels the countdown permanently and leaves an
-    /// explicit "Go to archive entry" CTA. Lookup failures and unknown UUIDs
-    /// surface as error toasts (previously silent).
+    /// to find the worktree across all archived ones, then navigates to the
+    /// archive entry immediately and shows a brief auto-dismissing notice
+    /// explaining that the target is archived
+    /// (spec: 2026-07-13-deeplink-archived-toast-design.md).
+    /// Lookup failures and unknown UUIDs surface as error toasts (previously
+    /// silent).
     @MainActor
     func navigateToArchivedWorktree(_ id: UUID) async {
         // Request-generation guard (F1). Two deep links (A then B) can have
@@ -526,23 +526,17 @@ extension AppState {
             return
         }
 
-        showToast(Toast(
-            id: UUID(),
-            message: "“\(wt.displayName)” is archived — showing its archive entry",
-            style: .progress
-        ))
-        let navigate: @MainActor () -> Void = { [weak self] in
-            self?.performArchivedNavigation(worktreeID: id, repoID: rid, archived: archived)
-        }
-        toastCTAAction = { [weak self] in
-            self?.dismissToast()
-            navigate()
-        }
-        startToastCountdown(onExpiry: navigate)
+        // Navigate immediately, then show a brief auto-dismissing notice so
+        // landing in the archive view is explained rather than surprising.
+        showTransientToast(
+            "“\(wt.displayName)” is archived — showing its archive entry",
+            style: .notice
+        )
+        performArchivedNavigation(worktreeID: id, repoID: rid, archived: archived)
     }
 
-    /// The pre-toast navigation tail: select the repo, populate its archived
-    /// rows, and flash-highlight the target. Runs on countdown expiry or CTA.
+    /// The navigation tail: select the repo, populate its archived rows, and
+    /// flash-highlight the target. Runs immediately once the lookup resolves.
     @MainActor
     private func performArchivedNavigation(worktreeID: UUID, repoID: UUID, archived: [Worktree]) {
         selectedWorktreeIDs = []

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -482,20 +482,38 @@ extension AppState {
     /// surface as error toasts (previously silent).
     @MainActor
     func navigateToArchivedWorktree(_ id: UUID) async {
+        // Request-generation guard (F1). Two deep links (A then B) can have
+        // overlapping lookups that resolve out of order; without this, A's
+        // late resolution would replace B's toast (even one the user
+        // hover-cancelled) and navigate to A. Stamp a fresh token now and
+        // drop any resolution that isn't the newest request. Mirrors the
+        // `revivingArchived[id] == nil` re-entrancy guard used for revive.
+        let myRequestID = UUID()
+        deepLinkRequestID = myRequestID
+
         let archived: [Worktree]
-        if let override = archivedLookupOverride {
-            archived = await override(id)
-        } else {
-            do {
+        do {
+            if let override = archivedLookupOverride {
+                archived = try await override(id)
+            } else {
                 archived = try await daemonClient.listWorktrees(
                     repoID: nil, status: .archived, includeSessionCounts: false
                 )
-            } catch {
-                logger.error("Deep-link archived lookup failed: \(error.localizedDescription)")
-                showErrorToast("Couldn't look up the worktree: \(error.localizedDescription)")
-                return
             }
+        } catch {
+            // Drop a stale failure before it clobbers a newer link's toast.
+            guard deepLinkRequestID == myRequestID else { return }
+            logger.error("Deep-link archived lookup failed: \(error.localizedDescription)")
+            showErrorToast("Couldn't look up the worktree: \(error.localizedDescription)")
+            return
         }
+
+        // Out-of-order RPC resolution: a newer deep link superseded this one
+        // while its lookup was in flight. Drop this stale resolution before it
+        // touches any toast/navigation state. (The toastID mechanism already
+        // covers post-toast staleness; this guard only covers the
+        // RPC-resolution window.)
+        guard deepLinkRequestID == myRequestID else { return }
 
         guard let wt = archived.first(where: { $0.id == id }) else {
             logger.warning("Deep link references unknown worktree \(id.uuidString, privacy: .public)")
@@ -533,6 +551,19 @@ extension AppState {
         archivedWorktrees[repoID] = archived.filter { $0.repoID == repoID }
         archivedWorktreesHasMore[repoID] = false
         highlightedArchivedWorktreeID = worktreeID
+        // Reconcile with fresh data (F2). The captured `archived` snapshot can
+        // be minutes old when the user hover-cancels and clicks the CTA later,
+        // leaving ghost rows for since-deleted/revived worktrees. The refresh
+        // also restores the per-row session-count enrichment the fast
+        // deep-link lookup skips (includeSessionCounts: false).
+        //
+        // Suppressed when the test seam is active: `archivedLookupOverride`
+        // replaces the archived-lookup daemon roundtrip, and this reconcile is
+        // a *second* daemon roundtrip that tests neither provide nor want
+        // touching the real daemon (CLAUDE.md: tests must not touch ~/tbd).
+        if archivedLookupOverride == nil {
+            Task { await self.refreshArchivedWorktrees(repoID: repoID) }
+        }
     }
 
     /// Public entry point for deep-link navigation. Synchronous fast path

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -218,12 +218,10 @@ final class AppState: ObservableObject {
 
     /// The single visible in-app toast; nil when hidden. See AppState+Toast.swift.
     @Published var activeToast: Toast?
-    /// Action for the toast's CTA button (`.action` style). Cleared on dismiss/replace.
-    var toastCTAAction: (() -> Void)?
-    /// One countdown/auto-dismiss tick. Tests shrink this to milliseconds.
+    /// One auto-dismiss tick. Tests shrink this to milliseconds.
     var toastTickDuration: Duration = .seconds(1)
-    /// In-flight countdown or auto-dismiss task for `activeToast`.
-    var toastCountdownTask: Task<Void, Never>?
+    /// In-flight auto-dismiss task for `activeToast`.
+    var toastDismissTask: Task<Void, Never>?
 
     /// Request-generation token for archived deep-link lookups. Stamped fresh
     /// at the start of every `navigateToArchivedWorktree(_:)`; a lookup that

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -214,6 +214,17 @@ final class AppState: ObservableObject {
     /// row, then clears the value after the flash animation completes.
     @Published var highlightedArchivedWorktreeID: UUID?
 
+    // MARK: - Toast (deep-link feedback)
+
+    /// The single visible in-app toast; nil when hidden. See AppState+Toast.swift.
+    @Published var activeToast: Toast?
+    /// Action for the toast's CTA button (`.action` style). Cleared on dismiss/replace.
+    var toastCTAAction: (() -> Void)?
+    /// One countdown/auto-dismiss tick. Tests shrink this to milliseconds.
+    var toastTickDuration: Duration = .seconds(1)
+    /// In-flight countdown or auto-dismiss task for `activeToast`.
+    var toastCountdownTask: Task<Void, Never>?
+
     /// Set briefly when external navigation (notification click, deep link,
     /// jump menu) lands on an active worktree. `SidebarView` observes this
     /// to scroll the worktree row into view, then clears the value.

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -225,6 +225,12 @@ final class AppState: ObservableObject {
     /// In-flight countdown or auto-dismiss task for `activeToast`.
     var toastCountdownTask: Task<Void, Never>?
 
+    /// Request-generation token for archived deep-link lookups. Stamped fresh
+    /// at the start of every `navigateToArchivedWorktree(_:)`; a lookup that
+    /// resolves after a newer deep link superseded it is dropped. Guards
+    /// out-of-order RPC resolution (deep link A then B, A resolves late).
+    var deepLinkRequestID: UUID?
+
     /// Set briefly when external navigation (notification click, deep link,
     /// jump menu) lands on an active worktree. `SidebarView` observes this
     /// to scroll the worktree row into view, then clears the value.
@@ -233,8 +239,8 @@ final class AppState: ObservableObject {
     /// Test seam: when set, replaces the daemon roundtrip for archived
     /// lookups in `navigateToArchivedWorktree(_:)`. Production code leaves
     /// this nil; tests assign a closure returning a deterministic worktree
-    /// list.
-    var archivedLookupOverride: ((UUID) async -> [Worktree])?
+    /// list — or one that throws, to exercise the RPC-failure toast branch.
+    var archivedLookupOverride: ((UUID) async throws -> [Worktree])?
 
     /// Test seam: when set, replaces the daemon rename RPC in
     /// `renameWorktree(id:displayName:)`. Production code leaves this nil;

--- a/Sources/TBDApp/Components/ToastOverlay.swift
+++ b/Sources/TBDApp/Components/ToastOverlay.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Renders `AppState.activeToast` as a bottom-anchored floating capsule.
+/// Renders `AppState.activeToast` as a bottom-right-anchored floating capsule.
 /// Purely presentational: every interaction (hover, CTA, dismiss) is
 /// forwarded to the AppState toast state machine (AppState+Toast.swift),
 /// which owns the countdown task and all transitions.
@@ -11,7 +11,7 @@ struct ToastOverlay: View {
         Group {
             if let toast = appState.activeToast {
                 ToastCard(toast: toast)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
         .animation(.spring(duration: 0.3), value: appState.activeToast)
@@ -37,7 +37,8 @@ private struct ToastCard: View {
                 .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.2), radius: 8, y: 2)
-        .padding(.bottom, 16)
+        .padding(.trailing, 16)
+        .padding(.bottom, 34)
         .onHover { appState.toastHoverChanged($0) }
         .accessibilityElement(children: .combine)
     }

--- a/Sources/TBDApp/Components/ToastOverlay.swift
+++ b/Sources/TBDApp/Components/ToastOverlay.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 /// Renders `AppState.activeToast` as a bottom-right-anchored floating capsule.
-/// Purely presentational: every interaction (hover, CTA, dismiss) is
-/// forwarded to the AppState toast state machine (AppState+Toast.swift),
-/// which owns the countdown task and all transitions.
+/// Purely presentational: it only reflects the current toast style. All
+/// transitions and auto-dismiss timing are owned by the AppState toast state
+/// machine (AppState+Toast.swift).
 struct ToastOverlay: View {
     @EnvironmentObject var appState: AppState
 
@@ -19,7 +19,6 @@ struct ToastOverlay: View {
 }
 
 private struct ToastCard: View {
-    @EnvironmentObject var appState: AppState
     let toast: Toast
 
     var body: some View {
@@ -27,7 +26,6 @@ private struct ToastCard: View {
             leadingIndicator
             Text(toast.message)
                 .lineLimit(2)
-            trailingControls
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -39,7 +37,6 @@ private struct ToastCard: View {
         .shadow(color: .black.opacity(0.2), radius: 8, y: 2)
         .padding(.trailing, 16)
         .padding(.bottom, 34)
-        .onHover { appState.toastHoverChanged($0) }
         .accessibilityElement(children: .combine)
     }
 
@@ -48,35 +45,12 @@ private struct ToastCard: View {
         switch toast.style {
         case .progress:
             ProgressView().controlSize(.small)
-        case .countdown, .action:
+        case .notice:
             Image(systemName: "archivebox")
                 .foregroundStyle(.secondary)
         case .error:
             Image(systemName: "exclamationmark.triangle")
                 .foregroundStyle(.yellow)
-        }
-    }
-
-    @ViewBuilder
-    private var trailingControls: some View {
-        switch toast.style {
-        case .countdown(let secondsRemaining):
-            Text("in \(secondsRemaining)…")
-                .monospacedDigit()
-                .foregroundStyle(.secondary)
-        case .action(let ctaLabel):
-            Button(ctaLabel) { appState.toastCTAAction?() }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-            Button {
-                appState.dismissToast()
-            } label: {
-                Image(systemName: "xmark")
-            }
-            .buttonStyle(.borderless)
-            .help("Dismiss")
-        case .progress, .error:
-            EmptyView()
         }
     }
 }

--- a/Sources/TBDApp/Components/ToastOverlay.swift
+++ b/Sources/TBDApp/Components/ToastOverlay.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// Renders `AppState.activeToast` as a bottom-anchored floating capsule.
+/// Purely presentational: every interaction (hover, CTA, dismiss) is
+/// forwarded to the AppState toast state machine (AppState+Toast.swift),
+/// which owns the countdown task and all transitions.
+struct ToastOverlay: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        Group {
+            if let toast = appState.activeToast {
+                ToastCard(toast: toast)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(.spring(duration: 0.3), value: appState.activeToast)
+    }
+}
+
+private struct ToastCard: View {
+    @EnvironmentObject var appState: AppState
+    let toast: Toast
+
+    var body: some View {
+        HStack(spacing: 10) {
+            leadingIndicator
+            Text(toast.message)
+                .lineLimit(2)
+            trailingControls
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.2), radius: 8, y: 2)
+        .padding(.bottom, 16)
+        .onHover { appState.toastHoverChanged($0) }
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private var leadingIndicator: some View {
+        switch toast.style {
+        case .progress:
+            ProgressView().controlSize(.small)
+        case .countdown, .action:
+            Image(systemName: "archivebox")
+                .foregroundStyle(.secondary)
+        case .error:
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundStyle(.yellow)
+        }
+    }
+
+    @ViewBuilder
+    private var trailingControls: some View {
+        switch toast.style {
+        case .countdown(let secondsRemaining):
+            Text("in \(secondsRemaining)…")
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+        case .action(let ctaLabel):
+            Button(ctaLabel) { appState.toastCTAAction?() }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            Button {
+                appState.dismissToast()
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.borderless)
+            .help("Dismiss")
+        case .progress, .error:
+            EmptyView()
+        }
+    }
+}

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -315,7 +315,7 @@ struct ContentView: View {
             StatusBarView()
         }
         .frame(minWidth: 800, minHeight: 500)
-        .overlay(alignment: .bottom) { ToastOverlay() }
+        .overlay(alignment: .bottomTrailing) { ToastOverlay() }
         .onChange(of: appState.selectedWorktreeIDs) { oldSelection, newSelection in
             overlayCoordinator.close()
             markSelectedWorktreesAsRead(newSelection)

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -315,6 +315,7 @@ struct ContentView: View {
             StatusBarView()
         }
         .frame(minWidth: 800, minHeight: 500)
+        .overlay(alignment: .bottom) { ToastOverlay() }
         .onChange(of: appState.selectedWorktreeIDs) { oldSelection, newSelection in
             overlayCoordinator.close()
             markSelectedWorktreesAsRead(newSelection)

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -513,7 +513,8 @@ actor DaemonClient {
         limit: Int? = nil,
         offset: Int? = nil,
         excludeArchived: Bool = false,
-        scratchOnly: Bool = false
+        scratchOnly: Bool = false,
+        includeSessionCounts: Bool? = nil
     ) async throws -> [Worktree] {
         return try await callAsync(
             method: RPCMethod.worktreeList,
@@ -523,7 +524,8 @@ actor DaemonClient {
                 limit: limit,
                 offset: offset,
                 excludeArchived: excludeArchived,
-                scratchOnly: scratchOnly
+                scratchOnly: scratchOnly,
+                includeSessionCounts: includeSessionCounts
             ),
             resultType: [Worktree].self
         )

--- a/Sources/TBDApp/Toast.swift
+++ b/Sources/TBDApp/Toast.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// A transient in-app toast. One toast is visible at a time
+/// (`AppState.activeToast`); showing a new one replaces the current.
+/// First client: deep-link navigation to archived worktrees.
+struct Toast: Equatable, Identifiable {
+    enum Style: Equatable {
+        /// Indeterminate work in progress (spinner).
+        case progress
+        /// Live countdown before an announced action runs.
+        case countdown(secondsRemaining: Int)
+        /// Countdown cancelled — explicit CTA + dismiss buttons.
+        case action(ctaLabel: String)
+        /// Failure notice; auto-dismisses.
+        case error
+    }
+
+    let id: UUID
+    var message: String
+    var style: Style
+}

--- a/Sources/TBDApp/Toast.swift
+++ b/Sources/TBDApp/Toast.swift
@@ -7,10 +7,8 @@ struct Toast: Equatable, Identifiable {
     enum Style: Equatable {
         /// Indeterminate work in progress (spinner).
         case progress
-        /// Live countdown before an announced action runs.
-        case countdown(secondsRemaining: Int)
-        /// Countdown cancelled — explicit CTA + dismiss buttons.
-        case action(ctaLabel: String)
+        /// Informational notice (archivebox icon); auto-dismisses.
+        case notice
         /// Failure notice; auto-dismisses.
         case error
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -96,7 +96,11 @@ extension RPCRouter {
         // cleaned up. Negative scan results are not cached, so without this
         // guard the poll re-scans the entire projects directory every 2s,
         // pegging the daemon at ~95% CPU.
-        if params.status == .archived {
+        //
+        // The deep-link archived lookup opts out via `includeSessionCounts ==
+        // false`: it only needs the target row's identity, not its session
+        // count, and enriching all archived rows made that lookup take ~19s.
+        if params.status == .archived && (params.includeSessionCounts ?? true) {
             for i in worktrees.indices where worktrees[i].status == .archived {
                 if let dir = ClaudeProjectDirectory.resolve(worktreePath: worktrees[i].path) {
                     worktrees[i].liveClaudeSessionCount = ClaudeSessionScanner.countSessionFiles(projectDir: dir)

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -832,13 +832,21 @@ public struct WorktreeListParams: Codable, Sendable {
     /// Note `repoID: nil` means "no repo filter" (every repo plus scratch),
     /// NOT "scratch only" — this flag is the only way to get scratch-only rows.
     public let scratchOnly: Bool?
+    /// When false, the daemon skips per-row live session-file counting for the
+    /// archived listing (an expensive `~/.claude/projects/*` scan per row). The
+    /// deep-link archived lookup opts out with `false` because it only needs the
+    /// row's identity, not its session count. Optional (nil == true) for
+    /// backward compatibility — old daemons ignore the unknown key and always
+    /// enrich; old clients omit it and get the enriched default.
+    public let includeSessionCounts: Bool?
     public init(
         repoID: UUID? = nil,
         status: WorktreeStatus? = nil,
         limit: Int? = nil,
         offset: Int? = nil,
         excludeArchived: Bool? = nil,
-        scratchOnly: Bool? = nil
+        scratchOnly: Bool? = nil,
+        includeSessionCounts: Bool? = nil
     ) {
         self.repoID = repoID
         self.status = status
@@ -846,6 +854,7 @@ public struct WorktreeListParams: Codable, Sendable {
         self.offset = offset
         self.excludeArchived = excludeArchived
         self.scratchOnly = scratchOnly
+        self.includeSessionCounts = includeSessionCounts
     }
 }
 

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -104,7 +104,7 @@ private func tearDown(_ suiteName: String) {
     let clock = ContinuousClock()
     let start = clock.now
     while appState.highlightedArchivedWorktreeID != archivedID {
-        if clock.now - start > .seconds(2) { break }
+        if clock.now - start > .seconds(15) { break }
         try? await Task.sleep(for: .milliseconds(2))
     }
 

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -91,12 +91,22 @@ private func tearDown(_ suiteName: String) {
     // Test seam: short-circuit the daemon RPC.
     appState.archivedLookupOverride = { _ in [archivedWT] }
     appState.worktrees = [:] // active miss
+    // Archived deep links now announce via a cancellable countdown toast
+    // before navigating; shrink the tick so the test doesn't wait 5 real
+    // seconds for the deferred navigation to fire.
+    appState.toastTickDuration = .milliseconds(5)
 
     let url = DeepLink.makeOpenWorktreeURL(archivedID)
     DeepLinkHandler.handle(url, appState: appState)
 
-    // navigateToArchivedWorktree is async — wait for it to settle.
-    try? await Task.sleep(nanoseconds: 50_000_000)
+    // navigateToArchivedWorktree is async and navigation is deferred behind
+    // the countdown — poll until the countdown expires and navigates.
+    let clock = ContinuousClock()
+    let start = clock.now
+    while appState.highlightedArchivedWorktreeID != archivedID {
+        if clock.now - start > .seconds(2) { break }
+        try? await Task.sleep(for: .milliseconds(2))
+    }
 
     #expect(appState.selectedRepoID == repoID)
     #expect(appState.highlightedArchivedWorktreeID == archivedID)

--- a/Tests/TBDAppTests/DeepLinkHandlerTests.swift
+++ b/Tests/TBDAppTests/DeepLinkHandlerTests.swift
@@ -91,16 +91,15 @@ private func tearDown(_ suiteName: String) {
     // Test seam: short-circuit the daemon RPC.
     appState.archivedLookupOverride = { _ in [archivedWT] }
     appState.worktrees = [:] // active miss
-    // Archived deep links now announce via a cancellable countdown toast
-    // before navigating; shrink the tick so the test doesn't wait 5 real
-    // seconds for the deferred navigation to fire.
+    // Archived deep links navigate immediately and show a brief auto-dismissing
+    // notice; shrink the tick so the notice's dismiss task doesn't linger.
     appState.toastTickDuration = .milliseconds(5)
 
     let url = DeepLink.makeOpenWorktreeURL(archivedID)
     DeepLinkHandler.handle(url, appState: appState)
 
-    // navigateToArchivedWorktree is async and navigation is deferred behind
-    // the countdown — poll until the countdown expires and navigates.
+    // navigateToArchivedWorktree is async (spawned in its own Task) — poll
+    // until its lookup resolves and it navigates immediately.
     let clock = ContinuousClock()
     let start = clock.now
     while appState.highlightedArchivedWorktreeID != archivedID {

--- a/Tests/TBDAppTests/DeepLinkToastTests.swift
+++ b/Tests/TBDAppTests/DeepLinkToastTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for the deep-link toast state machine (Toast model + AppState+Toast).
+///
+/// Every test constructs `AppState(userDefaults:)` against a throwaway suite —
+/// `UserDefaults.standard` on this unbundled executable is the developer's
+/// real `TBDApp.plist`. Countdown ticks are shrunk to 5ms via
+/// `toastTickDuration` so no test sleeps for real seconds.
+@MainActor
+@Suite("Deep-link toast")
+struct DeepLinkToastTests {
+
+    private func withState(_ body: (AppState) async -> Void) async {
+        let suiteName = "TBDAppTests.DeepLinkToast.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: defaults)
+        state.toastTickDuration = .milliseconds(5)
+        await body(state)
+    }
+
+    /// Poll `cond` on the main actor until true or deadline. Returns success.
+    private func waitUntil(
+        deadline: Duration = .seconds(2), _ cond: @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let start = clock.now
+        while !cond() {
+            if clock.now - start > deadline { return false }
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return true
+    }
+
+    // MARK: - showToast / dismissToast basics
+
+    @Test func showToast_publishesToast() async {
+        await withState { state in
+            state.showToast(Toast(id: UUID(), message: "Looking for worktree…", style: .progress))
+            #expect(state.activeToast?.message == "Looking for worktree…")
+            #expect(state.activeToast?.style == .progress)
+        }
+    }
+
+    @Test func dismissToast_clearsToastAndCTA() async {
+        await withState { state in
+            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
+            state.toastCTAAction = {}
+            state.dismissToast()
+            #expect(state.activeToast == nil)
+            #expect(state.toastCTAAction == nil)
+        }
+    }
+
+    // MARK: - Countdown
+
+    @Test func startToastCountdown_beginsAtFullSeconds() async {
+        await withState { state in
+            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
+            state.startToastCountdown(onExpiry: {})
+            #expect(state.activeToast?.style == .countdown(secondsRemaining: 5))
+        }
+    }
+
+    @Test func countdownExpiry_firesOnExpiryOnceAndDismisses() async {
+        await withState { state in
+            var fired = 0
+            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
+            state.startToastCountdown(onExpiry: { fired += 1 })
+            let expired = await waitUntil { state.activeToast == nil }
+            #expect(expired)
+            // Drain a few more ticks to prove it fires exactly once.
+            try? await Task.sleep(for: .milliseconds(50))
+            #expect(fired == 1)
+        }
+    }
+
+    @Test func hoverDuringCountdown_cancelsPermanentlyAndShowsCTA() async {
+        await withState { state in
+            var fired = false
+            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
+            state.startToastCountdown(onExpiry: { fired = true })
+            state.toastHoverChanged(true)
+            #expect(state.activeToast?.style == .action(ctaLabel: "Go to archive entry"))
+            // Mouse leaves — countdown must NOT resume.
+            state.toastHoverChanged(false)
+            try? await Task.sleep(for: .milliseconds(60))  // > 10 ticks
+            #expect(fired == false)
+            #expect(state.activeToast != nil)
+        }
+    }
+
+    @Test func hoverOutsideCountdownState_isIgnored() async {
+        await withState { state in
+            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
+            state.toastHoverChanged(true)
+            #expect(state.activeToast?.style == .progress)
+        }
+    }
+
+    @Test func newToast_replacesOldAndCancelsItsCountdown() async {
+        await withState { state in
+            var fired = false
+            state.showToast(Toast(id: UUID(), message: "old", style: .progress))
+            state.startToastCountdown(onExpiry: { fired = true })
+            state.showToast(Toast(id: UUID(), message: "new", style: .progress))
+            try? await Task.sleep(for: .milliseconds(60))
+            #expect(fired == false)
+            #expect(state.activeToast?.message == "new")
+        }
+    }
+
+    // MARK: - Error toast
+
+    @Test func errorToast_autoDismisses() async {
+        await withState { state in
+            state.showErrorToast("Worktree not found — it may have been deleted.")
+            #expect(state.activeToast?.style == .error)
+            let dismissed = await waitUntil { state.activeToast == nil }
+            #expect(dismissed)
+        }
+    }
+}

--- a/Tests/TBDAppTests/DeepLinkToastTests.swift
+++ b/Tests/TBDAppTests/DeepLinkToastTests.swift
@@ -37,7 +37,7 @@ struct DeepLinkToastTests {
 
     /// Poll `cond` on the main actor until true or deadline. Returns success.
     private func waitUntil(
-        deadline: Duration = .seconds(2), _ cond: @MainActor () -> Bool
+        deadline: Duration = .seconds(15), _ cond: @MainActor () -> Bool
     ) async -> Bool {
         let clock = ContinuousClock()
         let start = clock.now
@@ -103,6 +103,8 @@ struct DeepLinkToastTests {
             try? await Task.sleep(for: .milliseconds(60))  // > 10 ticks
             #expect(fired == false)
             #expect(state.activeToast != nil)
+            // Proves the state machine settled (not just starved by scheduler load).
+            #expect(state.activeToast?.style == .action(ctaLabel: "Go to archive entry"))
         }
     }
 

--- a/Tests/TBDAppTests/DeepLinkToastTests.swift
+++ b/Tests/TBDAppTests/DeepLinkToastTests.swift
@@ -268,4 +268,101 @@ struct DeepLinkToastTests {
             #expect(state.selectedWorktreeIDs == [id])
         }
     }
+
+    // MARK: - Request-generation guard (F1/F5)
+
+    /// F5 (spec line ~68): a second deep link mid-countdown restarts the state
+    /// machine for the new UUID. The toast retargets to B, and only B's repo is
+    /// ever navigated to — A's countdown is cancelled by the replacing toast.
+    @Test func secondDeepLinkMidCountdown_restartsForNewUUID() async {
+        await withState { state in
+            let repoA = UUID(), idA = UUID()
+            let repoB = UUID(), idB = UUID()
+            let a = makeArchived(id: idA, repoID: repoA)  // displayName "Fix Login"
+            var b = makeArchived(id: idB, repoID: repoB)
+            b.displayName = "Refactor DB"
+            state.archivedLookupOverride = { reqID in
+                if reqID == idA { return [a] }
+                if reqID == idB { return [b] }
+                return []
+            }
+
+            await state.navigateToArchivedWorktree(idA)
+            #expect(state.activeToast?.message.contains("Fix Login") == true)
+
+            await state.navigateToArchivedWorktree(idB)
+            // Toast now names B, countdown restarted.
+            #expect(state.activeToast?.message.contains("Refactor DB") == true)
+            #expect(state.activeToast?.style == .countdown(secondsRemaining: 5))
+
+            let navigated = await waitUntil {
+                state.highlightedArchivedWorktreeID == idB && state.activeToast == nil
+            }
+            #expect(navigated)
+            #expect(state.selectedRepoID == repoB)
+            // A must never have been navigated to.
+            #expect(state.selectedRepoID != repoA)
+        }
+    }
+
+    /// F1: two overlapping lookups (A slow, B fast) that resolve out of order.
+    /// A's late resolution must be dropped by the request-generation guard so
+    /// it can't clobber B's toast/navigation.
+    @Test func staleLookupResolution_doesNotClobberNewerRequest() async {
+        await withState { state in
+            let repoA = UUID(), idA = UUID()
+            let repoB = UUID(), idB = UUID()
+            let a = makeArchived(id: idA, repoID: repoA)  // displayName "Fix Login"
+            var b = makeArchived(id: idB, repoID: repoB)
+            b.displayName = "Refactor DB"
+            state.archivedLookupOverride = { reqID in
+                if reqID == idA {
+                    try? await Task.sleep(for: .milliseconds(100))
+                    return [a]
+                }
+                if reqID == idB { return [b] }
+                return []
+            }
+
+            // A's lookup starts first (production spawns each deep link in its
+            // own Task, so requests stamp their generation token in arrival
+            // order). Let A stamp its token and enter its slow lookup before B
+            // starts — otherwise B's own await would yield the actor back to A,
+            // inverting the stamp order this guard depends on.
+            let taskA = Task { await state.navigateToArchivedWorktree(idA) }
+            try? await Task.sleep(for: .milliseconds(10))
+            // B supersedes A (newest request); its lookup resolves immediately.
+            await state.navigateToArchivedWorktree(idB)
+            #expect(state.activeToast?.message.contains("Refactor DB") == true)
+
+            // Let A's slow lookup resolve — the guard must drop it.
+            _ = await taskA.value
+
+            let navigated = await waitUntil {
+                state.highlightedArchivedWorktreeID == idB && state.activeToast == nil
+            }
+            #expect(navigated)
+            #expect(state.selectedRepoID == repoB)
+            // A's late resolution never navigated to A or showed A's toast.
+            #expect(state.highlightedArchivedWorktreeID != idA)
+        }
+    }
+
+    // MARK: - RPC-failure branch (F4)
+
+    /// F4: a thrown lookup error exercises the same error-toast branch as a real
+    /// RPC failure. Previously the seam was non-throwing and this was untestable.
+    @Test func lookupThrows_showsErrorToast() async {
+        await withState { state in
+            struct LookupError: Error {}
+            state.archivedLookupOverride = { _ in throw LookupError() }
+
+            await state.navigateToArchivedWorktree(UUID())
+
+            #expect(state.activeToast?.style == .error)
+            #expect(state.activeToast?.message.hasPrefix("Couldn't look up the worktree") == true)
+            let dismissed = await waitUntil { state.activeToast == nil }
+            #expect(dismissed)
+        }
+    }
 }

--- a/Tests/TBDAppTests/DeepLinkToastTests.swift
+++ b/Tests/TBDAppTests/DeepLinkToastTests.swift
@@ -83,8 +83,9 @@ struct DeepLinkToastTests {
         await withState { state in
             state.showErrorToast("Worktree not found — it may have been deleted.")
             #expect(state.activeToast?.style == .error)
-            let dismissed = await waitUntil { state.activeToast == nil }
-            #expect(dismissed)
+            #expect(state.toastDismissTask != nil)
+            await state.toastDismissTask?.value
+            #expect(state.activeToast == nil)
         }
     }
 
@@ -92,8 +93,9 @@ struct DeepLinkToastTests {
         await withState { state in
             state.showTransientToast("heads up", style: .notice)
             #expect(state.activeToast?.style == .notice)
-            let dismissed = await waitUntil { state.activeToast == nil }
-            #expect(dismissed)
+            #expect(state.toastDismissTask != nil)
+            await state.toastDismissTask?.value
+            #expect(state.activeToast == nil)
         }
     }
 
@@ -117,8 +119,9 @@ struct DeepLinkToastTests {
             #expect(state.activeToast?.message.contains("Fix Login") == true)
             #expect(state.activeToast?.message.contains("archived") == true)
             // The notice auto-dismisses.
-            let dismissed = await waitUntil { state.activeToast == nil }
-            #expect(dismissed)
+            #expect(state.toastDismissTask != nil)
+            await state.toastDismissTask?.value
+            #expect(state.activeToast == nil)
         }
     }
 
@@ -130,8 +133,9 @@ struct DeepLinkToastTests {
 
             #expect(state.activeToast?.style == .error)
             #expect(state.activeToast?.message == "Worktree not found — it may have been deleted.")
-            let dismissed = await waitUntil { state.activeToast == nil }
-            #expect(dismissed)
+            #expect(state.toastDismissTask != nil)
+            await state.toastDismissTask?.value
+            #expect(state.activeToast == nil)
         }
     }
 
@@ -266,8 +270,9 @@ struct DeepLinkToastTests {
 
             #expect(state.activeToast?.style == .error)
             #expect(state.activeToast?.message.hasPrefix("Couldn't look up the worktree") == true)
-            let dismissed = await waitUntil { state.activeToast == nil }
-            #expect(dismissed)
+            #expect(state.toastDismissTask != nil)
+            await state.toastDismissTask?.value
+            #expect(state.activeToast == nil)
         }
     }
 }

--- a/Tests/TBDAppTests/DeepLinkToastTests.swift
+++ b/Tests/TBDAppTests/DeepLinkToastTests.swift
@@ -22,6 +22,19 @@ struct DeepLinkToastTests {
         await body(state)
     }
 
+    private func makeArchived(id: UUID, repoID: UUID?) -> Worktree {
+        Worktree(
+            id: id,
+            repoID: repoID,
+            name: "wt-\(id.uuidString.prefix(8))",
+            displayName: "Fix Login",
+            branch: "fix-login",
+            path: "/tmp/test",
+            status: .archived,
+            tmuxServer: "test-server"
+        )
+    }
+
     /// Poll `cond` on the main actor until true or deadline. Returns success.
     private func waitUntil(
         deadline: Duration = .seconds(2), _ cond: @MainActor () -> Bool
@@ -121,6 +134,136 @@ struct DeepLinkToastTests {
             #expect(state.activeToast?.style == .error)
             let dismissed = await waitUntil { state.activeToast == nil }
             #expect(dismissed)
+        }
+    }
+
+    // MARK: - Deep-link archived flow
+
+    @Test func archivedHit_showsCountdownToastWithDisplayName() async {
+        await withState { state in
+            let repoID = UUID()
+            let id = UUID()
+            state.archivedLookupOverride = { [wt = makeArchived(id: id, repoID: repoID)] _ in [wt] }
+
+            await state.navigateToArchivedWorktree(id)
+
+            #expect(state.activeToast?.style == .countdown(secondsRemaining: 5))
+            #expect(state.activeToast?.message.contains("Fix Login") == true)
+            #expect(state.activeToast?.message.contains("archived") == true)
+            // Navigation deferred: nothing selected yet.
+            #expect(state.selectedRepoID == nil)
+            #expect(state.highlightedArchivedWorktreeID == nil)
+        }
+    }
+
+    @Test func archivedCountdownExpiry_navigatesToArchiveEntry() async {
+        await withState { state in
+            let repoID = UUID()
+            let id = UUID()
+            state.archivedLookupOverride = { [wt = makeArchived(id: id, repoID: repoID)] _ in [wt] }
+
+            await state.navigateToArchivedWorktree(id)
+
+            let navigated = await waitUntil {
+                state.highlightedArchivedWorktreeID == id && state.activeToast == nil
+            }
+            #expect(navigated)
+            #expect(state.selectedRepoID == repoID)
+            #expect(state.selectedWorktreeIDs.isEmpty)
+            #expect(state.archivedWorktrees[repoID]?.map(\.id) == [id])
+        }
+    }
+
+    @Test func archivedHoverThenCTA_navigatesImmediately() async {
+        await withState { state in
+            let repoID = UUID()
+            let id = UUID()
+            state.archivedLookupOverride = { [wt = makeArchived(id: id, repoID: repoID)] _ in [wt] }
+
+            await state.navigateToArchivedWorktree(id)
+            state.toastHoverChanged(true)
+            #expect(state.activeToast?.style == .action(ctaLabel: "Go to archive entry"))
+
+            state.toastCTAAction?()
+
+            #expect(state.selectedRepoID == repoID)
+            #expect(state.highlightedArchivedWorktreeID == id)
+            #expect(state.activeToast == nil)
+        }
+    }
+
+    @Test func archivedHoverThenDismiss_neverNavigates() async {
+        await withState { state in
+            let repoID = UUID()
+            let id = UUID()
+            state.archivedLookupOverride = { [wt = makeArchived(id: id, repoID: repoID)] _ in [wt] }
+
+            await state.navigateToArchivedWorktree(id)
+            state.toastHoverChanged(true)
+            state.dismissToast()
+            try? await Task.sleep(for: .milliseconds(60))
+
+            #expect(state.selectedRepoID == nil)
+            #expect(state.highlightedArchivedWorktreeID == nil)
+            #expect(state.activeToast == nil)
+        }
+    }
+
+    @Test func unknownWorktree_showsErrorToast() async {
+        await withState { state in
+            state.archivedLookupOverride = { _ in [] }
+
+            await state.navigateToArchivedWorktree(UUID())
+
+            #expect(state.activeToast?.style == .error)
+            #expect(state.activeToast?.message == "Worktree not found — it may have been deleted.")
+            let dismissed = await waitUntil { state.activeToast == nil }
+            #expect(dismissed)
+        }
+    }
+
+    @Test func scratchWorktree_dismissesToastWithoutNavigation() async {
+        await withState { state in
+            let id = UUID()
+            state.archivedLookupOverride = { [wt = makeArchived(id: id, repoID: nil)] _ in [wt] }
+
+            await state.navigateToArchivedWorktree(id)
+
+            #expect(state.activeToast == nil)
+            #expect(state.selectedRepoID == nil)
+        }
+    }
+
+    @Test func navigateToWorktreeMiss_showsLookingToast() async {
+        await withState { state in
+            state.isInitialStateLoaded = true
+            // Slow lookup so the progress state is observable.
+            state.archivedLookupOverride = { _ in
+                try? await Task.sleep(for: .milliseconds(100))
+                return []
+            }
+
+            state.navigateToWorktree(UUID())
+
+            let looking = await waitUntil { state.activeToast?.style == .progress }
+            #expect(looking)
+            #expect(state.activeToast?.message == "Looking for worktree…")
+        }
+    }
+
+    @Test func activeWorktreeHit_showsNoToast() async {
+        await withState { state in
+            state.isInitialStateLoaded = true
+            let repoID = UUID()
+            let id = UUID()
+            var wt = makeArchived(id: id, repoID: repoID)
+            wt.status = .active
+            state.worktrees = [repoID: [wt]]
+
+            state.navigateToWorktree(id)
+
+            #expect(state.activeToast == nil)
+            #expect(state.selectedWorktreeIDs == [id])
         }
     }
 }

--- a/Tests/TBDAppTests/DeepLinkToastTests.swift
+++ b/Tests/TBDAppTests/DeepLinkToastTests.swift
@@ -7,7 +7,7 @@ import TBDShared
 ///
 /// Every test constructs `AppState(userDefaults:)` against a throwaway suite —
 /// `UserDefaults.standard` on this unbundled executable is the developer's
-/// real `TBDApp.plist`. Countdown ticks are shrunk to 5ms via
+/// real `TBDApp.plist`. Auto-dismiss ticks are shrunk to 5ms via
 /// `toastTickDuration` so no test sleeps for real seconds.
 @MainActor
 @Suite("Deep-link toast")
@@ -58,77 +58,26 @@ struct DeepLinkToastTests {
         }
     }
 
-    @Test func dismissToast_clearsToastAndCTA() async {
+    @Test func dismissToast_clearsToast() async {
         await withState { state in
             state.showToast(Toast(id: UUID(), message: "m", style: .progress))
-            state.toastCTAAction = {}
             state.dismissToast()
             #expect(state.activeToast == nil)
-            #expect(state.toastCTAAction == nil)
         }
     }
 
-    // MARK: - Countdown
-
-    @Test func startToastCountdown_beginsAtFullSeconds() async {
+    @Test func newToast_replacesOldAndCancelsItsDismissTask() async {
         await withState { state in
-            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
-            state.startToastCountdown(onExpiry: {})
-            #expect(state.activeToast?.style == .countdown(secondsRemaining: 5))
-        }
-    }
-
-    @Test func countdownExpiry_firesOnExpiryOnceAndDismisses() async {
-        await withState { state in
-            var fired = 0
-            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
-            state.startToastCountdown(onExpiry: { fired += 1 })
-            let expired = await waitUntil { state.activeToast == nil }
-            #expect(expired)
-            // Drain a few more ticks to prove it fires exactly once.
-            try? await Task.sleep(for: .milliseconds(50))
-            #expect(fired == 1)
-        }
-    }
-
-    @Test func hoverDuringCountdown_cancelsPermanentlyAndShowsCTA() async {
-        await withState { state in
-            var fired = false
-            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
-            state.startToastCountdown(onExpiry: { fired = true })
-            state.toastHoverChanged(true)
-            #expect(state.activeToast?.style == .action(ctaLabel: "Go to archive entry"))
-            // Mouse leaves — countdown must NOT resume.
-            state.toastHoverChanged(false)
-            try? await Task.sleep(for: .milliseconds(60))  // > 10 ticks
-            #expect(fired == false)
-            #expect(state.activeToast != nil)
-            // Proves the state machine settled (not just starved by scheduler load).
-            #expect(state.activeToast?.style == .action(ctaLabel: "Go to archive entry"))
-        }
-    }
-
-    @Test func hoverOutsideCountdownState_isIgnored() async {
-        await withState { state in
-            state.showToast(Toast(id: UUID(), message: "m", style: .progress))
-            state.toastHoverChanged(true)
-            #expect(state.activeToast?.style == .progress)
-        }
-    }
-
-    @Test func newToast_replacesOldAndCancelsItsCountdown() async {
-        await withState { state in
-            var fired = false
-            state.showToast(Toast(id: UUID(), message: "old", style: .progress))
-            state.startToastCountdown(onExpiry: { fired = true })
+            // The old transient toast schedules an auto-dismiss ~4 ticks out.
+            state.showTransientToast("old", style: .notice)
+            // Replacing it must cancel that task so it can't clear the new one.
             state.showToast(Toast(id: UUID(), message: "new", style: .progress))
-            try? await Task.sleep(for: .milliseconds(60))
-            #expect(fired == false)
+            try? await Task.sleep(for: .milliseconds(60))  // > old's ~4-tick deadline
             #expect(state.activeToast?.message == "new")
         }
     }
 
-    // MARK: - Error toast
+    // MARK: - Transient (notice / error) toast auto-dismiss
 
     @Test func errorToast_autoDismisses() async {
         await withState { state in
@@ -139,9 +88,18 @@ struct DeepLinkToastTests {
         }
     }
 
+    @Test func noticeToast_autoDismisses() async {
+        await withState { state in
+            state.showTransientToast("heads up", style: .notice)
+            #expect(state.activeToast?.style == .notice)
+            let dismissed = await waitUntil { state.activeToast == nil }
+            #expect(dismissed)
+        }
+    }
+
     // MARK: - Deep-link archived flow
 
-    @Test func archivedHit_showsCountdownToastWithDisplayName() async {
+    @Test func archivedHit_navigatesImmediatelyWithNoticeToast() async {
         await withState { state in
             let repoID = UUID()
             let id = UUID()
@@ -149,65 +107,18 @@ struct DeepLinkToastTests {
 
             await state.navigateToArchivedWorktree(id)
 
-            #expect(state.activeToast?.style == .countdown(secondsRemaining: 5))
-            #expect(state.activeToast?.message.contains("Fix Login") == true)
-            #expect(state.activeToast?.message.contains("archived") == true)
-            // Navigation deferred: nothing selected yet.
-            #expect(state.selectedRepoID == nil)
-            #expect(state.highlightedArchivedWorktreeID == nil)
-        }
-    }
-
-    @Test func archivedCountdownExpiry_navigatesToArchiveEntry() async {
-        await withState { state in
-            let repoID = UUID()
-            let id = UUID()
-            state.archivedLookupOverride = { [wt = makeArchived(id: id, repoID: repoID)] _ in [wt] }
-
-            await state.navigateToArchivedWorktree(id)
-
-            let navigated = await waitUntil {
-                state.highlightedArchivedWorktreeID == id && state.activeToast == nil
-            }
-            #expect(navigated)
-            #expect(state.selectedRepoID == repoID)
-            #expect(state.selectedWorktreeIDs.isEmpty)
-            #expect(state.archivedWorktrees[repoID]?.map(\.id) == [id])
-        }
-    }
-
-    @Test func archivedHoverThenCTA_navigatesImmediately() async {
-        await withState { state in
-            let repoID = UUID()
-            let id = UUID()
-            state.archivedLookupOverride = { [wt = makeArchived(id: id, repoID: repoID)] _ in [wt] }
-
-            await state.navigateToArchivedWorktree(id)
-            state.toastHoverChanged(true)
-            #expect(state.activeToast?.style == .action(ctaLabel: "Go to archive entry"))
-
-            state.toastCTAAction?()
-
+            // Navigation is immediate — no countdown, no deferral.
             #expect(state.selectedRepoID == repoID)
             #expect(state.highlightedArchivedWorktreeID == id)
-            #expect(state.activeToast == nil)
-        }
-    }
-
-    @Test func archivedHoverThenDismiss_neverNavigates() async {
-        await withState { state in
-            let repoID = UUID()
-            let id = UUID()
-            state.archivedLookupOverride = { [wt = makeArchived(id: id, repoID: repoID)] _ in [wt] }
-
-            await state.navigateToArchivedWorktree(id)
-            state.toastHoverChanged(true)
-            state.dismissToast()
-            try? await Task.sleep(for: .milliseconds(60))
-
-            #expect(state.selectedRepoID == nil)
-            #expect(state.highlightedArchivedWorktreeID == nil)
-            #expect(state.activeToast == nil)
+            #expect(state.selectedWorktreeIDs.isEmpty)
+            #expect(state.archivedWorktrees[repoID]?.map(\.id) == [id])
+            // And a brief notice explains the archive landing.
+            #expect(state.activeToast?.style == .notice)
+            #expect(state.activeToast?.message.contains("Fix Login") == true)
+            #expect(state.activeToast?.message.contains("archived") == true)
+            // The notice auto-dismisses.
+            let dismissed = await waitUntil { state.activeToast == nil }
+            #expect(dismissed)
         }
     }
 
@@ -271,10 +182,10 @@ struct DeepLinkToastTests {
 
     // MARK: - Request-generation guard (F1/F5)
 
-    /// F5 (spec line ~68): a second deep link mid-countdown restarts the state
-    /// machine for the new UUID. The toast retargets to B, and only B's repo is
-    /// ever navigated to — A's countdown is cancelled by the replacing toast.
-    @Test func secondDeepLinkMidCountdown_restartsForNewUUID() async {
+    /// F5: a second deep link supersedes the first. With auto-navigation each
+    /// link navigates immediately, so B's navigation simply wins — only B's
+    /// repo is ever selected.
+    @Test func secondDeepLink_navigatesToNewUUID() async {
         await withState { state in
             let repoA = UUID(), idA = UUID()
             let repoB = UUID(), idB = UUID()
@@ -288,26 +199,20 @@ struct DeepLinkToastTests {
             }
 
             await state.navigateToArchivedWorktree(idA)
-            #expect(state.activeToast?.message.contains("Fix Login") == true)
+            #expect(state.selectedRepoID == repoA)
 
             await state.navigateToArchivedWorktree(idB)
-            // Toast now names B, countdown restarted.
-            #expect(state.activeToast?.message.contains("Refactor DB") == true)
-            #expect(state.activeToast?.style == .countdown(secondsRemaining: 5))
-
-            let navigated = await waitUntil {
-                state.highlightedArchivedWorktreeID == idB && state.activeToast == nil
-            }
-            #expect(navigated)
+            // B navigated last; its repo is selected and its notice shown.
             #expect(state.selectedRepoID == repoB)
-            // A must never have been navigated to.
-            #expect(state.selectedRepoID != repoA)
+            #expect(state.highlightedArchivedWorktreeID == idB)
+            #expect(state.activeToast?.message.contains("Refactor DB") == true)
+            #expect(state.activeToast?.style == .notice)
         }
     }
 
     /// F1: two overlapping lookups (A slow, B fast) that resolve out of order.
     /// A's late resolution must be dropped by the request-generation guard so
-    /// it can't clobber B's toast/navigation.
+    /// it can't clobber B's navigation — no navigation to A, no A toast.
     @Test func staleLookupResolution_doesNotClobberNewerRequest() async {
         await withState { state in
             let repoA = UUID(), idA = UUID()
@@ -331,20 +236,20 @@ struct DeepLinkToastTests {
             // inverting the stamp order this guard depends on.
             let taskA = Task { await state.navigateToArchivedWorktree(idA) }
             try? await Task.sleep(for: .milliseconds(10))
-            // B supersedes A (newest request); its lookup resolves immediately.
+            // B supersedes A (newest request); its lookup resolves immediately
+            // and navigates right away.
             await state.navigateToArchivedWorktree(idB)
+            #expect(state.selectedRepoID == repoB)
+            #expect(state.highlightedArchivedWorktreeID == idB)
             #expect(state.activeToast?.message.contains("Refactor DB") == true)
 
             // Let A's slow lookup resolve — the guard must drop it.
             _ = await taskA.value
 
-            let navigated = await waitUntil {
-                state.highlightedArchivedWorktreeID == idB && state.activeToast == nil
-            }
-            #expect(navigated)
+            // A's late resolution never navigated to A nor showed A's toast.
             #expect(state.selectedRepoID == repoB)
-            // A's late resolution never navigated to A or showed A's toast.
-            #expect(state.highlightedArchivedWorktreeID != idA)
+            #expect(state.highlightedArchivedWorktreeID == idB)
+            #expect(state.activeToast?.message.contains("Fix Login") != true)
         }
     }
 

--- a/Tests/TBDDaemonTests/RPCRouterWorktreeTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterWorktreeTests.swift
@@ -149,6 +149,67 @@ extension RPCRouterTests {
         #expect(page.map(\.id) == [wt2.id])
     }
 
+    @Test("worktree.list archived enriches liveClaudeSessionCount by default")
+    func worktreeListArchivedEnrichesSessionCounts() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "b",
+            path: "/tmp/wt-\(UUID())",
+            tmuxServer: "srv"
+        )
+        try await db.worktrees.archive(id: wt.id)
+
+        // Default (includeSessionCounts nil == true): the archived row is
+        // enriched, so liveClaudeSessionCount is populated (0 here — the /tmp
+        // path has no `~/.claude/projects` dir — but non-nil is the point).
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(repoID: repo.id, status: .archived)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        let worktrees = try response.decodeResult([Worktree].self)
+        #expect(worktrees.count == 1)
+        #expect(worktrees[0].liveClaudeSessionCount != nil)
+    }
+
+    @Test("worktree.list archived with includeSessionCounts:false skips enrichment")
+    func worktreeListArchivedSkipsSessionCounts() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "wt",
+            branch: "b",
+            path: "/tmp/wt-\(UUID())",
+            tmuxServer: "srv"
+        )
+        try await db.worktrees.archive(id: wt.id)
+
+        // includeSessionCounts:false (deep-link lookup) skips the expensive
+        // per-row scan, so liveClaudeSessionCount stays nil.
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeList,
+            params: WorktreeListParams(
+                repoID: repo.id, status: .archived, includeSessionCounts: false
+            )
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        let worktrees = try response.decodeResult([Worktree].self)
+        #expect(worktrees.count == 1)
+        #expect(worktrees[0].liveClaudeSessionCount == nil)
+    }
+
     @Test("worktree.list with scratchOnly + archived returns only repo-less archived rows")
     func worktreeListScratchOnlyArchived() async throws {
         let repo = try await db.repos.create(

--- a/docs/superpowers/specs/2026-07-13-deeplink-archived-toast-design.md
+++ b/docs/superpowers/specs/2026-07-13-deeplink-archived-toast-design.md
@@ -44,11 +44,18 @@ Cold-start deep links keep the existing buffering (`pendingDeepLinkID`); the toa
 
 **`ToastState`** (new, `Sources/TBDApp/`) — a value published on `AppState` (e.g. `@Published var activeToast: Toast?`). `Toast` carries: `id`, message text, style (`.progress`, `.countdown(secondsRemaining:)`, `.action(ctaLabel:)`, `.error`), optional CTA action, dismissability. Deliberately minimal and reusable — deep-link is the first client; future banners (Nightwatch-style advisories) can adopt it, but no queueing until a second client needs it.
 
-**`ToastOverlay`** (new view) — attached via `.overlay(alignment: .bottom)` on `ContentView`. Rounded-rect material background, `.transition(.move(edge: .bottom).combined(with: .opacity))`, `onHover` forwarded to AppState (the view reports hover; AppState decides state transitions). Spinner for `.progress`, live seconds for `.countdown`, CTA + ✕ buttons for `.action`.
+**`ToastOverlay`** (new view) — attached via `.overlay(alignment: .bottomTrailing)` on `ContentView`. Rounded-rect material background, `.transition(.move(edge: .trailing).combined(with: .opacity))`, `onHover` forwarded to AppState (the view reports hover; AppState decides state transitions). Spinner for `.progress`, live seconds for `.countdown`, CTA + ✕ buttons for `.action`. Anchored bottom-**right**, not bottom-center: live verification found a bottom-center banner too disruptive (it sits over the content the user is reading), so the toast slides in from the trailing edge.
 
 **Countdown ownership** — the 5→1 tick loop is a `Task` owned by AppState (injectable tick duration for tests), not the view, so expiry navigation fires even if the view rebuilds. Hover-cancel and link-replacement cancel this task.
 
-**Touched existing code** — `navigateToArchivedWorktree` grows the toast transitions and moves its navigation tail behind the countdown; app activation moves to the start of the miss path. `DeepLinkHandler` and the daemon are untouched. No RPC or DB changes.
+**Touched existing code** — `navigateToArchivedWorktree` grows the toast transitions and moves its navigation tail behind the countdown; app activation moves to the start of the miss path. `DeepLinkHandler` is untouched.
+
+Two guards protect the deferred navigation against races:
+
+- **Request-generation guard (F1)** — two deep links (A then B) can have overlapping archived lookups that resolve out of order; without a guard, A's late resolution would replace B's toast (even a hover-cancelled one) and navigate to A. A fresh `deepLinkRequestID` token is stamped at the start of every `navigateToArchivedWorktree` call; after the lookup resolves (success or throw), a stale resolution whose token no longer matches is dropped before it touches toast/navigation state. Mirrors the `revivingArchived` re-entrancy guard.
+- **Reconcile-refresh (F2)** — the countdown-expiry / CTA navigation captures the archived snapshot at lookup time, which can be minutes old after a hover-cancel; navigating with it would repopulate `archivedWorktrees[repoID]` with ghost rows for since-deleted/revived worktrees. After the navigation tail runs, `performArchivedNavigation` kicks a `refreshArchivedWorktrees(repoID:)` to reconcile with fresh repo-scoped, paginated data (which also restores the per-row session-count enrichment the fast lookup skips).
+
+**RPC change (additive, opt-out)** — `worktree.list` gains an additive `includeSessionCounts: Bool?` flag. The deep-link archived lookup passes `includeSessionCounts: false` so the daemon skips per-row Claude-session enrichment; this was added post-approval after live verification measured ~19s to enrich 1074 archived rows. Default (`nil`/`true`) preserves the enriched behavior for every existing caller. No DB changes.
 
 ### Error handling
 
@@ -64,8 +71,9 @@ Cold-start deep links keep the existing buffering (`pendingDeepLinkID`); the toa
   - tick progression 5→1 → navigation callback fired exactly once, toast dismissed
   - hover during countdown → task cancelled, state becomes `.action` with CTA; no navigation ever fires
   - CTA click → navigation fired + dismissed; ✕ → dismissed, no navigation
-  - not-found / RPC error → `.error` state, auto-dismiss
+  - not-found / RPC error → `.error` state, auto-dismiss. The `archivedLookupOverride` test seam is `throws`-typed so a thrown error exercises the same `showErrorToast("Couldn't look up the worktree: …")` branch as a real RPC failure.
   - second deep link mid-countdown → first task cancelled, state machine restarted for new UUID
+  - stale lookup resolution (F1) → an older request resolving after a newer one superseded it is dropped by the request-generation guard (no toast clobber, no navigation to the stale target)
 - Live verification (per project lesson: transcript/UI bugs are live-only): trigger `open "tbd://open?worktree=<archived-uuid>"` against a running bundled app, screenshot the toast in looking/countdown/cancelled states, verify hover-cancel with a real pointer.
 
 ## Open questions

--- a/docs/superpowers/specs/2026-07-13-deeplink-archived-toast-design.md
+++ b/docs/superpowers/specs/2026-07-13-deeplink-archived-toast-design.md
@@ -1,7 +1,7 @@
-# Deep-link toast + cancellable countdown for archived worktrees
+# Deep-link toast for archived worktrees
 
 **Date:** 2026-07-13
-**Status:** Approved
+**Status:** Approved; amended 2026-07-13 — countdown dropped per user feedback, auto-navigate on lookup
 
 ## Problem
 
@@ -12,8 +12,7 @@ Current flow: `DeepLinkHandler.handle` → `AppState.navigateToWorktree` → act
 ## Goals
 
 - Immediate feedback ("Looking for worktree…") when a deep-link target is not in the active worktree list.
-- A visible, cancellable 5-second countdown before navigating to the archive entry, so navigation is never a surprise.
-- Hovering the toast cancels the countdown **permanently**; the toast then offers an explicit "Go to archive entry" CTA and a dismiss button.
+- Navigate to the archive entry immediately once the lookup resolves, with a brief auto-dismissing notice explaining that the target is archived, so landing in the archive view is never a surprise.
 - Surface the previously-silent not-found and RPC-failure cases.
 
 ## Non-goals
@@ -21,8 +20,8 @@ Current flow: `DeepLinkHandler.handle` → `AppState.navigateToWorktree` → act
 - Auto-reviving the archived worktree (stays a manual action; explicitly decided).
 - Toast queueing/stacking (one toast at a time; a new toast replaces the current one).
 - Scratch-space deep links (deep links carry repo-worktree UUIDs only today).
-- A third-party toast dependency (evaluated SimpleToast/AlertToast; the shell they provide is ~50 lines of SwiftUI and the interactive content — hover-cancel, countdown, CTA — is custom regardless).
-- A feature flag (small additive UI; countdown-gated navigation is a softer version of the navigation that already ships).
+- A third-party toast dependency (evaluated SimpleToast/AlertToast; the shell they provide is ~50 lines of SwiftUI and the state machine — progress/notice/error styling plus the AppState-owned auto-dismiss — is custom regardless).
+- A feature flag (small additive UI; the announced navigation is a softer version of the navigation that already ships).
 
 ## Design
 
@@ -30,51 +29,49 @@ Current flow: `DeepLinkHandler.handle` → `AppState.navigateToWorktree` → act
 
 1. **Active hit** — target found in active worktrees → navigate immediately, no toast (unchanged).
 2. **Active miss** — activate the app immediately (today activation waits for the lookup; the toast must be visible to be useful), show toast in **looking** state: spinner + "Looking for worktree…". Run the archived lookup.
-3. **Found archived** — toast transitions to **countdown** state: "'{display name}' is archived — showing its archive entry in {n}…", n counting 5→1 at 1s intervals.
-   - **Countdown expires** → perform the existing navigation tail (select repo, populate archived rows, scroll to + highlight the row), dismiss the toast.
-   - **Pointer enters the toast** → cancel the countdown permanently (no resume on exit). Toast transitions to **cancelled** state: same message minus the countdown, plus a **"Go to archive entry"** CTA button and a ✕ dismiss button. CTA click → navigate + dismiss. ✕ → dismiss only.
+3. **Found archived** — navigate immediately: perform the existing navigation tail (select repo, populate archived rows, scroll to + highlight the row), and show a **notice** toast "'{display name}' is archived — showing its archive entry" that auto-dismisses after ~4s so the archive landing is explained rather than surprising. No countdown, no CTA, no hover semantics.
 4. **Not found** (stale/deleted UUID) — toast transitions to **error** state: "Worktree not found — it may have been deleted." Auto-dismisses after ~4s.
 5. **Lookup RPC failure** — same error state with the failure message.
 
-A new deep link arriving while a toast is active cancels the in-flight countdown task and replaces the toast (restart the state machine for the new UUID).
+A new deep link arriving while a toast is active navigates immediately for the new UUID and replaces the toast (the previous toast's auto-dismiss task is cancelled).
 
 Cold-start deep links keep the existing buffering (`pendingDeepLinkID`); the toast flow begins when the buffered link is drained after initial state load.
 
 ### Components
 
-**`ToastState`** (new, `Sources/TBDApp/`) — a value published on `AppState` (e.g. `@Published var activeToast: Toast?`). `Toast` carries: `id`, message text, style (`.progress`, `.countdown(secondsRemaining:)`, `.action(ctaLabel:)`, `.error`), optional CTA action, dismissability. Deliberately minimal and reusable — deep-link is the first client; future banners (Nightwatch-style advisories) can adopt it, but no queueing until a second client needs it.
+**`ToastState`** (new, `Sources/TBDApp/`) — a value published on `AppState` (e.g. `@Published var activeToast: Toast?`). `Toast` carries: `id`, message text, style (`.progress`, `.notice`, `.error`). Deliberately minimal and reusable — deep-link is the first client; future banners (Nightwatch-style advisories) can adopt it, but no queueing until a second client needs it.
 
-**`ToastOverlay`** (new view) — attached via `.overlay(alignment: .bottomTrailing)` on `ContentView`. Rounded-rect material background, `.transition(.move(edge: .trailing).combined(with: .opacity))`, `onHover` forwarded to AppState (the view reports hover; AppState decides state transitions). Spinner for `.progress`, live seconds for `.countdown`, CTA + ✕ buttons for `.action`. Anchored bottom-**right**, not bottom-center: live verification found a bottom-center banner too disruptive (it sits over the content the user is reading), so the toast slides in from the trailing edge.
+**`ToastOverlay`** (new view) — attached via `.overlay(alignment: .bottomTrailing)` on `ContentView`. Rounded-rect material background, `.transition(.move(edge: .trailing).combined(with: .opacity))`. Purely presentational: spinner for `.progress`, archivebox icon for `.notice`, warning icon for `.error` — no interactive controls. Anchored bottom-**right**, not bottom-center: live verification found a bottom-center banner too disruptive (it sits over the content the user is reading), so the toast slides in from the trailing edge.
 
-**Countdown ownership** — the 5→1 tick loop is a `Task` owned by AppState (injectable tick duration for tests), not the view, so expiry navigation fires even if the view rebuilds. Hover-cancel and link-replacement cancel this task.
+**Auto-dismiss ownership** — transient toasts (`.notice`, `.error`) schedule a `toastDismissTask` on AppState (injectable tick duration for tests), not the view, so the ~4-tick dismiss fires even if the view rebuilds. Showing or dismissing a toast cancels any prior dismiss task, so a replaced toast's timer can't clear its successor.
 
-**Touched existing code** — `navigateToArchivedWorktree` grows the toast transitions and moves its navigation tail behind the countdown; app activation moves to the start of the miss path. `DeepLinkHandler` is untouched.
+**Touched existing code** — `navigateToArchivedWorktree` navigates immediately once the lookup resolves and shows the notice toast; app activation moves to the start of the miss path. `DeepLinkHandler` is untouched.
 
-Two guards protect the deferred navigation against races:
+Two guards protect the auto-navigation against races:
 
-- **Request-generation guard (F1)** — two deep links (A then B) can have overlapping archived lookups that resolve out of order; without a guard, A's late resolution would replace B's toast (even a hover-cancelled one) and navigate to A. A fresh `deepLinkRequestID` token is stamped at the start of every `navigateToArchivedWorktree` call; after the lookup resolves (success or throw), a stale resolution whose token no longer matches is dropped before it touches toast/navigation state. Mirrors the `revivingArchived` re-entrancy guard.
-- **Reconcile-refresh (F2)** — the countdown-expiry / CTA navigation captures the archived snapshot at lookup time, which can be minutes old after a hover-cancel; navigating with it would repopulate `archivedWorktrees[repoID]` with ghost rows for since-deleted/revived worktrees. After the navigation tail runs, `performArchivedNavigation` kicks a `refreshArchivedWorktrees(repoID:)` to reconcile with fresh repo-scoped, paginated data (which also restores the per-row session-count enrichment the fast lookup skips).
+- **Request-generation guard (F1)** — two deep links (A then B) can have overlapping archived lookups that resolve out of order; without a guard, A's late resolution would navigate to A after B already won. A fresh `deepLinkRequestID` token is stamped at the start of every `navigateToArchivedWorktree` call; after the lookup resolves (success or throw), a stale resolution whose token no longer matches is dropped before it touches toast/navigation state. Mirrors the `revivingArchived` re-entrancy guard.
+- **Reconcile-refresh (F2)** — navigation uses the archived snapshot captured at lookup time; with the fast deep-link lookup (`includeSessionCounts: false`) this snapshot skips per-row session-count enrichment, and can be briefly stale for since-deleted/revived worktrees. After the navigation tail runs, `performArchivedNavigation` kicks a `refreshArchivedWorktrees(repoID:)` to reconcile with fresh repo-scoped, paginated data (which also restores the per-row session-count enrichment).
 
 **RPC change (additive, opt-out)** — `worktree.list` gains an additive `includeSessionCounts: Bool?` flag. The deep-link archived lookup passes `includeSessionCounts: false` so the daemon skips per-row Claude-session enrichment; this was added post-approval after live verification measured ~19s to enrich 1074 archived rows. Default (`nil`/`true`) preserves the enriched behavior for every existing caller. No DB changes.
 
 ### Error handling
 
 - RPC failure or worktree-not-found → error toast (auto-dismiss ~4s); never silent.
-- Countdown task cancellation on: hover, toast replacement, ✕ dismiss, CTA click.
-- If navigation-on-expiry runs while the user has since navigated elsewhere manually, it still performs the archive navigation (same as today's late navigation, but now announced).
+- Auto-dismiss task cancellation on: toast replacement, explicit dismiss.
+- Navigation runs as soon as the lookup resolves; if the user has since navigated elsewhere manually, the archive navigation still lands them on the target (announced by the notice toast).
 
 ## Testing
 
-- Unit tests on the state machine with injectable tick duration (no real 5s sleeps):
+- Unit tests on the state machine with injectable tick duration (no real 4s sleeps):
   - active miss → `.progress` toast shown, app activation requested
-  - found archived → `.countdown` starting at 5
-  - tick progression 5→1 → navigation callback fired exactly once, toast dismissed
-  - hover during countdown → task cancelled, state becomes `.action` with CTA; no navigation ever fires
-  - CTA click → navigation fired + dismissed; ✕ → dismissed, no navigation
+  - active hit → no toast, worktree selected
+  - found archived → navigates immediately (repo selected, row highlighted, archived rows populated) and shows a `.notice` toast naming the worktree, which then auto-dismisses
+  - transient toasts (`.notice`, `.error`) auto-dismiss after ~4 ticks
+  - showing a new toast cancels the prior toast's auto-dismiss task so it can't clear the replacement
   - not-found / RPC error → `.error` state, auto-dismiss. The `archivedLookupOverride` test seam is `throws`-typed so a thrown error exercises the same `showErrorToast("Couldn't look up the worktree: …")` branch as a real RPC failure.
-  - second deep link mid-countdown → first task cancelled, state machine restarted for new UUID
-  - stale lookup resolution (F1) → an older request resolving after a newer one superseded it is dropped by the request-generation guard (no toast clobber, no navigation to the stale target)
-- Live verification (per project lesson: transcript/UI bugs are live-only): trigger `open "tbd://open?worktree=<archived-uuid>"` against a running bundled app, screenshot the toast in looking/countdown/cancelled states, verify hover-cancel with a real pointer.
+  - second deep link → navigates immediately for the new UUID; only the newer link's repo is selected
+  - stale lookup resolution (F1) → an older request resolving after a newer one superseded it is dropped by the request-generation guard (no navigation to the stale target, no stale toast)
+- Live verification (per project lesson: transcript/UI bugs are live-only): trigger `open "tbd://open?worktree=<archived-uuid>"` against a running bundled app, confirm it lands on the archive entry immediately and the notice toast appears then auto-dismisses.
 
 ## Open questions
 

--- a/docs/superpowers/specs/2026-07-13-deeplink-archived-toast-design.md
+++ b/docs/superpowers/specs/2026-07-13-deeplink-archived-toast-design.md
@@ -1,0 +1,73 @@
+# Deep-link toast + cancellable countdown for archived worktrees
+
+**Date:** 2026-07-13
+**Status:** Approved
+
+## Problem
+
+Clicking a `tbd://open?worktree=<uuid>` deep link whose target worktree is archived gives no feedback for several seconds, then abruptly navigates to the archived row after the user may have moved on. The delay is the archived-worktree lookup (`listWorktrees(status: .archived)` RPC) plus, on cold start, app launch and initial state load. There is no indication that (a) the app is looking, (b) the target is archived, or (c) navigation is about to happen. A deep link with a stale/deleted UUID fails completely silently.
+
+Current flow: `DeepLinkHandler.handle` → `AppState.navigateToWorktree` → active-list miss → `navigateToArchivedWorktree` (`Sources/TBDApp/AppState+Worktrees.swift:480-511`) → select repo, flash-highlight the archived row for ~0.9s. The app is only activated after the lookup completes. No revive is triggered (reviving stays a manual action from the archive list).
+
+## Goals
+
+- Immediate feedback ("Looking for worktree…") when a deep-link target is not in the active worktree list.
+- A visible, cancellable 5-second countdown before navigating to the archive entry, so navigation is never a surprise.
+- Hovering the toast cancels the countdown **permanently**; the toast then offers an explicit "Go to archive entry" CTA and a dismiss button.
+- Surface the previously-silent not-found and RPC-failure cases.
+
+## Non-goals
+
+- Auto-reviving the archived worktree (stays a manual action; explicitly decided).
+- Toast queueing/stacking (one toast at a time; a new toast replaces the current one).
+- Scratch-space deep links (deep links carry repo-worktree UUIDs only today).
+- A third-party toast dependency (evaluated SimpleToast/AlertToast; the shell they provide is ~50 lines of SwiftUI and the interactive content — hover-cancel, countdown, CTA — is custom regardless).
+- A feature flag (small additive UI; countdown-gated navigation is a softer version of the navigation that already ships).
+
+## Design
+
+### Behavior state machine
+
+1. **Active hit** — target found in active worktrees → navigate immediately, no toast (unchanged).
+2. **Active miss** — activate the app immediately (today activation waits for the lookup; the toast must be visible to be useful), show toast in **looking** state: spinner + "Looking for worktree…". Run the archived lookup.
+3. **Found archived** — toast transitions to **countdown** state: "'{display name}' is archived — showing its archive entry in {n}…", n counting 5→1 at 1s intervals.
+   - **Countdown expires** → perform the existing navigation tail (select repo, populate archived rows, scroll to + highlight the row), dismiss the toast.
+   - **Pointer enters the toast** → cancel the countdown permanently (no resume on exit). Toast transitions to **cancelled** state: same message minus the countdown, plus a **"Go to archive entry"** CTA button and a ✕ dismiss button. CTA click → navigate + dismiss. ✕ → dismiss only.
+4. **Not found** (stale/deleted UUID) — toast transitions to **error** state: "Worktree not found — it may have been deleted." Auto-dismisses after ~4s.
+5. **Lookup RPC failure** — same error state with the failure message.
+
+A new deep link arriving while a toast is active cancels the in-flight countdown task and replaces the toast (restart the state machine for the new UUID).
+
+Cold-start deep links keep the existing buffering (`pendingDeepLinkID`); the toast flow begins when the buffered link is drained after initial state load.
+
+### Components
+
+**`ToastState`** (new, `Sources/TBDApp/`) — a value published on `AppState` (e.g. `@Published var activeToast: Toast?`). `Toast` carries: `id`, message text, style (`.progress`, `.countdown(secondsRemaining:)`, `.action(ctaLabel:)`, `.error`), optional CTA action, dismissability. Deliberately minimal and reusable — deep-link is the first client; future banners (Nightwatch-style advisories) can adopt it, but no queueing until a second client needs it.
+
+**`ToastOverlay`** (new view) — attached via `.overlay(alignment: .bottom)` on `ContentView`. Rounded-rect material background, `.transition(.move(edge: .bottom).combined(with: .opacity))`, `onHover` forwarded to AppState (the view reports hover; AppState decides state transitions). Spinner for `.progress`, live seconds for `.countdown`, CTA + ✕ buttons for `.action`.
+
+**Countdown ownership** — the 5→1 tick loop is a `Task` owned by AppState (injectable tick duration for tests), not the view, so expiry navigation fires even if the view rebuilds. Hover-cancel and link-replacement cancel this task.
+
+**Touched existing code** — `navigateToArchivedWorktree` grows the toast transitions and moves its navigation tail behind the countdown; app activation moves to the start of the miss path. `DeepLinkHandler` and the daemon are untouched. No RPC or DB changes.
+
+### Error handling
+
+- RPC failure or worktree-not-found → error toast (auto-dismiss ~4s); never silent.
+- Countdown task cancellation on: hover, toast replacement, ✕ dismiss, CTA click.
+- If navigation-on-expiry runs while the user has since navigated elsewhere manually, it still performs the archive navigation (same as today's late navigation, but now announced).
+
+## Testing
+
+- Unit tests on the state machine with injectable tick duration (no real 5s sleeps):
+  - active miss → `.progress` toast shown, app activation requested
+  - found archived → `.countdown` starting at 5
+  - tick progression 5→1 → navigation callback fired exactly once, toast dismissed
+  - hover during countdown → task cancelled, state becomes `.action` with CTA; no navigation ever fires
+  - CTA click → navigation fired + dismissed; ✕ → dismissed, no navigation
+  - not-found / RPC error → `.error` state, auto-dismiss
+  - second deep link mid-countdown → first task cancelled, state machine restarted for new UUID
+- Live verification (per project lesson: transcript/UI bugs are live-only): trigger `open "tbd://open?worktree=<archived-uuid>"` against a running bundled app, screenshot the toast in looking/countdown/cancelled states, verify hover-cancel with a real pointer.
+
+## Open questions
+
+None.


### PR DESCRIPTION
## Summary

Clicking a `tbd://open?worktree=<uuid>` link for an **archived** worktree used to sit silent for ~19 seconds, then navigate long after the user had moved on — and a stale/deleted UUID failed with no feedback at all.

- **In-app toast feedback** (new minimal reusable layer: `Toast` model + `AppState+Toast` + `ToastOverlay`, bottom-right): "Looking for worktree…" with a spinner during the lookup, a brief auto-dismissing "'{name}' is archived — showing its archive entry" notice as we land, and error toasts for not-found / RPC failure (previously silent). The app now foregrounds *before* the lookup instead of after.
- **Root-cause perf fix:** the archived lookup was slow because `worktree.list(status: .archived)` enriches every archived row (1074 on the dogfood machine) with a Claude-session file count, each miss falling through to a full `~/.claude/projects` scan. Additive `includeSessionCounts: Bool?` opt-out on the RPC; the deep-link lookup passes `false` (archive pane keeps enriched behavior; both branches daemon-tested). Lookup drops from ~19s to milliseconds.
- **Race guards:** a request-generation token drops stale out-of-order lookup resolutions (two rapid deep links can't have the older one steal navigation), and post-navigation state reconciles via a repo-scoped `refreshArchivedWorktrees`.

Design evolution, captured in the committed spec (`docs/superpowers/specs/2026-07-13-deeplink-archived-toast-design.md`): the original approved design had a cancellable 5-second countdown before navigating; after dogfooding, the countdown was dropped in favor of navigating the moment the lookup resolves (`feat!` commit), and the toast moved from bottom-center to bottom-right ("bottom center is a bit too disruptive").

No feature flag: user-gesture-gated additive UI, no persisted-state mutation, no autonomous behavior (per CLAUDE.md's flag rubric). No DB changes; the RPC change is additive and optional.

## Test plan

- [x] `DeepLinkToastTests` — 13 tests: looking/notice/error states, immediate navigation with repo selection + row highlight, scratch no-op, stale-lookup race guard, second-link-wins, throwing-lookup error branch (seam made `throws`-typed), auto-dismiss timing via injectable tick
- [x] `RPCRouterWorktreeTests` — both `includeSessionCounts` branches (enriched by default; skipped when `false`)
- [x] `DeepLinkHandlerTests` (10) — end-to-end URL → navigation
- [x] Full suite green: 3498 tests / 420 suites; `swiftlint --strict` 0 violations
- [x] Live-verified on the dogfood machine: looking toast renders during lookup; RPC timing measured before/after (19.6s → ms-class for the app path)
- [ ] Manual: click an archived worktree's deep link — expect brief "Looking…" flash, instant landing on the highlighted archive row with a short notice toast, bottom-right

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7643CDFA-FBBC-4D9F-97BD-EED3789AA06B)