### PR TITLE
Feat: Per-repo Claude settings overlay, so overrides apply without passing --claude-settings on every spawn

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -346,6 +346,21 @@ extension AppState {
         }
     }
 
+    /// Set or clear a repo's Claude settings overlay fragment (nil clears).
+    func setRepoClaudeSettingsOverlay(repoID: UUID, overlay: String?) async {
+        do {
+            try await daemonClient.setRepoClaudeSettingsOverlay(repoID: repoID, overlay: overlay)
+            if let idx = repos.firstIndex(where: { $0.id == repoID }) {
+                var repo = repos[idx]
+                repo.claudeSettingsOverlay = overlay
+                repos[idx] = repo
+            }
+        } catch {
+            logger.error("Failed to set repo Claude settings overlay: \(error, privacy: .public)")
+            showAlert("Failed to set Claude settings overlay: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Set or clear a model profile's free-form env overrides.
     func setProfileEnvOverrides(profileID: UUID, overrides: [String: String]) async {
         do {

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -869,6 +869,14 @@ actor DaemonClient {
         )
     }
 
+    /// Set or clear a repo's Claude settings overlay fragment (nil clears).
+    func setRepoClaudeSettingsOverlay(repoID: UUID, overlay: String?) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.repoSetClaudeSettingsOverlay,
+            params: SetRepoClaudeSettingsOverlayParams(repoID: repoID, overlay: overlay)
+        )
+    }
+
     /// Set or clear a model profile's free-form env overrides.
     func setProfileEnvOverrides(profileID: UUID, overrides: [String: String]) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -112,6 +112,13 @@ struct RepoSettingsView: View {
                         Divider()
                             .padding(.vertical, 4)
 
+                        ClaudeSettingsOverlayEditor(
+                            initial: repo.claudeSettingsOverlay
+                        ) { await appState.setRepoClaudeSettingsOverlay(repoID: repo.id, overlay: $0) }
+
+                        Divider()
+                            .padding(.vertical, 4)
+
                         RepoHooksSettingsView(repoID: repoID, focusedHook: $focusedHook)
                     }
                     .padding()
@@ -162,5 +169,70 @@ struct RepoSettingsView: View {
             return "Inheriting: \(name)"
         }
         return "Inheriting: Default (claude keychain login)"
+    }
+}
+
+/// Minimal per-repo editor for the Claude settings overlay fragment: a
+/// monospaced multi-line JSON field with the same save flow as
+/// `EnvOverridesEditor`. Empty/whitespace text clears the fragment (NULL).
+/// Passthrough by design — no JSON validation beyond what the daemon logs
+/// at spawn time. See docs/claude-settings-overlay.md.
+private struct ClaudeSettingsOverlayEditor: View {
+    /// Hands the committed fragment (nil = cleared) to the caller for persistence.
+    let onSave: (String?) async -> Void
+
+    @State private var text: String
+    @State private var isSaving = false
+    @State private var showSaved = false
+
+    init(initial: String?, onSave: @escaping (String?) async -> Void) {
+        self.onSave = onSave
+        _text = State(initialValue: initial ?? "")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Claude settings overlay")
+                .font(.callout)
+                .fontWeight(.medium)
+            Text("JSON object deep-merged into TBD's --settings overlay on every Claude spawn in this repo (fresh, resume, wake). Leave empty to disable.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            TextEditor(text: $text)
+                .font(.body.monospaced())
+                .frame(minHeight: 60, maxHeight: 120)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color.secondary.opacity(0.3))
+                )
+
+            HStack {
+                Spacer()
+                if showSaved {
+                    Text("Saved")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .transition(.opacity)
+                }
+                Button("Save") { save() }
+                    .controlSize(.small)
+                    .disabled(isSaving)
+            }
+        }
+    }
+
+    private func save() {
+        isSaving = true
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let overlay = trimmed.isEmpty ? nil : text
+        Task {
+            await onSave(overlay)
+            isSaving = false
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
+        }
     }
 }

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -195,7 +195,7 @@ private struct ClaudeSettingsOverlayEditor: View {
             Text("Claude settings overlay")
                 .font(.callout)
                 .fontWeight(.medium)
-            Text("JSON object deep-merged into TBD's --settings overlay on every Claude spawn in this repo (fresh, resume, wake). Leave empty to disable.")
+            Text("JSON object deep-merged into TBD's --settings overlay when Claude spawns in this repo (fresh, resume, wake). Leave empty to disable.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -892,8 +892,8 @@ public final class TBDDatabase: Sendable {
         }
 
         // Per-repo Claude settings overlay fragment (JSON object string,
-        // plain-text passthrough). NULL = unset. Read fresh at every Claude
-        // spawn and deep-merged into TBD's per-session `--settings` overlay
+        // plain-text passthrough). NULL = unset. Resolved at Claude spawn
+        // time and deep-merged into TBD's per-session `--settings` overlay
         // beneath the per-spawn `--claude-settings` fragment. See
         // docs/claude-settings-overlay.md.
         migrator.registerMigration("v53_repo_claude_settings_overlay") { db in

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -891,6 +891,15 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "config", column: "gc_snapshot_retention_days", type: .integer, defaults: 30)
         }
 
