### PR TITLE
refactor(usage): unify reset-display + color policy behind a shared BucketPresentation

### DIFF
--- a/Sources/TBDApp/AccountPickerSheet.swift
+++ b/Sources/TBDApp/AccountPickerSheet.swift
@@ -100,6 +100,7 @@ private struct AccountPickerRow: View {
     let onPick: () -> Void
 
     @State private var isHovering = false
+    @Environment(\.colorScheme) private var colorScheme
 
     private var isSelectable: Bool {
         ProfileUsagePresentation.isSelectable(entry)
@@ -169,57 +170,42 @@ private struct AccountPickerRow: View {
     private func bucketRows(_ snapshot: ProfileUsageSnapshot) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
-                bucketRow(label: "5h", bucket: session, showsReset: true)
+                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(session), label: "5h")
             }
             if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
-                bucketRow(label: "week", bucket: weekly, showsReset: false)
+                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(weekly), label: "week")
             }
             ForEach(Array(ProfileUsagePresentation.scopedBuckets(snapshot).enumerated()),
                     id: \.offset) { _, scoped in
-                bucketRow(label: scoped.modelDisplayName ?? "model",
-                          bucket: scoped, showsReset: false)
+                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(scoped),
+                          label: scoped.modelDisplayName ?? "model")
             }
         }
     }
 
