### PR TITLE
Fix: Stop oh-my-zsh update prompts from blocking claude/codex session spawns

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -18,7 +18,10 @@ import TBDShared
 /// - Otherwise → `cmd` if set, else `shellFallback`.
 ///
 /// If we built a claude command (resume or fresh), `sensitiveEnv` carries the
-/// auth + routing env vars for the spawned session:
+/// auth + routing env vars for the spawned session (plus
+/// `DISABLE_AUTO_UPDATE=true`, an rc-affecting toggle that must reach the
+/// process env before .zshrc runs so oh-my-zsh's update prompt can't block
+/// the agent spawn):
 /// - oauth: `CLAUDE_CONFIG_DIR=<profileDir>` (no auth token; user `/login`s into this dir)
 /// - api key (direct or proxy): `ANTHROPIC_API_KEY=<secret>` + `CLAUDE_CONFIG_DIR=<profileDir>`
 ///   (+ `ANTHROPIC_BASE_URL`, `ANTHROPIC_MODEL` for proxy)
@@ -35,8 +38,10 @@ import TBDShared
 enum ClaudeSpawnCommandBuilder {
     struct Result: Equatable {
         let command: String
-        /// Env vars containing secrets OR routing config. Keep using tmux's
-        /// `-e KEY=VALUE` flag for all of these to avoid leaking via `ps`.
+        /// Env vars containing secrets, routing config, or rc-affecting
+        /// toggles (DISABLE_AUTO_UPDATE). Keep using tmux's `-e KEY=VALUE`
+        /// flag for all of these: secrets must not leak via `ps`, and rc
+        /// toggles must be set before .zshrc runs.
         let sensitiveEnv: [String: String]
     }
 
@@ -137,6 +142,15 @@ enum ClaudeSpawnCommandBuilder {
             }
             routingKeys.formUnion(["ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL", "CLAUDE_CONFIG_DIR"])
         }
+        // Suppress oh-my-zsh's interactive "Would you like to update?" prompt.
+        // It fires from .zshrc and would block the claude command until the
+        // user answers — but an agent tab runs a command, not an interactive
+        // shell for a human, so nothing should gate it. Plain shell tabs
+        // (`cmd` / `shellFallback`, early-returned above) keep update checks.
+        // Deliberately NOT a routing key: it must be in the process env
+        // BEFORE .zshrc runs, which only tmux's `-e` flag achieves — an
+        // inline export executes after rc files and would be useless.
+        env["DISABLE_AUTO_UPDATE"] = "true"
         // Registry-driven Claude spawn-env settings. This block only runs in
         // the Claude branches — the `cmd` / `shellFallback` branches return
         // earlier, before `env` exists — so non-Claude spawns are unaffected.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -505,7 +505,12 @@ extension WorktreeLifecycle {
                 "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
                 "CODEX_HOME": codexHome.path,
             ]
+            // omz-update suppression rides `-e` (process env before .zshrc)
+            // so the update prompt can't block the codex command; FORCED over
+            // user overrides (matching the claude path) — agent tabs must
+            // never block on the interactive prompt.
             primarySensitiveEnv = mergedEnvOverrides
