### PR TITLE
fix(restart): match WIP app process against bundle binary path, not unwrapped binary

### DIFF
--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -268,8 +268,11 @@ if [ "$install_to_applications" = true ]; then
     APP_EXEC_PATTERN="$(printf '%s' "$BUNDLED_EXEC_PATH" | sed 's/[.+*?()\[\]^$|\\]/\\&/g')"
 else
     # WIP build: skip /Applications install, launch from .build/debug instead.
-    # Use the unwrapped binary path for pgrep/pkill matching.
-    APP_EXEC_PATH="$(/usr/bin/readlink -f "$BUILD_DIR/TBDApp")"
+    # We launch via `open "$BUNDLE_DIR"` below, so the running process's
+    # command line is the bundle binary (.../TBD.app/Contents/MacOS/TBDApp),
+    # not the unwrapped swift-build output. Match pgrep/pkill against the
+    # resolved bundle path so the end-anchored pattern actually hits.
+    APP_EXEC_PATH="$(/usr/bin/readlink -f "$BUNDLE_MACOS/TBDApp")"
     APP_EXEC_PATTERN="$(printf '%s' "$APP_EXEC_PATH" | sed 's/[.+*?()\[\]^$|\\]/\\&/g')"
 fi
 


### PR DESCRIPTION
## Problem

On the WIP (non-installed) path, `restart.sh` launches the app with `open "$BUNDLE_DIR"` (`.build/debug/TBD.app`), so the live process's command line is the bundle binary: `.build/arm64-apple-macosx/debug/TBD.app/Contents/MacOS/TBDApp` (verified live via ps).

But the WIP branch computed the pgrep/pkill match pattern from the unwrapped swift-build output, `readlink -f "$BUILD_DIR/TBDApp"` → `.build/arm64-apple-macosx/debug/TBDApp`. Since both pgrep and pkill use an end-anchored full-path pattern (`^...$`), it could never match the running process. Two consequences on every WIP restart:

- A false `ERROR: App failed to launch` was printed even though the app launched fine.
- The preceding `pkill` never killed the previous WIP instance, leaving it running.

## Fix

One-line change: compute `APP_EXEC_PATH` from the bundle binary instead — `readlink -f "$BUNDLE_MACOS/TBDApp"`. Keeping `readlink -f` resolves the `.build/debug` symlink the same way the running process's kernel-reported path does, so the end-anchored pattern matches. This mirrors what the full-install path already does (it matches against the installed bundle's binary).

## Verification

- `bash -n scripts/restart.sh` passes
- `scripts/restart-guard-lib.test.sh` all green (guard lib contains no pattern logic, so no test changes needed)