-    private func bucketRow(label: String, bucket: ClaudeUsageLimitBucket,
-                           showsReset: Bool) -> some View {
-        let level = ProfileUsagePresentation.severityLevel(
-            severity: bucket.severity, percent: bucket.percent
-        )
+    private func bucketRow(presentation: ProfileUsagePresentation.BucketPresentation,
+                           label: String) -> some View {
+        let fillColor = presentation.fill.barColor(colorScheme)
         return HStack(spacing: 6) {
             Text(label)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .frame(width: 40, alignment: .leading)
-            ProgressView(value: min(max(bucket.percent, 0), 100), total: 100)
+            ProgressView(value: min(max(presentation.percent, 0), 100), total: 100)
                 .progressViewStyle(.linear)
-                .tint(level.color)
+                .tint(fillColor)
                 .frame(width: 140)
-            Text(ProfileUsagePresentation.percentText(bucket.percent))
+            Text(presentation.percentText)
                 .font(.caption)
                 .monospacedDigit()
-                .foregroundStyle(level == .normal ? AnyShapeStyle(.secondary) : AnyShapeStyle(level.color))
+                .foregroundStyle(presentation.fill == .normal ? AnyShapeStyle(.secondary) : AnyShapeStyle(fillColor))
                 .frame(width: 38, alignment: .trailing)
-            if showsReset, let resets = bucket.resetsAt {
-                Text("resets \(ProfileUsagePresentation.resetTimeText(resets))")
+            if presentation.resetDisplay != .tooltipOnly, let resetPhrase = presentation.resetPhrase {
+                Text(resetPhrase)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
             Spacer(minLength: 0)
-        }
-    }
-}
-
-// MARK: - Severity color
-
-extension ProfileUsagePresentation.SeverityLevel {
-    /// Bar/percent tint per severity tier.
-    var color: Color {
-        switch self {
-        case .normal: return .green
-        case .warning: return .orange
-        case .critical: return .red
         }
     }
 }

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -11,9 +11,12 @@ enum HoverCardTextStyle: Equatable {
 }
 
 /// Color treatment for a row value. Calm by default: color appears ONLY for
-/// warning/critical states, never as decoration.
+/// caution/warning/critical states, never as decoration. The four-tier hierarchy
+/// aligns with `ProfileUsagePresentation.FillLevel`.
 enum HoverCardTint: Equatable {
     case normal
+    /// Yellow: pace-aware caution tier (on track to warm but not yet alarmingly so).
+    case caution
     case warning
     case critical
 }
@@ -303,6 +306,7 @@ struct HoverCardView: View {
 
     private func valueColor(_ row: HoverCardRow) -> Color {
         switch row.tint {
+        case .caution: return .yellow
         case .warning: return .orange
         case .critical: return .red
         case .normal: return row.valueStyle == .mutedItalic ? Color.secondary : Color.primary

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -31,29 +31,23 @@ struct UsageBarsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
-                UsageBarRow(bucket: session,
+                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(session, now: now, timeZone: timeZone),
                             label: "5h:",
                             windowLabel: "5-hour window",
-                            windowDuration: ProfileUsagePresentation.sessionWindow,
-                            resetDisplay: .clock,
                             now: now,
                             timeZone: timeZone)
             }
             if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
-                UsageBarRow(bucket: weekly,
+                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(weekly, now: now, timeZone: timeZone),
                             label: "wk:",
                             windowLabel: "Weekly window",
-                            windowDuration: ProfileUsagePresentation.weeklyWindow,
-                            resetDisplay: .countdown,
                             now: now,
                             timeZone: timeZone)
             }
             ForEach(Array(ProfileUsagePresentation.scopedBuckets(snapshot).enumerated()), id: \.offset) { _, scoped in
-                UsageBarRow(bucket: scoped,
+                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(scoped, now: now, timeZone: timeZone),
                             label: ProfileUsagePresentation.familyAbbreviation(scoped.modelDisplayName) + ":",
                             windowLabel: ProfileUsagePresentation.familyName(scoped.modelDisplayName) + " weekly",
-                            windowDuration: ProfileUsagePresentation.weeklyWindow,
-                            resetDisplay: .tooltipOnly,
                             now: now,
                             timeZone: timeZone)
             }
@@ -63,29 +57,15 @@ struct UsageBarsView: View {
 
 // MARK: - One bar row
 
-/// How a row expresses its window's reset, inline and in the tooltip.
-private enum ResetDisplay {
-    /// "· 23:10" inline; tooltip "resets 23:10" (absolute clock, for 5h window).
-    case clock
-    /// "· 2d 5h" inline; tooltip "resets in 2d 5h" (relative countdown, for wk window).
-    case countdown
-    /// nothing inline; tooltip "resets in 2d 5h" (relative countdown, for scoped/F: rows).
-    case tooltipOnly
-}
-
 /// A single window's row: a fixed-width label, the flexible bar (fill + time
 /// marker), a fixed-width trailing percent, and a fixed-width trailing hint
 /// column. The four fixed columns keep bars vertically aligned across rows.
 private struct UsageBarRow: View {
-    let bucket: ClaudeUsageLimitBucket
+    let presentation: ProfileUsagePresentation.BucketPresentation
     /// Leading label ("5h:" / "wk:" / "F:").
     let label: String
     /// Spelled-out window name for the `.help` tooltip ("5-hour window" / "Fable weekly").
     let windowLabel: String
-    /// Window length feeding the time marker's elapsed fraction.
-    let windowDuration: TimeInterval
-    /// How this row displays its reset time (clock, countdown, or tooltip-only).
-    let resetDisplay: ResetDisplay
     let now: Date
     let timeZone: TimeZone
 
@@ -98,7 +78,7 @@ private struct UsageBarRow: View {
                 .foregroundStyle(.secondary)
                 .frame(width: 22, alignment: .leading)
             bar
-            Text(ProfileUsagePresentation.percentText(bucket.percent))
+            Text(presentation.percentText)
                 .font(.system(size: 10, weight: .semibold, design: .rounded))
                 .monospacedDigit()
                 .foregroundStyle(fillColor)
@@ -115,20 +95,7 @@ private struct UsageBarRow: View {
     /// to keep bars aligned. The 46pt width reserves space for both "· 23:10" and
     /// "· 2d 5h" at 9pt monospacedDigit.
     private var trailingResetHint: some View {
-        let hintText: String = {
-            guard let resetsAt = bucket.resetsAt else { return "" }
-            switch resetDisplay {
-            case .clock:
-                return "· \(ProfileUsagePresentation.resetTimeText(resetsAt, timeZone: timeZone))"
-            case .countdown:
-                guard let compact = ProfileUsagePresentation.compactResetCountdown(resetsAt, now: now) else {
-                    return ""
-                }
-                return "· \(compact)"
-            case .tooltipOnly:
-                return ""
-            }
-        }()
+        let hintText = presentation.resetInline.map { "· \($0)" } ?? ""
 
         return Text(hintText)
             .font(.system(size: 9, design: .rounded))
@@ -148,7 +115,7 @@ private struct UsageBarRow: View {
                 // Usage fill.
                 RoundedRectangle(cornerRadius: 2.5)
                     .fill(fillColor)
-                    .frame(width: geo.size.width * min(bucket.percent / 100, 1))
+                    .frame(width: geo.size.width * min(presentation.percent / 100, 1))
             }
             .frame(height: 5)
             // Time marker: a 9pt tick centered on the 5pt bar (overhangs 2pt
@@ -177,38 +144,11 @@ private struct UsageBarRow: View {
     /// pace data (no reset date, <15% elapsed) this is exactly the old
     /// severity coloring.
     private var fillColor: Color {
-        switch ProfileUsagePresentation.fillLevel(severity: bucket.severity,
-                                                  percent: bucket.percent,
-                                                  elapsedFraction: elapsedFraction) {
-        case .normal: return Self.adaptiveGreen(colorScheme)
-        case .caution: return Self.adaptiveYellow(colorScheme)
-        case .warning: return .orange
-        case .critical: return .red
-        }
+        presentation.fill.barColor(colorScheme)
     }
 
     private var elapsedFraction: Double? {
-        ProfileUsagePresentation.elapsedFraction(resetsAt: bucket.resetsAt,
-                                                 windowDuration: windowDuration,
-                                                 now: now)
-    }
-
-    /// Green that reads on both appearances: a brighter mint in dark mode, a
-    /// deeper forest in light mode (the light default green washes out on a
-    /// pale bar track).
-    private static func adaptiveGreen(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark
-            ? Color(red: 60 / 255, green: 199 / 255, blue: 95 / 255)
-            : Color(red: 27 / 255, green: 107 / 255, blue: 52 / 255)
-    }
-
-    /// Yellow that reads on both appearances: a bright warm yellow in dark
-    /// mode, a deeper amber in light mode (pure yellow washes out against the
-    /// pale bar track).
-    private static func adaptiveYellow(_ colorScheme: ColorScheme) -> Color {
-        colorScheme == .dark
-            ? Color(red: 235 / 255, green: 194 / 255, blue: 52 / 255)
-            : Color(red: 158 / 255, green: 110 / 255, blue: 6 / 255)
+        presentation.elapsedFraction
     }
 
     // MARK: Tooltip
@@ -216,16 +156,9 @@ private struct UsageBarRow: View {
     /// The spelled-out reset info the compact form omits, kept as a `.help`
     /// tooltip so nothing is lost: "5-hour window: 12% used · resets 23:10".
     private var helpText: String {
-        var text = "\(windowLabel): \(ProfileUsagePresentation.percentText(bucket.percent)) used"
-        if let resets = bucket.resetsAt {
-            switch resetDisplay {
-            case .clock:
-                text += " · resets \(ProfileUsagePresentation.resetTimeText(resets, timeZone: timeZone))"
-            case .countdown, .tooltipOnly:
-                if let relative = ProfileUsagePresentation.compactResetCountdown(resets, now: now) {
-                    text += " · resets in \(relative)"
-                }
-            }
+        var text = "\(windowLabel): \(presentation.percentText) used"
+        if let resetPhrase = presentation.resetPhrase {
+            text += " · \(resetPhrase)"
         }
         return text
     }

--- a/Sources/TBDApp/Components/UsageFillColor.swift
+++ b/Sources/TBDApp/Components/UsageFillColor.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Shared color mapping for usage fill levels, consumed by both the
+/// compact bars and the account picker to ensure consistency.
+extension ProfileUsagePresentation.FillLevel {
+    /// Bar/percent color for this fill level, adapted to the current appearance.
+    /// Green reads on both themes: brighter mint in dark mode, deeper forest in light.
+    /// Yellow reads on both themes: bright warm yellow in dark, deeper amber in light.
+    func barColor(_ colorScheme: ColorScheme) -> Color {
+        switch self {
+        case .normal:
+            return colorScheme == .dark
+                ? Color(red: 60 / 255, green: 199 / 255, blue: 95 / 255)
+                : Color(red: 27 / 255, green: 107 / 255, blue: 52 / 255)
+        case .caution:
+            return colorScheme == .dark
+                ? Color(red: 235 / 255, green: 194 / 255, blue: 52 / 255)
+                : Color(red: 158 / 255, green: 110 / 255, blue: 6 / 255)
+        case .warning:
+            return .orange
+        case .critical:
+            return .red
+        }
+    }
+}

--- a/Sources/TBDApp/Helpers/AccountHoverCards.swift
+++ b/Sources/TBDApp/Helpers/AccountHoverCards.swift
@@ -32,6 +32,7 @@ enum AccountHoverCards {
     static func claudeTabCard(terminal: Terminal,
                               profiles: [ModelProfileWithUsage],
                               timeZone: TimeZone = .current,
+                              now: Date = Date(),
                               enabled: Bool = true) -> HoverCardModel? {
         guard enabled else { return nil }
         guard terminal.kind == .claude || terminal.isClaudeResumable else { return nil }
@@ -46,7 +47,7 @@ enum AccountHoverCards {
                     model.titleCaption = notLoggedInCaption
                 }
                 model.rows.append(contentsOf: usageRows(for: entry.usageSnapshot,
-                                                        timeZone: timeZone))
+                                                        timeZone: timeZone, now: now))
             } else {
                 model.title = removedProfileLabel
                 model.titleStyle = .mutedItalic
@@ -66,42 +67,47 @@ enum AccountHoverCards {
     }
 
     /// Usage rows for a snapshot: 5h window (with reset time), weekly, and
-    /// per-family scoped buckets. Numbers are monospaced digits; tinted only
-    /// when the bucket is warning/critical — calm otherwise. Empty when the
-    /// profile has no usage data.
+    /// per-family scoped buckets. Numbers are monospaced digits; tinted per
+    /// pace-aware fill level. Empty when the profile has no usage data.
+    /// The weekly row now shows its reset countdown when available (closing
+    /// a gap where it silently omitted the weekly reset).
     static func usageRows(for snapshot: ProfileUsageSnapshot?,
-                          timeZone: TimeZone = .current) -> [HoverCardRow] {
+                          timeZone: TimeZone = .current,
+                          now: Date = Date()) -> [HoverCardRow] {
         guard let snapshot, !snapshot.buckets.isEmpty else { return [] }
         var rows: [HoverCardRow] = []
         if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
-            var value = ProfileUsagePresentation.percentText(session.percent)
-            if let resets = session.resetsAt {
-                value += " · resets \(ProfileUsagePresentation.resetTimeText(resets, timeZone: timeZone))"
+            let presentation = ProfileUsagePresentation.bucketPresentation(session, now: now, timeZone: timeZone)
+            var value = presentation.percentText
+            if let resetPhrase = presentation.resetPhrase {
+                value += " · \(resetPhrase)"
             }
             rows.append(HoverCardRow(label: "5h window", value: value,
-                                     monospacedDigits: true, tint: tint(for: session)))
+                                     monospacedDigits: true, tint: tint(for: presentation)))
         }
         if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
+            let presentation = ProfileUsagePresentation.bucketPresentation(weekly, now: now, timeZone: timeZone)
+            var value = presentation.percentText
+            if let resetPhrase = presentation.resetPhrase {
+                value += " · \(resetPhrase)"
+            }
             rows.append(HoverCardRow(label: "Week",
-                                     value: ProfileUsagePresentation.percentText(weekly.percent),
-                                     monospacedDigits: true, tint: tint(for: weekly)))
+                                     value: value,
+                                     monospacedDigits: true, tint: tint(for: presentation)))
         }
         for scoped in ProfileUsagePresentation.scopedBuckets(snapshot) {
+            let presentation = ProfileUsagePresentation.bucketPresentation(scoped, now: now, timeZone: timeZone)
             rows.append(HoverCardRow(label: scoped.modelDisplayName ?? "Model",
-                                     value: ProfileUsagePresentation.percentText(scoped.percent),
-                                     monospacedDigits: true, tint: tint(for: scoped)))
+                                     value: presentation.percentText,
+                                     monospacedDigits: true, tint: tint(for: presentation)))
         }
         return rows
     }
 
-    /// Map a bucket's severity to the card tint. `.normal` renders in the
-    /// calm primary color — color appears only for warning/critical.
-    static func tint(for bucket: ClaudeUsageLimitBucket) -> HoverCardTint {
-        switch ProfileUsagePresentation.severityLevel(severity: bucket.severity,
-                                                      percent: bucket.percent) {
-        case .normal: return .normal
-        case .warning: return .warning
-        case .critical: return .critical
-        }
+    /// Map a bucket presentation's pace-aware fill to the card tint.
+    /// The four-tier hierarchy (normal/caution/warning/critical) aligns with
+    /// `FillLevel`, so pace-aware coloring is consistent across all surfaces.
+    static func tint(for presentation: ProfileUsagePresentation.BucketPresentation) -> HoverCardTint {
+        ProfileUsagePresentation.hoverCardTint(for: presentation.fill)
     }
 }

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -203,13 +203,16 @@ enum ProfileUsagePresentation {
     /// Compact usage summary without a leading separator:
     /// "5h 0% ↺23:10 · wk 76% · F 100%". nil when there is no snapshot or it
     /// has no buckets (never logged in / poller hasn't fetched yet).
+    /// Routes through `resetDisplay(forKind:)` so reset-display policy is
+    /// centralized; output strings remain unchanged.
     static func usageSummary(for snapshot: ProfileUsageSnapshot?,
                              timeZone: TimeZone = .current) -> String? {
         guard let snapshot, !snapshot.buckets.isEmpty else { return nil }
         var parts: [String] = []
         if let session = sessionBucket(snapshot) {
             var part = "5h \(percentText(session.percent))"
-            if let resets = session.resetsAt {
+            // Session always uses clock display per resetDisplay(forKind:).
+            if let resets = session.resetsAt, resetDisplay(forKind: session.kind) == .clock {
                 part += " ↺\(resetTimeText(resets, timeZone: timeZone))"
             }
             parts.append(part)
@@ -262,7 +265,7 @@ enum ProfileUsagePresentation {
     /// `usageSummary` this drops the ↺ glyph in favor of "resets " and uses
     /// full family names instead of the single-letter abbreviation — the
     /// second line has the width. nil when there is no snapshot or it has no
-    /// buckets.
+    /// buckets. Routes through `resetDisplay(forKind:)` for consistency.
     static func usageDetailLine(for snapshot: ProfileUsageSnapshot?,
                                 timeZone: TimeZone = .current,
                                 now: Date = Date()) -> String? {
@@ -279,19 +282,17 @@ enum ProfileUsagePresentation {
         }
         if let session = sessionBucket(snapshot) {
             var part = percentPart("5h", session.percent)
-            // Reset granularity matches window scale: the 5h window resets
-            // today, so absolute clock time reads best.
-            if let resets = session.resetsAt {
+            // Session always uses clock display per resetDisplay(forKind:).
+            if let resets = session.resetsAt, resetDisplay(forKind: session.kind) == .clock {
                 part += " · resets \(resetTimeText(resets, timeZone: timeZone))"
             }
             parts.append(part)
         }
         if let weekly = weeklyAllBucket(snapshot) {
             var part = percentPart("week", weekly.percent)
-            // The weekly window is a planning horizon — "how long until the
-            // week ends" — so it shows a relative countdown. Weekly buckets
-            // share one reset instant, so it appears once, here.
-            if let resets = weekly.resetsAt,
+            // Weekly shows countdown per resetDisplay(forKind:).
+            if resetDisplay(forKind: weekly.kind) == .countdown,
+               let resets = weekly.resetsAt,
                let relative = compactResetCountdown(resets, now: now) {
                 part += " · resets in \(relative)"
             }
@@ -472,6 +473,135 @@ enum ProfileUsagePresentation {
             return "\(base) · last data \(ageText(since: fetchedAt, now: now)) ago"
         }
         return base
+    }
+
+    // MARK: - Reset display policy
+
+    /// How a bucket should express its reset time: inline (clock or countdown)
+    /// or in tooltips only. Centralized so all five rendering surfaces agree.
+    /// This is the single decision point for reset-display policy.
+    public enum ResetDisplay: Equatable {
+        /// "· 23:10" inline; tooltip "resets 23:10" (absolute clock time, for 5h window).
+        case clock
+        /// "· 2d 5h" inline; tooltip "resets in 2d 5h" (relative countdown, for weekly).
+        case countdown
+        /// Nothing inline; tooltip "resets in 2d 5h" (relative countdown, for scoped/model rows).
+        case tooltipOnly
+    }
+
+    /// Determine how a bucket's reset time should be displayed based on its kind.
+    /// Routes all five rendering surfaces through one decision point.
+    ///
+    /// - sessionKind ("session") → `.clock` (5-hour window, absolute time best)
+    /// - weeklyAllKind ("weekly_all") → `.countdown` (planning horizon, relative time)
+    /// - any other kind → `.tooltipOnly` (scoped/per-model, less critical to the main view)
+    static func resetDisplay(forKind kind: String) -> ResetDisplay {
+        switch kind {
+        case sessionKind: return .clock
+        case weeklyAllKind: return .countdown
+        default: return .tooltipOnly
+        }
+    }
+
+    /// Window duration for a bucket based on its kind.
+    /// Used to calculate the elapsed fraction (time marker position on the bar)
+    /// and to feed into pace-aware fill-level calculations.
+    static func windowDuration(forKind kind: String) -> TimeInterval {
+        switch kind {
+        case weeklyAllKind, weeklyScopedKind: return weeklyWindow
+        default: return sessionWindow
+        }
+    }
+
+    // MARK: - Unified bucket presentation model
+
+    /// Complete presentation data for a usage bucket: combines the API data with
+    /// all policy decisions (reset display, pace-aware fill level, reset text
+    /// fragments). A single source of truth consumed by all five rendering surfaces.
+    struct BucketPresentation: Equatable {
+        let kind: String
+        let percent: Double
+        let percentText: String
+        /// Pace-aware fill tier (green/yellow/orange/red).
+        let fill: FillLevel
+        /// How the reset should be displayed (clock, countdown, or tooltip-only).
+        let resetDisplay: ResetDisplay
+        /// Compact reset value without separators/prefix: "23:10" (clock) or "2d 5h" (countdown).
+        /// nil when resetDisplay == .tooltipOnly, or there is no reset date, or a countdown is past.
+        let resetInline: String?
+        /// Full reset phrase with "resets" prefix: "resets 23:10" (clock) or "resets in 2d 5h" (countdown/tooltipOnly).
+        /// Present whenever a reset date exists (any kind) — for tooltips, help text, and roomy rows.
+        /// nil when there is no reset date.
+        let resetPhrase: String?
+        /// Elapsed fraction through the window (0...1), for time marker positioning on bars.
+        /// nil when there is no reset date, duration is non-positive, or the reset is already past.
+        let elapsedFraction: Double?
+    }
+
+    /// Compute the unified presentation model for a bucket. Routes through
+    /// all policy decisions (reset display, pace-aware fill, reset text) in one place.
+    static func bucketPresentation(_ bucket: ClaudeUsageLimitBucket,
+                                   now: Date = Date(),
+                                   timeZone: TimeZone = .current) -> BucketPresentation {
+        let display = resetDisplay(forKind: bucket.kind)
+        let windowDuration = self.windowDuration(forKind: bucket.kind)
+        let elapsed = elapsedFraction(resetsAt: bucket.resetsAt,
+                                     windowDuration: windowDuration,
+                                     now: now)
+        let fill = fillLevel(severity: bucket.severity,
+                            percent: bucket.percent,
+                            elapsedFraction: elapsed)
+        let percent = bucket.percent
+        let percentText = self.percentText(percent)
+
+        // Compute resetInline and resetPhrase based on display type and reset date.
+        var resetInline: String?
+        var resetPhrase: String?
+
+        if let resetsAt = bucket.resetsAt {
+            switch display {
+            case .clock:
+                let clockText = resetTimeText(resetsAt, timeZone: timeZone)
+                resetInline = clockText
+                resetPhrase = "resets \(clockText)"
+
+            case .countdown:
+                if let compact = compactResetCountdown(resetsAt, now: now) {
+                    resetInline = compact
+                    resetPhrase = "resets in \(compact)"
+                }
+                // When countdown is past (nil), both remain nil.
+
+            case .tooltipOnly:
+                if let compact = compactResetCountdown(resetsAt, now: now) {
+                    resetPhrase = "resets in \(compact)"
+                }
+                // resetInline stays nil; resetPhrase shows only when countdown is valid.
+            }
+        }
+
+        return BucketPresentation(
+            kind: bucket.kind,
+            percent: percent,
+            percentText: percentText,
+            fill: fill,
+            resetDisplay: display,
+            resetInline: resetInline,
+            resetPhrase: resetPhrase,
+            elapsedFraction: elapsed
+        )
+    }
+
+    /// Map a `FillLevel` to the corresponding `HoverCardTint`, preserving the
+    /// four-tier hierarchy. Used so the hover card and picker both render
+    /// pace-aware colors consistently.
+    static func hoverCardTint(for fillLevel: FillLevel) -> HoverCardTint {
+        switch fillLevel {
+        case .normal: return .normal
+        case .caution: return .caution
+        case .warning: return .warning
+        case .critical: return .critical
+        }
     }
 
     // MARK: - Per-session tooltips

--- a/Tests/TBDAppTests/AccountHoverCardsTests.swift
+++ b/Tests/TBDAppTests/AccountHoverCardsTests.swift
@@ -74,7 +74,7 @@ struct ClaudeTabCardTests {
         let terminal = claudeTerminal(profileID: gmail.profile.id,
                                       createdAt: resetDate)
         let card = AccountHoverCards.claudeTabCard(terminal: terminal,
-                                                   profiles: [gmail], timeZone: utc)
+                                                   profiles: [gmail], timeZone: utc, now: resetDate)
         #expect(card?.title == "g@gmail.com")
         #expect(card?.titleStyle == .plain)
         let rows = card?.rows ?? []
@@ -184,21 +184,34 @@ struct UsageRowsTests {
     }
 
     @Test func tintIsCalmForNormalAndColoredOnlyForWarningCritical() {
-        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 10,
-                                                   severity: "normal")) == .normal)
-        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 80,
-                                                   severity: "warning")) == .warning)
-        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 99,
-                                                   severity: "critical")) == .critical)
-        // API omitted severity: falls back to percent thresholds.
-        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 10)) == .normal)
-        #expect(AccountHoverCards.tint(for: bucket(kind: "session", percent: 92)) == .critical)
+        // Tint now uses pace-aware fill level (from BucketPresentation) instead of just severity.
+        // Without elapsed fraction, the fill = severity floor, so behavior is the same.
+        let normal = ProfileUsagePresentation.bucketPresentation(
+            bucket(kind: "session", percent: 10, severity: "normal"), timeZone: utc)
+        #expect(AccountHoverCards.tint(for: normal) == .normal)
+
+        let warning = ProfileUsagePresentation.bucketPresentation(
+            bucket(kind: "session", percent: 80, severity: "warning"), timeZone: utc)
+        #expect(AccountHoverCards.tint(for: warning) == .warning)
+
+        let critical = ProfileUsagePresentation.bucketPresentation(
+            bucket(kind: "session", percent: 99, severity: "critical"), timeZone: utc)
+        #expect(AccountHoverCards.tint(for: critical) == .critical)
+
+        // API omitted severity: falls back to percent thresholds (no elapsed fraction).
+        let normalNoSeverity = ProfileUsagePresentation.bucketPresentation(
+            bucket(kind: "session", percent: 10), timeZone: utc)
+        #expect(AccountHoverCards.tint(for: normalNoSeverity) == .normal)
+
+        let criticalNoSeverity = ProfileUsagePresentation.bucketPresentation(
+            bucket(kind: "session", percent: 92), timeZone: utc)
+        #expect(AccountHoverCards.tint(for: criticalNoSeverity) == .critical)
     }
 
     @Test func scopedBucketWithoutFamilyNameFallsBackToModelLabel() {
         let rows = AccountHoverCards.usageRows(
             for: snapshot(buckets: [bucket(kind: "weekly_scoped", percent: 50)]),
-            timeZone: utc
+            timeZone: utc, now: Date()
         )
         #expect(rows.first?.label == "Model")
     }

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -313,6 +313,132 @@ struct FillLevelTests {
     }
 }
 
