### PR TITLE
Feat: cmd+click the PR button to open in the default browser

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -228,6 +228,11 @@ struct ContentView: View {
                             } label: {
                                 PRButtonLabel(prStatus: prStatus, isAutoArchiveArmed: armed, isAutoHibernateArmed: hibernateArmed)
                             } primaryAction: {
+                                // cmd+click opens the PR in the default browser instead of an in-app tab.
+                                if NSEvent.modifierFlags.contains(.command) {
+                                    NSWorkspace.shared.open(prURL)
+                                    return
+                                }
                                 let existingTabs = appState.tabs[worktreeID] ?? []
                                 if let existingIndex = existingTabs.firstIndex(where: {
                                     if case .webview(_, let url) = $0.content { return url == prURL }


### PR DESCRIPTION
## Summary
- The top-right PR split button always opened the PR in an in-app WKWebView tab, with no way to send it to your real browser.
- cmd+click now opens the PR in the default system browser (`NSWorkspace.shared.open`); a plain click keeps the existing in-app tab behavior.

## Test plan
- [ ] Click the PR button → PR opens in an in-app tab (unchanged).
- [ ] cmd+click the PR button → PR opens in the default browser, no in-app tab created.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=1374CD31-FF8C-412E-AB19-2D6CA1A8DF0C)