### PR TITLE
Compound: Ban 'blessed' and 'golden' from code and PR/commit text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ The main chat session agent should not write code directly. Delegate all impleme
 - Only stage and commit files you actually changed — never commit unrelated or other agents' modifications.
 - Always commit after completing work. Don't wait to be asked.
 - Use conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`
+- Never use the words "blessed" or "golden" — not in code, and not in PR titles, descriptions, or commit messages.
 - Verify your changes compile (`swift build`) before committing.
 - Run `swift test` if you changed daemon or shared code.
 - When adding a branching conditional that gates behavior (feature flags, toggles, mode switches), add a test for each branch. Verify the gated behavior is off when the flag is off, and that ungated behavior still works.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The main chat session agent should not write code directly. Delegate all impleme
 - Only stage and commit files you actually changed — never commit unrelated or other agents' modifications.
 - Always commit after completing work. Don't wait to be asked.
 - Use conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`
-- Never use the words "blessed" or "golden" — not in code, and not in PR titles, descriptions, or commit messages.
+- Banned words — never use these in code or in PR titles, descriptions, or commit messages: "blessed", "golden"
 - Verify your changes compile (`swift build`) before committing.
 - Run `swift test` if you changed daemon or shared code.
 - When adding a branching conditional that gates behavior (feature flags, toggles, mode switches), add a test for each branch. Verify the gated behavior is off when the flag is off, and that ungated behavior still works.


### PR DESCRIPTION
## Summary
- Adds a Workflow bullet to CLAUDE.md banning the words "blessed" and "golden" in code and in PR titles, descriptions, and commit messages.
- Word list trails the sentence so future additions are a one-word append.

## Test plan
- [ ] Docs-only change — no build/test impact.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A0A3976C-8551-49BA-8478-754623E16973)