### PR TITLE
Feat: Arm auto-archive-on-merge when spawning a worktree, via --archive-on-merge

### DIFF
--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -75,6 +75,9 @@ struct WorktreeCreate: AsyncParsableCommand {
     @Flag(name: .long, help: "Output JSON")
     var json = false
 
+    @Flag(name: .long, help: "Auto-archive this worktree when its PR merges (arms the per-worktree override; overrides the global default off).")
+    var archiveOnMerge = false
+
     mutating func validate() throws {
         if let folder = folder {
             if folder.isEmpty {
@@ -129,7 +132,8 @@ struct WorktreeCreate: AsyncParsableCommand {
                 siblingOfWorktreeID: parentingFields.siblingOfWorktreeID,
                 callerWorktreeID: parentingFields.callerWorktreeID,
                 suppressAutoParent: parentingFields.suppressAutoParent,
-                claudeSettingsOverlay: claudeSettings
+                claudeSettingsOverlay: claudeSettings,
+                autoArchiveOnMerge: archiveOnMerge ? true : nil
             ),
             resultType: Worktree.self
         )

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -36,6 +36,17 @@ extension RPCRouter {
             try? await db.worktrees.delete(id: pending.id)
             throw WorktreeLifecycleError.repoNotFound(params.repoID)
         }
+
+        // Arm the per-worktree auto-archive-on-merge override when the spawn
+        // requested it. nil leaves the row following the global default.
+        if let autoArchive = params.autoArchiveOnMerge {
+            do {
+                try await db.worktrees.setAutoArchiveOnMerge(id: pending.id, value: autoArchive)
+            } catch {
+                logger.warning("failed to arm auto-archive for \(pending.id, privacy: .public): \(error, privacy: .public)")
+            }
+        }
+
         let repoPath = repo.path
         let defaultBranch = repo.defaultBranch
         let fetchCache = self.fetchCache

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -875,7 +875,14 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// `prNumber` alone can't disambiguate: a fork head name may coincide with
     /// an unrelated local branch. Optional/defaulted for backward compatibility.
     public let checkoutPRHead: Bool?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil) {
+    /// When true, the daemon arms this worktree's per-worktree
+    /// auto-archive-on-merge override (sets the `autoArchiveOnMerge` column to
+    /// true), so it self-archives when its PR merges regardless of the global
+    /// default. nil means "follow the global default" (unchanged behavior).
+    /// Optional/defaulted for backward compatibility (old daemons ignore the
+    /// unknown key; old clients omit it).
+    public let autoArchiveOnMerge: Bool?
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, autoArchiveOnMerge: Bool? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
         self.parentWorktreeID = parentWorktreeID
@@ -887,6 +894,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
         self.claudeSettingsOverlay = claudeSettingsOverlay
         self.prNumber = prNumber
         self.checkoutPRHead = checkoutPRHead
+        self.autoArchiveOnMerge = autoArchiveOnMerge
     }
 }
 

--- a/Tests/TBDDaemonTests/RPCRouterWorktreeCreateBroadcastTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterWorktreeCreateBroadcastTests.swift
@@ -165,6 +165,55 @@ struct RPCRouterWorktreeCreateBroadcastTests {
         #expect(created.count == 1,
                 ".preSessionPending must produce exactly one .worktreeCreated total (no handler duplicate)")
     }
+
+    // Branching-conditional coverage (CLAUDE.md): the handler arms the
+    // per-worktree auto-archive-on-merge override only when the param is
+    // non-nil. Both branches are asserted below.
+
+    @Test func createWithAutoArchiveTrueArmsOverride() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeCreate,
+            params: WorktreeCreateParams(repoID: repo.id, autoArchiveOnMerge: true)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        let pending = try response.decodeResult(Worktree.self)
+
+        let row = try #require(try await db.worktrees.get(id: pending.id))
+        #expect(row.autoArchiveOnMerge == true)
+    }
+
+    @Test func createWithoutAutoArchiveLeavesOverrideNil() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let (router, _) = makeRouter(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Omitted (nil) → the row follows the global default (override unset).
+        let request = try RPCRequest(
+            method: RPCMethod.worktreeCreate,
+            params: WorktreeCreateParams(repoID: repo.id)
+        )
+        let response = await router.handle(request)
+        #expect(response.success)
+        let pending = try response.decodeResult(Worktree.self)
+
+        let row = try #require(try await db.worktrees.get(id: pending.id))
+        #expect(row.autoArchiveOnMerge == nil)
+    }
 }
 }
 


### PR DESCRIPTION
## Summary
- Adds a `--archive-on-merge` flag to `tbd worktree create`. When set, the new worktree self-archives once its PR merges — no need to arm the per-worktree toggle by hand afterward.
- Threads a new optional `autoArchiveOnMerge: Bool?` through `WorktreeCreateParams` (RPC). The daemon's `handleWorktreeCreate` sets the existing per-worktree `autoArchiveOnMerge` column (migration v32, already present) right after the row is inserted; omitting the flag leaves it `nil` so the worktree follows the global default (unchanged behavior).
- Reuses the whole existing merge→archive pipeline (`AutoArchiveOnMergeCoordinator`) — no new migration, no UI, no coordinator changes. Field is optional/defaulted so old daemons and clients stay compatible.

Note: this covers PR **merge**, not PR **close-without-merge** — the daemon only has a `.merged` transition callback today. Close-handling would be a separate change.

## Test plan
- [x] `swift build` clean
- [x] `swift test --filter WorktreeCreate` — 15/15 pass (incl. two new handler-path tests)
- [x] `swift test --filter AutoArchive` — 24/24 pass
- New tests assert both branches of the gate: `autoArchiveOnMerge: true` → row armed `true`; omitted → row stays `nil` (follows global default).

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=74780F21-C685-4727-AD3B-4B65E07D83E7)