### PR TITLE
fix(restart): add WIP guard to prevent accidental daemon/app takeover

### DIFF
--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -9,6 +9,9 @@ set -e
 #   scripts/restart.sh --app    # restart app only (no rebuild, no daemon restart)
 #   scripts/restart.sh --daemon # restart daemon only (no rebuild, no app restart)
 #   scripts/restart.sh --quick  # skip rebuild, restart everything
+#   scripts/restart.sh --dry-run # print blessed/not-blessed decision, touch nothing
+#   scripts/restart.sh --wip    # force install even if on a WIP branch
+#   TBD_INSTALL_WIP=1 scripts/restart.sh # same as --wip
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BUILD_DIR="$REPO_ROOT/.build/debug"
@@ -16,14 +19,181 @@ BUILD_DIR="$REPO_ROOT/.build/debug"
 app_only=false
 daemon_only=false
 skip_build=false
+dry_run=false
+force_wip=false
 
 for arg in "$@"; do
     case "$arg" in
         --app) app_only=true ;;
         --daemon) daemon_only=true ;;
         --quick) skip_build=true ;;
+        --dry-run) dry_run=true ;;
+        --wip) force_wip=true ;;
     esac
 done
+
+# Check TBD_INSTALL_WIP env var as well
+if [ -n "${TBD_INSTALL_WIP:-}" ]; then
+    force_wip=true
+fi
+
+# MARK: - WIP Guard
+#
+# Detect whether the current build is "blessed" — i.e., safe to install to
+# /Applications and restart the shared daemon. A blessed build must have:
+#  (a) A clean working tree (no tracked file changes)
+#  (b) HEAD as an ancestor of the main branch (upstream/main, origin/main, or main)
+#
+# Blessed builds proceed with full install + daemon restart. Non-blessed (WIP)
+# builds warn loudly and skip /Applications install + daemon restart, instead
+# launching from the worktree's own .build/debug/TBD.app so the dev loop works.
+# Escape hatch: --wip flag or TBD_INSTALL_WIP=1 forces the install anyway.
+
+is_wip_guard_enabled=true
+
+# Determine the main-branch ref to use for ancestry check.
+resolve_main_ref() {
+    # Try upstream/main first, then origin/main, then local main
+    if git -C "$REPO_ROOT" rev-parse upstream/main >/dev/null 2>&1; then
+        echo "upstream/main"
+    elif git -C "$REPO_ROOT" rev-parse origin/main >/dev/null 2>&1; then
+        echo "origin/main"
+    elif git -C "$REPO_ROOT" rev-parse main >/dev/null 2>&1; then
+        echo "main"
+    else
+        echo ""
+    fi
+}
+
+# Check if the working tree is clean (no tracked file changes).
+is_working_tree_clean() {
+    local output
+    output=$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no 2>/dev/null || echo "error")
+    if [ "$output" = "error" ]; then
+        return 1  # not a git repo or error
+    fi
+    [ -z "$output" ]
+}
+
+# Check if HEAD is an ancestor of the given ref.
+is_head_ancestor_of() {
+    local ref="$1"
+    if [ -z "$ref" ]; then
+        return 1
+    fi
+    git -C "$REPO_ROOT" merge-base --is-ancestor HEAD "$ref" 2>/dev/null
+}
+
+# Determine if the build is blessed.
+is_build_blessed() {
+    if ! is_working_tree_clean; then
+        return 1
+    fi
+    local main_ref
+    main_ref=$(resolve_main_ref)
+    if [ -z "$main_ref" ]; then
+        return 1
+    fi
+    is_head_ancestor_of "$main_ref"
+}
+
+# Get the currently installed worktree path from /Applications/TBD.app.
+get_installed_worktree_path() {
+    if [ -f "/Applications/TBD.app/Contents/SourceWorktreePath.txt" ]; then
+        cat "/Applications/TBD.app/Contents/SourceWorktreePath.txt"
+    else
+        echo "(not installed)"
+    fi
+}
+
+# Print a loud warning when the build is not blessed.
+warn_wip_build() {
+    local current_branch
+    current_branch=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+    local dirty_count=0
+    if ! is_working_tree_clean; then
+        dirty_count=$(git -C "$REPO_ROOT" status --porcelain --untracked-files=no 2>/dev/null | wc -l)
+    fi
+
+    local installed_path
+    installed_path=$(get_installed_worktree_path)
+
+    cat >&2 << 'EOF'
+
+===============================================================================
+WARNING: NOT BLESSED — WIP WORKTREE GUARD ACTIVE
+===============================================================================
+
+This worktree is on a feature branch or has uncommitted changes. To prevent
+accidental takeover of the shared daemon and /Applications/TBD.app, the full
+install is SKIPPED. Instead, the app will build and launch from this worktree's
+own .build/debug/TBD.app.
+
+CONSEQUENCES:
+  • Deep links (tbd://) will NOT route to this app (they'll route to the
+    currently-installed build in /Applications)
+  • The daemon continues running the previous worktree's build
+  • Dev loop works normally (build, code, reload)
+
+DETAILS:
+EOF
+    printf '  Branch: %s\n' "$current_branch" >&2
+    if [ "$dirty_count" -gt 0 ]; then
+        printf '  Dirty tracked files: %d\n' "$dirty_count" >&2
+    fi
+    printf '  Currently installed from: %s\n' "$installed_path" >&2
+
+    cat >&2 << 'EOF'
+
+TO OVERRIDE (force full install):
+  scripts/restart.sh --wip
+  or
+  TBD_INSTALL_WIP=1 scripts/restart.sh
+
+TO FIX (make it blessed):
+  • Commit your changes: git add -A && git commit -m "..."
+  • Rebase onto upstream/main: git rebase upstream/main
+  • Or push to a tracking branch
+
+===============================================================================
+
+EOF
+}
+
+# Determine install strategy and possibly print dry-run summary.
+build_is_blessed=false
+install_to_applications=true
+
+if [ "$is_wip_guard_enabled" = true ] && ! is_build_blessed; then
+    build_is_blessed=false
+    if [ "$force_wip" = false ]; then
+        install_to_applications=false
+    fi
+else
+    build_is_blessed=true
+fi
+
+if [ "$dry_run" = true ]; then
+    if [ "$build_is_blessed" = true ]; then
+        echo "BLESSED: Working tree is clean and HEAD is on/before main."
+        echo "Would install to /Applications and restart daemon."
+    else
+        echo "NOT BLESSED: WIP branch or dirty working tree."
+        if [ "$force_wip" = true ]; then
+            echo "Would install to /Applications and restart daemon (--wip override)."
+        else
+            echo "Would SKIP /Applications install and daemon restart."
+            echo "Would launch app from .build/debug/TBD.app instead."
+        fi
+    fi
+    exit 0
+fi
+
+# Print warning if not blessed (unless --wip forces it).
+if [ "$build_is_blessed" = false ] && [ "$force_wip" = false ]; then
+    warn_wip_build
+fi
 
 # MARK: - Opportunistic background disk reclaim
 #
