### PR TITLE
Fix: Forked Claude tabs no longer share the original's session UUID

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -13,6 +13,10 @@ import TBDShared
 /// - `resumeID` non-nil → `claude --resume <id> --dangerously-skip-permissions`
 ///   with optional trailing initial-prompt arg (delivered atomically with the
 ///   resume — no post-spawn paste, so it can never land in the wrong process).
+///   With `forkSession: true`, ` --fork-session` is appended: Claude Code's
+///   `--resume` REUSES the original session ID unless that flag is passed, and
+///   the `.fork` swap mode needs a genuinely new ID because the source session
+///   stays live (otherwise both processes write the same session JSONL).
 /// - `freshSessionID` non-nil → `claude --session-id <id> --dangerously-skip-permissions`
 ///   with optional `--append-system-prompt` and trailing initial-prompt arg.
 /// - Otherwise → `cmd` if set, else `shellFallback`.
@@ -47,6 +51,7 @@ enum ClaudeSpawnCommandBuilder {
 
     static func build(
         resumeID: String?,
+        forkSession: Bool = false,
         freshSessionID: String?,
         appendSystemPrompt: String?,
         initialPrompt: String?,
@@ -87,7 +92,8 @@ enum ClaudeSpawnCommandBuilder {
 
         let base: String
         if let resumeID {
-            var b = "claude --resume \(resumeID) --dangerously-skip-permissions\(settingsFlag)\(pluginFlag)"
+            let forkFlag = forkSession ? " --fork-session" : ""
+            var b = "claude --resume \(resumeID)\(forkFlag) --dangerously-skip-permissions\(settingsFlag)\(pluginFlag)"
             if let p = initialPrompt, !p.isEmpty {
                 b += " \(SystemPromptBuilder.shellEscape(p))"
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -973,10 +973,15 @@ extension RPCRouter {
         //   .fork — explicit "Fork session": spawn a NEW window + terminal row,
         //     leaving the source session untouched (the old behavior).
         //
-        // In both modes, if the existing session has conversation content,
-        // `claude --resume` forks it into a fresh session file (recaptured
-        // below). If the session is blank, resuming would produce "no
-        // conversation found", so we spawn a brand-new session instead.
+        // In both modes, if the existing session has conversation content we
+        // `claude --resume` it. `--resume` REUSES the original session ID;
+        // `.fork` mode additionally passes `--fork-session` so the fork gets a
+        // genuinely new ID (the source session stays live — same-ID resume
+        // would have both processes writing the same session JSONL), and the
+        // recapture below picks up that new ID. `.inPlace` keeps the same ID:
+        // the original process is killed, so same-ID resume is correct. If the
+        // session is blank, resuming would produce "no conversation found",
+        // so we spawn a brand-new session instead.
         let mode = params.resolvedMode
         let repo: Repo?
         if let rid = worktree.repoID {
@@ -1074,6 +1079,7 @@ extension RPCRouter {
             logger.debug("swap: resuming session \(resumeID, privacy: .public)")
             spawn = ClaudeSpawnCommandBuilder.build(
                 resumeID: resumeID,
+                forkSession: mode == .fork,
                 freshSessionID: nil,
                 appendSystemPrompt: nil,
                 initialPrompt: nil,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1327,10 +1327,12 @@ extension RPCRouter {
         }
     }
 
-    /// Schedule the post-resume session-id recapture. `claude --resume <id>`
-    /// forks the conversation into a NEW session file with a fresh UUID; mirror
-    /// the wake path's pattern — wait ~5s for Claude to settle, then capture the
-    /// new id from the pane and persist it against `terminalID`.
+    /// Schedule the post-resume session-id recapture. `claude --resume <id>
+    /// --fork-session` (the `.fork` swap path) forks the conversation into a NEW
+    /// session file with a fresh UUID; mirror the wake path's pattern — wait ~5s
+    /// for Claude to settle, then capture the new id from the pane and persist it
+    /// against `terminalID`. (On the `.inPlace` path there is no `--fork-session`,
+    /// so the id is unchanged and the recapture is a harmless no-op.)
     private func scheduleSessionRecapture(terminalID: UUID, paneID: String, server: String) {
         let tmuxRef = self.tmux
         let dbRef = self.db

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -28,6 +28,35 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(r.sensitiveEnv == ["CLAUDE_CODE_NO_FLICKER": "1", "DISABLE_AUTO_UPDATE": "true"])
     }
 
+    @Test("resume + forkSession appends --fork-session (fork needs a new session ID)")
+    func resumeWithForkSession() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc-123",
+            forkSession: true,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(r.command == "claude --resume abc-123 --fork-session --dangerously-skip-permissions")
+    }
+
+    @Test("resume default (forkSession false) omits --fork-session")
+    func resumeDefaultOmitsForkSession() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc-123",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh"
+        )
+        #expect(!r.command.contains("--fork-session"))
+    }
+
     @Test("fresh session id only")
     func freshOnly() {
         let r = ClaudeSpawnCommandBuilder.build(

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -636,6 +636,96 @@ struct ModelProfileSpawnTests {
         #expect(joined.contains("CLAUDE_CONFIG_DIR="))
     }
 
+    // MARK: - Swap over a NON-BLANK session: resume + --fork-session flag
+
+    /// Seed a real claude terminal, then give its session a NON-blank transcript
+    /// on disk (via `transcriptPath`) so `ClaudeSessionScanner.isSessionBlank`
+    /// returns false and `planTerminalSwap` picks the `.resume` branch. Returns
+    /// the created terminal.
+    private func seedNonBlankClaudeTerminal(
+        _ router: RPCRouter, _ db: TBDDatabase, worktreeID: UUID
+    ) async throws -> Terminal {
+        let createResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: worktreeID, type: .claude)
+        ))
+        #expect(createResp.success)
+        let term = try createResp.decodeResult(Terminal.self)
+        let sessionID = try #require(term.claudeSessionID)
+
+        // Write a transcript carrying a real user message; point the row at it so
+        // isSessionBlank reads content (not the empty projects scan) → non-blank.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-swap-transcript-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("\(sessionID).jsonl")
+        try #"{"type":"user","message":{"role":"user","content":"hello there"}}"#
+            .write(to: file, atomically: true, encoding: .utf8)
+        try await db.terminals.updateSession(id: term.id, sessionID: sessionID, transcriptPath: file.path)
+        return term
+    }
+
+    /// REGRESSION (PR #480): a `.fork` swap over a NON-BLANK session must reach
+    /// the `.resume` plan AND emit `--fork-session`, so the fork gets a genuinely
+    /// new session id while the source session keeps writing its own JSONL. The
+    /// blank-session sibling (`swapToDifferentToken`) can't catch this — it takes
+    /// the `.fresh` path, which never adds the flag.
+    @Test("fork on non-blank session: router emits claude --resume WITH --fork-session")
+    func forkOverNonBlankEmitsForkSessionFlag() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let a = try await seedOAuthProfile(db, name: "A")
+        let b = try await seedOAuthProfile(db, name: "B")
+        try await db.config.setDefaultProfileID(a.id)
+
+        let oldTerm = try await seedNonBlankClaudeTerminal(router, db, worktreeID: wt.id)
+
+        let beforeSwap = recorder.calls.count
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(terminalID: oldTerm.id, newProfileID: b.id, mode: .fork)
+        ))
+        #expect(swapResp.success)
+
+        let postSwap = Array(recorder.calls.dropFirst(beforeSwap))
+        let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
+        // Non-blank → resume plan, and .fork adds --fork-session.
+        #expect(joined.contains("claude --resume \(oldTerm.claudeSessionID!)"),
+                "fork over a non-blank session must resume the source id; got: \(joined)")
+        #expect(joined.contains("--fork-session"),
+                "fork mode must append --fork-session so the fork gets a new id; got: \(joined)")
+    }
+
+    /// Inverse branch guard: the same non-blank session swapped `.inPlace` still
+    /// resumes but must NOT carry `--fork-session` (the source process is killed,
+    /// so a same-id resume is correct — no fork).
+    @Test("in-place swap on non-blank session: resumes WITHOUT --fork-session")
+    func inPlaceOverNonBlankOmitsForkSessionFlag() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let a = try await seedOAuthProfile(db, name: "A")
+        let b = try await seedOAuthProfile(db, name: "B")
+        try await db.config.setDefaultProfileID(a.id)
+
+        let oldTerm = try await seedNonBlankClaudeTerminal(router, db, worktreeID: wt.id)
+
+        let beforeSwap = recorder.calls.count
+        let swapResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(terminalID: oldTerm.id, newProfileID: b.id, mode: .inPlace)
+        ))
+        #expect(swapResp.success)
+
+        let postSwap = Array(recorder.calls.dropFirst(beforeSwap))
+        let joined = postSwap.map { $0.joined(separator: " ") }.joined(separator: "\n")
+        #expect(joined.contains("claude --resume \(oldTerm.claudeSessionID!)"),
+                "in-place swap over a non-blank session must resume the source id; got: \(joined)")
+        #expect(!joined.contains("--fork-session"),
+                "in-place swap must NOT fork the session; got: \(joined)")
+    }
+
     // MARK: - Swap: to nil
 
     @Test("fork: to nil forks new tab with no env prefix; old tab untouched")


