### PR TITLE
perf(worktree): speed up creation with fetch coalescing and parallel checkout

### DIFF
--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -153,14 +153,14 @@ public struct GitManager: Sendable {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    /// Fetches from origin for the given branch.
-    public func fetch(repoPath: String, branch: String) async throws {
-        _ = try await run(arguments: ["fetch", "origin", branch], at: repoPath)
+    /// Fetches from origin for the given branch, with optional timeout override.
+    public func fetch(repoPath: String, branch: String, timeout: Duration? = nil) async throws {
+        _ = try await run(arguments: ["fetch", "origin", branch], at: repoPath, timeout: timeout)
     }
 
-    /// Fetches all refs from origin.
-    public func fetch(repoPath: String) async throws {
-        _ = try await run(arguments: ["fetch", "origin"], at: repoPath)
+    /// Fetches all refs from origin, with optional timeout override.
+    public func fetch(repoPath: String, timeout: Duration? = nil) async throws {
+        _ = try await run(arguments: ["fetch", "origin"], at: repoPath, timeout: timeout)
     }
 
     /// Returns the HEAD SHA for a branch or ref.
@@ -233,21 +233,24 @@ public struct GitManager: Sendable {
     }
 
     /// Creates a new worktree at `worktreePath` on a new branch based on `baseBranch`.
+    /// Enables parallel checkout for faster working-tree setup.
     public func worktreeAdd(repoPath: String, worktreePath: String, branch: String, baseBranch: String) async throws {
-        _ = try await run(arguments: ["worktree", "add", worktreePath, "-b", branch, baseBranch], at: repoPath)
+        _ = try await run(arguments: ["-c", "checkout.workers=0", "worktree", "add", worktreePath, "-b", branch, baseBranch], at: repoPath)
     }
 
     /// Adds a worktree at `worktreePath` using an existing branch (no -b flag).
+    /// Enables parallel checkout for faster working-tree setup.
     public func worktreeAddExisting(repoPath: String, worktreePath: String, branch: String) async throws {
-        _ = try await run(arguments: ["worktree", "add", worktreePath, branch], at: repoPath)
+        _ = try await run(arguments: ["-c", "checkout.workers=0", "worktree", "add", worktreePath, branch], at: repoPath)
     }
 
     /// Adds a worktree at `worktreePath` tracking an existing remote branch.
     /// Creates a local branch named `localBranch` from `remoteRef`
     /// (e.g. `origin/foo`) with upstream tracking configured.
+    /// Enables parallel checkout for faster working-tree setup.
     public func worktreeAddTrackingRemote(repoPath: String, worktreePath: String, localBranch: String, remoteRef: String) async throws {
         _ = try await run(
-            arguments: ["worktree", "add", "--track", "-b", localBranch, worktreePath, remoteRef],
+            arguments: ["-c", "checkout.workers=0", "worktree", "add", "--track", "-b", localBranch, worktreePath, remoteRef],
             at: repoPath
         )
     }
@@ -255,9 +258,10 @@ public struct GitManager: Sendable {
     /// Adds a worktree at `worktreePath`, creating a new branch pointing at the given SHA.
     /// Used as a fallback when the original branch was renamed/deleted but we have the
     /// archived HEAD SHA to recover the commit.
+    /// Enables parallel checkout for faster working-tree setup.
     public func worktreeAddNewBranch(repoPath: String, worktreePath: String, branch: String, sha: String) async throws {
         _ = try await run(
-            arguments: ["worktree", "add", "-b", branch, worktreePath, sha],
+            arguments: ["-c", "checkout.workers=0", "worktree", "add", "-b", branch, worktreePath, sha],
             at: repoPath
         )
     }
@@ -610,8 +614,9 @@ public struct GitManager: Sendable {
     /// cross-environment hang to exercise the kill path (a post-checkout hook did
     /// not fire on CI). Production callers never pass `executable`.
     private func run(arguments: [String], at directory: String,
+                     timeout: Duration? = nil,
                      executable: String = "/usr/bin/git") async throws -> String {
-        let timeout = subprocessTimeout
+        let resolvedTimeout = timeout ?? subprocessTimeout
         let commandDescription = "git " + arguments.joined(separator: " ")
         // All the mechanism (starvation-proof watchdog thread, authoritative
         // deadline, incremental pipe draining, no-EOF-wait, single-resume
@@ -623,11 +628,11 @@ public struct GitManager: Sendable {
             executable: executable,
             arguments: arguments,
             currentDirectory: directory,
-            timeout: timeout
+            timeout: resolvedTimeout
         ) {
         case .timedOut:
-            logger.warning("git subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")
-            throw GitTimeoutError(command: commandDescription, timeout: timeout)
+            logger.warning("git subprocess timed out after \(resolvedTimeout, privacy: .public): \(commandDescription, privacy: .public)")
+            throw GitTimeoutError(command: commandDescription, timeout: resolvedTimeout)
         case let .completed(status, stdoutData, stderrData):
             let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
             let stderr = String(data: stderrData, encoding: .utf8) ?? ""

--- a/Sources/TBDDaemon/Lifecycle/FetchCache.swift
+++ b/Sources/TBDDaemon/Lifecycle/FetchCache.swift
@@ -1,0 +1,92 @@
+import Foundation
+import os
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "fetchCache")
+
+/// Named constant for the fetch TTL (time-to-live) — fetches within this window are skipped.
+public let fetchCacheTTL: TimeInterval = 60
+
+/// Named constant for the fetch timeout — a hung fetch won't stall creation.
+public let fetchTimeout: Duration = .seconds(20)
+
+/// Coalesces fetch operations per repo using a TTL cache + singleflight.
+/// If a fetch for a repo succeeded within the TTL window, the next fetch is skipped.
+/// Multiple concurrent fetches for the same repo share a single in-flight operation.
+public actor FetchCache {
+    private struct CacheEntry {
+        let fetchedAt: Date
+    }
+
+    private let ttl: TimeInterval
+    private let now: @Sendable () -> Date
+    private let performFetch: @Sendable (String, Duration) async throws -> Void
+
+    private var lastFetchTime: [String: CacheEntry] = [:]
+    private var inFlightFetches: [String: Task<Void, Never>] = [:]
+
+    /// - Parameters:
+    ///   - ttl: How long a cached fetch stays fresh, in seconds.
+    ///   - now: Clock seam for tests; defaults to wall-clock `Date()`.
+    ///   - performFetch: The actual fetch operation; defaults to `gitManager.fetch`.
+    public init(
+        ttl: TimeInterval = fetchCacheTTL,
+        now: @Sendable @escaping () -> Date = { Date() },
+        performFetch: @Sendable @escaping (String, Duration) async throws -> Void = { repoPath, timeout in
+            let manager = GitManager()
+            try await manager.fetch(repoPath: repoPath, timeout: timeout)
+        }
+    ) {
+        self.ttl = ttl
+        self.now = now
+        self.performFetch = performFetch
+    }
+
+    /// Fetch the repo if no successful fetch exists within the TTL window.
+    /// Uses singleflight so concurrent calls for the same repo share one in-flight fetch.
+    /// Fetch failures do NOT update the cache, so retries can happen on next call.
+    public func fetchIfNeeded(
+        repoPath: String,
+        timeout: Duration = fetchTimeout
+    ) async {
+        // Check if we have a recent successful fetch within TTL
+        if let entry = lastFetchTime[repoPath] {
+            let elapsed = now().timeIntervalSince(entry.fetchedAt)
+            if elapsed < ttl {
+                logger.debug("fetch coalesced for \(repoPath, privacy: .public) (cached \(Int(elapsed))s ago)")
+                return
+            }
+        }
+
+        // Singleflight: if a fetch is already in-flight for this repo, wait for it
+        if let inFlight = inFlightFetches[repoPath] {
+            logger.debug("fetch singleflight for \(repoPath, privacy: .public) — waiting on in-flight")
+            await inFlight.value
+            return
+        }
+
+        // Launch the fetch and record it
+        let fetchTask = Task {
+            do {
+                try await performFetch(repoPath, timeout)
+                logger.debug("fetch succeeded for \(repoPath, privacy: .public)")
+                // Record success only on completion
+                await self.recordSuccessAsync(repoPath: repoPath)
+            } catch {
+                logger.debug("fetch timeout or error for \(repoPath, privacy: .public): \(error, privacy: .public)")
+                // Best-effort: don't record failure, so retries can happen
+            }
+        }
+
+        inFlightFetches[repoPath] = fetchTask
+        await fetchTask.value
+        inFlightFetches.removeValue(forKey: repoPath)
+    }
+
+    private func recordSuccess(repoPath: String) {
+        lastFetchTime[repoPath] = CacheEntry(fetchedAt: now())
+    }
+
+    private func recordSuccessAsync(repoPath: String) async {
+        recordSuccess(repoPath: repoPath)
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/FetchCache.swift
+++ b/Sources/TBDDaemon/Lifecycle/FetchCache.swift
@@ -19,21 +19,24 @@ public actor FetchCache {
 
     private let ttl: TimeInterval
     private let now: @Sendable () -> Date
-    private let performFetch: @Sendable (String, Duration) async throws -> Void
+    private let performFetch: @Sendable (String, String, Duration) async throws -> Void
 
+    // Cache and singleflight keyed by repoPath. Since callers always pass the repo's
+    // default branch (which is stable per repo), repoPath uniquely determines the branch.
     private var lastFetchTime: [String: CacheEntry] = [:]
     private var inFlightFetches: [String: Task<Void, Never>] = [:]
 
     /// - Parameters:
     ///   - ttl: How long a cached fetch stays fresh, in seconds.
     ///   - now: Clock seam for tests; defaults to wall-clock `Date()`.
-    ///   - performFetch: The actual fetch operation; defaults to `gitManager.fetch`.
+    ///   - performFetch: The actual fetch operation; defaults to `gitManager.fetch(branch:)`.
+    ///     Closure receives (repoPath, branch, timeout).
     public init(
         ttl: TimeInterval = fetchCacheTTL,
         now: @Sendable @escaping () -> Date = { Date() },
-        performFetch: @Sendable @escaping (String, Duration) async throws -> Void = { repoPath, timeout in
+        performFetch: @Sendable @escaping (String, String, Duration) async throws -> Void = { repoPath, branch, timeout in
             let manager = GitManager()
-            try await manager.fetch(repoPath: repoPath, timeout: timeout)
+            try await manager.fetch(repoPath: repoPath, branch: branch, timeout: timeout)
         }
     ) {
         self.ttl = ttl
@@ -41,11 +44,16 @@ public actor FetchCache {
         self.performFetch = performFetch
     }
 
-    /// Fetch the repo if no successful fetch exists within the TTL window.
+    /// Fetch the repo's default branch if no successful fetch exists within the TTL window.
     /// Uses singleflight so concurrent calls for the same repo share one in-flight fetch.
     /// Fetch failures do NOT update the cache, so retries can happen on next call.
+    /// - Parameters:
+    ///   - repoPath: The path to the repo being fetched.
+    ///   - branch: The repo's default branch (e.g., "main" or "master"). Fetch is scoped to this branch only.
+    ///   - timeout: How long the fetch is allowed to run; defaults to `fetchTimeout` (20s).
     public func fetchIfNeeded(
         repoPath: String,
+        branch: String,
         timeout: Duration = fetchTimeout
     ) async {
         // Check if we have a recent successful fetch within TTL
@@ -67,7 +75,7 @@ public actor FetchCache {
         // Launch the fetch and record it
         let fetchTask = Task {
             do {
-                try await performFetch(repoPath, timeout)
+                try await performFetch(repoPath, branch, timeout)
                 logger.debug("fetch succeeded for \(repoPath, privacy: .public)")
                 // Record success only on completion
                 await self.recordSuccessAsync(repoPath: repoPath)

--- a/Sources/TBDDaemon/Lifecycle/FetchCache.swift
+++ b/Sources/TBDDaemon/Lifecycle/FetchCache.swift
@@ -78,7 +78,7 @@ public actor FetchCache {
                 try await performFetch(repoPath, branch, timeout)
                 logger.debug("fetch succeeded for \(repoPath, privacy: .public)")
                 // Record success only on completion
-                await self.recordSuccessAsync(repoPath: repoPath)
+                await self.recordSuccess(repoPath: repoPath)
             } catch {
                 logger.debug("fetch timeout or error for \(repoPath, privacy: .public): \(error, privacy: .public)")
                 // Best-effort: don't record failure, so retries can happen
@@ -92,9 +92,5 @@ public actor FetchCache {
 
     private func recordSuccess(repoPath: String) {
         lastFetchTime[repoPath] = CacheEntry(fetchedAt: now())
-    }
-
-    private func recordSuccessAsync(repoPath: String) async {
-        recordSuccess(repoPath: repoPath)
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -201,8 +201,8 @@ extension WorktreeLifecycle {
                 atPath: parentDir,
                 withIntermediateDirectories: true
             )
-            let createDirElapsedMs = Int(-clock.now.duration(to: createDirStart).components.attoseconds / 1_000_000_000_000_000)
-            timingLogger.debug("createdir \(worktreeID.uuidString, privacy: .public) \(createDirElapsedMs)ms")
+            let createDirElapsedMs = createDirStart.duration(to: clock.now) / .milliseconds(1)
+            timingLogger.debug("createdir \(worktreeID.uuidString, privacy: .public) \(Int(createDirElapsedMs))ms")
 
             // 2. git worktree add (fetch was run beforehand in the RPC handler)
             let worktreeAddStart = clock.now
@@ -251,8 +251,8 @@ extension WorktreeLifecycle {
                 }
                 resultPath = result.path
             }
-            let worktreeAddElapsedMs = Int(-clock.now.duration(to: worktreeAddStart).components.attoseconds / 1_000_000_000_000_000)
-            timingLogger.debug("worktree-add \(worktreeID.uuidString, privacy: .public) \(worktreeAddElapsedMs)ms")
+            let worktreeAddElapsedMs = worktreeAddStart.duration(to: clock.now) / .milliseconds(1)
+            timingLogger.debug("worktree-add \(worktreeID.uuidString, privacy: .public) \(Int(worktreeAddElapsedMs))ms")
 
             // 3. Setup tmux terminals.
             let terminalSpawnStart = clock.now
@@ -280,8 +280,8 @@ extension WorktreeLifecycle {
                     worktreeID: worktree.id,
                     label: TerminalLabel.preSession
                 )))
-                let terminalSpawnElapsedMs = Int(-clock.now.duration(to: terminalSpawnStart).components.attoseconds / 1_000_000_000_000_000)
-                timingLogger.debug("terminal-spawn-presession \(worktreeID.uuidString, privacy: .public) \(terminalSpawnElapsedMs)ms")
+                let terminalSpawnElapsedMs = terminalSpawnStart.duration(to: clock.now) / .milliseconds(1)
+                timingLogger.debug("terminal-spawn-presession \(worktreeID.uuidString, privacy: .public) \(Int(terminalSpawnElapsedMs))ms")
                 let phase3 = Task.detached { [self] in
                     await runPreSessionPhase3(
                         preSession: preSession,
@@ -311,17 +311,17 @@ extension WorktreeLifecycle {
                 overrideProfileID: overrideProfileID,
                 claudeSettingsOverlay: claudeSettingsOverlay
             )
-            let terminalSpawnElapsedMs = Int(-clock.now.duration(to: terminalSpawnStart).components.attoseconds / 1_000_000_000_000_000)
-            timingLogger.debug("terminal-spawn \(worktreeID.uuidString, privacy: .public) \(terminalSpawnElapsedMs)ms")
+            let terminalSpawnElapsedMs = terminalSpawnStart.duration(to: clock.now) / .milliseconds(1)
+            timingLogger.debug("terminal-spawn \(worktreeID.uuidString, privacy: .public) \(Int(terminalSpawnElapsedMs))ms")
 
             // 4. Update status to active
             let markActiveStart = clock.now
             try await db.worktrees.updateStatus(id: worktreeID, status: .active)
-            let markActiveElapsedMs = Int(-clock.now.duration(to: markActiveStart).components.attoseconds / 1_000_000_000_000_000)
-            timingLogger.debug("mark-active \(worktreeID.uuidString, privacy: .public) \(markActiveElapsedMs)ms")
+            let markActiveElapsedMs = markActiveStart.duration(to: clock.now) / .milliseconds(1)
+            timingLogger.debug("mark-active \(worktreeID.uuidString, privacy: .public) \(Int(markActiveElapsedMs))ms")
 
-            let totalElapsedMs = Int(-clock.now.duration(to: phaseStart).components.attoseconds / 1_000_000_000_000_000)
-            timingLogger.info("complete-worktree \(worktreeID.uuidString, privacy: .public) total \(totalElapsedMs)ms")
+            let totalElapsedMs = phaseStart.duration(to: clock.now) / .milliseconds(1)
+            timingLogger.info("complete-worktree \(worktreeID.uuidString, privacy: .public) total \(Int(totalElapsedMs))ms")
             return .ready
 
         } catch {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -3,6 +3,7 @@ import os
 import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "worktreeLifecycle")
+private let timingLogger = Logger(subsystem: "com.tbd.daemon", category: "worktreeTiming")
 
 /// Result of `completeCreateWorktree`. The pre-session path defers the
 /// primary terminal spawn to a background task so the caller's serializer
@@ -190,21 +191,21 @@ extension WorktreeLifecycle {
         }
 
         do {
-            // 1. Best-effort fetch from origin
-            do {
-                try await git.fetch(repoPath: repo.path, branch: repo.defaultBranch)
-            } catch {
-                // Continue with local state if fetch fails
-            }
+            let clock = ContinuousClock()
+            let phaseStart = clock.now
 
-            // 2. Create parent directory
+            // 1. Create parent directory
+            let createDirStart = clock.now
             let parentDir = (worktree.path as NSString).deletingLastPathComponent
             try FileManager.default.createDirectory(
                 atPath: parentDir,
                 withIntermediateDirectories: true
             )
+            let createDirElapsedMs = Int(-clock.now.duration(to: createDirStart).components.attoseconds / 1_000_000_000_000_000)
+            timingLogger.debug("createdir \(worktreeID.uuidString, privacy: .public) \(createDirElapsedMs)ms")
 
-            // 3. git worktree add
+            // 2. git worktree add (fetch was run beforehand in the RPC handler)
+            let worktreeAddStart = clock.now
             let resultPath: String
             if let ref = existingBranchRef {
                 // Existing-branch flow: check out the chosen ref. Local branches
@@ -250,9 +251,12 @@ extension WorktreeLifecycle {
                 }
                 resultPath = result.path
             }
+            let worktreeAddElapsedMs = Int(-clock.now.duration(to: worktreeAddStart).components.attoseconds / 1_000_000_000_000_000)
+            timingLogger.debug("worktree-add \(worktreeID.uuidString, privacy: .public) \(worktreeAddElapsedMs)ms")
 
-            // 5. Setup tmux terminals.
-            // 5a. Blocking preSession hook: spawn its terminal FIRST and gate
+            // 3. Setup tmux terminals.
+            let terminalSpawnStart = clock.now
+            // 3a. Blocking preSession hook: spawn its terminal FIRST and gate
             // the primary terminals on its completion marker. The wait runs in
             // a background task so the caller's RepoSerializer lane is freed
             // immediately — never block it for the duration of the hook.
@@ -276,6 +280,8 @@ extension WorktreeLifecycle {
                     worktreeID: worktree.id,
                     label: TerminalLabel.preSession
                 )))
+                let terminalSpawnElapsedMs = Int(-clock.now.duration(to: terminalSpawnStart).components.attoseconds / 1_000_000_000_000_000)
+                timingLogger.debug("terminal-spawn-presession \(worktreeID.uuidString, privacy: .public) \(terminalSpawnElapsedMs)ms")
                 let phase3 = Task.detached { [self] in
                     await runPreSessionPhase3(
                         preSession: preSession,
@@ -292,7 +298,7 @@ extension WorktreeLifecycle {
                 return .preSessionPending(phase3: phase3)
             }
 
-            // 5b. No preSession hook: spawn primary terminals inline
+            // 3b. No preSession hook: spawn primary terminals inline
             // (behavior identical to before the preSession hook existed).
             _ = try await spawnPrimaryTerminals(
                 worktree: worktree, repo: repo,
@@ -305,9 +311,17 @@ extension WorktreeLifecycle {
                 overrideProfileID: overrideProfileID,
                 claudeSettingsOverlay: claudeSettingsOverlay
             )
+            let terminalSpawnElapsedMs = Int(-clock.now.duration(to: terminalSpawnStart).components.attoseconds / 1_000_000_000_000_000)
+            timingLogger.debug("terminal-spawn \(worktreeID.uuidString, privacy: .public) \(terminalSpawnElapsedMs)ms")
 
-            // 6. Update status to active
+            // 4. Update status to active
+            let markActiveStart = clock.now
             try await db.worktrees.updateStatus(id: worktreeID, status: .active)
+            let markActiveElapsedMs = Int(-clock.now.duration(to: markActiveStart).components.attoseconds / 1_000_000_000_000_000)
+            timingLogger.debug("mark-active \(worktreeID.uuidString, privacy: .public) \(markActiveElapsedMs)ms")
+
+            let totalElapsedMs = Int(-clock.now.duration(to: phaseStart).components.attoseconds / 1_000_000_000_000_000)
+            timingLogger.info("complete-worktree \(worktreeID.uuidString, privacy: .public) total \(totalElapsedMs)ms")
             return .ready
 
         } catch {

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -33,9 +33,10 @@ extension RPCRouter {
             throw WorktreeLifecycleError.repoNotFound(params.repoID)
         }
         let repoPath = repo.path
+        let defaultBranch = repo.defaultBranch
         let fetchCache = self.fetchCache
         Task {
-            await fetchCache.fetchIfNeeded(repoPath: repoPath)
+            await fetchCache.fetchIfNeeded(repoPath: repoPath, branch: defaultBranch)
         }
 
         // Phase 2: Fire-and-forget — git operations + tmux setup in background.
@@ -64,7 +65,7 @@ extension RPCRouter {
                 // Re-await the fetch to ensure it completes before git operations.
                 // FetchCache's singleflight means this either joins the in-flight
                 // fetch from phase 1.5, or is a no-op if cached within the 60s TTL.
-                await fetchCache.fetchIfNeeded(repoPath: repoPath)
+                await fetchCache.fetchIfNeeded(repoPath: repoPath, branch: defaultBranch)
 
                 let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, overrideProfileID: overrideProfileID, claudeSettingsOverlay: claudeSettingsOverlay)
                 switch completion {

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -25,6 +25,14 @@ extension RPCRouter {
             useExistingBranch: useExistingBranch
         )
 
+        // Phase 1.5: Fetch from origin (coalesced, with tight timeout)
+        // This runs OUTSIDE the serialized lane so back-to-back creates
+        // don't queue behind fetches.
+        guard let repo = try await db.repos.get(id: params.repoID) else {
+            throw WorktreeLifecycleError.repoNotFound(params.repoID)
+        }
+        await fetchCache.fetchIfNeeded(repoPath: repo.path)
+
         // Phase 2: Fire-and-forget — git operations + tmux setup in background.
         // Serialize per-repo so concurrent creates don't contend on .git/index.lock.
         let lifecycle = self.lifecycle

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -30,6 +30,9 @@ extension RPCRouter {
         // Phase 2 will re-await before git worktree add; FetchCache's singleflight
         // means the second await joins the in-flight fetch or is a no-op if cached.
         guard let repo = try await db.repos.get(id: params.repoID) else {
+            // Mirror completeCreateWorktree's guard: clean up the .creating row
+            // inserted by beginCreateWorktree so it can't be orphaned forever.
+            try? await db.worktrees.delete(id: pending.id)
             throw WorktreeLifecycleError.repoNotFound(params.repoID)
         }
         let repoPath = repo.path

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -26,12 +26,17 @@ extension RPCRouter {
         )
 
         // Phase 1.5: Fetch from origin (coalesced, with tight timeout)
-        // This runs OUTSIDE the serialized lane so back-to-back creates
-        // don't queue behind fetches.
+        // Fire off as a background task so it doesn't block the RPC response.
+        // Phase 2 will re-await before git worktree add; FetchCache's singleflight
+        // means the second await joins the in-flight fetch or is a no-op if cached.
         guard let repo = try await db.repos.get(id: params.repoID) else {
             throw WorktreeLifecycleError.repoNotFound(params.repoID)
         }
-        await fetchCache.fetchIfNeeded(repoPath: repo.path)
+        let repoPath = repo.path
+        let fetchCache = self.fetchCache
+        Task {
+            await fetchCache.fetchIfNeeded(repoPath: repoPath)
+        }
 
         // Phase 2: Fire-and-forget — git operations + tmux setup in background.
         // Serialize per-repo so concurrent creates don't contend on .git/index.lock.
@@ -56,6 +61,11 @@ extension RPCRouter {
         // — pending.repoID mirrors it but is now UUID? on the shared model.
         await repoSerializer.submit(repoID: params.repoID) {
             do {
+                // Re-await the fetch to ensure it completes before git operations.
+                // FetchCache's singleflight means this either joins the in-flight
+                // fetch from phase 1.5, or is a no-op if cached within the 60s TTL.
+                await fetchCache.fetchIfNeeded(repoPath: repoPath)
+
                 let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, overrideProfileID: overrideProfileID, claudeSettingsOverlay: claudeSettingsOverlay)
                 switch completion {
                 case .ready:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -66,6 +66,8 @@ public final class RPCRouter: Sendable {
     /// TTL cache for per-worktree upstream branch lookups, so `pr.list` stops
     /// spawning a `git config` subprocess per worktree on every poll.
     let upstreamBranchCache = UpstreamBranchCache()
+    /// Coalesces fetch operations per repo using a TTL cache + singleflight.
+    let fetchCache = FetchCache()
     /// Opt-in tmux control-mode wiring. `nil` when the daemon did not provide
     /// one (tests, older callers); when present, terminal handlers open a gated
     /// logging-only `tmux -CC` connection after each `ensureServer()`.

--- a/Tests/TBDDaemonTests/FetchCacheTests.swift
+++ b/Tests/TBDDaemonTests/FetchCacheTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Mutable clock for test time control + fetch call counter, both isolated for concurrency safety.
+private actor FetchCounter {
+    private(set) var count = 0
+    private(set) var lastRepoPath: String?
+
+    func increment(for repoPath: String) -> Int {
+        count += 1
+        lastRepoPath = repoPath
+        return count
+    }
+}
+
+private final class MutableClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+    init(_ start: Date) { self.value = start }
+    func now() -> Date { lock.lock(); defer { lock.unlock() }; return value }
+    func advance(by seconds: TimeInterval) { lock.lock(); value = value.addingTimeInterval(seconds); lock.unlock() }
+}
+
+struct FetchCacheTests {
+
+    // MARK: - (a) Cold start: first call invokes the fetch
+
+    @Test func coldStartInvokesFetch() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let counter = FetchCounter()
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
+            _ = await counter.increment(for: repoPath)
+        }
+
+        #expect(await counter.count == 0)
+
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        #expect(await counter.count == 1)
+        #expect(await counter.lastRepoPath == "/repo/a")
+    }
+
+    // MARK: - (b) Within TTL: second call SKIPPED (fetch not called again)
+
+    @Test func withinTTLSkipsFetch() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let counter = FetchCounter()
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
+            _ = await counter.increment(for: repoPath)
+        }
+
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        #expect(await counter.count == 1)
+
+        // Advance time within TTL: fetch should be skipped
+        clock.advance(by: 30)
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        #expect(await counter.count == 1, "fetch should not be called within TTL")
+    }
+
+    // MARK: - (c) Past TTL: after advancing clock beyond TTL, refetch
+
+    @Test func pastTTLRefetches() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let counter = FetchCounter()
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
+            _ = await counter.increment(for: repoPath)
+        }
+
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        #expect(await counter.count == 1)
+
+        // Advance time past TTL: fetch should happen again
+        clock.advance(by: 61)
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        #expect(await counter.count == 2, "fetch should be called after TTL expires")
+    }
+
+    // MARK: - (d) Failure path: when fetch throws, success NOT recorded (retry on next call)
+
+    @Test func failureDoesNotRecordSuccess() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let counter = FetchCounter()
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
+            _ = await counter.increment(for: repoPath)
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "mock fetch failure"])
+        }
+
+        // First call fails
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        #expect(await counter.count == 1)
+
+        // Within TTL, but failure wasn't recorded → retry should happen
+        clock.advance(by: 30)
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        #expect(await counter.count == 2, "fetch should retry after failure (failure not cached)")
+    }
+
+    @Test func failureDoesNotThrow() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { _, _ in
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "mock fetch failure"])
+        }
+
+        // fetchIfNeeded is best-effort; fetch failure must not throw
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        // If we get here without crashing, test passes
+        #expect(Bool(true))
+    }
+
+    // MARK: - (e) Singleflight: N concurrent calls for same repo share ONE in-flight fetch
+
+    @Test func singleflightSharesInFlightFetch() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let counter = FetchCounter()
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
+            _ = await counter.increment(for: repoPath)
+            // Simulate a slow fetch so concurrent calls overlap
+            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
+        }
+
+        // Launch 5 concurrent calls for the same repo
+        async let call1: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
+        async let call2: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
+        async let call3: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
+        async let call4: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
+        async let call5: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
+
+        _ = await (call1, call2, call3, call4, call5)
+
+        #expect(await counter.count == 1, "5 concurrent calls should share 1 in-flight fetch, not 5 parallel fetches")
+    }
+
+    // MARK: - Additional: Multiple repos are independent
+
+    @Test func multipleReposAreIndependent() async {
+        let clock = MutableClock(Date(timeIntervalSince1970: 0))
+        let counter = FetchCounter()
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
+            _ = await counter.increment(for: repoPath)
+        }
+
+        // Fetch two different repos
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/b")
+        #expect(await counter.count == 2)
+
+        // Advance time within TTL
+        clock.advance(by: 30)
+
+        // Calling /repo/a again: should be cached
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        #expect(await counter.count == 2)
+
+        // Calling /repo/b again: should be cached
+        await cache.fetchIfNeeded(repoPath: "/repo/b")
+        #expect(await counter.count == 2)
+
+        // Advance past TTL
+        clock.advance(by: 31)
+
+        // Both should refetch
+        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/b")
+        #expect(await counter.count == 4)
+    }
+}

--- a/Tests/TBDDaemonTests/FetchCacheTests.swift
+++ b/Tests/TBDDaemonTests/FetchCacheTests.swift
@@ -6,10 +6,12 @@ import Testing
 private actor FetchCounter {
     private(set) var count = 0
     private(set) var lastRepoPath: String?
+    private(set) var lastBranch: String?
 
-    func increment(for repoPath: String) -> Int {
+    func increment(for repoPath: String, branch: String) -> Int {
         count += 1
         lastRepoPath = repoPath
+        lastBranch = branch
         return count
     }
 }
@@ -29,15 +31,16 @@ struct FetchCacheTests {
     @Test func coldStartInvokesFetch() async {
         let clock = MutableClock(Date(timeIntervalSince1970: 0))
         let counter = FetchCounter()
-        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
-            _ = await counter.increment(for: repoPath)
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, branch, _ in
+            _ = await counter.increment(for: repoPath, branch: branch)
         }
 
         #expect(await counter.count == 0)
 
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         #expect(await counter.count == 1)
         #expect(await counter.lastRepoPath == "/repo/a")
+        #expect(await counter.lastBranch == "main")
     }
 
     // MARK: - (b) Within TTL: second call SKIPPED (fetch not called again)
@@ -45,16 +48,16 @@ struct FetchCacheTests {
     @Test func withinTTLSkipsFetch() async {
         let clock = MutableClock(Date(timeIntervalSince1970: 0))
         let counter = FetchCounter()
-        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
-            _ = await counter.increment(for: repoPath)
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, branch, _ in
+            _ = await counter.increment(for: repoPath, branch: branch)
         }
 
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         #expect(await counter.count == 1)
 
         // Advance time within TTL: fetch should be skipped
         clock.advance(by: 30)
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         #expect(await counter.count == 1, "fetch should not be called within TTL")
     }
 
@@ -63,16 +66,16 @@ struct FetchCacheTests {
     @Test func pastTTLRefetches() async {
         let clock = MutableClock(Date(timeIntervalSince1970: 0))
         let counter = FetchCounter()
-        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
-            _ = await counter.increment(for: repoPath)
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, branch, _ in
+            _ = await counter.increment(for: repoPath, branch: branch)
         }
 
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         #expect(await counter.count == 1)
 
         // Advance time past TTL: fetch should happen again
         clock.advance(by: 61)
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         #expect(await counter.count == 2, "fetch should be called after TTL expires")
     }
 
@@ -81,29 +84,29 @@ struct FetchCacheTests {
     @Test func failureDoesNotRecordSuccess() async {
         let clock = MutableClock(Date(timeIntervalSince1970: 0))
         let counter = FetchCounter()
-        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
-            _ = await counter.increment(for: repoPath)
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, branch, _ in
+            _ = await counter.increment(for: repoPath, branch: branch)
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "mock fetch failure"])
         }
 
         // First call fails
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         #expect(await counter.count == 1)
 
         // Within TTL, but failure wasn't recorded → retry should happen
         clock.advance(by: 30)
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         #expect(await counter.count == 2, "fetch should retry after failure (failure not cached)")
     }
 
     @Test func failureDoesNotThrow() async {
         let clock = MutableClock(Date(timeIntervalSince1970: 0))
-        let cache = FetchCache(ttl: 60, now: { clock.now() }) { _, _ in
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { _, _, _ in
             throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "mock fetch failure"])
         }
 
         // fetchIfNeeded is best-effort; fetch failure must not throw
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         // If we get here without crashing, test passes
         #expect(Bool(true))
     }
@@ -113,18 +116,18 @@ struct FetchCacheTests {
     @Test func singleflightSharesInFlightFetch() async {
         let clock = MutableClock(Date(timeIntervalSince1970: 0))
         let counter = FetchCounter()
-        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
-            _ = await counter.increment(for: repoPath)
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, branch, _ in
+            _ = await counter.increment(for: repoPath, branch: branch)
             // Simulate a slow fetch so concurrent calls overlap
             try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
         }
 
         // Launch 5 concurrent calls for the same repo
-        async let call1: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
-        async let call2: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
-        async let call3: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
-        async let call4: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
-        async let call5: Void = cache.fetchIfNeeded(repoPath: "/repo/a")
+        async let call1: Void = cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
+        async let call2: Void = cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
+        async let call3: Void = cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
+        async let call4: Void = cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
+        async let call5: Void = cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
 
         _ = await (call1, call2, call3, call4, call5)
 
@@ -136,32 +139,32 @@ struct FetchCacheTests {
     @Test func multipleReposAreIndependent() async {
         let clock = MutableClock(Date(timeIntervalSince1970: 0))
         let counter = FetchCounter()
-        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, _ in
-            _ = await counter.increment(for: repoPath)
+        let cache = FetchCache(ttl: 60, now: { clock.now() }) { repoPath, branch, _ in
+            _ = await counter.increment(for: repoPath, branch: branch)
         }
 
         // Fetch two different repos
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
-        await cache.fetchIfNeeded(repoPath: "/repo/b")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
+        await cache.fetchIfNeeded(repoPath: "/repo/b", branch: "main")
         #expect(await counter.count == 2)
 
         // Advance time within TTL
         clock.advance(by: 30)
 
         // Calling /repo/a again: should be cached
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
         #expect(await counter.count == 2)
 
         // Calling /repo/b again: should be cached
-        await cache.fetchIfNeeded(repoPath: "/repo/b")
+        await cache.fetchIfNeeded(repoPath: "/repo/b", branch: "main")
         #expect(await counter.count == 2)
 
         // Advance past TTL
         clock.advance(by: 31)
 
         // Both should refetch
-        await cache.fetchIfNeeded(repoPath: "/repo/a")
-        await cache.fetchIfNeeded(repoPath: "/repo/b")
+        await cache.fetchIfNeeded(repoPath: "/repo/a", branch: "main")
+        await cache.fetchIfNeeded(repoPath: "/repo/b", branch: "main")
         #expect(await counter.count == 4)
     }
 }


### PR DESCRIPTION
## Why

Worktree creation felt slow, especially on large repos. Diagnosis on a large working tree: `git fetch` ~1s, `git worktree add` ~5s (10k+ files / 260MB+ checkout), plus a per-repo serialization lane that queues concurrent creates behind each other's fetches. Not machine-specific and not universal — it's these stacked costs, worst on the biggest working trees.

## What

Four levers:

1. **Phase timing instrumentation** — each phase (createdir, worktree-add, terminal-spawn, mark-active) wrapped with `ContinuousClock` timing, logged via `os.Logger` (`com.tbd.daemon` / `worktreeTiming`) at `.debug`. Makes future regressions measurable.

2. **Fetch coalescing (`FetchCache` actor)** — per-repo TTL memo (60s) + singleflight. Skip the fetch if one succeeded within the window; N concurrent creates on the same repo share one in-flight fetch. Tight 20s timeout (vs 120s default) so a hung fetch can't stall creation. Failures are **not** cached, so retries still happen.

3. **Fetch moved out of the serialized lane** — runs *before* `repoSerializer.submit`, so back-to-back creates no longer queue behind each other's fetches. Only `git worktree add` + DB writes stay serialized (they need `.git/index.lock`). Best-effort semantics preserved: fetch failure/timeout must never fail creation.

4. **git parallel checkout** — `-c checkout.workers=0` on all `worktree add` variants; git auto-detects cores to write the working tree faster.

## Tests

New `FetchCacheTests` (7 tests) covering every branch of the TTL/singleflight/failure gating: cold start, within-TTL skip, past-TTL refetch, failure-not-cached (retry), failure-doesn't-throw, singleflight (5 concurrent → 1 fetch), multi-repo independence. Injection seams (`now` clock closure + `performFetch` closure) added so the cache is testable without real git.

`swift build` clean; `swift test --filter FetchCache` green.

## Not in scope

The next lever would be a warm "template" worktree to amortize the ~5s checkout floor — bigger design change, deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)