### PR TITLE
Fix: Volta-installed agents vanish from the New Tab menu when TBD launches outside a shell

### DIFF
--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -234,6 +234,7 @@ struct AgentExecutableAvailability: Equatable {
             .map(String.init)
         let fallbackDirs = [
             "\(homeDir)/.local/bin",
+            "\(homeDir)/.volta/bin",
             "/opt/homebrew/bin",
             "/usr/local/bin",
             "/usr/bin",

--- a/Tests/TBDAppTests/AddTabMenuTests.swift
+++ b/Tests/TBDAppTests/AddTabMenuTests.swift
@@ -74,6 +74,20 @@ private func makeExecutable(named name: String, in directory: URL) throws {
     #expect(availability.codex)
 }
 
+@Test func agentExecutableAvailability_detectsVoltaBinFallback() throws {
+    let home = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-agent-home-\(UUID().uuidString)", isDirectory: true)
+    let voltaBin = home.appendingPathComponent(".volta/bin", isDirectory: true)
+    try FileManager.default.createDirectory(at: voltaBin, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: home) }
+    try makeExecutable(named: "codex", in: voltaBin)
+
+    let availability = AgentExecutableAvailability.detect(path: nil, homeDir: home.path)
+
+    #expect(availability.claude == false)
+    #expect(availability.codex)
+}
+
 @MainActor
 @Test func addTabMenu_withNoProfiles_insertsNoProfileItems() {
     let menu = AddTabMenu.build(profiles: [], coordinator: makeCoordinator())


### PR DESCRIPTION
## Summary

**What's broken:** With `codex` installed via Volta (which intercepts `npm i -g`, so the shim lives only in `~/.volta/bin`), the New Tab "+" menu stops offering Codex whenever TBD.app runs with a PATH that lacks `~/.volta/bin` — typical for a GUI launch of `/Applications/TBD.app`. The same applies to a Volta-managed `claude`.

**Why it happens:** `AgentExecutableAvailability.isExecutableOnPath` scans the app process's PATH plus a hardcoded `fallbackDirs` list precisely to cover minimal GUI-launch PATHs, but that list (`~/.local/bin`, homebrew, system dirs) never included `~/.volta/bin`.

**How it got broken:** Latent since the availability gate was introduced in PR #245 — it only bites when the agent binary exists *solely* under Volta and the app's inherited PATH omits it, so it went unnoticed while launches happened from volta-enabled shells.

**What this PR does:** Adds `~/.volta/bin` to `fallbackDirs`. One line; detection already dedups and short-circuits, and the daemon-side spawn path (tmux login shell) is unaffected.

## Test plan
- [x] New test: executable at `<tmpHome>/.volta/bin/codex` with empty PATH → `codex: true` (`swift test --filter AddTabMenu`, 18 tests pass, new test confirmed executed)
- [ ] Live: with codex only in `~/.volta/bin`, open the "+" menu from a GUI-launched TBD.app — Codex appears

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=B9401F0C-140D-4987-815D-8533E0C0581B)