@@ -157,60 +327,71 @@ fi
 # exec path now that it runs from /Applications instead of .build/.
 printf '%s' "$REPO_ROOT" > "$BUNDLE_DIR/Contents/SourceWorktreePath.txt"
 
-# Sign + install to /Applications to satisfy macOS UNUserNotificationCenter:
-#  - Re-signing with --force --deep makes the codesign identifier match
-#    CFBundleIdentifier (com.tbd.app); SPM's default ad-hoc signature uses
-#    TBDApp-<hash>, which macOS uses for permission tracking and rejects.
-#  - /Applications is the only path macOS 15 accepts for requestAuthorization;
-#    bundles elsewhere return UNErrorDomain Code=1 with no permission dialog.
-#  - cp -cR uses APFS clonefile (copy-on-write, ~zero disk cost).
-#  - All TBD worktrees share CFBundleIdentifier=com.tbd.app, so whichever
-#    worktree most recently ran restart.sh "wins" /Applications — same
-#    last-restart-wins behavior already documented for tbd:// URL routing.
-# Prefer a stable self-signed identity so TCC permission grants/denials persist
-# across rebuilds. Ad-hoc signing (`--sign -`) gives TCC only a bare cdhash with
-# no stable anchor, so every rebuild — and even repeated accesses within one
-# build, when access is attributed via a spawned child like a `claude` session —
-# fails the stored code-requirement check and re-prompts (Desktop/Documents/
-# Downloads/Photos/etc.). A persistent leaf-cert anchor fixes that.
-# One-time setup creates the "TBD Dev Signing" identity in a dedicated
-# tbd-signing keychain (see docs/tcc-signing.md). If it's absent (e.g. a fresh
-# clone or another contributor's machine), fall back to ad-hoc so restart still works.
-SIGN_KEYCHAIN="$HOME/Library/Keychains/tbd-signing.keychain-db"
-SIGN_IDENTITY="TBD Dev Signing"
-if security find-identity -p codesigning "$SIGN_KEYCHAIN" 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
-    security unlock-keychain -p tbd-signing "$SIGN_KEYCHAIN" 2>/dev/null || true
-    codesign --force --deep --identifier com.github.cheapsteak.tbd \
-        --sign "$SIGN_IDENTITY" --keychain "$SIGN_KEYCHAIN" "$BUNDLE_DIR" >/dev/null
-else
-    codesign --force --deep --sign - "$BUNDLE_DIR" >/dev/null
-fi
-
+# Conditionally sign + install to /Applications (only if blessed or --wip).
+# For WIP builds not blessed, we'll skip this and launch from .build/debug instead.
 INSTALLED_BUNDLE="/Applications/TBD.app"