+// MARK: - Reset display policy
+
+@Suite("ProfileUsagePresentation — resetDisplay policy")
+struct ResetDisplayPolicyTests {
+    @Test func sessionKindUsesClockDisplay() {
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "session") == .clock)
+    }
+
+    @Test func weeklyAllKindUsesCountdownDisplay() {
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "weekly_all") == .countdown)
+    }
+
+    @Test func scopedKindUsesTooltipOnlyDisplay() {
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "weekly_scoped") == .tooltipOnly)
+    }
+
+    @Test func unknownKindDefaultsToTooltipOnly() {
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "future_kind") == .tooltipOnly)
+    }
+}
+
+@Suite("ProfileUsagePresentation — windowDuration")
+struct WindowDurationTests {
+    @Test func sessionKindUsesSessionWindow() {
+        #expect(ProfileUsagePresentation.windowDuration(forKind: "session") == ProfileUsagePresentation.sessionWindow)
+    }
+
+    @Test func weeklyAllKindUsesWeeklyWindow() {
+        #expect(ProfileUsagePresentation.windowDuration(forKind: "weekly_all") == ProfileUsagePresentation.weeklyWindow)
+    }
+
+    @Test func scopedKindUsesWeeklyWindow() {
+        #expect(ProfileUsagePresentation.windowDuration(forKind: "weekly_scoped") == ProfileUsagePresentation.weeklyWindow)
+    }
+
+    @Test func unknownKindDefaultsToSessionWindow() {
+        #expect(ProfileUsagePresentation.windowDuration(forKind: "future_kind") == ProfileUsagePresentation.sessionWindow)
+    }
+}
+
+// MARK: - Unified bucket presentation
+
+@Suite("ProfileUsagePresentation — BucketPresentation")
+struct BucketPresentationTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test func sessionBucketBuildsClockDisplay() {
+        // Use a reset date in the future relative to the test's 'now'.
+        // 45% early in the window (10% elapsed) → pace projection off (< 15% threshold), fill = normal floor
+        let futureReset = now.addingTimeInterval(0.9 * ProfileUsagePresentation.sessionWindow)  // 90% remaining
+        let sessionBucket = bucket(kind: "session", percent: 45, severity: "normal", resetsAt: futureReset)
+        let presentation = ProfileUsagePresentation.bucketPresentation(sessionBucket, now: now, timeZone: utc)
+        #expect(presentation.kind == "session")
+        #expect(presentation.percent == 45)
+        #expect(presentation.percentText == "45%")
+        #expect(presentation.resetDisplay == .clock)
+        #expect(presentation.resetInline != nil)  // Clock display should have reset inline
+        #expect(presentation.resetPhrase != nil)  // Should have reset phrase
+        #expect(presentation.fill == .normal)  // 10% elapsed, below gate
+        #expect(presentation.elapsedFraction != nil)
+    }
+
+    @Test func weeklyBucketBuildsCountdownDisplay() {
+        let weeklyBucket = bucket(kind: "weekly_all", percent: 76, severity: "warning")
+        let presentation = ProfileUsagePresentation.bucketPresentation(weeklyBucket, now: now, timeZone: utc)
+        #expect(presentation.kind == "weekly_all")
+        #expect(presentation.percent == 76)
+        #expect(presentation.percentText == "76%")
+        #expect(presentation.resetDisplay == .countdown)
+        #expect(presentation.resetInline == nil)  // No reset date on weekly bucket
+        #expect(presentation.resetPhrase == nil)
+        #expect(presentation.fill == .warning)
+        #expect(presentation.elapsedFraction == nil)
+    }
+
+    @Test func scopedBucketBuildsTooltipDisplay() {
+        let scopedBucket = bucket(kind: "weekly_scoped", percent: 100, severity: "critical", family: "Fable")
+        let presentation = ProfileUsagePresentation.bucketPresentation(scopedBucket, now: now, timeZone: utc)
+        #expect(presentation.kind == "weekly_scoped")
+        #expect(presentation.percent == 100)
+        #expect(presentation.percentText == "100%")
+        #expect(presentation.resetDisplay == .tooltipOnly)
+        #expect(presentation.resetInline == nil)
+        #expect(presentation.resetPhrase == nil)
+        #expect(presentation.fill == .critical)
+        #expect(presentation.elapsedFraction == nil)
+    }
+
+    @Test func paceAwareYellowTierInPresentation() {
+        // 55% at 0.65 elapsed on a session bucket → caution (yellow).
+        // elapsed = 0.65 * window means remaining = 0.35 * window
+        let sessionBucket = bucket(kind: "session", percent: 55, severity: "normal",
+                                   resetsAt: now.addingTimeInterval(0.35 * ProfileUsagePresentation.sessionWindow))
+        let presentation = ProfileUsagePresentation.bucketPresentation(sessionBucket, now: now, timeZone: utc)
+        #expect(presentation.fill == .caution)
+    }
+
+    @Test func countdownInResetPhraseWhenValid() {
+        // Weekly bucket with a reset date (hypothetically added by API in future).
+        let weekly = bucket(kind: "weekly_all", percent: 50, resetsAt: now.addingTimeInterval(2 * 24 * 3600))
+        let presentation = ProfileUsagePresentation.bucketPresentation(weekly, now: now, timeZone: utc)
+        #expect(presentation.resetDisplay == .countdown)
+        #expect(presentation.resetInline != nil)  // Now has countdown since we added a reset date
+        #expect(presentation.resetPhrase?.hasPrefix("resets in") ?? false)
+    }
+}
+
+@Suite("ProfileUsagePresentation — hoverCardTint mapping")
+struct HoverCardTintMappingTests {
+    @Test func normalFillMapsToNormalTint() {
+        #expect(ProfileUsagePresentation.hoverCardTint(for: .normal) == .normal)
+    }
+
+    @Test func cautionFillMapsToCautionTint() {
+        #expect(ProfileUsagePresentation.hoverCardTint(for: .caution) == .caution)
+    }
+
+    @Test func warningFillMapsToWarningTint() {
+        #expect(ProfileUsagePresentation.hoverCardTint(for: .warning) == .warning)
+    }
+
+    @Test func criticalFillMapsToCriticalTint() {
+        #expect(ProfileUsagePresentation.hoverCardTint(for: .critical) == .critical)
+    }
+}
+
 // MARK: - Pace projection: elapsed-time fraction
 
 @Suite("ProfileUsagePresentation — elapsedFraction")


