### PR TITLE
Fix: Clear stale 'in merge queue' badge once the PR ages out of the 100-PR poll window

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -139,9 +139,11 @@ public actor PRStatusManager {
         // Legacy path: viewer-authored batch + branch-name matching. On a fetch
         // or parse failure it contributes no matches, but the numbered path above
         // has already resolved independently.
+        var batchSucceeded = false
         if !unnumbered.isEmpty {
             if let jsonData = await runGHGraphQL(repoPath: repoPath) {
                 if let nodes = try? Self.parsePRNodes(from: jsonData) {
+                    batchSucceeded = true   // empty nodes is still a valid answer (viewer has no PRs)
                     let byBranch = Self.bestNodeByBranch(nodes)
                     for wt in unnumbered {
                         let candidates = Self.branchCandidates(localBranch: wt.branch, upstreamBranch: wt.upstreamBranch)
@@ -153,6 +155,19 @@ public actor PRStatusManager {
                     logger.warning("Failed to parse GraphQL response")
                 }
             }
+        }
+
+        // Fallback: unnumbered worktrees a *successful* batch left unmatched
+        // whose cached status still carries a PR number — resolve those by
+        // number (one extra aliased round trip, only when such worktrees
+        // exist). See `cachedNumberFallback` for the gating rationale.
+        let fallback = Self.cachedNumberFallback(
+            unnumbered: unnumbered,
+            matchedIDs: Set(matches.map(\.worktreeID)),
+            batchSucceeded: batchSucceeded,
+            cachedStatus: { cache[$0] })
+        if !fallback.isEmpty {
+            matches += await fetchNumberedMatches(fallback, repoPath: repoPath)
         }
 
         // Fetch per-PR signals concurrently; only non-green OPEN PRs need the query.
@@ -672,6 +687,45 @@ public actor PRStatusManager {
             if prNumber(item) != nil { numbered.append(item) } else { unnumbered.append(item) }
         }
         return (numbered, unnumbered)
+    }
+
+    /// Select the unnumbered worktrees the viewer batch left unmatched whose
+    /// cached status still carries a PR number, rewriting each with that number
+    /// so `fetchNumberedMatches` can resolve it directly. Once 100 newer PRs
+    /// exist, an old PR falls out of the viewer-authored batch (first 100 by
+    /// CREATED_AT DESC) and the cached number is the only remaining handle —
+    /// without it the stale cached status (e.g. "in merge queue") persists
+    /// forever and the merged transition / auto-archive never fires. Batch
+    /// matches always win: a branch re-pointed to a NEW PR must not get pinned
+    /// to the stale cached number, so only unmatched worktrees fall back.
+    ///
+    /// `batchSucceeded` must reflect whether the viewer batch actually parsed
+    /// (empty nodes still counts — the viewer legitimately has no PRs). On a
+    /// fetch/parse failure "unmatched" means nothing, and falling back would
+    /// resolve stale cached numbers for branches that may point at NEW PRs
+    /// (worst case: a stale MERGED number fires auto-archive off an unrelated
+    /// PR) — keeping the stale cache on failure is the pre-existing, safe
+    /// behavior, so a failed batch yields no fallback at all.
+    ///
+    /// Terminal cached states are excluded: `.merged` has no further transition
+    /// to observe, and `.closed` would otherwise be a permanent per-poll
+    /// by-number re-query — a reopened PR is recovered by the on-select
+    /// `refresh()` path (or a restored batch match), not this fallback. The
+    /// merged-transition case is unaffected: the pre-transition cached state is
+    /// non-terminal by definition.
+    static func cachedNumberFallback(
+        unnumbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)],
+        matchedIDs: Set<UUID>,
+        batchSucceeded: Bool,
+        cachedStatus: (UUID) -> PRStatus?
+    ) -> [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] {
+        guard batchSucceeded else { return [] }
+        return unnumbered.compactMap { wt in
+            guard !matchedIDs.contains(wt.id),
+                  let cached = cachedStatus(wt.id),
+                  cached.state != .merged, cached.state != .closed else { return nil }
+            return (wt.id, wt.branch, wt.upstreamBranch, wt.worktreePath, cached.number)
+        }
     }
 
     /// Build the branch → best-PR lookup used by the legacy (unnumbered) path.