+                .merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
             primarySessionID = nil
             primaryProfileID = nil
             primaryLabel = TerminalLabel.codex

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -67,10 +67,13 @@ extension WorktreeLifecycle {
     /// `zstyle ':omz:update' mode disabled`), so this skips its interactive
     /// "Would you like to update?" prompt that would otherwise block the hook
     /// command until the user answers or the preSession wait times out.
-    /// Deliberately per-window (never `setenv -g`): regular shell/claude/codex
-    /// tabs must keep omz update checks. Callers apply it only when the hook
-    /// actually resolves — a hook-less "Setup" tab is a plain shell and keeps
-    /// update checks.
+    /// Deliberately per-window (never `setenv -g`): plain shell tabs must
+    /// keep omz update checks — a human is present there. Agent (claude/codex)
+    /// tabs also suppress the prompt, but at their own spawn sites
+    /// (`ClaudeSpawnCommandBuilder` and the codex spawn env), since a spawned
+    /// agent command must never block on an interactive prompt. Callers apply
+    /// this env only when the hook actually resolves — a hook-less "Setup"
+    /// tab is a plain shell and keeps update checks.
     static let hookPaneEnv: [String: String] = ["DISABLE_AUTO_UPDATE": "true"]
 
     /// Wraps the hook so its exit code lands in the marker file and the pane

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -167,13 +167,18 @@ extension RPCRouter {
                 codexEnv["COLORFGBG"] = colorFgBg
             }
 
-            // Codex: the merged free-form overrides ARE the entire sensitive env.
-            // No profile is resolved for Codex, so the profile scope is nil.
+            // Codex: the merged free-form overrides plus omz-update suppression
+            // form the sensitive env. DISABLE_AUTO_UPDATE must go through `-e`
+            // (process env before .zshrc) — the `env:` dict is inlined AFTER rc
+            // files run, so oh-my-zsh's update prompt would still block the
+            // agent. FORCED over user overrides (matching the claude path): an
+            // agent tab runs a command and must never block on the interactive
+            // update prompt. No profile is resolved for Codex, so that scope is nil.
             let codexEnvOverrides = EnvOverrideResolver.merge(
                 global: createConfig?.envOverrides,
                 repo: repo?.envOverrides,
                 profile: nil
-            )
+            ).merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
             let window = try await tmux.createWindow(
                 server: worktree.tmuxServer,
                 session: "main",
@@ -562,8 +567,10 @@ extension RPCRouter {
             codexEnv["CODEX_HOME"] = codexHome.path
 
             // Codex: re-apply the merged free-form overrides (global < repo) so a
-            // recreated Codex pane keeps them. No profile is resolved here, so the
-            // profile scope is nil.
+            // recreated Codex pane keeps them, plus omz-update suppression via
+            // `-e` (must be in the process env before .zshrc; FORCED over user
+            // overrides — agent tabs must never block on the interactive update
+            // prompt). No profile is resolved here, so that scope is nil.
             let recreateConfig = try? await db.config.get()
             let recreateRepo: Repo?
             if let rid = worktree.repoID {
@@ -575,7 +582,7 @@ extension RPCRouter {
                 global: recreateConfig?.envOverrides,
                 repo: recreateRepo?.envOverrides,
                 profile: nil
-            )
+            ).merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
             let window = try await tmux.createWindow(
                 server: worktree.tmuxServer,
                 session: "main",

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -22,8 +22,10 @@ struct ClaudeSpawnCommandBuilderTests {
             shellFallback: "/bin/zsh"
         )
         #expect(r.command == "claude --resume abc-123 --dangerously-skip-permissions")
-        // Registry injects CLAUDE_CODE_NO_FLICKER=1 by default for all Claude spawns.
-        #expect(r.sensitiveEnv == ["CLAUDE_CODE_NO_FLICKER": "1"])
+        // Registry injects CLAUDE_CODE_NO_FLICKER=1 by default for all Claude
+        // spawns; DISABLE_AUTO_UPDATE=true suppresses the omz update prompt
+        // that would otherwise block the agent command.
+        #expect(r.sensitiveEnv == ["CLAUDE_CODE_NO_FLICKER": "1", "DISABLE_AUTO_UPDATE": "true"])
     }
 
     @Test("fresh session id only")
@@ -38,8 +40,10 @@ struct ClaudeSpawnCommandBuilderTests {
             shellFallback: "/bin/zsh"
         )
         #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions")
-        // Registry injects CLAUDE_CODE_NO_FLICKER=1 by default for all Claude spawns.
-        #expect(r.sensitiveEnv == ["CLAUDE_CODE_NO_FLICKER": "1"])
+        // Registry injects CLAUDE_CODE_NO_FLICKER=1 by default for all Claude
+        // spawns; DISABLE_AUTO_UPDATE=true suppresses the omz update prompt
+        // that would otherwise block the agent command.
+        #expect(r.sensitiveEnv == ["CLAUDE_CODE_NO_FLICKER": "1", "DISABLE_AUTO_UPDATE": "true"])
     }
 
     @Test("fresh + appendSystemPrompt")
@@ -117,6 +121,31 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv.isEmpty)
     }
 