### PR DESCRIPTION
## What

Unifies the **five** surfaces that render a profile's OAuth usage so they share one data model and one source of policy for (a) which reset time to show and how, and (b) the color tier. Previously each surface re-decided both, and they drifted — the per-session tab **hover card showed the 5h reset but silently omitted the weekly reset**, while the compact bars showed both:

| Surface | 5h reset (before) | Weekly reset (before) | Color (before) |
|---|---|---|---|
| `UsageBarsView` (compact bars) | `· 23:10` | `· 2d 5h` | `fillLevel` (pace-aware) |
| `AccountHoverCards` (tab hover) | `resets 23:10` | **— nothing —** | `severityLevel` (calm) |
| `AccountPickerSheet` | `resets 23:10` | — nothing — | `severityLevel` |
| `usageDetailLine` (menu 2nd line) | `resets 23:10` | `resets in 2d 5h` | n/a |
| `usageSummary` (menu 1 line) | `↺23:10` | — nothing — | n/a |

## How

New single source of truth in `ProfileUsagePresentation`:

- `resetDisplay(forKind:)` — the one place kind→reset-policy lives (session→`.clock`, weekly→`.countdown`, scoped→`.tooltipOnly`).
- `windowDuration(forKind:)` — kind→window length for the elapsed-fraction / pace projection.
- `struct BucketPresentation` + `bucketPresentation(_:now:timeZone:)` — a per-bucket model carrying `percent`, `fill` (pace-aware `FillLevel`), `resetDisplay`, `resetInline` (`"23:10"` / `"2d 5h"`), and `resetPhrase` (`"resets 23:10"` / `"resets in 2d 5h"`). Every visual surface renders from this.

