### PR TITLE
Fix: Command-click reuses the transcript pane (viewer slot) + per-pane back/forward history

### DIFF
--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -164,6 +164,7 @@ extension AppState {
         arr.remove(at: index)
         tabs[worktreeID] = arr
         worktreeTabOrders[worktreeID] = arr.map(\.id)
+        prunePaneHistories()
 
         for terminalID in terminalIDsInTab {
             Task {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -914,19 +914,22 @@ final class AppState: ObservableObject {
     }
 
     /// Resolves the removal side of a viewer route (transcript toggle-off).
-    /// A reused slot keeps its pre-transcript content in history: step back
-    /// and return the content to restore in place — the toggle round-trip
-    /// must not destroy the viewer the transcript replaced. With no back
-    /// history the pane is really going away, so forget its history.
+    /// A reused slot keeps its pre-transcript content in history: jump the
+    /// cursor to the nearest non-transcript entry (older side first — that's
+    /// what the transcript replaced — then newer) and return it to restore in
+    /// place. Skipping transcript entries means chained
+    /// transcript-for-another-terminal swaps never resurrect another
+    /// terminal's transcript. With no non-transcript entry the pane is
+    /// really going away, so forget its history.
     func popHistoryForRemovedPane(_ paneID: UUID) -> PaneContent? {
         if var history = paneHistories[paneID] {
-            // Toggle-off means "stop showing a transcript": skip past older
-            // transcript entries (chained transcript-for-another-terminal
-            // swaps) to the nearest non-transcript content.
-            while let previous = history.goBack() {
-                if case .liveTranscript = previous { continue }
+            let older = Array((history.cursor + 1)..<history.entries.count)
+            let newer = Array(stride(from: history.cursor - 1, through: 0, by: -1))
+            for index in older + newer {
+                if case .liveTranscript = history.entries[index] { continue }
+                guard let restored = history.go(to: index) else { continue }
                 paneHistories[paneID] = history
-                return previous
+                return restored
             }
         }
         paneHistories.removeValue(forKey: paneID)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -401,6 +401,11 @@ final class AppState: ObservableObject {
     @Published var layouts: [UUID: LayoutNode] = [:] {
         didSet { persistLayouts() }
     }
+    /// Back/forward history per viewer-class slot pane, keyed by the slot's
+    /// paneID (stable across in-place content replacements).
+    @Published var paneHistories: [UUID: PaneHistory] = [:] {
+        didSet { persistPaneHistories() }
+    }
     @Published var tabs: [UUID: [Tab]] = [:]
     @Published var activeTabIndices: [UUID: Int] = [:]
     @Published var worktreeTabOrders: [UUID: [UUID]] = [:]
@@ -692,6 +697,7 @@ final class AppState: ObservableObject {
     let macNotificationManager = MacNotificationManager()
 
     private static let layoutsKey = "com.tbd.app.layouts"
+    private static let paneHistoriesKey = "com.tbd.app.paneHistories"
     private static let dockRatioKey = "com.tbd.app.dockRatio"
     private static let selectionOrderKey = "com.tbd.app.selectionOrder"
     private static let skipAccountPickerKey = "com.tbd.app.accountPicker.useDefaultWithoutAsking"
@@ -707,6 +713,7 @@ final class AppState: ObservableObject {
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
         restoreLayouts()
+        restorePaneHistories()
         if let saved = userDefaults.object(forKey: Self.dockRatioKey) as? Double {
             dockRatio = max(0.1, min(0.6, CGFloat(saved)))
         }
@@ -884,6 +891,41 @@ final class AppState: ObservableObject {
         guard let data = userDefaults.data(forKey: Self.layoutsKey),
               let restored = try? JSONDecoder().decode([UUID: LayoutNode].self, from: data) else { return }
         layouts = restored
+    }
+
+    private func persistPaneHistories() {
+        guard let data = try? JSONEncoder().encode(paneHistories) else { return }
+        userDefaults.set(data, forKey: Self.paneHistoriesKey)
+    }
+
+    private func restorePaneHistories() {
+        guard let data = userDefaults.data(forKey: Self.paneHistoriesKey),
+              let restored = try? JSONDecoder().decode([UUID: PaneHistory].self, from: data) else { return }
+        paneHistories = restored
+    }
+
+    /// Pushes the outgoing content of an in-place slot replacement onto that
+    /// slot's history (see `ViewerRouteResult.replaced`).
+    func recordPaneReplacement(_ replacement: ViewerRouteResult.Replacement) {
+        paneHistories[replacement.paneID, default: PaneHistory()]
+            .recordReplacement(outgoing: replacement.outgoing, incoming: replacement.incoming)
+    }
+
+    /// Drops histories for slot panes no longer present in any tab layout or
+    /// tab root — closed panes and panes dropped by reconciliation. Keyed off
+    /// the GLOBAL layouts dict, so a per-worktree reconcile never prunes
+    /// another worktree's slots.
+    func prunePaneHistories() {
+        guard !paneHistories.isEmpty else { return }
+        var liveIDs = Set<UUID>()
+        for layout in layouts.values { liveIDs.formUnion(layout.allPaneIDs()) }
+        for tabList in tabs.values {
+            for tab in tabList { liveIDs.insert(tab.content.paneID) }
+        }
+        let pruned = paneHistories.filter { liveIDs.contains($0.key) }
+        if pruned.count != paneHistories.count {
+            paneHistories = pruned
+        }
     }
 
     // MARK: - Selection Persistence
@@ -1743,6 +1785,7 @@ final class AppState: ObservableObject {
 
         tabs[worktreeID] = currentTabs
         applyStoredOrder(worktreeID: worktreeID)
+        prunePaneHistories()
         if !alreadyLoadedOrder {
             Task { await loadTabStates(worktreeID: worktreeID) }
         }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -901,7 +901,9 @@ final class AppState: ObservableObject {
     private func restorePaneHistories() {
         guard let data = userDefaults.data(forKey: Self.paneHistoriesKey),
               let restored = try? JSONDecoder().decode([UUID: PaneHistory].self, from: data) else { return }
-        paneHistories = restored
+        // Corrupt/skewed persisted data with an out-of-range cursor would
+        // crash entries[cursor] lookups in the pane header's view body.
+        paneHistories = restored.filter { $0.value.isWellFormed }
     }
 
     /// Pushes the outgoing content of an in-place slot replacement onto that
@@ -909,6 +911,26 @@ final class AppState: ObservableObject {
     func recordPaneReplacement(_ replacement: ViewerRouteResult.Replacement) {
         paneHistories[replacement.paneID, default: PaneHistory()]
             .recordReplacement(outgoing: replacement.outgoing, incoming: replacement.incoming)
+    }
+
+    /// Resolves the removal side of a viewer route (transcript toggle-off).
+    /// A reused slot keeps its pre-transcript content in history: step back
+    /// and return the content to restore in place — the toggle round-trip
+    /// must not destroy the viewer the transcript replaced. With no back
+    /// history the pane is really going away, so forget its history.
+    func popHistoryForRemovedPane(_ paneID: UUID) -> PaneContent? {
+        if var history = paneHistories[paneID] {
+            // Toggle-off means "stop showing a transcript": skip past older
+            // transcript entries (chained transcript-for-another-terminal
+            // swaps) to the nearest non-transcript content.
+            while let previous = history.goBack() {
+                if case .liveTranscript = previous { continue }
+                paneHistories[paneID] = history
+                return previous
+            }
+        }
+        paneHistories.removeValue(forKey: paneID)
+        return nil
     }
 
     /// Drops histories for slot panes no longer present in any tab layout or

--- a/Sources/TBDApp/Panes/PaneHistory.swift
+++ b/Sources/TBDApp/Panes/PaneHistory.swift
@@ -1,19 +1,25 @@
 import Foundation
 
-/// Back/forward navigation history for one viewer-class "slot" pane.
+/// Tab-like MRU navigation history for one viewer-class "slot" pane.
 ///
-/// `entries` is the full trail (oldest first) INCLUDING the slot's current
-/// content; `cursor` indexes the current content. Every entry carries the
-/// slot's own `paneID`, so applying an entry via
-/// `LayoutNode.replacingContent(at:with:)` preserves view identity.
+/// `entries[0]` is the most recently committed content; `cursor` indexes the
+/// entry currently shown — the slot's current content IS `entries[cursor]`.
+/// Back/forward/jump only move the cursor and never reorder the list; a real
+/// navigation (`recordReplacement`) commits the current entry to the front,
+/// dedupes the incoming content (an entry moves rather than duplicates), and
+/// inserts it at index 0. Every entry carries the slot's own `paneID`, so
+/// applying an entry via `LayoutNode.replacingContent(at:with:)` preserves
+/// view identity.
 struct PaneHistory: Codable, Equatable, Sendable {
     static let maxEntries = 10
 
     private(set) var entries: [PaneContent] = []
     private(set) var cursor: Int = -1
 
-    var canGoBack: Bool { cursor > 0 }
-    var canGoForward: Bool { !entries.isEmpty && cursor < entries.count - 1 }
+    /// Back moves toward older entries (higher indices).
+    var canGoBack: Bool { !entries.isEmpty && cursor < entries.count - 1 }
+    /// Forward moves toward newer entries (lower indices).
+    var canGoForward: Bool { cursor > 0 }
 
     /// True when `(entries, cursor)` is internally consistent. In-process
     /// mutations preserve this; only decoded (persisted) data can violate it.
@@ -21,55 +27,45 @@ struct PaneHistory: Codable, Equatable, Sendable {
         entries.isEmpty ? cursor == -1 : entries.indices.contains(cursor)
     }
 
-    /// Entries behind the cursor, nearest first, paired with their absolute
-    /// index for `go(to:)`.
-    var backEntries: [(index: Int, content: PaneContent)] {
-        guard canGoBack else { return [] }
-        return (0..<cursor).reversed().map { ($0, entries[$0]) }
-    }
-
-    /// Entries ahead of the cursor, nearest first.
-    var forwardEntries: [(index: Int, content: PaneContent)] {
-        guard canGoForward else { return [] }
-        return ((cursor + 1)..<entries.count).map { ($0, entries[$0]) }
-    }
-
-    /// Records a content-navigation replacement: drops any forward entries,
-    /// appends the incoming content, and caps the trail at `maxEntries`
-    /// (dropping oldest). No-op when nothing actually changed.
+    /// Records a real content navigation (file click, transcript toggle):
+    /// moves the current entry to index 0, removes any existing occurrence
+    /// of `incoming` (one entry per content), inserts `incoming` at index 0,
+    /// and caps at `maxEntries` by evicting the tail — never the current
+    /// entry, which was just moved to the front. No-op when nothing changed.
     mutating func recordReplacement(outgoing: PaneContent, incoming: PaneContent) {
         guard outgoing != incoming else { return }
         if entries.isEmpty {
             entries = [outgoing]
-            cursor = 0
         } else {
-            entries.removeSubrange((cursor + 1)...)
             // The slot's live content is authoritative for the current entry.
             entries[cursor] = outgoing
+            entries.insert(entries.remove(at: cursor), at: 0)
         }
-        entries.append(incoming)
+        entries.removeAll { $0 == incoming }
+        entries.insert(incoming, at: 0)
         if entries.count > Self.maxEntries {
-            entries.removeFirst(entries.count - Self.maxEntries)
+            entries.removeLast(entries.count - Self.maxEntries)
         }
-        cursor = entries.count - 1
+        cursor = 0
     }
 
-    /// Moves the cursor back one entry and returns it. Navigation only moves
-    /// the cursor — it never re-pushes.
+    /// Moves the cursor one entry toward older and returns it. Navigation
+    /// only moves the cursor — it never reorders or re-pushes.
     mutating func goBack() -> PaneContent? {
         guard canGoBack else { return nil }
-        cursor -= 1
-        return entries[cursor]
-    }
-
-    /// Moves the cursor forward one entry and returns it.
-    mutating func goForward() -> PaneContent? {
-        guard canGoForward else { return nil }
         cursor += 1
         return entries[cursor]
     }
 
+    /// Moves the cursor one entry toward newer and returns it.
+    mutating func goForward() -> PaneContent? {
+        guard canGoForward else { return nil }
+        cursor -= 1
+        return entries[cursor]
+    }
+
     /// Jumps the cursor to an absolute entry index (from a history menu).
+    /// No reorder — selecting a menu entry only moves the cursor.
     mutating func go(to index: Int) -> PaneContent? {
         guard entries.indices.contains(index), index != cursor else { return nil }
         cursor = index

--- a/Sources/TBDApp/Panes/PaneHistory.swift
+++ b/Sources/TBDApp/Panes/PaneHistory.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Back/forward navigation history for one viewer-class "slot" pane.
+///
+/// `entries` is the full trail (oldest first) INCLUDING the slot's current
+/// content; `cursor` indexes the current content. Every entry carries the
+/// slot's own `paneID`, so applying an entry via
+/// `LayoutNode.replacingContent(at:with:)` preserves view identity.
+struct PaneHistory: Codable, Equatable, Sendable {
+    static let maxEntries = 10
+
+    private(set) var entries: [PaneContent] = []
+    private(set) var cursor: Int = -1
+
+    var canGoBack: Bool { cursor > 0 }
+    var canGoForward: Bool { !entries.isEmpty && cursor < entries.count - 1 }
+
+    /// Entries behind the cursor, nearest first, paired with their absolute
+    /// index for `go(to:)`.
+    var backEntries: [(index: Int, content: PaneContent)] {
+        guard canGoBack else { return [] }
+        return (0..<cursor).reversed().map { ($0, entries[$0]) }
+    }
+
+    /// Entries ahead of the cursor, nearest first.
+    var forwardEntries: [(index: Int, content: PaneContent)] {
+        guard canGoForward else { return [] }
+        return ((cursor + 1)..<entries.count).map { ($0, entries[$0]) }
+    }
+
+    /// Records a content-navigation replacement: drops any forward entries,
+    /// appends the incoming content, and caps the trail at `maxEntries`
+    /// (dropping oldest). No-op when nothing actually changed.
+    mutating func recordReplacement(outgoing: PaneContent, incoming: PaneContent) {
+        guard outgoing != incoming else { return }
+        if entries.isEmpty {
+            entries = [outgoing]
+            cursor = 0
+        } else {
+            entries.removeSubrange((cursor + 1)...)
+            // The slot's live content is authoritative for the current entry.
+            entries[cursor] = outgoing
+        }
+        entries.append(incoming)
+        if entries.count > Self.maxEntries {
+            entries.removeFirst(entries.count - Self.maxEntries)
+        }
+        cursor = entries.count - 1
+    }
+
+    /// Moves the cursor back one entry and returns it. Navigation only moves
+    /// the cursor — it never re-pushes.
+    mutating func goBack() -> PaneContent? {
+        guard canGoBack else { return nil }
+        cursor -= 1
+        return entries[cursor]
+    }
+
+    /// Moves the cursor forward one entry and returns it.
+    mutating func goForward() -> PaneContent? {
+        guard canGoForward else { return nil }
+        cursor += 1
+        return entries[cursor]
+    }
+
+    /// Jumps the cursor to an absolute entry index (from a history menu).
+    mutating func go(to index: Int) -> PaneContent? {
+        guard entries.indices.contains(index), index != cursor else { return nil }
+        cursor = index
+        return entries[index]
+    }
+}

--- a/Sources/TBDApp/Panes/PaneHistory.swift
+++ b/Sources/TBDApp/Panes/PaneHistory.swift
@@ -15,6 +15,12 @@ struct PaneHistory: Codable, Equatable, Sendable {
     var canGoBack: Bool { cursor > 0 }
     var canGoForward: Bool { !entries.isEmpty && cursor < entries.count - 1 }
 
+    /// True when `(entries, cursor)` is internally consistent. In-process
+    /// mutations preserve this; only decoded (persisted) data can violate it.
+    var isWellFormed: Bool {
+        entries.isEmpty ? cursor == -1 : entries.indices.contains(cursor)
+    }
+
     /// Entries behind the cursor, nearest first, paired with their absolute
     /// index for `go(to:)`.
     var backEntries: [(index: Int, content: PaneContent)] {

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -610,7 +610,13 @@ struct PanePlaceholder: View {
             appState.recordPaneReplacement(replaced)
         }
         if let removed = result.removedPaneID {
-            appState.paneHistories.removeValue(forKey: removed)
+            // Reused slot: restore its pre-transcript content in place instead
+            // of applying the removal layout.
+            if let previous = appState.popHistoryForRemovedPane(removed),
+               let restored = layout.replacingContent(at: removed, with: previous) {
+                layout = restored
+                return
+            }
         }
         layout = result.layout
     }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -255,13 +255,14 @@ struct PanePlaceholder: View {
     // MARK: - Slot History Navigation
 
     /// Back/forward chevrons for viewer-class slot panes. Primary click steps
-    /// one entry; the attached menu lists up to 10 entries for direct jumps.
+    /// one entry; both buttons' attached menus show the SAME full MRU list
+    /// (newest first, checkmark on the current entry) for direct jumps.
     @ViewBuilder
     private var historyNavigation: some View {
         let history = appState.paneHistories[content.paneID] ?? PaneHistory()
 
         historyMenu(
-            entries: history.backEntries,
+            history: history,
             icon: "chevron.left",
             help: "Back",
             primaryAction: { navigateHistory { $0.goBack() } }
@@ -269,7 +270,7 @@ struct PanePlaceholder: View {
         .disabled(!history.canGoBack)
 
         historyMenu(
-            entries: history.forwardEntries,
+            history: history,
             icon: "chevron.right",
             help: "Forward",
             primaryAction: { navigateHistory { $0.goForward() } }
@@ -278,20 +279,27 @@ struct PanePlaceholder: View {
     }
 
     private func historyMenu(
-        entries: [(index: Int, content: PaneContent)],
+        history: PaneHistory,
         icon: String,
         help: String,
         primaryAction: @escaping () -> Void
     ) -> some View {
         Menu {
-            ForEach(entries.prefix(PaneHistory.maxEntries), id: \.index) { entry in
-                Button(historyEntryLabel(entry.content)) {
-                    navigateHistory { $0.go(to: entry.index) }
-                }
+            ForEach(Array(history.entries.enumerated()), id: \.offset) { index, entry in
+                // Toggle renders as a checkmarked menu item on the cursor
+                // entry; selecting jumps the cursor without reordering.
+                Toggle(historyEntryLabel(entry), isOn: Binding(
+                    get: { index == history.cursor },
+                    set: { _ in navigateHistory { $0.go(to: index) } }
+                ))
             }
         } label: {
+            // Glyph matches the close button's spec exactly; the 16x16 frame
+            // + contentShape keeps the full hit target despite the smaller icon.
             Image(systemName: icon)
-                .font(.caption)
+                .font(.system(size: 9, weight: .bold))
+                .frame(width: 16, height: 16)
+                .contentShape(Rectangle())
         } primaryAction: {
             primaryAction()
         }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -101,6 +101,14 @@ struct PanePlaceholder: View {
     @ViewBuilder
     private var toolbar: some View {
         HStack(spacing: 8) {
+            // Leading so the chevrons sit in a stable spot on every viewer
+            // pane, unaffected by which trailing buttons a pane type has.
+            // Both buttons always render (16x16 fixed frames, disabled when
+            // unavailable), so the title never jumps.
+            if content.isViewerClass {
+                historyNavigation
+            }
+
             paneLabel
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -225,8 +233,6 @@ struct PanePlaceholder: View {
             }
 
         case .webview:
-            historyNavigation
-
             Button(action: copyWebviewURL) {
                 Image(systemName: didCopyURL ? "checkmark" : "doc.on.doc")
                     .font(.caption)
@@ -235,8 +241,6 @@ struct PanePlaceholder: View {
             .help("Copy URL")
 
         case .codeViewer:
-            historyNavigation
-
             if hasRenderableContent {
                 Button(action: { showSourceCode.toggle() }) {
                     Image(systemName: "chevron.left.forwardslash.chevron.right")
@@ -247,11 +251,8 @@ struct PanePlaceholder: View {
                 .help(showSourceCode ? "Show rendered view" : "Show source code")
             }
 
-        case .note:
+        case .note, .liveTranscript:
             EmptyView()
-
-        case .liveTranscript:
-            historyNavigation
         }
     }
 

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -222,20 +222,7 @@ struct PanePlaceholder: View {
             }
 
         case .webview:
-            // Placeholder for back/forward — will be wired in Task 6
-            Button(action: {}) {
-                Image(systemName: "chevron.left")
-                    .font(.caption)
-            }
-            .buttonStyle(.borderless)
-            .disabled(true)
-
-            Button(action: {}) {
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-            }
-            .buttonStyle(.borderless)
-            .disabled(true)
+            historyNavigation
 
             Button(action: copyWebviewURL) {
                 Image(systemName: didCopyURL ? "checkmark" : "doc.on.doc")
@@ -245,6 +232,8 @@ struct PanePlaceholder: View {
             .help("Copy URL")
 
         case .codeViewer:
+            historyNavigation
+
             if hasRenderableContent {
                 Button(action: { showSourceCode.toggle() }) {
                     Image(systemName: "chevron.left.forwardslash.chevron.right")
@@ -259,7 +248,84 @@ struct PanePlaceholder: View {
             EmptyView()
 
         case .liveTranscript:
-            EmptyView()
+            historyNavigation
+        }
+    }
+
+    // MARK: - Slot History Navigation
+
+    /// Back/forward chevrons for viewer-class slot panes. Primary click steps
+    /// one entry; the attached menu lists up to 10 entries for direct jumps.
+    @ViewBuilder
+    private var historyNavigation: some View {
+        let history = appState.paneHistories[content.paneID] ?? PaneHistory()
+
+        historyMenu(
+            entries: history.backEntries,
+            icon: "chevron.left",
+            help: "Back",
+            primaryAction: { navigateHistory { $0.goBack() } }
+        )
+        .disabled(!history.canGoBack)
+
+        historyMenu(
+            entries: history.forwardEntries,
+            icon: "chevron.right",
+            help: "Forward",
+            primaryAction: { navigateHistory { $0.goForward() } }
+        )
+        .disabled(!history.canGoForward)
+    }
+
+    private func historyMenu(
+        entries: [(index: Int, content: PaneContent)],
+        icon: String,
+        help: String,
+        primaryAction: @escaping () -> Void
+    ) -> some View {
+        Menu {
+            ForEach(entries.prefix(PaneHistory.maxEntries), id: \.index) { entry in
+                Button(historyEntryLabel(entry.content)) {
+                    navigateHistory { $0.go(to: entry.index) }
+                }
+            }
+        } label: {
+            Image(systemName: icon)
+                .font(.caption)
+        } primaryAction: {
+            primaryAction()
+        }
+        .menuIndicator(.hidden)
+        .buttonStyle(.borderless)
+        .fixedSize()
+        .help(help)
+    }
+
+    /// Applies a history navigation to this slot: mutate the slot's history,
+    /// then swap the layout content in place keeping the pane UUID. Goes
+    /// through `replacingContent` directly — never through the routing
+    /// functions — so navigating does not push new history entries.
+    private func navigateHistory(_ step: (inout PaneHistory) -> PaneContent?) {
+        guard var history = appState.paneHistories[content.paneID],
+              let target = step(&history),
+              let updated = layout.replacingContent(at: content.paneID, with: target)
+        else { return }
+        appState.paneHistories[content.paneID] = history
+        layout = updated
+    }
+
+    private func historyEntryLabel(_ content: PaneContent) -> String {
+        switch content {
+        case .codeViewer(_, let path):
+            return URL(fileURLWithPath: path).lastPathComponent
+        case .webview(_, let url):
+            return (url.host ?? "") + url.path
+        case .liveTranscript:
+            return "Transcript"
+        case .terminal:
+            return "Terminal"
+        case .note:
+            return "Note"
         }
     }
 
@@ -352,7 +418,11 @@ struct PanePlaceholder: View {
                     worktreePath: worktree.path,
                     remoteURL: appState.repos.first(where: { $0.id == worktree.repoID })?.remoteURL,
                     onFilePathClicked: { path in
-                        layout = routeFileClick(into: layout, terminalID: terminalID, path: path)
+                        let result = routeFileClick(into: layout, terminalID: terminalID, path: path)
+                        if let replaced = result.replaced {
+                            appState.recordPaneReplacement(replaced)
+                        }
+                        layout = result.layout
                     },
                     onTerminalNotification: { title, body in
                         debugLog("OSC 777: \(title) — \(body)")
@@ -491,6 +561,8 @@ struct PanePlaceholder: View {
             Task { await appState.deleteNote(noteID: noteID, worktreeID: worktree.id) }
         }
 
+        appState.paneHistories.removeValue(forKey: content.paneID)
+
         if let newLayout = layout.removePane(id: content.paneID) {
             layout = newLayout
         } else {
@@ -533,7 +605,14 @@ struct PanePlaceholder: View {
     }
 
     private func toggleTranscriptPane(terminalID: UUID) {
-        layout = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: content.paneID)
+        let result = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: content.paneID)
+        if let replaced = result.replaced {
+            appState.recordPaneReplacement(replaced)
+        }
+        if let removed = result.removedPaneID {
+            appState.paneHistories.removeValue(forKey: removed)
+        }
+        layout = result.layout
     }
 
     private func isTranscriptOpen(terminalID: UUID) -> Bool {

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -105,6 +105,10 @@ struct PanePlaceholder: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
+                // Scoped to the title only (not the whole header row) so
+                // right-click on the history chevrons / close button isn't
+                // swallowed by the file menu.
+                .headerFileContextMenu(for: content, transcriptPath: transcriptPath)
 
             Spacer()
 
@@ -125,7 +129,6 @@ struct PanePlaceholder: View {
         .onHover { hovering in
             isHeaderHovering = hovering
         }
-        .headerFileContextMenu(for: content, transcriptPath: transcriptPath)
     }
 
     /// Resolved Claude session JSONL path for liveTranscript panes; nil otherwise.
@@ -254,59 +257,64 @@ struct PanePlaceholder: View {
 
     // MARK: - Slot History Navigation
 
-    /// Back/forward chevrons for viewer-class slot panes. Primary click steps
-    /// one entry; both buttons' attached menus show the SAME full MRU list
+    /// Back/forward chevrons for viewer-class slot panes. Left-click steps
+    /// one entry; right-click either chevron shows the SAME full MRU list
     /// (newest first, checkmark on the current entry) for direct jumps.
     @ViewBuilder
     private var historyNavigation: some View {
         let history = appState.paneHistories[content.paneID] ?? PaneHistory()
 
-        historyMenu(
+        historyButton(
             history: history,
             icon: "chevron.left",
             help: "Back",
-            primaryAction: { navigateHistory { $0.goBack() } }
+            action: { navigateHistory { $0.goBack() } }
         )
         .disabled(!history.canGoBack)
 
-        historyMenu(
+        historyButton(
             history: history,
             icon: "chevron.right",
             help: "Forward",
-            primaryAction: { navigateHistory { $0.goForward() } }
+            action: { navigateHistory { $0.goForward() } }
         )
         .disabled(!history.canGoForward)
     }
 
-    private func historyMenu(
+    /// Plain Button + .contextMenu — NOT Menu(primaryAction:), whose label
+    /// right-click fell through to the header's context menu, and never
+    /// .onTapGesture, which blocks .contextMenu on macOS.
+    private func historyButton(
         history: PaneHistory,
         icon: String,
         help: String,
-        primaryAction: @escaping () -> Void
+        action: @escaping () -> Void
     ) -> some View {
-        Menu {
-            ForEach(Array(history.entries.enumerated()), id: \.offset) { index, entry in
-                // Toggle renders as a checkmarked menu item on the cursor
-                // entry; selecting jumps the cursor without reordering.
-                Toggle(historyEntryLabel(entry), isOn: Binding(
-                    get: { index == history.cursor },
-                    set: { _ in navigateHistory { $0.go(to: index) } }
-                ))
-            }
-        } label: {
-            // Glyph matches the close button's spec exactly; the 16x16 frame
-            // + contentShape keeps the full hit target despite the smaller icon.
+        Button(action: action) {
+            // Glyph sized a notch below the close button's 9pt; the 16x16
+            // frame + contentShape keeps the full hit target.
             Image(systemName: icon)
-                .font(.system(size: 9, weight: .bold))
+                .font(.system(size: 8, weight: .bold))
                 .frame(width: 16, height: 16)
                 .contentShape(Rectangle())
-        } primaryAction: {
-            primaryAction()
         }
-        .menuIndicator(.hidden)
         .buttonStyle(.borderless)
-        .fixedSize()
         .help(help)
+        .contextMenu {
+            ForEach(Array(history.entries.enumerated()), id: \.offset) { index, entry in
+                Button {
+                    navigateHistory { $0.go(to: index) }
+                } label: {
+                    // Explicit checkmark symbol on the cursor entry — renders
+                    // reliably in a .contextMenu, unlike Toggle state.
+                    if index == history.cursor {
+                        Label(historyEntryLabel(entry), systemImage: "checkmark")
+                    } else {
+                        Text(historyEntryLabel(entry))
+                    }
+                }
+            }
+        }
     }
 
     /// Applies a history navigation to this slot: mutate the slot's history,

--- a/Sources/TBDApp/Panes/TranscriptRouting.swift
+++ b/Sources/TBDApp/Panes/TranscriptRouting.swift
@@ -14,25 +14,37 @@ func isLiveTranscriptPane(_ content: PaneContent, for terminalID: UUID) -> Bool 
 
 /// Toggles the live-transcript pane for `terminalID`.
 ///
-/// If the tab's layout already contains a `.liveTranscript` pane for this
-/// terminal, that pane is removed (toggle off). Otherwise a new transcript
-/// pane is split horizontally off `fromPaneID` (toggle on), matching the
-/// original always-open behavior.
-func toggleTranscript(into layout: LayoutNode, terminalID: UUID, fromPaneID: UUID) -> LayoutNode {
+/// Toggle off: the tab already shows a transcript for this terminal — remove
+/// that pane. Toggle on: reuse an existing viewer-class slot in place
+/// (preserving its `paneID`, see `routeFileClick`); otherwise split
+/// horizontally off `fromPaneID`, matching the original always-open behavior.
+func toggleTranscript(into layout: LayoutNode, terminalID: UUID, fromPaneID: UUID) -> ViewerRouteResult {
     if let transcriptID = layout.firstPaneID(where: { isLiveTranscriptPane($0, for: terminalID) }) {
         if let updated = layout.removePane(id: transcriptID) {
             logger.debug("toggleTranscript[close]: transcriptID=\(transcriptID, privacy: .public)")
-            return updated
+            return ViewerRouteResult(layout: updated, removedPaneID: transcriptID)
         }
         // The toggle is driven from a sibling terminal pane, so a transcript is
         // never the sole pane here — this branch is defensive and unreachable.
-        return layout
+        return ViewerRouteResult(layout: layout)
+    }
+
+    if let outgoing = layout.firstPaneContent(where: \.isViewerClass) {
+        let slotID = outgoing.paneID
+        let incoming = PaneContent.liveTranscript(id: slotID, terminalID: terminalID)
+        if let updated = layout.replacingContent(at: slotID, with: incoming) {
+            logger.debug("toggleTranscript[swap]: slotID=\(slotID, privacy: .public) terminalID=\(terminalID, privacy: .public)")
+            return ViewerRouteResult(
+                layout: updated,
+                replaced: .init(paneID: slotID, outgoing: outgoing, incoming: incoming)
+            )
+        }
     }
 
     logger.debug("toggleTranscript[open]: terminalID=\(terminalID, privacy: .public) fromPaneID=\(fromPaneID, privacy: .public)")
-    return layout.splitPane(
+    return ViewerRouteResult(layout: layout.splitPane(
         id: fromPaneID,
         direction: .horizontal,
         newContent: .liveTranscript(id: UUID(), terminalID: terminalID)
-    )
+    ))
 }

--- a/Sources/TBDApp/Panes/ViewerRouting.swift
+++ b/Sources/TBDApp/Panes/ViewerRouting.swift
@@ -3,34 +3,62 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.app", category: "ViewerRouting")
 
+// MARK: - ViewerRouteResult
+
+/// Outcome of a content-navigation gesture (file click, transcript toggle).
+///
+/// `replaced` is non-nil when the gesture reused an existing viewer-class
+/// "slot" pane in place — the call site pushes `outgoing` onto that slot's
+/// `PaneHistory`. `removedPaneID` is non-nil when the gesture closed a pane
+/// (transcript toggle-off) — the call site prunes that pane's history.
+struct ViewerRouteResult: Equatable {
+    struct Replacement: Equatable {
+        let paneID: UUID
+        let outgoing: PaneContent
+        let incoming: PaneContent
+    }
+
+    let layout: LayoutNode
+    var replaced: Replacement? = nil
+    var removedPaneID: UUID? = nil
+}
+
+// MARK: - routeFileClick
+
 /// Decides where a terminal-link click should land.
 ///
-/// If the tab's layout already contains a `.codeViewer` pane, this returns
-/// the layout with that pane's `path` swapped (preserving the pane's `paneID`
-/// so SwiftUI keeps the view identity stable, including any `@StateObject`
-/// it owns — notably the `FileWatcher`).
+/// Reuse priority:
+/// 1. An existing `.codeViewer` pane — swap its `path`.
+/// 2. Any other viewer-class pane (`.liveTranscript`, `.webview`) — replace
+///    its content with a code viewer.
+/// 3. No viewer-class pane — split horizontally off the clicked terminal.
 ///
-/// Otherwise it falls back to splitting horizontally from the clicked terminal,
-/// matching the original behavior at `PanePlaceholder.swift:243-245`.
-func routeFileClick(into layout: LayoutNode, terminalID: UUID, path: String) -> LayoutNode {
-    let isViewer: (PaneContent) -> Bool = { content in
+/// In-place replacements preserve the pane's `paneID` so SwiftUI keeps the
+/// view identity stable, including any `@StateObject` it owns — notably the
+/// `FileWatcher` — and so the slot's `PaneHistory` stays keyed to one UUID.
+func routeFileClick(into layout: LayoutNode, terminalID: UUID, path: String) -> ViewerRouteResult {
+    let isCodeViewer: (PaneContent) -> Bool = { content in
         if case .codeViewer = content { return true } else { return false }
     }
 
-    if let viewerID = layout.firstPaneID(where: isViewer),
-       let updated = layout.replacingContent(
-           at: viewerID,
-           with: .codeViewer(id: viewerID, path: path)
-       )
+    if let outgoing = layout.firstPaneContent(where: isCodeViewer)
+        ?? layout.firstPaneContent(where: \.isViewerClass)
     {
-        logger.debug("routeFileClick[swap]: viewerID=\(viewerID, privacy: .public) path=\(path, privacy: .public)")
-        return updated
+        let slotID = outgoing.paneID
+        let incoming = PaneContent.codeViewer(id: slotID, path: path)
+        if let updated = layout.replacingContent(at: slotID, with: incoming) {
+            logger.debug("routeFileClick[swap]: slotID=\(slotID, privacy: .public) path=\(path, privacy: .public)")
+            return ViewerRouteResult(
+                layout: updated,
+                replaced: .init(paneID: slotID, outgoing: outgoing, incoming: incoming)
+            )
+        }
     }
 
     logger.debug("routeFileClick[split]: terminalID=\(terminalID, privacy: .public) path=\(path, privacy: .public)")
-    return layout.splitPane(
+    return ViewerRouteResult(layout: layout.splitPane(
         id: terminalID,
         direction: .horizontal,
         newContent: .codeViewer(id: UUID(), path: path)
-    )
+    ))
 }

--- a/Sources/TBDApp/Terminal/LayoutNode.swift
+++ b/Sources/TBDApp/Terminal/LayoutNode.swift
@@ -149,12 +149,18 @@ extension LayoutNode {
     /// Returns the id of the first pane (in pre-order, left-to-right traversal)
     /// whose content matches the predicate, or nil if none match.
     func firstPaneID(where predicate: (PaneContent) -> Bool) -> UUID? {
+        firstPaneContent(where: predicate)?.paneID
+    }
+
+    /// Returns the content of the first pane (in pre-order, left-to-right
+    /// traversal) matching the predicate, or nil if none match.
+    func firstPaneContent(where predicate: (PaneContent) -> Bool) -> PaneContent? {
         switch self {
         case .pane(let content):
-            return predicate(content) ? content.paneID : nil
+            return predicate(content) ? content : nil
         case .split(_, let children, _):
             for child in children {
-                if let found = child.firstPaneID(where: predicate) {
+                if let found = child.firstPaneContent(where: predicate) {
                     return found
                 }
             }

--- a/Sources/TBDApp/Terminal/PaneContent.swift
+++ b/Sources/TBDApp/Terminal/PaneContent.swift
@@ -18,6 +18,16 @@ enum PaneContent: Codable, Equatable, Sendable {
         case .liveTranscript(let id, _): return id
         }
     }
+
+    /// Viewer-class panes form one interchangeable "slot" per tab:
+    /// content-navigation gestures replace within the slot (preserving the
+    /// pane UUID); explicit split gestures still create new panes.
+    var isViewerClass: Bool {
+        switch self {
+        case .codeViewer, .webview, .liveTranscript: return true
+        case .terminal, .note: return false
+        }
+    }
 }
 
 // MARK: - Tab

--- a/Tests/TBDAppTests/PaneHistoryTests.swift
+++ b/Tests/TBDAppTests/PaneHistoryTests.swift
@@ -11,14 +11,15 @@ struct PaneHistoryTests {
         .codeViewer(id: slotID, path: path)
     }
 
-    @Test func recordReplacement_bootstrapsWithOutgoingThenIncoming() {
+    @Test func recordReplacement_bootstrapsMRUNewestFirst() {
         var history = PaneHistory()
         #expect(!history.canGoBack)
         #expect(!history.canGoForward)
 
         history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
 
-        #expect(history.entries == [viewer("/a"), viewer("/b")])
+        #expect(history.entries == [viewer("/b"), viewer("/a")], "entries[0] is newest")
+        #expect(history.cursor == 0)
         #expect(history.canGoBack)
         #expect(!history.canGoForward)
     }
@@ -34,6 +35,7 @@ struct PaneHistoryTests {
         history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
         history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/c"))
 
+        #expect(history.entries == [viewer("/c"), viewer("/b"), viewer("/a")])
         #expect(history.goBack() == viewer("/b"))
         #expect(history.goBack() == viewer("/a"))
         #expect(history.goBack() == nil, "at the oldest entry")
@@ -43,50 +45,98 @@ struct PaneHistoryTests {
         #expect(history.entries.count == 3, "navigation must not add entries")
     }
 
-    @Test func replacementAfterGoingBackDropsForwardEntries() {
+    /// The spec's worked example: navigating after going back COMMITS the
+    /// current entry to the front instead of truncating forward entries —
+    /// nothing is ever dropped by going back.
+    @Test func navigatingAfterGoingBackKeepsAllEntries() {
+        var history = PaneHistory()
+        history.recordReplacement(outgoing: viewer("/A"), incoming: viewer("/B"))
+        #expect(history.entries == [viewer("/B"), viewer("/A")])
+
+        #expect(history.goBack() == viewer("/A"))
+        #expect(history.entries == [viewer("/B"), viewer("/A")], "back never reorders")
+
+        history.recordReplacement(outgoing: viewer("/A"), incoming: viewer("/C"))
+        #expect(history.entries == [viewer("/C"), viewer("/A"), viewer("/B")],
+                "commit moves A to front, C inserted — B still reachable")
+        #expect(history.cursor == 0)
+
+        #expect(history.goBack() == viewer("/A"))
+        #expect(history.goBack() == viewer("/B"))
+        #expect(history.goForward() == viewer("/A"))
+    }
+
+    @Test func recordReplacement_dedupeMovesExistingEntryToFront() {
         var history = PaneHistory()
         history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
         history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/c"))
-        _ = history.goBack()  // now at /b
 
-        history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/d"))
+        // Navigating to /a — already in the list — moves it, never duplicates.
+        history.recordReplacement(outgoing: viewer("/c"), incoming: viewer("/a"))
 
-        #expect(history.entries == [viewer("/a"), viewer("/b"), viewer("/d")])
-        #expect(!history.canGoForward, "/c must be gone")
+        #expect(history.entries == [viewer("/a"), viewer("/c"), viewer("/b")])
+        #expect(history.cursor == 0)
     }
 
-    @Test func capsAtMaxEntriesDroppingOldest() {
+    @Test func capsAtMaxEntriesEvictingTail() {
         var history = PaneHistory()
         for i in 1...20 {
             history.recordReplacement(outgoing: viewer("/\(i - 1)"), incoming: viewer("/\(i)"))
         }
 
         #expect(history.entries.count == PaneHistory.maxEntries)
-        #expect(history.entries.first == viewer("/11"), "oldest entries dropped")
-        #expect(history.entries.last == viewer("/20"))
+        #expect(history.entries.first == viewer("/20"), "newest at index 0")
+        #expect(history.entries.last == viewer("/11"), "oldest entries evicted")
         #expect(!history.canGoForward)
     }
 
-    @Test func goToJumpsToAbsoluteIndex() {
+    @Test func capEvictsTailNeverTheCurrentEntry() {
+        var history = PaneHistory()
+        for i in 1...10 {
+            history.recordReplacement(outgoing: viewer("/\(i - 1)"), incoming: viewer("/\(i)"))
+        }
+        // Walk back to the oldest entry (/1) at the tail.
+        for _ in 1...9 { _ = history.goBack() }
+        #expect(history.cursor == 9)
+
+        // Navigating from /1 first commits it to the front, so the cap
+        // evicts the tail (/2) — never the entry the user was viewing.
+        history.recordReplacement(outgoing: viewer("/1"), incoming: viewer("/new"))
+
+        #expect(history.entries.count == PaneHistory.maxEntries)
+        #expect(history.entries[0] == viewer("/new"))
+        #expect(history.entries[1] == viewer("/1"), "current entry survived the cap")
+        #expect(!history.entries.contains(viewer("/2")), "tail evicted")
+        #expect(history.cursor == 0)
+    }
+
+    @Test func goToJumpsCursorWithoutReordering() {
         var history = PaneHistory()
         history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
         history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/c"))
+        let before = history.entries
 
-        #expect(history.go(to: 0) == viewer("/a"))
-        #expect(!history.canGoBack)
+        #expect(history.go(to: 2) == viewer("/a"))
+        #expect(history.entries == before, "jump never reorders")
+        #expect(!history.canGoBack, "cursor at the oldest entry")
         #expect(history.canGoForward)
-        #expect(history.go(to: 0) == nil, "jumping to the cursor is a no-op")
+        #expect(history.go(to: 2) == nil, "jumping to the cursor is a no-op")
         #expect(history.go(to: 99) == nil)
     }
 
-    @Test func backAndForwardEntriesAreNearestFirst() {
+    @Test func buttonEnablementFollowsCursor() {
         var history = PaneHistory()
         history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
         history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/c"))
-        _ = history.goBack()  // at /b
 
-        #expect(history.backEntries.map(\.content) == [viewer("/a")])
-        #expect(history.forwardEntries.map(\.content) == [viewer("/c")])
+        // cursor 0: back only.
+        #expect(history.canGoBack && !history.canGoForward)
+        _ = history.goBack()
+        // cursor 1 (middle): both.
+        #expect(history.canGoBack && history.canGoForward)
+        _ = history.goBack()
+        // cursor 2 (oldest): forward only.
+        #expect(!history.canGoBack && history.canGoForward)
     }
 }
 
@@ -148,7 +198,8 @@ struct PaneHistoryAppStateTests {
             #expect(state.popHistoryForRemovedPane(slotID) == viewer)
             #expect(state.paneHistories[slotID]?.canGoForward == true)
 
-            // No back history left: the pane really goes away, history with it.
+            // Only the transcript remains besides the cursor entry: the pane
+            // really goes away, history with it.
             #expect(state.popHistoryForRemovedPane(slotID) == nil)
             #expect(state.paneHistories[slotID] == nil)
         }
@@ -169,7 +220,7 @@ struct PaneHistoryAppStateTests {
         }
     }
 
-    @Test func popHistoryForRemovedPaneRemovesWhenOnlyTranscriptsBehind() {
+    @Test func popHistoryForRemovedPaneRemovesWhenOnlyTranscriptsRemain() {
         withIsolatedDefaults { defaults in
             let state = AppState(userDefaults: defaults)
             let slotID = UUID()
@@ -180,6 +231,21 @@ struct PaneHistoryAppStateTests {
             // Nothing non-transcript to restore: pane really closes, history goes.
             #expect(state.popHistoryForRemovedPane(slotID) == nil)
             #expect(state.paneHistories[slotID] == nil)
+        }
+    }
+
+    @Test func popHistoryForRemovedPaneFindsViewerOnTheNewerSide() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            let slotID = UUID()
+            let transcript = PaneContent.liveTranscript(id: slotID, terminalID: UUID())
+            let viewer = PaneContent.codeViewer(id: slotID, path: "/a")
+            // transcript → viewer, then jump BACK onto the transcript entry.
+            state.recordPaneReplacement(.init(paneID: slotID, outgoing: transcript, incoming: viewer))
+            _ = state.paneHistories[slotID]?.goBack()
+
+            // No older non-transcript entry — the newer viewer is restored.
+            #expect(state.popHistoryForRemovedPane(slotID) == viewer)
         }
     }
 
@@ -198,7 +264,7 @@ struct PaneHistoryAppStateTests {
             // Corrupt the persisted blob: cursor beyond entries.count.
             let key = "com.tbd.app.paneHistories"
             let blob = String(data: defaults.data(forKey: key)!, encoding: .utf8)!
-                .replacingOccurrences(of: "\"cursor\":1", with: "\"cursor\":9")
+                .replacingOccurrences(of: "\"cursor\":0", with: "\"cursor\":9")
             defaults.set(Data(blob.utf8), forKey: key)
 
             let restored = AppState(userDefaults: defaults)

--- a/Tests/TBDAppTests/PaneHistoryTests.swift
+++ b/Tests/TBDAppTests/PaneHistoryTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+
+@testable import TBDApp
+
+@Suite("PaneHistory")
+struct PaneHistoryTests {
+    private let slotID = UUID()
+
+    private func viewer(_ path: String) -> PaneContent {
+        .codeViewer(id: slotID, path: path)
+    }
+
+    @Test func recordReplacement_bootstrapsWithOutgoingThenIncoming() {
+        var history = PaneHistory()
+        #expect(!history.canGoBack)
+        #expect(!history.canGoForward)
+
+        history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
+
+        #expect(history.entries == [viewer("/a"), viewer("/b")])
+        #expect(history.canGoBack)
+        #expect(!history.canGoForward)
+    }
+
+    @Test func recordReplacement_identicalContentIsNoOp() {
+        var history = PaneHistory()
+        history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/a"))
+        #expect(history.entries.isEmpty)
+    }
+
+    @Test func backAndForwardMoveCursorWithoutPushing() {
+        var history = PaneHistory()
+        history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
+        history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/c"))
+
+        #expect(history.goBack() == viewer("/b"))
+        #expect(history.goBack() == viewer("/a"))
+        #expect(history.goBack() == nil, "at the oldest entry")
+        #expect(history.goForward() == viewer("/b"))
+        #expect(history.goForward() == viewer("/c"))
+        #expect(history.goForward() == nil, "at the newest entry")
+        #expect(history.entries.count == 3, "navigation must not add entries")
+    }
+
+    @Test func replacementAfterGoingBackDropsForwardEntries() {
+        var history = PaneHistory()
+        history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
+        history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/c"))
+        _ = history.goBack()  // now at /b
+
+        history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/d"))
+
+        #expect(history.entries == [viewer("/a"), viewer("/b"), viewer("/d")])
+        #expect(!history.canGoForward, "/c must be gone")
+    }
+
+    @Test func capsAtMaxEntriesDroppingOldest() {
+        var history = PaneHistory()
+        for i in 1...20 {
+            history.recordReplacement(outgoing: viewer("/\(i - 1)"), incoming: viewer("/\(i)"))
+        }
+
+        #expect(history.entries.count == PaneHistory.maxEntries)
+        #expect(history.entries.first == viewer("/11"), "oldest entries dropped")
+        #expect(history.entries.last == viewer("/20"))
+        #expect(!history.canGoForward)
+    }
+
+    @Test func goToJumpsToAbsoluteIndex() {
+        var history = PaneHistory()
+        history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
+        history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/c"))
+
+        #expect(history.go(to: 0) == viewer("/a"))
+        #expect(!history.canGoBack)
+        #expect(history.canGoForward)
+        #expect(history.go(to: 0) == nil, "jumping to the cursor is a no-op")
+        #expect(history.go(to: 99) == nil)
+    }
+
+    @Test func backAndForwardEntriesAreNearestFirst() {
+        var history = PaneHistory()
+        history.recordReplacement(outgoing: viewer("/a"), incoming: viewer("/b"))
+        history.recordReplacement(outgoing: viewer("/b"), incoming: viewer("/c"))
+        _ = history.goBack()  // at /b
+
+        #expect(history.backEntries.map(\.content) == [viewer("/a")])
+        #expect(history.forwardEntries.map(\.content) == [viewer("/c")])
+    }
+}
+
+// MARK: - AppState integration
+
+@MainActor
+@Suite("PaneHistory AppState integration")
+struct PaneHistoryAppStateTests {
+    private func withIsolatedDefaults(_ body: (UserDefaults) -> Void) {
+        let suiteName = "TBDAppTests.PaneHistory.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(defaults)
+    }
+
+    @Test func persistenceRoundTrip() {
+        withIsolatedDefaults { defaults in
+            let slotID = UUID()
+            var history = PaneHistory()
+            history.recordReplacement(
+                outgoing: .liveTranscript(id: slotID, terminalID: UUID()),
+                incoming: .codeViewer(id: slotID, path: "/a.md")
+            )
+
+            let state = AppState(userDefaults: defaults)
+            state.paneHistories[slotID] = history
+
+            // A fresh AppState on the same suite restores the identical history.
+            let restored = AppState(userDefaults: defaults)
+            #expect(restored.paneHistories[slotID] == history)
+        }
+    }
+
+    @Test func recordPaneReplacementPushesIntoKeyedHistory() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            let slotID = UUID()
+
+            state.recordPaneReplacement(.init(
+                paneID: slotID,
+                outgoing: .codeViewer(id: slotID, path: "/a"),
+                incoming: .codeViewer(id: slotID, path: "/b")
+            ))
+
+            #expect(state.paneHistories[slotID]?.canGoBack == true)
+        }
+    }
+
+    @Test func prunePaneHistoriesDropsOrphansKeepsLiveSlots() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            let tabID = UUID()
+            let liveSlotID = UUID()
+            let orphanID = UUID()
+            state.layouts[tabID] = .split(
+                direction: .horizontal,
+                children: [
+                    .pane(.terminal(terminalID: tabID)),
+                    .pane(.codeViewer(id: liveSlotID, path: "/a")),
+                ],
+                ratios: [0.5, 0.5]
+            )
+            var history = PaneHistory()
+            history.recordReplacement(
+                outgoing: .codeViewer(id: liveSlotID, path: "/old"),
+                incoming: .codeViewer(id: liveSlotID, path: "/a")
+            )
+            state.paneHistories = [liveSlotID: history, orphanID: history]
+
+            state.prunePaneHistories()
+
+            #expect(state.paneHistories[liveSlotID] == history)
+            #expect(state.paneHistories[orphanID] == nil, "orphaned histories must not accumulate")
+        }
+    }
+}

--- a/Tests/TBDAppTests/PaneHistoryTests.swift
+++ b/Tests/TBDAppTests/PaneHistoryTests.swift
@@ -135,6 +135,78 @@ struct PaneHistoryAppStateTests {
         }
     }
 
+    @Test func popHistoryForRemovedPaneRestoresPreviousContent() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            let slotID = UUID()
+            let viewer = PaneContent.codeViewer(id: slotID, path: "/a")
+            let transcript = PaneContent.liveTranscript(id: slotID, terminalID: UUID())
+            state.recordPaneReplacement(.init(paneID: slotID, outgoing: viewer, incoming: transcript))
+
+            // Toggle-off on a reused slot restores the pre-transcript content
+            // instead of destroying the pane; the transcript stays reachable.
+            #expect(state.popHistoryForRemovedPane(slotID) == viewer)
+            #expect(state.paneHistories[slotID]?.canGoForward == true)
+
+            // No back history left: the pane really goes away, history with it.
+            #expect(state.popHistoryForRemovedPane(slotID) == nil)
+            #expect(state.paneHistories[slotID] == nil)
+        }
+    }
+
+    @Test func popHistoryForRemovedPaneSkipsChainedTranscripts() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            let slotID = UUID()
+            let viewer = PaneContent.codeViewer(id: slotID, path: "/a")
+            let transcriptT1 = PaneContent.liveTranscript(id: slotID, terminalID: UUID())
+            let transcriptT2 = PaneContent.liveTranscript(id: slotID, terminalID: UUID())
+            state.recordPaneReplacement(.init(paneID: slotID, outgoing: viewer, incoming: transcriptT1))
+            state.recordPaneReplacement(.init(paneID: slotID, outgoing: transcriptT1, incoming: transcriptT2))
+
+            // Toggling T2's transcript off must not resurrect T1's transcript.
+            #expect(state.popHistoryForRemovedPane(slotID) == viewer)
+        }
+    }
+
+    @Test func popHistoryForRemovedPaneRemovesWhenOnlyTranscriptsBehind() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            let slotID = UUID()
+            let transcriptT1 = PaneContent.liveTranscript(id: slotID, terminalID: UUID())
+            let transcriptT2 = PaneContent.liveTranscript(id: slotID, terminalID: UUID())
+            state.recordPaneReplacement(.init(paneID: slotID, outgoing: transcriptT1, incoming: transcriptT2))
+
+            // Nothing non-transcript to restore: pane really closes, history goes.
+            #expect(state.popHistoryForRemovedPane(slotID) == nil)
+            #expect(state.paneHistories[slotID] == nil)
+        }
+    }
+
+    @Test func restoreDropsMalformedPersistedHistory() {
+        withIsolatedDefaults { defaults in
+            let slotID = UUID()
+            var history = PaneHistory()
+            history.recordReplacement(
+                outgoing: .codeViewer(id: slotID, path: "/a"),
+                incoming: .codeViewer(id: slotID, path: "/b")
+            )
+
+            let state = AppState(userDefaults: defaults)
+            state.paneHistories = [slotID: history]
+
+            // Corrupt the persisted blob: cursor beyond entries.count.
+            let key = "com.tbd.app.paneHistories"
+            let blob = String(data: defaults.data(forKey: key)!, encoding: .utf8)!
+                .replacingOccurrences(of: "\"cursor\":1", with: "\"cursor\":9")
+            defaults.set(Data(blob.utf8), forKey: key)
+
+            let restored = AppState(userDefaults: defaults)
+            #expect(restored.paneHistories[slotID] == nil,
+                    "an out-of-range cursor must not be restored (crashes entries[cursor])")
+        }
+    }
+
     @Test func prunePaneHistoriesDropsOrphansKeepsLiveSlots() {
         withIsolatedDefaults { defaults in
             let state = AppState(userDefaults: defaults)

--- a/Tests/TBDAppTests/TranscriptRoutingTests.swift
+++ b/Tests/TBDAppTests/TranscriptRoutingTests.swift
@@ -12,7 +12,9 @@ struct TranscriptRoutingTests {
 
         let result = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: terminalID)
 
-        guard case .split(let dir, let children, _) = result else {
+        #expect(result.replaced == nil)
+        #expect(result.removedPaneID == nil)
+        guard case .split(let dir, let children, _) = result.layout else {
             Issue.record("Expected split result"); return
         }
         #expect(dir == .horizontal)
@@ -39,39 +41,83 @@ struct TranscriptRoutingTests {
         let result = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: terminalID)
 
         // removePane collapses a 2-child split to the surviving child.
-        #expect(result == .pane(.terminal(terminalID: terminalID)))
+        #expect(result.layout == .pane(.terminal(terminalID: terminalID)))
+        #expect(result.removedPaneID == transcriptID, "call site prunes this pane's history")
+        #expect(result.replaced == nil)
     }
 
-    @Test func toggleTranscript_opensWhenExistingTranscriptIsForDifferentTerminal() {
+    @Test func toggleTranscript_reusesViewerSlotForDifferentTerminalsTranscript() {
         let terminalA = UUID()
         let terminalB = UUID()
-        let transcriptForB = UUID()
+        let slotID = UUID()
+        let outgoing = PaneContent.liveTranscript(id: slotID, terminalID: terminalB)
         let layout = LayoutNode.split(
             direction: .horizontal,
             children: [
                 .pane(.terminal(terminalID: terminalA)),
-                .pane(.liveTranscript(id: transcriptForB, terminalID: terminalB)),
+                .pane(outgoing),
             ],
             ratios: [0.5, 0.5]
         )
 
         let result = toggleTranscript(into: layout, terminalID: terminalA, fromPaneID: terminalA)
 
-        // B's transcript must survive untouched.
-        let transcriptIDs = transcriptTerminalIDs(in: result)
-        #expect(transcriptIDs.contains(terminalB), "B's transcript must not be closed")
-        #expect(transcriptIDs.contains(terminalA), "a new transcript for A must be added")
-        #expect(transcriptIDs.count == 2, "exactly two transcript panes expected")
+        // B's transcript is a viewer-class slot: A's transcript replaces it in
+        // place, keeping the slot UUID.
+        guard case .split(_, let children, _) = result.layout,
+              case .pane(.liveTranscript(let id, let tid)) = children[1]
+        else {
+            Issue.record("Expected transcript slot in right child"); return
+        }
+        #expect(id == slotID, "slot UUID must be preserved")
+        #expect(tid == terminalA)
+        #expect(result.replaced == .init(
+            paneID: slotID,
+            outgoing: outgoing,
+            incoming: .liveTranscript(id: slotID, terminalID: terminalA)
+        ))
     }
 
-    /// Collects the `terminalID` carried by every `.liveTranscript` pane in the tree.
-    private func transcriptTerminalIDs(in node: LayoutNode) -> [UUID] {
-        switch node {
-        case .pane(let content):
-            if case .liveTranscript(_, let tid) = content { return [tid] }
-            return []
-        case .split(_, let children, _):
-            return children.flatMap { transcriptTerminalIDs(in: $0) }
+    @Test func toggleTranscript_reusesCodeViewerSlot() {
+        let terminalID = UUID()
+        let slotID = UUID()
+        let outgoing = PaneContent.codeViewer(id: slotID, path: "/a.md")
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(outgoing),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: terminalID)
+
+        guard case .split(_, let children, _) = result.layout,
+              case .pane(.liveTranscript(let id, let tid)) = children[1]
+        else {
+            Issue.record("Expected codeViewer slot replaced by transcript"); return
         }
+        #expect(id == slotID)
+        #expect(tid == terminalID)
+        #expect(result.replaced?.outgoing == outgoing)
+    }
+
+    @Test func toggleTranscript_splitsWhenOnlyNonViewerPanesExist() {
+        let terminalID = UUID()
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(.note(noteID: UUID())),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = toggleTranscript(into: layout, terminalID: terminalID, fromPaneID: terminalID)
+
+        #expect(result.replaced == nil, "note panes are not viewer-class — must split")
+        #expect(result.layout.allPaneIDs().count == 3)
+        #expect(result.layout.firstPaneID(where: { isLiveTranscriptPane($0, for: terminalID) }) != nil)
     }
 }

--- a/Tests/TBDAppTests/ViewerRoutingTests.swift
+++ b/Tests/TBDAppTests/ViewerRoutingTests.swift
@@ -12,7 +12,8 @@ struct ViewerRoutingTests {
 
         let result = routeFileClick(into: layout, terminalID: terminalID, path: "/a.md")
 
-        guard case .split(let dir, let children, _) = result else {
+        #expect(result.replaced == nil, "a split is not a replacement — no history push")
+        guard case .split(let dir, let children, _) = result.layout else {
             Issue.record("Expected split result"); return
         }
         #expect(dir == .horizontal)
@@ -38,7 +39,7 @@ struct ViewerRoutingTests {
 
         let result = routeFileClick(into: layout, terminalID: terminalID, path: "/new.md")
 
-        guard case .split(_, let children, let ratios) = result,
+        guard case .split(_, let children, let ratios) = result.layout,
               case .pane(.codeViewer(let id, let path)) = children[1]
         else {
             Issue.record("Expected codeViewer in right child"); return
@@ -46,6 +47,11 @@ struct ViewerRoutingTests {
         #expect(id == viewerID, "paneID must be preserved across path replacement")
         #expect(path == "/new.md")
         #expect(ratios == [0.6, 0.4], "split ratios must be preserved")
+        #expect(result.replaced == .init(
+            paneID: viewerID,
+            outgoing: .codeViewer(id: viewerID, path: "/old.md"),
+            incoming: .codeViewer(id: viewerID, path: "/new.md")
+        ))
     }
 
     @Test func routeFileClick_findsAndReplacesNestedViewer() {
@@ -69,7 +75,7 @@ struct ViewerRoutingTests {
 
         let result = routeFileClick(into: layout, terminalID: terminalID, path: "/new")
 
-        guard case .split(_, let topChildren, _) = result,
+        guard case .split(_, let topChildren, _) = result.layout,
               case .split(_, let nested, _) = topChildren[1],
               case .pane(.codeViewer(let id, let path)) = nested[1]
         else {
@@ -77,5 +83,102 @@ struct ViewerRoutingTests {
         }
         #expect(id == viewerID)
         #expect(path == "/new")
+    }
+
+    @Test func routeFileClick_reusesLiveTranscriptSlotKeepingID() {
+        let terminalID = UUID()
+        let slotID = UUID()
+        let outgoing = PaneContent.liveTranscript(id: slotID, terminalID: terminalID)
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(outgoing),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = routeFileClick(into: layout, terminalID: terminalID, path: "/a.md")
+
+        guard case .split(_, let children, _) = result.layout,
+              case .pane(.codeViewer(let id, let path)) = children[1]
+        else {
+            Issue.record("Expected transcript slot replaced by codeViewer"); return
+        }
+        #expect(id == slotID, "slot UUID must be preserved")
+        #expect(path == "/a.md")
+        #expect(result.replaced == .init(
+            paneID: slotID,
+            outgoing: outgoing,
+            incoming: .codeViewer(id: slotID, path: "/a.md")
+        ))
+    }
+
+    @Test func routeFileClick_reusesWebviewSlotKeepingID() {
+        let terminalID = UUID()
+        let slotID = UUID()
+        let outgoing = PaneContent.webview(id: slotID, url: URL(string: "https://example.com/x")!)
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(outgoing),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = routeFileClick(into: layout, terminalID: terminalID, path: "/a.md")
+
+        guard case .split(_, let children, _) = result.layout,
+              case .pane(.codeViewer(let id, _)) = children[1]
+        else {
+            Issue.record("Expected webview slot replaced by codeViewer"); return
+        }
+        #expect(id == slotID)
+        #expect(result.replaced?.outgoing == outgoing)
+    }
+
+    @Test func routeFileClick_prefersCodeViewerOverOtherViewerClassPanes() {
+        let terminalID = UUID()
+        let transcriptID = UUID()
+        let viewerID = UUID()
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                // Transcript comes FIRST in traversal order — the code viewer
+                // must still win.
+                .pane(.liveTranscript(id: transcriptID, terminalID: terminalID)),
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(.codeViewer(id: viewerID, path: "/old.md")),
+            ],
+            ratios: [0.3, 0.4, 0.3]
+        )
+
+        let result = routeFileClick(into: layout, terminalID: terminalID, path: "/new.md")
+
+        #expect(result.replaced?.paneID == viewerID)
+        guard case .split(_, let children, _) = result.layout,
+              case .pane(.liveTranscript(let tid, _)) = children[0]
+        else {
+            Issue.record("Expected transcript untouched"); return
+        }
+        #expect(tid == transcriptID, "transcript must survive when a codeViewer exists")
+    }
+
+    @Test func routeFileClick_doesNotReuseNotePane() {
+        let terminalID = UUID()
+        let layout = LayoutNode.split(
+            direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: terminalID)),
+                .pane(.note(noteID: UUID())),
+            ],
+            ratios: [0.5, 0.5]
+        )
+
+        let result = routeFileClick(into: layout, terminalID: terminalID, path: "/a.md")
+
+        #expect(result.replaced == nil, "note panes are not viewer-class — must split instead")
+        #expect(result.layout.allPaneIDs().count == 3)
     }
 }


### PR DESCRIPTION
## Summary

**Problem:** command-clicking a file path while a transcript pane was open split a *third* column instead of reusing the pane the user was already looking at — every navigation gesture grew the layout.

**The viewer-slot model:** viewer-class panes (`codeViewer`, `liveTranscript`, `webview`) now form one interchangeable "slot" per tab. Content-navigation gestures (command-click, transcript toggle) replace content *in* the slot, preserving the pane UUID — so SwiftUI view identity (including the `FileWatcher` `@StateObject`) stays stable. Explicit split gestures still create new panes.

**Per-slot history:** each slot gets back/forward history (`PaneHistory`, cap 10, UserDefaults-persisted, pruned on pane close / tab close / reconcile). The shared pane header shows back/forward chevrons with press-and-hold jump menus for codeViewer, liveTranscript, and webview panes. Navigation moves the cursor only — it bypasses the routers, so back/forward never re-pushes entries.

**Review-loop fixes** (second commit, from a 5-agent review pass):
- Transcript toggle-off on a reused slot restores the nearest non-transcript history entry in place instead of destroying the pane (toggle round-trip no longer eats the viewer the transcript replaced; chained transcript entries are skipped so closing one transcript never resurrects another's).
- `closeTab` prunes pane histories immediately instead of waiting for the next reconcile.
- `restorePaneHistories` drops decoded histories with an out-of-range cursor — previously a corrupt/skewed persisted blob would crash `entries[cursor]` in the pane header's view body (launch crash loop).

No feature flag: gesture-driven additive UI per CLAUDE.md policy (no autonomous action, no destructive state mutation, no wholesale path replacement).

**Known follow-up candidate (deliberately out of scope):** the `openFilePreview` closures (file clicks from transcript tool cards) still bypass the slot/history machinery — pre-existing side-by-side preview UX, untouched here.

Design home: `docs/specs/2026-07-20-panel-agent-surface-a-mirror-design.md` §7 (on branch `panel-system-redesign`).

## Test plan

- [x] `swift build` clean
- [x] `swift test`: 3685 tests / 440 suites green (includes new PaneHistory unit + AppState integration suites covering cursor semantics, forward truncation, cap, prune, toggle-off restore, malformed-persistence guard)
- [x] `swiftlint --strict`: 0 violations
- [ ] Live check: command-click with transcript open swaps in place; chevron press-and-hold shows jump menu

[viewer-slot-history](https://cheapsteak.github.io/tbd/open/?worktree=308213B4-EA0D-4A90-8381-A31157D1B083)

## Iterations from live testing

- **History is a tab-like MRU list, not a browser stack** (`0f032883`): no forward-truncation — A → B → back → C keeps all three. Back/forward/jump move a cursor without reordering; only a new navigation commits (current entry to front, new entry ahead of it, dedupe by moving, cap 10 evicting the tail — never the entry you're on). Both chevrons' menus show the same full list with a checkmark on the current entry.
- **Right-click opens the history menu directly** (`14a22158`): chevrons are plain Buttons (left-click steps) with the MRU list as a true `.contextMenu`; the header's file context menu is rescoped to the title label so it no longer swallows right-clicks on the controls.
- **Stable chevron position** (`4c510537`): back/forward moved to the header's leading edge in fixed 16×16 slots (rendered disabled when no history), so the presence of pane-specific trailing buttons (`</>`, copy-URL) never shifts them. Glyphs sized 8pt bold to sit visually with the ✕; hit areas unchanged.