+    // MARK: - omz update-prompt suppression (agent tabs only)
+
+    @Test("claude branches suppress the omz update prompt; shell branches keep it")
+    func omzUpdateSuppressionScopedToAgentBranches() {
+        func build(resumeID: String?, freshSessionID: String?, cmd: String?) -> ClaudeSpawnCommandBuilder.Result {
+            ClaudeSpawnCommandBuilder.build(
+                resumeID: resumeID, freshSessionID: freshSessionID,
+                appendSystemPrompt: nil, initialPrompt: nil, profileSecret: nil,
+                cmd: cmd, shellFallback: "/bin/zsh"
+            )
+        }
+        // Agent (claude) branches: the spawned command must never block on
+        // oh-my-zsh's interactive update prompt, so it rides sensitiveEnv
+        // (tmux -e → process env before .zshrc). Never inlined in the command:
+        // an inline export runs after rc files and would be useless.
+        for r in [build(resumeID: "abc", freshSessionID: nil, cmd: nil),
+                  build(resumeID: nil, freshSessionID: "sid", cmd: nil)] {
+            #expect(r.sensitiveEnv["DISABLE_AUTO_UPDATE"] == "true")
+            #expect(!r.command.contains("DISABLE_AUTO_UPDATE"))
+        }
+        // Plain shell branches: a human is present, keep omz update checks.
+        #expect(build(resumeID: nil, freshSessionID: nil, cmd: "ls -la").sensitiveEnv["DISABLE_AUTO_UPDATE"] == nil)
+        #expect(build(resumeID: nil, freshSessionID: nil, cmd: nil).sensitiveEnv["DISABLE_AUTO_UPDATE"] == nil)
+    }
+
     // MARK: - Token branches: secret returned via sensitiveEnv, NOT in command
 
     @Test("resume + oauth secret: token NOT injected (oauth profiles get config dir instead)")
@@ -169,7 +198,11 @@ struct ClaudeSpawnCommandBuilderTests {
         )
         #expect(!r.command.contains(fakeOauth))
         // Registry injects CLAUDE_CODE_NO_FLICKER=1 by default for all Claude spawns.
-        #expect(r.sensitiveEnv == ["ANTHROPIC_API_KEY": fakeOauth, "CLAUDE_CODE_NO_FLICKER": "1"])
+        #expect(r.sensitiveEnv == [
+            "ANTHROPIC_API_KEY": fakeOauth,
+            "CLAUDE_CODE_NO_FLICKER": "1",
+            "DISABLE_AUTO_UPDATE": "true",
+        ])
     }
 
     @Test("cmd path ignores token (non-claude shell)")
@@ -598,7 +631,7 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv["CLAUDE_CONFIG_DIR"] == nil)
         #expect(r.sensitiveEnv["ANTHROPIC_CONFIG_DIR"] == nil)
         // Exactly these 5 keys (registry adds CLAUDE_CODE_NO_FLICKER=1 for all Claude spawns)
