### PR TITLE
refactor(usage): give the two relativeResetText overloads distinct names

### DIFF
--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -114,7 +114,7 @@ private struct UsageBarRow: View {
     private var trailingResetHint: some View {
         let countdownText: String = {
             guard showsInlineReset, usesRelativeReset, let resetsAt = bucket.resetsAt,
-                  let compact = ProfileUsagePresentation.relativeResetText(resetsAt, now: now) else {
+                  let compact = ProfileUsagePresentation.compactResetCountdown(resetsAt, now: now) else {
                 return ""
             }
             return "· \(compact)"
@@ -209,7 +209,7 @@ private struct UsageBarRow: View {
         var text = "\(windowLabel): \(ProfileUsagePresentation.percentText(bucket.percent)) used"
         if let resets = bucket.resetsAt {
             if usesRelativeReset {
-                if let relative = ProfileUsagePresentation.relativeResetText(resets, now: now) {
+                if let relative = ProfileUsagePresentation.compactResetCountdown(resets, now: now) {
                     text += " · resets in \(relative)"
                 }
             } else {

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -174,16 +174,16 @@ enum ProfileUsagePresentation {
         return trimmed.isEmpty ? "?" : trimmed
     }
 
-    /// Relative "how long until" a reset, at day/hour granularity: "in 2d 5h",
-    /// "in 5h", "in 43m", "now". The weekly window shows this (rather than an
-    /// absolute clock time like the 5h window) because at week scale the useful
-    /// planning question is time-remaining, not the wall-clock instant. nil
-    /// when there's no reset date to format.
+    /// Full phrase for relative "how long until" a reset, including the leading
+    /// "in " prefix: "in 2d 5h", "in 5h", "in 43m", "now". Returns nil if the
+    /// date is nil; otherwise always returns a string (even "now" for immediate resets).
+    /// Used for display contexts that want a complete phrase without additional
+    /// wrapping text.
     ///
-    /// Granularity rules: >= 1 day → "Nd Nh" (hours dropped when zero: "2d");
-    /// >= 1 hour but < 1 day → "Nh"; < 1 hour → "Nm"; already past / <1 min →
+    /// Granularity rules: >= 1 day → "in Nd Nh" (hours dropped when zero: "in 2d");
+    /// >= 1 hour but < 1 day → "in Nh"; < 1 hour → "in Nm"; already past / <1 min →
     /// "now". `now` is injectable for deterministic tests.
-    static func relativeResetText(_ date: Date?, now: Date = Date()) -> String? {
+    static func relativeResetPhrase(_ date: Date?, now: Date = Date()) -> String? {
         guard let date else { return nil }
         let seconds = date.timeIntervalSince(now)
         guard seconds >= 60 else { return "now" }
@@ -292,7 +292,7 @@ enum ProfileUsagePresentation {
             // week ends" — so it shows a relative countdown. Weekly buckets
             // share one reset instant, so it appears once, here.
             if let resets = weekly.resetsAt,
-               let relative = relativeResetText(resets, now: now) {
+               let relative = compactResetCountdown(resets, now: now) {
                 part += " · resets in \(relative)"
             }
             parts.append(part)
@@ -304,11 +304,13 @@ enum ProfileUsagePresentation {
         return parts.joined(separator: " · ")
     }
 
-    /// Compact relative countdown for planning-scale resets: "2d 5h", "3h",
-    /// "48m". nil when the instant is not in the future (a stale snapshot
-    /// shouldn't render a nonsense countdown). Minutes appear only under an
+    /// Compact relative countdown for planning-scale resets without a leading
+    /// prefix: "2d 5h", "3h", "48m". Returns nil when the instant is not in the
+    /// future (a stale snapshot shouldn't render a nonsense countdown). Used as
+    /// a building block for contexts that need just the duration, which they can
+    /// wrap in their own "resets in" or similar text. Minutes appear only under an
     /// hour; hour-scale drops minutes; day-scale carries the hour remainder.
-    static func relativeResetText(_ resetsAt: Date, now: Date = Date()) -> String? {
+    static func compactResetCountdown(_ resetsAt: Date, now: Date = Date()) -> String? {
         let interval = resetsAt.timeIntervalSince(now)
         guard interval > 0 else { return nil }
         let totalMinutes = Int((interval / 60).rounded(.up))

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -743,33 +743,33 @@ struct SkipAccountPickerPersistenceTests {
 
 // MARK: - Relative weekly reset (granularity matches window scale)
 
-@Suite("RelativeResetText")
-struct RelativeResetTextTests {
+@Suite("CompactResetCountdown")
+struct CompactResetCountdownTests {
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
 
     @Test func minutesUnderAnHour() {
         let resets = now.addingTimeInterval(48 * 60)
-        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == "48m")
+        #expect(ProfileUsagePresentation.compactResetCountdown(resets, now: now) == "48m")
     }
 
     @Test func hoursDropMinutes() {
         let resets = now.addingTimeInterval((3 * 60 + 20) * 60)
-        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == "3h")
+        #expect(ProfileUsagePresentation.compactResetCountdown(resets, now: now) == "3h")
     }
 
     @Test func daysCarryHourRemainder() {
         let resets = now.addingTimeInterval(((2 * 24 + 5) * 60 + 10) * 60)
-        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == "2d 5h")
+        #expect(ProfileUsagePresentation.compactResetCountdown(resets, now: now) == "2d 5h")
     }
 
     @Test func exactDaysOmitHours() {
         let resets = now.addingTimeInterval(3 * 24 * 60 * 60)
-        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == "3d")
+        #expect(ProfileUsagePresentation.compactResetCountdown(resets, now: now) == "3d")
     }
 
     @Test func pastInstantYieldsNil() {
         let resets = now.addingTimeInterval(-60)
-        #expect(ProfileUsagePresentation.relativeResetText(resets, now: now) == nil)
+        #expect(ProfileUsagePresentation.compactResetCountdown(resets, now: now) == nil)
     }
 
     @Test func weeklyResetAppearsOnceInDetailLine() {


### PR DESCRIPTION
## Summary

This PR eliminates a footgun in `ProfileUsagePresentation.swift` where two overloads of `relativeResetText()` had materially different output contracts but were only distinguishable by Optional-ness of the first parameter.

The two functions are now renamed to semantic, unambiguous names:
- `relativeResetPhrase()` - returns phrase WITH "in " prefix: "in 2d 5h", "in 5h", "in 43m", "now"
- `compactResetCountdown()` - returns compact duration without prefix: "2d 5h", "3h", "48m"; returns nil when reset is in the past

## Context

The defect was discovered during PR #454. Picking the wrong overload silently produced incorrect UI text:
- Using the compact form in a context expecting the phrase form would render "resets in 2d 5h" as "resets in in 2d 5h"
- Using the phrase form where nil-when-past is needed would fail to filter stale snapshots

Overload resolution on Optional-ness is too subtle a signal for two functions whose output differs this much.

## Changes

- Renamed both function definitions in `ProfileUsagePresentation.swift`
- Updated all 8 call sites (2 in `UsageBarsView.swift`, 1 in `usageDetailLine`, 5 in test suite)
- Enhanced docstrings to make each function's contract explicit
- Renamed test suite from "RelativeResetText" to "CompactResetCountdown" to match the primary overload

## Verification

- ✅ `swift build` passes
- ✅ All ProfileUsagePresentation tests pass (including 5 CompactResetCountdown tests)
- ✅ Behavior unchanged — this is a pure rename with no logic modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)