### PR TITLE
Fix: Branch filter in the new-worktree popout couldn't be typed into

### DIFF
--- a/Sources/TBDApp/Sidebar/FloatingMenuAnchor.swift
+++ b/Sources/TBDApp/Sidebar/FloatingMenuAnchor.swift
@@ -22,7 +22,7 @@ struct FloatingMenuAnchor<Content: View>: NSViewRepresentable {
             if let panel = coordinator.panel {
                 panel.updateContent(content)          // refresh (e.g. default-row highlight); no reposition
             } else {
-                let panel = FloatingPanel(content: content)
+                let panel = FloatingPanel(content: content, canBecomeKey: true)
                 coordinator.panel = panel
                 panel.showAsMenu(relativeTo: nsView)
             }

--- a/Sources/TBDApp/Sidebar/FloatingPanel.swift
+++ b/Sources/TBDApp/Sidebar/FloatingPanel.swift
@@ -1,12 +1,16 @@
 import AppKit
 import SwiftUI
 
-/// A borderless, non-activating floating panel for instant show/hide
-/// without stealing focus from the parent text field.
+/// A borderless, non-activating floating panel for instant show/hide.
+/// Non-key by default so hover overlays (e.g. the emoji picker) never steal
+/// focus from the parent rename field; pass `canBecomeKey: true` when the
+/// panel hosts its own text input (e.g. the branch filter field).
 class FloatingPanel: NSPanel {
     private var hostingView: NSHostingView<AnyView>?
+    private let keyCapable: Bool
 
-    init<Content: View>(content: Content) {
+    init<Content: View>(content: Content, canBecomeKey: Bool = false) {
+        keyCapable = canBecomeKey
         super.init(
             contentRect: .zero,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -87,6 +91,6 @@ class FloatingPanel: NSPanel {
         orderOut(nil)
     }
 
-    override var canBecomeKey: Bool { false }
+    override var canBecomeKey: Bool { keyCapable }
     override var canBecomeMain: Bool { false }
 }

--- a/Tests/TBDAppTests/FloatingPanelKeyTests.swift
+++ b/Tests/TBDAppTests/FloatingPanelKeyTests.swift
@@ -1,0 +1,20 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import TBDApp
+
+@Suite("FloatingPanel key capability")
+@MainActor
+struct FloatingPanelKeyTests {
+    @Test func nonKeyByDefault() {
+        #expect(FloatingPanel(content: Text("x")).canBecomeKey == false)
+    }
+
+    @Test func keyCapableWhenRequested() {
+        #expect(FloatingPanel(content: Text("x"), canBecomeKey: true).canBecomeKey == true)
+    }
+
+    @Test func jumpMenuPanelStillKeyCapable() {
+        #expect(JumpMenuPanel(content: Text("x")).canBecomeKey == true)
+    }
+}


### PR DESCRIPTION
## Summary
- **What's broken:** the "Filter branches" field in the new-worktree popout (hover/⌥-click the sidebar `+` → "Choose a branch…") shows a focus ring but eats no keystrokes.
- **Why:** the popout is hosted in `FloatingPanel`, which hard-codes `canBecomeKey = false` (deliberate for hover overlays like the emoji picker, which must not steal focus from the parent rename field). A window that can never become key never receives keyboard events.
- **Fix:** make key-capability a per-instance opt-in — `FloatingPanel(content:canBecomeKey:)` defaults to `false`, and `FloatingMenuAnchor` (the popout's presenter) passes `true`. Same pattern `JumpMenuPanel` already uses for its search field. Emoji picker and jump menu untouched.

Considered and rejected: scoping key-capability to just the branches page. The panel only takes key on an actual click inside it (appearing on hover doesn't), so the profiles page becoming key-capable only matters if the user deliberately clicks it mid-rename — normal focus-loss behavior, not worth threading SwiftUI page state into NSPanel.

## Test plan
- [x] `swift test --filter FloatingPanelKeyTests` — 3 tests (default false, opt-in true, JumpMenuPanel still true)
- [ ] Live: hover a repo's `+` → "Choose a branch…" → type in the filter field; branches filter as you type
- [ ] Live: rename a worktree while the emoji picker panel is open — typing stays in the rename field

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=D16312D7-7528-41E9-AAF9-441E9D0C8A82)