-        #expect(r.sensitiveEnv.keys.sorted() == ["ANTHROPIC_MODEL", "AWS_PROFILE", "AWS_REGION", "CLAUDE_CODE_NO_FLICKER", "CLAUDE_CODE_USE_BEDROCK"])
+        #expect(r.sensitiveEnv.keys.sorted() == ["ANTHROPIC_MODEL", "AWS_PROFILE", "AWS_REGION", "CLAUDE_CODE_NO_FLICKER", "CLAUDE_CODE_USE_BEDROCK", "DISABLE_AUTO_UPDATE"])
     }
 
     @Test("bedrock: AWS_PROFILE omitted when nil")

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -227,7 +227,10 @@ struct ModelProfileSpawnTests {
         defer { Task { await cleanup(db) } }
         let (repo, wt) = try await seedRepoAndWorktree(db)
         try await db.config.setPrimaryAgentPreference(.codex)
-        try await db.config.setEnvOverrides(["FOO": "bar"])
+        // DISABLE_AUTO_UPDATE=false is deliberately included: the omz-update
+        // suppression is FORCED on agent tabs (a user "false" would silently
+        // reintroduce the spawn-blockage bug), so it must be overridden to true.
+        try await db.config.setEnvOverrides(["FOO": "bar", "DISABLE_AUTO_UPDATE": "false"])
         try await db.repos.setEnvOverrides(id: repo.id, overrides: ["REPO_VAR": "rv"])
         // Re-fetch so the repo passed to spawnPrimaryTerminals carries its
         // freshly-persisted envOverrides (the spawn reads repo.envOverrides
@@ -241,11 +244,16 @@ struct ModelProfileSpawnTests {
         // Both scopes reach the Codex pane as sensitive -e env.
         #expect(recorder.joinedAll.contains("FOO=bar"))
         #expect(recorder.joinedAll.contains("REPO_VAR=rv"))
+        // The forced omz suppression wins over the user's explicit "false";
+        // other override keys merged untouched above.
+        #expect(recorder.joinedAll.contains("DISABLE_AUTO_UPDATE=true"))
+        #expect(!recorder.joinedAll.contains("DISABLE_AUTO_UPDATE=false"))
     }
 
-    /// With no env overrides configured, the Codex primary spawn injects no
-    /// sensitive `-e` env at all (the empty-config off branch).
-    @Test("spawn: empty config → Codex primary gets no -e env overrides")
+    /// With no env overrides configured, the Codex primary spawn's only
+    /// sensitive `-e` env is the omz update-prompt suppression (the
+    /// empty-config off branch injects no user overrides).
+    @Test("spawn: empty config → Codex primary gets only omz suppression as -e env")
     func codexEmptyConfigInjectsNothing() async throws {
         let codexHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-home-\(UUID().uuidString)")
@@ -265,11 +273,17 @@ struct ModelProfileSpawnTests {
             worktree: wt, repo: repo, skipClaude: false, preSessionTerminalID: nil
         )
 
-        // The Codex `new-window` call exists and carries no `-e` env flag.
+        // The Codex `new-window` call exists; its only `-e` env is the
+        // omz update-prompt suppression — an agent tab runs a command and
+        // must never block on the interactive "Would you like to update?"
+        // prompt. No user overrides leak in.
         let codexCall = try #require(recorder.calls.first {
             $0.contains("new-window") && ($0.last?.contains("codex") ?? false)
         })
-        #expect(!codexCall.contains("-e"))
+        let eIndices = codexCall.indices.filter { codexCall[$0] == "-e" }
+        #expect(eIndices.count == 1)
+        #expect(codexCall.contains("DISABLE_AUTO_UPDATE=true"),
+                "codex window must suppress the oh-my-zsh update prompt via -e")
         #expect(!recorder.joinedAll.contains("FOO=bar"))
     }
 

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -151,11 +151,12 @@ struct PreSessionHookTests {
                 "first window must be the primary agent")
         #expect(windowCalls[1].last?.contains("claude --session-id") == false,
                 "second window must be the setup hook/shell")
-        // omz-update suppression is scoped to windows that actually run a
-        // hook: with no setup hook configured, the "Setup" tab is a plain
-        // shell and must keep update checks, same as the primary agent.
-        #expect(!windowCalls[0].contains("DISABLE_AUTO_UPDATE=true"),
-                "primary terminal must keep oh-my-zsh update checks")
+        // omz-update suppression covers agent tabs (a spawned agent command
+        // must never block on the interactive update prompt) and hook panes;
+        // with no setup hook configured, the "Setup" tab is a plain shell
+        // for a human and must keep update checks.
+        #expect(hasProcessEnvFlag(windowCalls[0], "DISABLE_AUTO_UPDATE=true"),
+                "primary agent window must suppress the oh-my-zsh update prompt via -e")
         #expect(!windowCalls[1].contains("DISABLE_AUTO_UPDATE=true"),
                 "hook-less setup tab is a regular shell and must keep omz update checks")
         // Setup window carries the full documented hook env even with no