-rm -rf "$INSTALLED_BUNDLE"
-cp -cR "$BUNDLE_DIR" "$INSTALLED_BUNDLE"
-
-LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
-if [ -x "$LSREGISTER" ]; then
-    "$LSREGISTER" -f "$INSTALLED_BUNDLE" >/dev/null 2>&1 || true
-fi
-
-# Bump the installed bundle's mtime so Notification Center / System Settings
-# pick up an updated AppIcon.icns instead of serving a stale icon-cache entry.
-# `lsregister -f` alone doesn't always invalidate those caches; `touch` does.
-touch "$INSTALLED_BUNDLE"
-
-# The running TBDApp's command line is the installed bundle's binary, since
-# we launch from /Applications below. Match against that for pgrep/pkill so
-# we only ever affect THIS worktree's running TBDApp (it's the one that most
-# recently won /Applications). Sibling worktrees launched from their own
-# .build/.../TBD.app would not match.
 BUNDLED_EXEC_PATH="$INSTALLED_BUNDLE/Contents/MacOS/TBDApp"
-APP_EXEC_PATTERN="$(printf '%s' "$BUNDLED_EXEC_PATH" | sed 's/[.+*?()\[\]^$|\\]/\\&/g')"
+APP_EXEC_PATTERN=""
+
+if [ "$install_to_applications" = true ]; then
+    # Sign + install to /Applications to satisfy macOS UNUserNotificationCenter:
+    #  - Re-signing with --force --deep makes the codesign identifier match
+    #    CFBundleIdentifier (com.tbd.app); SPM's default ad-hoc signature uses
+    #    TBDApp-<hash>, which macOS uses for permission tracking and rejects.
+    #  - /Applications is the only path macOS 15 accepts for requestAuthorization;
+    #    bundles elsewhere return UNErrorDomain Code=1 with no permission dialog.
+    #  - cp -cR uses APFS clonefile (copy-on-write, ~zero disk cost).
+    #  - All TBD worktrees share CFBundleIdentifier=com.tbd.app, so whichever
+    #    worktree most recently ran restart.sh "wins" /Applications — same
+    #    last-restart-wins behavior already documented for tbd:// URL routing.
+    # Prefer a stable self-signed identity so TCC permission grants/denials persist
+    # across rebuilds. Ad-hoc signing (`--sign -`) gives TCC only a bare cdhash with
+    # no stable anchor, so every rebuild — and even repeated accesses within one
+    # build, when access is attributed via a spawned child like a `claude` session —
+    # fails the stored code-requirement check and re-prompts (Desktop/Documents/
+    # Downloads/Photos/etc.). A persistent leaf-cert anchor fixes that.
+    # One-time setup creates the "TBD Dev Signing" identity in a dedicated
+    # tbd-signing keychain (see docs/tcc-signing.md). If it's absent (e.g. a fresh
+    # clone or another contributor's machine), fall back to ad-hoc so restart still works.
+    SIGN_KEYCHAIN="$HOME/Library/Keychains/tbd-signing.keychain-db"
+    SIGN_IDENTITY="TBD Dev Signing"
+    if security find-identity -p codesigning "$SIGN_KEYCHAIN" 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+        security unlock-keychain -p tbd-signing "$SIGN_KEYCHAIN" 2>/dev/null || true
+        codesign --force --deep --identifier com.github.cheapsteak.tbd \
+            --sign "$SIGN_IDENTITY" --keychain "$SIGN_KEYCHAIN" "$BUNDLE_DIR" >/dev/null
+    else
+        codesign --force --deep --sign - "$BUNDLE_DIR" >/dev/null
+    fi
+
+    rm -rf "$INSTALLED_BUNDLE"
+    cp -cR "$BUNDLE_DIR" "$INSTALLED_BUNDLE"
+
+    LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister"
+    if [ -x "$LSREGISTER" ]; then
+        "$LSREGISTER" -f "$INSTALLED_BUNDLE" >/dev/null 2>&1 || true
+    fi
+
+    # Bump the installed bundle's mtime so Notification Center / System Settings
+    # pick up an updated AppIcon.icns instead of serving a stale icon-cache entry.
+    # `lsregister -f` alone doesn't always invalidate those caches; `touch` does.
+    touch "$INSTALLED_BUNDLE"
+
+    # The running TBDApp's command line is the installed bundle's binary, since
+    # we launch from /Applications below. Match against that for pgrep/pkill so
+    # we only ever affect THIS worktree's running TBDApp (it's the one that most
+    # recently won /Applications). Sibling worktrees launched from their own
+    # .build/.../TBD.app would not match.
+    APP_EXEC_PATTERN="$(printf '%s' "$BUNDLED_EXEC_PATH" | sed 's/[.+*?()\[\]^$|\\]/\\&/g')"
+else
+    # WIP build: skip /Applications install, launch from .build/debug instead.
+    # Use the unwrapped binary path for pgrep/pkill matching.
+    APP_EXEC_PATH="$(/usr/bin/readlink -f "$BUILD_DIR/TBDApp")"
+    APP_EXEC_PATTERN="$(printf '%s' "$APP_EXEC_PATH" | sed 's/[.+*?()\[\]^$|\\]/\\&/g')"
+fi
 
 # MARK: - Restart Daemon
 