--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -117,8 +117,14 @@ public actor PRStatusManager {
         fetchAllInProgress = true
         defer { fetchAllInProgress = false }
         let batchStartedAt = Date()
-        // All worktrees share one repo; any path works as gh's working directory for auth.
+        // Worktrees may span multiple repos. repoPath is only gh's working
+        // directory for the viewer batch (gh auth is host-scoped, so any
+        // checkout works); by-number lookups resolve each worktree's own repo.
         let repoPath = worktrees[0].worktreePath
+        // Each worktree's own path, for the nightwatch callback: its policy is
+        // loaded from (and its audit trail labeled with) the repo it belongs to.
+        let pathByID = Dictionary(worktrees.map { ($0.id, $0.worktreePath) },
+                                  uniquingKeysWith: { first, _ in first })
 
         // Worktrees created from a PR row carry its number; resolve those
         // directly (a fork PR's head never appears in the viewer-authored batch).
@@ -133,7 +139,7 @@ public actor PRStatusManager {
 
         // Numbered path: one aliased by-number query (skipped when none stored).
         if !numbered.isEmpty {
-            matches += await fetchNumberedMatches(numbered, repoPath: repoPath)
+            matches += await fetchNumberedMatches(numbered)
         }
 
         // Legacy path: viewer-authored batch + branch-name matching. On a fetch
@@ -167,7 +173,7 @@ public actor PRStatusManager {
             batchSucceeded: batchSucceeded,
             cachedStatus: { cache[$0] })
         if !fallback.isEmpty {
-            matches += await fetchNumberedMatches(fallback, repoPath: repoPath)
+            matches += await fetchNumberedMatches(fallback)
         }
 
         // Fetch per-PR signals concurrently; only non-green OPEN PRs need the query.
@@ -212,7 +218,7 @@ public actor PRStatusManager {
             let status = PRStatus(number: match.node.number, url: match.node.url, state: state, reason: reason,
                                   mergeQueuePosition: match.node.mergeQueuePosition)
             await apply(status, for: match.worktreeID)
-            await onPRStatusComputed?(match.worktreeID, status, repoPath)
+            await onPRStatusComputed?(match.worktreeID, status, pathByID[match.worktreeID] ?? repoPath)
         }
     }
 
@@ -977,45 +983,80 @@ public actor PRStatusManager {
         return resolved
     }
 
-    /// Resolve stored PR numbers directly via one aliased `pullRequest(number:)`
-    /// query — the only way to reach a fork PR, whose head branch never appears
-    /// in the viewer-authored batch. Degrades to no matches on any failure
+    /// Group by-number poll entries by their worktree's own repo. The daemon
+    /// manages worktrees across multiple repos, so one repo's owner/name must
+    /// never be applied to another worktree's PR number: the number usually
+    /// resolves to nothing in the wrong repo (silently dropping the match), but
+    /// can land on an unrelated PR — whose MERGED state would fire auto-archive
+    /// on the wrong worktree. Entries whose repo can't be resolved are dropped
+    /// (the caller keeps their cached status), matching the existing degrade
+    /// behavior. Group order follows first appearance; `cwd` is the first
+    /// grouped worktree's path, used as gh's working directory.
+    static func groupNumberedByRepo(
+        _ numbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)],
+        resolve: (String) -> (owner: String, name: String)?
+    ) -> [(owner: String, name: String, cwd: String, entries: [(worktreeID: UUID, number: Int)])] {
+        var order: [String] = []
+        var groups: [String: (owner: String, name: String, cwd: String, entries: [(worktreeID: UUID, number: Int)])] = [:]
+        for wt in numbered {
+            guard let number = wt.prNumber, let repo = resolve(wt.worktreePath) else { continue }
+            let key = "\(repo.owner)/\(repo.name)"
+            if groups[key] == nil {
+                groups[key] = (repo.owner, repo.name, wt.worktreePath, [])
+                order.append(key)
+            }
+            groups[key]?.entries.append((wt.id, number))
+        }
+        return order.compactMap { groups[$0] }
+    }
+
+    /// Resolve stored PR numbers directly via aliased `pullRequest(number:)`
+    /// queries — the only way to reach a fork PR, whose head branch never
+    /// appears in the viewer-authored batch. Each worktree's number is scoped
+    /// to its OWN repo: one aliased query per repo group (see
+    /// `groupNumberedByRepo`), with the TTL cache keeping `gh repo view`
+    /// spawns bounded. Degrades per group to no matches on any failure
     /// (owner/name unresolved, gh missing, non-zero exit, unparseable); the
     /// caller keeps prior cached status for those worktrees.
     private nonisolated func fetchNumberedMatches(
-        _ numbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)],
-        repoPath: String
+        _ numbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)]
     ) async -> [(worktreeID: UUID, node: PRNode)] {
-        guard let ownerRepo = await cachedNameWithOwner(repoPath: repoPath) else {
-            logger.debug("fetchAll: could not resolve owner/name for numbered PRs at \(repoPath, privacy: .public)")
-            return []
+        var resolved: [String: (owner: String, name: String)] = [:]
+        for path in Set(numbered.map(\.worktreePath)) {
+            if let ownerRepo = await cachedNameWithOwner(repoPath: path) {
+                resolved[path] = ownerRepo
+            } else {
+                logger.debug("fetchAll: could not resolve owner/name for numbered PRs at \(path, privacy: .public)")
+            }
         }
-        let entries: [(alias: String, number: Int, worktreeID: UUID)] = numbered.enumerated().compactMap { index, wt in
-            guard let number = wt.prNumber else { return nil }
-            return (alias: "pr\(index)", number: number, worktreeID: wt.id)
+        var matches: [(worktreeID: UUID, node: PRNode)] = []
+        for group in Self.groupNumberedByRepo(numbered, resolve: { resolved[$0] }) {
+            let aliased = group.entries.enumerated().map {
+                (alias: "pr\($0.offset)", worktreeID: $0.element.worktreeID, number: $0.element.number)
+            }
+            let query = Self.numberedPRQuery(aliases: aliased.map { ($0.alias, $0.number) })
+            let args = [
+                "api", "graphql",
+                "-f", "query=\(query)",
+                "-f", "owner=\(group.owner)",
+                "-f", "name=\(group.name)"
+            ]
+            guard let result = await runGHResult(args: args, repoPath: group.cwd),
+                  let data = Self.graphQLOutputData(stdout: result.stdout) else {
+                logger.debug("fetchAll: by-number query produced no data for \(group.owner, privacy: .public)/\(group.name, privacy: .public)")
+                continue
+            }
+            // `gh api graphql` exits non-zero when ONE aliased PR errors (stale,
+            // deleted, or inaccessible — likeliest for a fork PR) while still emitting
+            // usable `data` for the others. Parse whatever came back regardless of
+            // exit status; log the partial failure (regression guard, PR #208).
+            if result.exitStatus != 0 {
+                let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+                logger.debug("fetchAll: by-number query exited \(result.exitStatus, privacy: .public) with partial data for \(group.owner, privacy: .public)/\(group.name, privacy: .public): \(errSuffix, privacy: .public)")
+            }
+            matches += Self.parseNumberedPRNodes(from: data, aliases: aliased.map { ($0.alias, $0.worktreeID) })
         }
-        guard !entries.isEmpty else { return [] }
-        let query = Self.numberedPRQuery(aliases: entries.map { ($0.alias, $0.number) })
-        let args = [
-            "api", "graphql",
-            "-f", "query=\(query)",
-            "-f", "owner=\(ownerRepo.owner)",
-            "-f", "name=\(ownerRepo.name)"
-        ]
-        guard let result = await runGHResult(args: args, repoPath: repoPath),
-              let data = Self.graphQLOutputData(stdout: result.stdout) else {
-            logger.debug("fetchAll: by-number query produced no data for numbered PRs at \(repoPath, privacy: .public)")
-            return []
-        }
-        // `gh api graphql` exits non-zero when ONE aliased PR errors (stale,
-        // deleted, or inaccessible — likeliest for a fork PR) while still emitting
-        // usable `data` for the others. Parse whatever came back regardless of
-        // exit status; log the partial failure (regression guard, PR #208).
-        if result.exitStatus != 0 {
-            let errSuffix = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-            logger.debug("fetchAll: by-number query exited \(result.exitStatus, privacy: .public) with partial data at \(repoPath, privacy: .public): \(errSuffix, privacy: .public)")
-        }
-        return Self.parseNumberedPRNodes(from: data, aliases: entries.map { ($0.alias, $0.worktreeID) })
+        return matches
     }
 
     private nonisolated func runGHGraphQL(repoPath: String) async -> Data? {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -450,7 +450,8 @@ public final class RPCRouter: Sendable {
     }
 
     /// Scratch spaces are repo-less and have no PR — exclude them so the
-    /// poller's "all worktrees share one repo" assumption holds. Pulled out
+    /// poller only queries real checkouts (worktrees may span multiple repos;
+    /// by-number lookups scope to each worktree's own repo). Pulled out
     /// as a pure function (rather than inlined `.filter` in `computePRList`)
     /// so it's directly unit-testable without spinning up git/gh machinery.
     static func pollableWorktrees(_ worktrees: [Worktree]) -> [Worktree] {

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -1362,6 +1362,74 @@ struct PRStatusManagerTests {
         #expect(node?.number == 7)
     }
 
+    @Test("cachedNumberFallback excludes a worktree the batch matched, even with a cached number")
+    func cachedNumberFallbackExcludesBatchMatched() {
+        // A branch re-pointed to a NEW PR must not get pinned to the stale cached number.
+        let wt = UUID()
+        let unnumbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] =
+            [(wt, "feature-x", nil, "/tmp/repo", nil)]
+        let out = PRStatusManager.cachedNumberFallback(
+            unnumbered: unnumbered, matchedIDs: [wt], batchSucceeded: true,
+            cachedStatus: { _ in PRStatus(number: 42, url: "https://example.com/pr/42", state: .pending) })
+        #expect(out.isEmpty)
+    }
+
+    @Test("cachedNumberFallback includes an unmatched worktree, carrying its cached PR number")
+    func cachedNumberFallbackIncludesUnmatchedWithCachedNumber() {
+        // The stale PR fell out of the 100-PR viewer batch; the cached number is
+        // the only remaining handle to observe the merged transition.
+        let wt = UUID()
+        let unnumbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] =
+            [(wt, "old-branch", "origin/old-branch", "/tmp/repo", nil)]
+        let out = PRStatusManager.cachedNumberFallback(
+            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true,
+            cachedStatus: { _ in PRStatus(number: 457, url: "https://example.com/pr/457", state: .mergeable) })
+        #expect(out.count == 1)
+        #expect(out.first?.id == wt)
+        #expect(out.first?.prNumber == 457)
+        #expect(out.first?.branch == "old-branch")
+    }
+
+    @Test("cachedNumberFallback excludes an unmatched worktree with no cached entry")
+    func cachedNumberFallbackExcludesNoCachedEntry() {
+        let unnumbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] =
+            [(UUID(), "feature-y", nil, "/tmp/repo", nil)]
+        let out = PRStatusManager.cachedNumberFallback(
+            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true, cachedStatus: { _ in nil })
+        #expect(out.isEmpty)
+    }
+
+    @Test("cachedNumberFallback yields nothing when the viewer batch failed, even with unmatched cached numbers")
+    func cachedNumberFallbackSkippedOnBatchFailure() {
+        // On a fetch/parse failure "unmatched" means nothing — falling back could
+        // resolve a stale MERGED number and auto-archive off an unrelated PR.
+        let unnumbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] =
+            [(UUID(), "old-branch", nil, "/tmp/repo", nil)]
+        let out = PRStatusManager.cachedNumberFallback(
+            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: false,
+            cachedStatus: { _ in PRStatus(number: 457, url: "https://example.com/pr/457", state: .mergeable) })
+        #expect(out.isEmpty)
+    }
+
+    @Test("cachedNumberFallback excludes worktrees whose cached state is terminal (.merged / .closed)")
+    func cachedNumberFallbackExcludesTerminalCachedStates() {
+        // .merged has no further transition to observe; .closed is excluded to
+        // avoid a permanent per-poll re-query — a reopened PR is recovered by
+        // the on-select refresh() path (or a restored batch match), not the fallback.
+        let mergedWT = UUID(); let closedWT = UUID()
+        let unnumbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] =
+            [(mergedWT, "merged-branch", nil, "/tmp/repo", nil),
+             (closedWT, "closed-branch", nil, "/tmp/repo", nil)]
+        let statuses: [UUID: PRStatus] = [
+            mergedWT: PRStatus(number: 11, url: "https://example.com/pr/11", state: .merged),
+            closedWT: PRStatus(number: 12, url: "https://example.com/pr/12", state: .closed)
+        ]
+        let out = PRStatusManager.cachedNumberFallback(
+            unnumbered: unnumbered, matchedIDs: [], batchSucceeded: true,
+            cachedStatus: { statuses[$0] })
+        #expect(out.isEmpty)
+    }
+
     // MARK: - Partial-results tolerance (regression guard, PR #208)
 
     @Test("parseOpenPRNodes yields nodes from a body carrying BOTH an errors array and valid data.repository")

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -1430,6 +1430,56 @@ struct PRStatusManagerTests {
         #expect(out.isEmpty)
     }
 
