### PR TITLE
fix(terminal): make OSC 8 hyperlinks clickable by advertising tmux hyperlinks feature

### DIFF
--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -154,6 +154,22 @@ public struct TmuxManager: Sendable {
             + ["-PF", "#{window_id}"]
     }
 
+    /// Advertise the `hyperlinks` terminal-feature for TERM=xterm-256color so
+    /// tmux forwards OSC 8 hyperlink escape sequences to normal (non-control-mode)
+    /// attach clients instead of stripping them. The grouped-sessions attach
+    /// client (see `TerminalPanelView.makeViewerEnvironment`) runs with
+    /// TERM=xterm-256color, so the feature is keyed to that TERM to match.
+    ///
+    /// Uses `set -ga` (append) rather than `set -g` (replace): `-g` would
+    /// overwrite the whole terminal-features array, dropping tmux's built-in
+    /// xterm defaults (clipboard, ccolour, cstyle, focus, title). `-ga` appends,
+    /// so those defaults are preserved while hyperlink forwarding is added. tmux
+    /// strips OSC 8 hyperlinks for a normal-attach client unless this feature is
+    /// advertised.
+    public static func terminalFeaturesHyperlinksCommand(server: String) -> [String] {
+        ["-L", server, "set", "-ga", "terminal-features", "xterm-256color:hyperlinks"]
+    }
+
     public static func hasSessionCommand(server: String, session: String) -> [String] {
         ["-L", server, "has-session", "-t", session]
     }
@@ -351,7 +367,12 @@ public struct TmuxManager: Sendable {
         let hasSessionArgs = Self.hasSessionCommand(server: server, session: session)
         do {
             try await runTmux(hasSessionArgs)
-            // Session already exists, nothing to do
+            // Session already exists. Ensure hyperlink forwarding is enabled even on
+            // servers created before this option existed (tmux servers persist across
+            // app restarts). Uses `set -ga` to append so tmux's default xterm
+            // features (clipboard, focus, title, etc.) are preserved; OSC 8
+            // hyperlinks are stripped for a normal-attach client unless advertised.
+            _ = try? await runTmux(Self.terminalFeaturesHyperlinksCommand(server: server))
             return nil
         } catch {
             // Session does not exist, create it — capture the initial window ID
@@ -363,6 +384,10 @@ public struct TmuxManager: Sendable {
             _ = try? await runTmux(["-L", server, "set", "-g", "pane-border-style", "fg=black"])
             _ = try? await runTmux(["-L", server, "set", "-g", "pane-border-indicators", "off"])
             _ = try? await runTmux(["-L", server, "set", "-g", "default-terminal", "xterm-256color"])
+            // Advertise the `hyperlinks` terminal-feature so tmux forwards OSC 8
+            // hyperlink escape sequences to normal (non-control-mode) attach
+            // clients instead of stripping them (see helper doc comment).
+            _ = try? await runTmux(Self.terminalFeaturesHyperlinksCommand(server: server))
             // Enable mouse so scroll wheel enters copy-mode and scrolls history
             _ = try? await runTmux(["-L", server, "set", "-g", "mouse", "on"])
             // Enable extended key sequences so Shift+Arrow etc. pass through to applications

--- a/Tests/TBDDaemonTests/TmuxManagerTests.swift
+++ b/Tests/TBDDaemonTests/TmuxManagerTests.swift
@@ -64,6 +64,16 @@ import Testing
     #expect(args.contains("main"))
 }
 
+@Test func testTerminalFeaturesHyperlinksCommand() {
+    // OSC 8 hyperlinks emitted by Claude Code are stripped by tmux for normal
+    // (non-control-mode) attach clients unless the client's TERM advertises the
+    // `hyperlinks` terminal-feature. TBD's grouped-sessions attach client runs
+    // with TERM=xterm-256color, so server setup must advertise the feature keyed
+    // to that TERM for the sequences to reach SwiftTerm.
+    let args = TmuxManager.terminalFeaturesHyperlinksCommand(server: "tbd-a1b2c3d4")
+    #expect(args == ["-L", "tbd-a1b2c3d4", "set", "-ga", "terminal-features", "xterm-256color:hyperlinks"])
+}
+
 @Test func testNewWindowCommand() {
     let args = TmuxManager.newWindowCommand(
         server: "tbd-a1b2c3d4",


### PR DESCRIPTION
## Problem

Markdown-style links Claude Code prints in TBD's embedded terminal (OSC 8 hyperlinks: the URL lives in an escape sequence, only a label is visible) rendered as blue text but were **not clickable** (not even Cmd+click). Bare URLs worked fine.

## Root cause

Not a SwiftTerm parsing gap. Verified layer by layer:

1. Claude Code **does** emit proper OSC 8 (`ESC]8;id=…;https://…BEL  label  ESC]8;;BEL`).
2. SwiftTerm **does** parse OSC 8 and TBD already routes clicks through `requestOpenLink`.
3. The break is **tmux stripping the sequence**. TBD's default terminal path is a *normal* `tmux attach` client (control mode is opt-in/off). tmux renders its screen model to a normal client and **strips OSC 8 hyperlinks unless the client's TERM advertises the `hyperlinks` terminal-feature** — which TBD's server config never set. So SwiftTerm received zero hyperlink payloads (confirmed live: every cell `getPayload()==nil`). Control-mode `%output` forwards raw bytes and does *not* strip, so this only bites the default grouped-sessions path.
4. **Bare URLs survived only incidentally**: their visible URL *text* passes through and SwiftTerm's implicit URL regex re-detects it. Label-only markdown links have no visible URL, so they depend entirely on the stripped payload.

## Fix

Advertise the `hyperlinks` terminal-feature for `TERM=xterm-256color` (the grouped-sessions attach client's TERM, set in `TerminalPanelView.makeViewerEnvironment`) via `set -ga terminal-features "xterm-256color:hyperlinks"` in `TmuxManager.ensureServer`:

- Applied on **both** the server-creation path and the existing-server path (tmux servers persist across app restarts, so servers created before this change still get the option on the next ensure).
- Uses **`set -ga`** (append), not `set -g` (replace), so tmux's built-in xterm defaults (`clipboard`, `ccolour`, `cstyle`, `focus`, `title`) are preserved while hyperlink forwarding is added.

SwiftTerm already parses OSC 8 and TBD already opens the link via `requestOpenLink`, so forwarding the sequence is the whole fix.

## Verification

- **Live, end-to-end on the built app:** Cmd+click on a label-only markdown link now opens the URL ✅, and Cmd+hover shows the underline/highlight affordance ✅. Confirmed with both the raw `printf` OSC 8 test and real Claude Code markdown links.
- Instrumented the click path during diagnosis to confirm the payload now reaches SwiftTerm (`hasOSC8Payload=true`, `link(at:)` resolves the URL, `requestOpenLink` fires); all temporary instrumentation removed.
- `swift build` clean. `swift test`: **3511 tests / 421 suites pass**, including a new `testTerminalFeaturesHyperlinksCommand`.

## No feature flag

Small additive bug-fix config change: doesn't act autonomously, mutate/destroy state, or wholesale-replace a load-bearing path, so per the project's flag policy it doesn't require gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)