### PR TITLE
Fix: Remove dead space around profile rows in the new-worktree hover menu

### DIFF
--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -55,10 +55,12 @@ struct WorktreeProfilePickerView: View {
         }
         .frame(width: 300)
         // Height is per-page: `.branches` needs a 320pt minimum so the
-        // searchable list stays usable, while `.profiles` hugs its rows. The
-        // hosting `FloatingPanel` tracks SwiftUI content-size changes
-        // (NSHostingView sizing), so switching pages resizes the panel in
-        // place with its top edge pinned.
+        // searchable list stays usable, while `.profiles` hugs its rows.
+        // `FloatingPanel` never re-fits after `showAsMenu`, and doesn't need
+        // to: `NSHostingView`'s default `sizingOptions` constrain the panel to
+        // the SwiftUI content's ideal size, so AppKit autolayout resizes the
+        // borderless panel in place (top edge pinned) when `page` flips — no
+        // explicit `setFrame` hook (cf. `HoverCard.apply`) is required.
         .frame(minHeight: page == .branches ? 320 : nil, alignment: .top)
         .task {
             // Ensure the list (and usage suffixes) are populated even if the

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -16,7 +16,9 @@ import TBDShared
 ///    a back affordance. Selecting a branch creates a worktree on that existing
 ///    branch using the DEFAULT model (accepted tradeoff).
 ///
-/// Modeled on `BranchPickerView` for consistent popover sizing/styling.
+/// Width matches `BranchPickerView` for consistent popover styling; height is
+/// per-page (see `body`) so the short profiles list isn't padded out to the
+/// branch list's minimum.
 struct WorktreeProfilePickerView: View {
     let repoID: UUID
     /// When set, created worktrees are nested under this parent (the nested `+`
@@ -52,7 +54,12 @@ struct WorktreeProfilePickerView: View {
             }
         }
         .frame(width: 300)
-        .frame(minHeight: 320)
+        // Height is per-page: `.branches` needs a 320pt minimum so the
+        // searchable list stays usable, while `.profiles` hugs its rows. The
+        // hosting `FloatingPanel` tracks SwiftUI content-size changes
+        // (NSHostingView sizing), so switching pages resizes the panel in
+        // place with its top edge pinned.
+        .frame(minHeight: page == .branches ? 320 : nil, alignment: .top)
         .task {
             // Ensure the list (and usage suffixes) are populated even if the
             // user hasn't opened Settings yet this session.


### PR DESCRIPTION
## Summary

**What's broken:** hovering the `+` on a repo shows the "New worktree with…" profile picker floating a handful of rows in the middle of a much taller panel — empty space above the header and below the last profile.

**Why:** the view applied `.frame(minHeight: 320)` to *both* of its in-place pages. The 320pt minimum only exists for the "Choose a branch…" drill-in page (the searchable `BranchListView`); the profiles page is usually far shorter, so SwiftUI centered it inside the oversized frame.

**What this PR does:** makes the min-height conditional — the profiles page now hugs its content (top-aligned, width still 300), while the branches page keeps its 320pt minimum.

**Why no explicit panel re-fit is needed** (re: the review's High finding): `FloatingPanel` indeed never calls `setFrame` after `showAsMenu`, but `NSHostingView`'s default `sizingOptions` constrain the panel to the SwiftUI content's ideal size, so AppKit autolayout resizes the borderless panel in place when `page` flips — unlike `HoverCard`, whose hosted content is swapped from *outside* via `rootView` reassignment and therefore needs its explicit `invalidateIntrinsicContentSize()` + re-position hook. Confirmed two ways: a standalone harness replicating the exact setup (borderless `NSPanel` + `NSHostingView` contentView + internal `@State` page flip; observed 300×128 → 300×320 → back, top edge pinned), and manually in the real app built from this branch.

## Test plan
- [x] `swift build` passes
- [x] Hover the `+` next to a repo: the profile menu is only as tall as its rows (no dead space top/bottom)
- [x] Click "Choose a branch…": the panel grows to the 320pt list, top edge pinned; "Back" shrinks it again (verified manually in the running app)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=DE3F4520-AFD2-4A80-8626-6E2AD8D25D08)