Color unified onto the four-tier `FillLevel`:
- Shared `FillLevel.barColor(_:)` (new `UsageFillColor.swift`) so the bars **and** picker use identical shades.
- `HoverCardTint` gains a `.caution` (yellow) case so `FillLevel` maps 1:1 into the hover card.

## Behavior changes (intended)

- **The tab hover card now shows the weekly reset** (`Week  45% · resets in 2d 5h`) — the reported gap.
- The picker now shows the weekly reset too.
- The hover card + picker gain the bars' **pace-aware yellow tier** (they were previously calm — colored only at warning/critical). This was a deliberate opt-in: full consistency over calm.
- The two text formatters (`usageSummary`, `usageDetailLine`) now route their show/hide decision through `resetDisplay(forKind:)` — **output strings unchanged** (asserted by test).

## Tests

New suites: `resetDisplay policy` (all three branches), `BucketPresentation`, `windowDuration`, `FillLevel→HoverCardTint`. Updated `AccountHoverCardsTests` for the weekly-reset row + pace tints. `swift test` app usage suites: **127 passing**. `swift build` clean; `swiftlint --strict` clean.

## Stacked

Branches off #460 (`show-5h-reset-inline`), which is off #459. Until those merge, this PR's diff includes their commits — review the top commit (`refactor(usage): unify …`) for this change. Merge order: #459 → #460 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
