### PR TITLE
feat(usage): surface the weekly reset and per-model (Fable) rows in the compact meter

### DIFF
--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 import TBDShared
 
-/// A compact two-row usage meter for a Claude OAuth profile: the 5-hour session
-/// window and the weekly all-models window, each drawn as a thin bar with a
-/// pace-aware colored fill (green/yellow/orange/red — projection of end-of-window
-/// usage from the current burn rate, floored by the API severity so a
-/// warning/critical bucket never reads healthy), a neutral "time marker" tick
-/// showing how far through the window we are, and a trailing percent.
+/// A compact usage meter for a Claude OAuth profile: the 5-hour session
+/// window, the weekly all-models window, and per-model-family weekly windows,
+/// each drawn as a thin bar with a pace-aware colored fill (green/yellow/
+/// orange/red — projection of end-of-window usage from the current burn rate,
+/// floored by the API severity so a warning/critical bucket never reads
+/// healthy), a neutral "time marker" tick showing how far through the window
+/// we are, and a trailing percent (and inline reset countdown on the weekly
+/// all-models row).
+///
 ///
 /// Pure presentation over a `ProfileUsageSnapshot` (no picker/tab state), so it
 /// is reusable anywhere a snapshot is in hand. `now`/`timeZone` are injectable
@@ -34,6 +37,7 @@ struct UsageBarsView: View {
                             windowLabel: "5-hour window",
                             windowDuration: ProfileUsagePresentation.sessionWindow,
                             usesRelativeReset: false,
+                            showsInlineReset: false,
                             now: now,
                             timeZone: timeZone)
             }
@@ -43,6 +47,17 @@ struct UsageBarsView: View {
                             windowLabel: "Weekly window",
                             windowDuration: ProfileUsagePresentation.weeklyWindow,
                             usesRelativeReset: true,
+                            showsInlineReset: true,
+                            now: now,
+                            timeZone: timeZone)
+            }
+            ForEach(Array(ProfileUsagePresentation.scopedBuckets(snapshot).enumerated()), id: \.offset) { _, scoped in
+                UsageBarRow(bucket: scoped,
+                            label: ProfileUsagePresentation.familyAbbreviation(scoped.modelDisplayName) + ":",
+                            windowLabel: ProfileUsagePresentation.familyName(scoped.modelDisplayName) + " weekly",
+                            windowDuration: ProfileUsagePresentation.weeklyWindow,
+                            usesRelativeReset: true,
+                            showsInlineReset: false,
                             now: now,
                             timeZone: timeZone)
             }
