### PR TITLE
docs: land panel agent-surface specs

### DIFF
--- a/docs/specs/2026-07-20-panel-agent-surface-a-mirror-design.md
+++ b/docs/specs/2026-07-20-panel-agent-surface-a-mirror-design.md
@@ -1,0 +1,265 @@
+# Panel Agent Surface — Approach A: App-Owned Runtime, Daemon-Persisted Mirror
+
+**Status:** Draft for review (competing spec: Approach B, daemon-owned source of truth — see `2026-07-20-panel-agent-surface-b-daemon-owned-design.md`)
+**Date:** 2026-07-20
+
+## 1. Context & Goals
+
+TBD's app already has a real panel model (a recursive split tree of typed panes per tab), but it is invisible and unreachable from outside the app process. Agents spawned by TBD have exactly two UI levers today — `tbd notify` and `tbd terminal focus` — and the bundled `tbd` skill never mentions panels. Meanwhile panel layout persists only as a UserDefaults JSON blob the daemon knows nothing about, while tab labels/order/active-tab persist in the daemon DB: a split-brain.
+
+Goals of this design:
+
+1. **See** — an agent can query the pane tree for its worktree: which tabs and panes exist, the split arrangement and ratios, and what each pane renders as a *reference* (file path, URL, terminal ID, "transcript") — never rendered contents.
+2. **Arrange** — an agent can split, close, resize, move panes and switch tabs, through the same code paths user gestures use.
+3. **Unify persistence** — panel layout becomes reconstructable from the daemon DB, ending the UserDefaults/SQLite split-brain and laying the foundation for later two-way features (agent read-back of view state, user annotations).
+4. **Per-panel history** — each pane keeps a back/forward stack of its last ~10 contents, surviving app restart.
+5. **Native-feeling resize** — one shared divider component with a hover affordance replaces the five hand-rolled divider implementations.
+
+Non-goals (v1): rendering *new* content types ("show this HTML/markdown/diff" — deferred to a separate design), reading rendered contents back, annotations, cross-worktree arrangement by default.
+
+## 2. Current State (anchored)
+
+- **Model:** `PaneContent` enum — `.terminal(terminalID)`, `.webview(id,url)`, `.codeViewer(id,path)`, `.note(noteID)`, `.liveTranscript(id,terminalID)` (`Sources/TBDApp/Terminal/PaneContent.swift:5`). `Tab` wraps one primary `PaneContent` (`PaneContent.swift:25`). `LayoutNode` is the recursive `.pane`/`.split(direction,children,ratios)` tree (`Sources/TBDApp/Terminal/LayoutNode.swift:12`) with helpers (`splitPane`, `removePane`, `allPaneIDs`, `replacingContent(at:with:)`) and a hand-written Codable that keeps legacy on-disk compat (`LayoutNode.swift:192`).
+- **State:** all in `AppState`: `layouts: [UUID: LayoutNode]`, `tabs`, `activeTabIndices`, `worktreeTabOrders` (`Sources/TBDApp/AppState.swift:401-406`). The tree for a tab is `layouts[tab.id] ?? .pane(tab.content)` (`TerminalContainerView.swift:267-270`).
+- **Persistence split-brain:** layout trees → UserDefaults blob (`persistLayouts()`/`restoreLayouts()`, `AppState.swift:878-887`); tab labels/order/active → daemon DB (`tab` table + `worktree.tabOrder`/`activeTabID`, migrations `v19`/`v20`, `Sources/TBDDaemon/Database/Database.swift:433-449`; sparse rows per `TabStore.swift:44`).
+- **Mutation paths:** splits/close/viewer-reuse live in `PanePlaceholder.swift` (`splitRight()` :523, `createTerminalSplit` :546, `routeFileClick` via `Panes/ViewerRouting.swift:15`, `toggleTranscriptPane` :535 → `TranscriptRouting.swift:21`); tab switch/close/reorder in `AppState+Tabs.swift`.
+- **Agent surface:** none. No panel RPC, no panel CLI, no skill mention. Only push channel is `StateDelta` broadcast (`Sources/TBDShared/StateDelta.swift:6`), and the only agent-reachable UI deltas are notifications/focus.
+- **Known warts in scope:** `layouts` dict keyed by `tab.id` in the single-worktree path but by `worktreeID` in the multi-worktree grid (`TerminalContainerView.swift:572-576`); dead split stubs (`AppState+Worktrees.swift:1012-1034`).
+- **Dividers:** five hand-rolled `DragGesture` implementations (file panel `ContentView.swift:672-694`; terminal splits `SplitLayoutView.swift:161-233`; dock split `TerminalContainerView.swift:605-668`; dock cells `PinnedTerminalDock.swift:50-100`; archived list `ArchivedWorktreesView.swift:203-218`), sharing only the `.cursor()` AppKit cursor-rect bridge (`SplitLayoutView.swift:237-274`). Terminal-adjacent dividers deliberately defer commit to drag-end because live resize fires tmux resize RPCs (debounce serializer, `TerminalPanelView.swift:1009-1049`).
+
+## 3. Decisions (fixed, not open)
+
+- v1 agent verbs are **See** (layout + content references, never contents) and **Arrange** (split, close, resize ratios, move panes, switch tabs). **Show/render is deferred** to a separate future design; v1 introduces no new content types.
+- Agent-created splits may hold any *existing* pane type: terminal (new or existing), live transcript, code viewer on a path, webview on a URL, note.
+- **Transcript is a panel like any other.** No special-casing. The toolbar transcript trigger already derives its lit/dark state from the shared `isLiveTranscriptPane` check (`TranscriptRouting.swift:10`, used by both the toggle at `PanePlaceholder.swift:535` and the open-state check at `:540`), so "goes dark when not visible" already holds; no change needed beyond *not* adding protections.
+- Two-way (read-back, annotations) must not be precluded by the data model, but v1 is one-way push + reference/layout queries.
+- Per-panel history: stack of last **10** contents per pane slot; back/forward in the pane header; right-click on either button shows a jump menu; survives app restart.
+- Agent operations default-scope to the agent's own worktree (`TBD_WORKTREE_ID`); `--worktree <id|name>` overrides explicitly.
+- One shared divider component; hover affordance + existing `CursorRectView` cursor bridge; deferred-commit preserved for terminal panes; **not** NSSplitView.
+- Edge cleanups in scope: dual-keyed `layouts` dict, dead split stubs. Out of scope: `Tab.content` redundancy, transcript overlay/history-mode sprawl.
+- Arrange ships behind a **default-off** daemon config flag (CLAUDE.md: acts without a user gesture). See-queries are ungated.
+
+## 4. Architecture
+
+**Ownership rule: the app is the sole runtime authority and sole writer of the pane tree. The daemon holds a persisted, write-through mirror.**
+
+```
+             See (panel.list)                       Arrange (panel.split/close/...)
+  agent CLI ────────────────► daemon                agent CLI ──► daemon ─┐ validate vs mirror + flag
+                               │  answers from                            │ broadcast .panelCommand(cmdID)
+                               │  mirror (SQLite)                         ▼
+                               │                                         app ── applies via existing
+                               ▲                                          │     splitPane/removePane/
+                               │  panel.syncLayout (write-through,        │     routeFileClick paths
+                               │  debounced, echoes appliedCommandIDs)    │
+                               └──────────────────────────────────────────┘
+                                daemon completes CLI request when echo arrives
+```
+
+- **Persistence moves** from the UserDefaults blob to the daemon DB. `persistLayouts()` is replaced by a debounced `panel.syncLayout` RPC; `restoreLayouts()` is replaced by a fetch during initial state load. UserDefaults becomes a one-time import source (§5.4).
+- **See** is served entirely from the mirror. No app round-trip, works while the app is busy or closed (with an explicit staleness signal, §6.1).
+- **Arrange** flows CLI → daemon → validation → `StateDelta.panelCommand` broadcast → app applies on the main actor via the *same* functions user gestures call → app's next `syncLayout` echoes the applied command ID → daemon completes the CLI's pending request with the resulting layout. Commands are never applied by the daemon to its own copy; the mirror only ever changes because the app wrote it. This keeps exactly one writer and makes the sync protocol the easy kind.
+
+Why this shape (vs. Approach B): all the interactive, latency-sensitive, terminal-lifecycle-entangled mutation code stays where it is and keeps working; the daemon gains durable knowledge of layout without ever needing to understand SwiftUI-side invariants (e.g. "DockSplitView must stay mounted", `TerminalContainerView.swift` comments). The cost is a sync protocol whose failure modes are enumerated in §12.
+
+### 4.1 Types move to TBDShared
+
+`PaneContent`, `Tab`, `SplitDirection`, and `LayoutNode` move from `Sources/TBDApp/Terminal/` to `Sources/TBDShared/PaneLayout.swift` so the daemon can decode, validate, and summarize trees. They are already `Codable`/`Sendable` and depend only on Foundation (+`CGFloat`, available via Foundation on macOS). The legacy-format Codable compat (`LayoutNode.swift:192-213`) moves with them. App files re-export via `typealias` during the PR to keep the diff reviewable. View-layer helpers that reference app types stay behind in an app-side `extension`.
+
+### 4.2 Fixing the dual-keyed `layouts` dict (prerequisite)
+
+The multi-worktree grid keys the same `[UUID: LayoutNode]` store by `worktreeID` (`TerminalContainerView.swift:572-576`) while everything else keys by `tab.id`. Before mirroring, this becomes explicit: a `LayoutKey` enum (`case tab(UUID)`, `case worktreeGrid(UUID)`) or — simpler and preferred — the grid path gets its own small `gridLayouts: [UUID: LayoutNode]` store that is *not* mirrored (the grid is an ephemeral viewing mode, not worktree state). The mirror then contains only `tab.id`-keyed trees, and `panel.list` output is unambiguous. Dead stubs at `AppState+Worktrees.swift:1012-1034` are deleted in the same commit.
+
+## 5. Data Model & Persistence
+
+### 5.1 New table: `tab_layout`
+
+Migration `v53_tab_layouts` (next after `v52`, `Database.swift:875`):
+
+```sql
+CREATE TABLE tab_layout (
+  tab_id      TEXT PRIMARY KEY,   -- == Tab.id (== terminal/note UUID for those tabs)
+  worktree_id TEXT NOT NULL,
+  layout      TEXT NOT NULL,      -- LayoutNode JSON (existing wire format)
+  history     TEXT NOT NULL DEFAULT '{}',  -- {paneID: {entries:[PaneContent], cursor:Int}}
+  revision    INTEGER NOT NULL DEFAULT 0,  -- app-incremented, monotonic per tab
+  updated_at  DATETIME NOT NULL
+);
+CREATE INDEX idx_tab_layout_worktree ON tab_layout(worktree_id);
+```
+
+A dedicated table (rather than a column on `tab`) because `tab` rows are deliberately sparse — only labeled tabs get rows (`TabStore.swift:44`) — and un-sparsing `tab` would ripple through reconciliation.
+
+Per CLAUDE.md's three-place rule: (1) migration above; (2) new GRDB record `TabLayoutRecord` in `Sources/TBDDaemon/Database/TabLayoutStore.swift`; (3) shared Codable models in `Sources/TBDShared/PaneLayout.swift` (`PaneLayoutSnapshot`, `PaneHistory` — new fields optional/defaulted). Same commit.
+
+Also in `v53`: `config.panel_arrange_enabled BOOLEAN NOT NULL DEFAULT 0` (flag, §10).
+
+### 5.2 Write-through sync (app → daemon)
+
+`AppState.persistLayouts()` (`AppState.swift:878`) is replaced by:
+
+- Coalesce layout/history changes per worktree with a **250 ms debounce** (same spirit as the terminal resize debounce; a divider drag commit, which lands once on drag-end, produces one write).
+- RPC `panel.syncLayout` carries: `worktreeID`, full `[tabID: {layout, history, revision}]` for that worktree, and `appliedCommandIDs: [UUID]` (ack vehicle, §6.2). Full-state-per-worktree, not diffs — trees are small (KBs), and full writes make the mirror self-healing.
+- Revision increments on every app-side mutation. The daemon rejects writes whose revision is *lower* than stored (protects against a delayed in-flight write landing after a newer one).
+- On app launch and on daemon reconnect, the app pushes a full sync for every worktree it holds state for (self-heal after crashes; §12).
+
+### 5.3 Restore (daemon → app)
+
+During initial state load (where `loadTabStates` runs today, `AppState+Tabs.swift:19`) the app fetches `panel.getLayouts` for all worktrees and seeds `layouts` + history. The existing reconciliation (`reconcileTerminalTabs`, `AppState.swift:1704-1748`) then prunes panes whose terminals died, exactly as it does today — and the resulting corrections flow back through `syncLayout`, so the mirror converges.
+
+### 5.4 One-time UserDefaults import
+
+Only the app can read its own UserDefaults domain, so the import is app-side: at launch, if `panel.getLayouts` returns zero rows **and** the legacy `layoutsKey` blob exists, decode it and push via `syncLayout`. The UD key is left in place for one release as a rollback path, then the read/import code is deleted. No daemon involvement.
+
+## 6. RPC & CLI Surface
+
+### 6.1 See (ungated)
+
+New `RPCMethod` constants (`Sources/TBDShared/RPCProtocol.swift`, following the `config.setX` naming convention at :181-211):
+
+- `panel.list` — params `{worktreeID: UUID}` → result:
+
+```json
+{
+  "worktreeID": "…",
+  "appConnected": true,
+  "stalenessSeconds": 0.4,
+  "activeTabID": "…",
+  "tabs": [{
+    "tabID": "…", "label": "claude", "isActive": true,
+    "layout": {"split": {"direction": "horizontal", "ratios": [0.62, 0.38],
+      "children": [
+        {"pane": {"id": "…", "type": "terminal", "terminalID": "…", "shortID": "a3f2"}},
+        {"pane": {"id": "…", "type": "codeViewer", "path": "Sources/…/Foo.swift", "shortID": "9c41"}}
+      ]}}
+  }]
+}
+```
+
+  References only: `terminal` → terminalID (+ agent type from the terminal row), `codeViewer` → path, `webview` → URL, `liveTranscript` → its terminalID, `note` → noteID. Never contents. `appConnected` is derived from the app's live delta subscription; `stalenessSeconds` is `now - updated_at`. When the app is not connected, results are served anyway and marked stale — See degrades gracefully.
+- `panel.getLayouts` — app-restore fetch (app-only, not surfaced in CLI).
+- `panel.syncLayout` — app-only write-through (above).
+
+CLI: `tbd panel list [--worktree <id|name>] [--json]`. Human output is an indented tree with 4-char short IDs; `--json` is the raw result. Default worktree from `TBD_WORKTREE_ID`.
+
+### 6.2 Arrange (gated by `panel_arrange_enabled`)
+
+One command RPC per verb, all sharing the ack machinery:
+
+| RPCMethod | Params (all include `worktreeID`, optional `tabID` defaulting to active tab) |
+|---|---|
+| `panel.split` | `paneID` (target), `direction: h\|v`, `content: PaneContentSpec`, `ratio?` |
+| `panel.close` | `paneID` |
+| `panel.resize` | `paneID`, `ratio` (the pane's share within its parent split, 0.1–0.9) |
+| `panel.move` | `paneID`, `targetPaneID`, `direction: h\|v` |
+| `panel.selectTab` | `tabID` or `index` |
+
+`PaneContentSpec` (shared Codable): `terminal` (spawn new — reuses the `createTerminalForSplit` path, `AppState+Terminals.swift:253`), `terminal(existingID)`, `transcript(terminalID)`, `codeViewer(path)`, `webview(url)`, `note`. Note: `codeViewer`/`webview` here open *existing viewer types* as split content — this is arrange (placement of a known viewer), not the deferred show/render design (new content types, richer targeting, reuse policy).
+
+**Flow and ack.** The daemon: (1) rejects if the flag is off (clear error naming the flag); (2) rejects if no app is subscribed (`"TBD app is not running"` — commands never queue); (3) validates against the mirror (pane exists, ratio bounds, path exists for codeViewer, transcript's terminal is a claude session); (4) broadcasts `StateDelta.panelCommand(PanelCommandDelta)` — `{commandID: UUID, worktreeID, op}` — and parks the request. The app applies the op on the main actor through the existing mutation functions, records `commandID`, and its debounced `syncLayout` echoes `appliedCommandIDs`. When the echo lands, the daemon completes the parked request with the fresh `panel.list` payload. Timeout **3 s** → error `"app did not confirm within 3s (command may still have applied — re-run 'tbd panel list')"`. The app may also NACK in the echo (`failedCommands: [{commandID, reason}]`) for races the daemon's mirror validation couldn't see (e.g. pane closed by the user mid-flight).
+
+CLI:
+
+```
+tbd panel list        [--worktree W] [--json]
+tbd panel split  <paneID> --right|--below --content terminal|terminal:<id>|transcript[:<terminalID>]|code:<path>|web:<url>|note [--ratio 0.4]
+tbd panel close  <paneID>
+tbd panel resize <paneID> --ratio 0.6
+tbd panel move   <paneID> --target <paneID> --right|--below
+tbd panel select-tab <tabID|--index N>
+```
+
+`<paneID>` accepts full UUIDs or the unambiguous short-ID prefixes shown by `list`. All commands print the post-change tree (from the ack payload) so agents see the result without a second call.
+
+New `StateDelta` case: `panelCommand(PanelCommandDelta)` (`StateDelta.swift:6-34`). No `panelLayoutChanged` broadcast delta — there is exactly one app instance, and it is the writer.
+
+## 7. Panel History
+
+- **Model:** per pane slot (stable `paneID`), `PaneHistory { entries: [PaneContent], cursor: Int }`, capped at 10 (drop oldest). Lives in `AppState` beside `layouts`, mirrored in `tab_layout.history` via the same `syncLayout` write — restart-durable for free.
+- **Viewer-slot navigation (ships ahead of this spec as a standalone PR):** viewer-class panes (`.liveTranscript`, `.codeViewer`, `.webview`) form one interchangeable *slot* per tab. Content-navigation gestures — command-click on a file link, transcript toggle-on — **replace within the slot** (preserving the pane UUID for view identity and history keying) instead of splitting a new column; explicit split gestures still create panes. This distinguishes *navigate* (replace in slot, push history) from *arrange* (structural intent) and is why "transcript → markdown → back" works.
+- **Push points:** any in-place content replacement of a pane — `routeFileClick`'s slot reuse (`ViewerRouting.swift:15`), `toggleTranscript`'s slot navigation, and other `replacingContent(at:with:)` callers; agent-driven replacement joins later with show/render. Splits *create* panes (history starts fresh); closing a pane discards its history (its slot is gone). Terminal panes effectively never accumulate history today — fine.
+- **UI:** back/forward chevrons in the viewer pane header (`HeaderFileActions.swift` area), enabled per cursor position. Implemented as SwiftUI `Menu` with `primaryAction` (macOS 26): click = step, long-press/right-click = menu of up to 10 entries labeled by reference (file basename, URL host+path, "Transcript — <tab>"). This avoids the known `.onTapGesture`-blocks-`.contextMenu` trap.
+- Back/forward re-applies the entry via the same `replacingContent` path, which itself pushes nothing when navigating (a `isNavigating` reentrancy guard).
+- v1 history is **user-facing only**; `panel.list` does not expose stacks (two-way later). The daemon already persists them, so exposing is additive.
+
+## 8. Divider Unification
+
+One component, `PaneDivider(axis:style:commit:)` in `Sources/TBDApp/Terminal/PaneDivider.swift`:
+
+- **Two commit styles**, both today's semantics: `.live(Binding<CGFloat>, min, max)` (file panel, archived list) and `.deferred(preview: …, onCommit: …)` (terminal splits, dock split, dock cells — preserves the "one resize RPC per drag" property the debounce comments demand, `SplitLayoutView.swift:160`).
+- **Hover affordance:** the 1 pt separator line thickens to a 3 pt accent-tinted bar on hover (0.12 s fade), 8 pt hit target unchanged; cursor via the existing `CursorRectView` bridge (`SplitLayoutView.swift:248-274`), which exists precisely because `.onHover` push/pop is unreliable under attached gestures. During drag the bar stays highlighted (deferred style keeps its existing accent preview line).
+- **Double-click** resets to the split's even ratio (native NSSplitView behavior worth copying; trivial with `onTapGesture(count: 2)` on the divider, which carries no competing context menu).
+- Replaces all five call sites; the sidebar stays on native `NavigationSplitView`. No geometry model change — absolute-width and ratio-based callers keep their models; only the divider view unifies.
+
+This section is identical under Approach B — it is orthogonal to the ownership fork.
+
+## 9. Skill Guidance
+
+New section in `TBDSkillContent.body` (`Sources/TBDShared/TBDSkillContent.swift`), after "Pin / unpin a terminal":
+
+```markdown
+### See and arrange panels
+
+Each worktree tab is a tree of panels (terminals, file viewers, web views,
+transcript, notes). Inspect yours:
+
+    tbd panel list            # tree with short IDs, contents shown as references
+
+Rearrange (requires the user to have enabled panel control in settings):
+
+    tbd panel split a3f2 --right --content code:docs/plan.md   # open a file viewer beside pane a3f2
+    tbd panel split a3f2 --below --content transcript          # transcript under your terminal
+    tbd panel resize 9c41 --ratio 0.5
+    tbd panel close 9c41
+    tbd panel select-tab --index 0
+
+Rules:
+- Check `tbd panel list` first; prefer reusing/resizing existing panels over
+  creating new splits. Don't exceed ~3 panes per tab.
+- The layout belongs to the user. Don't close panels you didn't open, and
+  don't rearrange unprompted — arrange when asked, or when presenting
+  something the user requested.
+- Rendering new content (html strings, diffs) is not available yet — only
+  files on disk (`code:`), URLs (`web:`), terminals, transcript, notes.
+```
+
+The "Discovering current commands" section already tells agents to run `tbd panel --help`, so drift risk is bounded.
+
+## 10. Flag & Rollout
+
+- **Flag:** `config.panel_arrange_enabled`, default **OFF**, added in `v53` (`.defaults(to: false)`). Daemon-side gate in every `panel.*` arrange handler (See handlers ungated). Follows the `control_mode_enabled` / `hibernate_input_veto_enabled` precedent (`Database.swift:796,865`).
+- **Enable for soak:** `tbd config set panel-arrange on` (new `config.setPanelArrange` RPC + settings toggle in the app's settings pane, mirroring existing config toggles).
+- **Tests both branches** (CLAUDE.md): flag off → arrange RPC returns the gate error and no delta is broadcast; flag on → command flows. See-queries work regardless.
+- **Graduation:** ≥2 weeks dogfood with agents actively arranging; then flip the migration default for fresh installs **and** ship a forcing `UPDATE config SET panel_arrange_enabled = 1` migration for existing installs, accepting that an explicit opt-out is indistinguishable from backfill (documented trade; the cautionary `auto_hibernate` precedent is why we ship OFF first). Flag deletion one release later.
+
+## 11. Testing
+
+- **Daemon (`Tests/TBDDaemonTests`):** `v53` migration round-trip; `TabLayoutStore` CRUD + revision-rejection; `panel.syncLayout` persists and completes parked commands (ack correlation, including `failedCommands` NACK); `panel.list` staleness + `appConnected` fields; arrange validation failures (unknown pane, bad ratio, flag off, app not subscribed); timeout path (parked command expires with the re-check error).
+- **Shared:** `LayoutNode` moved intact — existing tests move with it; legacy-format decode compat test; `PaneHistory` push/cap/cursor/navigate-no-repush unit tests (pure logic).
+- **App-side (logic level):** command application maps each `PanelCommandOp` onto the same mutation functions user gestures call — test via `AppState` with injected `UserDefaults(suiteName:)` per CLAUDE.md; grid-store split (§4.2) regression test: grid layout changes never enter the mirrored store.
+- **CLI integration:** socket-level probe (echo JSON to `~/tbd/sock` pattern already used for `pr.list` diagnostics) exercising list → split → list with a fake app subscriber harness.
+- **Live verification** (not automated): divider hover affordance and history menu are visual — verify per the transcript-live-verify discipline (screenshot + eyes), since headless harnesses pass green while live rendering is broken.
+
+## 12. Risks & Open Questions
+
+Honest failure modes of the mirror:
+
+1. **App crash between apply and write-back.** A command is applied, the 250 ms debounce hasn't fired, app dies → mirror is stale and the CLI got a timeout. Mitigation: full-state push on next app launch converges the mirror; the timeout error text tells agents to re-run `panel.list`. Residual: a See query in the crash window returns pre-command state, and `stalenessSeconds` does not reveal this (the mirror's last write is recent). Accepted as rare; the ack timeout is the agent's signal that state is uncertain.
+2. **Stale mirror with app closed.** `panel.list` serves last-known state with `appConnected: false`. Arrange refuses outright. This is the designed degradation, but agents must be taught (skill text) that `appConnected: false` means "the user isn't looking at this."
+3. **Concurrent user drag vs. agent command.** Both mutate the same tree on the main actor, serialized by construction; syncs are whole-tree, so the mirror converges to whatever the app last held. A user drag can land between validation and apply (e.g. user closes the target pane) — the app NACKs with a reason. No locks needed.
+4. **Reconciliation prunes agent panes.** `reconcileTerminalTabs` (`AppState.swift:1707-1732`) drops layouts whose terminals died. An agent's split vanishing with its terminal is correct behavior, but the agent only learns via the next `panel.list`. Acceptable for v1.
+5. **Delayed writes / reordering.** Monotonic per-tab `revision` + daemon rejection of lower revisions; debounce coalescing makes this near-impossible to hit in practice.
+6. **Types-to-TBDShared layering.** `PaneContent.liveTranscript` etc. are UI concepts now visible to the daemon. The daemon treats them as opaque data + validation targets; it must never grow behavior keyed on pane *semantics* (that would be Approach B by accretion). Review guard: daemon code may switch on pane type only inside validation.
+
+Open questions for review:
+
+- Should `panel.selectTab` be arrange-gated? It's the least destructive verb; but it steals the user's visual context, which is exactly what the gesture-free-action rule targets. **Spec says: gated**, revisit at graduation.
+- Short-ID stability: short IDs are prefixes of pane UUIDs, stable for a pane's life. Good enough, or should `list` emit ordinal names (`t1`, `v2`)? Prefix chosen for greppability against `--json`.
+- Is 3 s the right ack timeout under heavy SwiftUI load (e.g. mid-transcript-stream)? Measure during soak.
+
+## 13. Future Work
+
+- **Show/render (next design):** new content types (render HTML string, markdown scratch content, diffs), reuse-vs-split placement policy, richer targeting ("beside my terminal"), agent-initiated content *replacement* (which then feeds pane history). The `PaneContentSpec` vocabulary and command/ack plumbing built here carry over unchanged.
+- **Two-way:** expose pane history and view state (scroll position, visible file region) through `panel.list`; the mirror already persists history, so this is additive daemon work plus app-side view-state capture.
+- **Annotations:** user marks on rendered content flowing back to the agent — requires the show/render design plus a content-addressing scheme; the `tab_layout` table's JSON columns are the natural anchor.
+- **Migration path to Approach B**, if ever needed: because all mutations already flow through typed command ops and the DB already holds the tree, promoting the daemon to owner is a directional flip of the same protocol, not a rewrite.

--- a/docs/specs/2026-07-20-panel-agent-surface-b-daemon-owned-design.md
+++ b/docs/specs/2026-07-20-panel-agent-surface-b-daemon-owned-design.md
@@ -1,0 +1,248 @@
+# Panel Agent Surface — Approach B: Daemon-Owned Panel State
+
+**Date:** 2026-07-20
+**Status:** Draft for review (competing spec: `2026-07-20-panel-agent-surface-a-mirror-design.md`)
+**Approach:** The daemon database becomes the single source of truth for the pane tree. The app is a renderer of subscribed state; every mutation — user click, divider drag, agent command — is a daemon RPC.
+
+## 1. Context & Goals
+
+TBD agents currently have no way to see or control the panel layout of their worktree. The bundled `tbd` skill (`Sources/TBDShared/TBDSkillContent.swift`) never mentions panels; the only UI levers an agent has are `tbd notify` and `tbd terminal focus`. Meanwhile the app already has a real pane model — `PaneContent` + a recursive `LayoutNode` split tree — but it lives entirely in `TBDApp`, persisted as a UserDefaults JSON blob the daemon never sees.
+
+Goals of this design:
+
+- **See** — an agent can query which panels exist in its worktree, their split arrangement, and what each renders (references only: file paths, URLs, terminal IDs — never rendered contents).
+- **Arrange** — an agent can split, close, resize, move panes, and switch tabs, through the same semantics the user's clicks use.
+- **Per-panel history** — every pane slot remembers its last ~10 contents; users navigate back/forward from the pane header.
+- **Unify** the five copy-pasted divider implementations into one component with a native-feeling hover affordance.
+- Establish the state architecture that later supports two-way interaction (agent reads view state; user annotations on content).
+
+Non-goals for v1: rendering new content types ("show this HTML/markdown" — deferred to a separate design), reading rendered contents, annotations.
+
+## 2. Current State
+
+Anchored summary; full detail in the research notes.
+
+- **Model (good):** `PaneContent` — five cases: `.terminal(terminalID)`, `.webview(id:url:)`, `.codeViewer(id:path:)`, `.note(noteID)`, `.liveTranscript(id:terminalID:)` (`Sources/TBDApp/Terminal/PaneContent.swift:5`). `Tab` wraps one primary `PaneContent` (`PaneContent.swift:25`). `LayoutNode` is a recursive `.pane`/`.split(direction:children:ratios:)` tree with helpers (`splitPane`, `removePane`, `replacingContent(at:with:)`) and a backward-compatible hand-written Codable (`Sources/TBDApp/Terminal/LayoutNode.swift:12,192`).
+- **State & persistence (split-brained):** `AppState.layouts: [UUID: LayoutNode]` with `didSet { persistLayouts() }` to a UserDefaults blob (`Sources/TBDApp/AppState.swift:401,878-887`). Tab labels/order/active tab live in the daemon DB (`tab` table + `worktree.tabOrder`/`activeTabID`, migrations `v19`/`v20`, `Sources/TBDDaemon/Database/Database.swift:433-449`). The daemon has no knowledge of the pane tree.
+- **Dual keying (footgun):** `layouts` is keyed by `tab.id` in the single-worktree path (`Sources/TBDApp/Terminal/TerminalContainerView.swift:268-269`) and by `worktreeID` in the multi-worktree grid (`TerminalContainerView.swift:572-576`) — one dictionary, two semantics.
+- **Mutation paths:** no central API. Splits/closes happen by rebinding `layout` inside `PanePlaceholder` (`splitRight` `:523`, `createTerminalSplit` `:546`, `routeFileClick` via `Sources/TBDApp/Panes/ViewerRouting.swift:15`, `toggleTranscript` via `Sources/TBDApp/Panes/TranscriptRouting.swift:21`). Tab ops in `Sources/TBDApp/AppState+Tabs.swift`. Tab existence is re-derived by reconciliation against live terminals (`reconcileTerminalTabs`, `AppState.swift:1704-1748`), which also prunes panes whose terminals died (`removingTerminalPanes(notIn:)`).
+- **Resize:** five hand-rolled `DragGesture` dividers (file panel `ContentView.swift:672-694`, terminal splits `SplitLayoutView.swift:161-233`, dock split `TerminalContainerView.swift:605-668`, dock cells `PinnedTerminalDock.swift:50-100`, archived list `ArchivedWorktreesView.swift:203-218`). Terminal-adjacent dividers deliberately defer commit to release because live resize fires tmux resize RPCs (debounced ~100ms, `TerminalPanelView.swift:1009-1049`).
+- **History:** none for panes. Only sidebar selection history (`AppState+Navigation.swift`).
+- **Transcript:** `.liveTranscript` is already an ordinary pane; the toolbar toggle and pane routing share `isLiveTranscriptPane` (`TranscriptRouting.swift:10`) so the trigger already reflects visibility. (The unrelated History *mode* and click-to-zoom overlay are out of scope.)
+
+## 3. Decisions
+
+Fixed inputs to this design (settled during brainstorming; identical in both competing specs):
+
+1. v1 agent verbs are **See** (layout + content references) and **Arrange** (split, close, resize, move, switch tabs). **Show/render is deferred** to a separate future design; v1 introduces no new content types.
+2. Agent-created splits may hold any *existing* pane type: terminal (new or existing), live transcript, code viewer on a path, webview on a URL, note.
+3. The transcript is a panel like any other — no special-casing, no protection. The toolbar transcript trigger reflects visibility (dark when no transcript pane): already implemented via the shared `isLiveTranscriptPane` check; no change required beyond keeping that invariant when mutations move server-side.
+4. Two-way interaction (agent reads view state; user annotations) is the future direction; v1 ships one-way arrange plus reference/layout queries only.
+5. Per-panel history: last 10 contents per pane slot; back/forward buttons in the pane header; right-click shows a dropdown of entries; survives restart.
+6. Agent operations are scoped to the agent's own worktree by default (`TBD_WORKTREE_ID`); cross-worktree requires explicit `--worktree`.
+7. One shared divider component with hover affordance and the existing `CursorRectView` cursor bridge; deferred-commit preserved for terminal panes. Not NSSplitView.
+8. Edge cleanups in scope: the dual-keyed `layouts` dictionary; dead split stubs (`AppState+Worktrees.swift:1012-1034`). Out of scope: `Tab.content` redundancy, transcript overlay/History-mode sprawl.
+
+## 4. Architecture
+
+### 4.1 Ownership
+
+The daemon owns the pane tree per `(worktreeID, tabID)`. The app holds a local replica and renders from it. All mutations are expressed as **semantic operations** sent to the daemon:
+
+```
+splitPane(tabID, targetPaneID, direction, newContent)
+closePane(tabID, paneID)
+setRatios(tabID, splitPath, ratios)
+replaceContent(tabID, paneID, newContent)   // also drives history
+movePane(tabID, paneID, toTargetPaneID, direction)
+setActiveTab(worktreeID, tabID)             // exists today as worktree.setActiveTab
+```
+
+The daemon applies the operation to its stored tree, bumps a per-tab version, persists, appends to history where applicable, and broadcasts a `layoutChanged` StateDelta carrying the full new tree + version for that tab. Both the app and (indirectly) CLI queries observe the same authoritative state. Whole-tree *writes* from clients are rejected by design — semantic ops are the only mutation interface — so two concurrent editors (user + agent) interleave at operation granularity instead of clobbering each other's trees. The one exception is the one-time UserDefaults import (§5.4) and a `layout.set` escape hatch used only by the migration/import path, not exposed in the CLI.
+
+### 4.2 Interactivity: optimistic apply + version reconcile
+
+The render loop must never wait on a socket. Protocol:
+
+1. App performs the mutation **locally first** (same pure `LayoutNode` helpers as today), tags it with a client-generated `opID`, renders immediately.
+2. App sends the semantic op (with `opID` and the base version it applied against) to the daemon.
+3. Daemon applies against its authoritative tree. If the base version matches, result is identical to the app's optimistic state; the echoed `layoutChanged(tree, version, opID)` is a no-op for the originating app (it recognizes its own `opID` and just adopts the version).
+4. If versions diverge (an agent op landed between the app's read and write), the daemon still applies the semantic op to the *current* tree (semantic ops compose: split-by-target-pane, close-by-paneID, ratios-by-split-path all address stable IDs). The echo's tree differs from the optimistic one; the app replaces its replica with the echo. Because ops address pane IDs rather than indices, the common races (agent closes pane X while user splits pane Y) merge correctly; a genuinely conflicting op (both target the same pane) resolves in daemon arrival order — last writer wins at op granularity, and the user sees the merged result within one round-trip (~1ms on a Unix socket).
+5. **Divider drags never stream.** During drag the divider shows the existing preview indicator (deferred-commit behavior, `SplitLayoutView.swift:160`); exactly one `setRatios` op is sent on release. Ratio previews are pure local view state. This matches today's behavior and keeps 60fps with zero socket traffic mid-drag.
+
+`replaceContent`-class churn from user clicks (e.g. `routeFileClick` swapping a code-viewer path per click) follows the same path — one op per click is well within budget.
+
+### 4.3 Structural stability guarantee
+
+The known failure class is terminal-destroying re-renders: swapping the container structure kills SwiftTerm views and their tmux sessions (comment at `TerminalContainerView.swift` on `DockSplitView`; the `routeFileClick` pane-ID-preserving swap exists for the same reason, `ViewerRouting.swift`). Therefore the app **never rebuilds its replica wholesale while healthy**: echoes that match the optimistic state are ignored; divergent echoes are applied by *diffing pane IDs* (panes present in both survive with identity intact; only added/removed panes mount/unmount). This diff-apply is the riskiest new code in Approach B and gets dedicated tests (§11).
+
+### 4.4 Failure modes
+
+- **Daemon down / socket error:** the app keeps mutating its local replica and queues unsent ops (bounded, coalescing ratio ops). On reconnect it replays the queue; if the daemon's version moved meanwhile (it can't have — only the app and CLI mutate, and the CLI requires the daemon — but crash-recovery skew can), the app performs one full-tree `layout.set` reconcile guarded by the migration escape hatch. Layout editing is never blocked by daemon absence.
+- **User drag races agent op:** handled by §4.2 step 4; worst case the user's ratio commit applies to a tree where the target split vanished — the daemon rejects with a stale-target error, the app drops the op and adopts the echo. No crash, no zombie state.
+- **App crash mid-apply:** daemon state is authoritative and durable; on relaunch the app loads trees via `layout.get` and reconciliation prunes dead terminals (§5.3). Nothing depends on the app having acked.
+- **Two app instances:** already disallowed by the single-app model (LaunchServices/one-daemon); not designed for.
+
+## 5. Data Model & Persistence
+
+### 5.1 Model relocation
+
+`PaneContent`, `Tab`, `SplitDirection`, `LayoutNode` move from `Sources/TBDApp/Terminal/` to `Sources/TBDShared/` (the daemon must decode and manipulate them). The hand-written backward-compatible Codable (`LayoutNode.swift:192`, legacy `{"type":"terminal"}` format) moves with it unchanged — the DB rows and the UserDefaults import both flow through it. App-only rendering helpers stay behind in TBDApp as extensions.
+
+This also resolves the dual-keying cleanup: the daemon schema forces the key to be `(worktreeID, tabID)`; the multi-worktree grid's `layouts[worktreeID]` hack (`TerminalContainerView.swift:572-576`) is rewritten against the same keyed store with an explicit synthetic tab, not a UUID pun.
+
+### 5.2 Schema (migration `v53_pane_layouts`)
+
+```sql
+CREATE TABLE pane_layout (
+    worktreeID TEXT NOT NULL,
+    tabID      TEXT NOT NULL,
+    tree       TEXT NOT NULL,   -- LayoutNode JSON (existing Codable)
+    version    INTEGER NOT NULL DEFAULT 0,
+    updatedAt  DATETIME NOT NULL,
+    PRIMARY KEY (worktreeID, tabID)
+);
+CREATE TABLE pane_history (
+    worktreeID TEXT NOT NULL,
+    tabID      TEXT NOT NULL,
+    paneID     TEXT NOT NULL,
+    position   INTEGER NOT NULL,        -- 0 = newest
+    content    TEXT NOT NULL,           -- PaneContent JSON
+    replacedAt DATETIME NOT NULL,
+    PRIMARY KEY (worktreeID, tabID, paneID, position)
+);
+```
+
+Per the three-place rule (CLAUDE.md): migration in `Database.swift`, GRDB record types (`PaneLayoutStore.swift`), and Codable models in `TBDShared/Models.swift` (the moved `LayoutNode`/`PaneContent` serve as the models; new fields optional/defaulted) — one commit. `tree` stays a JSON blob *per tab* (not per-pane rows): the tree is small (<2KB), always read/written whole, and the semantic-op merge happens in Swift, not SQL. History is row-per-entry because it's append/trim and queried per-pane.
+
+Config flags (same migration): `config.agent_arrange_enabled` default **0**, `config.daemon_layout_enabled` default **0** (§10).
+
+### 5.3 Reconciliation moves daemon-side (genuine advantage)
+
+Today `reconcileTerminalTabs` (`AppState.swift:1704-1748`) prunes panes whose terminals died — app-side, on app timelines, and only while the app runs. Under B, the daemon owns both the layout **and** the terminal lifecycle (it creates/destroys terminals), so pruning becomes an internal daemon consequence: terminal removal → prune `.terminal`/`.liveTranscript` panes referencing it across stored trees → broadcast `layoutChanged`. The app's reconciliation shrinks to tab-list presentation. This closes a real hole: layouts stay consistent even when terminals die while the app is closed (today the blob goes stale and is patched at next launch).
+
+### 5.4 One-time import
+
+On first app launch with `daemon_layout_enabled`, the app decodes the existing UserDefaults blob (`AppState.swift:882-887`), pairs entries with known tabs, and pushes them via the `layout.set` import path; the daemon accepts only rows it has no entry for. The blob is left in place (rollback safety) and ignored thereafter; deleted in a later release.
+
+## 6. RPC & CLI Surface
+
+### 6.1 RPC methods (`RPCProtocol.swift`, naming per existing `noun.verb` convention)
+
+| Method | Params → Result | Notes |
+|---|---|---|
+| `layout.get` | worktreeID, tabID? → trees + versions (+ optional history heads) | See; app relaunch load |
+| `layout.split` | tabID, targetPaneID, direction, newContent, opID?, baseVersion? → tree, version | newContent restricted to existing `PaneContent` cases; `terminal` may be `new` (daemon spawns via existing terminal-create path) or an existing terminalID |
+| `layout.close` | tabID, paneID, opID?, baseVersion? → tree, version | auto-unwraps single-child splits (existing `removePane` semantics) |
+| `layout.setRatios` | tabID, splitPath, ratios, … → tree, version | one op per drag release |
+| `layout.replaceContent` | tabID, paneID, newContent, … → tree, version | pushes old content to history |
+| `layout.move` | tabID, paneID, targetPaneID, direction, … → tree, version | |
+| `layout.historyGet` / `layout.historyNavigate` | paneID (+offset) → entries / tree | §7 |
+| `layout.set` | worktreeID, tabID, tree | import/reconcile escape hatch; not in CLI |
+
+New StateDelta: `case layoutChanged(LayoutDelta)` — worktreeID, tabID, tree, version, originOpID?, plus `case paneHistoryChanged(PaneHistoryDelta)`. Wire-up follows the standard six-step RPC recipe (skill §"Adding New RPC Methods").
+
+Agent calls are validated: worktree scoping (params must match the caller's `TBD_WORKTREE_ID` unless `--worktree` given), `agent_arrange_enabled` flag gate on all mutating methods when the caller is a CLI session (the app's own calls bypass the flag), content-type allowlist (reject unknown/future `PaneContent`).
+
+### 6.2 CLI (`tbd panel …`, new `Sources/TBDCLI/Commands/Panel.swift`)
+
+```
+tbd panel list   [--worktree <id>] [--json]     # tabs + tree + references per pane
+tbd panel split  --pane <paneID> --direction right|down
+                 --content terminal|transcript|file:<path>|url:<url>|note [--terminal <id>]
+tbd panel close  --pane <paneID>
+tbd panel resize --split <splitPath> --ratios 0.6,0.4
+tbd panel move   --pane <paneID> --target <paneID> --direction right|down
+tbd panel tab    --activate <tabID>
+tbd panel history --pane <paneID> [--back|--forward|--go <n>]
+```
+
+`panel list` output (JSON) is the See contract: per tab — id, label, active; tree of `{split, direction, ratios, children}` / `{pane, id, type, ref}` where `ref` is the file path, URL, terminal ID, or transcript's terminal ID. Never contents. Human-readable default output is an indented tree.
+
+Because the daemon is the source of truth, `panel list` needs no app round-trip and is correct even while the app is closed; mutations equally apply daemon-side and render whenever the app is (re)attached — CLI results are real acks (the RPC response carries the post-op tree), not eventual-consistency reads.
+
+## 7. Panel History
+
+**Viewer-slot navigation (ships ahead of this spec as a standalone app-side PR):** viewer-class panes (`.liveTranscript`, `.codeViewer`, `.webview`) form one interchangeable *slot* per tab; content-navigation gestures (command-click on a file link, transcript toggle-on) replace within the slot — preserving the pane UUID — instead of splitting a new column. Explicit splits remain structural. Under B, those replacements become `replaceContent` ops.
+
+History is keyed by stable `paneID` (which `routeFileClick` already deliberately preserves across content swaps, `ViewerRouting.swift`). On every `replaceContent` (user click or agent op), the daemon prepends the outgoing `PaneContent` to `pane_history`, trims to 10, broadcasts `paneHistoryChanged`. Back/forward are `layout.historyNavigate` calls that atomically swap current content with the history entry (forward stack maintained by position sign or a cursor column — implementation detail for the plan).
+
+UI: pane headers gain back/forward buttons (enabled per history availability); right-click (or long-press) on either button shows an `NSMenu` of up to 10 entries labeled by reference (filename, URL host+path, "Terminal ⌗", "Transcript"). Selecting jumps directly.
+
+Daemon-side history is the architectural freebie of Approach B: durable across app restarts by construction, no extra sync, and later queryable by agents ("what was this pane showing before") without new plumbing. Close-pane discards history for that paneID (panes are slots; a closed slot is gone — revisit if users ask for "reopen closed pane").
+
+## 8. Divider Unification
+
+One `PaneDivider` component (new file, `Sources/TBDApp/Terminal/PaneDivider.swift`) replacing the five implementations:
+
+- Configurable axis, hit-target width (8pt), min/max constraint (absolute or ratio), and commit mode: `.live` (file panel, archived list) or `.deferred` (all terminal-adjacent dividers — preview indicator during drag, commit on release; rationale comments preserved).
+- Hover affordance: on hover (and during drag) the 1pt separator line animates to a 3pt accent-tinted bar — approximating NSSplitView's divider feedback; plus the existing `CursorRectView` cursor bridge (`SplitLayoutView.swift:237-274`), kept because `.onHover` push/pop is unreliable under attached gestures (comment at `:238-240`).
+- Double-click resets to the ideal/default width or 50:50 ratio (native splitter convention).
+- Under B, `.deferred` commit for layout-tree dividers emits `layout.setRatios`; `.live` dividers (file panel width — not part of the pane tree) keep their `@AppStorage` binding. The component is agnostic: it takes a commit closure.
+
+The sidebar stays on `NavigationSplitView` (already native). `MainAreaSizeKey` measurement points (`TerminalContainerView.swift:19,202,489,549`) are untouched — `PaneDivider` is a drop-in at existing positions in the view tree.
+
+## 9. Skill Guidance
+
+New section in `TBDSkillContent.body` (after "Pin / unpin a terminal"):
+
+```markdown
+### See and arrange the panel layout
+
+Each worktree tab is a tree of panels (terminals, transcript, file viewer,
+web view, notes). You can inspect and rearrange it:
+
+    tbd panel list --json          # tabs, split tree, and what each panel shows
+                                   # (references only: paths, URLs, terminal ids)
+    tbd panel split --pane <id> --direction right --content file:docs/plan.md
+    tbd panel close --pane <id>
+    tbd panel resize --split <path> --ratios 0.7,0.3
+
+Guidelines:
+- Check `panel list` before arranging — respect the user's current layout;
+  prefer splitting your own terminal's pane over rearranging others.
+- The transcript is a normal panel; don't close it unless asked.
+- Every panel keeps back/forward history, so replacements are recoverable —
+  but don't rely on the user to undo your changes.
+- Requires the "agent panel control" setting; if commands fail with
+  "disabled", tell the user to enable it in TBD settings.
+```
+
+(Exact copy finalized in the implementation plan; the skill already documents discovery via `tbd --help`.)
+
+## 10. Flag & Rollout
+
+Two independent flags, per the CLAUDE.md default-off policy:
+
+1. **`daemon_layout_enabled`** (config column, default 0) — gates the ownership move itself. This wholesale-replaces a load-bearing path (layout state/persistence), squarely inside the flag policy. OFF: app keeps today's UserDefaults path; daemon tables exist but idle. ON: import runs, app switches to replica+ops. Soak on the developer's install; graduate by flipping via forcing `UPDATE` migration (per the `auto_hibernate` lesson), then delete the UserDefaults path a release later.
+2. **`agent_arrange_enabled`** (config column, default 0) — gates CLI/agent *mutations* only (`panel list` See queries are always allowed; read-only). Requires `daemon_layout_enabled`. Graduates independently once arrange semantics have soaked.
+
+Both branches tested (CLAUDE.md branching-conditional rule). Rollout order: land schema + store + RPC (inert) → land app replica path behind flag 1 → dogfood → enable flag 2 → skill section ships with flag 2's graduation.
+
+**Honest phasing note for reviewers:** Phase "schema + store + RPC + app dual-writes while still authoritative" is, almost verbatim, the whole of Approach A. Approach B is not an alternative to A so much as A **plus** an ownership inversion at the end. If B is chosen, the de-risked path still builds A first and then flips authority; the real decision is whether to commit now to the second step (and its diff-apply/optimistic-echo machinery) or defer it until two-way features demand it.
+
+## 11. Testing
+
+- **LayoutNode op semantics (TBDShared):** pure-function tests for split/close/move/setRatios/replaceContent against ID-addressed trees, including stale-target rejection and single-child unwrap. Property test: any op sequence yields a valid tree (ratios sum ~1, no empty splits).
+- **Daemon store (TBDDaemonTests, in-memory GRDB):** versioning, history append/trim/navigate, terminal-death pruning across stored trees, import-only-when-absent, both flag branches (mutations rejected when `agent_arrange_enabled=0`; UserDefaults path untouched when `daemon_layout_enabled=0`).
+- **Optimistic-echo reconcile (app-side unit):** own-op echo is a no-op; divergent echo diff-apply preserves pane identity for surviving panes (assert same object identity via pane-ID diff output, the §4.3 guarantee); queued-op replay after simulated disconnect.
+- **RPC integration:** CLI-shaped calls through the router with `TBD_HOME` isolation; worktree-scope enforcement; content-type allowlist rejection.
+- **Divider component:** commit-mode behavior (deferred emits exactly one op per drag), constraint clamping. Visual hover affordance verified live (per project precedent, layout/visual issues are live-only — screenshot pass in the PR).
+- Tests must not touch `~/tbd` (`TBD_HOME` seams) and reuse `TmuxManager(dryRun:)` where terminal spawns are implied.
+
+## 12. Risks & Open Questions
+
+- **Diff-apply replica updates (highest risk).** Getting pane-identity-preserving echo application wrong destroys terminal views (the documented failure class). Mitigation: §4.3 tests + the flag; but this machinery does not exist today and is the bulk of B's app-side cost.
+- **Rewrite surface.** All layout mutation sites (`PanePlaceholder`, `ViewerRouting`, `TranscriptRouting`, `AppState+Tabs`, reconciliation ~`AppState.swift:1700-1780`, multi-worktree grid) move from direct binding writes to op-emission; the five divider sites are touched twice (unification + op plumbing). Estimated 2–3× the diff of Approach A for the same v1 feature set.
+- **Two sources of truth during the soak.** While `daemon_layout_enabled` is off for some installs and on for others, bugs bifurcate by flag state; support burden until graduation.
+- **Op granularity of `setRatios` addressing (`splitPath`).** Split nodes have no stable IDs today; path-addressing is fragile under concurrent structural edits. Open question: add stable IDs to `.split` nodes (Codable change, still backward-compatible via the custom decoder) — recommended, decide in the plan.
+- **Terminal spawn inside `layout.split --content terminal:new`.** Composing terminal creation (async, session instrumentation) with a layout op needs care to avoid a pane referencing a terminal that failed to spawn. Likely: spawn first, then split referencing the concrete ID; the CLI does this in two RPCs under the hood.
+- **Note panes** are worktree-scoped app constructs (`AppState+Notes.swift`); verify note creation via agent op doesn't need extra daemon knowledge.
+- Does the multi-worktree grid get real tabs (synthetic tab row) or stay a special case reading a single tree? Leaning synthetic tab; decide in the plan.
+
+## 13. Future Work
+
+- **Show/render (deferred design):** new content types — rendered HTML strings, diffs, richer markdown targets — arrive as new `PaneContent` cases; under B they slot in with zero new sync work (one enum case + renderer + allowlist entry).
+- **Two-way:** agent queries of view state (scroll position, selection) and eventually user **annotations** on content. B's daemon-owned store is the natural home: annotations become rows keyed by (paneID, content ref), agents read them via `layout.get` extensions.
+- **Pane-content read-back** (agent reads what a panel displays) — explicitly out of scope until the show/render design lands.
+- Migrating the three sanctioned TUI scrapers and the transcript overlay/History-mode sprawl remain independent tracks.

--- a/docs/specs/2026-07-22-panel-agent-surface-c-primary-anchor-design.md
+++ b/docs/specs/2026-07-22-panel-agent-surface-c-primary-anchor-design.md
@@ -1,0 +1,826 @@
+# Panel Agent Surface — Approach C: Daemon-Owned Primary-Anchor Layout
+
+**Date:** 2026-07-22
+
+**Status:** Adopted — Phase 1 shipped in PR #478 (2026-07-22)
+
+**Supersedes:**
+`2026-07-20-panel-agent-surface-a-mirror-design.md` and
+`2026-07-20-panel-agent-surface-b-daemon-owned-design.md`
+
+## 1. Summary
+
+TBD will expose side-panel layout to agents through a daemon-owned surface model.
+Each workspace tab has exactly one non-removable **primary anchor** and zero or
+more viewer panels arranged around it in a recursive split tree.
+
+Terminals are never side-panel content. A terminal is primary content in its own
+workspace tab. Creating a terminal creates a workspace tab; closing that tab
+kills the terminal session. The panel API can neither create nor embed a
+terminal, so layout navigation never has to decide whether replacing a view
+should hide, orphan, or destroy a live session.
+
+Viewer panels can show files (source or rendered), web pages, transcripts, and
+notes. A viewer panel is a stable slot with back/forward history. Command-click
+and agent `panel.open` operations reuse a suitable viewer panel when possible or
+create a new panel beside the primary anchor. There are no pane-local tabs; the
+history controls and their right-click jump menu provide lightweight switching
+among recently viewed references.
+
+The daemon is the sole durable authority. Agent operations work while the app is
+closed and appear when the app next connects. The app may render user gestures
+optimistically, but it never persists or resolves conflicts independently of the
+daemon.
+
+## 2. Goals and non-goals
+
+### Goals
+
+1. **See:** agents can inspect workspace tabs, viewer panels, split structure,
+   ratios, and content references without reading rendered contents.
+2. **Arrange:** agents can open, close, split, move, resize, and navigate viewer
+   panels, and can select a workspace tab.
+3. **Single durable authority:** tab surfaces remain correct whether or not the
+   app is running.
+4. **Safe resource semantics:** panel navigation cannot create, orphan, or kill
+   terminal sessions.
+5. **Stable rendering identity:** authoritative tree updates preserve unaffected
+   SwiftUI/AppKit view state.
+6. **Viewer history:** each viewer panel retains its last 10 references across
+   app and daemon restarts.
+7. **Future extensibility:** new renderable reference types and later view-state
+   or annotation features can be added without changing ownership again.
+
+### Non-goals for v1
+
+- Arbitrary inline content supplied over RPC, such as raw HTML or Markdown
+  strings. v1 opens durable references: files, URLs, notes, and transcripts.
+- Reading rendered panel contents back through the panel API.
+- Pane-local tabs.
+- Terminal splits or terminal content in side panels.
+- Agent control of the pinned-terminal dock or multi-worktree grid.
+- Persisting ephemeral view details such as scroll position, selection, find
+  state, or web navigation internals.
+- Treating the local RPC boundary as a security sandbox. TBD already trusts
+  processes running as the same macOS user; the agent-control flag establishes
+  product consent, not hostile-process isolation.
+
+## 3. Fixed product decisions
+
+1. The daemon owns the durable surface; the app is a subscribed renderer.
+2. Agent mutations are accepted while the app is closed.
+3. Every workspace tab has exactly one primary anchor.
+4. Terminals may only be workspace-tab primary content.
+5. `tbd terminal create` creates a workspace tab, never a side panel.
+6. Closing a terminal workspace tab kills that terminal session.
+7. Closing a viewer panel removes only the view. Closing a note panel does not
+   delete the note; `note.delete` remains explicit. Because deletion currently
+   happens only via pane close, the same change must add an explicit
+   delete-note affordance in the app, or notes become unremovable.
+8. Transcript panels reference but do not own terminal sessions.
+9. Viewer navigation uses back/forward history and the existing right-click jump
+   menu design, not pane-local tabs.
+10. Cross-worktree control uses the same API with an explicit `worktreeID` (CLI
+    `--worktree`). It is uncommon but not artificially restricted.
+11. Agent mutations ship behind a default-off daemon config flag. Read-only
+    inspection is ungated.
+12. The multi-worktree grid is presentation-only app state and is not part of
+    the persisted or agent-visible panel surface.
+
+## 4. Current state and why it must change
+
+The app currently stores `layouts: [UUID: LayoutNode]` and persists it as a
+UserDefaults JSON blob (`AppState.swift:401-403,878-887`). Tab labels, ordering,
+and active selection are already daemon-persisted, but the `tab` table is sparse:
+only tabs with label overrides have rows (`TabStore.swift:44-45`). Actual tab
+existence is reconstructed app-side from terminals and notes.
+
+`PaneContent` currently combines visual identity and resource identity. A
+terminal's pane ID is its terminal ID; a note's pane ID is its note ID; viewer
+cases carry separate generated IDs (`PaneContent.swift:5-20`). That prevents a
+panel slot from retaining its identity independently of the content it displays.
+
+`LayoutNode.split` has no split-node ID (`LayoutNode.swift:12-14`), and divider
+commit finds a target split by comparing its complete child arrays
+(`SplitLayoutView.swift:131-153`). The view also iterates children by array
+offset (`SplitLayoutView.swift:82-108`). Those identities are not stable enough
+for concurrent semantic operations or authoritative tree replacement.
+
+The existing model also permits terminal leaves anywhere in the tree. Closing a
+note pane deletes the underlying note, while removing a terminal pane leaves its
+terminal alive and reconciliation can later recreate a tab for it
+(`PanePlaceholder.swift:488-503`, `AppState.swift:1685-1748`). Exposing those
+semantics to agents would make `panel.close` content-dependent and surprising.
+
+Finally, the same `layouts` dictionary is keyed by tab ID in single-worktree mode
+and worktree ID in the multi-worktree grid (`TerminalContainerView.swift:267-270,
+570-577`). The latter path is not a real persisted tab layout and must be split
+out before migration.
+
+## 5. Domain model
+
+The durable surface types and pure mutation logic live in `TBDShared`, with no
+SwiftUI or daemon dependencies.
+
+### 5.1 Stable identity types
+
+Use distinct nominal wrappers (or documented UUID typealiases during the first
+implementation) for:
+
+- `WorkspaceTabID`
+- `PanelID`
+- `SplitID`
+- `PanelOperationID`
+
+Resource identifiers such as `TerminalID` and `NoteID` are never used as panel
+or split identity.
+
+### 5.2 Workspace tab and primary content
+
+```swift
+public struct WorkspaceTabSurface: Codable, Sendable, Equatable {
+    public let id: UUID
+    public let worktreeID: UUID
+    public var label: String?
+    public var primary: PrimaryContent
+    public var layout: PanelLayoutNode
+    public var revision: UInt64
+}
+
+public enum PrimaryContent: Codable, Sendable, Equatable {
+    case terminal(terminalID: UUID)
+    case note(noteID: UUID)
+    case file(FileReference)
+    case web(URL)
+    case transcript(terminalID: UUID)
+}
+```
+
+`PrimaryContent` includes all legacy top-level content so migration never has to
+discard a viewer-only tab. The invariant is one-way: terminals are allowed only
+as primary content; viewer content may be primary or auxiliary. Note that
+`.transcript` as primary content is new surface — today transcripts exist only
+as split panes; it is included so migration and future layouts never need a
+special case, not as a committed UI feature.
+
+The primary anchor in the tree does not duplicate `PrimaryContent`. It refers to
+the workspace tab's primary rendering slot:
+
+```swift
+public indirect enum PanelLayoutNode: Codable, Sendable, Equatable {
+    case primary
+    case panel(PanelSlot)
+    case split(SplitNode)
+}
+```
+
+Every valid tree contains exactly one `.primary` node.
+
+### 5.3 Viewer panels
+
+```swift
+public struct PanelSlot: Codable, Sendable, Equatable {
+    public let id: UUID
+    public var content: PanelContent
+}
+
+public enum PanelContent: Codable, Sendable, Equatable {
+    case file(FileReference)
+    case web(URL)
+    case transcript(terminalID: UUID)
+    case note(noteID: UUID)
+}
+
+public struct FileReference: Codable, Sendable, Equatable {
+    public var path: String
+    public var presentation: FilePresentation
+}
+
+public enum FilePresentation: String, Codable, Sendable {
+    case automatic
+    case source
+    case rendered
+}
+```
+
+For paths inside a worktree, the daemon stores a normalized worktree-relative
+path. Absolute paths are retained when explicitly supplied and supported by the
+existing viewer. `automatic` renders known renderable formats such as Markdown
+and otherwise shows source. Switching source/rendered presentation is navigation
+within the same panel; it does not create a new panel.
+
+### 5.4 Split nodes
+
+```swift
+public struct SplitNode: Codable, Sendable, Equatable {
+    public let id: UUID
+    public var direction: SplitDirection
+    public var children: [PanelLayoutNode]
+    public var ratios: [Double]
+}
+```
+
+The model remains n-ary for compatibility with the current layout. Ratios must
+match child count, each child must meet the minimum share, and normalized ratios
+must sum to approximately 1.0. Resize operations target `SplitID`; they never
+identify a split through tree position or child equality.
+
+### 5.5 Invariants
+
+The shared validator and reducer enforce:
+
+- exactly one primary anchor per workspace tab;
+- globally unique panel IDs within a tab;
+- globally unique split IDs within a tab;
+- no empty or one-child split nodes after normalization;
+- valid, normalized ratios;
+- no terminal case in `PanelContent` or any panel-creation specification;
+- referenced notes and transcripts belong to an allowed worktree/resource;
+- close and move operations cannot target the primary anchor;
+- a mutation either returns a fully valid tree or a typed error without change.
+
+## 6. Viewer navigation and history
+
+A viewer panel is a stable navigation slot. Navigating it changes
+`PanelSlot.content` but preserves `PanelSlot.id`, so pane-owned view identity and
+history remain stable.
+
+```swift
+public struct PanelHistory: Codable, Sendable, Equatable {
+    public var entries: [PanelContent]
+    public var cursor: Int
+}
+```
+
+History rules (matching the MRU semantics shipped in PR #472 — a tab-like
+most-recently-viewed list, not a browser stack; there is no forward-branch
+truncation):
+
+- retain at most 10 entries per panel; `entries[0]` is the most recently
+  committed reference and `cursor` indexes the currently displayed entry;
+- back moves the cursor toward older entries (cursor + 1), forward toward
+  newer (cursor − 1), and jump sets it directly; none of these reorder the
+  list, so the jump menu holds its order while the user flips through it;
+- a normal navigation commits: the current entry moves to the front if not
+  already there, any existing occurrence of the destination is removed (an
+  entry moves rather than duplicates), the destination is inserted at the
+  front, and the cursor resets to zero; navigating to the current entry is
+  a no-op;
+- the cap evicts the oldest (tail) entry, which is never the current entry
+  because a commit moves the current entry to the front first;
+- closing a panel deletes its history;
+- a deleted note or terminal removes invalid note/transcript history entries;
+- if current content becomes invalid, navigate to the nearest valid history
+  entry or close the panel when none remains (this generalizes the transcript
+  toggle-off restore behavior shipped in PR #472: dismissing a transcript from
+  a reused slot restores the nearest non-transcript entry rather than
+  destroying the panel);
+- history stores reconstructable references, never rendered content or live
+  view/controller state.
+
+`entries[cursor]` is always equal to `PanelSlot.content`; a new panel starts with
+one entry and cursor zero. The duplication lets layout queries summarize current
+content without loading history, while the store transaction and validator keep
+the two representations consistent.
+
+The app presents the established back/forward controls at the leading edge of
+the viewer header (fixed slots, per PR #472). Primary click steps through
+history; right-click opens the jump menu — both buttons show the same full
+list, newest first, with a checkmark on the current entry. This menu is
+deliberately tab-like, but entries are navigation history, not independently
+mounted tabs.
+
+### 6.1 Default file-routing policy
+
+Command-click in a terminal or viewer issues the same semantic `open` intent as
+the CLI:
+
+1. In the active workspace tab, prefer the most recently navigated viewer panel
+   (the daemon can derive this durably from `panel_history.updated_at`), falling
+   back to deterministic pre-order traversal.
+2. If one exists, navigate that panel to the new reference and push history.
+3. Otherwise split a new viewer panel to the right of the primary anchor at a
+   default 35% share.
+4. Never replace, embed, hide, or kill the primary terminal.
+
+The most-recently-navigated preference supersedes the interim reuse order
+shipped in PR #472 (prefer an existing code viewer, then any viewer-class
+pane); it is a deliberate behavior change, not drift.
+
+An explicit “Open to Side” placement always creates a new panel. An explicit
+“Replace Panel” placement targets a particular `PanelID` and pushes its history.
+
+## 7. Ownership and runtime architecture
+
+### 7.1 Authority
+
+The daemon is the only committed-state writer:
+
+```text
+ app gesture ── semantic operation ──┐
+                                     ▼
+ agent CLI ── semantic operation ──► PanelCoordinator actor
+                                     │
+                            shared pure reducer
+                                     │
+                              SQLite transaction
+                                     │
+                         snapshot/result + StateDelta
+                              │                    │
+                              ▼                    ▼
+                           caller            subscribed app
+```
+
+The daemon owns:
+
+- workspace-tab existence and ordering;
+- primary-content association;
+- active workspace tab;
+- panel layout and revisions;
+- viewer history;
+- semantic validation and conflict resolution;
+- cleanup when referenced notes or terminals disappear.
+
+The app owns only presentation state such as hover, divider drag preview,
+keyboard focus, scroll position, and temporary optimistic projections.
+
+### 7.2 PanelCoordinator
+
+A daemon `PanelCoordinator` actor serializes operations per worktree, applies the
+shared reducer, persists the resulting surface and history in one database
+transaction, and broadcasts only after commit. GRDB write serialization is not
+a replacement for this domain boundary: the coordinator also orders validation,
+resource reconciliation, result construction, and broadcasts.
+
+Operations carry:
+
+```swift
+public struct PanelOperationEnvelope: Codable, Sendable {
+    public let operationID: UUID
+    public let worktreeID: UUID
+    public let tabID: UUID
+    public let baseRevision: UInt64?
+    public let origin: PanelOperationOrigin
+    public let operation: PanelOperation
+}
+```
+
+`origin` supports feature gating and diagnostics (`appUser`, `agentCLI`,
+`daemonReconcile`); it is not a security credential.
+
+### 7.3 Semantic operations
+
+```swift
+public enum PanelOperation: Codable, Sendable {
+    case open(content: PanelContentSpec, placement: PanelPlacement)
+    case close(panelID: UUID)
+    case move(panelID: UUID, placement: PanelPlacement)
+    case resize(splitID: UUID, ratios: [Double])
+    case navigate(panelID: UUID, destination: PanelContentSpec)
+    case history(panelID: UUID, action: PanelHistoryAction)
+    case selectTab(tabID: UUID)
+}
+```
+
+`PanelPlacement` supports automatic reuse, replacement of a specific panel, and
+insertion before/after/above/below the primary anchor or a specific panel. The
+wire vocabulary uses user-facing edges; split direction is derived internally.
+
+There is deliberately no terminal content specification and no generic
+whole-tree `set` method exposed to clients.
+
+### 7.4 Versions, idempotency, and conflicts
+
+- Every successful mutation increments that tab's monotonic revision.
+- `operationID` is unique and idempotent. The daemon persists a bounded recent
+  operation record so reconnect/retry after a response loss cannot apply twice.
+- `baseRevision` is advisory for semantic rebase, not an unconditional compare-
+  and-swap gate.
+- If the base is stale but all targets still exist, apply the operation to the
+  current authoritative tree.
+- If a target was removed or changed incompatibly, return a typed stale-target
+  error and leave state unchanged.
+- Duplicate operation IDs return the original committed result.
+- State deltas and RPC results include revision and `operationID`, allowing the
+  app to deduplicate the response/subscription race.
+
+### 7.5 App optimistic projection
+
+The app keeps:
+
+```text
+confirmed daemon snapshot + ordered pending user operations = rendered snapshot
+```
+
+For a user gesture, the app runs the shared reducer locally and renders the
+projection immediately, then sends the operation. On an authoritative result or
+delta it adopts the newer confirmed snapshot, removes the matching pending
+operation, and reapplies any remaining pending operations. If a pending target
+became invalid, the app drops that projection and presents a non-blocking error.
+
+The app does not maintain an offline write queue. If the daemon is unavailable,
+committed layout controls are temporarily disabled and the app shows its normal
+connection failure UI. This preserves one authority and avoids a recovery-time
+whole-tree overwrite.
+
+### 7.6 Stable SwiftUI identity
+
+Before switching authority, rendering must use stable IDs:
+
+- split children are keyed by their `PanelID`/`SplitID` identity, never array
+  offset;
+- panel-owned state objects are keyed by `PanelID`;
+- the primary renderer is keyed by workspace-tab identity and primary resource;
+- an authoritative tree replacement with unchanged IDs must preserve unaffected
+  terminal, file-watcher, webview, and transcript view identity.
+
+This makes normal SwiftUI reconciliation the diff engine. There is no separate
+hand-written view-tree “diff apply” protocol.
+
+## 8. Persistence
+
+The daemon needs first-class rows for every workspace tab; the existing sparse
+`tab` metadata table cannot represent the authoritative aggregate.
+
+Illustrative schema (exact migration number chosen at implementation time):
+
+```sql
+CREATE TABLE workspace_tab_surface (
+    id              TEXT PRIMARY KEY,
+    worktree_id     TEXT NOT NULL,
+    primary_content TEXT NOT NULL,  -- PrimaryContent JSON
+    label           TEXT,
+    position        INTEGER NOT NULL,
+    layout          TEXT NOT NULL,  -- PanelLayoutNode JSON
+    revision        INTEGER NOT NULL DEFAULT 0,
+    updated_at      DATETIME NOT NULL
+);
+CREATE INDEX idx_workspace_tab_surface_worktree
+    ON workspace_tab_surface(worktree_id, position);
+
+CREATE TABLE panel_history (
+    panel_id   TEXT PRIMARY KEY,
+    tab_id     TEXT NOT NULL,
+    history    TEXT NOT NULL,       -- PanelHistory JSON
+    updated_at DATETIME NOT NULL
+);
+CREATE INDEX idx_panel_history_tab ON panel_history(tab_id);
+
+CREATE TABLE panel_operation_receipt (
+    operation_id TEXT PRIMARY KEY,
+    worktree_id  TEXT NOT NULL,
+    tab_id       TEXT NOT NULL,
+    revision     INTEGER NOT NULL,
+    result       TEXT NOT NULL,
+    applied_at   DATETIME NOT NULL
+);
+```
+
+The store writes layout, affected history, ordering, active-tab changes, and
+operation receipt atomically. Old receipts are pruned by count/age; they are not
+an event-sourcing log. The current snapshot remains the authority.
+
+Per the repository migration rule, the schema migration, GRDB record/store
+types, and backward-compatible `TBDShared` Codable models land together. Existing
+migrations are never modified.
+
+## 9. Resource lifecycle reconciliation
+
+Panel operations have no terminal-creation or terminal-destruction side effects.
+Terminal lifecycle remains a workspace-tab concern:
+
+- terminal creation creates a terminal record and its primary workspace tab as
+  one coordinated daemon workflow;
+- closing a terminal workspace tab kills its tmux session, deletes the terminal
+  record, deletes the complete tab surface/history, updates ordering/selection,
+  and broadcasts the committed result;
+- external terminal death performs the same durable surface cleanup;
+- closing a file, web, transcript, or note panel only removes that panel;
+- deleting a note explicitly removes primary tabs and panel/history references
+  to that note;
+- deleting a terminal prunes transcript panels and transcript history entries
+  that reference it across the worktree;
+- the pinned-terminal dock is a separate presentation of the terminal resource;
+  deleting the terminal removes it from the dock through existing terminal
+  lifecycle state, not through panel layout.
+
+Terminal-tab close is a recoverable daemon workflow, not one database
+transaction pretending it can atomically include tmux:
+
+1. Validate the tab and durably mark its terminal as closing.
+2. In the same database transaction, remove the tab surface and dependent
+   transcript panels/history, update order/selection, and record the operation.
+3. Broadcast the committed surface, then kill the tmux resource.
+4. Delete/finalize the closing terminal record after the kill attempt.
+5. On daemon startup, finish any terminal records left in the closing state.
+
+Thus the UI and surface stop referencing the session immediately, and a daemon
+crash between layout commit and tmux cleanup cannot leave a permanent orphan.
+
+Closing a non-terminal primary tab removes that tab presentation but does not
+delete its note or other referenced resource. Reopening such a resource is an
+explicit note/file action; reconciliation never recreates a closed tab merely
+because its resource still exists.
+
+This replaces the current app-side rule that infers a new tab for every terminal
+not found in a layout. Placement is explicit daemon state, so there are no
+“unrepresented” live terminals to rediscover.
+
+## 10. RPC, deltas, and CLI
+
+### 10.1 RPC
+
+Add a small surface rather than one method per layout verb:
+
+- `panel.get` — authoritative surface for one worktree or tab.
+- `panel.apply` — one `PanelOperationEnvelope`; returns the committed affected
+  tab/worktree snapshot.
+
+`StateDelta.panelSurfaceChanged` carries `worktreeID`, affected tab snapshots,
+removed tab IDs, active tab ID, revision metadata, and originating operation ID.
+The full affected tab snapshot is preferred over structural wire diffs: trees
+are small, IDs are stable, and full payloads are self-healing.
+
+Read results are authoritative even when the app is closed. They do not need
+`appConnected` or `stalenessSeconds`. App presence may later be exposed for
+attention/focus features, but it is not part of layout correctness.
+
+### 10.2 Agent feature gate
+
+`config.agent_panel_control_enabled` is added default-off. `panel.apply` rejects
+`origin: agentCLI` while off and names the setting in its typed error. App-user
+operations and daemon reconciliation are unaffected. `panel.get` is ungated.
+
+The origin field and local socket are not treated as an adversarial security
+boundary. This is consistent with the rest of TBD's same-user CLI surface and
+avoids capability/token complexity that does not match the product threat model.
+
+### 10.3 CLI
+
+```text
+tbd panel list [--worktree <id|name>] [--tab <id>] [--json]
+
+tbd panel open <file|url|note|transcript>
+    [--worktree <id|name>] [--tab <id>]
+    [--automatic|--source|--rendered]
+    [--replace <panel-id>]
+    [--target primary|<panel-id>] [--left|--right|--above|--below]
+
+tbd panel close <panel-id> [--worktree <id|name>]
+tbd panel move <panel-id> --target primary|<panel-id>
+    --left|--right|--above|--below [--worktree <id|name>]
+tbd panel resize <split-id> --ratios <r1,r2,...> [--worktree <id|name>]
+tbd panel select-tab <tab-id> [--worktree <id|name>]
+```
+
+When `--worktree` is absent, the CLI uses `TBD_WORKTREE_ID`, then cwd resolution.
+An explicit override is accepted normally. IDs accept full UUIDs or an
+unambiguous prefix emitted by `panel list`.
+
+`panel open` defaults to the automatic routing policy in §6.1. Its file argument
+is resolved relative to the selected worktree root, not the CLI process cwd,
+unless an explicit absolute path is supplied. Mutating commands print the
+committed post-operation tree so an agent gets read-after-write confirmation
+without a second call.
+
+The CLI intentionally has no terminal panel syntax. Attempts such as
+`--content terminal` fail during argument parsing rather than becoming daemon
+operations.
+
+### 10.4 Agent skill guidance
+
+The bundled skill should teach intent before syntax:
+
+- inspect before rearranging;
+- use `panel open` and automatic reuse for ordinary file presentation;
+- create a new side only when simultaneous comparison is useful;
+- do not exceed a small number of panels without user direction;
+- viewer panels never contain or control terminal sessions;
+- use `tbd terminal create` for another terminal workspace tab;
+- `--worktree` may target another worktree when the task calls for it;
+- panel changes persist even if the app is currently closed.
+
+Exact examples are generated from the implemented CLI help during the plan so
+the skill does not document flags that do not exist.
+
+## 11. Migration from current layouts
+
+Migration must preserve every live terminal and as much viewer arrangement as
+possible.
+
+### 11.1 Prerequisite cleanup
+
+1. Move the layout model and reducer to `TBDShared`.
+2. Separate the multi-worktree grid's `layouts[worktreeID]` storage from real
+   tab layouts; grid state remains app-local and is not imported.
+3. Introduce stable panel IDs separate from content/resource IDs.
+4. Introduce stable split IDs during decode when absent.
+5. Render split children by stable identity.
+6. Route all current app mutations through semantic reducer functions before
+   changing persistence ownership.
+
+### 11.2 One-time UserDefaults import
+
+Only the app can reliably read its UserDefaults domain. With daemon-surface mode
+enabled, it fetches the daemon surface first. For worktrees/tabs with no imported
+surface, it decodes the legacy blob and submits a dedicated internal import RPC.
+The import is create-if-absent and cannot overwrite an existing daemon surface.
+
+For each legacy tab:
+
+1. Use `Tab.content` as `PrimaryContent` and create one `.primary` anchor.
+2. Find the legacy leaf corresponding to that primary resource and replace it
+   with the primary anchor.
+3. Convert non-terminal legacy leaves to viewer panels with new stable panel
+   IDs while preserving paths, URLs, notes, transcripts, split direction, and
+   ratios where valid.
+4. For every additional terminal leaf, create a separate primary terminal
+   workspace tab. Never kill or discard it.
+5. Remove now-empty branches and normalize ratios.
+6. Generate stable IDs for every surviving split.
+7. Preserve existing label/order/active-tab metadata; promoted terminal tabs are
+   inserted immediately after their source tab in traversal order.
+8. Validate the result before committing anything for that worktree.
+
+Per-panel histories persisted by PR #472 (the `com.tbd.app.paneHistories`
+UserDefaults blob) are imported in the same pass: entries are re-keyed to the
+new stable panel ID of each surviving converted panel, entries referencing
+discarded panes are dropped, and imported histories are validated by the same
+well-formedness rules as live ones.
+
+The legacy UserDefaults keys (layouts and histories) remain untouched for one
+rollback release. Import status is recorded daemon-side; an empty legitimate
+layout is distinguishable from “not imported.”
+
+### 11.3 Shadow comparison, not Approach A command routing
+
+Before authority flips, the app may dual-write imported semantic results to an
+inert daemon store and compare normalized snapshots for diagnostics. It must not
+implement Approach A's broadcast-command/parked-ACK protocol. Shadow writes are
+a migration validation tool only; agent mutation remains disabled until the
+daemon path becomes authoritative.
+
+## 12. Rollout
+
+Two default-off daemon flags separate ownership risk from autonomous agent use:
+
+1. `daemon_panel_surface_enabled` — controls import and daemon ownership.
+2. `agent_panel_control_enabled` — controls agent-originated mutations and
+   requires daemon surface ownership.
+
+Suggested sequence:
+
+1. Land shared IDs, model, validator, reducer, and property tests.
+2. Land renderer identity fixes and remove terminal-split creation from UI.
+3. Land schema/store/coordinator and import code inert behind flag 1.
+4. Run shadow import/compare against real layouts; fix every divergence.
+5. Enable daemon ownership for developer dogfood; keep agent mutation off.
+6. Migrate terminal creation/deletion and tab reconciliation to explicit surface
+   ownership.
+7. Land read-only `panel list` and viewer history UI.
+8. Land CLI mutation commands behind flag 2 and update the bundled skill.
+9. Soak app-user operations before actively dogfooding agent arrangement.
+10. Graduate flags independently using new migrations for defaults/forced
+    updates as required by repository policy; remove the legacy UserDefaults
+    import only after a rollback release.
+
+Divider unification may land independently before or after these phases. It uses
+the same deferred-commit behavior for layout dividers but is not a prerequisite
+for ownership.
+
+## 13. Testing
+
+### Shared model and reducer
+
+- decode legacy terminal/pane/split JSON;
+- generate stable IDs during migration;
+- exactly-one-primary validation;
+- reject terminal panel specifications;
+- split/close/move/resize/navigate/history semantics;
+- stale-target errors;
+- ratio normalization and minimums;
+- history cap with tail eviction (never the current entry), MRU commit
+  reordering, dedupe-by-move, cursor traversal without reordering, and
+  invalid-reference cleanup;
+- property tests over arbitrary valid operation sequences: the output remains
+  valid, contains one primary, and never contains a terminal panel.
+
+### Daemon/store
+
+- migration and import create-if-absent behavior;
+- atomic snapshot/history/order/receipt writes;
+- monotonic revision and duplicate-operation replay;
+- stale-base semantic application versus stale-target rejection;
+- agent flag on/off branches;
+- mutations while no app subscriber exists;
+- terminal/note deletion reconciliation across primary tabs, panels, and
+  history;
+- terminal creation always produces a primary workspace tab;
+- worktree archive/delete cleans all new rows.
+
+### App
+
+- confirmed-plus-pending optimistic projection;
+- response/delta deduplication by operation ID;
+- authoritative rebase with pending operations;
+- failed pending operation rollback and user feedback;
+- stable view identity when unrelated panels move, resize, open, or close;
+- command-click automatic reuse and no-viewer fallback split;
+- back/forward/right-click jump behavior;
+- multi-worktree grid state never enters daemon persistence;
+- daemon-disconnected layout controls do not accumulate offline writes.
+
+### Migration fixtures
+
+- one terminal only;
+- terminal plus code viewer;
+- nested mixed viewer splits;
+- multiple terminal leaves (all promoted, none killed);
+- note primary with viewer panels;
+- viewer-only legacy primary;
+- transcript referencing primary and non-primary terminals;
+- malformed ratios and missing legacy resources;
+- active/order/label preservation;
+- rollback leaves the UserDefaults blob readable.
+
+### CLI/RPC
+
+- default worktree from `TBD_WORKTREE_ID` and cwd fallback;
+- explicit cross-worktree override;
+- UUID-prefix ambiguity errors;
+- file path normalization relative to target worktree;
+- read-after-write result matches persisted snapshot;
+- terminal content rejected before mutation;
+- app-closed list/open/close/move/resize/select-tab flow.
+
+All integration tests follow the repository's `TBD_HOME` isolation rules and
+must never touch the developer's live `~/tbd` state.
+
+## 14. Risks and mitigations
+
+### First-class tab ownership is a broad migration
+
+Today tabs are partially inferred app state. Making them authoritative touches
+terminal creation, notes, ordering, selection, close, restore, and worktree
+cleanup. Mitigate with semantic centralization first, create-if-absent import,
+shadow comparison, two flags, and a rollback release.
+
+### SwiftUI identity regressions can disrupt live viewers
+
+Stable IDs in the data model are insufficient if the renderer still keys by
+offset or reconstructs controllers under changing structural identity. Treat
+identity tests and live terminal/file/web verification as an ownership-flip
+gate, not polish.
+
+### Promoting legacy split terminals changes presentation
+
+The no-terminal-panel invariant necessarily turns old split terminals into
+workspace tabs. The sessions survive, ordering is deterministic, and the import
+should show a one-time explanatory toast or release note rather than silently
+appearing as a random rearrangement.
+
+### Automatic viewer reuse may surprise users
+
+Use the most recently active compatible viewer and preserve history, so the
+previous destination is one Back click away. “Open to Side” remains explicit
+when simultaneous visibility matters. Dogfood the reuse policy separately from
+daemon ownership.
+
+### App-closed mutations can change the next launch
+
+This is intentional. RPC results are authoritative, operations are idempotent,
+and the next app connection loads the committed surface. The CLI and skill must
+state that panel changes persist even while the app is closed.
+
+## 15. Future work
+
+- raw/scratch rendered content with a durable content-addressing scheme;
+- view-state mirrors such as visible file range and scroll position;
+- user annotations keyed by panel content reference;
+- richer placement intents (“beside my terminal”, “reuse the plan panel”);
+- reopen-closed-panel history, distinct from per-panel navigation history;
+- saved workspace layout templates;
+- agent inspection of navigation history if a concrete use case emerges;
+- explicit tuck-away/archive workflows for non-terminal primary content;
+- panel control for other presentation surfaces only if they acquire a durable
+  product model (the pinned dock and multi-worktree grid remain out of scope).
+
+## 16. Acceptance criteria
+
+The design is complete when all of the following hold:
+
+1. An agent can inspect and mutate viewer panels with the app closed.
+2. Reopening the app renders exactly the daemon's committed surface.
+3. No panel operation can create, embed, replace, close, or orphan a terminal
+   session.
+4. Creating a terminal creates a primary workspace tab; closing that tab kills
+   the terminal.
+5. Command-click never replaces a terminal and either reuses viewer history or
+   creates a viewer panel.
+6. Every tab layout always contains exactly one primary anchor.
+7. Unaffected live views retain identity across authoritative updates.
+8. Existing split terminal sessions survive migration as separate tabs.
+9. Viewer history survives restart and its right-click menu replaces the need
+   for pane-local tabs.
+10. The legacy UserDefaults blob is no longer an active writer after authority
+    flips, and no competing app-owned mirror protocol remains.


### PR DESCRIPTION
Approach C (daemon-owned primary-anchor layout) is the adopted design for TBD's panel agent surface, superseding approaches A (mirror) and B (daemon-owned split); A and B are kept here as decision records. Phase 1 of C has already merged as #478; Phase 2 planning is underway. Landing all three specs on main so implementers and reviewers can cite them directly. No code changes.

