### PR TITLE
Feat: Copy a shareable link to a worktree or tab from its context menu

### DIFF
--- a/Sources/TBDApp/DeepLinkHandler.swift
+++ b/Sources/TBDApp/DeepLinkHandler.swift
@@ -10,10 +10,10 @@ private let logger = Logger(subsystem: "com.tbd.app", category: "deeplink")
 enum DeepLinkHandler {
     @MainActor
     static func handle(_ url: URL, appState: AppState) {
-        guard let worktreeID = DeepLink.parseOpenURL(url) else {
+        guard let target = DeepLink.parseOpenURL(url) else {
             logger.warning("Ignoring malformed deep link: \(url.absoluteString, privacy: .public)")
             return
         }
-        appState.navigateToWorktree(worktreeID)
+        appState.navigateToWorktree(target.worktree, terminalID: target.terminal)
     }
 }

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -22,6 +22,8 @@ enum RowActionMenu {
         case openInFinder
         case copyPath
         case copyBranch
+        /// Copy the shareable https deep link that opens this worktree.
+        case copyLink
         case archiveScratch
         case deleteScratch
         /// Manually hibernate all idle Claude sessions in this worktree.
@@ -283,6 +285,7 @@ enum RowActionMenu {
         var items: [Item] = [
             .action(Action(kind: .openInFinder, title: "Open in Finder")),
             .action(Action(kind: .copyPath, title: "Copy Path")),
+            .action(Action(kind: .copyLink, title: "Copy Link")),
         ]
         if !context.branch.isEmpty {
             items.append(.action(Action(kind: .copyBranch, title: "Copy Branch Name")))

--- a/Sources/TBDApp/Helpers/RowActionMenu.swift
+++ b/Sources/TBDApp/Helpers/RowActionMenu.swift
@@ -206,7 +206,7 @@ enum RowActionMenu {
     ///    Create Nested Worktree / New worktree from this branch.
     /// 4. Maintenance — Re-run pre-session hook when one resolves, else Create
     ///    pre-session hook… (repo-backed rows only).
-    /// 5. Filesystem — Open in Finder, Copy Path.
+    /// 5. Filesystem — Open in Finder, Copy Path, Copy Link.
     /// 6. (scratch only) Delete Scratch Space, with the promote-hint caption
     ///    beneath it.
     ///
@@ -278,9 +278,9 @@ enum RowActionMenu {
         Array(sections.filter { !$0.isEmpty }.joined(separator: [Item.divider]))
     }
 
-    /// Filesystem section: Open in Finder, Copy Path, and Copy Branch Name (the
-    /// last only when the worktree has a branch to copy). Shared by all three
-    /// branches so they stay in lockstep.
+    /// Filesystem section: Open in Finder, Copy Path, Copy Link, and Copy
+    /// Branch Name (the last only when the worktree has a branch to copy).
+    /// Shared by all three branches so they stay in lockstep.
     private static func filesystemActions(context: Context) -> [Item] {
         var items: [Item] = [
             .action(Action(kind: .openInFinder, title: "Open in Finder")),

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -107,6 +107,13 @@ struct RowActionMenuActions {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(worktree.branch, forType: .string)
 
+        case .copyLink:
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(
+                DeepLink.makeShareableOpenURL(worktree.id).absoluteString,
+                forType: .string
+            )
+
         case .archiveScratch:
             let wtID = worktree.id
             Task { await appState.archiveScratch(id: wtID) }

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -841,6 +841,17 @@ private struct TabBarItem: View {
         return "Copy Path"
     }
 
+    /// The terminal this tab renders, for deep-link anchoring — nil for
+    /// non-terminal panes (webview, code viewer, note), whose links fall back
+    /// to the worktree alone.
+    private var linkTerminalID: UUID? {
+        switch tab.content {
+        case .terminal(let terminalID): return terminalID
+        case .liveTranscript(_, let terminalID): return terminalID
+        default: return nil
+        }
+    }
+
     @ViewBuilder
     private var contextMenuContent: some View {
         if let path = copyablePath {
@@ -848,8 +859,16 @@ private struct TabBarItem: View {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(path, forType: .string)
             }
-            Divider()
         }
+
+        Button("Copy Link") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(
+                DeepLink.makeShareableOpenURL(worktreeID, terminalID: linkTerminalID).absoluteString,
+                forType: .string
+            )
+        }
+        Divider()
 
         if isClaudeTerminal {
             Button(formatProfileHeader(terminal?.profileID)) {}

--- a/Sources/TBDShared/DeepLinks.swift
+++ b/Sources/TBDShared/DeepLinks.swift
@@ -4,23 +4,53 @@ import Foundation
 public enum DeepLink {
     public static let scheme = "tbd"
     public static let openHost = "open"
+    /// GitHub Pages redirector that forwards its query onto `tbd://open` —
+    /// the shareable https form of a deep link (works in chat apps and
+    /// browsers that won't linkify a custom scheme).
+    public static let redirectorBase = "https://cheapsteak.github.io/tbd/open/"
 
-    /// Build a `tbd://open?worktree=<uuid>` URL for the given worktree.
-    public static func makeOpenWorktreeURL(_ id: UUID) -> URL {
+    /// Build a `tbd://open?worktree=<uuid>[&terminal=<uuid>]` URL for the
+    /// given worktree, optionally anchored to a specific terminal's tab.
+    public static func makeOpenWorktreeURL(_ id: UUID, terminalID: UUID? = nil) -> URL {
         var components = URLComponents()
         components.scheme = scheme
         components.host = openHost
-        components.queryItems = [URLQueryItem(name: "worktree", value: id.uuidString)]
+        components.queryItems = queryItems(worktreeID: id, terminalID: terminalID)
         guard let url = components.url else {
             preconditionFailure("DeepLink components produced an invalid URL")
         }
         return url
     }
 
-    /// Parse a `tbd://open?worktree=<uuid>` URL. Returns the worktree UUID on
-    /// success, or `nil` if the URL doesn't match the expected shape. Does NOT
-    /// validate that the worktree exists.
-    public static func parseOpenURL(_ url: URL) -> UUID? {
+    /// Build the shareable https form:
+    /// `https://cheapsteak.github.io/tbd/open/?worktree=<uuid>[&terminal=<uuid>]`.
+    /// The redirector page forwards both params onto the `tbd://` scheme.
+    public static func makeShareableOpenURL(_ id: UUID, terminalID: UUID? = nil) -> URL {
+        guard var components = URLComponents(string: redirectorBase) else {
+            preconditionFailure("DeepLink redirector base is an invalid URL")
+        }
+        components.queryItems = queryItems(worktreeID: id, terminalID: terminalID)
+        guard let url = components.url else {
+            preconditionFailure("DeepLink components produced an invalid URL")
+        }
+        return url
+    }
+
+    private static func queryItems(worktreeID: UUID, terminalID: UUID?) -> [URLQueryItem] {
+        var items = [URLQueryItem(name: "worktree", value: worktreeID.uuidString)]
+        if let terminalID {
+            items.append(URLQueryItem(name: "terminal", value: terminalID.uuidString))
+        }
+        return items
+    }
+
+    /// Parse a `tbd://open?worktree=<uuid>[&terminal=<uuid>]` URL. Returns the
+    /// worktree UUID (and the terminal UUID when present) on success, or `nil`
+    /// if the URL doesn't match the expected shape. A missing or malformed
+    /// `terminal` param never rejects the URL — the worktree still parses with
+    /// a nil terminal, so older or hand-edited links degrade gracefully. Does
+    /// NOT validate that the worktree or terminal exists.
+    public static func parseOpenURL(_ url: URL) -> (worktree: UUID, terminal: UUID?)? {
         guard
             let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
             components.scheme == scheme,
@@ -31,6 +61,8 @@ public enum DeepLink {
         else {
             return nil
         }
-        return id
+        let terminal = items.first(where: { $0.name == "terminal" })?.value
+            .flatMap(UUID.init(uuidString:))
+        return (worktree: id, terminal: terminal)
     }
 }

--- a/Tests/TBDAppTests/RowActionMenuTests.swift
+++ b/Tests/TBDAppTests/RowActionMenuTests.swift
@@ -71,6 +71,7 @@ struct RowActionMenuRegularTests {
             .createPreSessionHook,
             .openInFinder,
             .copyPath,
+            .copyLink,
             .copyBranch,
         ])
         // Section boundaries: after archive, after the hibernation block,
@@ -93,6 +94,7 @@ struct RowActionMenuRegularTests {
             .createPreSessionHook,
             .openInFinder,
             .copyPath,
+            .copyLink,
             .copyBranch,
         ])
         #expect(dividerIndices(items) == [2, 5, 7])
@@ -104,7 +106,7 @@ struct RowActionMenuRegularTests {
         // filesystem sections remain, joined by a single divider.
         let ctx = RowActionMenu.Context(hasRepoID: false, branch: "")
         let items = RowActionMenu.items(context: ctx)
-        #expect(kinds(items) == [.rename, .archive, .openInFinder, .copyPath])
+        #expect(kinds(items) == [.rename, .archive, .openInFinder, .copyPath, .copyLink])
         #expect(dividerIndices(items) == [2])
         expectWellFormedDividers(items)
     }
@@ -252,9 +254,10 @@ struct RowActionMenuScratchTests {
             .forkSession(terminalID: s.terminalID, profileID: s.profileID),
             .openInFinder,
             .copyPath,
+            .copyLink,
             .deleteScratch,
         ])
-        #expect(dividerIndices(items) == [2, 7, 9, 12])
+        #expect(dividerIndices(items) == [2, 7, 9, 13])
         // Promote hint caption is the very last item, under Delete.
         #expect(items.last == .caption(RowActionMenu.promoteHint))
         #expect(kinds(items).last == .deleteScratch)
@@ -272,9 +275,10 @@ struct RowActionMenuScratchTests {
             .archiveScratch,
             .openInFinder,
             .copyPath,
+            .copyLink,
             .deleteScratch,
         ])
-        #expect(dividerIndices(items) == [2, 5])
+        #expect(dividerIndices(items) == [2, 6])
         #expect(items.last == .caption(RowActionMenu.promoteHint))
         expectWellFormedDividers(items)
     }
@@ -303,6 +307,7 @@ struct RowActionMenuScratchTests {
             .forkSession(terminalID: s.terminalID, profileID: s.profileID),
             .openInFinder,
             .copyPath,
+            .copyLink,
             .deleteScratch,
         ])
         expectWellFormedDividers(items)
@@ -327,12 +332,12 @@ struct RowActionMenuScratchTests {
 struct RowActionMenuMainTests {
     @Test func mainShowsOnlyFinderAndCopyWhenPathPresent() {
         let ctx = RowActionMenu.Context(pathIsEmpty: false, status: .main)
-        #expect(kinds(RowActionMenu.items(context: ctx)) == [.openInFinder, .copyPath])
+        #expect(kinds(RowActionMenu.items(context: ctx)) == [.openInFinder, .copyPath, .copyLink])
     }
 
     @Test func creatingBehavesLikeMain() {
         let ctx = RowActionMenu.Context(pathIsEmpty: false, status: .creating)
-        #expect(kinds(RowActionMenu.items(context: ctx)) == [.openInFinder, .copyPath])
+        #expect(kinds(RowActionMenu.items(context: ctx)) == [.openInFinder, .copyPath, .copyLink])
     }
 
     @Test func emptyPathMainYieldsNoItems() {

--- a/Tests/TBDSharedTests/DeepLinksTests.swift
+++ b/Tests/TBDSharedTests/DeepLinksTests.swift
@@ -10,10 +10,37 @@ import Foundation
     #expect(url.absoluteString == "tbd://open?worktree=12345678-1234-1234-1234-123456789ABC")
 }
 
+@Test func makeOpenWorktreeURL_withTerminal_appendsTerminalParam() {
+    let id = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
+    let terminal = UUID(uuidString: "ABCDEFAB-0000-0000-0000-000000000001")!
+    let url = DeepLink.makeOpenWorktreeURL(id, terminalID: terminal)
+    #expect(url.absoluteString ==
+        "tbd://open?worktree=12345678-1234-1234-1234-123456789ABC&terminal=ABCDEFAB-0000-0000-0000-000000000001")
+}
+
 @Test func parseOpenURL_happyPath_returnsUUID() {
     let id = UUID()
     let url = DeepLink.makeOpenWorktreeURL(id)
-    #expect(DeepLink.parseOpenURL(url) == id)
+    let parsed = DeepLink.parseOpenURL(url)
+    #expect(parsed?.worktree == id)
+    #expect(parsed?.terminal == nil)
+}
+
+@Test func parseOpenURL_withTerminal_roundTrips() {
+    let id = UUID()
+    let terminal = UUID()
+    let url = DeepLink.makeOpenWorktreeURL(id, terminalID: terminal)
+    let parsed = DeepLink.parseOpenURL(url)
+    #expect(parsed?.worktree == id)
+    #expect(parsed?.terminal == terminal)
+}
+
+@Test func parseOpenURL_malformedTerminal_keepsWorktreeDropsTerminal() {
+    let id = UUID()
+    let url = URL(string: "tbd://open?worktree=\(id.uuidString)&terminal=not-a-uuid")!
+    let parsed = DeepLink.parseOpenURL(url)
+    #expect(parsed?.worktree == id)
+    #expect(parsed?.terminal == nil)
 }
 
 @Test func parseOpenURL_rejectsWrongScheme() {
@@ -39,5 +66,20 @@ import Foundation
 @Test func parseOpenURL_acceptsExtraQueryItems() {
     let id = UUID()
     let url = URL(string: "tbd://open?worktree=\(id.uuidString)&future=anchor")!
-    #expect(DeepLink.parseOpenURL(url) == id)
+    #expect(DeepLink.parseOpenURL(url)?.worktree == id)
+}
+
+@Test func makeShareableOpenURL_buildsRedirectorURL() {
+    let id = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
+    let url = DeepLink.makeShareableOpenURL(id)
+    #expect(url.absoluteString ==
+        "https://cheapsteak.github.io/tbd/open/?worktree=12345678-1234-1234-1234-123456789ABC")
+}
+
+@Test func makeShareableOpenURL_withTerminal_appendsTerminalParam() {
+    let id = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC")!
+    let terminal = UUID(uuidString: "ABCDEFAB-0000-0000-0000-000000000001")!
+    let url = DeepLink.makeShareableOpenURL(id, terminalID: terminal)
+    #expect(url.absoluteString ==
+        "https://cheapsteak.github.io/tbd/open/?worktree=12345678-1234-1234-1234-123456789ABC&terminal=ABCDEFAB-0000-0000-0000-000000000001")
 }

--- a/docs/open/index.html
+++ b/docs/open/index.html
@@ -54,6 +54,10 @@
       var raw = params.get('worktree') || '';
       // Accept either a UUID or a worktree slug (letters, digits, hyphens, underscores).
       var ok = /^[A-Za-z0-9_-]{1,128}$/.test(raw);
+      // Optional terminal anchor: same validation; invalid → drop it but keep
+      // the worktree (graceful degradation, mirrors the app's parser).
+      var rawTerminal = params.get('terminal') || '';
+      var terminalOk = /^[A-Za-z0-9_-]{1,128}$/.test(rawTerminal);
       var status = document.getElementById('status');
       var manual = document.getElementById('manual');
       var link = document.getElementById('link');
@@ -67,6 +71,11 @@
       }
 
       var target = 'tbd://open?worktree=' + encodeURIComponent(raw);
+      if (terminalOk) {
+        target += '&terminal=' + encodeURIComponent(rawTerminal);
+      } else if (rawTerminal) {
+        console.log('[tbd-open] terminal param invalid — dropping it, keeping worktree');
+      }
       console.log('[tbd-open] computed target:', target);
       link.href = target;
       manual.hidden = false;


### PR DESCRIPTION
## Summary
- Adds a **Copy Link** action to the sidebar worktree row context menu and the tab bar's tab context menu, copying an https deep link that opens TBD to that worktree — and, for terminal/transcript tabs, selects that tab.
- Deep links gain an optional `terminal` param: `tbd://open?worktree=<uuid>&terminal=<uuid>`. `parseOpenURL` degrades gracefully — a missing or malformed `terminal` still opens the worktree (the `&future=anchor` forward-compat test still passes). The app threads the parsed terminal ID into the existing `navigateToWorktree(_:terminalID:)` tab-selection plumbing, including the cold-start buffer.
- Copied links use the Pages redirector form (`https://cheapsteak.github.io/tbd/open/?worktree=<uuid>[&terminal=<uuid>]`) so they're clickable when pasted into GitHub/Slack; `docs/open/index.html` now forwards the `terminal` param with the same regex validation as `worktree`, dropping it (but keeping the redirect) if invalid.

No feature flag: small additive UI, no autonomous behavior or state mutation.

## Test plan
- [ ] `swift test` — full suite green (3678 tests), including new DeepLinks round-trip/degradation cases and updated RowActionMenu divider-index expectations
- [ ] Right-click a sidebar worktree row → Copy Link → paste: worktree-only redirector URL
- [ ] Right-click a terminal tab → Copy Link → paste: URL includes `&terminal=<uuid>`; opening it (after redeploying Pages via merge) switches to that worktree and selects that tab
- [ ] Right-click a non-terminal tab (code viewer/note) → Copy Link copies the worktree-only link

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=C0504EAE-FBB0-42E3-AEDA-E3A5F7E1CF71)