### PR TITLE
Feat: Drag-and-drop reorder model profiles in settings

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -508,6 +508,30 @@ extension AppState {
         }
     }
 
+    // MARK: - Reorder
+
+    /// Reorder model profiles, triggered by SwiftUI `.onMove` in the settings
+    /// profile list. Mirrors `AppState.reorderTopLevelWorktrees`: updates
+    /// locally first (optimistic), then persists via RPC; rolls back on error.
+    /// Unlike worktrees, profiles are a flat global list — no nesting/repo
+    /// scoping to filter around.
+    func reorderModelProfiles(fromOffsets source: IndexSet, toOffset destination: Int) {
+        let previous = modelProfiles
+        var rows = modelProfiles
+        rows.move(fromOffsets: source, toOffset: destination)
+        modelProfiles = rows
+
+        let orderedIDs = rows.map(\.profile.id)
+        Task {
+            do {
+                try await daemonClient.reorderModelProfiles(profileIDs: orderedIDs)
+            } catch {
+                logger.error("reorderModelProfiles RPC failed: \(error.localizedDescription, privacy: .public)")
+                await MainActor.run { self.modelProfiles = previous }
+            }
+        }
+    }
+
     // MARK: - Nightwatch Mode
 
     /// Set the nightwatch mode (off, daywatch, or nightwatch).

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1326,6 +1326,14 @@ actor DaemonClient {
         )
     }
 
+    /// Reorder model profiles.
+    func reorderModelProfiles(profileIDs: [UUID]) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.modelProfileReorder,
+            params: ModelProfileReorderParams(profileIDs: profileIDs)
+        )
+    }
+
     /// Set or clear the global model-profile override applied to scratch terminal spawns.
     func setScratchProfileOverride(_ id: UUID?) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -70,6 +70,9 @@ struct ModelProfilesSettingsView: View {
                 ModelProfileRow(entry: entry)
                     .environmentObject(appState)
             }
+            .onMove { source, destination in
+                appState.reorderModelProfiles(fromOffsets: source, toOffset: destination)
+            }
         }
         .listStyle(.inset)
         .frame(minHeight: 200)

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -924,6 +924,15 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        // Drag-and-drop reordering for model profiles (mirrors v11's worktree
+        // sortOrder). Initialize existing rows from rowid to preserve current
+        // insertion order.
+        migrator.registerMigration("v56_model_profiles_sort_order") { db in
+            try db.addColumnIfMissing(
+                table: "model_profiles", column: "sort_order", type: .integer, defaults: 0)
+            try db.execute(sql: "UPDATE model_profiles SET sort_order = rowid")
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/ModelProfileRecord.swift
+++ b/Sources/TBDDaemon/Database/ModelProfileRecord.swift
@@ -24,6 +24,7 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
     var env_overrides: String?
     var created_at: Date
     var last_used_at: Date?
+    var sort_order: Int = 0
 
     init(from profile: ModelProfile) {
         self.id = profile.id.uuidString
@@ -38,6 +39,7 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
         self.env_overrides = EnvOverridesCoding.encode(profile.envOverrides)
         self.created_at = profile.createdAt
         self.last_used_at = profile.lastUsedAt
+        self.sort_order = profile.sortOrder
     }
 
     /// Failable decode: skips (returns nil after a logged warning) rather than
@@ -59,7 +61,8 @@ struct ModelProfileRecord: Codable, FetchableRecord, PersistableRecord, Sendable
             fallbackModels: Self.decodeFallbackModels(fallback_models),
             envOverrides: EnvOverridesCoding.decode(env_overrides),
             createdAt: created_at,
-            lastUsedAt: last_used_at
+            lastUsedAt: last_used_at,
+            sortOrder: sort_order
         )
     }
 
@@ -87,23 +90,56 @@ public struct ModelProfileStore: Sendable {
         self.writer = writer
     }
 
