### PR TITLE
Feat: Pick a Claude model per spawn from the worktree picker, in tighter usage rows

### DIFF
--- a/Sources/TBDApp/AccountPickerSheet.swift
+++ b/Sources/TBDApp/AccountPickerSheet.swift
@@ -101,6 +101,8 @@ private struct AccountPickerRow: View {
 
     @State private var isHovering = false
     @Environment(\.colorScheme) private var colorScheme
+    @AppStorage(AppState.usageResetTimeStyleKey)
+    private var usageResetTimeStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset
 
     private var isSelectable: Bool {
         ProfileUsagePresentation.isSelectable(entry)
@@ -170,14 +172,14 @@ private struct AccountPickerRow: View {
     private func bucketRows(_ snapshot: ProfileUsageSnapshot) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
-                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(session), label: "5h")
+                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(session, style: usageResetTimeStyle), label: "5h")
             }
             if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
-                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(weekly), label: "week")
+                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(weekly, style: usageResetTimeStyle), label: "week")
             }
             ForEach(Array(ProfileUsagePresentation.scopedBuckets(snapshot).enumerated()),
                     id: \.offset) { _, scoped in
-                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(scoped),
+                bucketRow(presentation: ProfileUsagePresentation.bucketPresentation(scoped, style: usageResetTimeStyle),
                           label: scoped.modelDisplayName ?? "model")
             }
         }

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -453,11 +453,12 @@ extension AppState {
             }
     }
 