-if [ "$app_only" = false ]; then
+if [ "$app_only" = false ] && [ "$install_to_applications" = true ]; then
     echo "Stopping daemon..."
     if [ -f ~/tbd/tbdd.pid ]; then
         pid=$(cat ~/tbd/tbdd.pid)
@@ -235,6 +416,8 @@ if [ "$app_only" = false ]; then
     else
         echo "  WARNING: Daemon socket not found after 3s"
     fi
+elif [ "$app_only" = false ] && [ "$install_to_applications" = false ]; then
+    echo "(Skipping daemon restart for WIP worktree)"
 fi
 
 # MARK: - Restart App
@@ -244,20 +427,39 @@ if [ "$daemon_only" = false ]; then
     # Match end-anchored against the resolved exec path so we only ever
     # affect THIS worktree's running TBDApp — never swift build subprocesses,
     # editors, or sibling worktrees whose command line contains "TBDApp".
-    pkill -f "^${APP_EXEC_PATTERN}\$" 2>/dev/null && sleep 0.3 || true
+    if [ -n "$APP_EXEC_PATTERN" ]; then
+        pkill -f "^${APP_EXEC_PATTERN}\$" 2>/dev/null && sleep 0.3 || true
+    fi
 
     echo "Starting app..."
-    open "$INSTALLED_BUNDLE" --stdout /tmp/tbdapp.log --stderr /tmp/tbdapp.log
+    if [ "$install_to_applications" = true ]; then
+        # Launch from /Applications (blessed or --wip override)
+        open "$INSTALLED_BUNDLE" --stdout /tmp/tbdapp.log --stderr /tmp/tbdapp.log
+    else
+        # Launch from .build/debug (WIP worktree, no install to /Applications)
+        open "$BUNDLE_DIR" --stdout /tmp/tbdapp.log --stderr /tmp/tbdapp.log
+    fi
+
     # `open` returns immediately after asking LaunchServices to spawn the app.
     # Give it a moment, then verify the process is alive.
     sleep 0.5