+    /// Create a new model profile. Automatically assigns
+    /// sortOrder = max(sortOrder) + 1 (profiles are global — no repoID scoping).
     public func create(name: String, kind: CredentialKind,
                        baseURL: String? = nil, model: String? = nil,
                        awsRegion: String? = nil, awsProfile: String? = nil,
                        fallbackModels: [String]? = nil) async throws -> ModelProfile {
-        let profile = ModelProfile(name: name, kind: kind, baseURL: baseURL, model: model,
-                                   awsRegion: awsRegion, awsProfile: awsProfile,
-                                   fallbackModels: fallbackModels)
-        let record = ModelProfileRecord(from: profile)
         try await writer.write { db in
+            let maxOrder = try Int.fetchOne(
+                db, sql: "SELECT MAX(sort_order) FROM model_profiles"
+            ) ?? 0
+            let profile = ModelProfile(name: name, kind: kind, baseURL: baseURL, model: model,
+                                       awsRegion: awsRegion, awsProfile: awsProfile,
+                                       fallbackModels: fallbackModels, sortOrder: maxOrder + 1)
+            let record = ModelProfileRecord(from: profile)
             try record.insert(db)
+            return profile
         }
-        return profile
     }
 
     public func list() async throws -> [ModelProfile] {
         try await writer.read { db in
-            try ModelProfileRecord.fetchAll(db).compactMap { $0.toModel() }
+            try ModelProfileRecord
+                .order(Column("sort_order"))
+                .fetchAll(db).compactMap { $0.toModel() }
+        }
+    }
+
+    /// Reorder model profiles. Only affects the profiles in the provided list;
+    /// any other profile not in the list is pushed to sortOrder values after
+    /// the reordered ones. Mirrors `WorktreeStore.reorder` — profiles are
+    /// global, so there's no repo scoping.
+    public func reorder(profileIDs: [UUID]) async throws {
+        try await writer.write { db in
+            for (index, profileID) in profileIDs.enumerated() {
+                try db.execute(
+                    sql: "UPDATE model_profiles SET sort_order = ? WHERE id = ?",
+                    arguments: [index, profileID.uuidString]
+                )
+            }
+            // Push any profiles not in the provided list to after the reordered ones.
+            let idStrings = profileIDs.map(\.uuidString)
+            let placeholders = idStrings.map { _ in "?" }.joined(separator: ",")
+            let args: [any DatabaseValueConvertible] = [profileIDs.count] + idStrings
+            try db.execute(
+                sql: """
+                    UPDATE model_profiles SET sort_order = ? + rowid
+                    WHERE id NOT IN (\(placeholders))
+                    """,
+                arguments: StatementArguments(args)
+            )
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ModelProfileHandlers.swift
@@ -340,6 +340,15 @@ extension RPCRouter {
         return .ok()
     }
 
+    // MARK: - Reorder
+
+    func handleModelProfileReorder(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ModelProfileReorderParams.self, from: paramsData)
+        try await db.modelProfiles.reorder(profileIDs: params.profileIDs)
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     func handleModelProfileSetRepoOverride(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ModelProfileSetRepoOverrideParams.self, from: paramsData)
         guard try await db.repos.get(id: params.repoID) != nil else {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -288,6 +288,8 @@ public final class RPCRouter: Sendable {
                 return try await handleModelProfileSetPrimaryAgentPreference(request.paramsData)
             case RPCMethod.modelProfileSetRepoOverride:
                 return try await handleModelProfileSetRepoOverride(request.paramsData)
+            case RPCMethod.modelProfileReorder:
+                return try await handleModelProfileReorder(request.paramsData)
             case RPCMethod.configSetEnvOverrides:
                 return try await handleConfigSetEnvOverrides(request.paramsData)
             case RPCMethod.repoSetEnvOverrides:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -472,13 +472,17 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
     public var envOverrides: [String: String]
     public var createdAt: Date
     public var lastUsedAt: Date?
+    /// Drag-and-drop display order (mirrors `Worktree.sortOrder`). Defaults to
+    /// 0 so existing JSON/rows without this field still decode.
+    public var sortOrder: Int
 
     public init(id: UUID = UUID(), name: String, kind: CredentialKind,
                 baseURL: String? = nil, model: String? = nil,
                 awsRegion: String? = nil, awsProfile: String? = nil,
                 fallbackModels: [String]? = nil,
                 envOverrides: [String: String] = [:],
-                createdAt: Date = Date(), lastUsedAt: Date? = nil) {
+                createdAt: Date = Date(), lastUsedAt: Date? = nil,
+                sortOrder: Int = 0) {
         self.id = id
         self.name = name
         self.kind = kind
@@ -490,11 +494,12 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
         self.envOverrides = envOverrides
         self.createdAt = createdAt
         self.lastUsedAt = lastUsedAt
+        self.sortOrder = sortOrder
     }
 
     enum CodingKeys: String, CodingKey {
         case id, name, kind, baseURL, model, awsRegion, awsProfile, fallbackModels
-        case envOverrides, createdAt, lastUsedAt
+        case envOverrides, createdAt, lastUsedAt, sortOrder
     }
 
     public init(from decoder: Decoder) throws {
@@ -511,6 +516,7 @@ public struct ModelProfile: Codable, Sendable, Identifiable, Equatable {
             [String: String].self, forKey: .envOverrides) ?? [:]
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         lastUsedAt = try c.decodeIfPresent(Date.self, forKey: .lastUsedAt)
+        sortOrder = try c.decodeIfPresent(Int.self, forKey: .sortOrder) ?? 0
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -153,6 +153,7 @@ public enum RPCMethod {
     public static let modelProfileSetGlobalDefault = "modelProfile.setGlobalDefault"
     public static let modelProfileSetPrimaryAgentPreference = "modelProfile.setPrimaryAgentPreference"
     public static let modelProfileSetRepoOverride = "modelProfile.setRepoOverride"
+    public static let modelProfileReorder = "modelProfile.reorder"
     public static let modelProfileFetchUsage = "modelProfile.fetchUsage"
     public static let modelProfileUsageRefresh = "modelProfile.usageRefresh"
     public static let modelProfileHealthCheck = "modelProfile.healthCheck"
@@ -1050,6 +1051,15 @@ public struct WorktreeReorderParams: Codable, Sendable {
     public let worktreeIDs: [UUID]
     public init(repoID: UUID, worktreeIDs: [UUID]) {
         self.repoID = repoID; self.worktreeIDs = worktreeIDs
+    }
+}
+
+/// Params for `modelProfile.reorder`. Profiles are global — no repoID scoping
+/// (unlike `WorktreeReorderParams`).
+public struct ModelProfileReorderParams: Codable, Sendable {
+    public let profileIDs: [UUID]
+    public init(profileIDs: [UUID]) {
+        self.profileIDs = profileIDs
     }
 }
 

--- a/Tests/TBDDaemonTests/ModelProfileStoreTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileStoreTests.swift
@@ -158,4 +158,57 @@ struct ModelProfileStoreTests {
         let fetched = try await db.modelProfiles.get(id: p.id)
         #expect(fetched?.awsProfile == nil)
     }
+
+    // MARK: - Reorder (mirrors WorktreeStoreTests.reorderChangesListOrder)
+
+    @Test("create auto-assigns increasing sortOrder")
+    func createAssignsSortOrder() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let p1 = try await db.modelProfiles.create(name: "first", kind: .oauth)
+        let p2 = try await db.modelProfiles.create(name: "second", kind: .oauth)
+        let p3 = try await db.modelProfiles.create(name: "third", kind: .oauth)
+
+        #expect(p1.sortOrder < p2.sortOrder)
+        #expect(p2.sortOrder < p3.sortOrder)
+    }
+
+    @Test("list returns profiles ordered by sortOrder")
+    func listOrdersBySortOrder() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let p1 = try await db.modelProfiles.create(name: "first", kind: .oauth)
+        let p2 = try await db.modelProfiles.create(name: "second", kind: .oauth)
+        let p3 = try await db.modelProfiles.create(name: "third", kind: .oauth)
+
+        let listed = try await db.modelProfiles.list()
+        #expect(listed.map(\.id) == [p1.id, p2.id, p3.id])
+    }
+
+    @Test("reorder changes list order and persists sortOrder")
+    func reorderChangesListOrder() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let p1 = try await db.modelProfiles.create(name: "first", kind: .oauth)
+        let p2 = try await db.modelProfiles.create(name: "second", kind: .oauth)
+        let p3 = try await db.modelProfiles.create(name: "third", kind: .oauth)
+
+        // Reorder: third, first, second
+        try await db.modelProfiles.reorder(profileIDs: [p3.id, p1.id, p2.id])
+
+        let listed = try await db.modelProfiles.list()
+        #expect(listed.map(\.id) == [p3.id, p1.id, p2.id])
+        #expect(listed.map(\.sortOrder) == [0, 1, 2])
+    }
+
+    @Test("reorder pushes non-listed profiles after the reordered ones")
+    func reorderPushesUnlistedAfter() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let p1 = try await db.modelProfiles.create(name: "first", kind: .oauth)
+        let p2 = try await db.modelProfiles.create(name: "second", kind: .oauth)
+        let p3 = try await db.modelProfiles.create(name: "third", kind: .oauth)
+
+        // Only reorder p2 and p1; p3 is not listed and should be pushed after.
+        try await db.modelProfiles.reorder(profileIDs: [p2.id, p1.id])
+
+        let listed = try await db.modelProfiles.list()
+        #expect(listed.map(\.id) == [p2.id, p1.id, p3.id])
+    }
 }


### PR DESCRIPTION
## Summary
- Model profiles could only appear in insertion order, with no way to prioritize the ones you actually use. This adds drag-and-drop reordering in the Model Profiles settings list.
- Order is persisted server-side and now drives every consumer of the profile list: the settings list and the global-default picker (both iterate `appState.modelProfiles` directly). The spawn-time account picker still sorts primarily by usage rank; the new order acts only as its final stable tie-breaker.
- Implemented as a faithful 1:1 mirror of the existing **worktree** reorder pipeline across all layers — no new pattern invented.

## What changed (per layer)
- **Migration** (`v56_model_profiles_sort_order`): idempotent `sort_order` column via `addColumnIfMissing`, initialized `SET sort_order = rowid` to preserve current insertion order.
- **GRDB record / store** (`ModelProfileRecord.swift`): `list()` now orders by `sort_order`; `create()` auto-assigns `MAX(sort_order)+1`; new `reorder(profileIDs:)` reindex (indexed UPDATE + push unlisted rows after).
- **Shared model** (`Models.swift`): `ModelProfile.sortOrder` decoded with `decodeIfPresent(...) ?? 0` so old rows/JSON still decode. Column + record + model land in the same commit per the migration rule.
- **RPC**: `modelProfile.reorder` method + `ModelProfileReorderParams`, daemon handler broadcasting `.modelProfilesChanged`.
- **App**: `DaemonClient.reorderModelProfiles`, `AppState.reorderModelProfiles` (optimistic move + rollback on RPC failure), `.onMove` on the settings `List`.

## Test plan
- [x] `swift build` succeeds; `swiftlint --strict` clean (0 violations).
- [x] `ModelProfileStoreTests`: create assigns increasing order, list orders by `sort_order`, reorder changes order, unlisted rows pushed after.
- [x] Full `swift test --parallel -j 2` — 3745 tests green.
- [ ] Manual: drag rows in Settings → Model Profiles; order persists across app restart and matches the global-default picker.

## Notes
No feature flag — a user-gesture reorder isn't autonomous/destructive behavior, so the default-off-flag rule doesn't apply.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=8DE0BF50-8397-4D26-906F-6E7DB9782FC0)