### PR TITLE
feat: --claude-settings spawn flag — pass a Claude settings fragment into TBD's per-session overlay

### DIFF
--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -37,6 +37,9 @@ struct TerminalCreate: AsyncParsableCommand {
     @Option(name: .long, help: "Read initial prompt from a file (use - for stdin)")
     var promptFile: String?
 
+    @Option(name: .long, help: "Extra Claude Code settings as a JSON object, deep-merged into TBD's per-session --settings overlay for the spawned agent (Claude only). Example: '{\"skillOverrides\":{\"some-skill\":\"off\"}}'")
+    var claudeSettings: String?
+
     @Flag(name: .long, help: "Output JSON")
     var json = false
 
@@ -46,7 +49,7 @@ struct TerminalCreate: AsyncParsableCommand {
 
         let terminal: Terminal = try client.call(
             method: RPCMethod.terminalCreate,
-            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, prompt: try resolvePrompt(inline: prompt, file: promptFile)),
+            params: TerminalCreateParams(worktreeID: worktreeID, cmd: cmd, type: type, prompt: try resolvePrompt(inline: prompt, file: promptFile), claudeSettingsOverlay: claudeSettings),
             resultType: Terminal.self
         )
 

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -53,6 +53,9 @@ struct WorktreeCreate: AsyncParsableCommand {
     @Option(name: .long, help: "Read initial prompt from a file (use - for stdin)")
     var promptFile: String?
 
+    @Option(name: .long, help: "Extra Claude Code settings as a JSON object, deep-merged into TBD's per-session --settings overlay for the spawned agent (Claude only). Example: '{\"skillOverrides\":{\"some-skill\":\"off\"}}'")
+    var claudeSettings: String?
+
     @Option(
         name: .customLong("position"),
         help: ArgumentHelp(
@@ -125,7 +128,8 @@ struct WorktreeCreate: AsyncParsableCommand {
                 parentWorktreeID: nil,
                 siblingOfWorktreeID: parentingFields.siblingOfWorktreeID,
                 callerWorktreeID: parentingFields.callerWorktreeID,
-                suppressAutoParent: parentingFields.suppressAutoParent
+                suppressAutoParent: parentingFields.suppressAutoParent,
+                claudeSettingsOverlay: claudeSettings
             ),
             resultType: Worktree.self
         )

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -216,12 +216,13 @@ public enum ClaudeHookOverlay {
 
     /// Resolve the `--settings` overlay path for a spawn.
     ///
-    /// - No fallback models (nil/empty) → returns the shared global
-    ///   `overlayPath` unchanged (hooks-only, the pre-existing behavior).
-    /// - Fallback models present → writes a PER-SESSION overlay file that
-    ///   merges hooks + the `fallbackModel` array (because `fallbackModel` is
-    ///   per-profile and the global overlay is shared across all sessions),
-    ///   then returns that file's path.
+    /// - Both fallback models AND `extraSettingsJSON` absent → returns the
+    ///   shared global `overlayPath` unchanged (hooks-only, pre-existing behavior).
+    /// - Fallback models present OR a non-empty `extraSettingsJSON` fragment
+    ///   supplied → writes a PER-SESSION overlay file that merges hooks + the
+    ///   `fallbackModel` array (per-profile) + the fragment (both are session-
+    ///   specific, and the global overlay is shared across all sessions), then
+    ///   returns that file's path.
     ///
     /// The per-session path is keyed by `sessionKey` (a session/terminal/
     /// worktree-unique string) so concurrent sessions with different profiles

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -108,7 +108,15 @@ public enum ClaudeHookOverlay {
     /// keys (it does NOT merge across multiple `--settings` flags), so the
     /// fallback list MUST ride in the same file as the hooks — hence this
     /// merged body rather than a second overlay.
-    public static func generateBody(fallbackModels: [String]? = nil) throws -> Data {
+    ///
+    /// `extraSettings`, when present, is DEEP-MERGED into the body after
+    /// `fallbackModel`: object-valued keys present in both recurse; any other
+    /// clash lets the `extraSettings` value win. This preserves TBD's `hooks`
+    /// when the fragment only adds top-level keys (e.g. `skillOverrides`).
+    public static func generateBody(
+        fallbackModels: [String]? = nil,
+        extraSettings: [String: Any]? = nil
+    ) throws -> Data {
         var body: [String: Any] = [
             "hooks": [
                 "SessionStart": [
@@ -166,10 +174,44 @@ public enum ClaudeHookOverlay {
         if let fallbackModels, !fallbackModels.isEmpty {
             body["fallbackModel"] = fallbackModels
         }
+        if let extraSettings {
+            deepMerge(&body, extraSettings)
+        }
         return try JSONSerialization.data(
             withJSONObject: body,
             options: [.prettyPrinted, .sortedKeys]
         )
+    }
+
+    /// Recursive dict merge: for a key present in both, if BOTH values are
+    /// `[String: Any]` recurse; otherwise the `overlay` value wins.
+    private static func deepMerge(_ base: inout [String: Any], _ overlay: [String: Any]) {
+        for (key, overlayValue) in overlay {
+            if var baseChild = base[key] as? [String: Any],
+               let overlayChild = overlayValue as? [String: Any] {
+                deepMerge(&baseChild, overlayChild)
+                base[key] = baseChild
+            } else {
+                base[key] = overlayValue
+            }
+        }
+    }
+
+    /// Parse an `extraSettingsJSON` fragment into a settings dict. Returns nil
+    /// for nil/empty input; also returns nil (with a warning) when the string
+    /// isn't a valid JSON object, so a malformed fragment degrades to "no extra
+    /// settings" rather than aborting the spawn.
+    private static func parseExtraSettings(_ json: String?) -> [String: Any]? {
+        guard let json, !json.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dict = object as? [String: Any] else {
+            logger.warning("Ignoring malformed claudeSettingsOverlay fragment (not a JSON object): \(json, privacy: .public)")
+            return nil
+        }
+        return dict
     }
 
     /// Resolve the `--settings` overlay path for a spawn.
@@ -191,16 +233,33 @@ public enum ClaudeHookOverlay {
     /// shared global `overlayPath` is returned instead. This guarantees a
     /// spawn always has a usable `--settings` path — it degrades to "no
     /// fallback models" rather than aborting the spawn.
+    ///
+    /// `extraSettingsJSON` (a JSON OBJECT string) also forces a per-session
+    /// overlay and is deep-merged into the body. If it's nil/empty it's
+    /// ignored; if it fails to parse as a JSON object it's logged and dropped
+    /// (the fragment degrades to nothing — a bad fragment must never abort the
+    /// spawn).
+    ///
+    /// ponytail: the fragment applies at FRESH spawn only. Wake/hibernation
+    /// resume does NOT reapply it — that would need persisting the fragment on
+    /// the terminal DB row via a migration (out of scope for v1).
     public static func resolveOverlayPath(
         fallbackModels: [String]?,
-        sessionKey: String
+        sessionKey: String,
+        extraSettingsJSON: String? = nil
     ) -> String {
-        guard let fallbackModels, !fallbackModels.isEmpty else {
+        let hasFallback = !(fallbackModels?.isEmpty ?? true)
+        // A non-empty fragment string forces a per-session overlay even if it
+        // later fails to parse — a malformed fragment degrades to hooks-only,
+        // it must not silently fall back to (and mutate) the shared global file.
+        let hasExtra = !(extraSettingsJSON?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        guard hasFallback || hasExtra else {
             return overlayPath
         }
+        let extraSettings = parseExtraSettings(extraSettingsJSON)
         let path = perSessionOverlayPath(sessionKey: sessionKey)
         do {
-            let data = try generateBody(fallbackModels: fallbackModels)
+            let data = try generateBody(fallbackModels: fallbackModels, extraSettings: extraSettings)
             let parent = (path as NSString).deletingLastPathComponent
             try FileManager.default.createDirectory(
                 atPath: parent,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -25,12 +25,12 @@ extension WorktreeLifecycle {
     ///
     /// This is the legacy all-in-one method. Prefer `beginCreateWorktree` +
     /// `completeCreateWorktree` for non-blocking creation.
-    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false) async throws -> Worktree {
+    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false, claudeSettingsOverlay: String? = nil) async throws -> Worktree {
         let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude, parentWorktreeID: parentWorktreeID, siblingOfWorktreeID: siblingOfWorktreeID, callerWorktreeID: callerWorktreeID, suppressAutoParent: suppressAutoParent, useExistingBranch: useExistingBranch)
         // Pass the original branch ref (may include `origin/` prefix) through
         // so phase 2 can dispatch to the correct git command.
         let existingBranchRef = useExistingBranch ? branch : nil
-        let completion = try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef)
+        let completion = try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef, claudeSettingsOverlay: claudeSettingsOverlay)
         // Legacy synchronous contract: the returned worktree is fully set up.
         // Await phase 3 inline when a preSession hook gated the primary spawn.
         if case .preSessionPending(let phase3) = completion {
@@ -180,7 +180,7 @@ extension WorktreeLifecycle {
     /// When `existingBranchRef` is non-nil, the worktree is checked out from
     /// that existing ref (local or `origin/*`) — no fresh branch is created.
     @discardableResult
-    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, overrideProfileID: UUID? = nil) async throws -> WorktreeCreateCompletion {
+    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, overrideProfileID: UUID? = nil, claudeSettingsOverlay: String? = nil) async throws -> WorktreeCreateCompletion {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -285,7 +285,8 @@ extension WorktreeLifecycle {
                         initialPrompt: initialPrompt,
                         cols: cols, rows: rows,
                         completionAction: .markActive,
-                        overrideProfileID: overrideProfileID
+                        overrideProfileID: overrideProfileID,
+                        claudeSettingsOverlay: claudeSettingsOverlay
                     )
                 }
                 return .preSessionPending(phase3: phase3)
@@ -301,7 +302,8 @@ extension WorktreeLifecycle {
                 cols: cols,
                 rows: rows,
                 preSessionTerminalID: nil,
-                overrideProfileID: overrideProfileID
+                overrideProfileID: overrideProfileID,
+                claudeSettingsOverlay: claudeSettingsOverlay
             )
 
             // 6. Update status to active
@@ -419,7 +421,8 @@ extension WorktreeLifecycle {
         cols: Int? = nil,
         rows: Int? = nil,
         preSessionTerminalID: UUID?,
-        overrideProfileID: UUID? = nil
+        overrideProfileID: UUID? = nil,
+        claudeSettingsOverlay: String? = nil
     ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
@@ -560,7 +563,8 @@ extension WorktreeLifecycle {
                 shellFallback: defaultShell,
                 settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
-                    sessionKey: plannedTerminalID1.uuidString
+                    sessionKey: plannedTerminalID1.uuidString,
+                    extraSettingsJSON: claudeSettingsOverlay
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -564,7 +564,10 @@ extension WorktreeLifecycle {
                 settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
                     sessionKey: plannedTerminalID1.uuidString,
-                    extraSettingsJSON: claudeSettingsOverlay
+                    // Fragment applies to FRESH primary spawns only; an archived-
+                    // session resume must not reapply it. Hooks overlay still
+                    // resolves for resumes — only extraSettingsJSON goes nil.
+                    extraSettingsJSON: isResume ? nil : claudeSettingsOverlay
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -277,7 +277,8 @@ extension WorktreeLifecycle {
         initialPrompt: String? = nil,
         cols: Int? = nil, rows: Int? = nil,
         completionAction: PreSessionCompletionAction,
-        overrideProfileID: UUID? = nil
+        overrideProfileID: UUID? = nil,
+        claudeSettingsOverlay: String? = nil
     ) async {
         let outcome = await waitForPreSessionCompletion(
             preSession: preSession, tmuxServer: worktree.tmuxServer
@@ -344,7 +345,8 @@ extension WorktreeLifecycle {
                 // On success the hook tab is about to be deleted — never splice
                 // it into tab order. On failure it stays, at index 1 as before.
                 preSessionTerminalID: succeeded ? nil : preSession.terminalID,
-                overrideProfileID: overrideProfileID
+                overrideProfileID: overrideProfileID,
+                claudeSettingsOverlay: claudeSettingsOverlay
             )
             for terminal in created {
                 subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -320,7 +320,8 @@ extension RPCRouter {
             settingsOverlayPath: isClaudeType
                 ? ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
-                    sessionKey: plannedTerminalID.uuidString
+                    sessionKey: plannedTerminalID.uuidString,
+                    extraSettingsJSON: params.claudeSettingsOverlay
                   )
                 : nil,
             pluginDirPath: isClaudeType ? PluginDirWriter.pluginDirPath : nil,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -321,7 +321,10 @@ extension RPCRouter {
                 ? ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
                     sessionKey: plannedTerminalID.uuidString,
-                    extraSettingsJSON: params.claudeSettingsOverlay
+                    // Fragment applies to FRESH primary spawns only; a resume
+                    // must not reapply it. Hooks overlay still resolves for
+                    // resumes — only extraSettingsJSON goes nil.
+                    extraSettingsJSON: params.resumeSessionID == nil ? params.claudeSettingsOverlay : nil
                   )
                 : nil,
             pluginDirPath: isClaudeType ? PluginDirWriter.pluginDirPath : nil,

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -40,12 +40,15 @@ extension RPCRouter {
         // Explicit per-creation model-profile override (sidebar `+` picker).
         // nil preserves the repo/scratch/global precedence chain.
         let overrideProfileID = params.profileID
+        // General Claude settings passthrough, deep-merged into the per-session
+        // --settings overlay on the fresh-primary spawn (see ClaudeHookOverlay).
+        let claudeSettingsOverlay = params.claudeSettingsOverlay
         // handleWorktreeCreate is always repo-scoped (scratch creation uses a
         // separate RPC), so params.repoID is the reliable non-optional source
         // — pending.repoID mirrors it but is now UUID? on the shared model.
         await repoSerializer.submit(repoID: params.repoID) {
             do {
-                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, overrideProfileID: overrideProfileID)
+                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, overrideProfileID: overrideProfileID, claudeSettingsOverlay: claudeSettingsOverlay)
                 switch completion {
                 case .ready:
                     subs.broadcast(delta: .worktreeCreated(WorktreeDelta(

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -822,7 +822,12 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// existing precedence-based resolution. Not persisted — creation-time only.
     /// Optional/defaulted for backward compatibility with older clients.
     public let profileID: UUID?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil) {
+    /// Extra Claude Code settings (a JSON OBJECT string) deep-merged into TBD's
+    /// per-session `--settings` overlay for this spawn's Claude agent. General
+    /// passthrough — TBD does not interpret the contents. Optional/defaulted for
+    /// backward compatibility (old daemons ignore the unknown key; old clients omit it).
+    public let claudeSettingsOverlay: String?
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, claudeSettingsOverlay: String? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
         self.parentWorktreeID = parentWorktreeID
@@ -831,6 +836,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
         self.suppressAutoParent = suppressAutoParent
         self.useExistingBranch = useExistingBranch
         self.profileID = profileID
+        self.claudeSettingsOverlay = claudeSettingsOverlay
     }
 }
 
@@ -1039,10 +1045,16 @@ public struct TerminalCreateParams: Codable, Sendable {
     /// COLORFGBG environment variable value computed from active terminal color scheme's
     /// background luminance. Format: "0;15" for light bg or "15;0" for dark bg.
     public let colorFgBg: String?
-    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideProfileID: UUID? = nil, loginSession: Bool? = nil, cols: Int? = nil, rows: Int? = nil, colorFgBg: String? = nil) {
+    /// Extra Claude Code settings (a JSON OBJECT string) deep-merged into TBD's
+    /// per-session `--settings` overlay for this spawn's Claude agent. General
+    /// passthrough — TBD does not interpret the contents. Optional/defaulted for
+    /// backward compatibility (old daemons ignore the unknown key; old clients omit it).
+    public let claudeSettingsOverlay: String?
+    public init(worktreeID: UUID, cmd: String? = nil, type: TerminalCreateType? = nil, resumeSessionID: String? = nil, prompt: String? = nil, overrideProfileID: UUID? = nil, loginSession: Bool? = nil, cols: Int? = nil, rows: Int? = nil, colorFgBg: String? = nil, claudeSettingsOverlay: String? = nil) {
         self.worktreeID = worktreeID; self.cmd = cmd; self.type = type; self.resumeSessionID = resumeSessionID; self.prompt = prompt; self.overrideProfileID = overrideProfileID
         self.loginSession = loginSession
         self.cols = cols; self.rows = rows; self.colorFgBg = colorFgBg
+        self.claudeSettingsOverlay = claudeSettingsOverlay
     }
 }
 

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -256,6 +256,117 @@ extension TBDHomeSerialized {
         #expect(FileManager.default.fileExists(atPath: ClaudeHookOverlay.overlayPath))
     }
 
+    // MARK: - Extra settings passthrough (claudeSettingsOverlay)
+
+    @Test func generateBodyWithNilExtraSettingsIsHooksOnly() throws {
+        // OFF branch: byte-identical to the hooks-only default. No extra keys.
+        let baseline = try ClaudeHookOverlay.generateBody()
+        let data = try ClaudeHookOverlay.generateBody(extraSettings: nil)
+        #expect(data == baseline)
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        // Only `hooks` at top level (no fallbackModel, no fragment keys).
+        #expect(parsed?.keys.sorted() == ["hooks"])
+    }
+
+    @Test func generateBodyWithExtraSettingsMergesAndKeepsHooks() throws {
+        let extra: [String: Any] = ["skillOverrides": ["x": "off"]]
+        let data = try ClaudeHookOverlay.generateBody(extraSettings: extra)
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        // Fragment landed…
+        let overrides = parsed?["skillOverrides"] as? [String: Any]
+        #expect(overrides?["x"] as? String == "off")
+        // …and the original hooks dict is intact.
+        #expect(parsed?["hooks"] != nil)
+        #expect((parsed?["hooks"] as? [String: Any])?["SessionStart"] != nil)
+    }
+
+    @Test func generateBodyDeepMergesNestedObjectRatherThanReplacing() throws {
+        // A fragment that shares a nested object key with hooks: the merge must
+        // recurse and PRESERVE the sibling keys, not replace the whole `hooks`.
+        let extra: [String: Any] = ["hooks": ["MyEvent": "value"]]
+        let data = try ClaudeHookOverlay.generateBody(extraSettings: extra)
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let hooks = parsed?["hooks"] as? [String: Any]
+        // The added key is present…
+        #expect(hooks?["MyEvent"] as? String == "value")
+        // …and the pre-existing hook events survive (deep merge, not replace).
+        #expect(hooks?["SessionStart"] != nil)
+        #expect(hooks?["Stop"] != nil)
+    }
+
+    @Test func resolveOverlayPathWithNilExtraSettingsReturnsGlobalPath() throws {
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            extraSettingsJSON: nil
+        )
+        #expect(path == ClaudeHookOverlay.overlayPath)
+    }
+
+    @Test func resolveOverlayPathWithEmptyExtraSettingsReturnsGlobalPath() throws {
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            extraSettingsJSON: "   "
+        )
+        #expect(path == ClaudeHookOverlay.overlayPath)
+    }
+
+    @Test func resolveOverlayPathWithExtraSettingsWritesPerSessionMergedFile() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let key = UUID().uuidString
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: key,
+            extraSettingsJSON: #"{"skillOverrides":{"longeye-code-review":"off"}}"#
+        )
+        // Per-session file (not the shared global overlay).
+        #expect(path != ClaudeHookOverlay.overlayPath)
+        #expect(path.contains(ClaudeHookOverlay.perSessionPrefix))
+        #expect(FileManager.default.fileExists(atPath: path))
+
+        // On-disk overlay merges the fragment AND keeps hooks.
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        let overrides = parsed?["skillOverrides"] as? [String: Any]
+        #expect(overrides?["longeye-code-review"] as? String == "off")
+    }
+
+    @Test func resolveOverlayPathWithMalformedExtraSettingsDoesNotThrowAndKeepsHooks() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        // Malformed fragment: still forces a per-session write (non-empty
+        // string), degrades to hooks-only, never throws/aborts.
+        let key = UUID().uuidString
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: key,
+            extraSettingsJSON: "{not json"
+        )
+        #expect(path.contains(ClaudeHookOverlay.perSessionPrefix))
+        #expect(FileManager.default.fileExists(atPath: path))
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        // Fragment ignored; hooks preserved.
+        #expect(parsed?["hooks"] != nil)
+        #expect(parsed?["skillOverrides"] == nil)
+    }
+
     @Test func roundtripsAsValidJSON() throws {
         let data = try ClaudeHookOverlay.generateBody()
         // Must round-trip — a malformed overlay file would crash Claude


### PR DESCRIPTION
## What

Adds a general, Claude-scoped **settings passthrough** at spawn: an optional `--claude-settings '<json>'` flag on `tbd worktree create` and `tbd terminal create`. TBD deep-merges the fragment into the **per-session `--settings` overlay it already writes** for that Claude agent.

```
tbd worktree create --repo longeye-app --prompt '<brief>' \
  --claude-settings '{"skillOverrides":{"longeye-code-review":"off"}}'
```

## Why

On-call child worktrees were drifting to a heavy project review skill because a spawn couldn't scope Claude settings per-agent. Rather than a bespoke `--skill-override` flag (which would breed one flag per concern), this exposes Claude Code's own settings layering generically — one flag, any Claude setting. TBD stays **policy-free**; the caller (e.g. an on-call orchestrator) decides what to pass. The motivating use is hiding `longeye-code-review` so `/code-review` unambiguously resolves to the built-in, but nothing here is longeye-specific.

## How it works (verified)

Claude Code's `--settings` **deep-merges** object-valued keys (like `skillOverrides`) with the project/user `settings.json` layers — empirically confirmed: a fragment of just `{skillOverrides:{x:off}}` leaves the project's other ~56 `name-only` entries intact and only adds `x:off`. But **multiple `--settings` flags do not cross-merge** (Claude takes the first file's scalar keys — the same reason `fallbackModel` already rides inside TBD's one overlay file). So the fragment is **deep-merged into TBD's single overlay file**, not passed as a second `--settings`.

- `ClaudeHookOverlay.generateBody(fallbackModels:extraSettings:)` — recursive `deepMerge` (nested objects recurse, else the fragment wins); TBD's `hooks` are preserved when the fragment only adds top-level keys.
- `resolveOverlayPath(...extraSettingsJSON:)` — writes a **per-session** overlay (keyed by terminal UUID, reusing the existing per-session mechanism + its teardown/prune cleanup) whenever fallback models **or** a non-empty fragment are present; otherwise returns the shared global overlay unchanged.
- **Fail-safe:** a malformed/empty/non-object fragment is logged and dropped — it never throws, never aborts the spawn, and never mutates the shared global overlay.
- **Fresh-spawn-only:** the fragment reaches only fresh-primary Claude spawns (worktree-create primary incl. the preSession phase-3 detached spawn; terminal-create). Resume / wake / profile-swap / restored-archived-session / hibernation paths pass `nil`, and this is now **code-enforced** at each call site (review follow-up), not just caller-convention.

## Not behind a feature flag

The behavior is opt-in and **inert unless the flag/param is passed** — it doesn't act autonomously, kill processes, or mutate persisted state, so it doesn't meet the default-off-flag bar in CLAUDE.md.

## Known ceiling (v1)

The fragment applies at **fresh spawn only**; wake/hibernation-resume does not reapply it. Persisting it across resume would need a terminal-row column + migration — out of scope for v1 (on-call children are short-lived). Marked with a `ponytail:` comment at `resolveOverlayPath`.

## Tests

`ClaudeHookOverlay` (25, +7 new): fragment-absent → overlay byte-identical to before; fragment-present → deep-merged with hooks intact; nested-object merge (not replace); per-session-vs-global gate; malformed fragment → no throw, hooks retained. `ClaudeSpawnCommandBuilder` (43) regression-clean. `swiftlint --strict` clean.

## Companion PR

The longeye-app oncall-orchestration docs are updated separately to (a) name the built-in `code-review` explicitly and (b) spawn on-call children with `--claude-settings '{"skillOverrides":{"longeye-code-review":"off"}}'`. **That doc PR depends on this flag and must merge after this one** (else a spawn would pass an unknown option).

[20260715-well-panther](https://cheapsteak.github.io/tbd/open/?worktree=88D96E4D-223C-4108-A74C-1E0CF22224A3)