@@ -191,11 +192,12 @@ struct PreSessionHookTests {
         // Windows: [claude, setup]. With a setup hook resolved, the setup
         // window must carry `-e DISABLE_AUTO_UPDATE=true` (process env, set
         // before .zshrc runs) so the omz updater prompt can't delay the hook;
-        // the primary agent window must not.
+        // the primary agent window carries it too — a spawned agent command
+        // must never block on the interactive update prompt.
         let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
         #expect(windowCalls.count == 2)
-        #expect(!windowCalls[0].contains("DISABLE_AUTO_UPDATE=true"),
-                "primary terminal must keep oh-my-zsh update checks")
+        #expect(hasProcessEnvFlag(windowCalls[0], "DISABLE_AUTO_UPDATE=true"),
+                "primary agent window must suppress the oh-my-zsh update prompt via -e")
         #expect(hasProcessEnvFlag(windowCalls[1], "DISABLE_AUTO_UPDATE=true"),
                 "setup hook window must suppress the oh-my-zsh update prompt via -e")
         #expect(windowCalls[1].last?.contains(".worktree-hooks/setup") == true,
@@ -314,11 +316,11 @@ struct PreSessionHookTests {
         // (TBD_EVENT=setup) — windows are [pre-session, claude, setup].
         let allWindowCalls = recorder.snapshot().filter { $0.contains("new-window") }
         #expect(allWindowCalls.count == 3)
-        // Only windows that actually run a hook suppress the omz updater:
-        // this fixture has no setup hook, so the "Setup" tab is a plain shell
-        // and keeps update checks, same as the primary agent.
-        #expect(!allWindowCalls[1].contains("DISABLE_AUTO_UPDATE=true"),
-                "primary terminal must keep oh-my-zsh update checks")
+        // Hook panes and agent tabs suppress the omz updater; this fixture
+        // has no setup hook, so the "Setup" tab is a plain shell for a human
+        // and keeps update checks.
+        #expect(hasProcessEnvFlag(allWindowCalls[1], "DISABLE_AUTO_UPDATE=true"),
+                "primary agent window must suppress the oh-my-zsh update prompt via -e")
         #expect(!allWindowCalls[2].contains("DISABLE_AUTO_UPDATE=true"),
                 "hook-less setup tab is a regular shell and must keep omz update checks")
         let setupBody = allWindowCalls[2].last ?? ""

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -564,6 +564,17 @@ func testHandleTerminalCreateCodexLaunchCommand() async throws {
     }, "created codex tab must launch codex with the TBD profile; got bodies: \(bodies)")
     #expect(!bodies.contains { $0.contains("codex --full-auto") },
             "created codex tab must not use removed --full-auto flag; got bodies: \(bodies)")
+    // The codex window must carry `-e DISABLE_AUTO_UPDATE=true` (process env,
+    // set before .zshrc runs) so oh-my-zsh's interactive update prompt can't
+    // block the spawned codex command.
+    // Adjacency-checked like PreSessionHookTests.hasProcessEnvFlag (that
+    // helper is file-private): a bare substring match could false-positive
+    // on the shell command body.
+    let codexCall = try #require(recorded.snapshot().first { $0.contains("new-window") })
+    let hasFlag = codexCall.firstIndex(of: "DISABLE_AUTO_UPDATE=true")
+        .map { $0 > codexCall.startIndex && codexCall[codexCall.index(before: $0)] == "-e" } ?? false
+    #expect(hasFlag,
+            "codex window must suppress the oh-my-zsh update prompt via -e; got: \(codexCall)")
 }
 
 @Test("handleTerminalCreate passes initial prompt to fresh Codex sessions")