-    if pgrep -f "^${APP_EXEC_PATTERN}\$" >/dev/null; then
+    if [ -n "$APP_EXEC_PATTERN" ] && pgrep -f "^${APP_EXEC_PATTERN}\$" >/dev/null; then
         APP_PID=$(pgrep -f "^${APP_EXEC_PATTERN}\$" | head -1)
-        echo "  App launched (PID $APP_PID) — logs: /tmp/tbdapp.log"
+        if [ "$install_to_applications" = true ]; then
+            echo "  App launched from /Applications (PID $APP_PID) — logs: /tmp/tbdapp.log"
+        else
+            echo "  App launched from .build/debug (PID $APP_PID) — logs: /tmp/tbdapp.log"
+        fi
     else
         echo "  ERROR: App failed to launch. Last lines of /tmp/tbdapp.log:"
         tail -20 /tmp/tbdapp.log
     fi
+fi
+
+if [ "$install_to_applications" = false ] && [ "$daemon_only" = false ]; then
+    echo ""
+    echo "Note: Deep links (tbd://) will NOT route to this app. Restart the"
+    echo "intended worktree to make it the handler for tbd:// URLs."
 fi
 
 echo "Done. Tmux sessions preserved."


### PR DESCRIPTION
## Summary

Add a safety guard to `scripts/restart.sh` to prevent WIP worktrees from silently taking over the shared daemon and `/Applications/TBD.app`.

A build is "blessed" (safe to install) only if:
- The working tree is clean (no tracked file changes)
- HEAD is an ancestor of main (on or before upstream/main)

**Blessed** builds proceed with full install to /Applications and daemon restart (current behavior).

**Non-blessed** (WIP/dirty) builds:
- Print a loud, actionable warning (branch name, dirty file count, currently-installed worktree path)
- Skip /Applications install and daemon restart
- Launch app from worktree's own `.build/debug/TBD.app` so dev loop works uninterrupted
- Note that deep links (tbd://) will route to the installed build, not this worktree

## Escape hatch

- `scripts/restart.sh --wip`: force full install even if not blessed
- `TBD_INSTALL_WIP=1 scripts/restart.sh`: env var alternative
- `scripts/restart.sh --dry-run`: print decision and what would happen (testing only)

## Problem context

Four takeover incidents this week on Adam's machine:
- WIP worktree `20260715-innovative-ostrich` ran restart.sh, replacing the user's app+daemon with a broken-input build multiple times (2026-07-16 and 14:38)
- Because the app's self-heal resurrects the daemon from the LAST-installed build's recorded SourceWorktreePath, a single WIP takeover persists across reboots until manually fixed

## Test plan

1. On a WIP branch with uncommitted changes:
   - `bash scripts/restart.sh --dry-run` → shows "NOT BLESSED" + skip-install plan
2. With `--wip` override:
   - `bash scripts/restart.sh --dry-run --wip` → shows "NOT BLESSED" but would install (override)
3. On a clean, up-to-date main state (after PR merges):
   - `bash scripts/restart.sh --dry-run` → shows "BLESSED" + install plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)