@@ -53,19 +68,23 @@ struct UsageBarsView: View {
 // MARK: - One bar row
 
 /// A single window's row: a fixed-width label, the flexible bar (fill + time
-/// marker), and a fixed-width trailing percent — the three fixed columns keep
-/// bars vertically aligned across rows.
+/// marker), a fixed-width trailing percent, and a fixed-width trailing hint
+/// column. The four fixed columns keep bars vertically aligned across rows.
 private struct UsageBarRow: View {
     let bucket: ClaudeUsageLimitBucket
-    /// Leading label ("5h:" / "wk:").
+    /// Leading label ("5h:" / "wk:" / "F:").
     let label: String
-    /// Spelled-out window name for the `.help` tooltip ("5-hour window").
+    /// Spelled-out window name for the `.help` tooltip ("5-hour window" / "Fable weekly").
     let windowLabel: String
     /// Window length feeding the time marker's elapsed fraction.
     let windowDuration: TimeInterval
     /// The 5h window shows an absolute reset clock; the weekly window shows a
     /// relative countdown ("resets in 2d 5h").
     let usesRelativeReset: Bool
+    /// Whether to show the inline trailing countdown ("· 2d 5h"). When true,
+    /// requires usesRelativeReset to be true to render the countdown. The trailing
+    /// column is still reserved on all rows for bar alignment.
+    let showsInlineReset: Bool
     let now: Date
     let timeZone: TimeZone
 
@@ -90,11 +109,12 @@ private struct UsageBarRow: View {
 
     // MARK: Trailing reset countdown
 
-    /// Fourth column: weekly reset countdown (inline hint) on the wk row only,
-    /// empty but space-reserving on the 5h row to keep bars aligned.
+    /// Fourth column: weekly reset countdown (inline hint) on rows where
+    /// showsInlineReset is true, empty but space-reserving on other rows
+    /// to keep bars aligned.
     private var trailingResetHint: some View {
         let countdownText: String = {
-            guard usesRelativeReset, let resetsAt = bucket.resetsAt,
+            guard showsInlineReset, usesRelativeReset, let resetsAt = bucket.resetsAt,
                   let compact = ProfileUsagePresentation.relativeResetText(resetsAt, now: now) else {
                 return ""
             }
@@ -213,6 +233,12 @@ private struct UsageBarRow: View {
         ClaudeUsageLimitBucket(kind: kind, percent: percent, severity: severity,
                                resetsAt: resetsIn.map { now.addingTimeInterval($0) })
     }
+    func scopedBucket(_ name: String, _ percent: Double, severity: String? = nil,
+                      resetsIn: TimeInterval? = nil) -> ClaudeUsageLimitBucket {
+        ClaudeUsageLimitBucket(kind: "weekly_scoped", percent: percent, severity: severity,
+                               resetsAt: resetsIn.map { now.addingTimeInterval($0) },
+                               modelDisplayName: name)
+    }
     func snap(_ buckets: [ClaudeUsageLimitBucket]) -> ProfileUsageSnapshot {
         ProfileUsageSnapshot(buckets: buckets, fetchedAt: now,
                              lastAttemptAt: now, status: "ok", statusKind: .ok)
@@ -232,6 +258,7 @@ private struct UsageBarRow: View {
         UsageBarsView(snapshot: snap([
             bucket("session", 55, severity: "normal", resetsIn: 1.75 * 3600),
             bucket("weekly_all", 55, severity: "normal", resetsIn: 2.95 * 24 * 3600),
+            scopedBucket("Fable", 15, severity: "normal", resetsIn: 2.95 * 24 * 3600),
         ]), now: now)
 
         // Near limit.

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -10,7 +10,6 @@ import TBDShared
 /// we are, and a trailing percent (and inline reset countdown on the weekly
 /// all-models row).
 ///
-///
 /// Pure presentation over a `ProfileUsageSnapshot` (no picker/tab state), so it
 /// is reusable anywhere a snapshot is in hand. `now`/`timeZone` are injectable
 /// for previews and deterministic layout. A row is skipped entirely when its

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -83,8 +83,29 @@ private struct UsageBarRow: View {
                 .monospacedDigit()
                 .foregroundStyle(fillColor)
                 .frame(width: 30, alignment: .trailing)
+            trailingResetHint
         }
         .help(helpText)
+    }
+
+    // MARK: Trailing reset countdown
+
+    /// Fourth column: weekly reset countdown (inline hint) on the wk row only,
+    /// empty but space-reserving on the 5h row to keep bars aligned.
+    private var trailingResetHint: some View {
+        let countdownText: String = {
+            guard usesRelativeReset, let resetsAt = bucket.resetsAt,
+                  let compact = ProfileUsagePresentation.relativeResetText(resetsAt, now: now) else {
+                return ""
+            }
+            return "· \(compact)"
+        }()
+
+        return Text(countdownText)
+            .font(.system(size: 9, design: .rounded))
+            .monospacedDigit()
+            .foregroundStyle(.tertiary)
+            .frame(width: 46, alignment: .leading)
     }
 
     // MARK: Bar geometry
@@ -225,7 +246,7 @@ private struct UsageBarRow: View {
             bucket("weekly_all", 30, severity: "normal"),
         ]), now: now)
     }
-    .frame(width: 220)
+    .frame(width: 260)
     .padding()
 }
 #endif


### PR DESCRIPTION
## Why

Two gaps in the compact usage meter (the popover on "New worktree with…"):

1. **You couldn't see when the week ends.** `resetsAt` was always in the snapshot and the countdown string was always computable, but it only surfaced through the macOS `.help()` hover tooltip — slow to appear, pixel-precise to trigger, with no hint it existed. The roomier `AccountPickerSheet` shows `resets 23:10` inline for the 5h row but explicitly passes `showsReset: false` for the week row, so the weekly reset was the one number never visible at rest anywhere.
2. **No Fable row.** `UsageBarsView` never iterated `scopedBuckets(snapshot)`, even though `AccountPickerSheet` already rendered them — hence Fable being findable in settings but not here.

## What

```
5h: ███░░░░░░░  38%
wk: █░░░░░░░░░   8%  · 2d 5h
F:  ██░░░░░░░░  15%
```

- A tertiary 9pt `· 2d 5h` countdown on the `wk:` row, reusing the existing compact `relativeResetText` formatter.
- A `ForEach` over `scopedBuckets`, labeled via `familyAbbreviation` (`F:`) in the existing 22pt label column, with `"Fable weekly"` spelled out in the tooltip.

## Design notes

- The meter's discipline is fixed-width columns so bars stay aligned across rows and accounts. The new trailing column is **reserved on every row** (46pt) and left blank where unused, so the `wk` bar doesn't end up narrower than the `5h` bar.
- Weekly buckets share one reset instant, so the countdown appears once — on `wk:`, not repeated on `F:`. That required decoupling "show the inline countdown" from "phrase the tooltip relatively": a naive reuse of `usesRelativeReset` would either duplicate the countdown on `F:` or show a misleading absolute clock for a reset days away. Hence the new `showsInlineReset`.
- The `.help()` tooltip is unchanged; the redundancy with the inline hint is intentional.

## Testing

- `swift build` passes.
- All 71 `ProfileUsagePresentation` tests pass. No new tests: the changes reuse already-tested formatters and the added gate is display-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)