+    @Test("groupNumberedByRepo groups multi-repo entries by their own repo, in first-appearance order")
+    func groupNumberedByRepoGroupsMultiRepo() {
+        // One repo's owner/name must never be applied to another worktree's PR
+        // number — the wrong repo could hold an unrelated (even MERGED) PR.
+        let a = UUID(); let b = UUID(); let c = UUID()
+        let numbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] = [
+            (a, "b1", nil, "/wt/tbd-1", 457),
+            (b, "b2", nil, "/wt/acme-prod-1", 9),
+            (c, "b3", nil, "/wt/tbd-2", 460)
+        ]
+        let repos = ["/wt/tbd-1": ("acme", "tbd"), "/wt/tbd-2": ("acme", "tbd"),
+                     "/wt/acme-prod-1": ("acme", "acme-prod")]
+        let groups = PRStatusManager.groupNumberedByRepo(numbered) { repos[$0] }
+        #expect(groups.count == 2)
+        #expect(groups.first?.owner == "acme")
+        #expect(groups.first?.name == "tbd")
+        #expect(groups.first?.cwd == "/wt/tbd-1")
+        #expect(groups.first?.entries.map { $0.worktreeID } == [a, c])
+        #expect(groups.first?.entries.map { $0.number } == [457, 460])
+        #expect(groups.last?.name == "acme-prod")
+        #expect(groups.last?.entries.map { $0.worktreeID } == [b])
+    }
+
+    @Test("groupNumberedByRepo drops entries whose repo can't be resolved")
+    func groupNumberedByRepoDropsUnresolved() {
+        let a = UUID()
+        let numbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] = [
+            (a, "b1", nil, "/wt/known", 1),
+            (UUID(), "b2", nil, "/wt/unknown", 2)
+        ]
+        let groups = PRStatusManager.groupNumberedByRepo(numbered) {
+            $0 == "/wt/known" ? ("acme", "tbd") : nil
+        }
+        #expect(groups.count == 1)
+        #expect(groups.first?.entries.map { $0.worktreeID } == [a])
+    }
+
+    @Test("groupNumberedByRepo passes a single-repo set through as one group")
+    func groupNumberedByRepoSingleRepoPassthrough() {
+        let a = UUID(); let b = UUID()
+        let numbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)] = [
+            (a, "b1", nil, "/wt/one", 10),
+            (b, "b2", nil, "/wt/two", 11)
+        ]
+        let groups = PRStatusManager.groupNumberedByRepo(numbered) { _ in ("acme", "tbd") }
+        #expect(groups.count == 1)
+        #expect(groups.first?.cwd == "/wt/one")
+        #expect(groups.first?.entries.map { $0.number } == [10, 11])
+    }
+
     // MARK: - Partial-results tolerance (regression guard, PR #208)
 
     @Test("parseOpenPRNodes yields nodes from a body carrying BOTH an errors array and valid data.repository")


