### PR TITLE
fix(daemon): reboot-robust supervision — verify pid is a live TBDDaemon, eager launch ensure

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -727,6 +727,14 @@ final class AppState: ObservableObject {
         if !Self.isRunningUnderTests {
             Task {
                 await connectAndLoadInitialState()
+                // Eager ensure: a macOS-driven relaunch (reboot + Spotlight, OS
+                // "quit and reopen") often finds the daemon dead with stale
+                // socket/pid files. `connectAndLoadInitialState`'s plain connect
+                // can't clear those, so recovery would otherwise wait for the
+                // 2s poll to route to the cleanup-aware spawn. Run it now.
+                if !isConnected {
+                    await startDaemonAndConnect()
+                }
                 startPolling()
             }
         }

--- a/Sources/TBDApp/Helpers/DaemonLiveness.swift
+++ b/Sources/TBDApp/Helpers/DaemonLiveness.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import TBDShared
 
 /// Validates that a pid recorded in the daemon pid file really is a live
 /// TBDDaemon process.
@@ -9,11 +10,13 @@ import Foundation
 /// A bare `kill(pid, 0) == 0` check then reports "daemon running", the app
 /// skips spawning its sibling daemon, and every connect to the dead socket
 /// fails with no recovery path. Checking the pid's executable name via
-/// libproc closes that hole.
+/// libproc closes that hole — the shared implementation lives in
+/// `TBDShared.ProcessLiveness` so the daemon (`PIDFile`, `Daemon`) applies the
+/// identical check without importing TBDApp.
 enum DaemonLiveness {
     /// Last path component every real daemon binary has, wherever it was
     /// built (`<worktree>/.build/debug/TBDDaemon`, a bundle sibling, ...).
-    static let daemonExecutableName = "TBDDaemon"
+    static let daemonExecutableName = ProcessLiveness.daemonExecutableName
 
     /// True when `pid` is a live process whose executable's last path
     /// component is `TBDDaemon`.
@@ -24,12 +27,14 @@ enum DaemonLiveness {
     static func isLiveTBDDaemon(
         pid: pid_t,
         isAlive: (pid_t) -> Bool = { kill($0, 0) == 0 },
-        executablePath: (pid_t) -> String? = processExecutablePath
+        executablePath: (pid_t) -> String? = ProcessLiveness.executablePath
     ) -> Bool {
-        guard pid > 0 else { return false }
-        guard isAlive(pid) else { return false }
-        guard let path = executablePath(pid), !path.isEmpty else { return false }
-        return (path as NSString).lastPathComponent == daemonExecutableName
+        ProcessLiveness.isLiveNamedProcess(
+            pid: pid,
+            name: daemonExecutableName,
+            isAlive: isAlive,
+            executablePath: executablePath
+        )
     }
 
     /// Parse the daemon pid file's contents. Nil when malformed. Pure — the
@@ -39,24 +44,7 @@ enum DaemonLiveness {
     }
 
     /// Resolve a pid's executable path via libproc's `proc_pidpath`.
-    /// Nil when the pid is dead or the kernel refuses (e.g. another user's
-    /// process) — callers must treat that as "not our daemon".
     static func processExecutablePath(pid: pid_t) -> String? {
-        // PROC_PIDPATHINFO_MAXSIZE (4 * MAXPATHLEN); the macro itself is
-        // unavailable to Swift's Clang importer.
-        var buffer = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
-        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
-        guard length > 0 else { return nil }
-        // proc_pidpath NUL-terminates at `length`; truncate to the path's
-        // actual bytes before decoding so trailing zero-fill from the
-        // oversized buffer isn't folded into the string (String(cString:)
-        // stopped at the first NUL for free — String(decoding:as:) does not).
-        let pathBytes = buffer.prefix(Int(length)).map { UInt8(bitPattern: $0) }
-        // String(bytes:encoding:) is failable and would turn an invalid-UTF8
-        // path into `nil` ("not our daemon"); String(cString:) never failed
-        // that way (lossy U+FFFD repair), so String(decoding:as:) is the
-        // correct like-for-like replacement here, not Data.
-        // swiftlint:disable:next optional_data_string_conversion
-        return String(decoding: pathBytes, as: UTF8.self)
+        ProcessLiveness.executablePath(pid: pid)
     }
 }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -252,13 +252,16 @@ public final class Daemon: Sendable {
         // 2. Clean up stale PID/socket files
         pidFile.cleanupIfStale()
 
-        // 3. Check if another daemon is already running
-        if let existingPID = pidFile.read() {
-            // Process is alive (kill(pid, 0) == 0 means it exists)
-            if kill(existingPID, 0) == 0 {
-                daemonLogger.error("Another daemon is already running (PID \(existingPID, privacy: .public)). Exiting.")
-                Foundation.exit(1)
-            }
+        // 3. Check if another daemon is already running. Verify the pid is a
+        // live TBDDaemon, not merely a live process: after a reboot the recorded
+        // pid can be recycled by something unrelated, and a bare kill(pid, 0)
+        // would make this fresh daemon abort forever until that pid frees —
+        // exactly the multi-minute "disconnected on restart" gap. cleanupIfStale
+        // above already removed the pid/socket in that case, so read() is nil.
+        if let existingPID = pidFile.read(),
+           ProcessLiveness.isLiveNamedProcess(pid: existingPID, name: ProcessLiveness.daemonExecutableName) {
+            daemonLogger.error("Another daemon is already running (PID \(existingPID, privacy: .public)). Exiting.")
+            Foundation.exit(1)
         }
 
         // 4. Write PID file

--- a/Sources/TBDDaemon/PIDFile.swift
+++ b/Sources/TBDDaemon/PIDFile.swift
@@ -23,9 +23,16 @@ public struct PIDFile: Sendable {
         return pid
     }
 
-    public func isStale() -> Bool {
+    /// Stale when the recorded pid is not a *live TBDDaemon*. A bare
+    /// `kill(pid, 0)` is insufficient: after a reboot the recorded pid can be
+    /// recycled by an unrelated process, which would read as "daemon alive" and
+    /// leave the dead socket in place — so a freshly-spawned daemon aborts (see
+    /// Daemon.start's existing-pid gate). Verify the executable name too.
+    public func isStale(
+        isLiveDaemon: (pid_t) -> Bool = { ProcessLiveness.isLiveNamedProcess(pid: $0, name: ProcessLiveness.daemonExecutableName) }
+    ) -> Bool {
         guard let pid = read() else { return false }
-        return kill(pid, 0) != 0
+        return !isLiveDaemon(pid)
     }
 
     public func remove() {

--- a/Sources/TBDShared/ProcessLiveness.swift
+++ b/Sources/TBDShared/ProcessLiveness.swift
@@ -1,0 +1,54 @@
+import Darwin
+import Foundation
+
+/// Verifies that a pid refers to a live process whose executable has a given
+/// last path component — the canonical "is this really our process?" check.
+///
+/// A bare `kill(pid, 0) == 0` is not enough: a pid recorded in a file (e.g. the
+/// daemon pid file) survives reboots, and after a reboot the recorded pid can be
+/// recycled by an arbitrary unrelated process. `kill` then reports "alive", so a
+/// stale pid file reads as a running daemon — the socket is never cleaned, and a
+/// freshly-spawned daemon aborts thinking one already runs. Checking the pid's
+/// executable name via libproc closes that hole. Lives in TBDShared so both the
+/// daemon (`PIDFile`, `Daemon`) and the app (`DaemonLiveness`) share one
+/// implementation across the module boundary (the daemon cannot import TBDApp).
+public enum ProcessLiveness {
+    /// Last path component every real daemon binary has, wherever it was built
+    /// (`<worktree>/.build/debug/TBDDaemon`, a bundle sibling, ...).
+    public static let daemonExecutableName = "TBDDaemon"
+
+    /// True when `pid` is a live process whose executable's last path component
+    /// equals `name`.
+    ///
+    /// `isAlive` and `executablePath` are injection seams so both branches are
+    /// unit-testable without real processes; production callers use the
+    /// defaults (`kill(pid, 0)` + `proc_pidpath`).
+    public static func isLiveNamedProcess(
+        pid: pid_t,
+        name: String,
+        isAlive: (pid_t) -> Bool = { kill($0, 0) == 0 },
+        executablePath: (pid_t) -> String? = ProcessLiveness.executablePath
+    ) -> Bool {
+        guard pid > 0 else { return false }
+        guard isAlive(pid) else { return false }
+        guard let path = executablePath(pid), !path.isEmpty else { return false }
+        return (path as NSString).lastPathComponent == name
+    }
+
+    /// Resolve a pid's executable path via libproc's `proc_pidpath`.
+    /// Nil when the pid is dead or the kernel refuses (e.g. another user's
+    /// process) — callers must treat that as "not our process".
+    public static func executablePath(pid: pid_t) -> String? {
+        // PROC_PIDPATHINFO_MAXSIZE (4 * MAXPATHLEN); the macro itself is
+        // unavailable to Swift's Clang importer.
+        var buffer = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
+        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard length > 0 else { return nil }
+        // proc_pidpath NUL-terminates at `length`; truncate to the path's
+        // actual bytes before decoding so trailing zero-fill from the oversized
+        // buffer isn't folded into the string.
+        let pathBytes = buffer.prefix(Int(length)).map { UInt8(bitPattern: $0) }
+        // swiftlint:disable:next optional_data_string_conversion
+        return String(decoding: pathBytes, as: UTF8.self)
+    }
+}

--- a/Tests/TBDDaemonTests/PIDFileStaleTests.swift
+++ b/Tests/TBDDaemonTests/PIDFileStaleTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite struct PIDFileStaleTests {
+    private func tmpPidPath() -> String {
+        NSTemporaryDirectory() + "pidfile-stale-\(UUID().uuidString).pid"
+    }
+
+    @Test func missingPidFileIsNotStale() {
+        // No pid recorded → nothing to clean up → not stale.
+        let f = PIDFile(path: tmpPidPath())
+        #expect(f.isStale(isLiveDaemon: { _ in false }) == false)
+    }
+
+    @Test func liveDaemonPidIsNotStale() throws {
+        let path = tmpPidPath()
+        try "12345".write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let f = PIDFile(path: path)
+        #expect(f.isStale(isLiveDaemon: { $0 == 12345 }) == false)
+    }
+
+    // Recycled pid: the recorded pid is alive but is NOT a TBDDaemon. The old
+    // kill(pid,0) check called this "not stale" and left the dead socket, which
+    // wedged a freshly-spawned daemon. It must now read as stale.
+    @Test func recycledNonDaemonPidIsStale() throws {
+        let path = tmpPidPath()
+        try "12345".write(toFile: path, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        let f = PIDFile(path: path)
+        #expect(f.isStale(isLiveDaemon: { _ in false }) == true)
+    }
+}

--- a/Tests/TBDSharedTests/ProcessLivenessTests.swift
+++ b/Tests/TBDSharedTests/ProcessLivenessTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite struct ProcessLivenessTests {
+    // Seams let both branches run without real processes.
+    private func check(pid: pid_t, alive: Bool, path: String?) -> Bool {
+        ProcessLiveness.isLiveNamedProcess(
+            pid: pid,
+            name: ProcessLiveness.daemonExecutableName,
+            isAlive: { _ in alive },
+            executablePath: { _ in path }
+        )
+    }
+
+    @Test func nonPositivePidIsNotLive() {
+        #expect(check(pid: 0, alive: true, path: "/x/TBDDaemon") == false)
+        #expect(check(pid: -1, alive: true, path: "/x/TBDDaemon") == false)
+    }
+
+    @Test func deadPidIsNotLive() {
+        #expect(check(pid: 42, alive: false, path: "/x/TBDDaemon") == false)
+    }
+
+    @Test func aliveWithNoResolvablePathIsNotLive() {
+        #expect(check(pid: 42, alive: true, path: nil) == false)
+        #expect(check(pid: 42, alive: true, path: "") == false)
+    }
+
+    // The reboot recycled-pid case: some OTHER live process now holds the pid.
+    @Test func aliveButDifferentExecutableIsNotLive() {
+        #expect(check(pid: 42, alive: true, path: "/usr/bin/login") == false)
+        #expect(check(pid: 42, alive: true, path: "/x/TBDDaemonHelper") == false)
+    }
+
+    @Test func aliveTBDDaemonIsLive() {
+        #expect(check(pid: 42, alive: true, path: "/Users/x/.build/debug/TBDDaemon") == true)
+        #expect(check(pid: 42, alive: true, path: "/Applications/TBD.app/Contents/MacOS/TBDDaemon") == true)
+    }
+}


### PR DESCRIPTION
## The "disconnected on restart" root cause

After a macOS-driven relaunch (reboot + Spotlight, OS "quit and reopen"), the daemon could be dead for minutes while the app showed "disconnected". Cause: the daemon's stale-file cleanup (`PIDFile.isStale`) and its already-running gate (`Daemon.start`) both used a bare `kill(pid, 0)`. After a reboot the dead daemon's recorded pid can be **recycled by an unrelated process** — `kill` then reports "alive", so:
- `cleanupIfStale()` leaves the dead socket in place, and
- the existing-pid gate `exit(1)`s thinking a daemon already runs.

Every freshly-spawned daemon aborts until that recycled pid frees. Meanwhile the app's launch path only reaches its cleanup-aware respawn after several failed poll cycles.

## Fix

- **`TBDShared.ProcessLiveness.isLiveNamedProcess(pid:name:)`** — `kill(pid,0)` AND a `proc_pidpath` executable-name check; the canonical "is this really our process". The app's `DaemonLiveness` now delegates to it (it was a private duplicate of the same libproc logic); the daemon reuses it across the module boundary (it can't import TBDApp).
- **`PIDFile.isStale()`** and **`Daemon.start`'s existing-pid gate** now require a *live TBDDaemon* — a recycled pid is correctly stale → socket cleaned → the fresh daemon binds instead of aborting.
- **`AppState.init`** — if the launch connect fails, run the cleanup-aware `startDaemonAndConnect()` immediately instead of waiting for the 2s poll.

## Tests

`ProcessLivenessTests` (dead / recycled-non-daemon / live, via injection seams) and `PIDFileStaleTests` (missing / live / recycled) — the recycled-pid case is the regression this fixes. Existing `DaemonLivenessTests` still pass via the delegation. `swift build` + these suites verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)