--- a/docs/env-overrides.md
+++ b/docs/env-overrides.md
@@ -43,7 +43,9 @@ merged = global ∪ repo ∪ profile-freeform
 final  = merged ∪ builderAuthRouting        // auth/routing is final
 ```
 
-A free-form var can set anything the builder does **not** already set, but it cannot clobber a key the builder owns. This keeps a stray free-form override from silently breaking model connectivity. (Codex does not get structured Claude routing env — its auth stays via `CODEX_HOME` — so for Codex the merged free-form map is the entirety of the injected env.)
+A free-form var can set anything the builder does **not** already set, but it cannot clobber a key the builder owns. This keeps a stray free-form override from silently breaking model connectivity. (Codex does not get structured Claude routing env — its auth stays via `CODEX_HOME` — so for Codex the injected env is the merged free-form map plus one forced key, below.)
+
+One key is forced on **both** claude and codex agent tabs and cannot be overridden: `DISABLE_AUTO_UPDATE=true`. An agent tab runs a command, not an interactive shell for a human, so oh-my-zsh's interactive update prompt (fired from `.zshrc`) must never block the spawn — a free-form override of `false` would silently reintroduce that blockage. Plain shell tabs keep omz update checks.
 
 ## Values are free-form
 

--- a/docs/worktree-hooks.md
+++ b/docs/worktree-hooks.md
@@ -53,7 +53,7 @@ Hooks run with `cwd` set to the worktree path and receive these environment vari
 
 Hooks have a 60-second timeout (`preSession`: 600 seconds). A non-zero exit status is logged but does not block the lifecycle action.
 
-`preSession` and `setup` hook terminals additionally run with `DISABLE_AUTO_UPDATE=true` in their process environment, so oh-my-zsh's interactive "Would you like to update?" prompt can't block the hook. This applies only when the hook actually exists — a hook-less "Setup" tab is a plain shell — and regular shell/agent tabs are unaffected and keep omz update checks.
+`preSession` and `setup` hook terminals additionally run with `DISABLE_AUTO_UPDATE=true` in their process environment, so oh-my-zsh's interactive "Would you like to update?" prompt can't block the hook. This applies only when the hook actually exists — a hook-less "Setup" tab is a plain shell. Agent (claude/codex) tabs also run with `DISABLE_AUTO_UPDATE=true` (set at their own spawn sites), since a spawned agent command must never block on an interactive prompt; only plain shell tabs keep omz update checks.
 
 ## Example
 


### PR DESCRIPTION
## Summary

**What's broken:** spawning a claude (or codex) session in a worktree can hang on oh-my-zsh's interactive "Would you like to update?" prompt — the agent never starts until someone finds the tab and answers. Just bit a longeye-app worktree's claude spawn.

**Why it happens:** agent tabs run `zsh -ic "claude ..."`, so `.zshrc` (and omz's update check) executes *before* the agent command. PR #322 fixed this for preSession/setup **hook** panes only and deliberately kept update checks on claude/codex tabs — but nobody is present in an agent tab to answer the prompt, so that scoping left every agent spawn exposed.

**What this PR does:** forces `DISABLE_AUTO_UPDATE=true` into the spawned window's process environment via tmux's `-e` flag (same `sensitiveEnv` mechanism as #322, visible during rc execution) for:
- all claude spawn paths in one place — `ClaudeSpawnCommandBuilder` (create, revive, hibernation wake, RPC spawn, profile-switch respawn)
- all three codex spawn sites (tab create, dead-window recreate, primary spawn)

Forced non-overridable on both paths — a user `envOverrides` value of `false` would silently reintroduce the blockage. Plain shell tabs and the hook-less Setup tab keep omz update checks unchanged (a human is there to answer).

Not flag-gated: bug fix, no autonomous behavior or state mutation.

## Test plan
- [x] `ClaudeSpawnCommandBuilderTests`: resume/fresh branches carry `DISABLE_AUTO_UPDATE` in `sensitiveEnv` (never inlined in the command string); `cmd`/`shellFallback` branches don't
- [x] `ModelProfileSpawnTests`: a user envOverride `DISABLE_AUTO_UPDATE=false` is forced back to `true` on codex spawn; other override keys merge exactly as before
- [x] `PreSessionHookTests`: agent windows assert the `-e` flag present; hook-less Setup tab still asserts absence
- [x] 303 tests / 14 suites across all affected families pass; `swift build` clean
- [ ] Spawn a claude session in a repo with omz update-check enabled and confirm no prompt blocks startup

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=703E28A5-ECD4-4C4C-8BBF-75826DC533F8)