### PR DESCRIPTION
## Summary

**What's broken:** a worktree kept showing the merge-queue bus icon ("in merge queue, position 6") for a PR that merged a week earlier. The merged transition (and with it auto-archive-on-merge) never fired.

**Why it happens:** worktrees without a stored `pr_number` are resolved by the poll's viewer-authored batch — the 100 newest PRs by creation date, matched by branch name. Once 100 newer PRs exist, the old PR falls out of that window, the worktree gets no match, and `fetchAll` deliberately keeps the stale cached status (persisted to the DB and re-hydrated on every daemon restart) — forever.

**What this PR does:**

- **Commit 1 — cached-number fallback.** The stale cached `PRStatus` still carries the PR number, so batch-unmatched worktrees now fall back to the existing aliased `pullRequest(number:)` lookup, which always finds an old PR. The merge is finally observed, the bus clears, and the merged transition fires as designed. Guarded so it only runs when the viewer batch itself succeeded (a failed batch can't be distinguished from "no match", and acting on a stale number there could fire auto-archive off the wrong PR), and skips terminal cached states (`.merged`/`.closed`) so settled worktrees aren't re-queried every poll.
- **Commit 2 — by-number lookups scoped per repo.** Found while tracing the caller: `computePRList` feeds worktrees from *all* repos into one `fetchAll`, but every by-number lookup resolved `owner/name` from `worktrees[0]`'s path. A cross-repo number usually nulls out (silently defeating the fallback), but when the number exists in the wrong repo it resolves an unrelated PR — and an unrelated *merged* PR would fire auto-archive on the wrong worktree. This latently affected the pre-existing #457 numbered path too. By-number lookups now group entries by each worktree's own resolved repo (one aliased query per repo), and `onPRStatusComputed` gets each worktree's own path so Nightwatch loads the right repo's policy.

## Test plan

- [x] `swift build` clean; `swift test --filter PRStatusManagerTests` — 107 tests pass (11 new: fallback selection incl. batch-failure and terminal-state gating, per-repo grouping)
- [x] Live-verified: with the fixed daemon running, `pr.list` now reports `{"state":"merged","reason":"Merged"}` for the affected worktree (longeye PR #14924, aged ~1400 PRs out of the batch window) — bus icon replaced by the merged glyph in the sidebar

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9860BD8D-EB22-451C-A371-326F867ED494)