### PR DESCRIPTION
## Summary

**What's broken:** "Fork Session" spawned a new tab that shared the *same* session UUID as the source. Two live `claude` processes then appended to the same session JSONL, risking interleaved/corrupted transcripts, and the DB pointed both terminal rows at one session.

**Why it happens:** The fork path spawns `claude --resume <id>` and relied on Claude Code's old behavior where `--resume` forked into a fresh session file. Current Claude Code (2.1.x) *reuses* the original session ID on `--resume` and only mints a new one with the explicit `--fork-session` flag. So `scheduleSessionRecapture` dutifully "recaptured" the identical ID.

**How it got broken:** Latent — the code was correct when written; a Claude Code CLI semantics change (bare `--resume` stopped forking) turned it into a bug. No test caught it because the builder was never asserted against the live CLI's fork behavior, and the fork-mode swap tests exercise blank sessions (which take the fresh-spawn path, not resume).

**What this PR does:** Adds a `forkSession` flag to `ClaudeSpawnCommandBuilder` that appends `--fork-session` on the resume path, and passes `forkSession: mode == .fork` from the swapProfile handler. `.inPlace` ("Switch account") deliberately does *not* fork — same-ID resume is correct there since the original process is killed. Recapture then picks up the genuinely-new ID on the fork path as originally designed.

Out of scope (left untouched): hibernation wake and history/terminal.create resume — same-ID resume is intended for those (original process is dead).

## Test plan
- [x] `swift build`
- [x] `swift test --filter ClaudeSpawnCommandBuilder` (46 tests) — new `resumeWithForkSession` / `resumeDefaultOmitsForkSession` cover both branches
- [x] `swift test --filter ModelProfileSpawnTests` (28) + `TerminalSwapPlanTests` (5)
- [ ] Live: Fork a non-blank Claude session; confirm the new tab's session UUID differs from the source and both transcripts stay independent

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=26E4DAB9-CE05-4E06-B573-37395C34CBC4)

https://claude.ai/code/session_012NPnXFcgreWBNqJVRSPiNt