+        // Per-repo Claude settings overlay fragment (JSON object string,
+        // plain-text passthrough). NULL = unset. Read fresh at every Claude
+        // spawn and deep-merged into TBD's per-session `--settings` overlay
+        // beneath the per-spawn `--claude-settings` fragment. See
+        // docs/claude-settings-overlay.md.
+        migrator.registerMigration("v53_repo_claude_settings_overlay") { db in
+            try db.addColumnIfMissing(table: "repo", column: "claude_settings_overlay", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/RepoStore.swift
+++ b/Sources/TBDDaemon/Database/RepoStore.swift
@@ -24,6 +24,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var hidden: Bool
     var expanded: Bool
     var env_overrides: String?
+    var claude_settings_overlay: String?
 
     init(from repo: Repo) {
         self.id = repo.id.uuidString
@@ -41,6 +42,7 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.hidden = repo.hidden
         self.expanded = repo.expanded
         self.env_overrides = EnvOverridesCoding.encode(repo.envOverrides)
+        self.claude_settings_overlay = repo.claudeSettingsOverlay
     }
 
     /// Failable decode: skips (returns nil after a logged warning) rather than
@@ -66,7 +68,8 @@ struct RepoRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             status: RepoStatus(rawValue: status) ?? .ok,
             hidden: hidden,
             expanded: expanded,
-            envOverrides: EnvOverridesCoding.decode(env_overrides)
+            envOverrides: EnvOverridesCoding.decode(env_overrides),
+            claudeSettingsOverlay: claude_settings_overlay
         )
     }
 }