-    /// Force an immediate daemon-side OAuth usage sweep and merge the returned
-    /// snapshots into local state. The account picker calls this on open —
-    /// cached snapshots stay on screen and update in place when fresh data
-    /// lands. Failures are logged but never surfaced as a blocking alert
-    /// (the picker degrades to cached data).
+    /// Ask the daemon to refresh stale OAuth usage (fresh or backing-off
+    /// profiles are skipped server-side) and merge the returned snapshots
+    /// into local state. The account picker calls this on open — cached
+    /// snapshots stay on screen and update in place when fresh data lands.
+    /// Failures are logged but never surfaced as a blocking alert (the picker
+    /// degrades to cached data).
     func refreshUsageSnapshots(profileID: UUID? = nil) async {
         do {
             let result = try await daemonClient.refreshProfileUsage(id: profileID)

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -20,7 +20,10 @@ extension AppState {
     /// `profileID` is an optional explicit model-profile override chosen at
     /// creation time (sidebar `+` profile picker). nil resolves the profile via
     /// the daemon's normal repo/scratch/global precedence chain (today's behavior).
-    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil, profileID: UUID? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, displayName: String? = nil) {
+    /// `model` is an optional per-spawn Claude model override (picker model
+    /// buttons); it applies to the initial spawn only — later respawns fall
+    /// back to the profile default.
+    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil, profileID: UUID? = nil, model: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, displayName: String? = nil) {
         // Optimistic placeholder so the row appears instantly. When picking an
         // existing branch we use its local name so the placeholder name
         // doesn't briefly show a fake `tbd/*` value.
@@ -69,6 +72,7 @@ extension AppState {
                     parentWorktreeID: parentWorktreeID,
                     useExistingBranch: existingBranch != nil,
                     profileID: profileID,
+                    model: model,
                     prNumber: prNumber,
                     checkoutPRHead: checkoutPRHead
                 )

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1990,6 +1990,15 @@ final class AppState: ObservableObject {
     /// UI on very large transcripts, so it is opt-in and fails closed.
     static let enableTranscriptKey = "enableTranscript"
 
+    /// UserDefaults key for the usage reset-time display preference
+    /// (Settings → Claude → "Usage reset times"). Stores the raw value of
+    /// `ProfileUsagePresentation.ResetTimeStyle`; defaults to `.timeOfReset`.
+    /// Read via `@AppStorage` in the view layer and injected into the
+    /// presentation helpers as a parameter — never read from
+    /// `UserDefaults.standard` inside them (tests construct with explicit
+    /// values).
+    static let usageResetTimeStyleKey = "usageResetTimeStyle"
+
     /// Fail-closed read of the experimental live-transcript toggle for
     /// non-View callers (the View layer uses `@AppStorage` directly).
     /// Defaults to false when the user has never touched the toggle, matching

--- a/Sources/TBDApp/Components/HoverCard.swift
+++ b/Sources/TBDApp/Components/HoverCard.swift
@@ -306,7 +306,7 @@ struct HoverCardView: View {
 
     private func valueColor(_ row: HoverCardRow) -> Color {
         switch row.tint {
-        case .caution: return .yellow
+        case .caution: return .orange  // matches warning: tracker's bars have no yellow tier
         case .warning: return .orange
         case .critical: return .red
         case .normal: return row.valueStyle == .mutedItalic ? Color.secondary : Color.primary

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -3,8 +3,8 @@ import TBDShared
 
 /// A compact usage meter for a Claude OAuth profile: the 5-hour session
 /// window, the weekly all-models window, and per-model-family weekly windows,
-/// each drawn as a thin bar with a pace-aware colored fill (green/yellow/
-/// orange/red — projection of end-of-window usage from the current burn rate,
+/// each drawn as a thin bar with a pace-aware colored fill (green/orange/
+/// red — projection of end-of-window usage from the current burn rate,
 /// floored by the API severity so a warning/critical bucket never reads
 /// healthy), a neutral "time marker" tick showing how far through the window
 /// we are, and a trailing percent (and inline reset countdown on the weekly
@@ -143,9 +143,9 @@ private struct UsageBarRow: View {
     // MARK: Colors
 
     /// Pace-aware fill (shared by the bar and the trailing percent): green
-    /// (adaptive) when on a sustainable pace, yellow (adaptive) when the
-    /// projected end-of-window usage is warming (75–90%), orange when it will
-    /// likely graze the limit (90–100%), red when on pace to exceed. The API
+    /// (adaptive) when on a sustainable pace, orange when the projected
+    /// end-of-window usage is warming (75–90%) or will likely graze the
+    /// limit (90–100%), red when on pace to exceed. The API
     /// severity (or the >=75/>=90 percent fallback) floors the tier, so a
     /// warning/critical bucket never renders healthier than before; without
     /// pace data (no reset date, <15% elapsed) this is exactly the old
@@ -203,7 +203,7 @@ private struct UsageBarRow: View {
 
         // Mid usage — the projection lands in the caution/warning bands even
         // while the marker sits just ahead of the fill. Session projects to
-        // ~85% (yellow "warming"); weekly projects to ~95% (orange) despite
+        // ~85% (caution "warming"); weekly projects to ~95% (warning) despite
         // the API still saying "normal".
         UsageBarsView(snapshot: snap([
             bucket("session", 55, severity: "normal", resetsIn: 1.75 * 3600),

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -95,18 +95,20 @@ private struct UsageBarRow: View {
 
     // MARK: Trailing reset hint
 
-    /// Fourth column: reset display inline ("at 7:59 pm" / "at Fri 7 pm" /
+    /// Fourth column: reset display inline ("at 7:59pm" / "at Fri 7pm" /
     /// "in 4d 2h", prefix baked into `resetInline`) on rows where resetDisplay
     /// shows inline; empty but space-reserving on other rows to keep bars
-    /// aligned. The 78pt fixed width fits the widest form measured at this
-    /// font ("at Wed 12:59 pm" = 75pt at 9pt rounded monospacedDigit) while
+    /// aligned. The 75pt fixed width fits the widest form measured at this
+    /// font ("at Wed 12:59pm" = 72.6pt at 9pt rounded monospacedDigit) while
     /// keeping rows column-aligned; the flexible bar absorbs the difference.
+    /// `.secondary` (not `.tertiary`) keeps the reset legible in the popover
+    /// while still subordinate to the semibold percent column.
     private var trailingResetHint: some View {
         Text(presentation.resetInline ?? "")
             .font(.system(size: 9, design: .rounded))
             .monospacedDigit()
-            .foregroundStyle(.tertiary)
-            .frame(width: 78, alignment: .leading)
+            .foregroundStyle(.secondary)
+            .frame(width: 75, alignment: .leading)
     }
 
     // MARK: Bar geometry

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -95,12 +95,17 @@ private struct UsageBarRow: View {
 
     // MARK: Trailing reset hint
 
-    /// Fourth column: reset display inline ("at 7:59pm" / "at Fri 7pm" /
+    /// Fourth column: reset display inline ("at 8pm" / "at Fri 7pm" /
     /// "in 4d 2h", prefix baked into `resetInline`) on rows where resetDisplay
     /// shows inline; empty but space-reserving on other rows to keep bars
-    /// aligned. The 75pt fixed width fits the widest form measured at this
-    /// font ("at Wed 12:59pm" = 72.6pt at 9pt rounded monospacedDigit) while
-    /// keeping rows column-aligned; the flexible bar absorbs the difference.
+    /// aligned. The 74pt fixed width fits the true worst case at FULL size —
+    /// "at Wed 10:30pm" / "at Wed 12:30pm" = 72.6pt at 9pt rounded
+    /// monospacedDigit — with no minimumScaleFactor, so every string renders
+    /// at identical size (a visible scale-down on one row next to a full-size
+    /// neighbor read as a glitch). Leading alignment keeps every reset string
+    /// starting at the same x across rows. The width win over the old 75pt
+    /// column comes from the strings themselves (ceil-rounding + dropped ":00"
+    /// make "at 8pm" the common case); the flexible bar absorbs the difference.
     /// `.secondary` (not `.tertiary`) keeps the reset legible in the popover
     /// while still subordinate to the semibold percent column.
     private var trailingResetHint: some View {
@@ -108,7 +113,8 @@ private struct UsageBarRow: View {
             .font(.system(size: 9, design: .rounded))
             .monospacedDigit()
             .foregroundStyle(.secondary)
-            .frame(width: 75, alignment: .leading)
+            .lineLimit(1)
+            .frame(width: 74, alignment: .leading)
     }
 
     // MARK: Bar geometry

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -7,9 +7,8 @@ import TBDShared
 /// orange/red — projection of end-of-window usage from the current burn rate,
 /// floored by the API severity so a warning/critical bucket never reads
 /// healthy), a neutral "time marker" tick showing how far through the window
-/// we are, and a trailing percent. Reset info renders as ONE compact line
-/// below the bars ("resets 14:59 · wk 4d 7h") instead of a per-row trailing
-/// column, so the bars get the full width.
+/// we are, and a trailing percent (and inline reset countdown on the weekly
+/// all-models row).
 ///
 /// Pure presentation over a `ProfileUsageSnapshot` (no picker/tab state), so it
 /// is reusable anywhere a snapshot is in hand. `now`/`timeZone` are injectable
@@ -52,40 +51,15 @@ struct UsageBarsView: View {
                             now: now,
                             timeZone: timeZone)
             }
-            if let resetLine {
-                Text(resetLine)
-                    .font(.system(size: 9, design: .rounded))
-                    .monospacedDigit()
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(1)
-            }
         }
-    }
-
-    /// One compact line combining the session clock and weekly countdown,
-    /// e.g. "resets 14:59 · wk 4d 7h". Segments without reset data are
-    /// omitted; nil (no line) when neither window has any. Scoped ("F:")
-    /// buckets stay tooltip-only, as before.
-    private var resetLine: String? {
-        var parts: [String] = []
-        if let session = ProfileUsagePresentation.sessionBucket(snapshot),
-           let inline = ProfileUsagePresentation.bucketPresentation(session, now: now, timeZone: timeZone).resetInline {
-            parts.append("resets \(inline)")
-        }
-        if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot),
-           let inline = ProfileUsagePresentation.bucketPresentation(weekly, now: now, timeZone: timeZone).resetInline {
-            parts.append("wk \(inline)")
-        }
-        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 }
 
 // MARK: - One bar row
 
 /// A single window's row: a fixed-width label, the flexible bar (fill + time
-/// marker), and a fixed-width trailing percent. The fixed columns keep bars
-/// vertically aligned across rows; reset info lives on the shared line below
-/// the bars (and in each row's tooltip).
+/// marker), a fixed-width trailing percent, and a fixed-width trailing hint
+/// column. The four fixed columns keep bars vertically aligned across rows.
 private struct UsageBarRow: View {
     let presentation: ProfileUsagePresentation.BucketPresentation
     /// Leading label ("5h:" / "wk:" / "F:").
@@ -109,8 +83,25 @@ private struct UsageBarRow: View {
                 .monospacedDigit()
                 .foregroundStyle(fillColor)
                 .frame(width: 30, alignment: .trailing)
+            trailingResetHint
         }
         .help(helpText)
+    }
+
+    // MARK: Trailing reset hint
+
+    /// Fourth column: reset display inline (clock for 5h, countdown for wk) on rows
+    /// where resetDisplay shows inline; empty but space-reserving on other rows
+    /// to keep bars aligned. The 46pt width reserves space for both "· 23:10" and
+    /// "· 2d 5h" at 9pt monospacedDigit.
+    private var trailingResetHint: some View {
+        let hintText = presentation.resetInline.map { "· \($0)" } ?? ""
+
+        return Text(hintText)
+            .font(.system(size: 9, design: .rounded))
+            .monospacedDigit()
+            .foregroundStyle(.tertiary)
+            .frame(width: 46, alignment: .leading)
     }
 
     // MARK: Bar geometry

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -7,8 +7,9 @@ import TBDShared
 /// orange/red — projection of end-of-window usage from the current burn rate,
 /// floored by the API severity so a warning/critical bucket never reads
 /// healthy), a neutral "time marker" tick showing how far through the window
-/// we are, and a trailing percent (and inline reset countdown on the weekly
-/// all-models row).
+/// we are, and a trailing percent. Reset info renders as ONE compact line
+/// below the bars ("resets 14:59 · wk 4d 7h") instead of a per-row trailing
+/// column, so the bars get the full width.
 ///
 /// Pure presentation over a `ProfileUsageSnapshot` (no picker/tab state), so it
 /// is reusable anywhere a snapshot is in hand. `now`/`timeZone` are injectable
@@ -51,15 +52,40 @@ struct UsageBarsView: View {
                             now: now,
                             timeZone: timeZone)
             }
+            if let resetLine {
+                Text(resetLine)
+                    .font(.system(size: 9, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
         }
+    }
+
+    /// One compact line combining the session clock and weekly countdown,
+    /// e.g. "resets 14:59 · wk 4d 7h". Segments without reset data are
+    /// omitted; nil (no line) when neither window has any. Scoped ("F:")
+    /// buckets stay tooltip-only, as before.
+    private var resetLine: String? {
+        var parts: [String] = []
+        if let session = ProfileUsagePresentation.sessionBucket(snapshot),
+           let inline = ProfileUsagePresentation.bucketPresentation(session, now: now, timeZone: timeZone).resetInline {
+            parts.append("resets \(inline)")
+        }
+        if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot),
+           let inline = ProfileUsagePresentation.bucketPresentation(weekly, now: now, timeZone: timeZone).resetInline {
+            parts.append("wk \(inline)")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 }
 
 // MARK: - One bar row
 
 /// A single window's row: a fixed-width label, the flexible bar (fill + time
-/// marker), a fixed-width trailing percent, and a fixed-width trailing hint
-/// column. The four fixed columns keep bars vertically aligned across rows.
+/// marker), and a fixed-width trailing percent. The fixed columns keep bars
+/// vertically aligned across rows; reset info lives on the shared line below
+/// the bars (and in each row's tooltip).
 private struct UsageBarRow: View {
     let presentation: ProfileUsagePresentation.BucketPresentation
     /// Leading label ("5h:" / "wk:" / "F:").
@@ -83,25 +109,8 @@ private struct UsageBarRow: View {
                 .monospacedDigit()
                 .foregroundStyle(fillColor)
                 .frame(width: 30, alignment: .trailing)
-            trailingResetHint
         }
         .help(helpText)
-    }
-
-    // MARK: Trailing reset hint
-
-    /// Fourth column: reset display inline (clock for 5h, countdown for wk) on rows
-    /// where resetDisplay shows inline; empty but space-reserving on other rows
-    /// to keep bars aligned. The 46pt width reserves space for both "· 23:10" and
-    /// "· 2d 5h" at 9pt monospacedDigit.
-    private var trailingResetHint: some View {
-        let hintText = presentation.resetInline.map { "· \($0)" } ?? ""
-
-        return Text(hintText)
-            .font(.system(size: 9, design: .rounded))
-            .monospacedDigit()
-            .foregroundStyle(.tertiary)
-            .frame(width: 46, alignment: .leading)
     }
 
     // MARK: Bar geometry

--- a/Sources/TBDApp/Components/UsageBarsView.swift
+++ b/Sources/TBDApp/Components/UsageBarsView.swift
@@ -17,13 +17,18 @@ import TBDShared
 /// data at all.
 struct UsageBarsView: View {
     let snapshot: ProfileUsageSnapshot?
+    /// The user's reset-time display preference (time-of-reset vs time-until).
+    /// Injected by the hosting view from `@AppStorage(AppState.usageResetTimeStyleKey)`.
+    let resetStyle: ProfileUsagePresentation.ResetTimeStyle
     let now: Date
     let timeZone: TimeZone
 
     init(snapshot: ProfileUsageSnapshot?,
+         resetStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset,
          now: Date = Date(),
          timeZone: TimeZone = .current) {
         self.snapshot = snapshot
+        self.resetStyle = resetStyle
         self.now = now
         self.timeZone = timeZone
     }
@@ -31,21 +36,21 @@ struct UsageBarsView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
-                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(session, now: now, timeZone: timeZone),
+                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(session, style: resetStyle, now: now, timeZone: timeZone),
                             label: "5h:",
                             windowLabel: "5-hour window",
                             now: now,
                             timeZone: timeZone)
             }
             if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
-                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(weekly, now: now, timeZone: timeZone),
+                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(weekly, style: resetStyle, now: now, timeZone: timeZone),
                             label: "wk:",
                             windowLabel: "Weekly window",
                             now: now,
                             timeZone: timeZone)
             }
             ForEach(Array(ProfileUsagePresentation.scopedBuckets(snapshot).enumerated()), id: \.offset) { _, scoped in
-                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(scoped, now: now, timeZone: timeZone),
+                UsageBarRow(presentation: ProfileUsagePresentation.bucketPresentation(scoped, style: resetStyle, now: now, timeZone: timeZone),
                             label: ProfileUsagePresentation.familyAbbreviation(scoped.modelDisplayName) + ":",
                             windowLabel: ProfileUsagePresentation.familyName(scoped.modelDisplayName) + " weekly",
                             now: now,
@@ -90,18 +95,18 @@ private struct UsageBarRow: View {
 
     // MARK: Trailing reset hint
 
-    /// Fourth column: reset display inline (clock for 5h, countdown for wk) on rows
-    /// where resetDisplay shows inline; empty but space-reserving on other rows
-    /// to keep bars aligned. The 46pt width reserves space for both "· 23:10" and
-    /// "· 2d 5h" at 9pt monospacedDigit.
+    /// Fourth column: reset display inline ("at 7:59 pm" / "at Fri 7 pm" /
+    /// "in 4d 2h", prefix baked into `resetInline`) on rows where resetDisplay
+    /// shows inline; empty but space-reserving on other rows to keep bars
+    /// aligned. The 78pt fixed width fits the widest form measured at this
+    /// font ("at Wed 12:59 pm" = 75pt at 9pt rounded monospacedDigit) while
+    /// keeping rows column-aligned; the flexible bar absorbs the difference.
     private var trailingResetHint: some View {
-        let hintText = presentation.resetInline.map { "· \($0)" } ?? ""
-
-        return Text(hintText)
+        Text(presentation.resetInline ?? "")
             .font(.system(size: 9, design: .rounded))
             .monospacedDigit()
             .foregroundStyle(.tertiary)
-            .frame(width: 46, alignment: .leading)
+            .frame(width: 78, alignment: .leading)
     }
 
     // MARK: Bar geometry

--- a/Sources/TBDApp/Components/UsageFillColor.swift
+++ b/Sources/TBDApp/Components/UsageFillColor.swift
@@ -3,9 +3,11 @@ import SwiftUI
 /// Shared color mapping for usage fill levels, consumed by both the
 /// compact bars and the account picker to ensure consistency.
 extension ProfileUsagePresentation.FillLevel {
-    /// Bar/percent color for this fill level, adapted to the current appearance.
-    /// Green reads on both themes: brighter mint in dark mode, deeper forest in light.
-    /// Yellow reads on both themes: bright warm yellow in dark, deeper amber in light.
+    /// Bar/percent color for this fill level, matching Claude-Usage-Tracker's
+    /// three-tier scheme exactly: adaptive green (brighter mint in dark mode,
+    /// deeper forest in light), then plain system orange/red. `.caution` and
+    /// `.warning` intentionally share orange — the tracker's bars have no
+    /// separate yellow tier.
     func barColor(_ colorScheme: ColorScheme) -> Color {
         switch self {
         case .normal:
@@ -13,9 +15,7 @@ extension ProfileUsagePresentation.FillLevel {
                 ? Color(red: 60 / 255, green: 199 / 255, blue: 95 / 255)
                 : Color(red: 27 / 255, green: 107 / 255, blue: 52 / 255)
         case .caution:
-            return colorScheme == .dark
-                ? Color(red: 235 / 255, green: 194 / 255, blue: 52 / 255)
-                : Color(red: 158 / 255, green: 110 / 255, blue: 6 / 255)
+            return .orange
         case .warning:
             return .orange
         case .critical:

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -455,10 +455,10 @@ actor DaemonClient {
     /// When `useExistingBranch` is true, `branch` MUST be set to an existing
     /// ref name (local like `foo` or remote like `origin/foo`) — the daemon
     /// checks it out instead of creating a new `tbd/*` branch.
-    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false, profileID: UUID? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil) async throws -> Worktree {
+    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false, profileID: UUID? = nil, model: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil) async throws -> Worktree {
         return try await callAsync(
             method: RPCMethod.worktreeCreate,
-            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch, profileID: profileID, prNumber: prNumber, checkoutPRHead: checkoutPRHead),
+            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch, profileID: profileID, model: model, prNumber: prNumber, checkoutPRHead: checkoutPRHead),
             resultType: Worktree.self
         )
     }

--- a/Sources/TBDApp/Helpers/AccountHoverCards.swift
+++ b/Sources/TBDApp/Helpers/AccountHoverCards.swift
@@ -31,6 +31,7 @@ enum AccountHoverCards {
     /// is a feature-rich, easy-to-skim take on session-usage display.
     static func claudeTabCard(terminal: Terminal,
                               profiles: [ModelProfileWithUsage],
+                              resetStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset,
                               timeZone: TimeZone = .current,
                               now: Date = Date(),
                               enabled: Bool = true) -> HoverCardModel? {
@@ -47,6 +48,7 @@ enum AccountHoverCards {
                     model.titleCaption = notLoggedInCaption
                 }
                 model.rows.append(contentsOf: usageRows(for: entry.usageSnapshot,
+                                                        resetStyle: resetStyle,
                                                         timeZone: timeZone, now: now))
             } else {
                 model.title = removedProfileLabel
@@ -72,12 +74,13 @@ enum AccountHoverCards {
     /// The weekly row now shows its reset countdown when available (closing
     /// a gap where it silently omitted the weekly reset).
     static func usageRows(for snapshot: ProfileUsageSnapshot?,
+                          resetStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset,
                           timeZone: TimeZone = .current,
                           now: Date = Date()) -> [HoverCardRow] {
         guard let snapshot, !snapshot.buckets.isEmpty else { return [] }
         var rows: [HoverCardRow] = []
         if let session = ProfileUsagePresentation.sessionBucket(snapshot) {
-            let presentation = ProfileUsagePresentation.bucketPresentation(session, now: now, timeZone: timeZone)
+            let presentation = ProfileUsagePresentation.bucketPresentation(session, style: resetStyle, now: now, timeZone: timeZone)
             var value = presentation.percentText
             if let resetPhrase = presentation.resetPhrase {
                 value += " · \(resetPhrase)"
@@ -86,7 +89,7 @@ enum AccountHoverCards {
                                      monospacedDigits: true, tint: tint(for: presentation)))
         }
         if let weekly = ProfileUsagePresentation.weeklyAllBucket(snapshot) {
-            let presentation = ProfileUsagePresentation.bucketPresentation(weekly, now: now, timeZone: timeZone)
+            let presentation = ProfileUsagePresentation.bucketPresentation(weekly, style: resetStyle, now: now, timeZone: timeZone)
             var value = presentation.percentText
             if let resetPhrase = presentation.resetPhrase {
                 value += " · \(resetPhrase)"

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -152,10 +152,31 @@ enum ProfileUsagePresentation {
         "\(Int(percent.rounded()))%"
     }
 
-    /// "23:10" — reset times are compact 24h clock times (menu width is precious).
+    /// "7:59 pm" — reset clock times render 12-hour with lowercase am/pm so
+    /// they can't be misread as an hour count ("19:59" ≈ "in 19h 59m").
+    /// POSIX locale + explicit symbols keep the output locale-stable.
     static func resetTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "h:mm a"
+        formatter.amSymbol = "am"
+        formatter.pmSymbol = "pm"
+        formatter.timeZone = timeZone
+        return formatter.string(from: date)
+    }
+
+    /// "Fri 7 pm" / "Fri 6:59 pm" — weekday + 12h time for resets days away
+    /// (the weekly window's time-of-reset form). Minutes are dropped on the
+    /// hour to keep the fragment compact.
+    static func weekdayResetTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        let onTheHour = calendar.component(.minute, from: date) == 0
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = onTheHour ? "EEE h a" : "EEE h:mm a"
+        formatter.amSymbol = "am"
+        formatter.pmSymbol = "pm"
         formatter.timeZone = timeZone
         return formatter.string(from: date)
     }
@@ -201,18 +222,18 @@ enum ProfileUsagePresentation {
     }
 
     /// Compact usage summary without a leading separator:
-    /// "5h 0% ↺23:10 · wk 76% · F 100%". nil when there is no snapshot or it
-    /// has no buckets (never logged in / poller hasn't fetched yet).
-    /// Routes through `resetDisplay(forKind:)` so reset-display policy is
-    /// centralized; output strings remain unchanged.
+    /// "5h 0% ↺11:10 pm · wk 76% · F 100%". nil when there is no snapshot or
+    /// it has no buckets (never logged in / poller hasn't fetched yet).
+    /// This legacy flat-string form keeps a FIXED format (clock for 5h,
+    /// nothing for weekly) regardless of the `ResetTimeStyle` preference —
+    /// the preference flows through `BucketPresentation` surfaces.
     static func usageSummary(for snapshot: ProfileUsageSnapshot?,
                              timeZone: TimeZone = .current) -> String? {
         guard let snapshot, !snapshot.buckets.isEmpty else { return nil }
         var parts: [String] = []
         if let session = sessionBucket(snapshot) {
             var part = "5h \(percentText(session.percent))"
-            // Session always uses clock display per resetDisplay(forKind:).
-            if let resets = session.resetsAt, resetDisplay(forKind: session.kind) == .clock {
+            if let resets = session.resetsAt {
                 part += " ↺\(resetTimeText(resets, timeZone: timeZone))"
             }
             parts.append(part)
@@ -261,11 +282,13 @@ enum ProfileUsagePresentation {
     }
 
     /// Spelled-out usage line for the roomier second row: "5h 16% used ·
-    /// resets 23:09 · week 79% · resets in 2d 5h · Fable 100%". Unlike
+    /// resets 11:09 pm · week 79% · resets in 2d 5h · Fable 100%". Unlike
     /// `usageSummary` this drops the ↺ glyph in favor of "resets " and uses
     /// full family names instead of the single-letter abbreviation — the
     /// second line has the width. nil when there is no snapshot or it has no
-    /// buckets. Routes through `resetDisplay(forKind:)` for consistency.
+    /// buckets. Like `usageSummary`, this legacy flat-string form keeps a
+    /// FIXED format (clock for 5h, countdown for weekly) regardless of the
+    /// `ResetTimeStyle` preference.
     static func usageDetailLine(for snapshot: ProfileUsageSnapshot?,
                                 timeZone: TimeZone = .current,
                                 now: Date = Date()) -> String? {
@@ -282,17 +305,14 @@ enum ProfileUsagePresentation {
         }
         if let session = sessionBucket(snapshot) {
             var part = percentPart("5h", session.percent)
-            // Session always uses clock display per resetDisplay(forKind:).
-            if let resets = session.resetsAt, resetDisplay(forKind: session.kind) == .clock {
+            if let resets = session.resetsAt {
                 part += " · resets \(resetTimeText(resets, timeZone: timeZone))"
             }
             parts.append(part)
         }
         if let weekly = weeklyAllBucket(snapshot) {
             var part = percentPart("week", weekly.percent)
-            // Weekly shows countdown per resetDisplay(forKind:).
-            if resetDisplay(forKind: weekly.kind) == .countdown,
-               let resets = weekly.resetsAt,
+            if let resets = weekly.resetsAt,
                let relative = compactResetCountdown(resets, now: now) {
                 part += " · resets in \(relative)"
             }
@@ -310,20 +330,27 @@ enum ProfileUsagePresentation {
     /// future (a stale snapshot shouldn't render a nonsense countdown). Used as
     /// a building block for contexts that need just the duration, which they can
     /// wrap in their own "resets in" or similar text. Minutes appear only under an
-    /// hour; hour-scale drops minutes; day-scale carries the hour remainder.
-    static func compactResetCountdown(_ resetsAt: Date, now: Date = Date()) -> String? {
+    /// hour; hour-scale drops minutes (unless `minutesAtHourScale` — used for the
+    /// 5h session window, where a bare "2h" loses too much: "2h 10m"); day-scale
+    /// carries the hour remainder.
+    static func compactResetCountdown(_ resetsAt: Date, now: Date = Date(),
+                                      minutesAtHourScale: Bool = false) -> String? {
         let interval = resetsAt.timeIntervalSince(now)
         guard interval > 0 else { return nil }
         let totalMinutes = Int((interval / 60).rounded(.up))
         let days = totalMinutes / (24 * 60)
         let hours = (totalMinutes % (24 * 60)) / 60
+        let minutes = totalMinutes % 60
         if days > 0 {
             return hours > 0 ? "\(days)d \(hours)h" : "\(days)d"
         }
         if hours > 0 {
+            if minutesAtHourScale, minutes > 0 {
+                return "\(hours)h \(minutes)m"
+            }
             return "\(hours)h"
         }
-        return "\(max(totalMinutes % 60, 1))m"
+        return "\(max(minutes, 1))m"
     }
 
     /// Two-line menu-row model for a profile: identity on the primary line, and
@@ -477,28 +504,45 @@ enum ProfileUsagePresentation {
 
     // MARK: - Reset display policy
 
-    /// How a bucket should express its reset time: inline (clock or countdown)
-    /// or in tooltips only. Centralized so all five rendering surfaces agree.
-    /// This is the single decision point for reset-display policy.
+    /// User display preference for reset instants (Settings → Claude →
+    /// "Usage reset times", `AppState.usageResetTimeStyleKey`): absolute
+    /// time-of-reset (default) or relative time-until-reset. Injected as a
+    /// parameter — never read from UserDefaults here — so tests construct
+    /// with explicit values.
+    enum ResetTimeStyle: String, CaseIterable {
+        /// "at 7:59 pm" (session) / "at Fri 7 pm" (weekly). The default.
+        case timeOfReset
+        /// "in 2h 10m" (session) / "in 4d 2h" (weekly).
+        case timeUntilReset
+    }
+
+    /// How a bucket should express its reset time: inline (clock, weekday
+    /// clock, or countdown) or in tooltips only. Centralized so all rendering
+    /// surfaces agree. This is the single decision point for reset-display policy.
     public enum ResetDisplay: Equatable {
-        /// "· 23:10" inline; tooltip "resets 23:10" (absolute clock time, for 5h window).
+        /// "at 7:59 pm" inline; tooltip "resets at 7:59 pm" (absolute clock time, 5h window).
         case clock
-        /// "· 2d 5h" inline; tooltip "resets in 2d 5h" (relative countdown, for weekly).
+        /// "at Fri 7 pm" inline; tooltip "resets at Fri 7 pm" (weekday + time, weekly window).
+        case weekdayClock
+        /// "in 2h 10m" / "in 4d 2h" inline; tooltip "resets in …" (relative countdown).
         case countdown
         /// Nothing inline; tooltip "resets in 2d 5h" (relative countdown, for scoped/model rows).
         case tooltipOnly
     }
 
-    /// Determine how a bucket's reset time should be displayed based on its kind.
-    /// Routes all five rendering surfaces through one decision point.
+    /// Determine how a bucket's reset time should be displayed based on its
+    /// kind and the user's `ResetTimeStyle` preference. Routes all rendering
+    /// surfaces through one decision point.
     ///
-    /// - sessionKind ("session") → `.clock` (5-hour window, absolute time best)
-    /// - weeklyAllKind ("weekly_all") → `.countdown` (planning horizon, relative time)
-    /// - any other kind → `.tooltipOnly` (scoped/per-model, less critical to the main view)
-    static func resetDisplay(forKind kind: String) -> ResetDisplay {
+    /// - sessionKind ("session") → `.clock` (time-of-reset) / `.countdown` (time-until)
+    /// - weeklyAllKind ("weekly_all") → `.weekdayClock` (time-of-reset) / `.countdown` (time-until)
+    /// - any other kind → `.tooltipOnly` in BOTH styles (scoped/per-model,
+    ///   less critical to the main view)
+    static func resetDisplay(forKind kind: String,
+                             style: ResetTimeStyle = .timeOfReset) -> ResetDisplay {
         switch kind {
-        case sessionKind: return .clock
-        case weeklyAllKind: return .countdown
+        case sessionKind: return style == .timeOfReset ? .clock : .countdown
+        case weeklyAllKind: return style == .timeOfReset ? .weekdayClock : .countdown
         default: return .tooltipOnly
         }
     }
@@ -524,12 +568,14 @@ enum ProfileUsagePresentation {
         let percentText: String
         /// Pace-aware fill tier (green/yellow/orange/red).
         let fill: FillLevel
-        /// How the reset should be displayed (clock, countdown, or tooltip-only).
+        /// How the reset should be displayed (clock, weekday clock, countdown, or tooltip-only).
         let resetDisplay: ResetDisplay
-        /// Compact reset value without separators/prefix: "23:10" (clock) or "2d 5h" (countdown).
+        /// Inline reset column text, prefix included: "at 7:59 pm" (clock),
+        /// "at Fri 7 pm" (weekday clock), or "in 4d 2h" (countdown).
         /// nil when resetDisplay == .tooltipOnly, or there is no reset date, or a countdown is past.
         let resetInline: String?
-        /// Full reset phrase with "resets" prefix: "resets 23:10" (clock) or "resets in 2d 5h" (countdown/tooltipOnly).
+        /// Full reset phrase with "resets" prefix: "resets at 7:59 pm" (clock),
+        /// "resets at Fri 7 pm" (weekday clock), or "resets in 2d 5h" (countdown/tooltipOnly).
         /// Present whenever a reset date exists (any kind) — for tooltips, help text, and roomy rows.
         /// nil when there is no reset date.
         let resetPhrase: String?
@@ -539,11 +585,15 @@ enum ProfileUsagePresentation {
     }
 
     /// Compute the unified presentation model for a bucket. Routes through
-    /// all policy decisions (reset display, pace-aware fill, reset text) in one place.
+    /// all policy decisions (reset display, pace-aware fill, reset text) in
+    /// one place. `style` is the user's reset-time display preference — the
+    /// caller reads it (via `@AppStorage(AppState.usageResetTimeStyleKey)`)
+    /// and injects it here.
     static func bucketPresentation(_ bucket: ClaudeUsageLimitBucket,
+                                   style: ResetTimeStyle = .timeOfReset,
                                    now: Date = Date(),
                                    timeZone: TimeZone = .current) -> BucketPresentation {
-        let display = resetDisplay(forKind: bucket.kind)
+        let display = resetDisplay(forKind: bucket.kind, style: style)
         let windowDuration = self.windowDuration(forKind: bucket.kind)
         let elapsed = elapsedFraction(resetsAt: bucket.resetsAt,
                                      windowDuration: windowDuration,
@@ -561,14 +611,18 @@ enum ProfileUsagePresentation {
         if let resetsAt = bucket.resetsAt {
             switch display {
             case .clock:
-                let clockText = resetTimeText(resetsAt, timeZone: timeZone)
-                resetInline = clockText
-                resetPhrase = "resets \(clockText)"
+                resetInline = "at \(resetTimeText(resetsAt, timeZone: timeZone))"
+
+            case .weekdayClock:
+                resetInline = "at \(weekdayResetTimeText(resetsAt, timeZone: timeZone))"
 
             case .countdown:
-                if let compact = compactResetCountdown(resetsAt, now: now) {
-                    resetInline = compact
-                    resetPhrase = "resets in \(compact)"
+                // Session countdowns keep minute precision ("in 2h 10m") —
+                // on a 5h window a bare "2h" loses too much; weekly stays "4d 2h".
+                if let compact = compactResetCountdown(
+                    resetsAt, now: now,
+                    minutesAtHourScale: bucket.kind == sessionKind) {
+                    resetInline = "in \(compact)"
                 }
                 // When countdown is past (nil), both remain nil.
 
@@ -577,6 +631,10 @@ enum ProfileUsagePresentation {
                     resetPhrase = "resets in \(compact)"
                 }
                 // resetInline stays nil; resetPhrase shows only when countdown is valid.
+            }
+            if let inline = resetInline {
+                // "resets at 7:59 pm" / "resets at Fri 7 pm" / "resets in 4d 2h".
+                resetPhrase = "resets \(inline)"
             }
         }
 

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -152,20 +152,21 @@ enum ProfileUsagePresentation {
         "\(Int(percent.rounded()))%"
     }
 
-    /// "7:59 pm" — reset clock times render 12-hour with lowercase am/pm so
-    /// they can't be misread as an hour count ("19:59" ≈ "in 19h 59m").
+    /// "7:59pm" — reset clock times render 12-hour with lowercase am/pm (no
+    /// space, keeps the fragment narrow) so they can't be misread as an hour
+    /// count ("19:59" ≈ "in 19h 59m").
     /// POSIX locale + explicit symbols keep the output locale-stable.
     static func resetTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "h:mm a"
+        formatter.dateFormat = "h:mma"
         formatter.amSymbol = "am"
         formatter.pmSymbol = "pm"
         formatter.timeZone = timeZone
         return formatter.string(from: date)
     }
 
-    /// "Fri 7 pm" / "Fri 6:59 pm" — weekday + 12h time for resets days away
+    /// "Fri 7pm" / "Fri 6:59pm" — weekday + 12h time for resets days away
     /// (the weekly window's time-of-reset form). Minutes are dropped on the
     /// hour to keep the fragment compact.
     static func weekdayResetTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {
@@ -174,7 +175,7 @@ enum ProfileUsagePresentation {
         let onTheHour = calendar.component(.minute, from: date) == 0
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = onTheHour ? "EEE h a" : "EEE h:mm a"
+        formatter.dateFormat = onTheHour ? "EEE ha" : "EEE h:mma"
         formatter.amSymbol = "am"
         formatter.pmSymbol = "pm"
         formatter.timeZone = timeZone
@@ -222,7 +223,7 @@ enum ProfileUsagePresentation {
     }
 
     /// Compact usage summary without a leading separator:
-    /// "5h 0% ↺11:10 pm · wk 76% · F 100%". nil when there is no snapshot or
+    /// "5h 0% ↺11:10pm · wk 76% · F 100%". nil when there is no snapshot or
     /// it has no buckets (never logged in / poller hasn't fetched yet).
     /// This legacy flat-string form keeps a FIXED format (clock for 5h,
     /// nothing for weekly) regardless of the `ResetTimeStyle` preference —
@@ -282,7 +283,7 @@ enum ProfileUsagePresentation {
     }
 
     /// Spelled-out usage line for the roomier second row: "5h 16% used ·
-    /// resets 11:09 pm · week 79% · resets in 2d 5h · Fable 100%". Unlike
+    /// resets 11:09pm · week 79% · resets in 2d 5h · Fable 100%". Unlike
     /// `usageSummary` this drops the ↺ glyph in favor of "resets " and uses
     /// full family names instead of the single-letter abbreviation — the
     /// second line has the width. nil when there is no snapshot or it has no
@@ -510,7 +511,7 @@ enum ProfileUsagePresentation {
     /// parameter — never read from UserDefaults here — so tests construct
     /// with explicit values.
     enum ResetTimeStyle: String, CaseIterable {
-        /// "at 7:59 pm" (session) / "at Fri 7 pm" (weekly). The default.
+        /// "at 7:59pm" (session) / "at Fri 7pm" (weekly). The default.
         case timeOfReset
         /// "in 2h 10m" (session) / "in 4d 2h" (weekly).
         case timeUntilReset
@@ -520,9 +521,9 @@ enum ProfileUsagePresentation {
     /// clock, or countdown) or in tooltips only. Centralized so all rendering
     /// surfaces agree. This is the single decision point for reset-display policy.
     public enum ResetDisplay: Equatable {
-        /// "at 7:59 pm" inline; tooltip "resets at 7:59 pm" (absolute clock time, 5h window).
+        /// "at 7:59pm" inline; tooltip "resets at 7:59pm" (absolute clock time, 5h window).
         case clock
-        /// "at Fri 7 pm" inline; tooltip "resets at Fri 7 pm" (weekday + time, weekly window).
+        /// "at Fri 7pm" inline; tooltip "resets at Fri 7pm" (weekday + time, weekly window).
         case weekdayClock
         /// "in 2h 10m" / "in 4d 2h" inline; tooltip "resets in …" (relative countdown).
         case countdown
@@ -570,12 +571,12 @@ enum ProfileUsagePresentation {
         let fill: FillLevel
         /// How the reset should be displayed (clock, weekday clock, countdown, or tooltip-only).
         let resetDisplay: ResetDisplay
-        /// Inline reset column text, prefix included: "at 7:59 pm" (clock),
-        /// "at Fri 7 pm" (weekday clock), or "in 4d 2h" (countdown).
+        /// Inline reset column text, prefix included: "at 7:59pm" (clock),
+        /// "at Fri 7pm" (weekday clock), or "in 4d 2h" (countdown).
         /// nil when resetDisplay == .tooltipOnly, or there is no reset date, or a countdown is past.
         let resetInline: String?
-        /// Full reset phrase with "resets" prefix: "resets at 7:59 pm" (clock),
-        /// "resets at Fri 7 pm" (weekday clock), or "resets in 2d 5h" (countdown/tooltipOnly).
+        /// Full reset phrase with "resets" prefix: "resets at 7:59pm" (clock),
+        /// "resets at Fri 7pm" (weekday clock), or "resets in 2d 5h" (countdown/tooltipOnly).
         /// Present whenever a reset date exists (any kind) — for tooltips, help text, and roomy rows.
         /// nil when there is no reset date.
         let resetPhrase: String?
@@ -633,7 +634,7 @@ enum ProfileUsagePresentation {
                 // resetInline stays nil; resetPhrase shows only when countdown is valid.
             }
             if let inline = resetInline {
-                // "resets at 7:59 pm" / "resets at Fri 7 pm" / "resets in 4d 2h".
+                // "resets at 7:59pm" / "resets at Fri 7pm" / "resets in 4d 2h".
                 resetPhrase = "resets \(inline)"
             }
         }

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -152,34 +152,39 @@ enum ProfileUsagePresentation {
         "\(Int(percent.rounded()))%"
     }
 
-    /// "7:59pm" — reset clock times render 12-hour with lowercase am/pm (no
-    /// space, keeps the fragment narrow) so they can't be misread as an hour
-    /// count ("19:59" ≈ "in 19h 59m").
+    /// "8pm" / "7:30pm" — reset clock times render 12-hour with lowercase
+    /// am/pm (no space, keeps the fragment narrow) so they can't be misread
+    /// as an hour count ("19:59" ≈ "in 19h 59m"). Minutes are dropped on the
+    /// hour, and the instant is ceiled to the next minute first — the API's
+    /// reset instants land a fraction under the hour (7:59:59.9), which a
+    /// flooring formatter renders as the misleading "7:59pm".
     /// POSIX locale + explicit symbols keep the output locale-stable.
     static func resetTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "h:mma"
-        formatter.amSymbol = "am"
-        formatter.pmSymbol = "pm"
-        formatter.timeZone = timeZone
-        return formatter.string(from: date)
+        clockText(date, weekday: false, timeZone: timeZone)
     }
 
-    /// "Fri 7pm" / "Fri 6:59pm" — weekday + 12h time for resets days away
-    /// (the weekly window's time-of-reset form). Minutes are dropped on the
-    /// hour to keep the fragment compact.
+    /// "Fri 7pm" / "Fri 6:30pm" — weekday + 12h time for resets days away
+    /// (the weekly window's time-of-reset form). Same ceil-to-minute and
+    /// drop-:00 rules as `resetTimeText`.
     static func weekdayResetTimeText(_ date: Date, timeZone: TimeZone = .current) -> String {
+        clockText(date, weekday: true, timeZone: timeZone)
+    }
+
+    /// Shared impl for the two clock fragments: ceil to the next minute,
+    /// then format, omitting ":00" minutes.
+    private static func clockText(_ date: Date, weekday: Bool, timeZone: TimeZone) -> String {
+        let rounded = Date(timeIntervalSinceReferenceDate:
+            (date.timeIntervalSinceReferenceDate / 60).rounded(.up) * 60)
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = timeZone
-        let onTheHour = calendar.component(.minute, from: date) == 0
+        let onTheHour = calendar.component(.minute, from: rounded) == 0
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = onTheHour ? "EEE ha" : "EEE h:mma"
+        formatter.dateFormat = (weekday ? "EEE " : "") + (onTheHour ? "ha" : "h:mma")
         formatter.amSymbol = "am"
         formatter.pmSymbol = "pm"
         formatter.timeZone = timeZone
-        return formatter.string(from: date)
+        return formatter.string(from: rounded)
     }
 
     /// "F" for "Fable" — single-letter family abbreviation for menu rows.

--- a/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
+++ b/Sources/TBDApp/Helpers/ProfileUsagePresentation.swift
@@ -59,7 +59,7 @@ enum ProfileUsagePresentation {
     // MARK: - Pace-aware fill tier
 
     /// Fill tiers for the usage bars, ordered by urgency. A superset of
-    /// `SeverityLevel` with one extra `caution` (yellow) tier between normal
+    /// `SeverityLevel` with one extra `caution` tier between normal
     /// and warning that only pace projection can produce — "you're burning
     /// faster than the window, but not yet alarmingly so".
     enum FillLevel: Int, Comparable {
@@ -83,7 +83,7 @@ enum ProfileUsagePresentation {
     /// and tier it —
     ///
     /// - projected < 0.75 → `.normal` (green: sustainable pace)
-    /// - 0.75 ..< 0.90 → `.caution` (yellow: warming — on track to land close)
+    /// - 0.75 ..< 0.90 → `.caution` (orange, same hue as warning: warming — on track to land close)
     /// - 0.90 ..< 1.00 → `.warning` (orange: will likely graze the limit)
     /// - >= 1.00 → `.critical` (red: on pace to exceed)
     ///
@@ -567,7 +567,7 @@ enum ProfileUsagePresentation {
         let kind: String
         let percent: Double
         let percentText: String
-        /// Pace-aware fill tier (green/yellow/orange/red).
+        /// Pace-aware fill tier (green/orange/orange/red — caution shares warning's hue).
         let fill: FillLevel
         /// How the reset should be displayed (clock, weekday clock, countdown, or tooltip-only).
         let resetDisplay: ResetDisplay

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -175,7 +175,7 @@ struct GeneralSettingsTab: View {
                     Text("Time of reset").tag(ProfileUsagePresentation.ResetTimeStyle.timeOfReset)
                     Text("Time until reset").tag(ProfileUsagePresentation.ResetTimeStyle.timeUntilReset)
                 }
-                .help("How usage-window resets are shown: the wall-clock time they reset (\"at 7:59 pm\", \"at Fri 7 pm\") or the time remaining (\"in 2h 10m\", \"in 4d 2h\").")
+                .help("How usage-window resets are shown: the wall-clock time they reset (\"at 7:59pm\", \"at Fri 7pm\") or the time remaining (\"in 2h 10m\", \"in 4d 2h\").")
             }
 
             Section("Session Hibernation") {

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -40,6 +40,8 @@ struct GeneralSettingsTab: View {
     @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
     @AppStorage(AppState.showScratchSectionKey) private var showScratchSection: Bool = true
     @AppStorage(AppState.showClaudeTabUsageTooltipKey) private var showClaudeTabUsageTooltip: Bool = true
+    @AppStorage(AppState.usageResetTimeStyleKey)
+    private var usageResetTimeStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset
     @AppStorage("enableNotificationSounds") private var enableSounds: Bool = true
     @AppStorage("notificationSoundName") private var soundName: String = "Blow"
     @AppStorage("notificationSoundCustomPath") private var customPath: String = ""
@@ -169,6 +171,11 @@ struct GeneralSettingsTab: View {
                 .help("When a turn dies on a transient API error (connection drop, server error, overload), TBD types \"continue\" after a backoff (60s, 2m, 5m, 10m) and gives up after 4 straight failures. Off by default. Auth and billing errors are never retried.")
                 Toggle("Show usage tooltip on Claude tabs", isOn: $showClaudeTabUsageTooltip)
                     .help("Show a hover card on Claude tabs with the session's account, profile, 5h/weekly usage, and spawn time.")
+                Picker("Usage reset times", selection: $usageResetTimeStyle) {
+                    Text("Time of reset").tag(ProfileUsagePresentation.ResetTimeStyle.timeOfReset)
+                    Text("Time until reset").tag(ProfileUsagePresentation.ResetTimeStyle.timeUntilReset)
+                }
+                .help("How usage-window resets are shown: the wall-clock time they reset (\"at 7:59 pm\", \"at Fri 7 pm\") or the time remaining (\"in 2h 10m\", \"in 4d 2h\").")
             }
 
             Section("Session Hibernation") {

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -251,6 +251,8 @@ private struct ClaudeProfileRow: View {
     let onSelect: () -> Void
 
     @State private var isHovered = false
+    @AppStorage(AppState.usageResetTimeStyleKey)
+    private var usageResetTimeStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset
 
     var body: some View {
         HStack(spacing: 6) {
@@ -288,7 +290,7 @@ private struct ClaudeProfileRow: View {
     private var subtitleView: some View {
         switch subtitle {
         case .bars:
-            UsageBarsView(snapshot: entry.usageSnapshot)
+            UsageBarsView(snapshot: entry.usageSnapshot, resetStyle: usageResetTimeStyle)
         case .text(let text, let showsSkeleton):
             if let text, !text.isEmpty {
                 subtitleText(text)

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -258,21 +258,23 @@ private struct ClaudeProfileRow: View {
         HStack(spacing: 6) {
             ModelRailView(onSelectModel: onSelectModel)
             Button(action: onSelect) {
-                HStack(spacing: 6) {
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text(ProfileLoginPresentation.menuItemTitle(for: entry))
-                            .font(.system(size: 12))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                        subtitleView
-                    }
-                    Spacer(minLength: 4)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(ProfileLoginPresentation.menuItemTitle(for: entry))
+                        .font(.system(size: 12))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    subtitleView
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
         }
-        .padding(.horizontal, 10)
+        .padding(.leading, 10)
+        // Tighter than the plain rows' 10pt: the usage-bars table should run
+        // to within ~8pt of the popover's right edge (the old inner
+        // Spacer + shared 10pt inset left ~20pt of dead space there).
+        .padding(.trailing, 8)
         .padding(.vertical, 5)
         .frame(maxWidth: .infinity, alignment: .leading)
         // Let the row's natural content height (title + subtitle/bars) drive

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -273,6 +273,10 @@ private struct ClaudeProfileRow: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 5)
         .frame(maxWidth: .infinity, alignment: .leading)
+        // Let the row's natural content height (title + subtitle/bars) drive
+        // its size — the rail stretches to match, never the other way around,
+        // and the popover's minHeight can't balloon the row.
+        .fixedSize(horizontal: false, vertical: true)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(isHovered || highlighted ? Color.accentColor.opacity(0.15) : Color.clear)
@@ -321,17 +325,25 @@ private struct ModelRailView: View {
     ]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 0) {
             ForEach(Self.models, id: \.id) { model in
                 ModelRailButton(title: model.label, help: model.help) {
                     onSelectModel(model.id)
                 }
             }
         }
+        // Natural width (widest capsule), but stretch vertically to the row's
+        // full height so the three buttons divide it into equal-thirds hit
+        // areas.
+        .fixedSize(horizontal: true, vertical: false)
     }
 }
 
-/// One small capsule button in the model rail.
+/// One segment of the model rail, styled like a vertical segmented control:
+/// the visible surface fills its full third of the rail (full rail width x
+/// 1/3 of the row height, minus a 1pt inset between segments), with the
+/// label centered. Hover feedback covers the whole segment; the hit area
+/// includes the inset so the thirds stay contiguous.
 private struct ModelRailButton: View {
     let title: String
     let help: String
@@ -345,12 +357,13 @@ private struct ModelRailButton: View {
                 .font(.system(size: 9))
                 .foregroundStyle(isHovered ? Color.primary : Color.secondary)
                 .padding(.horizontal, 5)
-                .padding(.vertical, 1)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(
-                    Capsule()
+                    RoundedRectangle(cornerRadius: 4)
                         .fill(isHovered ? Color.accentColor.opacity(0.3) : Color.primary.opacity(0.06))
                 )
-                .contentShape(Capsule())
+                .padding(.vertical, 1)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -101,13 +101,16 @@ struct WorktreeProfilePickerView: View {
                     let isSelectable = ProfileUsagePresentation.isSelectable(entry)
                     let isTheDefault = entry.profile.id == appState.defaultProfileID
                     Group {
-                        if showsUsageBars(for: entry) {
-                            // OAuth profile with a usage snapshot that has
-                            // buckets: render the two-bar meter instead of the
-                            // single-line usage text.
-                            UsageBarsProfileRow(
+                        if entry.profile.kind == .oauth && isSelectable {
+                            // Selectable Claude account: always render the
+                            // model rail — model selection must not depend on
+                            // usage data being available. The subtitle is the
+                            // two-bar meter when a snapshot has buckets, else
+                            // the same text/skeleton line as the plain rows.
+                            ClaudeProfileRow(
                                 entry: entry,
                                 highlighted: isTheDefault && highlightDefaultProfile,
+                                subtitle: claudeRowSubtitle(for: entry),
                                 onSelectModel: { model in
                                     pick(profileID: entry.profile.id, model: model)
                                 }
@@ -186,12 +189,21 @@ struct WorktreeProfilePickerView: View {
             || ProfileUsagePresentation.weeklyAllBucket(entry.usageSnapshot) != nil
     }
 
-    /// Resolve the fixed-height subtitle for a profile row. Precedence:
+    /// Subtitle for a selectable Claude row: the two-bar meter when the
+    /// snapshot has buckets, otherwise the same text/skeleton precedence as
+    /// `profileSubtitle` (usage note → first-poll skeleton → reserved blank).
+    private func claudeRowSubtitle(for entry: ModelProfileWithUsage) -> ClaudeProfileRow.Subtitle {
+        if showsUsageBars(for: entry) { return .bars }
+        let line = ProfileUsagePresentation.menuLine(for: entry)
+        return .text(line.secondary, showsSkeleton: line.secondary == nil && entry.usageSnapshot == nil)
+    }
+
+    /// Resolve the fixed-height subtitle for a non-Claude-row profile
+    /// (selectable OAuth rows render via `ClaudeProfileRow` instead).
+    /// Precedence:
     ///  1. A real usage / login note from `menuLine` (`usageNote`) — shown as-is.
-    ///  2. Logged-in OAuth awaiting its first usage poll → skeleton (the ONE
-    ///     genuine "loading" state).
-    ///  3. Logged-out OAuth → a plain "not logged in" note (no skeleton).
-    ///  4. API-key / Bedrock → the profile's own static kind descriptor.
+    ///  2. Logged-out OAuth → a plain "not logged in" note (no skeleton).
+    ///  3. API-key / Bedrock → the profile's own static kind descriptor.
     private func profileSubtitle(
         for entry: ModelProfileWithUsage,
         usageNote: String?
@@ -201,10 +213,7 @@ struct WorktreeProfilePickerView: View {
         }
         switch entry.profile.kind {
         case .oauth:
-            if ProfileUsagePresentation.isSelectable(entry) {
-                // Logged in; skeleton only until the first snapshot lands.
-                return (nil, entry.usageSnapshot == nil)
-            }
+            // Selectable OAuth never reaches this path; only logged-out rows.
             return ("Not logged in — run /login", false)
         case .apiKey, .bedrock:
             // Static descriptor from ModelProfile — never a loading state.
@@ -216,38 +225,36 @@ struct WorktreeProfilePickerView: View {
     }
 }
 
-/// A profile row whose subtitle is the two-bar usage meter rather than a text
-/// line. Mirrors `ProfilePickerRow`'s chrome (title, hover highlight) but
-/// hosts `UsageBarsView`, which sizes to its bars — the fixed-single-line
-/// reservation only applies to the text rows. The leading slot is a vertical
-/// rail of per-spawn model buttons (Fable/Opus/Sonnet): clicking one picks
-/// this profile AND requests that model for the spawn; clicking anywhere else
-/// on the row keeps the profile's default model. The rail sits OUTSIDE the
-/// row's Button so its buttons don't fight the row's hit-testing.
-private struct UsageBarsProfileRow: View {
+/// A selectable Claude (OAuth) profile row. Mirrors `ProfilePickerRow`'s
+/// chrome (title, hover highlight); the subtitle is either the two-bar usage
+/// meter (`.bars`) or the same fixed-height text/skeleton line as the plain
+/// rows (`.text`) so the rail never depends on usage data. The leading slot
+/// is a vertical rail of per-spawn model buttons (Fable/Opus/Sonnet):
+/// clicking one picks this profile AND requests that model for the spawn;
+/// clicking anywhere else on the row keeps the profile's default model. The
+/// rail sits OUTSIDE the row's Button so its buttons don't fight the row's
+/// hit-testing.
+private struct ClaudeProfileRow: View {
+    enum Subtitle {
+        /// Two-bar usage meter drawn from the entry's snapshot.
+        case bars
+        /// Single text line; skeleton is reserved for the ONE genuine loading
+        /// case (logged-in OAuth awaiting its first poll). Nil text with no
+        /// skeleton reserves the line's height so the row doesn't shift.
+        case text(String?, showsSkeleton: Bool)
+    }
+
     let entry: ModelProfileWithUsage
     var highlighted: Bool = false
+    let subtitle: Subtitle
     var onSelectModel: (String) -> Void = { _ in }
     let onSelect: () -> Void
 
     @State private var isHovered = false
 
-    /// Per-spawn model buttons: label + exact model id.
-    private static let models: [(label: String, id: String, help: String)] = [
-        ("Fable", "claude-fable-5", "Spawn with Claude Fable 5"),
-        ("Opus", "claude-opus-4-8", "Spawn with Claude Opus 4.8"),
-        ("Sonnet", "claude-sonnet-5", "Spawn with Claude Sonnet 5"),
-    ]
-
     var body: some View {
         HStack(spacing: 6) {
-            VStack(alignment: .leading, spacing: 2) {
-                ForEach(Self.models, id: \.id) { model in
-                    ModelRailButton(title: model.label, help: model.help) {
-                        onSelectModel(model.id)
-                    }
-                }
-            }
+            ModelRailView(onSelectModel: onSelectModel)
             Button(action: onSelect) {
                 HStack(spacing: 6) {
                     VStack(alignment: .leading, spacing: 3) {
@@ -255,7 +262,7 @@ private struct UsageBarsProfileRow: View {
                             .font(.system(size: 12))
                             .lineLimit(1)
                             .truncationMode(.tail)
-                        UsageBarsView(snapshot: entry.usageSnapshot)
+                        subtitleView
                     }
                     Spacer(minLength: 4)
                 }
@@ -271,6 +278,56 @@ private struct UsageBarsProfileRow: View {
                 .fill(isHovered || highlighted ? Color.accentColor.opacity(0.15) : Color.clear)
         )
         .onHover { isHovered = $0 }
+    }
+
+    @ViewBuilder
+    private var subtitleView: some View {
+        switch subtitle {
+        case .bars:
+            UsageBarsView(snapshot: entry.usageSnapshot)
+        case .text(let text, let showsSkeleton):
+            if let text, !text.isEmpty {
+                subtitleText(text)
+            } else if showsSkeleton {
+                subtitleText("resets 00:00 · week 00% used")
+                    .redacted(reason: .placeholder)
+            } else {
+                subtitleText(" ")
+                    .hidden()
+            }
+        }
+    }
+
+    /// Matches `ProfilePickerRow.subtitleText` so both Claude subtitle states
+    /// and the plain rows share font/size/line-limit.
+    private func subtitleText(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10))
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+}
+
+/// The vertical rail of per-spawn model buttons on a Claude row.
+private struct ModelRailView: View {
+    let onSelectModel: (String) -> Void
+
+    /// Per-spawn model buttons: label + exact model id.
+    private static let models: [(label: String, id: String, help: String)] = [
+        ("Fable", "claude-fable-5", "Spawn with Claude Fable 5"),
+        ("Opus", "claude-opus-4-8", "Spawn with Claude Opus 4.8"),
+        ("Sonnet", "claude-sonnet-5", "Spawn with Claude Sonnet 5"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(Self.models, id: \.id) { model in
+                ModelRailButton(title: model.label, help: model.help) {
+                    onSelectModel(model.id)
+                }
+            }
+        }
     }
 }
 

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -107,7 +107,10 @@ struct WorktreeProfilePickerView: View {
                             // single-line usage text.
                             UsageBarsProfileRow(
                                 entry: entry,
-                                highlighted: isTheDefault && highlightDefaultProfile
+                                highlighted: isTheDefault && highlightDefaultProfile,
+                                onSelectModel: { model in
+                                    pick(profileID: entry.profile.id, model: model)
+                                }
                             ) {
                                 pick(profileID: entry.profile.id)
                             }
@@ -117,7 +120,6 @@ struct WorktreeProfilePickerView: View {
                             ProfilePickerRow(
                                 title: line.primary,
                                 subtitle: subtitle.text,
-                                systemImage: "person.crop.circle",
                                 highlighted: isTheDefault && highlightDefaultProfile,
                                 // Always reserve subtitle height so the row never
                                 // shifts, whichever state it resolves to.
@@ -166,10 +168,12 @@ struct WorktreeProfilePickerView: View {
         }
     }
 
-    private func pick(profileID: UUID?) {
+    /// `model` is an optional per-spawn Claude model override (the row's model
+    /// rail); nil keeps the profile's default model.
+    private func pick(profileID: UUID?, model: String? = nil) {
         dismiss()
         onClose()
-        appState.createWorktree(repoID: repoID, parentWorktreeID: parentWorktreeID, profileID: profileID)
+        appState.createWorktree(repoID: repoID, parentWorktreeID: parentWorktreeID, profileID: profileID, model: model)
     }
 
     /// Whether a profile row should render the two-bar usage meter (instead of
@@ -213,50 +217,96 @@ struct WorktreeProfilePickerView: View {
 }
 
 /// A profile row whose subtitle is the two-bar usage meter rather than a text
-/// line. Mirrors `ProfilePickerRow`'s chrome (icon, title, hover highlight,
-/// "default" chip) but hosts `UsageBarsView`, which sizes to its two bars — the
-/// fixed-single-line reservation only applies to the text rows.
+/// line. Mirrors `ProfilePickerRow`'s chrome (title, hover highlight) but
+/// hosts `UsageBarsView`, which sizes to its bars — the fixed-single-line
+/// reservation only applies to the text rows. The leading slot is a vertical
+/// rail of per-spawn model buttons (Fable/Opus/Sonnet): clicking one picks
+/// this profile AND requests that model for the spawn; clicking anywhere else
+/// on the row keeps the profile's default model. The rail sits OUTSIDE the
+/// row's Button so its buttons don't fight the row's hit-testing.
 private struct UsageBarsProfileRow: View {
     let entry: ModelProfileWithUsage
     var highlighted: Bool = false
+    var onSelectModel: (String) -> Void = { _ in }
     let onSelect: () -> Void
 
     @State private var isHovered = false
 
+    /// Per-spawn model buttons: label + exact model id.
+    private static let models: [(label: String, id: String, help: String)] = [
+        ("Fable", "claude-fable-5", "Spawn with Claude Fable 5"),
+        ("Opus", "claude-opus-4-8", "Spawn with Claude Opus 4.8"),
+        ("Sonnet", "claude-sonnet-5", "Spawn with Claude Sonnet 5"),
+    ]
+
     var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: 6) {
-                Image(systemName: "person.crop.circle")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 14)
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(ProfileLoginPresentation.menuItemTitle(for: entry))
-                        .font(.system(size: 12))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                    UsageBarsView(snapshot: entry.usageSnapshot)
+        HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(Self.models, id: \.id) { model in
+                    ModelRailButton(title: model.label, help: model.help) {
+                        onSelectModel(model.id)
+                    }
                 }
-                Spacer(minLength: 4)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(isHovered || highlighted ? Color.accentColor.opacity(0.15) : Color.clear)
-            )
-            .contentShape(Rectangle())
+            Button(action: onSelect) {
+                HStack(spacing: 6) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(ProfileLoginPresentation.menuItemTitle(for: entry))
+                            .font(.system(size: 12))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        UsageBarsView(snapshot: entry.usageSnapshot)
+                    }
+                    Spacer(minLength: 4)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isHovered || highlighted ? Color.accentColor.opacity(0.15) : Color.clear)
+        )
+        .onHover { isHovered = $0 }
+    }
+}
+
+/// One small capsule button in the model rail.
+private struct ModelRailButton: View {
+    let title: String
+    let help: String
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 9))
+                .foregroundStyle(isHovered ? Color.primary : Color.secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(
+                    Capsule()
+                        .fill(isHovered ? Color.accentColor.opacity(0.3) : Color.primary.opacity(0.06))
+                )
+                .contentShape(Capsule())
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
+        .help(help)
     }
 }
 
 private struct ProfilePickerRow: View {
     let title: String
     let subtitle: String?
-    let systemImage: String
+    /// Leading icon; nil renders no icon view (profile rows). The
+    /// "Choose a branch…" navigation row keeps its branch icon.
+    var systemImage: String? = nil
     var highlighted: Bool = false
     /// When true, a subtitle line is always rendered at full height — real text
     /// when available, otherwise an invisible placeholder — so the row height
@@ -279,10 +329,12 @@ private struct ProfilePickerRow: View {
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 6) {
-                Image(systemName: systemImage)
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 14)
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 14)
+                }
                 VStack(alignment: .leading, spacing: 1) {
                     Text(title)
                         .font(.system(size: 12))

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -530,6 +530,8 @@ private struct TabBarItem: View {
     @AppStorage("codeViewer.showSidebar") private var showSidebar = false
     @AppStorage(AppState.showClaudeTabUsageTooltipKey)
     private var showClaudeTabUsageTooltip: Bool = true
+    @AppStorage(AppState.usageResetTimeStyleKey)
+    private var usageResetTimeStyle: ProfileUsagePresentation.ResetTimeStyle = .timeOfReset
     @EnvironmentObject private var appState: AppState
 
     private var showClose: Bool {
@@ -571,6 +573,7 @@ private struct TabBarItem: View {
         return AccountHoverCards.claudeTabCard(
             terminal: terminal,
             profiles: appState.modelProfiles,
+            resetStyle: usageResetTimeStyle,
             enabled: showClaudeTabUsageTooltip
         )
     }

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -173,7 +173,7 @@ struct ProfileList: AsyncParsableCommand {
     @Flag(name: .long, help: "Output JSON")
     var json = false
 
-    @Flag(name: .long, help: "Force a fresh usage fetch for all logged-in OAuth profiles before listing")
+    @Flag(name: .long, help: "Refresh usage for stale logged-in OAuth profiles before listing (skips fresh or rate-limited profiles)")
     var refresh = false
 
     mutating func run() async throws {

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -73,6 +73,21 @@ func usageResetCell(_ date: Date?, now: Date = Date()) -> String {
     return formatter.string(from: date)
 }
 
+/// Age marker for a usage snapshot: nil while fresh (under 5 minutes),
+/// otherwise "(updated 12m ago)" / "(updated 3h ago)" / "(updated 2d ago)".
+/// The daemon persists snapshots across restarts, so an "ok" row can carry
+/// arbitrarily old numbers — this makes that visible.
+func usageAgeMarker(fetchedAt: Date?, now: Date = Date()) -> String? {
+    guard let fetchedAt else { return nil }
+    let age = now.timeIntervalSince(fetchedAt)
+    guard age >= 5 * 60 else { return nil }
+    let minutes = Int(age / 60)
+    if minutes < 60 { return "(updated \(minutes)m ago)" }
+    let hours = minutes / 60
+    if hours < 24 { return "(updated \(hours)h ago)" }
+    return "(updated \(hours / 24)d ago)"
+}
+
 /// Resolve a user-supplied profile reference against the daemon's profile
 /// list. Accepts an exact name, a unique case-insensitive name, or a profile
 /// UUID (escape hatch for scripting). Throws a `CLIError` with actionable
@@ -243,6 +258,9 @@ struct ProfileList: AsyncParsableCommand {
             if let snapshot, !snapshot.isOK {
                 trailing.append("[stale*]")
                 staleNotes.append("  * \(entry.profile.name): \(snapshot.status)")
+            }
+            if let marker = usageAgeMarker(fetchedAt: snapshot?.fetchedAt) {
+                trailing.append(marker)
             }
             cells.append((trailing.joined(separator: " "), 0))
             print(tableRow(cells))

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -9,9 +9,12 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "oauthUsagePo
 /// Complements `ClaudeUsagePoller` (which serves API-key profiles from
 /// TBD-stored secrets on a 30-min cadence, persisted in the DB): this one
 /// sweeps every logged-in OAuth profile roughly every 90 seconds using
-/// CLI-mediated credentials (`LiveProfileUsageFetcher`), holding results
-/// purely in memory — the spawn-time account picker renders instantly from
-/// this cache and can force a fresh sweep via `modelProfile.usageRefresh`.
+/// CLI-mediated credentials (`LiveProfileUsageFetcher`). Results live in
+/// memory and — on successful fetches — in a DB-backed cache
+/// (`OAuthUsageSnapshotStore`), so a daemon restart shows the last-known
+/// bars (stale) instead of "usage unavailable". The spawn-time account
+/// picker renders instantly from this cache and can request a
+/// refresh-if-stale sweep via `modelProfile.usageRefresh`.
 ///
 /// Rules:
 /// - Eligible profiles: `kind == .oauth` with a non-nil login identity
@@ -30,6 +33,11 @@ public actor OAuthProfileUsagePoller {
     public static let cadence: TimeInterval = 90
     public static let interProfileStagger: TimeInterval = 2
 
+    /// `sweepNow` (the RPC / picker-open path) skips profiles whose snapshot
+    /// was fetched more recently than this — opening the picker repeatedly
+    /// must not turn into a fetch per open.
+    public static let refreshFreshness: TimeInterval = 30
+
     /// Backoff schedule for a profile whose fetch failed. Doubles per
     /// consecutive failure, jittered, capped. A 429 with a `Retry-After`
     /// overrides this with the server's own value. Kept below the picker's
@@ -41,6 +49,8 @@ public actor OAuthProfileUsagePoller {
     // MARK: - Dependencies (closures so tests need no DB or filesystem)
 
     public typealias ProfilesProvider = @Sendable () async throws -> [ModelProfile]
+    public typealias SnapshotLoader = @Sendable () async -> [UUID: ProfileUsageSnapshot]
+    public typealias SnapshotPersister = @Sendable (UUID, ProfileUsageSnapshot) async -> Void
 
     private let profilesProvider: ProfilesProvider
     private let loginIdentity: @Sendable (UUID) -> String?
@@ -50,6 +60,11 @@ public actor OAuthProfileUsagePoller {
     private let sleeper: @Sendable (TimeInterval) async throws -> Void
     private let now: @Sendable () -> Date
     private let jitter: @Sendable (TimeInterval) -> TimeInterval
+    /// Persistence seams (nil = memory-only, e.g. most tests). `loadPersisted`
+    /// seeds the in-memory cache at `start()`; `persist` is called on every
+    /// successful fetch. Backoff state is deliberately NOT persisted.
+    private let loadPersisted: SnapshotLoader?
+    private let persist: SnapshotPersister?
 
     // MARK: - State
 
@@ -57,10 +72,11 @@ public actor OAuthProfileUsagePoller {
     private var loopTask: Task<Void, Never>?
 
     /// Per-profile backoff bookkeeping. `consecutiveFailures` drives the
-    /// exponential schedule; `nextEligibleAt` is when a scheduled sweep may try
-    /// this profile again. Isolated per profile so one account's rate limit
-    /// never delays another's polling. A forced sweep (`sweepNow`) ignores this
-    /// gate — the user explicitly asked.
+    /// exponential schedule; `nextEligibleAt` is when a sweep may try this
+    /// profile again. Isolated per profile so one account's rate limit never
+    /// delays another's polling. Every sweep honors this gate — including the
+    /// picker-open RPC path (`sweepNow`), which must not re-hammer a
+    /// rate-limited endpoint. In-memory only; a daemon restart resets it.
     private struct BackoffState {
         var consecutiveFailures: Int = 0
         var nextEligibleAt: Date?
@@ -77,8 +93,12 @@ public actor OAuthProfileUsagePoller {
         broadcast: @escaping @Sendable () -> Void,
         sleeper: (@Sendable (TimeInterval) async throws -> Void)? = nil,
         now: (@Sendable () -> Date)? = nil,
-        jitter: (@Sendable (TimeInterval) -> TimeInterval)? = nil
+        jitter: (@Sendable (TimeInterval) -> TimeInterval)? = nil,
+        loadPersisted: SnapshotLoader? = nil,
+        persist: SnapshotPersister? = nil
     ) {
+        self.loadPersisted = loadPersisted
+        self.persist = persist
         self.profilesProvider = profilesProvider
         self.loginIdentity = loginIdentity
         self.configDirPath = configDirPath
@@ -94,9 +114,11 @@ public actor OAuthProfileUsagePoller {
 
     // MARK: - Lifecycle
 
-    /// Launches the sweep loop. Idempotent.
-    public func start() {
+    /// Loads persisted snapshots (so readers immediately see last-known data,
+    /// stale or not), then launches the sweep loop. Idempotent.
+    public func start() async {
         guard loopTask == nil else { return }
+        await loadPersistedSnapshots()
         loopTask = Task { [weak self] in
             await self?.runLoop()
         }
@@ -109,11 +131,27 @@ public actor OAuthProfileUsagePoller {
     }
 
     private func runLoop() async {
+        // Startup sweep: skip profiles whose persisted snapshot is younger
+        // than the cadence — they'd have been swept at most one tick ago by
+        // the previous daemon, and the next scheduled sweep covers them.
+        var skipFresherThan: TimeInterval? = Self.cadence
         while !Task.isCancelled {
             // Scheduled sweeps honor per-profile backoff windows.
-            await sweep(only: nil, forced: false)
+            await sweep(only: nil, skipFresherThan: skipFresherThan)
+            skipFresherThan = nil
             try? await sleeper(Self.cadence)
         }
+    }
+
+    /// Seed the in-memory cache from the DB-backed store, once, before any
+    /// sweep. Ineligible ghosts (deleted profiles, logged-out accounts) are
+    /// pruned by the first full sweep.
+    private func loadPersistedSnapshots() async {
+        guard let loadPersisted, snapshots.isEmpty else { return }
+        let loaded = await loadPersisted()
+        guard !loaded.isEmpty else { return }
+        snapshots = loaded
+        broadcast()
     }
 
     // MARK: - Reads
@@ -124,35 +162,42 @@ public actor OAuthProfileUsagePoller {
         snapshots[profileID]
     }
 
-    // MARK: - Forced sweep (RPC `modelProfile.usageRefresh`)
+    // MARK: - Refresh-if-stale sweep (RPC `modelProfile.usageRefresh`)
 
-    /// Fetch fresh usage now — all logged-in OAuth profiles when `profileID`
-    /// is nil, or just the one profile. Returns the post-sweep snapshots
-    /// (filtered to the requested profile when one was given).
+    /// Refresh usage for stale, eligible profiles — all logged-in OAuth
+    /// profiles when `profileID` is nil, or just the one profile. Returns the
+    /// post-sweep snapshots (filtered to the requested profile when one was
+    /// given).
     ///
-    /// This is the user-explicit path (RPC `modelProfile.usageRefresh`), so it
-    /// bypasses per-profile backoff windows — the user asked, so we try even a
-    /// rate-limited profile.
+    /// This is the RPC path (`modelProfile.usageRefresh`, fired on every
+    /// picker open and by `tbd profile list --refresh`). It does NOT bypass
+    /// per-profile backoff windows — opening the picker against a 429ing
+    /// endpoint must not re-hammer it — and skips profiles whose snapshot is
+    /// younger than `refreshFreshness`.
     @discardableResult
     public func sweepNow(profileID: UUID? = nil) async -> [UUID: ProfileUsageSnapshot] {
-        await sweep(only: profileID, forced: true)
+        await sweep(only: profileID, skipFresherThan: Self.refreshFreshness)
         if let profileID {
             return snapshots.filter { $0.key == profileID }
         }
         return snapshots
     }
 
-    /// Test seam: run the SCHEDULED sweep path (honoring backoff) synchronously,
-    /// as the background loop would. Not part of the public runtime API.
+    /// Test seams. Not part of the public runtime API.
     @discardableResult
-    func sweepNow(profileID: UUID?, forcedForTest: Bool) async -> [UUID: ProfileUsageSnapshot] {
-        await sweep(only: profileID, forced: forcedForTest)
+    func sweepForTest(only: UUID? = nil,
+                      skipFresherThan: TimeInterval? = nil) async -> [UUID: ProfileUsageSnapshot] {
+        await sweep(only: only, skipFresherThan: skipFresherThan)
         return snapshots
+    }
+
+    func loadPersistedForTest() async {
+        await loadPersistedSnapshots()
     }
 
     // MARK: - Sweep
 
-    private func sweep(only: UUID?, forced: Bool) async {
+    private func sweep(only: UUID?, skipFresherThan: TimeInterval?) async {
         let allProfiles: [ModelProfile]
         do {
             allProfiles = try await profilesProvider()
@@ -173,14 +218,21 @@ public actor OAuthProfileUsagePoller {
             backoff = backoff.filter { eligibleIDs.contains($0.key) }
         }
 
-        // A forced sweep (only != nil) always tries the requested profile.
-        // A scheduled sweep skips any profile still inside its backoff window,
-        // so a rate-limited account isn't hammered every cadence tick — but the
-        // stagger + isolation mean the others still poll normally.
+        // Every sweep skips profiles still inside their backoff window, so a
+        // rate-limited account isn't hammered — by the cadence tick OR by the
+        // picker-open RPC. Stagger + isolation mean the others still poll
+        // normally. `skipFresherThan` additionally skips profiles whose data
+        // is recent enough (startup sweep, picker-open refresh).
         let candidates = only.map { id in eligible.filter { $0.id == id } } ?? eligible
         let currentTime = now()
         let targets = candidates.filter { profile in
-            forced || isEligibleNow(profile.id, at: currentTime)
+            guard isEligibleNow(profile.id, at: currentTime) else { return false }
+            if let window = skipFresherThan,
+               let fetchedAt = snapshots[profile.id]?.fetchedAt,
+               currentTime.timeIntervalSince(fetchedAt) < window {
+                return false
+            }
+            return true
         }
 
         var didFetch = false
@@ -191,7 +243,7 @@ public actor OAuthProfileUsagePoller {
             if Task.isCancelled { break }
             didFetch = true
             let status = await fetcher.fetchUsage(configDirPath: configDirPath(profile.id))
-            record(status, for: profile.id)
+            await record(status, for: profile.id)
         }
 
         if hasMeaningfulChange(from: before, to: snapshots) {
@@ -206,18 +258,22 @@ public actor OAuthProfileUsagePoller {
         return time >= next
     }
 
-    private func record(_ status: ProfileUsageFetchStatus, for profileID: UUID) {
+    private func record(_ status: ProfileUsageFetchStatus, for profileID: UUID) async {
         let timestamp = now()
         switch status {
         case .ok(let buckets):
             backoff[profileID] = BackoffState()  // reset schedule on success
-            snapshots[profileID] = ProfileUsageSnapshot(
+            let snapshot = ProfileUsageSnapshot(
                 buckets: buckets,
                 fetchedAt: timestamp,
                 lastAttemptAt: timestamp,
                 status: "ok",
                 statusKind: .ok
             )
+            snapshots[profileID] = snapshot
+            if let persist {
+                await persist(profileID, snapshot)
+            }
             logger.debug("usage sweep ok for profile \(profileID, privacy: .public): \(buckets.count, privacy: .public) buckets")
         default:
             let reason = status.failureReason ?? "unknown"

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -51,6 +51,8 @@ public actor OAuthProfileUsagePoller {
     public typealias ProfilesProvider = @Sendable () async throws -> [ModelProfile]
     public typealias SnapshotLoader = @Sendable () async -> [UUID: ProfileUsageSnapshot]
     public typealias SnapshotPersister = @Sendable (UUID, ProfileUsageSnapshot) async -> Void
+    /// Deletes persisted rows for every profile NOT in the given set.
+    public typealias SnapshotPruner = @Sendable (Set<UUID>) async -> Void
 
     private let profilesProvider: ProfilesProvider
     private let loginIdentity: @Sendable (UUID) -> String?
@@ -65,11 +67,17 @@ public actor OAuthProfileUsagePoller {
     /// successful fetch. Backoff state is deliberately NOT persisted.
     private let loadPersisted: SnapshotLoader?
     private let persist: SnapshotPersister?
+    /// Called on every full sweep with the eligible profile set, so DB rows
+    /// for deleted/logged-out profiles don't reload as ghosts each restart.
+    private let prunePersisted: SnapshotPruner?
 
     // MARK: - State
 
     private var snapshots: [UUID: ProfileUsageSnapshot] = [:]
     private var loopTask: Task<Void, Never>?
+    /// Set before `start()`'s first suspension so a reentrant double-start
+    /// can't launch a second loop.
+    private var started = false
 
     /// Per-profile backoff bookkeeping. `consecutiveFailures` drives the
     /// exponential schedule; `nextEligibleAt` is when a sweep may try this
@@ -95,10 +103,12 @@ public actor OAuthProfileUsagePoller {
         now: (@Sendable () -> Date)? = nil,
         jitter: (@Sendable (TimeInterval) -> TimeInterval)? = nil,
         loadPersisted: SnapshotLoader? = nil,
-        persist: SnapshotPersister? = nil
+        persist: SnapshotPersister? = nil,
+        prunePersisted: SnapshotPruner? = nil
     ) {
         self.loadPersisted = loadPersisted
         self.persist = persist
+        self.prunePersisted = prunePersisted
         self.profilesProvider = profilesProvider
         self.loginIdentity = loginIdentity
         self.configDirPath = configDirPath
@@ -117,7 +127,8 @@ public actor OAuthProfileUsagePoller {
     /// Loads persisted snapshots (so readers immediately see last-known data,
     /// stale or not), then launches the sweep loop. Idempotent.
     public func start() async {
-        guard loopTask == nil else { return }
+        guard !started else { return }
+        started = true
         await loadPersistedSnapshots()
         loopTask = Task { [weak self] in
             await self?.runLoop()
@@ -128,6 +139,7 @@ public actor OAuthProfileUsagePoller {
     public func stop() {
         loopTask?.cancel()
         loopTask = nil
+        started = false
     }
 
     private func runLoop() async {
@@ -143,15 +155,27 @@ public actor OAuthProfileUsagePoller {
         }
     }
 
-    /// Seed the in-memory cache from the DB-backed store, once, before any
-    /// sweep. Ineligible ghosts (deleted profiles, logged-out accounts) are
-    /// pruned by the first full sweep.
+    /// Seed the in-memory cache from the DB-backed store before any sweep.
+    /// Ineligible ghosts (deleted profiles, logged-out accounts) are pruned —
+    /// from memory AND their persisted rows — by the first full sweep.
+    ///
+    /// Actors are reentrant across the `await`: an RPC-triggered `sweepNow`
+    /// can fetch fresher data while the load is in flight. So the result is
+    /// MERGED per profile, keeping whichever snapshot has the newer
+    /// `fetchedAt`, never replacing the dict wholesale.
     private func loadPersistedSnapshots() async {
-        guard let loadPersisted, snapshots.isEmpty else { return }
+        guard let loadPersisted else { return }
         let loaded = await loadPersisted()
-        guard !loaded.isEmpty else { return }
-        snapshots = loaded
-        broadcast()
+        var changed = false
+        for (id, persisted) in loaded {
+            if let current = snapshots[id],
+               (current.fetchedAt ?? .distantPast) >= (persisted.fetchedAt ?? .distantPast) {
+                continue
+            }
+            snapshots[id] = persisted
+            changed = true
+        }
+        if changed { broadcast() }
     }
 
     // MARK: - Reads
@@ -216,6 +240,9 @@ public actor OAuthProfileUsagePoller {
         if only == nil {
             snapshots = snapshots.filter { eligibleIDs.contains($0.key) }
             backoff = backoff.filter { eligibleIDs.contains($0.key) }
+            if let prunePersisted {
+                await prunePersisted(eligibleIDs)
+            }
         }
 
         // Every sweep skips profiles still inside their backoff window, so a

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -656,14 +656,21 @@ public final class Daemon: Sendable {
             await poller.start()
 
             // 12c. Start per-profile OAuth usage poller (90s cadence,
-            // in-memory snapshots for the spawn-time account picker).
+            // snapshots for the spawn-time account picker, DB-cached so
+            // restarts show last-known bars instead of "usage unavailable").
             let configDirManager = rpcRouter.configDirManager
             let oauthPoller = OAuthProfileUsagePoller(
                 profilesProvider: { [database] in try await database.modelProfiles.list() },
                 loginIdentity: { id in configDirManager.loginIdentity(forProfileID: id) },
                 configDirPath: { id in configDirManager.configDirectory(forProfileID: id).path },
                 fetcher: LiveProfileUsageFetcher(),
-                broadcast: { [weak subs] in subs?.broadcast(delta: .modelProfilesChanged) }
+                broadcast: { [weak subs] in subs?.broadcast(delta: .modelProfilesChanged) },
+                loadPersisted: { [database] in
+                    (try? await database.oauthUsageSnapshots.loadAll()) ?? [:]
+                },
+                persist: { [database] id, snapshot in
+                    try? await database.oauthUsageSnapshots.upsert(profileID: id, snapshot: snapshot)
+                }
             )
             self.oauthUsagePoller = oauthPoller
             rpcRouter.oauthUsagePoller = oauthPoller

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -670,6 +670,9 @@ public final class Daemon: Sendable {
                 },
                 persist: { [database] id, snapshot in
                     try? await database.oauthUsageSnapshots.upsert(profileID: id, snapshot: snapshot)
+                },
+                prunePersisted: { [database] eligibleIDs in
+                    try? await database.oauthUsageSnapshots.deleteExcept(profileIDs: eligibleIDs)
                 }
             )
             self.oauthUsagePoller = oauthPoller

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -17,6 +17,7 @@ public final class TBDDatabase: Sendable {
     public let notes: NoteStore
     public let modelProfiles: ModelProfileStore
     public let modelProfileUsage: ModelProfileUsageStore
+    public let oauthUsageSnapshots: OAuthUsageSnapshotStore
     public let config: ConfigStore
     public let meta: TBDMetaStore
     public let tabs: TabStore
@@ -50,6 +51,7 @@ public final class TBDDatabase: Sendable {
         self.notes = NoteStore(writer: pool)
         self.modelProfiles = ModelProfileStore(writer: pool)
         self.modelProfileUsage = ModelProfileUsageStore(writer: pool)
+        self.oauthUsageSnapshots = OAuthUsageSnapshotStore(writer: pool)
         self.config = ConfigStore(writer: pool)
         self.meta = TBDMetaStore(writer: pool)
         self.tabs = TabStore(writer: pool)
@@ -83,6 +85,7 @@ public final class TBDDatabase: Sendable {
         self.notes = NoteStore(writer: queue)
         self.modelProfiles = ModelProfileStore(writer: queue)
         self.modelProfileUsage = ModelProfileUsageStore(writer: queue)
+        self.oauthUsageSnapshots = OAuthUsageSnapshotStore(writer: queue)
         self.config = ConfigStore(writer: queue)
         self.meta = TBDMetaStore(writer: queue)
         self.tabs = TabStore(writer: queue)
@@ -906,6 +909,19 @@ public final class TBDDatabase: Sendable {
         // which is the only way fork PRs (no matching local branch) get tracked.
         migrator.registerMigration("v54_worktree_pr_number") { db in
             try db.addColumnIfMissing(table: "worktree", column: "pr_number", type: .integer)
+        }
+
+        // Last-known OAuth usage snapshot per profile (JSON blob of the shared
+        // ProfileUsageSnapshot model), so daemon restarts render stale-but-real
+        // usage bars immediately instead of "usage unavailable" and the
+        // startup sweep can skip profiles whose data is still fresh. Cache
+        // state — rows regenerate on the next successful fetch.
+        migrator.registerMigration("v55_oauth_usage_snapshot_cache") { db in
+            try db.createTableIfNotExists("oauth_profile_usage_snapshot") { t in
+                t.primaryKey("profile_id", .text).notNull()
+                    .references("model_profiles", onDelete: .cascade)
+                t.column("snapshot_json", .text).notNull()
+            }
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/OAuthUsageSnapshotRecord.swift
+++ b/Sources/TBDDaemon/Database/OAuthUsageSnapshotRecord.swift
@@ -1,0 +1,65 @@
+import Foundation
+import GRDB
+import os
+import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
+
+/// Last-known OAuth usage snapshot per profile, persisted as a JSON blob of
+/// the shared `ProfileUsageSnapshot` model (which carries its own `fetchedAt`,
+/// so staleness stays computable after a reload). Daemon-internal cache state
+/// — not user-authored config — so it lives in the DB, and rows regenerate on
+/// the next successful fetch. Profile deletion cascades via the FK.
+struct OAuthUsageSnapshotRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "oauth_profile_usage_snapshot"
+
+    var profile_id: String
+    var snapshot_json: String
+}
+
+public struct OAuthUsageSnapshotStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    public func upsert(profileID: UUID, snapshot: ProfileUsageSnapshot) async throws {
+        // Default (deferredToDate) date strategy: doubles round-trip exactly.
+        let data = try JSONEncoder().encode(snapshot)
+        guard let json = String(bytes: data, encoding: .utf8) else {
+            // Unreachable in practice — JSONEncoder emits UTF-8 — but the
+            // store must never write a blob it can't read back.
+            return
+        }
+        let record = OAuthUsageSnapshotRecord(
+            profile_id: profileID.uuidString,
+            snapshot_json: json
+        )
+        try await writer.write { db in
+            try record.save(db)
+        }
+    }
+
+    /// All persisted snapshots keyed by profile ID. Malformed rows (bad UUID
+    /// or undecodable JSON) are skipped with a logged warning, never thrown —
+    /// this is a cache, and the poller refills it.
+    public func loadAll() async throws -> [UUID: ProfileUsageSnapshot] {
+        try await writer.read { db in
+            let records = try OAuthUsageSnapshotRecord.fetchAll(db)
+            var byProfileID: [UUID: ProfileUsageSnapshot] = [:]
+            byProfileID.reserveCapacity(records.count)
+            for record in records {
+                guard let uuid = UUID(uuidString: record.profile_id),
+                      let snapshot = try? JSONDecoder().decode(
+                        ProfileUsageSnapshot.self, from: Data(record.snapshot_json.utf8))
+                else {
+                    decodeLogger.warning("Skipping oauth_profile_usage_snapshot row: malformed \(record.profile_id, privacy: .public)")
+                    continue
+                }
+                byProfileID[uuid] = snapshot
+            }
+            return byProfileID
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/OAuthUsageSnapshotRecord.swift
+++ b/Sources/TBDDaemon/Database/OAuthUsageSnapshotRecord.swift
@@ -41,6 +41,18 @@ public struct OAuthUsageSnapshotStore: Sendable {
         }
     }
 
+    /// Delete rows for every profile NOT in `profileIDs`. Full sweeps call
+    /// this so snapshots for deleted or logged-out profiles don't reload as
+    /// ghosts on the next daemon restart.
+    public func deleteExcept(profileIDs: Set<UUID>) async throws {
+        let keep = profileIDs.map(\.uuidString)
+        try await writer.write { db in
+            _ = try OAuthUsageSnapshotRecord
+                .filter(!keep.contains(Column("profile_id")))
+                .deleteAll(db)
+        }
+    }
+
     /// All persisted snapshots keyed by profile ID. Malformed rows (bad UUID
     /// or undecodable JSON) are skipped with a logged warning, never thrown —
     /// this is a cache, and the poller refills it.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -769,9 +769,10 @@ extension WorktreeLifecycle {
                     profileSecret: resolvedProfile?.secret,
                     profileKind: resolvedProfile?.kind,
                     profileBaseURL: resolvedProfile?.baseURL,
-                    // Same per-spawn override as the primary terminal: these
-                    // restores happen at worktree-create time too.
-                    profileModel: modelOverride ?? resolvedProfile?.model,
+                    // No per-spawn model override here: archived-session
+                    // restores only happen on revive/recovery, whose callers
+                    // never pass one (create never carries archived sessions).
+                    profileModel: resolvedProfile?.model,
                     profileAwsRegion: resolvedProfile?.awsRegion,
                     profileAwsProfile: resolvedProfile?.awsProfile,
                     profileConfigDir: restoreProfileConfigDir,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -203,7 +203,7 @@ extension WorktreeLifecycle {
     /// When `existingBranchRef` is non-nil, the worktree is checked out from
     /// that existing ref (local or `origin/*`) — no fresh branch is created.
     @discardableResult
-    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, checkoutPRHead: Bool = false, overrideProfileID: UUID? = nil, claudeSettingsOverlay: String? = nil) async throws -> WorktreeCreateCompletion {
+    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, checkoutPRHead: Bool = false, overrideProfileID: UUID? = nil, modelOverride: String? = nil, claudeSettingsOverlay: String? = nil) async throws -> WorktreeCreateCompletion {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -340,6 +340,7 @@ extension WorktreeLifecycle {
                         cols: cols, rows: rows,
                         completionAction: .markActive,
                         overrideProfileID: overrideProfileID,
+                        modelOverride: modelOverride,
                         claudeSettingsOverlay: claudeSettingsOverlay
                     )
                 }
@@ -357,6 +358,7 @@ extension WorktreeLifecycle {
                 rows: rows,
                 preSessionTerminalID: nil,
                 overrideProfileID: overrideProfileID,
+                modelOverride: modelOverride,
                 claudeSettingsOverlay: claudeSettingsOverlay
             )
             let terminalSpawnElapsedMs = terminalSpawnStart.duration(to: clock.now) / .milliseconds(1)
@@ -484,6 +486,7 @@ extension WorktreeLifecycle {
         rows: Int? = nil,
         preSessionTerminalID: UUID?,
         overrideProfileID: UUID? = nil,
+        modelOverride: String? = nil,
         claudeSettingsOverlay: String? = nil
     ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
@@ -622,7 +625,9 @@ extension WorktreeLifecycle {
                 profileSecret: resolvedProfile?.secret,
                 profileKind: resolvedProfile?.kind,
                 profileBaseURL: resolvedProfile?.baseURL,
-                profileModel: resolvedProfile?.model,
+                // Per-spawn model override (picker model buttons) wins over
+                // the profile default for this initial spawn only.
+                profileModel: modelOverride ?? resolvedProfile?.model,
                 profileAwsRegion: resolvedProfile?.awsRegion,
                 profileAwsProfile: resolvedProfile?.awsProfile,
                 profileConfigDir: profileConfigDir,
@@ -764,7 +769,9 @@ extension WorktreeLifecycle {
                     profileSecret: resolvedProfile?.secret,
                     profileKind: resolvedProfile?.kind,
                     profileBaseURL: resolvedProfile?.baseURL,
-                    profileModel: resolvedProfile?.model,
+                    // Same per-spawn override as the primary terminal: these
+                    // restores happen at worktree-create time too.
+                    profileModel: modelOverride ?? resolvedProfile?.model,
                     profileAwsRegion: resolvedProfile?.awsRegion,
                     profileAwsProfile: resolvedProfile?.awsProfile,
                     profileConfigDir: restoreProfileConfigDir,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -281,6 +281,7 @@ extension WorktreeLifecycle {
         cols: Int? = nil, rows: Int? = nil,
         completionAction: PreSessionCompletionAction,
         overrideProfileID: UUID? = nil,
+        modelOverride: String? = nil,
         claudeSettingsOverlay: String? = nil
     ) async {
         let outcome = await waitForPreSessionCompletion(
@@ -349,6 +350,7 @@ extension WorktreeLifecycle {
                 // it into tab order. On failure it stays, at index 1 as before.
                 preSessionTerminalID: succeeded ? nil : preSession.terminalID,
                 overrideProfileID: overrideProfileID,
+                modelOverride: modelOverride,
                 claudeSettingsOverlay: claudeSettingsOverlay
             )
             for terminal in created {

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -407,12 +407,14 @@ extension RPCRouter {
         }
     }
 
-    // MARK: - Usage Refresh (forced sweep of the in-memory OAuth usage poller)
+    // MARK: - Usage Refresh (refresh-if-stale sweep of the OAuth usage poller)
 
-    /// `modelProfile.usageRefresh` — force a fresh usage sweep for all
-    /// logged-in OAuth profiles (params.id == nil) or one profile, and return
-    /// the post-sweep snapshots. The spawn-time account picker calls this on
-    /// open; background staleness is otherwise bounded by the poller cadence.
+    /// `modelProfile.usageRefresh` — sweep stale, eligible profiles (all
+    /// logged-in OAuth profiles when params.id == nil, else one) and return
+    /// the post-sweep snapshots. Profiles with a snapshot fresher than
+    /// `OAuthProfileUsagePoller.refreshFreshness` or inside a backoff window
+    /// are skipped (cached snapshot returned) — the picker calls this on
+    /// every open, and that must never re-hammer a rate-limited endpoint.
     /// The poller broadcasts `.modelProfilesChanged` itself when data changes.
     func handleModelProfileUsageRefresh(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ModelProfileUsageRefreshParams.self, from: paramsData)

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -72,6 +72,9 @@ extension RPCRouter {
         // Explicit per-creation model-profile override (sidebar `+` picker).
         // nil preserves the repo/scratch/global precedence chain.
         let overrideProfileID = params.profileID
+        // Per-spawn Claude model override (picker model buttons). Initial
+        // spawn only — respawns fall back to the profile default.
+        let modelOverride = params.model
         // General Claude settings passthrough, deep-merged into the per-session
         // --settings overlay on the fresh-primary spawn (see ClaudeHookOverlay).
         let claudeSettingsOverlay = params.claudeSettingsOverlay
@@ -85,7 +88,7 @@ extension RPCRouter {
                 // fetch from phase 1.5, or is a no-op if cached within the 60s TTL.
                 await fetchCache.fetchIfNeeded(repoPath: repoPath, branch: defaultBranch)
 
-                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, checkoutPRHead: checkoutPRHead, overrideProfileID: overrideProfileID, claudeSettingsOverlay: claudeSettingsOverlay)
+                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, checkoutPRHead: checkoutPRHead, overrideProfileID: overrideProfileID, modelOverride: modelOverride, claudeSettingsOverlay: claudeSettingsOverlay)
                 switch completion {
                 case .ready:
                     subs.broadcast(delta: .worktreeCreated(WorktreeDelta(

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -637,8 +637,11 @@ public enum ProfileUsageStatusKind: String, Codable, Sendable, Equatable {
     case unknown
 }
 
-/// In-memory per-profile usage snapshot for logged-in OAuth profiles,
-/// maintained by the daemon's background poller (never persisted).
+/// Per-profile usage snapshot for logged-in OAuth profiles, maintained by
+/// the daemon's background poller. Persisted by the daemon as a regenerating
+/// JSON cache (`oauth_profile_usage_snapshot` table, migration v55), so new
+/// fields MUST stay decode-compatible with older stored JSON (optional or
+/// defaulted).
 public struct ProfileUsageSnapshot: Codable, Sendable, Equatable {
     /// Buckets from the last successful fetch (empty if none succeeded yet).
     public var buckets: [ClaudeUsageLimitBucket]

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -620,10 +620,11 @@ public struct ModelProfileFetchUsageResult: Codable, Sendable {
     public init(usage: ModelProfileUsage) { self.usage = usage }
 }
 
-/// Params for `modelProfile.usageRefresh` — force an immediate usage sweep of
-/// the daemon's in-memory OAuth usage poller (the picker dialog calls this on
-/// open). `id == nil` refreshes every logged-in OAuth profile; a non-nil id
-/// refreshes just that profile.
+/// Params for `modelProfile.usageRefresh` — sweep the daemon's OAuth usage
+/// poller for stale, eligible profiles (the picker dialog calls this on
+/// open). Profiles with a fresh snapshot or inside a rate-limit backoff
+/// window are skipped; their cached snapshot is returned instead. `id == nil`
+/// covers every logged-in OAuth profile; a non-nil id just that profile.
 public struct ModelProfileUsageRefreshParams: Codable, Sendable {
     public let id: UUID?
     public init(id: UUID? = nil) { self.id = id }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -856,6 +856,12 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// existing precedence-based resolution. Not persisted — creation-time only.
     /// Optional/defaulted for backward compatibility with older clients.
     public let profileID: UUID?
+    /// Explicit per-creation Claude model override (e.g. "claude-fable-5"),
+    /// injected as ANTHROPIC_MODEL for the new worktree's INITIAL Claude spawn
+    /// only — later respawns (hibernation wake, new sessions) fall back to the
+    /// profile default. nil preserves the profile's own model. Optional/
+    /// defaulted for backward compatibility with older clients.
+    public let model: String?
     /// Extra Claude Code settings (a JSON OBJECT string) deep-merged into TBD's
     /// per-session `--settings` overlay for this spawn's Claude agent. General
     /// passthrough — TBD does not interpret the contents. Optional/defaulted for
@@ -882,7 +888,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// Optional/defaulted for backward compatibility (old daemons ignore the
     /// unknown key; old clients omit it).
     public let autoArchiveOnMerge: Bool?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, autoArchiveOnMerge: Bool? = nil) {
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, model: String? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, autoArchiveOnMerge: Bool? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
         self.parentWorktreeID = parentWorktreeID
@@ -891,6 +897,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
         self.suppressAutoParent = suppressAutoParent
         self.useExistingBranch = useExistingBranch
         self.profileID = profileID
+        self.model = model
         self.claudeSettingsOverlay = claudeSettingsOverlay
         self.prNumber = prNumber
         self.checkoutPRHead = checkoutPRHead

--- a/Tests/TBDAppTests/AccountHoverCardsTests.swift
+++ b/Tests/TBDAppTests/AccountHoverCardsTests.swift
@@ -80,7 +80,7 @@ struct ClaudeTabCardTests {
         let rows = card?.rows ?? []
         #expect(rows.count == 5)
         #expect(rows[0] == HoverCardRow(label: "Profile", value: "Gmail"))
-        #expect(rows[1] == HoverCardRow(label: "5h window", value: "0% · resets at 11:10 pm",
+        #expect(rows[1] == HoverCardRow(label: "5h window", value: "0% · resets at 11:10pm",
                                         monospacedDigits: true, tint: .normal))
         #expect(rows[2] == HoverCardRow(label: "Week", value: "76%",
                                         monospacedDigits: true, tint: .warning))

--- a/Tests/TBDAppTests/AccountHoverCardsTests.swift
+++ b/Tests/TBDAppTests/AccountHoverCardsTests.swift
@@ -80,7 +80,7 @@ struct ClaudeTabCardTests {
         let rows = card?.rows ?? []
         #expect(rows.count == 5)
         #expect(rows[0] == HoverCardRow(label: "Profile", value: "Gmail"))
-        #expect(rows[1] == HoverCardRow(label: "5h window", value: "0% · resets 23:10",
+        #expect(rows[1] == HoverCardRow(label: "5h window", value: "0% · resets at 11:10 pm",
                                         monospacedDigits: true, tint: .normal))
         #expect(rows[2] == HoverCardRow(label: "Week", value: "76%",
                                         monospacedDigits: true, tint: .warning))

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -1016,13 +1016,15 @@ struct CompactResetCountdownTests {
 @Suite("ProfileUsagePresentation — reset clock text")
 struct ResetClockTextTests {
     /// Build a UTC instant from wall-clock components.
-    private func utcDate(month: Int, day: Int, hour: Int, minute: Int) -> Date {
+    private func utcDate(month: Int, day: Int, hour: Int, minute: Int,
+                         second: Int = 0) -> Date {
         var components = DateComponents()
         components.year = 2026
         components.month = month
         components.day = day
         components.hour = hour
         components.minute = minute
+        components.second = second
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = utc
         return calendar.date(from: components)!
@@ -1042,7 +1044,26 @@ struct ResetClockTextTests {
         #expect(ProfileUsagePresentation.resetTimeText(
             utcDate(month: 7, day: 3, hour: 0, minute: 15), timeZone: utc) == "12:15am")
         #expect(ProfileUsagePresentation.resetTimeText(
-            utcDate(month: 7, day: 3, hour: 12, minute: 0), timeZone: utc) == "12:00pm")
+            utcDate(month: 7, day: 3, hour: 12, minute: 0), timeZone: utc) == "12pm")
+    }
+
+    @Test func clockFormDropsMinutesOnTheHour() {
+        #expect(ProfileUsagePresentation.resetTimeText(
+            utcDate(month: 7, day: 3, hour: 20, minute: 0), timeZone: utc) == "8pm")
+    }
+
+    @Test func secondsUnderTheHourCeilToNextHour() {
+        // The API's reset instants land a fraction under the hour; a flooring
+        // formatter renders the misleading "7:59pm" — ceil to the minute first.
+        #expect(ProfileUsagePresentation.resetTimeText(
+            utcDate(month: 7, day: 3, hour: 19, minute: 59, second: 59), timeZone: utc) == "8pm")
+        #expect(ProfileUsagePresentation.weekdayResetTimeText(
+            utcDate(month: 7, day: 3, hour: 17, minute: 59, second: 59), timeZone: utc) == "Fri 6pm")
+    }
+
+    @Test func exactHalfHourKeepsMinutes() {
+        #expect(ProfileUsagePresentation.resetTimeText(
+            utcDate(month: 7, day: 3, hour: 19, minute: 30), timeZone: utc) == "7:30pm")
     }
 
     @Test func weekdayFormCarriesWeekdayAndMinutes() {

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -7,7 +7,8 @@ import TBDShared
 
 private let utc = TimeZone(identifier: "UTC")!
 
-/// 2026-07-03 23:10:00 UTC — renders as "23:10" in the UTC fixtures below.
+/// 2026-07-03 23:10:00 UTC (a Friday) — renders as "11:10 pm" in the UTC
+/// fixtures below ("Fri 11:10 pm" in the weekday form).
 private let resetDate: Date = {
     var components = DateComponents()
     components.year = 2026
@@ -47,7 +48,7 @@ private func entry(name: String,
     )
 }
 
-/// The live-verified Gmail shape: 5h 0% resetting 23:10, weekly 76%, Fable 100%.
+/// The live-verified Gmail shape: 5h 0% resetting 11:10 pm, weekly 76%, Fable 100%.
 private let gmailSnapshot = snapshot(buckets: [
     bucket(kind: "session", percent: 0, severity: "normal", resetsAt: resetDate),
     bucket(kind: "weekly_all", percent: 76, severity: "warning"),
@@ -69,7 +70,7 @@ private func claudeTerminal(profileID: UUID? = nil,
 struct UsageSuffixTests {
     @Test func fullSnapshotComposesCompactSuffix() {
         let suffix = ProfileUsagePresentation.usageSuffix(for: gmailSnapshot, timeZone: utc)
-        #expect(suffix == " · 5h 0% ↺23:10 · wk 76% · F 100%")
+        #expect(suffix == " · 5h 0% ↺11:10 pm · wk 76% · F 100%")
     }
 
     @Test func missingSnapshotProducesEmptySuffix() {
@@ -103,7 +104,7 @@ struct UsageSuffixTests {
     @Test func menuItemTitleCombinesIdentityAndUsage() {
         let gmail = entry(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: gmailSnapshot)
         #expect(ProfileUsagePresentation.menuItemTitle(for: gmail, timeZone: utc)
-                == "Gmail — g@x.co · 5h 0% ↺23:10 · wk 76% · F 100%")
+                == "Gmail — g@x.co · 5h 0% ↺11:10 pm · wk 76% · F 100%")
     }
 
     @Test func menuItemTitleWithoutSnapshotIsIdentityOnly() {
@@ -125,7 +126,7 @@ struct UsageSuffixTests {
 struct TwoLineMenuTests {
     @Test func fullSnapshotSpellsOutUsageWithUsedLabelOnce() {
         let line = ProfileUsagePresentation.usageDetailLine(for: gmailSnapshot, timeZone: utc)
-        #expect(line == "5h 0% used · resets 23:10 · week 76% · Fable 100%")
+        #expect(line == "5h 0% used · resets 11:10 pm · week 76% · Fable 100%")
     }
 
     @Test func usedLabelAppearsExactlyOnceOnTheFirstPercentage() {
@@ -149,7 +150,7 @@ struct TwoLineMenuTests {
             bucket(kind: "weekly_all", percent: 79),
         ])
         #expect(ProfileUsagePresentation.usageDetailLine(for: noFable, timeZone: utc)
-                == "5h 16% used · resets 23:10 · week 79%")
+                == "5h 16% used · resets 11:10 pm · week 79%")
     }
 
     @Test func sessionWithoutResetOmitsClockFragmentButKeepsUsed() {
@@ -170,7 +171,7 @@ struct TwoLineMenuTests {
         let gmail = entry(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: gmailSnapshot)
         let line = ProfileUsagePresentation.menuLine(for: gmail, timeZone: utc)
         #expect(line.primary == "Gmail — g@x.co")
-        #expect(line.secondary == "5h 0% used · resets 23:10 · week 76% · Fable 100%")
+        #expect(line.secondary == "5h 0% used · resets 11:10 pm · week 76% · Fable 100%")
     }
 
     @Test func menuLineWithoutSnapshotHasNilSecondary() {
@@ -317,12 +318,14 @@ struct FillLevelTests {
 
 @Suite("ProfileUsagePresentation — resetDisplay policy")
 struct ResetDisplayPolicyTests {
-    @Test func sessionKindUsesClockDisplay() {
+    // Default style (timeOfReset): absolute times inline.
+
+    @Test func sessionKindUsesClockDisplayByDefault() {
         #expect(ProfileUsagePresentation.resetDisplay(forKind: "session") == .clock)
     }
 
-    @Test func weeklyAllKindUsesCountdownDisplay() {
-        #expect(ProfileUsagePresentation.resetDisplay(forKind: "weekly_all") == .countdown)
+    @Test func weeklyAllKindUsesWeekdayClockDisplayByDefault() {
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "weekly_all") == .weekdayClock)
     }
 
     @Test func scopedKindUsesTooltipOnlyDisplay() {
@@ -331,6 +334,25 @@ struct ResetDisplayPolicyTests {
 
     @Test func unknownKindDefaultsToTooltipOnly() {
         #expect(ProfileUsagePresentation.resetDisplay(forKind: "future_kind") == .tooltipOnly)
+    }
+
+    // timeUntilReset style: relative countdowns inline.
+
+    @Test func sessionKindUsesCountdownUnderTimeUntilStyle() {
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "session",
+                                                      style: .timeUntilReset) == .countdown)
+    }
+
+    @Test func weeklyAllKindUsesCountdownUnderTimeUntilStyle() {
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "weekly_all",
+                                                      style: .timeUntilReset) == .countdown)
+    }
+
+    @Test func scopedAndUnknownKindsStayTooltipOnlyUnderTimeUntilStyle() {
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "weekly_scoped",
+                                                      style: .timeUntilReset) == .tooltipOnly)
+        #expect(ProfileUsagePresentation.resetDisplay(forKind: "future_kind",
+                                                      style: .timeUntilReset) == .tooltipOnly)
     }
 }
 
@@ -375,13 +397,13 @@ struct BucketPresentationTests {
         #expect(presentation.elapsedFraction != nil)
     }
 
-    @Test func weeklyBucketBuildsCountdownDisplay() {
+    @Test func weeklyBucketBuildsWeekdayClockDisplay() {
         let weeklyBucket = bucket(kind: "weekly_all", percent: 76, severity: "warning")
         let presentation = ProfileUsagePresentation.bucketPresentation(weeklyBucket, now: now, timeZone: utc)
         #expect(presentation.kind == "weekly_all")
         #expect(presentation.percent == 76)
         #expect(presentation.percentText == "76%")
-        #expect(presentation.resetDisplay == .countdown)
+        #expect(presentation.resetDisplay == .weekdayClock)
         #expect(presentation.resetInline == nil)  // No reset date on weekly bucket
         #expect(presentation.resetPhrase == nil)
         #expect(presentation.fill == .warning)
@@ -411,12 +433,65 @@ struct BucketPresentationTests {
     }
 
     @Test func countdownInResetPhraseWhenValid() {
-        // Weekly bucket with a reset date (hypothetically added by API in future).
+        // Weekly bucket with a reset date, under the time-until preference.
         let weekly = bucket(kind: "weekly_all", percent: 50, resetsAt: now.addingTimeInterval(2 * 24 * 3600))
-        let presentation = ProfileUsagePresentation.bucketPresentation(weekly, now: now, timeZone: utc)
+        let presentation = ProfileUsagePresentation.bucketPresentation(
+            weekly, style: .timeUntilReset, now: now, timeZone: utc)
         #expect(presentation.resetDisplay == .countdown)
-        #expect(presentation.resetInline != nil)  // Now has countdown since we added a reset date
+        #expect(presentation.resetInline != nil)
         #expect(presentation.resetPhrase?.hasPrefix("resets in") ?? false)
+    }
+
+    // MARK: Preference modes — exact inline strings per bucket kind.
+
+    @Test func sessionTimeOfResetInlineIsAtClockTime() {
+        // now two hours before the 11:10 pm fixture reset.
+        let now = resetDate.addingTimeInterval(-2 * 3600)
+        let session = bucket(kind: "session", percent: 20, resetsAt: resetDate)
+        let presentation = ProfileUsagePresentation.bucketPresentation(
+            session, style: .timeOfReset, now: now, timeZone: utc)
+        #expect(presentation.resetInline == "at 11:10 pm")
+        #expect(presentation.resetPhrase == "resets at 11:10 pm")
+    }
+
+    @Test func weeklyTimeOfResetInlineIsAtWeekdayTime() {
+        // resetDate is a Friday; 4 days out → weekday + 12h time.
+        let now = resetDate.addingTimeInterval(-4 * 24 * 3600)
+        let weekly = bucket(kind: "weekly_all", percent: 50, resetsAt: resetDate)
+        let presentation = ProfileUsagePresentation.bucketPresentation(
+            weekly, style: .timeOfReset, now: now, timeZone: utc)
+        #expect(presentation.resetInline == "at Fri 11:10 pm")
+        #expect(presentation.resetPhrase == "resets at Fri 11:10 pm")
+    }
+
+    @Test func sessionTimeUntilInlineKeepsMinutePrecision() {
+        let session = bucket(kind: "session", percent: 20,
+                             resetsAt: now.addingTimeInterval((2 * 60 + 10) * 60))
+        let presentation = ProfileUsagePresentation.bucketPresentation(
+            session, style: .timeUntilReset, now: now, timeZone: utc)
+        #expect(presentation.resetInline == "in 2h 10m")
+        #expect(presentation.resetPhrase == "resets in 2h 10m")
+    }
+
+    @Test func weeklyTimeUntilInlineIsDayHourCountdown() {
+        let weekly = bucket(kind: "weekly_all", percent: 50,
+                            resetsAt: now.addingTimeInterval((4 * 24 + 2) * 3600))
+        let presentation = ProfileUsagePresentation.bucketPresentation(
+            weekly, style: .timeUntilReset, now: now, timeZone: utc)
+        #expect(presentation.resetInline == "in 4d 2h")
+        #expect(presentation.resetPhrase == "resets in 4d 2h")
+    }
+
+    @Test func scopedStaysTooltipOnlyInBothStyles() {
+        let scoped = bucket(kind: "weekly_scoped", percent: 45,
+                            resetsAt: now.addingTimeInterval(2 * 24 * 3600), family: "Fable")
+        for style in ProfileUsagePresentation.ResetTimeStyle.allCases {
+            let presentation = ProfileUsagePresentation.bucketPresentation(
+                scoped, style: style, now: now, timeZone: utc)
+            #expect(presentation.resetDisplay == .tooltipOnly)
+            #expect(presentation.resetInline == nil)
+            #expect(presentation.resetPhrase == "resets in 2d")
+        }
     }
 }
 
@@ -649,7 +724,7 @@ struct StalenessNoteTests {
 struct SecondaryLineHonestyTests {
     @Test func healthyFreshShowsUsageNumbers() {
         let line = ProfileUsagePresentation.secondaryLine(for: gmailSnapshot, timeZone: utc)
-        #expect(line == "5h 0% used · resets 23:10 · week 76% · Fable 100%")
+        #expect(line == "5h 0% used · resets 11:10 pm · week 76% · Fable 100%")
     }
 
     @Test func rateLimitedProfileShowsRetryNoteNotStaleNumbers() {
@@ -712,7 +787,7 @@ struct SessionTooltipTests {
         )
         #expect(tooltip == """
         Account: g@x.co (Gmail)
-        Usage: 5h 0% ↺23:10 · wk 76% · F 100%
+        Usage: 5h 0% ↺11:10 pm · wk 76% · F 100%
         Spawned: 2026-07-03 23:10
         """)
     }
@@ -883,6 +958,28 @@ struct CompactResetCountdownTests {
         #expect(ProfileUsagePresentation.compactResetCountdown(resets, now: now) == "3h")
     }
 
+    @Test func hourScaleKeepsMinutesWhenAsked() {
+        // The session window's countdown form: "2h 10m", not a lossy "2h".
+        let resets = now.addingTimeInterval((2 * 60 + 10) * 60)
+        #expect(ProfileUsagePresentation.compactResetCountdown(
+            resets, now: now, minutesAtHourScale: true) == "2h 10m")
+    }
+
+    @Test func hourScaleWithZeroMinutesStaysBare() {
+        let resets = now.addingTimeInterval(2 * 3600)
+        #expect(ProfileUsagePresentation.compactResetCountdown(
+            resets, now: now, minutesAtHourScale: true) == "2h")
+    }
+
+    @Test func minutesAtHourScaleLeavesSubHourAndDayScalesUnchanged() {
+        let subHour = now.addingTimeInterval(48 * 60)
+        #expect(ProfileUsagePresentation.compactResetCountdown(
+            subHour, now: now, minutesAtHourScale: true) == "48m")
+        let dayScale = now.addingTimeInterval(((2 * 24 + 5) * 60 + 10) * 60)
+        #expect(ProfileUsagePresentation.compactResetCountdown(
+            dayScale, now: now, minutesAtHourScale: true) == "2d 5h")
+    }
+
     @Test func daysCarryHourRemainder() {
         let resets = now.addingTimeInterval(((2 * 24 + 5) * 60 + 10) * 60)
         #expect(ProfileUsagePresentation.compactResetCountdown(resets, now: now) == "2d 5h")
@@ -908,8 +1005,56 @@ struct CompactResetCountdownTests {
                    resetsAt: weeklyReset, family: "Fable"),
         ])
         let line = ProfileUsagePresentation.usageDetailLine(for: snap, timeZone: utc, now: now)
-        #expect(line == "5h 16% used · resets 23:10 · week 79% · resets in 2d 5h · Fable 45%")
+        #expect(line == "5h 16% used · resets 11:10 pm · week 79% · resets in 2d 5h · Fable 45%")
         // The shared weekly instant renders once (on the week segment), not per family.
         #expect(line?.components(separatedBy: "resets in").count == 2)
+    }
+}
+
+// MARK: - Clock formatting (am/pm)
+
+@Suite("ProfileUsagePresentation — reset clock text")
+struct ResetClockTextTests {
+    /// Build a UTC instant from wall-clock components.
+    private func utcDate(month: Int, day: Int, hour: Int, minute: Int) -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utc
+        return calendar.date(from: components)!
+    }
+
+    @Test func eveningRendersTwelveHourWithPM() {
+        #expect(ProfileUsagePresentation.resetTimeText(
+            utcDate(month: 7, day: 3, hour: 19, minute: 59), timeZone: utc) == "7:59 pm")
+    }
+
+    @Test func morningRendersTwelveHourWithAM() {
+        #expect(ProfileUsagePresentation.resetTimeText(
+            utcDate(month: 7, day: 3, hour: 9, minute: 5), timeZone: utc) == "9:05 am")
+    }
+
+    @Test func midnightAndNoonUseTwelve() {
+        #expect(ProfileUsagePresentation.resetTimeText(
+            utcDate(month: 7, day: 3, hour: 0, minute: 15), timeZone: utc) == "12:15 am")
+        #expect(ProfileUsagePresentation.resetTimeText(
+            utcDate(month: 7, day: 3, hour: 12, minute: 0), timeZone: utc) == "12:00 pm")
+    }
+
+    @Test func weekdayFormCarriesWeekdayAndMinutes() {
+        // 2026-07-03 is a Friday.
+        #expect(ProfileUsagePresentation.weekdayResetTimeText(
+            utcDate(month: 7, day: 3, hour: 18, minute: 59), timeZone: utc) == "Fri 6:59 pm")
+    }
+
+    @Test func weekdayFormDropsMinutesOnTheHour() {
+        #expect(ProfileUsagePresentation.weekdayResetTimeText(
+            utcDate(month: 7, day: 3, hour: 19, minute: 0), timeZone: utc) == "Fri 7 pm")
+        #expect(ProfileUsagePresentation.weekdayResetTimeText(
+            utcDate(month: 7, day: 6, hour: 9, minute: 0), timeZone: utc) == "Mon 9 am")
     }
 }

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -7,8 +7,8 @@ import TBDShared
 
 private let utc = TimeZone(identifier: "UTC")!
 
-/// 2026-07-03 23:10:00 UTC (a Friday) — renders as "11:10 pm" in the UTC
-/// fixtures below ("Fri 11:10 pm" in the weekday form).
+/// 2026-07-03 23:10:00 UTC (a Friday) — renders as "11:10pm" in the UTC
+/// fixtures below ("Fri 11:10pm" in the weekday form).
 private let resetDate: Date = {
     var components = DateComponents()
     components.year = 2026
@@ -48,7 +48,7 @@ private func entry(name: String,
     )
 }
 
-/// The live-verified Gmail shape: 5h 0% resetting 11:10 pm, weekly 76%, Fable 100%.
+/// The live-verified Gmail shape: 5h 0% resetting 11:10pm, weekly 76%, Fable 100%.
 private let gmailSnapshot = snapshot(buckets: [
     bucket(kind: "session", percent: 0, severity: "normal", resetsAt: resetDate),
     bucket(kind: "weekly_all", percent: 76, severity: "warning"),
@@ -70,7 +70,7 @@ private func claudeTerminal(profileID: UUID? = nil,
 struct UsageSuffixTests {
     @Test func fullSnapshotComposesCompactSuffix() {
         let suffix = ProfileUsagePresentation.usageSuffix(for: gmailSnapshot, timeZone: utc)
-        #expect(suffix == " · 5h 0% ↺11:10 pm · wk 76% · F 100%")
+        #expect(suffix == " · 5h 0% ↺11:10pm · wk 76% · F 100%")
     }
 
     @Test func missingSnapshotProducesEmptySuffix() {
@@ -104,7 +104,7 @@ struct UsageSuffixTests {
     @Test func menuItemTitleCombinesIdentityAndUsage() {
         let gmail = entry(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: gmailSnapshot)
         #expect(ProfileUsagePresentation.menuItemTitle(for: gmail, timeZone: utc)
-                == "Gmail — g@x.co · 5h 0% ↺11:10 pm · wk 76% · F 100%")
+                == "Gmail — g@x.co · 5h 0% ↺11:10pm · wk 76% · F 100%")
     }
 
     @Test func menuItemTitleWithoutSnapshotIsIdentityOnly() {
@@ -126,7 +126,7 @@ struct UsageSuffixTests {
 struct TwoLineMenuTests {
     @Test func fullSnapshotSpellsOutUsageWithUsedLabelOnce() {
         let line = ProfileUsagePresentation.usageDetailLine(for: gmailSnapshot, timeZone: utc)
-        #expect(line == "5h 0% used · resets 11:10 pm · week 76% · Fable 100%")
+        #expect(line == "5h 0% used · resets 11:10pm · week 76% · Fable 100%")
     }
 
     @Test func usedLabelAppearsExactlyOnceOnTheFirstPercentage() {
@@ -150,7 +150,7 @@ struct TwoLineMenuTests {
             bucket(kind: "weekly_all", percent: 79),
         ])
         #expect(ProfileUsagePresentation.usageDetailLine(for: noFable, timeZone: utc)
-                == "5h 16% used · resets 11:10 pm · week 79%")
+                == "5h 16% used · resets 11:10pm · week 79%")
     }
 
     @Test func sessionWithoutResetOmitsClockFragmentButKeepsUsed() {
@@ -171,7 +171,7 @@ struct TwoLineMenuTests {
         let gmail = entry(name: "Gmail", loginIdentity: "g@x.co", usageSnapshot: gmailSnapshot)
         let line = ProfileUsagePresentation.menuLine(for: gmail, timeZone: utc)
         #expect(line.primary == "Gmail — g@x.co")
-        #expect(line.secondary == "5h 0% used · resets 11:10 pm · week 76% · Fable 100%")
+        #expect(line.secondary == "5h 0% used · resets 11:10pm · week 76% · Fable 100%")
     }
 
     @Test func menuLineWithoutSnapshotHasNilSecondary() {
@@ -445,13 +445,13 @@ struct BucketPresentationTests {
     // MARK: Preference modes — exact inline strings per bucket kind.
 
     @Test func sessionTimeOfResetInlineIsAtClockTime() {
-        // now two hours before the 11:10 pm fixture reset.
+        // now two hours before the 11:10pm fixture reset.
         let now = resetDate.addingTimeInterval(-2 * 3600)
         let session = bucket(kind: "session", percent: 20, resetsAt: resetDate)
         let presentation = ProfileUsagePresentation.bucketPresentation(
             session, style: .timeOfReset, now: now, timeZone: utc)
-        #expect(presentation.resetInline == "at 11:10 pm")
-        #expect(presentation.resetPhrase == "resets at 11:10 pm")
+        #expect(presentation.resetInline == "at 11:10pm")
+        #expect(presentation.resetPhrase == "resets at 11:10pm")
     }
 
     @Test func weeklyTimeOfResetInlineIsAtWeekdayTime() {
@@ -460,8 +460,8 @@ struct BucketPresentationTests {
         let weekly = bucket(kind: "weekly_all", percent: 50, resetsAt: resetDate)
         let presentation = ProfileUsagePresentation.bucketPresentation(
             weekly, style: .timeOfReset, now: now, timeZone: utc)
-        #expect(presentation.resetInline == "at Fri 11:10 pm")
-        #expect(presentation.resetPhrase == "resets at Fri 11:10 pm")
+        #expect(presentation.resetInline == "at Fri 11:10pm")
+        #expect(presentation.resetPhrase == "resets at Fri 11:10pm")
     }
 
     @Test func sessionTimeUntilInlineKeepsMinutePrecision() {
@@ -724,7 +724,7 @@ struct StalenessNoteTests {
 struct SecondaryLineHonestyTests {
     @Test func healthyFreshShowsUsageNumbers() {
         let line = ProfileUsagePresentation.secondaryLine(for: gmailSnapshot, timeZone: utc)
-        #expect(line == "5h 0% used · resets 11:10 pm · week 76% · Fable 100%")
+        #expect(line == "5h 0% used · resets 11:10pm · week 76% · Fable 100%")
     }
 
     @Test func rateLimitedProfileShowsRetryNoteNotStaleNumbers() {
@@ -787,7 +787,7 @@ struct SessionTooltipTests {
         )
         #expect(tooltip == """
         Account: g@x.co (Gmail)
-        Usage: 5h 0% ↺11:10 pm · wk 76% · F 100%
+        Usage: 5h 0% ↺11:10pm · wk 76% · F 100%
         Spawned: 2026-07-03 23:10
         """)
     }
@@ -1005,7 +1005,7 @@ struct CompactResetCountdownTests {
                    resetsAt: weeklyReset, family: "Fable"),
         ])
         let line = ProfileUsagePresentation.usageDetailLine(for: snap, timeZone: utc, now: now)
-        #expect(line == "5h 16% used · resets 11:10 pm · week 79% · resets in 2d 5h · Fable 45%")
+        #expect(line == "5h 16% used · resets 11:10pm · week 79% · resets in 2d 5h · Fable 45%")
         // The shared weekly instant renders once (on the week segment), not per family.
         #expect(line?.components(separatedBy: "resets in").count == 2)
     }
@@ -1030,31 +1030,31 @@ struct ResetClockTextTests {
 
     @Test func eveningRendersTwelveHourWithPM() {
         #expect(ProfileUsagePresentation.resetTimeText(
-            utcDate(month: 7, day: 3, hour: 19, minute: 59), timeZone: utc) == "7:59 pm")
+            utcDate(month: 7, day: 3, hour: 19, minute: 59), timeZone: utc) == "7:59pm")
     }
 
     @Test func morningRendersTwelveHourWithAM() {
         #expect(ProfileUsagePresentation.resetTimeText(
-            utcDate(month: 7, day: 3, hour: 9, minute: 5), timeZone: utc) == "9:05 am")
+            utcDate(month: 7, day: 3, hour: 9, minute: 5), timeZone: utc) == "9:05am")
     }
 
     @Test func midnightAndNoonUseTwelve() {
         #expect(ProfileUsagePresentation.resetTimeText(
-            utcDate(month: 7, day: 3, hour: 0, minute: 15), timeZone: utc) == "12:15 am")
+            utcDate(month: 7, day: 3, hour: 0, minute: 15), timeZone: utc) == "12:15am")
         #expect(ProfileUsagePresentation.resetTimeText(
-            utcDate(month: 7, day: 3, hour: 12, minute: 0), timeZone: utc) == "12:00 pm")
+            utcDate(month: 7, day: 3, hour: 12, minute: 0), timeZone: utc) == "12:00pm")
     }
 
     @Test func weekdayFormCarriesWeekdayAndMinutes() {
         // 2026-07-03 is a Friday.
         #expect(ProfileUsagePresentation.weekdayResetTimeText(
-            utcDate(month: 7, day: 3, hour: 18, minute: 59), timeZone: utc) == "Fri 6:59 pm")
+            utcDate(month: 7, day: 3, hour: 18, minute: 59), timeZone: utc) == "Fri 6:59pm")
     }
 
     @Test func weekdayFormDropsMinutesOnTheHour() {
         #expect(ProfileUsagePresentation.weekdayResetTimeText(
-            utcDate(month: 7, day: 3, hour: 19, minute: 0), timeZone: utc) == "Fri 7 pm")
+            utcDate(month: 7, day: 3, hour: 19, minute: 0), timeZone: utc) == "Fri 7pm")
         #expect(ProfileUsagePresentation.weekdayResetTimeText(
-            utcDate(month: 7, day: 6, hour: 9, minute: 0), timeZone: utc) == "Mon 9 am")
+            utcDate(month: 7, day: 6, hour: 9, minute: 0), timeZone: utc) == "Mon 9am")
     }
 }

--- a/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
+++ b/Tests/TBDAppTests/ProfileUsagePresentationTests.swift
@@ -227,7 +227,7 @@ struct FillLevelTests {
     }
 
     @Test func projectionInWarmingBandIsCaution() {
-        // 55% used at 0.65 elapsed → projected ≈ 0.846 → yellow.
+        // 55% used at 0.65 elapsed → projected ≈ 0.846 → caution.
         #expect(ProfileUsagePresentation.fillLevel(
             severity: "normal", percent: 55, elapsedFraction: 0.65) == .caution)
         // Band edges: exactly 0.75 is caution, just below is normal.
@@ -423,8 +423,8 @@ struct BucketPresentationTests {
         #expect(presentation.elapsedFraction == nil)
     }
 
-    @Test func paceAwareYellowTierInPresentation() {
-        // 55% at 0.65 elapsed on a session bucket → caution (yellow).
+    @Test func paceAwareCautionTierInPresentation() {
+        // 55% at 0.65 elapsed on a session bucket → caution.
         // elapsed = 0.65 * window means remaining = 0.35 * window
         let sessionBucket = bucket(kind: "session", percent: 55, severity: "normal",
                                    resetsAt: now.addingTimeInterval(0.35 * ProfileUsagePresentation.sessionWindow))

--- a/Tests/TBDCLITests/ProfileCommandsTests.swift
+++ b/Tests/TBDCLITests/ProfileCommandsTests.swift
@@ -42,6 +42,22 @@ struct ProfileCommandsTests {
         #expect(profileIdentityCell(kind: .bedrock, loginIdentity: "stray@example.com") == "—")
     }
 
+    // MARK: - Usage age marker
+
+    @Test func usageAgeMarker_freshOrUnknown_isNil() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        #expect(usageAgeMarker(fetchedAt: nil, now: now) == nil)
+        #expect(usageAgeMarker(fetchedAt: now.addingTimeInterval(-299), now: now) == nil)
+    }
+
+    @Test func usageAgeMarker_formatsMinutesHoursDays() {
+        let now = Date(timeIntervalSince1970: 1_750_000_000)
+        #expect(usageAgeMarker(fetchedAt: now.addingTimeInterval(-300), now: now) == "(updated 5m ago)")
+        #expect(usageAgeMarker(fetchedAt: now.addingTimeInterval(-59 * 60), now: now) == "(updated 59m ago)")
+        #expect(usageAgeMarker(fetchedAt: now.addingTimeInterval(-3 * 3600), now: now) == "(updated 3h ago)")
+        #expect(usageAgeMarker(fetchedAt: now.addingTimeInterval(-49 * 3600), now: now) == "(updated 2d ago)")
+    }
+
     // MARK: - Name resolution
 
     @Test func resolveProfile_exactName() throws {

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -355,6 +355,73 @@ struct ModelProfileSpawnTests {
         #expect(recorder.joinedAll.contains("CLAUDE_CODE_USE_BEDROCK=1"))
     }
 
+    // MARK: - Spawn: per-creation model override (picker model buttons)
+
+    /// A worktree-create spawn with a model override injects it as
+    /// ANTHROPIC_MODEL, winning over the profile's own model for this spawn.
+    @Test("spawn: modelOverride wins over the profile's model as ANTHROPIC_MODEL")
+    func spawnModelOverrideWinsOverProfileModel() async throws {
+        let (lifecycle, db, recorder) = makeLifecycleFixture()
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        try await db.config.setPrimaryAgentPreference(.claude)
+        let profile = try await db.modelProfiles.create(
+            name: "WithModel", kind: .oauth, model: "claude-opus-4-8"
+        )
+        try await db.config.setDefaultProfileID(profile.id)
+
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: wt, repo: repo, skipClaude: false,
+            preSessionTerminalID: nil,
+            modelOverride: "claude-fable-5"
+        )
+
+        #expect(recorder.joinedAll.contains("ANTHROPIC_MODEL=claude-fable-5"))
+        #expect(!recorder.joinedAll.contains("ANTHROPIC_MODEL=claude-opus-4-8"))
+    }
+
+    /// Branch guard: with no override, the profile's own model is injected
+    /// unchanged (today's behavior).
+    @Test("spawn: nil modelOverride keeps the profile's model")
+    func spawnNilModelOverrideKeepsProfileModel() async throws {
+        let (lifecycle, db, recorder) = makeLifecycleFixture()
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        try await db.config.setPrimaryAgentPreference(.claude)
+        let profile = try await db.modelProfiles.create(
+            name: "WithModel", kind: .oauth, model: "claude-opus-4-8"
+        )
+        try await db.config.setDefaultProfileID(profile.id)
+
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: wt, repo: repo, skipClaude: false,
+            preSessionTerminalID: nil
+        )
+
+        #expect(recorder.joinedAll.contains("ANTHROPIC_MODEL=claude-opus-4-8"))
+        #expect(!recorder.joinedAll.contains("claude-fable-5"))
+    }
+
+    /// Branch guard: an override on a profile WITHOUT a model still injects
+    /// the override (the `??` fallback isn't required for injection).
+    @Test("spawn: modelOverride injects even when the profile has no model")
+    func spawnModelOverrideWithoutProfileModel() async throws {
+        let (lifecycle, db, recorder) = makeLifecycleFixture()
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        try await db.config.setPrimaryAgentPreference(.claude)
+        let profile = try await seedOAuthProfile(db, name: "NoModel")
+        try await db.config.setDefaultProfileID(profile.id)
+
+        _ = try await lifecycle.spawnPrimaryTerminals(
+            worktree: wt, repo: repo, skipClaude: false,
+            preSessionTerminalID: nil,
+            modelOverride: "claude-sonnet-5"
+        )
+
+        #expect(recorder.joinedAll.contains("ANTHROPIC_MODEL=claude-sonnet-5"))
+    }
+
     // MARK: - Spawn: fallbackModels overlay routing
 
     @Test("spawn: profile WITHOUT fallbackModels uses the global overlay path")

--- a/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
@@ -409,6 +409,73 @@ struct OAuthProfileUsagePollerTests {
         // The stale one was refetched now.
         #expect(await poller.snapshot(for: stale.id)?.fetchedAt == fixedNow)
     }
+
+    /// Actor reentrancy: a sweep can land fresher data while `start()` is
+    /// suspended in `loadPersisted()`. The load must merge per profile by
+    /// `fetchedAt` — never clobber a fresher in-memory snapshot — while still
+    /// seeding profiles the sweep didn't cover.
+    @Test func loadPersistedMergesByFreshnessInsteadOfReplacing() async {
+        let sweptProfile = oauthProfile(named: "Swept")
+        let cachedOnly = oauthProfile(named: "CachedOnly")
+        let fixedNow = Date(timeIntervalSince1970: 1_750_000_000)
+        func snap(age: TimeInterval) -> ProfileUsageSnapshot {
+            ProfileUsageSnapshot(
+                buckets: okBuckets,
+                fetchedAt: fixedNow.addingTimeInterval(-age),
+                lastAttemptAt: fixedNow.addingTimeInterval(-age),
+                status: "ok", statusKind: .ok
+            )
+        }
+        let persisted = [sweptProfile.id: snap(age: 600), cachedOnly.id: snap(age: 600)]
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [sweptProfile], loggedIn: [sweptProfile.id],
+            fetcher: fetcher, broadcasts: broadcasts, now: fixedNow,
+            loadPersisted: { persisted }
+        )
+
+        // Racing sweep fetches sweptProfile fresh (fetchedAt == fixedNow)...
+        _ = await poller.sweepNow()
+        // ...then the interleaved load resumes.
+        await poller.loadPersistedForTest()
+
+        // Fresher in-memory snapshot survives; stale persisted one loses.
+        #expect(await poller.snapshot(for: sweptProfile.id)?.fetchedAt == fixedNow)
+        // Profile only present in the cache is still seeded.
+        #expect(await poller.snapshot(for: cachedOnly.id) == persisted[cachedOnly.id])
+    }
+
+    @Test func fullSweepPrunesPersistedRowsForIneligibleProfiles() async {
+        let eligible = oauthProfile(named: "In")
+        let loggedOut = oauthProfile(named: "Out")
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let prunedSets = LockedBox<[Set<UUID>]>([])
+        let poller = OAuthProfileUsagePoller(
+            profilesProvider: { [eligible, loggedOut] },
+            loginIdentity: { id in id == eligible.id ? "someone@example.com" : nil },
+            configDirPath: { id in "/profiles/\(id.uuidString.lowercased())/claude" },
+            fetcher: fetcher,
+            broadcast: { broadcasts.bump() },
+            sleeper: { _ in },
+            prunePersisted: { ids in prunedSets.mutate { $0.append(ids) } }
+        )
+
+        _ = await poller.sweepNow()                          // full sweep: prunes
+        _ = await poller.sweepNow(profileID: eligible.id)    // targeted: must not
+
+        #expect(prunedSets.value == [[eligible.id]])
+    }
+}
+
+/// Minimal thread-safe box for recording seam calls.
+private final class LockedBox<T: Sendable>: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "LockedBox")
+    private var _value: T
+    init(_ value: T) { _value = value }
+    var value: T { queue.sync { _value } }
+    func mutate(_ body: (inout T) -> Void) { queue.sync { body(&_value) } }
 }
 
 // MARK: - Backoff scheduling

--- a/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
@@ -62,7 +62,9 @@ private func makePoller(
     loggedIn: Set<UUID>,
     fetcher: ScriptedProfileUsageFetcher,
     broadcasts: BroadcastCounter,
-    now: Date = Date(timeIntervalSince1970: 1_750_000_000)
+    now: Date = Date(timeIntervalSince1970: 1_750_000_000),
+    loadPersisted: OAuthProfileUsagePoller.SnapshotLoader? = nil,
+    persist: OAuthProfileUsagePoller.SnapshotPersister? = nil
 ) -> OAuthProfileUsagePoller {
     OAuthProfileUsagePoller(
         profilesProvider: { profiles },
@@ -71,8 +73,20 @@ private func makePoller(
         fetcher: fetcher,
         broadcast: { broadcasts.bump() },
         sleeper: { _ in },
-        now: { now }
+        now: { now },
+        loadPersisted: loadPersisted,
+        persist: persist
     )
+}
+
+/// Thread-safe recorder for the poller's `persist` seam.
+private final class SnapshotBox: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "SnapshotBox")
+    private var _saved: [UUID: ProfileUsageSnapshot] = [:]
+    var saved: [UUID: ProfileUsageSnapshot] { queue.sync { _saved } }
+    func save(_ id: UUID, _ snapshot: ProfileUsageSnapshot) {
+        queue.sync { _saved[id] = snapshot }
+    }
 }
 
 // MARK: - Tests
@@ -146,7 +160,8 @@ struct OAuthProfileUsagePollerTests {
         let successFetchedAt = first[profile.id]?.fetchedAt
         #expect(first[profile.id]?.status == "ok")
 
-        let second = await poller.sweepNow()
+        // Scheduled-path sweep (sweepNow would skip: the snapshot is fresh).
+        let second = await poller.sweepForTest()
         let stale = second[profile.id]
         #expect(stale?.buckets == okBuckets)             // old data retained
         #expect(stale?.fetchedAt == successFetchedAt)    // success timestamp preserved
@@ -174,15 +189,25 @@ struct OAuthProfileUsagePollerTests {
         let profile = oauthProfile(named: "Dead")
         let fetcher = ScriptedProfileUsageFetcher(default: .httpError(401))
         let broadcasts = BroadcastCounter()
-        let poller = makePoller(
-            profiles: [profile], loggedIn: [profile.id],
-            fetcher: fetcher, broadcasts: broadcasts
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_750_000_000))
+        let poller = OAuthProfileUsagePoller(
+            profilesProvider: { [profile] },
+            loginIdentity: { _ in "someone@example.com" },
+            configDirPath: { id in "/profiles/\(id.uuidString.lowercased())/claude" },
+            fetcher: fetcher,
+            broadcast: { broadcasts.bump() },
+            sleeper: { _ in },
+            now: { clock.now },
+            jitter: { _ in 0 }
         )
 
-        await poller.sweepNow()
+        await poller.sweepForTest()
         #expect(broadcasts.count == 1)  // nil → failed is a change
-        await poller.sweepNow()
-        await poller.sweepNow()
+        clock.advance(31)               // past the 30s backoff from failure 1
+        await poller.sweepForTest()
+        clock.advance(61)               // past the 60s backoff from failure 2
+        await poller.sweepForTest()
+        #expect(fetcher.calls.count == 3)
         #expect(broadcasts.count == 1)  // same failure text: no re-broadcast
     }
 
@@ -288,6 +313,102 @@ struct OAuthProfileUsagePollerTests {
         #expect(second[profile.id]?.status == "ok")
         #expect(broadcasts.count == 1)
     }
+
+    // MARK: - Persistence across restarts
+
+    @Test func persistedSnapshotsAreVisibleBeforeAnyFetch() async {
+        let profile = oauthProfile(named: "Cached")
+        let fixedNow = Date(timeIntervalSince1970: 1_750_000_000)
+        let saved = ProfileUsageSnapshot(
+            buckets: okBuckets,
+            fetchedAt: fixedNow.addingTimeInterval(-600),
+            lastAttemptAt: fixedNow.addingTimeInterval(-600),
+            status: "ok", statusKind: .ok
+        )
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [profile], loggedIn: [profile.id],
+            fetcher: fetcher, broadcasts: broadcasts,
+            loadPersisted: { [profile.id: saved] }
+        )
+
+        await poller.loadPersistedForTest()
+
+        #expect(await poller.snapshot(for: profile.id) == saved)
+        #expect(fetcher.calls.isEmpty)          // load is not a fetch
+        #expect(broadcasts.count == 1)          // loaded cache is announced
+    }
+
+    @Test func successfulFetchPersistsAndReloadsIntoFreshPoller() async {
+        let profile = oauthProfile(named: "P")
+        let box = SnapshotBox()
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [profile], loggedIn: [profile.id],
+            fetcher: fetcher, broadcasts: broadcasts,
+            persist: { box.save($0, $1) }
+        )
+        _ = await poller.sweepNow()
+        #expect(box.saved[profile.id]?.buckets == okBuckets)
+        #expect(box.saved[profile.id]?.fetchedAt != nil)  // staleness computable
+
+        // "Daemon restart": a fresh poller instance loads the persisted data.
+        let reloaded = makePoller(
+            profiles: [profile], loggedIn: [profile.id],
+            fetcher: fetcher, broadcasts: broadcasts,
+            loadPersisted: { box.saved }
+        )
+        await reloaded.loadPersistedForTest()
+        #expect(await reloaded.snapshot(for: profile.id) == box.saved[profile.id])
+    }
+
+    @Test func failedFetchDoesNotPersist() async {
+        let profile = oauthProfile(named: "Bad")
+        let box = SnapshotBox()
+        let fetcher = ScriptedProfileUsageFetcher(default: .httpError(500))
+        let broadcasts = BroadcastCounter()
+        let poller = makePoller(
+            profiles: [profile], loggedIn: [profile.id],
+            fetcher: fetcher, broadcasts: broadcasts,
+            persist: { box.save($0, $1) }
+        )
+        _ = await poller.sweepNow()
+        #expect(box.saved.isEmpty)
+    }
+
+    @Test func startupSweepSkipsFreshPersistedAndFetchesStale() async {
+        let fresh = oauthProfile(named: "Fresh")
+        let stale = oauthProfile(named: "Stale")
+        let fixedNow = Date(timeIntervalSince1970: 1_750_000_000)
+        func snap(age: TimeInterval) -> ProfileUsageSnapshot {
+            ProfileUsageSnapshot(
+                buckets: okBuckets,
+                fetchedAt: fixedNow.addingTimeInterval(-age),
+                lastAttemptAt: fixedNow.addingTimeInterval(-age),
+                status: "ok", statusKind: .ok
+            )
+        }
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let broadcasts = BroadcastCounter()
+        let persisted = [fresh.id: snap(age: 10), stale.id: snap(age: 300)]
+        let poller = makePoller(
+            profiles: [fresh, stale], loggedIn: [fresh.id, stale.id],
+            fetcher: fetcher, broadcasts: broadcasts, now: fixedNow,
+            loadPersisted: { persisted }
+        )
+        await poller.loadPersistedForTest()
+
+        // Startup sweep gates on the cadence: only the stale profile fetches.
+        _ = await poller.sweepForTest(skipFresherThan: OAuthProfileUsagePoller.cadence)
+
+        #expect(fetcher.calls == ["/profiles/\(stale.id.uuidString.lowercased())/claude"])
+        // The fresh profile keeps its persisted snapshot untouched.
+        #expect(await poller.snapshot(for: fresh.id)?.fetchedAt == fixedNow.addingTimeInterval(-10))
+        // The stale one was refetched now.
+        #expect(await poller.snapshot(for: stale.id)?.fetchedAt == fixedNow)
+    }
 }
 
 // MARK: - Backoff scheduling
@@ -332,7 +453,7 @@ private final class MutableClock: @unchecked Sendable {
         let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
         let poller = scheduledPoller(profile: profile, fetcher: fetcher, clock: clock)
 
-        // Forced sweep records the 429 and arms the 300s backoff.
+        // First sweep records the 429 and arms the 300s backoff.
         _ = await poller.sweepNow()
         #expect(fetcher.calls.count == 1)
         #expect(await poller.snapshot(for: profile.id)?.statusKind == .rateLimited)
@@ -340,28 +461,52 @@ private final class MutableClock: @unchecked Sendable {
         // A scheduled sweep only 100s later must SKIP this profile (still inside
         // the 300s Retry-After window).
         clock.advance(100)
-        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        _ = await poller.sweepForTest()
         #expect(fetcher.calls.count == 1)  // no new fetch
 
         // Past the window: scheduled sweep tries again and recovers.
         clock.advance(300)
-        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        _ = await poller.sweepForTest()
         #expect(fetcher.calls.count == 2)
         #expect(await poller.snapshot(for: profile.id)?.statusKind == .ok)
     }
 
-    @Test func forcedSweepIgnoresBackoffWindow() async {
+    @Test func refreshSweepRespectsBackoffWindow() async {
         let profile = oauthProfile(named: "Limited")
         let dir = "/profiles/\(profile.id.uuidString.lowercased())/claude"
-        let fetcher = ScriptedProfileUsageFetcher(default: .rateLimited(retryAfter: 600))
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
         fetcher.enqueue(configDirPath: dir, .rateLimited(retryAfter: 600))
         let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
         let poller = scheduledPoller(profile: profile, fetcher: fetcher, clock: clock)
 
         _ = await poller.sweepNow()               // arms 600s backoff
         #expect(fetcher.calls.count == 1)
-        // A user-forced refresh 1s later still fetches (explicit intent).
+        // Picker-open refresh 1s later must NOT bypass the backoff window —
+        // reopening the picker against a 429ing endpoint stays quiet.
         clock.advance(1)
+        _ = await poller.sweepNow()
+        #expect(fetcher.calls.count == 1)
+        // Past the window, the refresh fetches again and recovers.
+        clock.advance(600)
+        _ = await poller.sweepNow()
+        #expect(fetcher.calls.count == 2)
+        #expect(await poller.snapshot(for: profile.id)?.statusKind == .ok)
+    }
+
+    @Test func refreshSweepSkipsFreshSnapshots() async {
+        let profile = oauthProfile(named: "Healthy")
+        let fetcher = ScriptedProfileUsageFetcher(default: .ok(okBuckets))
+        let clock = MutableClock(Date(timeIntervalSince1970: 1_000_000))
+        let poller = scheduledPoller(profile: profile, fetcher: fetcher, clock: clock)
+
+        _ = await poller.sweepNow()
+        #expect(fetcher.calls.count == 1)
+        // Reopening the picker 10s later: snapshot is fresh (< 30s) → no fetch.
+        clock.advance(10)
+        _ = await poller.sweepNow()
+        #expect(fetcher.calls.count == 1)
+        // 31s after the fetch it's stale enough to refresh.
+        clock.advance(21)
         _ = await poller.sweepNow()
         #expect(fetcher.calls.count == 2)
     }
@@ -375,24 +520,24 @@ private final class MutableClock: @unchecked Sendable {
 
         // Failure 1 → base backoff (30s). A scheduled sweep at +29s is skipped,
         // at +31s it runs (failure 2), which arms ~60s.
-        _ = await poller.sweepNow()  // forced; failure 1, arms 30s
+        _ = await poller.sweepForTest()  // failure 1, arms 30s
         #expect(fetcher.calls.count == 1)
 
         clock.advance(29)
-        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        _ = await poller.sweepForTest()
         #expect(fetcher.calls.count == 1)  // still gated
 
         clock.advance(2)  // now +31s
-        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        _ = await poller.sweepForTest()
         #expect(fetcher.calls.count == 2)  // failure 2, arms ~60s
 
         // +31s from failure-2 is NOT enough now (window doubled to 60s).
         clock.advance(31)
-        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        _ = await poller.sweepForTest()
         #expect(fetcher.calls.count == 2)  // still gated by the longer window
 
         clock.advance(30)  // +61s total from failure 2
-        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        _ = await poller.sweepForTest()
         #expect(fetcher.calls.count == 3)
     }
 
@@ -421,7 +566,7 @@ private final class MutableClock: @unchecked Sendable {
         // Scheduled sweep shortly after: limited is gated, but healthy still
         // polls — proving isolation.
         clock.advance(10)
-        _ = await poller.sweepNow(profileID: nil, forcedForTest: false)
+        _ = await poller.sweepForTest()
         // Only the healthy profile fetched again.
         #expect(fetcher.calls.count == firstCalls + 1)
         #expect(await poller.snapshot(for: healthy.id)?.statusKind == .ok)

--- a/Tests/TBDDaemonTests/OAuthUsageSnapshotStoreTests.swift
+++ b/Tests/TBDDaemonTests/OAuthUsageSnapshotStoreTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// DB-level coverage for the OAuth usage snapshot cache (migration
+/// `v55_oauth_usage_snapshot_cache`): the JSON blob round-trips the shared
+/// `ProfileUsageSnapshot` model exactly, replaces on upsert, cascades on
+/// profile delete, and tolerates malformed rows.
+@Suite("OAuthUsageSnapshotStore")
+struct OAuthUsageSnapshotStoreTests {
+
+    private let buckets = [
+        ClaudeUsageLimitBucket(kind: "session", group: "session", percent: 42,
+                               resetsAt: Date(timeIntervalSince1970: 1_800_000_000)),
+        ClaudeUsageLimitBucket(kind: "weekly_all", group: "weekly", percent: 7),
+    ]
+
+    private func snapshot(fetchedAt: Date) -> ProfileUsageSnapshot {
+        ProfileUsageSnapshot(buckets: buckets, fetchedAt: fetchedAt,
+                             lastAttemptAt: fetchedAt, status: "ok", statusKind: .ok)
+    }
+
+    @Test func upsertRoundTripsExactSnapshot() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let profile = try await db.modelProfiles.create(name: "P", kind: .oauth)
+        // Fractional seconds: fetchedAt must survive exactly so staleness
+        // stays computable after a daemon restart.
+        let snap = snapshot(fetchedAt: Date(timeIntervalSince1970: 1_750_000_000.25))
+
+        try await db.oauthUsageSnapshots.upsert(profileID: profile.id, snapshot: snap)
+
+        let all = try await db.oauthUsageSnapshots.loadAll()
+        #expect(all == [profile.id: snap])
+    }
+
+    @Test func upsertReplacesExistingRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let profile = try await db.modelProfiles.create(name: "P", kind: .oauth)
+        try await db.oauthUsageSnapshots.upsert(
+            profileID: profile.id, snapshot: snapshot(fetchedAt: Date(timeIntervalSince1970: 1)))
+        let newer = snapshot(fetchedAt: Date(timeIntervalSince1970: 2))
+        try await db.oauthUsageSnapshots.upsert(profileID: profile.id, snapshot: newer)
+
+        let all = try await db.oauthUsageSnapshots.loadAll()
+        #expect(all.count == 1)
+        #expect(all[profile.id] == newer)
+    }
+
+    @Test func profileDeleteCascades() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let profile = try await db.modelProfiles.create(name: "P", kind: .oauth)
+        try await db.oauthUsageSnapshots.upsert(
+            profileID: profile.id, snapshot: snapshot(fetchedAt: Date(timeIntervalSince1970: 1)))
+
+        try await db.modelProfiles.delete(id: profile.id)
+
+        let all = try await db.oauthUsageSnapshots.loadAll()
+        #expect(all.isEmpty)
+    }
+
+    @Test func malformedRowIsSkippedNotThrown() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let good = try await db.modelProfiles.create(name: "G", kind: .oauth)
+        let bad = try await db.modelProfiles.create(name: "B", kind: .oauth)
+        let snap = snapshot(fetchedAt: Date(timeIntervalSince1970: 1))
+        try await db.oauthUsageSnapshots.upsert(profileID: good.id, snapshot: snap)
+        try await db.writerForTests.write { sqlDb in
+            try sqlDb.execute(
+                sql: "INSERT INTO oauth_profile_usage_snapshot (profile_id, snapshot_json) VALUES (?, ?)",
+                arguments: [bad.id.uuidString, "not json"]
+            )
+        }
+
+        let all = try await db.oauthUsageSnapshots.loadAll()
+        #expect(all == [good.id: snap])
+    }
+}

--- a/Tests/TBDDaemonTests/OAuthUsageSnapshotStoreTests.swift
+++ b/Tests/TBDDaemonTests/OAuthUsageSnapshotStoreTests.swift
@@ -75,4 +75,18 @@ struct OAuthUsageSnapshotStoreTests {
         let all = try await db.oauthUsageSnapshots.loadAll()
         #expect(all == [good.id: snap])
     }
+
+    @Test func deleteExceptRemovesOnlyRowsOutsideTheKeepSet() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let keep = try await db.modelProfiles.create(name: "Keep", kind: .oauth)
+        let drop = try await db.modelProfiles.create(name: "Drop", kind: .oauth)
+        let snap = snapshot(fetchedAt: Date(timeIntervalSince1970: 1))
+        try await db.oauthUsageSnapshots.upsert(profileID: keep.id, snapshot: snap)
+        try await db.oauthUsageSnapshots.upsert(profileID: drop.id, snapshot: snap)
+
+        try await db.oauthUsageSnapshots.deleteExcept(profileIDs: [keep.id])
+
+        let all = try await db.oauthUsageSnapshots.loadAll()
+        #expect(all == [keep.id: snap])
+    }
 }

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -449,7 +449,8 @@ import Testing
         folder: "my-folder",
         branch: "feat/my-branch",
         displayName: "My Display Name",
-        prompt: "Build the thing"
+        prompt: "Build the thing",
+        model: "claude-fable-5"
     )
     let data = try JSONEncoder().encode(params)
     let decoded = try JSONDecoder().decode(WorktreeCreateParams.self, from: data)
@@ -458,6 +459,7 @@ import Testing
     #expect(decoded.branch == "feat/my-branch")
     #expect(decoded.displayName == "My Display Name")
     #expect(decoded.prompt == "Build the thing")
+    #expect(decoded.model == "claude-fable-5")
 }
 
 @Test func testWorktreeCreateParamsRoundTripWithNilFields() throws {
@@ -470,6 +472,7 @@ import Testing
     #expect(decoded.branch == nil)
     #expect(decoded.displayName == nil)
     #expect(decoded.prompt == nil)
+    #expect(decoded.model == nil)
 }
 
 @Test func repoDecodesLegacyJSONWithoutNewFields() throws {


### PR DESCRIPTION
## Summary
- Adds a **Fable / Opus / Sonnet** button rail to each selectable Claude account row in the "New worktree with…" picker — clicking a model spawns the worktree with that model (`ANTHROPIC_MODEL` override); clicking the row body keeps the account's default. The rail renders regardless of usage-data availability. Codex/Bedrock rows unchanged.
- Condenses the usage rows: the fixed 46pt trailing reset column is gone (bars widen to fill it) and the reset info moves to a single 9pt line below the bars (`resets 14:59 · wk 4d 7h`), without spacing the bars apart. The do-nothing person icon on profile rows is removed.
- Plumbing: `WorktreeCreateParams` gains an optional `model` field, threaded app → RPC → daemon → `ClaudeSpawnCommandBuilder.build(profileModel:)` where it wins over the profile's model. The builder's existing `ANTHROPIC_MODEL` injection is untouched.
- **Usage poller resilience** (motivated by rate-limit behavior seen while testing): OAuth usage snapshots now persist across daemon restarts (migration `v55_oauth_usage_snapshot_cache`, regenerating JSON cache keyed by profile, pruned on sweep and cascade-deleted with the profile). Restarts show last-known stale bars instead of "usage unavailable — retrying" and skip the startup fetch for fresh (<90s) snapshots; persisted cache merges by `fetchedAt` so a racing sweep is never clobbered. Picker-open refresh (`modelProfile.usageRefresh`) no longer bypasses per-profile 429 backoff and skips snapshots fresher than 30s. `tbd profile list` now shows an `(updated Xm ago)` marker on snapshots older than 5 minutes.

Model IDs sent: `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-5`.

**Flag rationale:** no default-off flag — the picker changes are user-gesture-gated additive UI, and the poller change only *reduces* autonomous network activity; the new table is a regenerating cache whose loss is harmless.

**Scope note:** the model override applies to the initial spawn only. Respawns (hibernation wake, revive/recovery, additional sessions in the worktree) fall back to the profile default — persisting the choice per-worktree would need a config column and is deliberately out of scope.

**Known visual nit:** with the person icon gone, titles start at different x-offsets across row kinds (branch row keeps its icon; Codex/Bedrock rows have no rail). Alignment is a design call pending a live look.

## Test plan
- [ ] `swift build` + full `swift test` green (3646 tests; incl. model-override spawn tests, snapshot store round-trip/upsert/cascade/prune, poller merge-by-freshness + startup freshness gate + backoff-respecting refresh, CLI age marker)
- [ ] `scripts/restart.sh`, open the new-worktree picker: person icons gone, bars wider with one reset line beneath, Fable/Opus/Sonnet rail on Claude rows — including rows whose usage hasn't loaded
- [ ] Spawn via a model button; verify `echo $ANTHROPIC_MODEL` in the new session matches; spawn via row body → profile default
- [ ] Restart the daemon: usage bars show last-known (stale) data immediately instead of "usage unavailable — retrying"; no immediate refetch burst for fresh snapshots

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=3042D2AB-132B-4CE6-86C7-3F2E10D54DE9)