### PR TITLE
Feat: Create worktrees from any open PR — including fork PRs — right from the branch picker

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -20,7 +20,7 @@ extension AppState {
     /// `profileID` is an optional explicit model-profile override chosen at
     /// creation time (sidebar `+` profile picker). nil resolves the profile via
     /// the daemon's normal repo/scratch/global precedence chain (today's behavior).
-    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil, profileID: UUID? = nil) {
+    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil, profileID: UUID? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, displayName: String? = nil) {
         // Optimistic placeholder so the row appears instantly. When picking an
         // existing branch we use its local name so the placeholder name
         // doesn't briefly show a fake `tbd/*` value.
@@ -36,7 +36,7 @@ extension AppState {
         let placeholder = Worktree(
             repoID: repoID,
             name: placeholderName,
-            displayName: placeholderName,
+            displayName: displayName ?? placeholderName,
             branch: placeholderBranch,
             path: "",
             status: .creating,
@@ -64,10 +64,13 @@ extension AppState {
                 let wt = try await daemonClient.createWorktree(
                     repoID: repoID,
                     branch: existingBranch?.name,
+                    displayName: displayName,
                     cols: size.cols, rows: size.rows,
                     parentWorktreeID: parentWorktreeID,
                     useExistingBranch: existingBranch != nil,
-                    profileID: profileID
+                    profileID: profileID,
+                    prNumber: prNumber,
+                    checkoutPRHead: checkoutPRHead
                 )
                 // Replace the placeholder with the real worktree, carrying
                 // over any rename the user typed while creation was in

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -264,6 +264,18 @@ extension AppState {
         }
     }
 
+    /// List open PRs for a repo, for the branch picker's second load phase.
+    /// Rethrows so callers can distinguish a fetch failure (keep showing
+    /// branches, no PR pills) from a genuinely empty list.
+    func listOpenPRs(repoID: UUID) async throws -> [OpenPRInfo] {
+        do {
+            return try await daemonClient.listOpenPRs(repoID: repoID)
+        } catch {
+            logger.error("Failed to list open PRs: \(error)")
+            throw error
+        }
+    }
+
     /// Archive a worktree. Scratch-aware by construction: repo-less scratch
     /// spaces are delegated to `archiveScratch(id:)` — the repo-worktree
     /// `worktree.archive` RPC rejects them with `repoNotFound` — so callers

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -455,10 +455,10 @@ actor DaemonClient {
     /// When `useExistingBranch` is true, `branch` MUST be set to an existing
     /// ref name (local like `foo` or remote like `origin/foo`) — the daemon
     /// checks it out instead of creating a new `tbd/*` branch.
-    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false, profileID: UUID? = nil) async throws -> Worktree {
+    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false, profileID: UUID? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil) async throws -> Worktree {
         return try await callAsync(
             method: RPCMethod.worktreeCreate,
-            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch, profileID: profileID),
+            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch, profileID: profileID, prNumber: prNumber, checkoutPRHead: checkoutPRHead),
             resultType: Worktree.self
         )
     }

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -507,6 +507,17 @@ actor DaemonClient {
         return result.branches
     }
 
+    /// List open PRs for a repo (branch picker, two-phase load). Degrades to
+    /// `[]` daemon-side on any `gh`/GraphQL failure — never an RPC error.
+    func listOpenPRs(repoID: UUID) async throws -> [OpenPRInfo] {
+        let result = try await callAsync(
+            method: RPCMethod.repoListOpenPRs,
+            params: RepoListOpenPRsParams(repoID: repoID),
+            resultType: RepoListOpenPRsResult.self
+        )
+        return result.prs
+    }
+
     /// List worktrees, optionally filtered by repo and/or status, with optional pagination.
     /// Pass `excludeArchived: true` to skip archived rows (used by the 2 s poll so
     /// the 87 % of payload that is immediately dropped client-side never crosses the wire).

--- a/Sources/TBDApp/Sidebar/BranchPickerMerge.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerMerge.swift
@@ -24,11 +24,18 @@ func mergePickerItems(branches: [BranchInfo], prs: [OpenPRInfo]) -> [PickerItem]
     // A PR decorates a branch only when it is same-repo AND some branch carries
     // its head name. Fork PRs never decorate (a fork head like "main" can collide
     // with an unrelated local branch — see forkDoesNotDecorateCoincidentalLocal).
+    // Only ONE PR per head branch can claim the decoration slot; any same-repo PR
+    // that loses the race (two PRs sharing a head, e.g. same head → different
+    // base) must still surface as its own PR-only row rather than vanish.
     var decoration: [String: OpenPRInfo] = [:]
+    var claimed = Set<Int>()   // PR numbers that took a decoration slot
     for pr in prs where !pr.isCrossRepository && branchLocalNames.contains(pr.headRefName) {
-        if decoration[pr.headRefName] == nil { decoration[pr.headRefName] = pr }
+        if decoration[pr.headRefName] == nil {
+            decoration[pr.headRefName] = pr
+            claimed.insert(pr.number)
+        }
     }
-    let prOnly = prs.filter { $0.isCrossRepository || !branchLocalNames.contains($0.headRefName) }
+    let prOnly = prs.filter { !claimed.contains($0.number) }
     let prOnlyRows = prOnly.map { PickerItem(branch: nil, pr: $0) }
 
     var result: [PickerItem] = []

--- a/Sources/TBDApp/Sidebar/BranchPickerMerge.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerMerge.swift
@@ -16,8 +16,10 @@ struct PickerItem: Equatable, Identifiable {
 /// Merge open PRs into the branch list. A non-fork PR whose `headRefName` matches
 /// a branch row's `localName` decorates that (first-matching) row; every other PR
 /// — fork PRs, and non-fork PRs with no local branch — becomes its own row,
-/// inserted after local branches and before the first remote branch. Existing
-/// branch order is preserved.
+/// inserted after local branches and before the first remote branch. Finally, the
+/// list is stably partitioned so every PR-carrying row (decorated branch or
+/// PR-only) floats to the top, above plain branches — each group keeping its
+/// existing relative order.
 func mergePickerItems(branches: [BranchInfo], prs: [OpenPRInfo]) -> [PickerItem] {
     let branchLocalNames = Set(branches.map(\.localName))
 
@@ -50,7 +52,10 @@ func mergePickerItems(branches: [BranchInfo], prs: [OpenPRInfo]) -> [PickerItem]
         result.append(PickerItem(branch: branch, pr: pr))
     }
     if !insertedPROnly { result.append(contentsOf: prOnlyRows) }
-    return result
+
+    // Stable partition: PR-carrying rows float to the top, plain branches after —
+    // `filter` preserves relative order within each group.
+    return result.filter { $0.pr != nil } + result.filter { $0.pr == nil }
 }
 
 /// Case-insensitive typeahead: branch name/localName, PR number, PR title, owner

--- a/Sources/TBDApp/Sidebar/BranchPickerMerge.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerMerge.swift
@@ -1,0 +1,65 @@
+import TBDShared
+
+/// One row in the branch picker's combined branches + open-PRs list.
+///
+/// - `branch != nil, pr == nil`  → plain branch row.
+/// - `branch != nil, pr != nil`  → same-repo PR decorating an existing branch
+///   (selecting it checks out the branch; the PR number is stamped for status).
+/// - `branch == nil, pr != nil`  → PR-only row (fork PR, or a same-repo PR whose
+///   head branch has not been fetched locally). Selecting it fetches the PR head.
+struct PickerItem: Equatable, Identifiable {
+    let branch: BranchInfo?
+    let pr: OpenPRInfo?
+    var id: String { branch?.name ?? "pr-\(pr!.number)" }
+}
+
+/// Merge open PRs into the branch list. A non-fork PR whose `headRefName` matches
+/// a branch row's `localName` decorates that (first-matching) row; every other PR
+/// — fork PRs, and non-fork PRs with no local branch — becomes its own row,
+/// inserted after local branches and before the first remote branch. Existing
+/// branch order is preserved.
+func mergePickerItems(branches: [BranchInfo], prs: [OpenPRInfo]) -> [PickerItem] {
+    let branchLocalNames = Set(branches.map(\.localName))
+
+    // A PR decorates a branch only when it is same-repo AND some branch carries
+    // its head name. Fork PRs never decorate (a fork head like "main" can collide
+    // with an unrelated local branch — see forkDoesNotDecorateCoincidentalLocal).
+    var decoration: [String: OpenPRInfo] = [:]
+    for pr in prs where !pr.isCrossRepository && branchLocalNames.contains(pr.headRefName) {
+        if decoration[pr.headRefName] == nil { decoration[pr.headRefName] = pr }
+    }
+    let prOnly = prs.filter { $0.isCrossRepository || !branchLocalNames.contains($0.headRefName) }
+    let prOnlyRows = prOnly.map { PickerItem(branch: nil, pr: $0) }
+
+    var result: [PickerItem] = []
+    var insertedPROnly = false
+    for branch in branches {
+        if branch.isRemote && !insertedPROnly {
+            result.append(contentsOf: prOnlyRows)
+            insertedPROnly = true
+        }
+        // Only the first branch row for a given localName gets the pill.
+        let pr = decoration.removeValue(forKey: branch.localName)
+        result.append(PickerItem(branch: branch, pr: pr))
+    }
+    if !insertedPROnly { result.append(contentsOf: prOnlyRows) }
+    return result
+}
+
+/// Case-insensitive typeahead: branch name/localName, PR number, PR title, owner
+/// login, and (for PR-only rows) the head branch name shown as the row title.
+func matchesFilter(_ item: PickerItem, query: String) -> Bool {
+    let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+    if q.isEmpty { return true }
+    if let b = item.branch,
+       b.name.lowercased().contains(q) || b.localName.lowercased().contains(q) {
+        return true
+    }
+    if let pr = item.pr {
+        if String(pr.number).contains(q) { return true }
+        if pr.title.lowercased().contains(q) { return true }
+        if pr.headOwner.lowercased().contains(q) { return true }
+        if pr.headRefName.lowercased().contains(q) { return true }
+    }
+    return false
+}

--- a/Sources/TBDApp/Sidebar/BranchPickerView.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerView.swift
@@ -50,17 +50,11 @@ struct BranchListView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 6) {
-                TextField("Filter branches & PRs", text: $query)
-                    .textFieldStyle(.roundedBorder)
-                    .focused($searchFocused)
-                    .onSubmit { selectFirstMatch() }
-                if prsLoading {
-                    ProgressView()
-                        .controlSize(.mini)
-                }
-            }
-            .padding(8)
+            TextField("Filter branches & PRs", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .focused($searchFocused)
+                .onSubmit { selectFirstMatch() }
+                .padding(8)
 
             Divider()
 
@@ -72,7 +66,7 @@ struct BranchListView: View {
                     Spacer()
                 }
                 .padding(16)
-            } else if filteredItems.isEmpty {
+            } else if filteredItems.isEmpty && !prsLoading {
                 Text(emptyStateMessage)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -80,6 +74,9 @@ struct BranchListView: View {
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
+                        if prsLoading {
+                            PRLoadingPlaceholderRow()
+                        }
                         ForEach(filteredItems) { item in
                             BranchPickerRow(item: item) {
                                 pick(item)
@@ -143,6 +140,24 @@ struct BranchListView: View {
         if let first = filteredItems.first {
             pick(first)
         }
+    }
+}
+
+/// Non-interactive row shown at the top of the list while the open-PR fetch
+/// (`prsLoading`) is in flight. PR rows float to the top once loaded (see
+/// 20c8fbfb), so the placeholder occupies that same slot.
+private struct PRLoadingPlaceholderRow: View {
+    var body: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Loading pull requests…")
+                .font(.system(size: 12))
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Sources/TBDApp/Sidebar/BranchPickerView.swift
+++ b/Sources/TBDApp/Sidebar/BranchPickerView.swift
@@ -34,27 +34,33 @@ struct BranchListView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var branches: [BranchInfo] = []
+    @State private var openPRs: [OpenPRInfo] = []
     @State private var query: String = ""
     @State private var isLoading: Bool = true
     @State private var loadError: Bool = false
+    /// True while the open-PR query is in flight (two-phase load). Branches
+    /// render immediately; PR rows pop in when this clears.
+    @State private var prsLoading: Bool = false
     @FocusState private var searchFocused: Bool
 
-    private var filteredBranches: [BranchInfo] {
-        let trimmed = query.trimmingCharacters(in: .whitespaces).lowercased()
-        if trimmed.isEmpty { return branches }
-        return branches.filter { branch in
-            branch.name.lowercased().contains(trimmed) ||
-                branch.localName.lowercased().contains(trimmed)
-        }
+    private var filteredItems: [PickerItem] {
+        mergePickerItems(branches: branches, prs: openPRs)
+            .filter { matchesFilter($0, query: query) }
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            TextField("Filter branches", text: $query)
-                .textFieldStyle(.roundedBorder)
-                .focused($searchFocused)
-                .padding(8)
-                .onSubmit { selectFirstMatch() }
+            HStack(spacing: 6) {
+                TextField("Filter branches & PRs", text: $query)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($searchFocused)
+                    .onSubmit { selectFirstMatch() }
+                if prsLoading {
+                    ProgressView()
+                        .controlSize(.mini)
+                }
+            }
+            .padding(8)
 
             Divider()
 
@@ -66,7 +72,7 @@ struct BranchListView: View {
                     Spacer()
                 }
                 .padding(16)
-            } else if filteredBranches.isEmpty {
+            } else if filteredItems.isEmpty {
                 Text(emptyStateMessage)
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -74,9 +80,9 @@ struct BranchListView: View {
             } else {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(filteredBranches) { branch in
-                            BranchPickerRow(branch: branch) {
-                                pick(branch)
+                        ForEach(filteredItems) { item in
+                            BranchPickerRow(item: item) {
+                                pick(item)
                             }
                         }
                     }
@@ -94,6 +100,11 @@ struct BranchListView: View {
             }
             isLoading = false
             searchFocused = true
+            // Phase two: PR rows pop in after branches render. A PR-list
+            // failure never blocks or errors the branch list (branches-only).
+            prsLoading = true
+            openPRs = (try? await appState.listOpenPRs(repoID: repoID)) ?? []
+            prsLoading = false
         }
     }
 
@@ -101,53 +112,83 @@ struct BranchListView: View {
     /// state or a genuinely empty repo, so the user can tell a load failure
     /// apart from "no matching branches".
     private var emptyStateMessage: String {
-        if !branches.isEmpty { return "No matches" }
+        if !branches.isEmpty || !openPRs.isEmpty { return "No matches" }
         if loadError { return "Failed to load branches" }
         return "No branches found"
     }
 
-    private func pick(_ branch: BranchInfo) {
+    private func pick(_ item: PickerItem) {
         dismiss()
         onClose()
         // Branch selection always uses the default model (no profile override).
-        appState.createWorktree(repoID: repoID, parentWorktreeID: parentWorktreeID, existingBranch: branch)
+        if let branch = item.branch {
+            // Plain branch row, or a same-repo PR decorating an existing branch:
+            // check out the branch exactly as today; stamp the PR number (if any)
+            // for status tracking only — no pull-ref fetch (checkoutPRHead false).
+            appState.createWorktree(
+                repoID: repoID, parentWorktreeID: parentWorktreeID,
+                existingBranch: branch, prNumber: item.pr?.number)
+        } else if let pr = item.pr {
+            // PR-only row (fork PR, or a same-repo PR whose head is unfetched):
+            // fetch refs/pull/<n>/head into a fresh local branch.
+            let branch = BranchInfo(name: pr.headRefName, localName: pr.headRefName, isRemote: false)
+            appState.createWorktree(
+                repoID: repoID, parentWorktreeID: parentWorktreeID,
+                existingBranch: branch, prNumber: pr.number, checkoutPRHead: true,
+                displayName: "#\(pr.number) \(pr.title)")
+        }
     }
 
     private func selectFirstMatch() {
-        if let first = filteredBranches.first {
+        if let first = filteredItems.first {
             pick(first)
         }
     }
 }
 
 struct BranchPickerRow: View {
-    let branch: BranchInfo
+    let item: PickerItem
     let onSelect: () -> Void
 
     @State private var isHovered = false
 
+    /// Row title: the branch name, or (PR-only rows) the PR head branch name.
+    private var title: String {
+        item.branch?.name ?? item.pr?.headRefName ?? ""
+    }
+    private var isRemote: Bool { item.branch?.isRemote ?? false }
+    /// Remote rows use a cloud; everything else (local branch or PR-only) uses
+    /// the branch glyph. PR-ness is conveyed by the pill, not the icon.
+    private var iconName: String {
+        isRemote ? "cloud" : "arrow.triangle.branch"
+    }
+
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 6) {
-                Image(systemName: branch.isRemote ? "cloud" : "arrow.triangle.branch")
+                Image(systemName: iconName)
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .frame(width: 14)
-                Text(branch.name)
-                    .font(.system(size: 12))
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    // Fork PR-only rows show the PR title as a secondary subtitle.
+                    if item.branch == nil, let pr = item.pr {
+                        Text(pr.title)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
                 Spacer(minLength: 4)
-                if branch.isRemote {
-                    Text("remote")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(
-                            RoundedRectangle(cornerRadius: 3)
-                                .fill(Color.secondary.opacity(0.10))
-                        )
+                if let pr = item.pr {
+                    prPill(pr)
+                } else if isRemote {
+                    pill("remote")
                 }
             }
             .padding(.horizontal, 10)
@@ -161,5 +202,25 @@ struct BranchPickerRow: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
+    }
+
+    /// `PR #454` for same-repo, `zionts · PR #454` for fork PRs; dimmed for drafts.
+    private func prPill(_ pr: OpenPRInfo) -> some View {
+        let label = pr.isCrossRepository && !pr.headOwner.isEmpty
+            ? "\(pr.headOwner) · PR #\(pr.number)"
+            : "PR #\(pr.number)"
+        return pill(label).opacity(pr.isDraft ? 0.5 : 1.0)
+    }
+
+    private func pill(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(Color.secondary.opacity(0.10))
+            )
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -900,6 +900,14 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "repo", column: "claude_settings_overlay", type: .text)
         }
 
+        // Number of the GitHub PR a worktree was created from, if any. Nullable —
+        // NULL means "not created from a PR". Lets PRStatusManager resolve status
+        // by direct number lookup instead of viewer-authored/branch-name matching,
+        // which is the only way fork PRs (no matching local branch) get tracked.
+        migrator.registerMigration("v54_worktree_pr_number") { db in
+            try db.addColumnIfMissing(table: "worktree", column: "pr_number", type: .integer)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -30,6 +30,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var autoHibernateOnMerge: Bool?
     var prStatus: String?  // JSON-encoded PRStatus, nil when never observed
     var promotedToRepoID: String?  // set only on promoted scratch rows
+    var pr_number: Int?  // number of the PR this worktree was created from, nil otherwise
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -56,6 +57,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.autoHibernateOnMerge = wt.autoHibernateOnMerge
         self.prStatus = wt.prStatus.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         self.promotedToRepoID = wt.promotedToRepoID?.uuidString
+        self.pr_number = wt.prNumber
     }
 
     /// Failable decode: skips (returns nil after a logged warning) only when the
@@ -111,7 +113,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             autoArchiveOnMerge: autoArchiveOnMerge,
             autoHibernateOnMerge: autoHibernateOnMerge,
             promotedToRepoID: promotedToRepoID.flatMap { UUID(uuidString: $0) },
-            prStatus: pr
+            prStatus: pr,
+            prNumber: pr_number
         )
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -174,7 +174,8 @@ public struct WorktreeStore: Sendable {
         path: String,
         tmuxServer: String,
         status: WorktreeStatus = .active,
-        parentWorktreeID: UUID? = nil
+        parentWorktreeID: UUID? = nil,
+        prNumber: Int? = nil
     ) async throws -> Worktree {
         try await writer.write { db in
             let maxOrder: Int
@@ -200,7 +201,8 @@ public struct WorktreeStore: Sendable {
                 status: status,
                 tmuxServer: tmuxServer,
                 sortOrder: maxOrder + 1,
-                parentWorktreeID: parentWorktreeID
+                parentWorktreeID: parentWorktreeID,
+                prNumber: prNumber
             )
             let record = WorktreeRecord(from: wt)
             try record.insert(db)

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -163,6 +163,30 @@ public struct GitManager: Sendable {
         _ = try await run(arguments: ["fetch", "origin"], at: repoPath, timeout: timeout)
     }
 
+    /// True if `refs/heads/<name>` exists locally. Used to pick a
+    /// non-clobbering local branch name before force-fetching a pull ref.
+    public func localBranchExists(repoPath: String, name: String) async throws -> Bool {
+        do {
+            _ = try await run(arguments: ["show-ref", "--verify", "--quiet", "refs/heads/\(name)"], at: repoPath)
+            return true
+        } catch {
+            // show-ref --quiet exits 1 when the ref is missing — treat any
+            // failure as "absent" (same convention as `refExists`).
+            return false
+        }
+    }
+
+    /// Fetches a PR head (same-repo or fork — `refs/pull/<n>/head` exists for
+    /// both) into a local branch. The `+` force-updates, so callers MUST pass a
+    /// branch name verified free via `localBranchExists` / uniquification, or an
+    /// unrelated same-named branch is silently rewritten.
+    public func fetchPullRequestHead(repoPath: String, number: Int, localBranch: String) async throws {
+        _ = try await run(
+            arguments: ["fetch", "origin", "+refs/pull/\(number)/head:refs/heads/\(localBranch)"],
+            at: repoPath
+        )
+    }
+
     /// Returns the HEAD SHA for a branch or ref.
     public func headSHA(repoPath: String, ref: String = "HEAD") async throws -> String {
         let output = try await run(arguments: ["rev-parse", ref], at: repoPath)

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -165,13 +165,18 @@ public struct GitManager: Sendable {
 
     /// True if `refs/heads/<name>` exists locally. Used to pick a
     /// non-clobbering local branch name before force-fetching a pull ref.
+    ///
+    /// Fails closed, unlike the read-only `refExists`: this result gates
+    /// whether `fetchPullRequestHead`'s `+refs/pull/<n>/head:refs/heads/<name>`
+    /// force-refspec is safe to run against `name`. Only the benign "ref
+    /// missing" case (`show-ref --quiet` exits 1) is treated as absent — any
+    /// other failure (timeout, spawn failure, other exit codes) is rethrown so
+    /// a bad answer here can't let the force-fetch silently clobber a branch.
     public func localBranchExists(repoPath: String, name: String) async throws -> Bool {
         do {
             _ = try await run(arguments: ["show-ref", "--verify", "--quiet", "refs/heads/\(name)"], at: repoPath)
             return true
-        } catch {
-            // show-ref --quiet exits 1 when the ref is missing — treat any
-            // failure as "absent" (same convention as `refExists`).
+        } catch let error as GitError where error.exitCode == 1 {
             return false
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -175,8 +175,9 @@ extension WorktreeLifecycle {
     /// local `refs/heads/<name>` exists. Mirrors `uniqueFolderName`'s loop but
     /// probes git refs instead of paths: the PR-head fetch uses a `+` force
     /// refspec, so a colliding name would silently rewrite an unrelated branch;
-    /// this picks a free name first. Caps at -1000, then falls through (the
-    /// fetch/worktree-add fails loudly if every candidate is taken).
+    /// this picks a free name first. Caps at -1000; if every candidate through
+    /// `base-1000` is taken it THROWS rather than returning the taken `base` —
+    /// returning it would let the force refspec clobber that existing branch.
     private func uniqueLocalBranchName(repoPath: String, base: String) async throws -> String {
         if try await git.localBranchExists(repoPath: repoPath, name: base) == false {
             return base
@@ -187,7 +188,8 @@ extension WorktreeLifecycle {
                 return candidate
             }
         }
-        return base
+        throw WorktreeLifecycleError.createFailed(
+            "no free local branch name for '\(base)' after 1000 attempts; refusing to reuse it (the force-fetch refspec would clobber the existing branch)")
     }
 
     /// Phase 2: Async. Performs git fetch, git worktree add, tmux setup,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -26,12 +26,12 @@ extension WorktreeLifecycle {
     ///
     /// This is the legacy all-in-one method. Prefer `beginCreateWorktree` +
     /// `completeCreateWorktree` for non-blocking creation.
-    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false, prNumber: Int? = nil, claudeSettingsOverlay: String? = nil) async throws -> Worktree {
+    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false, prNumber: Int? = nil, checkoutPRHead: Bool = false, claudeSettingsOverlay: String? = nil) async throws -> Worktree {
         let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude, parentWorktreeID: parentWorktreeID, siblingOfWorktreeID: siblingOfWorktreeID, callerWorktreeID: callerWorktreeID, suppressAutoParent: suppressAutoParent, useExistingBranch: useExistingBranch, prNumber: prNumber)
         // Pass the original branch ref (may include `origin/` prefix) through
         // so phase 2 can dispatch to the correct git command.
         let existingBranchRef = useExistingBranch ? branch : nil
-        let completion = try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef, claudeSettingsOverlay: claudeSettingsOverlay)
+        let completion = try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef, checkoutPRHead: checkoutPRHead, claudeSettingsOverlay: claudeSettingsOverlay)
         // Legacy synchronous contract: the returned worktree is fully set up.
         // Await phase 3 inline when a preSession hook gated the primary spawn.
         if case .preSessionPending(let phase3) = completion {
@@ -201,7 +201,7 @@ extension WorktreeLifecycle {
     /// When `existingBranchRef` is non-nil, the worktree is checked out from
     /// that existing ref (local or `origin/*`) — no fresh branch is created.
     @discardableResult
-    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, overrideProfileID: UUID? = nil, claudeSettingsOverlay: String? = nil) async throws -> WorktreeCreateCompletion {
+    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, checkoutPRHead: Bool = false, overrideProfileID: UUID? = nil, claudeSettingsOverlay: String? = nil) async throws -> WorktreeCreateCompletion {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -233,14 +233,18 @@ extension WorktreeLifecycle {
                 // `--track -b <localName> <path> origin/<name>` to create a
                 // local tracking branch.
                 do {
-                    if let prNumber = worktree.prNumber {
-                        // PR-head checkout: fetch refs/pull/<n>/head into a
-                        // collision-free local branch (the `+` refspec
-                        // force-updates, so reusing an existing ref name would
-                        // silently rewrite an unrelated branch), then check it
-                        // out via the plain existing-branch path. Works
-                        // identically for same-repo and fork PRs — no fork
-                        // remote is ever added.
+                    if checkoutPRHead, let prNumber = worktree.prNumber {
+                        // Fork-PR checkout: the PR head has no local ref, so
+                        // fetch refs/pull/<n>/head into a collision-free local
+                        // branch (the `+` refspec force-updates, so reusing an
+                        // existing ref name would silently rewrite an unrelated
+                        // branch), then check it out via the plain
+                        // existing-branch path. No fork remote is ever added.
+                        //
+                        // Decorated same-repo rows (prNumber set, checkoutPRHead
+                        // false) fall through to the else-branches below and
+                        // check out the existing branch unchanged — prNumber is
+                        // already stamped on the row for status tracking.
                         let localBranch = try await uniqueLocalBranchName(
                             repoPath: repo.path, base: worktree.branch
                         )

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -26,8 +26,8 @@ extension WorktreeLifecycle {
     ///
     /// This is the legacy all-in-one method. Prefer `beginCreateWorktree` +
     /// `completeCreateWorktree` for non-blocking creation.
-    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false, claudeSettingsOverlay: String? = nil) async throws -> Worktree {
-        let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude, parentWorktreeID: parentWorktreeID, siblingOfWorktreeID: siblingOfWorktreeID, callerWorktreeID: callerWorktreeID, suppressAutoParent: suppressAutoParent, useExistingBranch: useExistingBranch)
+    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false, prNumber: Int? = nil, claudeSettingsOverlay: String? = nil) async throws -> Worktree {
+        let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude, parentWorktreeID: parentWorktreeID, siblingOfWorktreeID: siblingOfWorktreeID, callerWorktreeID: callerWorktreeID, suppressAutoParent: suppressAutoParent, useExistingBranch: useExistingBranch, prNumber: prNumber)
         // Pass the original branch ref (may include `origin/` prefix) through
         // so phase 2 can dispatch to the correct git command.
         let existingBranchRef = useExistingBranch ? branch : nil
@@ -48,7 +48,7 @@ extension WorktreeLifecycle {
     /// Phase 1: Synchronous-fast. Generates a name, inserts a DB row with
     /// `status = .creating`, and returns the worktree immediately.
     /// NO git operations happen here.
-    public func beginCreateWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false) async throws -> Worktree {
+    public func beginCreateWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false, prNumber: Int? = nil) async throws -> Worktree {
         // 1. Fetch repo
         guard let repo = try await db.repos.get(id: repoID) else {
             throw WorktreeLifecycleError.repoNotFound(repoID)
@@ -138,7 +138,8 @@ extension WorktreeLifecycle {
             path: worktreePath,
             tmuxServer: tmuxServer,
             status: .creating,
-            parentWorktreeID: resolvedParent
+            parentWorktreeID: resolvedParent,
+            prNumber: prNumber
         )
 
         return worktree
@@ -167,6 +168,25 @@ extension WorktreeLifecycle {
             }
         }
         // Fall through to the original; `git worktree add` will fail loudly.
+        return base
+    }
+
+    /// Returns `base`, or `base-2`, `base-3`, … — the first name for which no
+    /// local `refs/heads/<name>` exists. Mirrors `uniqueFolderName`'s loop but
+    /// probes git refs instead of paths: the PR-head fetch uses a `+` force
+    /// refspec, so a colliding name would silently rewrite an unrelated branch;
+    /// this picks a free name first. Caps at -1000, then falls through (the
+    /// fetch/worktree-add fails loudly if every candidate is taken).
+    private func uniqueLocalBranchName(repoPath: String, base: String) async throws -> String {
+        if try await git.localBranchExists(repoPath: repoPath, name: base) == false {
+            return base
+        }
+        for suffix in 2...1000 {
+            let candidate = "\(base)-\(suffix)"
+            if try await git.localBranchExists(repoPath: repoPath, name: candidate) == false {
+                return candidate
+            }
+        }
         return base
     }
 
@@ -213,7 +233,29 @@ extension WorktreeLifecycle {
                 // `--track -b <localName> <path> origin/<name>` to create a
                 // local tracking branch.
                 do {
-                    if ref.hasPrefix("origin/") {
+                    if let prNumber = worktree.prNumber {
+                        // PR-head checkout: fetch refs/pull/<n>/head into a
+                        // collision-free local branch (the `+` refspec
+                        // force-updates, so reusing an existing ref name would
+                        // silently rewrite an unrelated branch), then check it
+                        // out via the plain existing-branch path. Works
+                        // identically for same-repo and fork PRs — no fork
+                        // remote is ever added.
+                        let localBranch = try await uniqueLocalBranchName(
+                            repoPath: repo.path, base: worktree.branch
+                        )
+                        try await git.fetchPullRequestHead(
+                            repoPath: repo.path, number: prNumber, localBranch: localBranch
+                        )
+                        try await git.worktreeAddExisting(
+                            repoPath: repo.path,
+                            worktreePath: worktree.path,
+                            branch: localBranch
+                        )
+                        if localBranch != worktree.branch {
+                            try await db.worktrees.updateBranch(id: worktreeID, branch: localBranch)
+                        }
+                    } else if ref.hasPrefix("origin/") {
                         try await git.worktreeAddTrackingRemote(
                             repoPath: repo.path,
                             worktreePath: worktree.path,

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -16,6 +16,12 @@ public actor PRStatusManager {
 
     private var cache: [UUID: PRStatus] = [:]
 
+    /// TTL cache for `resolveNameWithOwner` so the periodic poll's by-number and
+    /// open-PR queries don't spawn a `gh repo view` subprocess per call. Keyed by
+    /// repoPath; ~15-min TTL (a checkout's owner/name effectively never changes).
+    /// Actor-isolated, so no locking — mirrors `RPCRouter.upstreamBranchCache`.
+    private var ownerRepoCache: [String: (value: (owner: String, name: String), expiry: Date)] = [:]
+
     /// Reentrancy guard: a previous poll still running means a new `fetchAll` is skipped
     /// so two generations of batch data can't interleave their cache writes.
     private var fetchAllInProgress = false
@@ -212,8 +218,15 @@ public actor PRStatusManager {
     /// merge-queue field set the batch query does. `gh repo view` resolves the
     /// checkout's `owner/name` so the query can scope to this repo+branch —
     /// which, unlike the 100-PR viewer batch, always finds an old PR.
-    public func refresh(worktreeID: UUID, branch: String, upstreamBranch: String?, repoPath: String) async -> PRStatus? {
-        guard let ownerRepo = await resolveNameWithOwner(repoPath: repoPath) else {
+    public func refresh(worktreeID: UUID, branch: String, upstreamBranch: String?, repoPath: String, prNumber: Int? = nil) async -> PRStatus? {
+        // A stored PR number (fork PRs, or a PR whose head we renamed locally)
+        // can't be found by head branch — resolve it directly, mirroring
+        // fetchAll's number-first path. Only fall back to the branch path when no
+        // number is stored.
+        if let prNumber {
+            return await refreshByNumber(worktreeID: worktreeID, number: prNumber, repoPath: repoPath)
+        }
+        guard let ownerRepo = await cachedNameWithOwner(repoPath: repoPath) else {
             return cache[worktreeID]   // can't resolve owner/name → leave cache unchanged
         }
         let candidates = Self.branchCandidates(localBranch: branch, upstreamBranch: upstreamBranch)
@@ -230,36 +243,88 @@ public actor PRStatusManager {
                 continue
             }
 
-            let signals: (failing: Bool, pending: Bool)
-            if obj.state != "OPEN" {
-                signals = (false, false)   // mapState ignores signals for MERGED/CLOSED
-            } else if let fetched = await fetchCheckSignals(url: obj.url, number: obj.number, repoPath: repoPath) {
-                signals = fetched
-            } else if let cached = cache[worktreeID] {
-                return cached   // transient failure: keep the previous status rather than guessing
-            } else {
-                signals = (false, false)   // bootstrap with no data; the next poll corrects it
-            }
-
-            let (state, reason) = Self.mapStateAndReason(
-                ghState: obj.state,
-                mergeStateStatus: obj.mergeStateStatus,
-                reviewDecision: obj.reviewDecision ?? "",
-                isDraft: obj.isDraft,
-                requiredChecksFailing: signals.failing,
-                requiredChecksPending: signals.pending
-            )
-            let status = PRStatus(number: obj.number, url: obj.url, state: state, reason: reason,
-                                  mergeQueuePosition: obj.mergeQueuePosition)
-            await apply(status, for: worktreeID)
-            lastDirectUpdate[worktreeID] = Date()
-            await onPRStatusComputed?(worktreeID, status, repoPath)
-            return status
+            return await applyRefreshedNode(
+                worktreeID: worktreeID, number: obj.number, url: obj.url, state: obj.state,
+                mergeStateStatus: obj.mergeStateStatus, reviewDecision: obj.reviewDecision ?? "",
+                isDraft: obj.isDraft, mergeQueuePosition: obj.mergeQueuePosition, repoPath: repoPath)
         }
 
         // gh exited non-zero or parse failed for every candidate — leave cache unchanged.
         logger.debug("refresh: no candidate branch yielded a PR for worktree \(worktreeID, privacy: .public); keeping cached status")
         return cache[worktreeID]
+    }
+
+    /// Refresh a single worktree by its stored PR number — one aliased
+    /// `pullRequest(number:)` lookup (the only way to reach a fork PR, whose head
+    /// never appears in a branch query). Tolerant of a non-zero `gh` exit that
+    /// still carries usable `data` (a sibling batch error). Leaves the cache
+    /// untouched on any failure to resolve the number.
+    private func refreshByNumber(worktreeID: UUID, number: Int, repoPath: String) async -> PRStatus? {
+        guard let ownerRepo = await cachedNameWithOwner(repoPath: repoPath) else {
+            return cache[worktreeID]
+        }
+        let query = Self.numberedPRQuery(aliases: [(alias: "pr0", number: number)])
+        let args = [
+            "api", "graphql",
+            "-f", "query=\(query)",
+            "-f", "owner=\(ownerRepo.owner)",
+            "-f", "name=\(ownerRepo.name)"
+        ]
+        guard let result = await runGHResult(args: args, repoPath: repoPath),
+              let data = Self.graphQLOutputData(stdout: result.stdout) else {
+            logger.debug("refresh: by-number query produced no data for PR #\(number, privacy: .public); keeping cached status")
+            return cache[worktreeID]
+        }
+        if result.exitStatus != 0 {
+            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.debug("refresh: by-number query exited \(result.exitStatus, privacy: .public) with partial data for PR #\(number, privacy: .public): \(errSuffix, privacy: .public)")
+        }
+        let matches = Self.parseNumberedPRNodes(from: data, aliases: [(alias: "pr0", worktreeID: worktreeID)])
+        guard let node = matches.first?.node else {
+            logger.debug("refresh: PR #\(number, privacy: .public) did not resolve by number; keeping cached status")
+            return cache[worktreeID]
+        }
+        return await applyRefreshedNode(
+            worktreeID: worktreeID, number: node.number, url: node.url, state: node.state,
+            mergeStateStatus: node.mergeStateStatus, reviewDecision: node.reviewDecision,
+            isDraft: node.isDraft, mergeQueuePosition: node.mergeQueuePosition, repoPath: repoPath)
+    }
+
+    /// Compute check signals for a resolved PR node, map to a `PRStatus`, write it
+    /// to the cache via `apply`, mark the direct-update timestamp, and fire the
+    /// nightwatch callback. Shared by both refresh paths (by-number, by-branch) so
+    /// their signal/apply logic can't drift. When per-check signals are
+    /// unavailable it keeps the prior cached status (transient failure) or, with
+    /// no cache to keep, bootstraps with no-signal state (the next poll corrects).
+    private func applyRefreshedNode(
+        worktreeID: UUID, number: Int, url: String, state: String,
+        mergeStateStatus: String, reviewDecision: String, isDraft: Bool,
+        mergeQueuePosition: Int?, repoPath: String
+    ) async -> PRStatus {
+        let signals: (failing: Bool, pending: Bool)
+        if state != "OPEN" {
+            signals = (false, false)   // mapState ignores signals for MERGED/CLOSED
+        } else if let fetched = await fetchCheckSignals(url: url, number: number, repoPath: repoPath) {
+            signals = fetched
+        } else if let cached = cache[worktreeID] {
+            return cached   // transient failure: keep the previous status rather than guessing
+        } else {
+            signals = (false, false)   // bootstrap with no data; the next poll corrects it
+        }
+        let (mappedState, reason) = Self.mapStateAndReason(
+            ghState: state,
+            mergeStateStatus: mergeStateStatus,
+            reviewDecision: reviewDecision,
+            isDraft: isDraft,
+            requiredChecksFailing: signals.failing,
+            requiredChecksPending: signals.pending
+        )
+        let status = PRStatus(number: number, url: url, state: mappedState, reason: reason,
+                              mergeQueuePosition: mergeQueuePosition)
+        await apply(status, for: worktreeID)
+        lastDirectUpdate[worktreeID] = Date()
+        await onPRStatusComputed?(worktreeID, status, repoPath)
+        return status
     }
 
     /// For tests only: seed a cache entry. Routes through `apply` so the
@@ -760,7 +825,7 @@ public actor PRStatusManager {
     /// unparseable response) degrades to `[]` with a `.debug` log — never
     /// throws, matching the picker's "PR data is best-effort" contract.
     public nonisolated func fetchOpenPRs(repoPath: String) async -> [OpenPRInfo] {
-        guard let ownerRepo = await resolveNameWithOwner(repoPath: repoPath) else {
+        guard let ownerRepo = await cachedNameWithOwner(repoPath: repoPath) else {
             logger.debug("listOpenPRs: could not resolve owner/name for \(repoPath, privacy: .public)")
             return []
         }
@@ -774,10 +839,18 @@ public actor PRStatusManager {
             logger.debug("listOpenPRs: gh did not launch for \(repoPath, privacy: .public)")
             return []
         }
-        guard result.exitStatus == 0, let data = Self.graphQLOutputData(stdout: result.stdout) else {
+        guard let data = Self.graphQLOutputData(stdout: result.stdout) else {
             let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            logger.debug("listOpenPRs: gh graphql exited \(result.exitStatus, privacy: .public): \(errSuffix, privacy: .public)")
+            logger.debug("listOpenPRs: gh graphql produced no data (exit \(result.exitStatus, privacy: .public)): \(errSuffix, privacy: .public)")
             return []
+        }
+        // `gh api graphql` exits non-zero when ANY node errors (a stale/deleted/
+        // inaccessible fork PR) yet still emits usable `data` for the rest. Parse
+        // whatever came back rather than discarding the whole batch — mirrors
+        // `runGHGraphQL`'s partial-results tolerance (regression guard, PR #208).
+        if result.exitStatus != 0 {
+            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.debug("listOpenPRs: gh graphql exited \(result.exitStatus, privacy: .public) with partial data: \(errSuffix, privacy: .public)")
         }
         return Self.parseOpenPRNodes(from: data)
     }
@@ -837,6 +910,19 @@ public actor PRStatusManager {
         return (owner: String(parts[0]), name: String(parts[1]))
     }
 
+    /// `resolveNameWithOwner` behind a ~15-min TTL cache so the periodic poll
+    /// (by-number query) and picker (open-PR query) stop spawning a `gh repo
+    /// view` subprocess on every call. A checkout's owner/name is effectively
+    /// immutable, so a stale entry is harmless within the TTL.
+    private func cachedNameWithOwner(repoPath: String) async -> (owner: String, name: String)? {
+        if let entry = ownerRepoCache[repoPath], entry.expiry > Date() {
+            return entry.value
+        }
+        guard let resolved = await resolveNameWithOwner(repoPath: repoPath) else { return nil }
+        ownerRepoCache[repoPath] = (value: resolved, expiry: Date().addingTimeInterval(15 * 60))
+        return resolved
+    }
+
     /// Resolve stored PR numbers directly via one aliased `pullRequest(number:)`
     /// query — the only way to reach a fork PR, whose head branch never appears
     /// in the viewer-authored batch. Degrades to no matches on any failure
@@ -846,7 +932,7 @@ public actor PRStatusManager {
         _ numbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)],
         repoPath: String
     ) async -> [(worktreeID: UUID, node: PRNode)] {
-        guard let ownerRepo = await resolveNameWithOwner(repoPath: repoPath) else {
+        guard let ownerRepo = await cachedNameWithOwner(repoPath: repoPath) else {
             logger.debug("fetchAll: could not resolve owner/name for numbered PRs at \(repoPath, privacy: .public)")
             return []
         }
@@ -863,10 +949,17 @@ public actor PRStatusManager {
             "-f", "name=\(ownerRepo.name)"
         ]
         guard let result = await runGHResult(args: args, repoPath: repoPath),
-              result.exitStatus == 0,
               let data = Self.graphQLOutputData(stdout: result.stdout) else {
-            logger.debug("fetchAll: by-number query failed for numbered PRs at \(repoPath, privacy: .public)")
+            logger.debug("fetchAll: by-number query produced no data for numbered PRs at \(repoPath, privacy: .public)")
             return []
+        }
+        // `gh api graphql` exits non-zero when ONE aliased PR errors (stale,
+        // deleted, or inaccessible — likeliest for a fork PR) while still emitting
+        // usable `data` for the others. Parse whatever came back regardless of
+        // exit status; log the partial failure (regression guard, PR #208).
+        if result.exitStatus != 0 {
+            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.debug("fetchAll: by-number query exited \(result.exitStatus, privacy: .public) with partial data at \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
         }
         return Self.parseNumberedPRNodes(from: data, aliases: entries.map { ($0.alias, $0.worktreeID) })
     }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -105,7 +105,7 @@ public actor PRStatusManager {
 
     /// Fetch all viewer PRs in one GraphQL call and update cache for all known worktrees.
     /// worktrees: list of (id, branch, upstreamBranch, worktreePath) for active non-main worktrees.
-    public func fetchAll(worktrees: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String)]) async {
+    public func fetchAll(worktrees: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)]) async {
         guard !worktrees.isEmpty else { return }
         guard !fetchAllInProgress else { return }   // a previous poll is still running; skip to avoid interleaved generations
         fetchAllInProgress = true
@@ -114,40 +114,38 @@ public actor PRStatusManager {
         // All worktrees share one repo; any path works as gh's working directory for auth.
         let repoPath = worktrees[0].worktreePath
 
-        guard let jsonData = await runGHGraphQL(repoPath: repoPath) else { return }
+        // Worktrees created from a PR row carry its number; resolve those
+        // directly (a fork PR's head never appears in the viewer-authored batch).
+        // Everything else uses the legacy viewer-batch branch-name matching,
+        // byte-identical to before.
+        let (numbered, unnumbered) = Self.partitionByPRNumber(worktrees) { $0.prNumber }
 
-        guard let nodes = try? Self.parsePRNodes(from: jsonData) else {
-            logger.warning("Failed to parse GraphQL response")
-            return
-        }
-
-        // Build branch → PRNode lookup. When multiple PRs share a branch,
-        // pick the best one: sort by state priority (OPEN > MERGED > CLOSED),
-        // then by createdAt descending (newest first within the same state).
-        var byBranch: [String: PRNode] = [:]
-        for node in nodes {
-            if let existing = byBranch[node.headRefName] {
-                let nodePriority = Self.prPriority(node.state)
-                let existingPriority = Self.prPriority(existing.state)
-                if nodePriority > existingPriority {
-                    byBranch[node.headRefName] = node
-                } else if nodePriority == existingPriority && node.createdAt > existing.createdAt {
-                    byBranch[node.headRefName] = node
-                }
-            } else {
-                byBranch[node.headRefName] = node
-            }
-        }
-
-        // Collect matches first.
         // Do NOT clear entries for missing worktrees — the batch query is
         // limited to 100 PRs across all repos, so older PRs may not appear.
         // Those entries may have been populated by a targeted `refresh` call.
         var matches: [(worktreeID: UUID, node: PRNode)] = []
-        for wt in worktrees {
-            let candidates = Self.branchCandidates(localBranch: wt.branch, upstreamBranch: wt.upstreamBranch)
-            if let node = candidates.compactMap({ byBranch[$0] }).first {
-                matches.append((wt.id, node))
+
+        // Numbered path: one aliased by-number query (skipped when none stored).
+        if !numbered.isEmpty {
+            matches += await fetchNumberedMatches(numbered, repoPath: repoPath)
+        }
+
+        // Legacy path: viewer-authored batch + branch-name matching. On a fetch
+        // or parse failure it contributes no matches, but the numbered path above
+        // has already resolved independently.
+        if !unnumbered.isEmpty {
+            if let jsonData = await runGHGraphQL(repoPath: repoPath) {
+                if let nodes = try? Self.parsePRNodes(from: jsonData) {
+                    let byBranch = Self.bestNodeByBranch(nodes)
+                    for wt in unnumbered {
+                        let candidates = Self.branchCandidates(localBranch: wt.branch, upstreamBranch: wt.upstreamBranch)
+                        if let node = candidates.compactMap({ byBranch[$0] }).first {
+                            matches.append((wt.id, node))
+                        }
+                    }
+                } else {
+                    logger.warning("Failed to parse GraphQL response")
+                }
             }
         }
 
@@ -598,6 +596,80 @@ public actor PRStatusManager {
         public let mergeQueuePosition: Int?
     }
 
+    /// Split poll inputs by whether the worktree carries a stored PR number.
+    /// Numbered entries resolve via a direct `pullRequest(number:)` lookup (the
+    /// only way to reach a fork PR, whose head never appears in the viewer batch);
+    /// the rest fall through to the legacy viewer-authored branch-name matching.
+    static func partitionByPRNumber<T>(_ items: [T], prNumber: (T) -> Int?) -> (numbered: [T], unnumbered: [T]) {
+        var numbered: [T] = []
+        var unnumbered: [T] = []
+        for item in items {
+            if prNumber(item) != nil { numbered.append(item) } else { unnumbered.append(item) }
+        }
+        return (numbered, unnumbered)
+    }
+
+    /// Build the branch → best-PR lookup used by the legacy (unnumbered) path.
+    /// When multiple PRs share a branch, pick the best: highest state priority
+    /// (OPEN > MERGED > CLOSED), then newest `createdAt` within the same state.
+    static func bestNodeByBranch(_ nodes: [PRNode]) -> [String: PRNode] {
+        var byBranch: [String: PRNode] = [:]
+        for node in nodes {
+            if let existing = byBranch[node.headRefName] {
+                let nodePriority = prPriority(node.state)
+                let existingPriority = prPriority(existing.state)
+                if nodePriority > existingPriority {
+                    byBranch[node.headRefName] = node
+                } else if nodePriority == existingPriority && node.createdAt > existing.createdAt {
+                    byBranch[node.headRefName] = node
+                }
+            } else {
+                byBranch[node.headRefName] = node
+            }
+        }
+        return byBranch
+    }
+
+    /// The per-PR field selection shared by the viewer batch and the by-number
+    /// aliased query, so the two can't drift and both parse into `PRNode`.
+    static let prNodeFieldSelection =
+        "number url state mergeStateStatus reviewDecision headRefName createdAt isDraft "
+        + "statusCheckRollup { state } mergeQueueEntry { position }"
+
+    /// One aliased query resolving several worktrees' stored PR numbers in a
+    /// single round trip: `pr0: pullRequest(number: 454) { … }` etc. under the
+    /// repo object. Numbers are Int literals (injection-safe); `owner`/`name`
+    /// are GraphQL variables bound at the call site.
+    static func numberedPRQuery(aliases: [(alias: String, number: Int)]) -> String {
+        let selections = aliases
+            .map { "\($0.alias): pullRequest(number: \($0.number)) { \(prNodeFieldSelection) }" }
+            .joined(separator: "\n    ")
+        return """
+        query($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) {
+            \(selections)
+          }
+        }
+        """
+    }
+
+    /// Pure parse of the by-number aliased response. Each alias maps to a
+    /// worktree; a null/absent `pullRequest` (deleted or inaccessible PR) or a
+    /// malformed shape yields no match for that worktree — never a crash.
+    static func parseNumberedPRNodes(from data: Data, aliases: [(alias: String, worktreeID: UUID)]) -> [(worktreeID: UUID, node: PRNode)] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = root["data"] as? [String: Any],
+              let repository = dataObj["repository"] as? [String: Any] else {
+            logger.debug("fetchAll: malformed by-number GraphQL response, resolving no numbered worktrees")
+            return []
+        }
+        return aliases.compactMap { alias, worktreeID in
+            guard let prObj = repository[alias] as? [String: Any],
+                  let node = prNode(from: prObj) else { return nil }
+            return (worktreeID, node)
+        }
+    }
+
     public static func parsePRNodes(from data: Data) throws -> [PRNode] {
         guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataObj = root["data"] as? [String: Any],
@@ -607,30 +679,34 @@ public actor PRStatusManager {
             throw PRStatusError.invalidJSON
         }
 
-        return nodes.compactMap { $0 as? [String: Any] }.compactMap { node -> PRNode? in
-            guard let number = node["number"] as? Int,
-                  let url = node["url"] as? String,
-                  let state = node["state"] as? String,
-                  let mergeStateStatus = node["mergeStateStatus"] as? String,
-                  let headRefName = node["headRefName"] as? String,
-                  let createdAt = node["createdAt"] as? String else { return nil }
-            let reviewDecision = node["reviewDecision"] as? String ?? ""
-            let isDraft = node["isDraft"] as? Bool ?? false
-            let statusCheckRollup = node["statusCheckRollup"] as? [String: Any]
-            let statusCheckRollupState = statusCheckRollup?["state"] as? String
-            // A null/absent mergeQueueEntry (not queued) yields nil; only a real
-            // entry carrying an Int position gates the bus icon.
-            let mergeQueueEntry = node["mergeQueueEntry"] as? [String: Any]
-            let mergeQueuePosition = mergeQueueEntry?["position"] as? Int
-            return PRNode(number: number, url: url, state: state,
-                          mergeStateStatus: mergeStateStatus,
-                          reviewDecision: reviewDecision,
-                          headRefName: headRefName,
-                          createdAt: createdAt,
-                          isDraft: isDraft,
-                          statusCheckRollupState: statusCheckRollupState,
-                          mergeQueuePosition: mergeQueuePosition)
-        }
+        return nodes.compactMap { $0 as? [String: Any] }.compactMap(prNode(from:))
+    }
+
+    /// Extract one `PRNode` from a GraphQL PR object, shared by the viewer-batch
+    /// parse and the by-number parse (same `prNodeFieldSelection`).
+    static func prNode(from node: [String: Any]) -> PRNode? {
+        guard let number = node["number"] as? Int,
+              let url = node["url"] as? String,
+              let state = node["state"] as? String,
+              let mergeStateStatus = node["mergeStateStatus"] as? String,
+              let headRefName = node["headRefName"] as? String,
+              let createdAt = node["createdAt"] as? String else { return nil }
+        let reviewDecision = node["reviewDecision"] as? String ?? ""
+        let isDraft = node["isDraft"] as? Bool ?? false
+        let statusCheckRollup = node["statusCheckRollup"] as? [String: Any]
+        let statusCheckRollupState = statusCheckRollup?["state"] as? String
+        // A null/absent mergeQueueEntry (not queued) yields nil; only a real
+        // entry carrying an Int position gates the bus icon.
+        let mergeQueueEntry = node["mergeQueueEntry"] as? [String: Any]
+        let mergeQueuePosition = mergeQueueEntry?["position"] as? Int
+        return PRNode(number: number, url: url, state: state,
+                      mergeStateStatus: mergeStateStatus,
+                      reviewDecision: reviewDecision,
+                      headRefName: headRefName,
+                      createdAt: createdAt,
+                      isDraft: isDraft,
+                      statusCheckRollupState: statusCheckRollupState,
+                      mergeQueuePosition: mergeQueuePosition)
     }
 
     /// Pure parse of the `repo.listOpenPRs` GraphQL response
@@ -761,17 +837,47 @@ public actor PRStatusManager {
         return (owner: String(parts[0]), name: String(parts[1]))
     }
 
+    /// Resolve stored PR numbers directly via one aliased `pullRequest(number:)`
+    /// query — the only way to reach a fork PR, whose head branch never appears
+    /// in the viewer-authored batch. Degrades to no matches on any failure
+    /// (owner/name unresolved, gh missing, non-zero exit, unparseable); the
+    /// caller keeps prior cached status for those worktrees.
+    private nonisolated func fetchNumberedMatches(
+        _ numbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)],
+        repoPath: String
+    ) async -> [(worktreeID: UUID, node: PRNode)] {
+        guard let ownerRepo = await resolveNameWithOwner(repoPath: repoPath) else {
+            logger.debug("fetchAll: could not resolve owner/name for numbered PRs at \(repoPath, privacy: .public)")
+            return []
+        }
+        let entries: [(alias: String, number: Int, worktreeID: UUID)] = numbered.enumerated().compactMap { index, wt in
+            guard let number = wt.prNumber else { return nil }
+            return (alias: "pr\(index)", number: number, worktreeID: wt.id)
+        }
+        guard !entries.isEmpty else { return [] }
+        let query = Self.numberedPRQuery(aliases: entries.map { ($0.alias, $0.number) })
+        let args = [
+            "api", "graphql",
+            "-f", "query=\(query)",
+            "-f", "owner=\(ownerRepo.owner)",
+            "-f", "name=\(ownerRepo.name)"
+        ]
+        guard let result = await runGHResult(args: args, repoPath: repoPath),
+              result.exitStatus == 0,
+              let data = Self.graphQLOutputData(stdout: result.stdout) else {
+            logger.debug("fetchAll: by-number query failed for numbered PRs at \(repoPath, privacy: .public)")
+            return []
+        }
+        return Self.parseNumberedPRNodes(from: data, aliases: entries.map { ($0.alias, $0.worktreeID) })
+    }
+
     private nonisolated func runGHGraphQL(repoPath: String) async -> Data? {
         let query = """
         {
           viewer {
             pullRequests(first: 100, states: [OPEN, MERGED, CLOSED],
                          orderBy: {field: CREATED_AT, direction: DESC}) {
-              nodes {
-                number url state mergeStateStatus reviewDecision headRefName createdAt isDraft
-                statusCheckRollup { state }
-                mergeQueueEntry { position }
-              }
+              nodes { \(Self.prNodeFieldSelection) }
             }
           }
         }

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -633,6 +633,79 @@ public actor PRStatusManager {
         }
     }
 
+    /// Pure parse of the `repo.listOpenPRs` GraphQL response
+    /// (`openPRsQuery`). Never throws — any malformed/unexpected shape
+    /// (network hiccup, schema drift, truncated output) degrades to an
+    /// empty list with a `.debug` log line, matching the RPC's own
+    /// never-error-just-degrade contract (spec §1).
+    public static func parseOpenPRNodes(from data: Data) -> [OpenPRInfo] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataObj = root["data"] as? [String: Any],
+              let repository = dataObj["repository"] as? [String: Any],
+              let prs = repository["pullRequests"] as? [String: Any],
+              let nodes = prs["nodes"] as? [Any] else {
+            logger.debug("listOpenPRs: malformed GraphQL response, returning empty list")
+            return []
+        }
+
+        if nodes.count >= 100 {
+            logger.debug("listOpenPRs: hit the 100-PR page cap; list may be truncated")
+        }
+
+        return nodes.compactMap { $0 as? [String: Any] }.compactMap { node -> OpenPRInfo? in
+            guard let number = node["number"] as? Int,
+                  let title = node["title"] as? String,
+                  let headRefName = node["headRefName"] as? String else { return nil }
+            let isDraft = node["isDraft"] as? Bool ?? false
+            let isCrossRepository = node["isCrossRepository"] as? Bool ?? false
+            let headOwner = (node["headRepositoryOwner"] as? [String: Any])?["login"] as? String ?? ""
+            return OpenPRInfo(number: number, title: title, headRefName: headRefName,
+                              headOwner: headOwner, isCrossRepository: isCrossRepository, isDraft: isDraft)
+        }
+    }
+
+    /// Repo-scoped query for `repo.listOpenPRs`: every OPEN PR (own, teammates',
+    /// fork), newest-updated first, capped at one page of 100 (spec §1 non-goal:
+    /// no pagination in v1).
+    static func openPRsQuery() -> String {
+        """
+        query($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) {
+            pullRequests(states: [OPEN], first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
+              nodes { number title headRefName isDraft isCrossRepository headRepositoryOwner { login } }
+            }
+          }
+        }
+        """
+    }
+
+    /// Fetch all open PRs for the repo at `repoPath` (`repo.listOpenPRs` RPC).
+    /// Every failure path (gh missing, unauthenticated/offline, non-zero exit,
+    /// unparseable response) degrades to `[]` with a `.debug` log — never
+    /// throws, matching the picker's "PR data is best-effort" contract.
+    public nonisolated func fetchOpenPRs(repoPath: String) async -> [OpenPRInfo] {
+        guard let ownerRepo = await resolveNameWithOwner(repoPath: repoPath) else {
+            logger.debug("listOpenPRs: could not resolve owner/name for \(repoPath, privacy: .public)")
+            return []
+        }
+        let args = [
+            "api", "graphql",
+            "-f", "query=\(Self.openPRsQuery())",
+            "-f", "owner=\(ownerRepo.owner)",
+            "-f", "name=\(ownerRepo.name)"
+        ]
+        guard let result = await runGHResult(args: args, repoPath: repoPath) else {
+            logger.debug("listOpenPRs: gh did not launch for \(repoPath, privacy: .public)")
+            return []
+        }
+        guard result.exitStatus == 0, let data = Self.graphQLOutputData(stdout: result.stdout) else {
+            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            logger.debug("listOpenPRs: gh graphql exited \(result.exitStatus, privacy: .public): \(errSuffix, privacy: .public)")
+            return []
+        }
+        return Self.parseOpenPRNodes(from: data)
+    }
+
     /// Parse the single-PR refresh response (`prByBranchQuery`).
     ///
     /// Walks `data.repository.pullRequests.nodes` and returns the best node —

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -190,10 +190,24 @@ extension RPCRouter {
         }
 
         let prs = await prManager.fetchOpenPRs(repoPath: repo.path)
-        let inUse = Set((try? await git.worktreeList(repoPath: repo.path))?.map(\.branch).filter { !$0.isEmpty } ?? [])
-        let filtered = prs.filter { !inUse.contains($0.headRefName) }
+        let inUseBranches = Set((try? await git.worktreeList(repoPath: repo.path))?.map(\.branch).filter { !$0.isEmpty } ?? [])
+        // A PR head fetched into a uniquified/renamed local branch (e.g. head
+        // "foo" checked out as "foo-2") no longer matches by head name, but the
+        // worktree row carries the PR number — filter on that too.
+        let inUsePRNumbers = Set((try? await db.worktrees.list(repoID: repo.id, status: .active))?.compactMap(\.prNumber) ?? [])
+        let filtered = Self.filterOpenPRsNotInUse(prs, inUseBranches: inUseBranches, inUsePRNumbers: inUsePRNumbers)
 
         return try RPCResponse(result: RepoListOpenPRsResult(prs: filtered))
+    }
+
+    /// Drop PRs already checked out in a worktree — by head branch name OR by a
+    /// number stamped on an active worktree row (covers a PR whose head was
+    /// fetched under a uniquified local branch, whose name no longer matches).
+    /// Pure so it's unit-testable without git/gh/db.
+    static func filterOpenPRsNotInUse(
+        _ prs: [OpenPRInfo], inUseBranches: Set<String>, inUsePRNumbers: Set<Int>
+    ) -> [OpenPRInfo] {
+        prs.filter { !inUseBranches.contains($0.headRefName) && !inUsePRNumbers.contains($0.number) }
     }
 
     func handleRepoRename(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -178,6 +178,24 @@ extension RPCRouter {
         return try RPCResponse(result: RepoListBranchesResult(branches: branches))
     }
 
+    /// Repo-scoped open-PR list for the branch picker (spec §1). Degrades to an
+    /// empty list rather than an RPC error on any `gh`/GraphQL failure — see
+    /// `PRStatusManager.fetchOpenPRs`. Drops PRs already checked out in a
+    /// worktree, mirroring `listBranches`' in-use filter.
+    func handleRepoListOpenPRs(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(RepoListOpenPRsParams.self, from: paramsData)
+
+        guard let repo = try await db.repos.get(id: params.repoID) else {
+            return RPCResponse(error: "Repository not found: \(params.repoID)")
+        }
+
+        let prs = await prManager.fetchOpenPRs(repoPath: repo.path)
+        let inUse = Set((try? await git.worktreeList(repoPath: repo.path))?.map(\.branch).filter { !$0.isEmpty } ?? [])
+        let filtered = prs.filter { !inUse.contains($0.headRefName) }
+
+        return try RPCResponse(result: RepoListOpenPRsResult(prs: filtered))
+    }
+
     func handleRepoRename(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(RepoRenameParams.self, from: paramsData)
 

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -193,8 +193,14 @@ extension RPCRouter {
         let inUseBranches = Set((try? await git.worktreeList(repoPath: repo.path))?.map(\.branch).filter { !$0.isEmpty } ?? [])
         // A PR head fetched into a uniquified/renamed local branch (e.g. head
         // "foo" checked out as "foo-2") no longer matches by head name, but the
-        // worktree row carries the PR number — filter on that too.
-        let inUsePRNumbers = Set((try? await db.worktrees.list(repoID: repo.id, status: .active))?.compactMap(\.prNumber) ?? [])
+        // worktree row carries the PR number — filter on that too. Use
+        // excludeArchived (not status: .active) so a worktree still
+        // `.creating` — several seconds of tmux/terminal spawn — still counts
+        // as in-use; otherwise its PR is selectable again during that window,
+        // letting a second worktree land on the same PR (matches the
+        // "globalLiveRows" excludeArchived convention in
+        // WorktreeLifecycle+Reconcile.swift).
+        let inUsePRNumbers = Set((try? await db.worktrees.list(repoID: repo.id, excludeArchived: true))?.compactMap(\.prNumber) ?? [])
         let filtered = Self.filterOpenPRsNotInUse(prs, inUseBranches: inUseBranches, inUsePRNumbers: inUsePRNumbers)
 
         return try RPCResponse(result: RepoListOpenPRsResult(prs: filtered))

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -209,11 +209,18 @@ extension RPCRouter {
     /// Drop PRs already checked out in a worktree — by head branch name OR by a
     /// number stamped on an active worktree row (covers a PR whose head was
     /// fetched under a uniquified local branch, whose name no longer matches).
-    /// Pure so it's unit-testable without git/gh/db.
+    /// The branch-name check applies only to same-repo PRs: a fork PR's head
+    /// branch lives in the contributor's namespace, so a name matching a
+    /// checked-out origin branch (e.g. a fork PR opened off "main") is
+    /// coincidental, not the same ref — only the stored-PR-number check
+    /// applies to fork PRs. Pure so it's unit-testable without git/gh/db.
     static func filterOpenPRsNotInUse(
         _ prs: [OpenPRInfo], inUseBranches: Set<String>, inUsePRNumbers: Set<Int>
     ) -> [OpenPRInfo] {
-        prs.filter { !inUseBranches.contains($0.headRefName) && !inUsePRNumbers.contains($0.number) }
+        prs.filter { pr in
+            let branchInUse = !pr.isCrossRepository && inUseBranches.contains(pr.headRefName)
+            return !branchInUse && !inUsePRNumbers.contains(pr.number)
+        }
     }
 
     func handleRepoRename(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -22,7 +22,8 @@ extension RPCRouter {
             siblingOfWorktreeID: params.siblingOfWorktreeID,
             callerWorktreeID: params.callerWorktreeID,
             suppressAutoParent: params.suppressAutoParent ?? false,
-            useExistingBranch: useExistingBranch
+            useExistingBranch: useExistingBranch,
+            prNumber: params.prNumber
         )
 
         // Phase 1.5: Fetch from origin (coalesced, with tight timeout)

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -55,6 +55,9 @@ extension RPCRouter {
         // Pass the raw branch ref (possibly `origin/...`) to phase 2 so it
         // can dispatch to the right git command.
         let existingBranchRef = useExistingBranch ? params.branch : nil
+        // Fork-PR rows opt into the refs/pull/<n>/head fetch; decorated
+        // same-repo rows leave this false and check out the existing branch.
+        let checkoutPRHead = params.checkoutPRHead ?? false
         // Explicit per-creation model-profile override (sidebar `+` picker).
         // nil preserves the repo/scratch/global precedence chain.
         let overrideProfileID = params.profileID
@@ -71,7 +74,7 @@ extension RPCRouter {
                 // fetch from phase 1.5, or is a no-op if cached within the 60s TTL.
                 await fetchCache.fetchIfNeeded(repoPath: repoPath, branch: defaultBranch)
 
-                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, overrideProfileID: overrideProfileID, claudeSettingsOverlay: claudeSettingsOverlay)
+                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, checkoutPRHead: checkoutPRHead, overrideProfileID: overrideProfileID, claudeSettingsOverlay: claudeSettingsOverlay)
                 switch completion {
                 case .ready:
                     subs.broadcast(delta: .worktreeCreated(WorktreeDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -424,7 +424,7 @@ public final class RPCRouter: Sendable {
     private func computePRList() async throws -> PRListResult {
         // Fetch fresh PR data for all active worktrees before returning the cache.
         let worktrees = Self.pollableWorktrees(try await db.worktrees.list(status: .active))
-        var infos: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String)] = []
+        var infos: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] = []
         infos.reserveCapacity(worktrees.count)
         for wt in worktrees {
             // Route the per-worktree `git config` lookup through the TTL cache
@@ -439,7 +439,8 @@ public final class RPCRouter: Sendable {
                 id: wt.id,
                 branch: wt.branch,
                 upstreamBranch: upstreamBranch,
-                worktreePath: wt.path
+                worktreePath: wt.path,
+                prNumber: wt.prNumber
             ))
         }
         await prManager.fetchAll(worktrees: infos)

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -473,7 +473,8 @@ public final class RPCRouter: Sendable {
             worktreeID: wt.id,
             branch: wt.branch,
             upstreamBranch: upstreamBranch,
-            repoPath: wt.path
+            repoPath: wt.path,
+            prNumber: wt.prNumber
         )
         return try RPCResponse(result: PRRefreshResult(status: status))
     }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -164,6 +164,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRepoSetExpanded(request.paramsData)
             case RPCMethod.repoListBranches:
                 return try await handleRepoListBranches(request.paramsData)
+            case RPCMethod.repoListOpenPRs:
+                return try await handleRepoListOpenPRs(request.paramsData)
             case RPCMethod.worktreeCreate:
                 return try await handleWorktreeCreate(request.paramsData)
             case RPCMethod.worktreeList:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -152,6 +152,12 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// Set only on promoted scratch rows: the repo created by `tbd scratch promote`.
     public var promotedToRepoID: UUID?
 
+    /// Number of the GitHub PR this worktree was created from, if any. `nil` for
+    /// worktrees created from a plain branch. Lets `PRStatusManager` resolve
+    /// status by direct number lookup — the only way fork PRs (no matching
+    /// local branch) get tracked.
+    public var prNumber: Int?
+
     /// A scratch space is a repo-less worktree. Derived — no separate column.
     public var isScratch: Bool { repoID == nil }
 
@@ -172,7 +178,8 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 autoArchiveOnMerge: Bool? = nil,
                 autoHibernateOnMerge: Bool? = nil,
                 promotedToRepoID: UUID? = nil,
-                prStatus: PRStatus? = nil) {
+                prStatus: PRStatus? = nil,
+                prNumber: Int? = nil) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -193,6 +200,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.autoHibernateOnMerge = autoHibernateOnMerge
         self.promotedToRepoID = promotedToRepoID
         self.prStatus = prStatus
+        self.prNumber = prNumber
     }
 
     enum CodingKeys: String, CodingKey {
@@ -201,7 +209,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         case archivedClaudeSessions, sortOrder, archivedHeadSHA
         case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge
         case autoHibernateOnMerge
-        case promotedToRepoID, prStatus
+        case promotedToRepoID, prStatus, prNumber
     }
 
     public init(from decoder: Decoder) throws {
@@ -226,6 +234,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         autoHibernateOnMerge = try c.decodeIfPresent(Bool.self, forKey: .autoHibernateOnMerge)
         promotedToRepoID = try c.decodeIfPresent(UUID.self, forKey: .promotedToRepoID)
         prStatus = try c.decodeIfPresent(PRStatus.self, forKey: .prStatus)
+        prNumber = try c.decodeIfPresent(Int.self, forKey: .prNumber)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -178,6 +178,7 @@ public enum RPCMethod {
     public static let worktreeSetActiveTab = "worktree.setActiveTab"
     public static let appearanceUpdateColorFgBg = "appearance.updateColorFgBg"
     public static let repoListBranches = "repo.listBranches"
+    public static let repoListOpenPRs = "repo.listOpenPRs"
     public static let configSetEnvOverrides       = "config.setEnvOverrides"
     public static let repoSetEnvOverrides         = "repo.setEnvOverrides"
     public static let modelProfileSetEnvOverrides = "modelProfile.setEnvOverrides"
@@ -236,6 +237,39 @@ public struct RepoListBranchesParams: Codable, Sendable {
 public struct RepoListBranchesResult: Codable, Sendable {
     public let branches: [BranchInfo]
     public init(branches: [BranchInfo]) { self.branches = branches }
+}
+
+// MARK: - Open PR Listing
+
+/// One open PR on a repo, for the `repo.listOpenPRs` RPC (branch picker).
+public struct OpenPRInfo: Codable, Sendable, Equatable, Identifiable {
+    public let number: Int
+    public let title: String
+    public let headRefName: String
+    public let headOwner: String        // headRepositoryOwner.login; "" if absent
+    public let isCrossRepository: Bool
+    public let isDraft: Bool
+    public var id: Int { number }
+
+    public init(number: Int, title: String, headRefName: String, headOwner: String,
+                isCrossRepository: Bool, isDraft: Bool) {
+        self.number = number
+        self.title = title
+        self.headRefName = headRefName
+        self.headOwner = headOwner
+        self.isCrossRepository = isCrossRepository
+        self.isDraft = isDraft
+    }
+}
+
+public struct RepoListOpenPRsParams: Codable, Sendable {
+    public let repoID: UUID
+    public init(repoID: UUID) { self.repoID = repoID }
+}
+
+public struct RepoListOpenPRsResult: Codable, Sendable {
+    public let prs: [OpenPRInfo]
+    public init(prs: [OpenPRInfo]) { self.prs = prs }
 }
 
 // MARK: - Legacy Hook Detection / Removal

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -861,13 +861,21 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// passthrough — TBD does not interpret the contents. Optional/defaulted for
     /// backward compatibility (old daemons ignore the unknown key; old clients omit it).
     public let claudeSettingsOverlay: String?
-    /// GitHub PR number this worktree is being created from. Set (together with
-    /// `useExistingBranch == true`) when the picker checks out a PR: the daemon
-    /// fetches `refs/pull/<n>/head` into a local branch and stamps the number on
-    /// the row so `PRStatusManager` tracks it by number. Optional/defaulted for
-    /// backward compatibility (old daemons ignore the unknown key; old clients omit it).
+    /// GitHub PR number this worktree is being created from. Stamped on the row
+    /// (with `useExistingBranch == true`) so `PRStatusManager` tracks it by
+    /// number — set for BOTH decorated same-repo rows and fork rows.
+    /// Optional/defaulted for backward compatibility (old daemons ignore the
+    /// unknown key; old clients omit it).
     public let prNumber: Int?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil) {
+    /// When true, the daemon fetches `refs/pull/<prNumber>/head` into a fresh
+    /// local branch and checks THAT out (fork PRs, whose head has no local
+    /// ref). When false/omitted, `branch` is checked out via the plain
+    /// existing-branch path even if `prNumber` is set — this is the decorated
+    /// same-repo row, which must behave exactly like picking that branch today.
+    /// `prNumber` alone can't disambiguate: a fork head name may coincide with
+    /// an unrelated local branch. Optional/defaulted for backward compatibility.
+    public let checkoutPRHead: Bool?
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
         self.parentWorktreeID = parentWorktreeID
@@ -878,6 +886,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
         self.profileID = profileID
         self.claudeSettingsOverlay = claudeSettingsOverlay
         self.prNumber = prNumber
+        self.checkoutPRHead = checkoutPRHead
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -861,7 +861,13 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// passthrough — TBD does not interpret the contents. Optional/defaulted for
     /// backward compatibility (old daemons ignore the unknown key; old clients omit it).
     public let claudeSettingsOverlay: String?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, claudeSettingsOverlay: String? = nil) {
+    /// GitHub PR number this worktree is being created from. Set (together with
+    /// `useExistingBranch == true`) when the picker checks out a PR: the daemon
+    /// fetches `refs/pull/<n>/head` into a local branch and stamps the number on
+    /// the row so `PRStatusManager` tracks it by number. Optional/defaulted for
+    /// backward compatibility (old daemons ignore the unknown key; old clients omit it).
+    public let prNumber: Int?
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
         self.parentWorktreeID = parentWorktreeID
@@ -871,6 +877,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
         self.useExistingBranch = useExistingBranch
         self.profileID = profileID
         self.claudeSettingsOverlay = claudeSettingsOverlay
+        self.prNumber = prNumber
     }
 }
 

--- a/Tests/TBDAppTests/BranchPickerMergeTests.swift
+++ b/Tests/TBDAppTests/BranchPickerMergeTests.swift
@@ -36,11 +36,32 @@ struct BranchPickerMergeTests {
         let prs = [pr(454, head: "show-weekly-reset", owner: "zionts", fork: true)]
         let items = mergePickerItems(branches: branches, prs: prs)
         #expect(items.count == 3)
-        // Order: local main, PR-only fork row, remote dev.
-        #expect(items[0].branch?.name == "main")
+        // PR-carrying rows float to the top: fork row first, then plain branches
+        // in their original relative order (main, then remote dev).
+        #expect(items[0].branch == nil)
+        #expect(items[0].pr?.number == 454)
+        #expect(items[1].branch?.name == "main")
+        #expect(items[2].branch?.name == "origin/dev")
+    }
+
+    @Test("PR-carrying rows float to the top, preserving relative order within each group")
+    func prRowsFloatToTop() {
+        let branches = [local("a"), local("b"), remote("dev")]
+        let prs = [
+            pr(200, head: "b", title: "b decoration"),
+            pr(454, head: "fork-head", owner: "zionts", fork: true)
+        ]
+        let items = mergePickerItems(branches: branches, prs: prs)
+        #expect(items.count == 4)
+        // pr != nil group first (decorated b, then fork row — original relative
+        // order preserved), then plain rows (a, then remote dev).
+        #expect(items[0].branch?.name == "b")
+        #expect(items[0].pr?.number == 200)
         #expect(items[1].branch == nil)
         #expect(items[1].pr?.number == 454)
-        #expect(items[2].branch?.name == "origin/dev")
+        #expect(items[2].branch?.name == "a")
+        #expect(items[2].pr == nil)
+        #expect(items[3].branch?.name == "origin/dev")
     }
 
     @Test("non-fork PR with no matching branch still gets its own row (unfetched head)")
@@ -49,8 +70,9 @@ struct BranchPickerMergeTests {
         let prs = [pr(77, head: "not-fetched-yet", fork: false)]
         let items = mergePickerItems(branches: branches, prs: prs)
         #expect(items.count == 2)
-        #expect(items.last?.branch == nil)
-        #expect(items.last?.pr?.number == 77)
+        // PR-carrying row floats to the top.
+        #expect(items.first?.branch == nil)
+        #expect(items.first?.pr?.number == 77)
     }
 
     @Test("two same-repo PRs on one head branch: one decorates, the other gets its own row")
@@ -85,8 +107,9 @@ struct BranchPickerMergeTests {
         let items = mergePickerItems(branches: branches, prs: prs)
         #expect(items.count == 2)
         #expect(items.first { $0.branch?.name == "main" }?.pr == nil)
-        #expect(items.last?.branch == nil)
-        #expect(items.last?.pr?.number == 9)
+        // PR-carrying row floats to the top even though it doesn't decorate "main".
+        #expect(items.first?.branch == nil)
+        #expect(items.first?.pr?.number == 9)
     }
 
     @Test("PR-only rows go before remotes even with no local branches")

--- a/Tests/TBDAppTests/BranchPickerMergeTests.swift
+++ b/Tests/TBDAppTests/BranchPickerMergeTests.swift
@@ -1,0 +1,101 @@
+import Testing
+import TBDShared
+@testable import TBDApp
+
+/// Pure merge/dedup/filter logic for the branch picker's combined
+/// branches + open-PRs list. View-free so it can be unit-tested directly.
+@Suite("Branch picker merge/filter")
+struct BranchPickerMergeTests {
+    private func local(_ name: String) -> BranchInfo {
+        BranchInfo(name: name, localName: name, isRemote: false)
+    }
+    private func remote(_ name: String) -> BranchInfo {
+        BranchInfo(name: "origin/\(name)", localName: name, isRemote: true)
+    }
+    private func pr(_ number: Int, head: String, owner: String = "",
+                    fork: Bool = false, draft: Bool = false,
+                    title: String = "A title") -> OpenPRInfo {
+        OpenPRInfo(number: number, title: title, headRefName: head, headOwner: owner,
+                   isCrossRepository: fork, isDraft: draft)
+    }
+
+    @Test("same-repo PR decorates its matching branch row (no extra row)")
+    func sameRepoDecorates() {
+        let branches = [local("feature-x"), local("main")]
+        let prs = [pr(454, head: "feature-x", title: "Weekly reset")]
+        let items = mergePickerItems(branches: branches, prs: prs)
+        #expect(items.count == 2)
+        let decorated = items.first { $0.branch?.name == "feature-x" }
+        #expect(decorated?.pr?.number == 454)
+        #expect(items.first { $0.branch?.name == "main" }?.pr == nil)
+    }
+
+    @Test("fork PR appends a new row between local and remote branches")
+    func forkPRAppendedBetween() {
+        let branches = [local("main"), remote("dev")]
+        let prs = [pr(454, head: "show-weekly-reset", owner: "zionts", fork: true)]
+        let items = mergePickerItems(branches: branches, prs: prs)
+        #expect(items.count == 3)
+        // Order: local main, PR-only fork row, remote dev.
+        #expect(items[0].branch?.name == "main")
+        #expect(items[1].branch == nil)
+        #expect(items[1].pr?.number == 454)
+        #expect(items[2].branch?.name == "origin/dev")
+    }
+
+    @Test("non-fork PR with no matching branch still gets its own row (unfetched head)")
+    func nonForkNoMatchGetsRow() {
+        let branches = [local("main")]
+        let prs = [pr(77, head: "not-fetched-yet", fork: false)]
+        let items = mergePickerItems(branches: branches, prs: prs)
+        #expect(items.count == 2)
+        #expect(items.last?.branch == nil)
+        #expect(items.last?.pr?.number == 77)
+    }
+
+    @Test("fork PR whose head name coincides with a local branch does NOT decorate it")
+    func forkDoesNotDecorateCoincidentalLocal() {
+        let branches = [local("main")]
+        let prs = [pr(9, head: "main", fork: true, title: "fork from their main")]
+        let items = mergePickerItems(branches: branches, prs: prs)
+        #expect(items.count == 2)
+        #expect(items.first { $0.branch?.name == "main" }?.pr == nil)
+        #expect(items.last?.branch == nil)
+        #expect(items.last?.pr?.number == 9)
+    }
+
+    @Test("PR-only rows go before remotes even with no local branches")
+    func prOnlyBeforeRemotesNoLocals() {
+        let branches = [remote("dev")]
+        let prs = [pr(1, head: "fork-head", fork: true)]
+        let items = mergePickerItems(branches: branches, prs: prs)
+        #expect(items.count == 2)
+        #expect(items[0].branch == nil)
+        #expect(items[1].branch?.name == "origin/dev")
+    }
+
+    @Test("filter matches branch name, PR number, title word, and owner login")
+    func filterMatches() {
+        let branches = [local("feature-x")]
+        let prs = [pr(454, head: "show-weekly-reset", owner: "zionts", fork: true,
+                      title: "Show weekly reset")]
+        let items = mergePickerItems(branches: branches, prs: prs)
+        let forkRow = items.first { $0.pr?.number == 454 }!
+        let branchRow = items.first { $0.branch?.name == "feature-x" }!
+
+        #expect(matchesFilter(forkRow, query: "454"))
+        #expect(matchesFilter(forkRow, query: "weekly"))
+        #expect(matchesFilter(forkRow, query: "zionts"))
+        #expect(matchesFilter(branchRow, query: "feature"))
+        #expect(!matchesFilter(branchRow, query: "454"))
+    }
+
+    @Test("empty query returns all rows")
+    func emptyQueryAll() {
+        let branches = [local("main")]
+        let prs = [pr(1, head: "fork", fork: true)]
+        let items = mergePickerItems(branches: branches, prs: prs)
+        #expect(items.allSatisfy { matchesFilter($0, query: "") })
+        #expect(items.allSatisfy { matchesFilter($0, query: "   ") })
+    }
+}

--- a/Tests/TBDAppTests/BranchPickerMergeTests.swift
+++ b/Tests/TBDAppTests/BranchPickerMergeTests.swift
@@ -53,6 +53,31 @@ struct BranchPickerMergeTests {
         #expect(items.last?.pr?.number == 77)
     }
 
+    @Test("two same-repo PRs on one head branch: one decorates, the other gets its own row")
+    func twoSameRepoPRsSharingHeadBothSurface() {
+        // Same head branch, different base → two open PRs. The first decorates the
+        // branch row; the second must not vanish just because its head is a local
+        // branch name — it falls through to a PR-only row.
+        let branches = [local("feature-x"), local("main")]
+        let prs = [
+            pr(100, head: "feature-x", title: "feature-x → main"),
+            pr(101, head: "feature-x", title: "feature-x → release")
+        ]
+        let items = mergePickerItems(branches: branches, prs: prs)
+
+        // Two items involve "feature-x": the decorated branch row + the PR-only row.
+        let involving = items.filter { $0.branch?.localName == "feature-x" || $0.pr?.headRefName == "feature-x" }
+        #expect(involving.count == 2)
+
+        let decorated = items.first { $0.branch?.name == "feature-x" }
+        #expect(decorated?.pr?.number == 100)
+        let prOnly = items.first { $0.branch == nil && $0.pr != nil }
+        #expect(prOnly?.pr?.number == 101)
+
+        // PickerItem.id is branch name OR "pr-<number>", so no id collision.
+        #expect(Set(items.map(\.id)).count == items.count)
+    }
+
     @Test("fork PR whose head name coincides with a local branch does NOT decorate it")
     func forkDoesNotDecorateCoincidentalLocal() {
         let branches = [local("main")]

--- a/Tests/TBDDaemonTests/MigrationV54Tests.swift
+++ b/Tests/TBDDaemonTests/MigrationV54Tests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite struct MigrationV54Tests {
+
+    @Test func prNumberColumnExists() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.read { dbConn in
+            let columns = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(worktree)")
+            let names = columns.compactMap { $0["name"] as String? }
+            #expect(names.contains("pr_number"))
+        }
+    }
+
+    @Test func existingRowDecodesNilPRNumber() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/v54-\(UUID())", displayName: "v54", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v54-wt-\(UUID())", tmuxServer: "srv"
+        )
+        let fetched = try await db.worktrees.get(id: wt.id)
+        #expect(fetched?.prNumber == nil)
+    }
+
+    @Test func prNumberRoundTripsThroughDB() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/v54b-\(UUID())", displayName: "v54b", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w2", branch: "b2",
+            path: "/tmp/v54-wt2-\(UUID())", tmuxServer: "srv"
+        )
+        try await db.writerForTests.write { dbConn in
+            try dbConn.execute(
+                sql: "UPDATE worktree SET pr_number = ? WHERE id = ?",
+                arguments: [454, wt.id.uuidString]
+            )
+        }
+        let fetched = try await db.worktrees.get(id: wt.id)
+        #expect(fetched?.prNumber == 454)
+    }
+}

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -1152,4 +1152,111 @@ struct PRStatusManagerTests {
         let all = await manager.allStatuses()
         #expect(all[id] == merged)
     }
+
+    // MARK: - parseOpenPRNodes (repo.listOpenPRs)
+
+    @Test("parseOpenPRNodes parses a fork PR and a draft PR")
+    func parseOpenPRNodesHappyPath() {
+        let json = """
+        {
+          "data": {
+            "repository": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 454,
+                    "title": "Weekly reset job",
+                    "headRefName": "show-weekly-reset",
+                    "isDraft": false,
+                    "isCrossRepository": true,
+                    "headRepositoryOwner": { "login": "zionts" }
+                  },
+                  {
+                    "number": 12,
+                    "title": "WIP: refactor",
+                    "headRefName": "tbd/refactor",
+                    "isDraft": true,
+                    "isCrossRepository": false,
+                    "headRepositoryOwner": { "login": "acme" }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let prs = PRStatusManager.parseOpenPRNodes(from: json)
+        #expect(prs.count == 2)
+        #expect(prs[0].number == 454)
+        #expect(prs[0].title == "Weekly reset job")
+        #expect(prs[0].headRefName == "show-weekly-reset")
+        #expect(prs[0].headOwner == "zionts")
+        #expect(prs[0].isCrossRepository == true)
+        #expect(prs[0].isDraft == false)
+        #expect(prs[1].number == 12)
+        #expect(prs[1].isDraft == true)
+        #expect(prs[1].isCrossRepository == false)
+    }
+
+    @Test("parseOpenPRNodes returns empty for empty nodes")
+    func parseOpenPRNodesEmptyNodes() {
+        let json = """
+        {
+          "data": {
+            "repository": {
+              "pullRequests": {
+                "nodes": []
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let prs = PRStatusManager.parseOpenPRNodes(from: json)
+        #expect(prs.isEmpty)
+    }
+
+    @Test("parseOpenPRNodes returns empty for malformed JSON")
+    func parseOpenPRNodesMalformed() {
+        let json = "{ not valid json".data(using: .utf8)!
+        let prs = PRStatusManager.parseOpenPRNodes(from: json)
+        #expect(prs.isEmpty)
+    }
+
+    @Test("parseOpenPRNodes returns empty when the outer shape is missing repository")
+    func parseOpenPRNodesMissingRepository() {
+        let json = """
+        { "data": { "somethingElse": true } }
+        """.data(using: .utf8)!
+        let prs = PRStatusManager.parseOpenPRNodes(from: json)
+        #expect(prs.isEmpty)
+    }
+
+    @Test("parseOpenPRNodes defaults headOwner to empty string when headRepositoryOwner is absent")
+    func parseOpenPRNodesMissingHeadRepositoryOwner() {
+        let json = """
+        {
+          "data": {
+            "repository": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "title": "Same-repo PR",
+                    "headRefName": "tbd/same-repo",
+                    "isDraft": false,
+                    "isCrossRepository": false
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let prs = PRStatusManager.parseOpenPRNodes(from: json)
+        #expect(prs.count == 1)
+        #expect(prs[0].headOwner == "")
+    }
 }

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -1362,6 +1362,80 @@ struct PRStatusManagerTests {
         #expect(node?.number == 7)
     }
 
+    // MARK: - Partial-results tolerance (regression guard, PR #208)
+
+    @Test("parseOpenPRNodes yields nodes from a body carrying BOTH an errors array and valid data.repository")
+    func parseOpenPRNodesToleratesPartialErrors() {
+        // `gh api graphql` exits non-zero and includes `errors` when one node
+        // fails, yet still returns usable `data`. The parse must read the data
+        // regardless — the caller no longer bails on the non-zero exit.
+        let json = """
+        {
+          "errors": [
+            { "type": "NOT_FOUND", "message": "Could not resolve to a PullRequest." }
+          ],
+          "data": {
+            "repository": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 454,
+                    "title": "Weekly reset job",
+                    "headRefName": "show-weekly-reset",
+                    "isDraft": false,
+                    "isCrossRepository": true,
+                    "headRepositoryOwner": { "login": "zionts" }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let prs = PRStatusManager.parseOpenPRNodes(from: json)
+        #expect(prs.count == 1)
+        #expect(prs[0].number == 454)
+    }
+
+    @Test("parseNumberedPRNodes yields matches from a body carrying BOTH an errors array and valid data.repository")
+    func parseNumberedPRNodesToleratesPartialErrors() {
+        // One aliased PR errored (stale/deleted fork PR) → non-zero exit + errors,
+        // but the sibling aliases still carry usable nodes.
+        let wt = UUID()
+        let json = """
+        {
+          "errors": [
+            { "path": ["repository", "pr1"], "message": "Could not resolve to a PullRequest." }
+          ],
+          "data": {
+            "repository": {
+              "pr0": {
+                "number": 454,
+                "url": "https://github.com/acme/acme/pull/454",
+                "state": "OPEN",
+                "mergeStateStatus": "CLEAN",
+                "reviewDecision": "APPROVED",
+                "headRefName": "show-weekly-reset",
+                "createdAt": "2026-07-10T00:00:00Z",
+                "isDraft": false,
+                "statusCheckRollup": { "state": "SUCCESS" },
+                "mergeQueueEntry": { "position": 3 }
+              },
+              "pr1": null
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let matches = PRStatusManager.parseNumberedPRNodes(
+            from: json,
+            aliases: [(alias: "pr0", worktreeID: wt), (alias: "pr1", worktreeID: UUID())])
+        #expect(matches.count == 1)
+        #expect(matches.first?.worktreeID == wt)
+        #expect(matches.first?.node.number == 454)
+    }
+
     @Test("numberedPRQuery is brace-balanced and aliases each PR number")
     func numberedPRQueryBraceBalancedAndAliased() {
         let query = PRStatusManager.numberedPRQuery(aliases: [(alias: "pr0", number: 454), (alias: "pr1", number: 12)])

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -1259,4 +1259,117 @@ struct PRStatusManagerTests {
         #expect(prs.count == 1)
         #expect(prs[0].headOwner == "")
     }
+
+    // MARK: - Number-first path (fetchAll partition + by-number resolution)
+
+    @Test("partitionByPRNumber splits stored-number worktrees from the rest (both branches of the conditional)")
+    func partitionByPRNumberSplits() {
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let items: [(id: UUID, prNumber: Int?)] = [
+            (a, 454),   // numbered → by-number path
+            (b, nil),   // unnumbered → legacy branch-name path
+            (c, 12)     // numbered → by-number path
+        ]
+        let (numbered, unnumbered) = PRStatusManager.partitionByPRNumber(items) { $0.prNumber }
+        #expect(numbered.map { $0.id } == [a, c])
+        #expect(unnumbered.map { $0.id } == [b])
+    }
+
+    @Test("parseNumberedPRNodes resolves a numbered (fork) worktree from the by-number response")
+    func parseNumberedPRNodesResolvesForkPR() {
+        // The fork PR's head branch never appears in the viewer-authored batch;
+        // the stored number resolves it directly under its alias.
+        let wt = UUID()
+        let json = """
+        {
+          "data": {
+            "repository": {
+              "pr0": {
+                "number": 454,
+                "url": "https://github.com/acme/acme/pull/454",
+                "state": "OPEN",
+                "mergeStateStatus": "CLEAN",
+                "reviewDecision": "APPROVED",
+                "headRefName": "show-weekly-reset",
+                "createdAt": "2026-07-10T00:00:00Z",
+                "isDraft": false,
+                "statusCheckRollup": { "state": "SUCCESS" },
+                "mergeQueueEntry": { "position": 3 }
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let matches = PRStatusManager.parseNumberedPRNodes(from: json, aliases: [(alias: "pr0", worktreeID: wt)])
+        #expect(matches.count == 1)
+        #expect(matches.first?.worktreeID == wt)
+        #expect(matches.first?.node.number == 454)
+        #expect(matches.first?.node.headRefName == "show-weekly-reset")
+        #expect(matches.first?.node.mergeQueuePosition == 3)
+    }
+
+    @Test("parseNumberedPRNodes skips a null pullRequest (deleted/inaccessible PR) without crashing")
+    func parseNumberedPRNodesSkipsNullPullRequest() {
+        let wt = UUID()
+        let json = """
+        { "data": { "repository": { "pr0": null } } }
+        """.data(using: .utf8)!
+        let matches = PRStatusManager.parseNumberedPRNodes(from: json, aliases: [(alias: "pr0", worktreeID: wt)])
+        #expect(matches.isEmpty)
+    }
+
+    @Test("parseNumberedPRNodes returns empty for a malformed outer shape")
+    func parseNumberedPRNodesMalformed() {
+        let matches = PRStatusManager.parseNumberedPRNodes(
+            from: "{ not json".data(using: .utf8)!,
+            aliases: [(alias: "pr0", worktreeID: UUID())])
+        #expect(matches.isEmpty)
+    }
+
+    @Test("unnumbered worktree still resolves via the legacy viewer-authored branch match (regression)")
+    func unnumberedResolvesViaLegacyBranchMatch() throws {
+        // The viewer batch carries a node for the worktree's branch; a worktree
+        // with no stored number must still match it exactly as before.
+        let json = """
+        {
+          "data": {
+            "viewer": {
+              "pullRequests": {
+                "nodes": [
+                  {
+                    "number": 7,
+                    "url": "https://github.com/acme/acme/pull/7",
+                    "state": "OPEN",
+                    "mergeStateStatus": "CLEAN",
+                    "reviewDecision": "APPROVED",
+                    "headRefName": "feature-x",
+                    "createdAt": "2026-07-01T00:00:00Z",
+                    "isDraft": false,
+                    "statusCheckRollup": { "state": "SUCCESS" }
+                  }
+                ]
+              }
+            }
+          }
+        }
+        """.data(using: .utf8)!
+
+        let nodes = try PRStatusManager.parsePRNodes(from: json)
+        let byBranch = PRStatusManager.bestNodeByBranch(nodes)
+        let candidates = PRStatusManager.branchCandidates(localBranch: "feature-x", upstreamBranch: nil)
+        let node = candidates.compactMap { byBranch[$0] }.first
+        #expect(node?.number == 7)
+    }
+
+    @Test("numberedPRQuery is brace-balanced and aliases each PR number")
+    func numberedPRQueryBraceBalancedAndAliased() {
+        let query = PRStatusManager.numberedPRQuery(aliases: [(alias: "pr0", number: 454), (alias: "pr1", number: 12)])
+        let opens = query.filter { $0 == "{" }.count
+        let closes = query.filter { $0 == "}" }.count
+        #expect(opens == closes, "unbalanced braces (\(opens) open vs \(closes) close) in: \(query)")
+        #expect(query.contains("pr0: pullRequest(number: 454)"))
+        #expect(query.contains("pr1: pullRequest(number: 12)"))
+        #expect(query.contains("repository(owner: $owner, name: $name)"))
+    }
 }

--- a/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
@@ -283,4 +283,38 @@ extension RPCRouterTests {
         #expect(!response.success)
         #expect(response.error?.contains("Unknown method") == true)
     }
+
+    // MARK: - repo.listOpenPRs in-use filter
+
+    private func openPR(_ number: Int, head: String) -> OpenPRInfo {
+        OpenPRInfo(number: number, title: "PR \(number)", headRefName: head,
+                   headOwner: "acme", isCrossRepository: false, isDraft: false)
+    }
+
+    @Test("filterOpenPRsNotInUse drops a PR whose number is stamped on a worktree even when branch names differ")
+    func filterOpenPRsDropsByStoredNumber() {
+        // The PR head was fetched under a uniquified local branch ("feature-2"),
+        // so its head name ("feature") is NOT in the in-use branch set, but the
+        // worktree row carries PR #42 — the number filter must still drop it.
+        let prs = [openPR(42, head: "feature"), openPR(43, head: "other")]
+        let filtered = RPCRouter.filterOpenPRsNotInUse(
+            prs, inUseBranches: ["feature-2"], inUsePRNumbers: [42])
+        #expect(filtered.map(\.number) == [43])
+    }
+
+    @Test("filterOpenPRsNotInUse still drops a PR by matching head branch name")
+    func filterOpenPRsDropsByBranchName() {
+        let prs = [openPR(42, head: "feature"), openPR(43, head: "other")]
+        let filtered = RPCRouter.filterOpenPRsNotInUse(
+            prs, inUseBranches: ["feature"], inUsePRNumbers: [])
+        #expect(filtered.map(\.number) == [43])
+    }
+
+    @Test("filterOpenPRsNotInUse keeps PRs that are neither checked out nor stamped")
+    func filterOpenPRsKeepsFree() {
+        let prs = [openPR(42, head: "feature"), openPR(43, head: "other")]
+        let filtered = RPCRouter.filterOpenPRsNotInUse(
+            prs, inUseBranches: ["unrelated"], inUsePRNumbers: [99])
+        #expect(filtered.map(\.number) == [42, 43])
+    }
 }

--- a/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
@@ -286,9 +286,9 @@ extension RPCRouterTests {
 
     // MARK: - repo.listOpenPRs in-use filter
 
-    private func openPR(_ number: Int, head: String) -> OpenPRInfo {
+    private func openPR(_ number: Int, head: String, fork: Bool = false) -> OpenPRInfo {
         OpenPRInfo(number: number, title: "PR \(number)", headRefName: head,
-                   headOwner: "acme", isCrossRepository: false, isDraft: false)
+                   headOwner: "acme", isCrossRepository: fork, isDraft: false)
     }
 
     @Test("filterOpenPRsNotInUse drops a PR whose number is stamped on a worktree even when branch names differ")
@@ -316,5 +316,31 @@ extension RPCRouterTests {
         let filtered = RPCRouter.filterOpenPRsNotInUse(
             prs, inUseBranches: ["unrelated"], inUsePRNumbers: [99])
         #expect(filtered.map(\.number) == [42, 43])
+    }
+
+    @Test("filterOpenPRsNotInUse keeps a fork PR whose head name coincidentally matches an in-use branch")
+    func filterOpenPRsKeepsForkWithMatchingBranchName() {
+        // Fork PR head lives in the contributor's namespace, not origin's — a
+        // same-named checked-out branch is a coincidence, not the same ref.
+        let prs = [openPR(42, head: "main", fork: true)]
+        let filtered = RPCRouter.filterOpenPRsNotInUse(
+            prs, inUseBranches: ["main"], inUsePRNumbers: [])
+        #expect(filtered.map(\.number) == [42])
+    }
+
+    @Test("filterOpenPRsNotInUse still drops a fork PR by stored PR number")
+    func filterOpenPRsDropsForkByStoredNumber() {
+        let prs = [openPR(42, head: "main", fork: true)]
+        let filtered = RPCRouter.filterOpenPRsNotInUse(
+            prs, inUseBranches: ["main"], inUsePRNumbers: [42])
+        #expect(filtered.map(\.number) == [])
+    }
+
+    @Test("filterOpenPRsNotInUse still drops a same-repo PR by matching head branch name")
+    func filterOpenPRsDropsSameRepoByBranchName() {
+        let prs = [openPR(42, head: "feature", fork: false)]
+        let filtered = RPCRouter.filterOpenPRsNotInUse(
+            prs, inUseBranches: ["feature"], inUsePRNumbers: [])
+        #expect(filtered.map(\.number) == [])
     }
 }

--- a/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
+++ b/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
@@ -42,6 +42,24 @@ import Testing
         return (cloneTempDir, cloneRepoDir, prSHA)
     }
 
+    /// `localBranchExists` gates the force-refspec in `fetchPullRequestHead`,
+    /// so it must fail CLOSED: only the benign "ref missing" exit-1 case may
+    /// return `false`. A non-exit-1 failure (here: `show-ref` run inside a
+    /// plain, non-git directory exits 128 with "fatal: not a git repository")
+    /// must propagate as a thrown `GitError` instead of being reported as
+    /// "branch absent".
+    @Test func localBranchExistsThrowsOnNonRefMissingFailure() async throws {
+        let notARepo = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-not-a-repo-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: notARepo, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: notARepo) }
+
+        let git = GitManager()
+        await #expect(throws: GitError.self) {
+            _ = try await git.localBranchExists(repoPath: notARepo.path, name: "whatever")
+        }
+    }
+
     @Test func fetchPullRequestHeadCreatesLocalBranchAtPullCommit() async throws {
         let (tempDir, cloneRepoDir, prSHA) = try await makePRFixture(number: 7)
         defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
+++ b/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Task 2: PR-head checkout. Covers the GitManager primitive
+/// (`fetchPullRequestHead` / `localBranchExists`) plus the lifecycle PR-create
+/// dispatch, including the collision-safety guard that the `+` force refspec
+/// must never clobber an unrelated pre-existing local branch of the same name.
+@Suite struct WorktreePRCheckoutTests {
+
+    /// Builds a bare "origin" carrying `refs/pull/<number>/head` at a commit
+    /// that `main` does not contain, plus a fresh clone tracking it. Returns
+    /// the clone's temp dir (caller owns cleanup), repo dir, and the pull-head
+    /// SHA. Mirrors how GitHub exposes a PR: the commit is reachable only
+    /// through the pull ref, not through any `refs/heads/*` branch.
+    private func makePRFixture(number: Int) async throws -> (tempDir: URL, cloneRepoDir: URL, prSHA: String) {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-pr-test-\(UUID().uuidString)")
+        let remoteDir = parent.appendingPathComponent("remote.git")
+        let sourceDir = parent.appendingPathComponent("source")
+        let cloneTempDir = parent.appendingPathComponent("clone-host")
+        let cloneRepoDir = cloneTempDir.appendingPathComponent("repo")
+        for dir in [remoteDir, sourceDir, cloneTempDir] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+
+        try await shell("git init --bare -b main", at: remoteDir)
+        try await shell("git init -b main && git commit --allow-empty -m 'init'", at: sourceDir)
+        try await shell("git remote add origin '\(remoteDir.path)' && git push origin main", at: sourceDir)
+        // A PR-head commit main never gets: push it so its objects land in the
+        // bare, then expose it ONLY through refs/pull/<n>/head and delete the
+        // normal branch — exactly the shape of a fork/teammate PR.
+        try await shell("git checkout -b prwork && git commit --allow-empty -m 'pr work'", at: sourceDir)
+        try await shell("git push origin prwork", at: sourceDir)
+        let prSHA = try await GitManager().headSHA(repoPath: sourceDir.path, ref: "prwork")
+        try await shell("git update-ref refs/pull/\(number)/head \(prSHA)", at: remoteDir)
+        try await shell("git update-ref -d refs/heads/prwork", at: remoteDir)
+
+        try await shell("git clone '\(remoteDir.path)' '\(cloneRepoDir.path)'", at: cloneTempDir)
+        return (cloneTempDir, cloneRepoDir, prSHA)
+    }
+
+    @Test func fetchPullRequestHeadCreatesLocalBranchAtPullCommit() async throws {
+        let (tempDir, cloneRepoDir, prSHA) = try await makePRFixture(number: 7)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let git = GitManager()
+        let existsBefore = try await git.localBranchExists(repoPath: cloneRepoDir.path, name: "pr-7")
+        #expect(existsBefore == false)
+
+        try await git.fetchPullRequestHead(repoPath: cloneRepoDir.path, number: 7, localBranch: "pr-7")
+
+        let existsAfter = try await git.localBranchExists(repoPath: cloneRepoDir.path, name: "pr-7")
+        #expect(existsAfter == true)
+        let sha = try await git.headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/pr-7")
+        #expect(sha == prSHA)
+    }
+
+    @Test func createFromPRChecksOutPullHeadAndStampsNumber() async throws {
+        let (tempDir, cloneRepoDir, prSHA) = try await makePRFixture(number: 7)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+        )
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: cloneRepoDir)
+
+        let wt = try await lifecycle.createWorktree(
+            repoID: repo.id, branch: "feature-x", skipClaude: true,
+            useExistingBranch: true, prNumber: 7
+        )
+
+        #expect(wt.status == .active)
+        #expect(wt.branch == "feature-x")
+        #expect(wt.prNumber == 7)
+        // Worktree HEAD sits on the pull-ref commit, not on main.
+        let head = try await GitManager().headSHA(worktreePath: wt.path)
+        #expect(head == prSHA)
+
+        let stored = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(stored.prNumber == 7)
+    }
+
+    @Test func createFromPRDoesNotClobberExistingLocalBranch() async throws {
+        let (tempDir, cloneRepoDir, prSHA) = try await makePRFixture(number: 7)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Pre-existing, unrelated local branch sharing the PR head name. The
+        // `+refs/pull/7/head:refs/heads/feature-x` refspec would force-rewrite
+        // it — the lifecycle must uniquify the local branch name first.
+        try await shell("git branch feature-x", at: cloneRepoDir)
+        let originalSHA = try await GitManager().headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/feature-x")
+        #expect(originalSHA != prSHA)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+        )
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: cloneRepoDir)
+
+        let wt = try await lifecycle.createWorktree(
+            repoID: repo.id, branch: "feature-x", skipClaude: true,
+            useExistingBranch: true, prNumber: 7
+        )
+
+        // Landed on the uniquified branch at the pull-ref commit...
+        #expect(wt.branch == "feature-x-2")
+        #expect(wt.prNumber == 7)
+        let head = try await GitManager().headSHA(worktreePath: wt.path)
+        #expect(head == prSHA)
+
+        // ...and the original branch is untouched by the force refspec.
+        let afterSHA = try await GitManager().headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/feature-x")
+        #expect(afterSHA == originalSHA)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
+++ b/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
@@ -70,7 +70,7 @@ import Testing
 
         let wt = try await lifecycle.createWorktree(
             repoID: repo.id, branch: "feature-x", skipClaude: true,
-            useExistingBranch: true, prNumber: 7
+            useExistingBranch: true, prNumber: 7, checkoutPRHead: true
         )
 
         #expect(wt.status == .active)
@@ -103,7 +103,7 @@ import Testing
 
         let wt = try await lifecycle.createWorktree(
             repoID: repo.id, branch: "feature-x", skipClaude: true,
-            useExistingBranch: true, prNumber: 7
+            useExistingBranch: true, prNumber: 7, checkoutPRHead: true
         )
 
         // Landed on the uniquified branch at the pull-ref commit...
@@ -115,5 +115,40 @@ import Testing
         // ...and the original branch is untouched by the force refspec.
         let afterSHA = try await GitManager().headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/feature-x")
         #expect(afterSHA == originalSHA)
+    }
+
+    /// Decorated same-repo row: `prNumber` is set for status tracking, but
+    /// `checkoutPRHead` is false, so selecting it must behave exactly like
+    /// picking that existing branch — NO pull-ref fetch, NO `feature-x-2` clone.
+    @Test func createFromDecoratedBranchRowChecksOutExistingBranch() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        try await shell("git branch feature-x", at: repoDir)
+        let branchSHA = try await GitManager().headSHA(repoPath: repoDir.path, ref: "refs/heads/feature-x")
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+        )
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // prNumber stamped, checkoutPRHead omitted (defaults false).
+        let wt = try await lifecycle.createWorktree(
+            repoID: repo.id, branch: "feature-x", skipClaude: true,
+            useExistingBranch: true, prNumber: 9
+        )
+
+        #expect(wt.status == .active)
+        #expect(wt.branch == "feature-x")     // existing branch, not uniquified
+        #expect(wt.prNumber == 9)             // still stamped for status tracking
+        let head = try await GitManager().headSHA(worktreePath: wt.path)
+        #expect(head == branchSHA)
+        // No stray duplicate branch was created by a pull-ref fetch.
+        let dupExists = try await GitManager().localBranchExists(repoPath: repoDir.path, name: "feature-x-2")
+        #expect(dupExists == false)
+
+        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+        #expect(listed.contains { $0.branch == "feature-x" && $0.path.hasSuffix("/feature-x") })
     }
 }

--- a/Tests/TBDSharedTests/PRNumberCodableTests.swift
+++ b/Tests/TBDSharedTests/PRNumberCodableTests.swift
@@ -1,0 +1,28 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct PRNumberCodableTests {
+    @Test func worktreeDefaultsToNilWhenKeyMissing() throws {
+        // JSON without the new key must still decode (backward compat).
+        let json = """
+        {"id":"\(UUID().uuidString)","repoID":"\(UUID().uuidString)","name":"w",
+         "displayName":"w","branch":"b","path":"/p","status":"active",
+         "createdAt":0,"tmuxServer":"s"}
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        let wt = try decoder.decode(Worktree.self, from: json)
+        #expect(wt.prNumber == nil)
+    }
+
+    @Test func worktreeRoundTripsExplicitValues() throws {
+        for value: Int? in [nil, 454] {
+            var wt = Worktree(repoID: UUID(), name: "w", displayName: "w",
+                              branch: "b", path: "/p", tmuxServer: "s")
+            wt.prNumber = value
+            let data = try JSONEncoder().encode(wt)
+            let back = try JSONDecoder().decode(Worktree.self, from: data)
+            #expect(back.prNumber == value)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **The gap:** the new-worktree branch picker only lists local + `origin/*` refs, so fork PR branches (e.g. `zionts:show-weekly-reset`, #454) could never appear, and there was no one-click path from "open PR" to "worktree on that code".
- **Now:** the picker's flat list interleaves all open PRs (two-phase load — branches render instantly, PRs pop in from a new repo-scoped `repo.listOpenPRs` gh GraphQL RPC; gh failures degrade silently to branches-only). Same-repo PRs decorate their existing branch row with a `PR #452` pill; fork PRs get their own row (`zionts · PR #454`, title subtitle, drafts dimmed). Typeahead matches branch, number, title, and owner.
- **Checkout:** PR-only rows fetch `refs/pull/<n>/head` into a collision-free local branch (`+` force-refspec is gated behind an explicit `checkoutPRHead` param and pre-flight branch-name uniquification, so it can never clobber an unrelated branch; no fork remote is ever added). Decorated rows keep today's plain branch checkout.
- **Tracking:** a new nullable `worktree.pr_number` column (migration v54) is stamped at creation; `PRStatusManager` resolves those worktrees by direct `pullRequest(number:)` lookup — the only way a fork PR ever lights up the toolbar PR button and auto-archive-on-merge. Unnumbered worktrees keep the legacy viewer-batch path byte-identically.

Post-implementation review pass fixed two High findings before this PR: partial-GraphQL-results tolerance (regression guard for #208 — one stale alias no longer zeroes the batch) and same-head sibling PRs vanishing from the merged list. Design doc: `docs/superpowers/plans/2026-07-16-prs-in-branch-picker-design.md` (uncommitted, house rule).

**Stacked on #455** (the branch-filter typing fix) — merge that first; GitHub will auto-retarget this to `main`.

## Test plan
- [x] 3,568 tests / 428 suites green; `swiftlint --strict` clean
- [x] New coverage: merge/dedup/filter (8), PR checkout incl. clobber-safety + decorated-row semantics (4), by-number status resolution both branches (6+), listOpenPRs parse/partial-results (7), migration/codable (5), in-use filtering (3)
- [ ] Live: picker shows #454 `zionts:show-weekly-reset`; selecting it creates a worktree on the PR head with the PR button lit
- [ ] Live: selecting an own-PR decorated branch row checks out the existing branch (no `-2` duplicate)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=D16312D7-7528-41E9-AAF9-441E9D0C8A82)