@@ -213,6 +216,17 @@ public struct RepoStore: Sendable {
             try db.execute(
                 sql: "UPDATE repo SET env_overrides = ? WHERE id = ?",
                 arguments: [json, id.uuidString]
+            )
+        }
+    }
+
+    /// Set or clear the per-repo Claude settings overlay fragment.
+    /// nil (or the caller mapping empty text to nil) clears to NULL.
+    public func setClaudeSettingsOverlay(id: UUID, overlay: String?) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE repo SET claude_settings_overlay = ? WHERE id = ?",
+                arguments: [overlay, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -243,9 +243,11 @@ public enum ClaudeHookOverlay {
     /// dropped without discarding the other, and a bad fragment must never
     /// abort the spawn.
     ///
-    /// The repo fragment is read fresh from the repo row at every spawn, so it
-    /// applies on ALL spawn paths (fresh create, resume, wake, profile swap).
-    /// The per-spawn fragment applies at FRESH spawn only — callers gate it.
+    /// The repo fragment is resolved from the repo row at spawn time (on
+    /// preSession-gated creates and archived-worktree revives, from the row as
+    /// of create/revive entry), so it applies on ALL spawn paths (fresh create,
+    /// resume, wake, profile swap). The per-spawn fragment applies at FRESH
+    /// spawn only — callers gate it.
     public static func resolveOverlayPath(
         fallbackModels: [String]?,
         sessionKey: String,

--- a/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
+++ b/Sources/TBDDaemon/Hooks/ClaudeHookOverlay.swift
@@ -235,18 +235,21 @@ public enum ClaudeHookOverlay {
     /// spawn always has a usable `--settings` path — it degrades to "no
     /// fallback models" rather than aborting the spawn.
     ///
-    /// `extraSettingsJSON` (a JSON OBJECT string) also forces a per-session
-    /// overlay and is deep-merged into the body. If it's nil/empty it's
-    /// ignored; if it fails to parse as a JSON object it's logged and dropped
-    /// (the fragment degrades to nothing — a bad fragment must never abort the
-    /// spawn).
+    /// `repoSettingsJSON` (the repo row's persisted fragment) and
+    /// `extraSettingsJSON` (the per-spawn param) are JSON OBJECT strings that
+    /// also force a per-session overlay and are deep-merged into the body —
+    /// repo fragment first, per-spawn fragment on top (per-spawn wins
+    /// collisions). Each parses independently: a malformed one is logged and
+    /// dropped without discarding the other, and a bad fragment must never
+    /// abort the spawn.
     ///
-    /// ponytail: the fragment applies at FRESH spawn only. Wake/hibernation
-    /// resume does NOT reapply it — that would need persisting the fragment on
-    /// the terminal DB row via a migration (out of scope for v1).
+    /// The repo fragment is read fresh from the repo row at every spawn, so it
+    /// applies on ALL spawn paths (fresh create, resume, wake, profile swap).
+    /// The per-spawn fragment applies at FRESH spawn only — callers gate it.
     public static func resolveOverlayPath(
         fallbackModels: [String]?,
         sessionKey: String,
+        repoSettingsJSON: String? = nil,
         extraSettingsJSON: String? = nil
     ) -> String {
         let hasFallback = !(fallbackModels?.isEmpty ?? true)
@@ -254,10 +257,17 @@ public enum ClaudeHookOverlay {
         // later fails to parse — a malformed fragment degrades to hooks-only,
         // it must not silently fall back to (and mutate) the shared global file.
         let hasExtra = !(extraSettingsJSON?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            || !(repoSettingsJSON?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         guard hasFallback || hasExtra else {
             return overlayPath
         }
-        let extraSettings = parseExtraSettings(extraSettingsJSON)
+        // Repo fragment first, per-spawn fragment deep-merged on top.
+        var extraSettings = parseExtraSettings(repoSettingsJSON)
+        if let perSpawn = parseExtraSettings(extraSettingsJSON) {
+            var base = extraSettings ?? [:]
+            deepMerge(&base, perSpawn)
+            extraSettings = base
+        }
         let path = perSessionOverlayPath(sessionKey: sessionKey)
         do {
             let data = try generateBody(fallbackModels: fallbackModels, extraSettings: extraSettings)

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -511,7 +511,9 @@ public actor HibernationCoordinator {
         )
         let overlayPath = ClaudeHookOverlay.resolveOverlayPath(
             fallbackModels: resolvedProfile?.fallbackModels,
-            sessionKey: terminal.id.uuidString
+            sessionKey: terminal.id.uuidString,
+            // Repo fragment is persisted config — reapplied on wake.
+            repoSettingsJSON: repo?.claudeSettingsOverlay
         )
         let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
         // Pre-accept Claude's folder-trust dialog for scratch spaces so a wake

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -564,9 +564,13 @@ extension WorktreeLifecycle {
                 settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
                     sessionKey: plannedTerminalID1.uuidString,
-                    // Fragment applies to FRESH primary spawns only; an archived-
-                    // session resume must not reapply it. Hooks overlay still
-                    // resolves for resumes — only extraSettingsJSON goes nil.
+                    // Repo fragment is persisted config — applies on every
+                    // spawn path, resume included.
+                    repoSettingsJSON: repo?.claudeSettingsOverlay,
+                    // Per-spawn fragment applies to FRESH primary spawns only;
+                    // an archived-session resume must not reapply it. Hooks
+                    // overlay still resolves for resumes — only
+                    // extraSettingsJSON goes nil.
                     extraSettingsJSON: isResume ? nil : claudeSettingsOverlay
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
@@ -701,7 +705,8 @@ extension WorktreeLifecycle {
                     shellFallback: defaultShell,
                     settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                         fallbackModels: resolvedProfile?.fallbackModels,
-                        sessionKey: plannedID.uuidString
+                        sessionKey: plannedID.uuidString,
+                        repoSettingsJSON: repo?.claudeSettingsOverlay
                     ),
                     pluginDirPath: PluginDirWriter.pluginDirPath,
                     envSettingOverrides: claudeEnvOverrides

--- a/Sources/TBDDaemon/Server/RPCRouter+EnvOverridesHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+EnvOverridesHandlers.swift
@@ -18,6 +18,12 @@ extension RPCRouter {
         return .ok()
     }
 
+    func handleRepoSetClaudeSettingsOverlay(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(SetRepoClaudeSettingsOverlayParams.self, from: data)
+        try await db.repos.setClaudeSettingsOverlay(id: params.repoID, overlay: params.overlay)
+        return .ok()
+    }
+
     func handleModelProfileSetEnvOverrides(_ data: Data) async throws -> RPCResponse {
         let params = try decoder.decode(SetProfileEnvOverridesParams.self, from: data)
         try await db.modelProfiles.setEnvOverrides(id: params.profileID, overrides: params.overrides)

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -321,9 +321,12 @@ extension RPCRouter {
                 ? ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolvedProfile?.fallbackModels,
                     sessionKey: plannedTerminalID.uuidString,
-                    // Fragment applies to FRESH primary spawns only; a resume
-                    // must not reapply it. Hooks overlay still resolves for
-                    // resumes — only extraSettingsJSON goes nil.
+                    // Repo fragment is persisted config — applies on every
+                    // spawn path, resume included.
+                    repoSettingsJSON: repo?.claudeSettingsOverlay,
+                    // Per-spawn fragment applies to FRESH spawns only; a
+                    // resume must not reapply it. Hooks overlay still resolves
+                    // for resumes — only extraSettingsJSON goes nil.
                     extraSettingsJSON: params.resumeSessionID == nil ? params.claudeSettingsOverlay : nil
                   )
                 : nil,
@@ -1078,7 +1081,8 @@ extension RPCRouter {
                 shellFallback: "",
                 settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolved?.fallbackModels,
-                    sessionKey: plannedTerminalID.uuidString
+                    sessionKey: plannedTerminalID.uuidString,
+                    repoSettingsJSON: repo?.claudeSettingsOverlay
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides
@@ -1107,7 +1111,8 @@ extension RPCRouter {
                 shellFallback: "",
                 settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
                     fallbackModels: resolved?.fallbackModels,
-                    sessionKey: plannedTerminalID.uuidString
+                    sessionKey: plannedTerminalID.uuidString,
+                    repoSettingsJSON: repo?.claudeSettingsOverlay
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
                 envSettingOverrides: claudeEnvOverrides

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -288,6 +288,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetEnvOverrides(request.paramsData)
             case RPCMethod.repoSetEnvOverrides:
                 return try await handleRepoSetEnvOverrides(request.paramsData)
+            case RPCMethod.repoSetClaudeSettingsOverlay:
+                return try await handleRepoSetClaudeSettingsOverlay(request.paramsData)
             case RPCMethod.modelProfileSetEnvOverrides:
                 return try await handleModelProfileSetEnvOverrides(request.paramsData)
             case RPCMethod.modelProfileFetchUsage:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -26,7 +26,7 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
     /// Free-form env-var overrides applied to spawned sessions (repo scope).
     public var envOverrides: [String: String]
     /// Claude settings overlay fragment (JSON object string) deep-merged into
-    /// TBD's per-session `--settings` overlay at every Claude spawn. nil =
+    /// TBD's per-session `--settings` overlay at Claude spawn time. nil =
     /// unset. Passthrough — TBD does not interpret the contents.
     public var claudeSettingsOverlay: String?
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -25,6 +25,10 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
     public var expanded: Bool
     /// Free-form env-var overrides applied to spawned sessions (repo scope).
     public var envOverrides: [String: String]
+    /// Claude settings overlay fragment (JSON object string) deep-merged into
+    /// TBD's per-session `--settings` overlay at every Claude spawn. nil =
+    /// unset. Passthrough — TBD does not interpret the contents.
+    public var claudeSettingsOverlay: String?
 
     public init(id: UUID = UUID(), path: String, remoteURL: String? = nil,
                 displayName: String, defaultBranch: String = "main", createdAt: Date = Date(),
@@ -33,7 +37,8 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
                 worktreeSlot: String? = nil, worktreeRoot: String? = nil,
                 status: RepoStatus = .ok, hidden: Bool = false,
                 expanded: Bool = true,
-                envOverrides: [String: String] = [:]) {
+                envOverrides: [String: String] = [:],
+                claudeSettingsOverlay: String? = nil) {
         self.id = id
         self.path = path
         self.remoteURL = remoteURL
@@ -49,13 +54,14 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         self.hidden = hidden
         self.expanded = expanded
         self.envOverrides = envOverrides
+        self.claudeSettingsOverlay = claudeSettingsOverlay
     }
 
     enum CodingKeys: String, CodingKey {
         case id, path, remoteURL, displayName, defaultBranch, createdAt
         case renamePrompt, customInstructions, profileOverrideID
         case worktreeSlot, worktreeRoot, status, hidden, expanded
-        case envOverrides
+        case envOverrides, claudeSettingsOverlay
     }
 
     public init(from decoder: Decoder) throws {
@@ -76,6 +82,8 @@ public struct Repo: Codable, Sendable, Identifiable, Equatable {
         expanded = try c.decodeIfPresent(Bool.self, forKey: .expanded) ?? true
         envOverrides = try c.decodeIfPresent(
             [String: String].self, forKey: .envOverrides) ?? [:]
+        claudeSettingsOverlay = try c.decodeIfPresent(
+            String.self, forKey: .claudeSettingsOverlay)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -180,6 +180,7 @@ public enum RPCMethod {
     public static let repoListBranches = "repo.listBranches"
     public static let configSetEnvOverrides       = "config.setEnvOverrides"
     public static let repoSetEnvOverrides         = "repo.setEnvOverrides"
+    public static let repoSetClaudeSettingsOverlay = "repo.setClaudeSettingsOverlay"
     public static let modelProfileSetEnvOverrides = "modelProfile.setEnvOverrides"
     public static let worktreeSetAutoArchive = "worktree.setAutoArchive"
     public static let worktreeSetAutoHibernate = "worktree.setAutoHibernate"
@@ -1299,6 +1300,17 @@ public struct SetRepoEnvOverridesParams: Codable, Sendable, Equatable {
     public init(repoID: UUID, overrides: [String: String]) {
         self.repoID = repoID
         self.overrides = overrides
+    }
+}
+
+/// Params for `repo.setClaudeSettingsOverlay` — per-repo Claude settings
+/// overlay fragment (JSON object string). nil clears to unset.
+public struct SetRepoClaudeSettingsOverlayParams: Codable, Sendable, Equatable {
+    public let repoID: UUID
+    public let overlay: String?
+    public init(repoID: UUID, overlay: String?) {
+        self.repoID = repoID
+        self.overlay = overlay
     }
 }
 

--- a/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeHookOverlayTests.swift
@@ -367,6 +367,159 @@ extension TBDHomeSerialized {
         #expect(parsed?["skillOverrides"] == nil)
     }
 
+    // MARK: - Repo settings fragment (per-repo claude_settings_overlay)
+
+    @Test func resolveOverlayPathWithNilRepoFragmentReturnsGlobalPath() throws {
+        // OFF branch of the new gate: nil repo fragment + nil per-spawn
+        // fragment behaves exactly as before (shared global overlay).
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            repoSettingsJSON: nil,
+            extraSettingsJSON: nil
+        )
+        #expect(path == ClaudeHookOverlay.overlayPath)
+    }
+
+    @Test func resolveOverlayPathWithNilRepoFragmentAndPerSpawnMatchesPerSpawnOnly() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        // OFF branch with a per-spawn fragment: nil repo fragment must not
+        // change the pre-existing per-spawn behavior.
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            repoSettingsJSON: nil,
+            extraSettingsJSON: #"{"skillOverrides":{"x":"off"}}"#
+        )
+        #expect(path.contains(ClaudeHookOverlay.perSessionPrefix))
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        #expect(((parsed?["skillOverrides"] as? [String: Any])?["x"] as? String) == "off")
+    }
+
+    @Test func resolveOverlayPathWithRepoFragmentAloneWritesPerSessionMergedFile() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            repoSettingsJSON: #"{"skillOverrides":{"heavy-skill":"off"}}"#
+        )
+        #expect(path != ClaudeHookOverlay.overlayPath)
+        #expect(path.contains(ClaudeHookOverlay.perSessionPrefix))
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        let overrides = parsed?["skillOverrides"] as? [String: Any]
+        #expect(overrides?["heavy-skill"] as? String == "off")
+    }
+
+    @Test func repoAndPerSpawnFragmentsMergeWithPerSpawnWinningCollisions() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            repoSettingsJSON: #"{"skillOverrides":{"shared":"repo","repoOnly":"on"},"repoKey":1}"#,
+            extraSettingsJSON: #"{"skillOverrides":{"shared":"spawn"},"spawnKey":2}"#
+        )
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        // Non-colliding keys from BOTH fragments are unioned…
+        #expect(parsed?["repoKey"] as? Int == 1)
+        #expect(parsed?["spawnKey"] as? Int == 2)
+        let overrides = parsed?["skillOverrides"] as? [String: Any]
+        #expect(overrides?["repoOnly"] as? String == "on")
+        // …the collision goes to the per-spawn fragment…
+        #expect(overrides?["shared"] as? String == "spawn")
+        // …and hooks survive.
+        #expect(parsed?["hooks"] != nil)
+    }
+
+    @Test func malformedRepoFragmentDegradesButValidPerSpawnStillApplies() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            repoSettingsJSON: "{not json",
+            extraSettingsJSON: #"{"spawnKey":"still-applies"}"#
+        )
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        #expect(parsed?["spawnKey"] as? String == "still-applies")
+    }
+
+    @Test func malformedPerSpawnFragmentDegradesButValidRepoStillApplies() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            repoSettingsJSON: #"{"repoKey":"still-applies"}"#,
+            extraSettingsJSON: "{not json"
+        )
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?["hooks"] != nil)
+        #expect(parsed?["repoKey"] as? String == "still-applies")
+    }
+
+    @Test func bothFragmentsMalformedDegradesToHooksOnlyPerSessionFile() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-overlay-test-\(UUID().uuidString)")
+        setenv("TBD_HOME", tmp.path, 1)
+        defer {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        let path = ClaudeHookOverlay.resolveOverlayPath(
+            fallbackModels: nil,
+            sessionKey: UUID().uuidString,
+            repoSettingsJSON: "{nope",
+            extraSettingsJSON: "[1,2]"
+        )
+        // Still per-session (non-empty fragments force it), hooks-only body.
+        #expect(path.contains(ClaudeHookOverlay.perSessionPrefix))
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        #expect(parsed?.keys.sorted() == ["hooks"])
+    }
+
     @Test func roundtripsAsValidJSON() throws {
         let data = try ClaudeHookOverlay.generateBody()
         // Must round-trip — a malformed overlay file would crash Claude

--- a/Tests/TBDDaemonTests/RPCRouterEnvOverridesTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterEnvOverridesTests.swift
@@ -56,6 +56,30 @@ extension RPCRouterTests {
         #expect(stored?.envOverrides == ["FOO": "bar"])
     }
 
+    @Test("repo.setClaudeSettingsOverlay persists and clears the fragment")
+    func repoSetClaudeSettingsOverlay() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+
+        let fragment = #"{"skillOverrides":{"x":"off"}}"#
+        let set = try RPCRequest(
+            method: RPCMethod.repoSetClaudeSettingsOverlay,
+            params: SetRepoClaudeSettingsOverlayParams(repoID: repo.id, overlay: fragment)
+        )
+        #expect(await router.handle(set).success)
+        #expect(try await db.repos.get(id: repo.id)?.claudeSettingsOverlay == fragment)
+
+        let clear = try RPCRequest(
+            method: RPCMethod.repoSetClaudeSettingsOverlay,
+            params: SetRepoClaudeSettingsOverlayParams(repoID: repo.id, overlay: nil)
+        )
+        #expect(await router.handle(clear).success)
+        #expect(try await db.repos.get(id: repo.id)?.claudeSettingsOverlay == nil)
+    }
+
     @Test("modelProfile.setEnvOverrides persists per-profile overrides")
     func modelProfileSetEnvOverrides() async throws {
         let profile = try await db.modelProfiles.create(name: "P", kind: .oauth)

--- a/Tests/TBDDaemonTests/RepoClaudeSettingsOverlayTests.swift
+++ b/Tests/TBDDaemonTests/RepoClaudeSettingsOverlayTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("repo claude_settings_overlay")
+struct RepoClaudeSettingsOverlayTests {
+    @Test func defaultsNil() async throws {
+        // Rows created without the field (and pre-v53 rows, which the
+        // migration leaves NULL) decode as nil.
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/cso", displayName: "cso", defaultBranch: "main")
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.claudeSettingsOverlay == nil)
+    }
+
+    @Test func overlayRoundTrip() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/cso2", displayName: "cso2", defaultBranch: "main")
+        let fragment = #"{"skillOverrides":{"heavy-skill":"off"}}"#
+        try await db.repos.setClaudeSettingsOverlay(id: repo.id, overlay: fragment)
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.claudeSettingsOverlay == fragment)
+    }
+
+    @Test func nilClearsToNull() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/cso3", displayName: "cso3", defaultBranch: "main")
+        try await db.repos.setClaudeSettingsOverlay(id: repo.id, overlay: "{}")
+        try await db.repos.setClaudeSettingsOverlay(id: repo.id, overlay: nil)
+        let fetched = try await db.repos.get(id: repo.id)
+        #expect(fetched?.claudeSettingsOverlay == nil)
+    }
+}

--- a/docs/claude-settings-overlay.md
+++ b/docs/claude-settings-overlay.md
@@ -1,0 +1,40 @@
+# Claude settings overlay
+
+TBD spawns Claude Code with a `--settings` overlay file that carries its own
+hooks. Two opt-in fragments — JSON object strings — can be deep-merged into
+that overlay. TBD is a pure passthrough: it never interprets or validates the
+fragment contents beyond "is it a JSON object".
+
+## Scopes and precedence
+
+Merged in order (later wins key collisions; object-valued keys recurse):
+
+1. **TBD hooks base** — the generated overlay body (hooks, optional
+   `fallbackModel`).
+2. **Repo fragment** — per-repo config, edited in the repo's settings pane
+   ("Claude settings overlay") and stored on the repo row
+   (`claude_settings_overlay`, plain text). Empty/whitespace clears it.
+3. **Per-spawn fragment** — the `--claude-settings` flag on
+   `tbd worktree create` / `tbd terminal create` (PR #451).
+
+## When each applies
+
+- The **repo fragment** is read fresh from the repo row at every Claude
+  spawn, so it applies on ALL spawn paths: fresh create, resume,
+  hibernation wake, recreate-window*, and profile swap.
+  (*recreate-window respawns as shell/codex, never Claude, so no overlay
+  is involved there.)
+- The **per-spawn fragment** applies at fresh spawn only; resumes and wakes
+  do not reapply it.
+
+## Malformed fragments
+
+Each fragment parses independently. A malformed one is logged
+(`com.tbd.daemon` / `claude-overlay`) and dropped — the spawn proceeds with
+the remaining valid fragment(s), degrading at worst to hooks-only. A bad
+fragment never aborts a spawn.
+
+## Caveat
+
+The repo fragment is stored as plain text in `~/tbd/state.db` and written
+verbatim into the per-session overlay file — do not put secrets in it.

--- a/docs/claude-settings-overlay.md
+++ b/docs/claude-settings-overlay.md
@@ -19,11 +19,14 @@ Merged in order (later wins key collisions; object-valued keys recurse):
 
 ## When each applies
 
-- The **repo fragment** is read fresh from the repo row at every Claude
-  spawn, so it applies on ALL spawn paths: fresh create, resume,
-  hibernation wake, recreate-window*, and profile swap.
-  (*recreate-window respawns as shell/codex, never Claude, so no overlay
-  is involved there.)
+- The **repo fragment** is resolved from the repo row at spawn time, so it
+  applies on ALL spawn paths: fresh create, resume, hibernation wake,
+  recreate-window*, and profile swap. Hibernation wake and the RPC spawn
+  handlers read the row fresh; preSession-hook-gated creates and
+  archived-worktree revives use the row as of create/revive entry (the
+  snapshot threads through the detached spawn phase, which can run minutes
+  later). (*recreate-window respawns as shell/codex, never Claude, so no
+  overlay is involved there.)
 - The **per-spawn fragment** applies at fresh spawn only; resumes and wakes
   do not reapply it.
 


### PR DESCRIPTION
## Summary
- Follows up #451: the `--claude-settings` spawn fragment can now be configured once per repo as first-class config, instead of riding on every spawn command. New nullable `claude_settings_overlay` column on `repo` (migration `v53`), edited in the per-repo settings pane next to Environment overrides, mirroring the env-overrides pattern (RPC, store, UI).
- The repo fragment deep-merges into TBD's per-session `--settings` overlay on **all** Claude spawn paths — fresh create, preSession phase-3, archived-worktree revive, hibernation wake, and profile swap — which retires #451's known ceiling (per-spawn fragment applied at fresh spawn only). Any per-spawn `--claude-settings` fragment still merges on top and wins collisions.
- Malformed fragments parse independently, log, and degrade to hooks-only — a bad repo fragment can't abort a spawn or discard a valid per-spawn fragment (and vice versa). TBD stays policy-free: pure passthrough, no interpretation of contents.

No feature flag: inert unless the repo field is set (opt-in via user gesture, not autonomous, not destructive) — same justification as #451. Values are stored plain-text in `state.db`, same as env overrides; documented in `docs/claude-settings-overlay.md`.

## Test plan
- [ ] `swift test` — 3532/3532 pass. New coverage: repo-fragment-alone, repo + per-spawn merge precedence (per-spawn wins, keys unioned), each malformed-fragment combination, nil-fragment gate branches, DB roundtrip (save / NULL→nil / clear), RPC handler set+clear roundtrip.
- [ ] Manual: set a fragment (e.g. `{"skillOverrides":{"acme-review":"off"}}`) in the repo settings pane, spawn a Claude session in that repo, confirm the per-session overlay file contains the merged fragment; clear the field, respawn, confirm it's gone.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=0A1871A3-DC05-406D-B131-AC8807C3E555)