### PR TITLE
Fix: Give the sidebar filter bar breathing room when the nightwatch row is hidden

### DIFF
--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -72,6 +72,7 @@ struct SidebarView: View {
                     filterMenu
                 }
                 .padding(.horizontal, 12)
+                .padding(.top, nightwatchExperimental ? 0 : 8)
                 .padding(.bottom, 8)
             }
             .background(.bar)


### PR DESCRIPTION
## Summary
- With the experimental nightwatch/daywatch toggle off (the default), the sidebar's bottom filter bar sat flush against the divider, looking cut off — the only top spacing in that inset came from the nightwatch row's own padding.
- Adds 8pt of top padding to the Add Repository / filter HStack only when the nightwatch row is hidden; spacing with the row visible is unchanged.

## Test plan
- [ ] With the nightwatch experimental setting off, the bottom bar has a small gap below the divider
- [ ] With it on, spacing around the nightwatch row is unchanged

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=0D400F01-F500-471C-ADEC-80CDBE89A702)