### PR TITLE
feat: panel surface phase 2 — daemon store, coordinator, legacy import (spec C §12.3-5, inert behind flags)

### DIFF
--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -44,6 +44,11 @@ extension AppState {
             logger.error("loadTabStates failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
             handleConnectionError(error)
         }
+        // Gated one-shot legacy panel import (spec C §11.2) — fires at most
+        // once per launch regardless of whether this particular listTabs
+        // call succeeded, since it imports from AppState's already-loaded
+        // in-memory state, not from this call's response.
+        triggerPanelImportIfNeeded()
     }
 
     // MARK: - Active tab persistence

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -6,6 +6,9 @@ import TBDShared
 import os
 
 private let logger = Logger(subsystem: "com.tbd.app", category: "AppState")
+/// Spec C §11.3 — log-only shadow-compare diagnostic. Dedicated category so
+/// it can be streamed/filtered independently of the rest of AppState.
+private let shadowCompareLogger = Logger(subsystem: "com.tbd.app", category: "panelShadow")
 /// Dedicated channel for RPC/poll-cadence observability (storm diagnostics).
 /// Silent by default; activate with `log stream --level debug`.
 private let perfRPCLogger = Logger(subsystem: "com.tbd.app", category: "perf-rpc")
@@ -708,6 +711,10 @@ final class AppState: ObservableObject {
     /// no protocol), so trigger tests can record calls without a real daemon.
     lazy var panelImportTrigger: @MainActor (PanelImportParams) async throws -> PanelImportResult =
         { [daemonClient] params in try await daemonClient.panelImportLegacy(params) }
+    /// How the shadow-compare diagnostic (spec C §11.3) fetches the daemon's
+    /// imported surface — injectable for the same reason as `panelImportTrigger`.
+    lazy var panelGetFetcher: @MainActor (UUID) async throws -> PanelGetResult =
+        { [daemonClient] worktreeID in try await daemonClient.panelGet(worktreeID: worktreeID) }
     /// Guards the one-shot legacy panel import to at most once per launch.
     /// Deliberately NOT persisted — the daemon's create-if-absent import guard
     /// (spec C §11.2) is the real idempotence boundary; this only avoids
@@ -1066,9 +1073,46 @@ final class AppState: ObservableObject {
                     _ = try await panelImportTrigger(params)
                 } catch {
                     logger.error("panelImportLegacy failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+                    continue
                 }
+                // Spec C §11.3 — shadow compare runs once, right after this
+                // worktree's import call succeeds (whether it imported just
+                // now or the daemon already had a surface from a prior
+                // launch). Diagnostics only; never blocks/gates the import
+                // above, which has already completed by this point.
+                await runPanelShadowCompare(worktreeID: worktreeID)
             }
         }
+    }
+
+    /// Spec C §11.3 — migration-validation shadow compare. Log-only: never
+    /// mutates state, never surfaces to the user, never throws in a way that
+    /// affects the caller (all failures are logged and swallowed here).
+    /// Re-converts the CURRENT live legacy state (not the params already sent
+    /// to `panelImportTrigger` — state may have moved on since) via the same
+    /// `LegacySurfaceImporter.convert` the daemon's import path used, fetches
+    /// the daemon's imported surface, and logs any divergence.
+    private func runPanelShadowCompare(worktreeID: UUID) async {
+        let params = buildPanelImportParams(worktreeID: worktreeID)
+        let local = LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: params.tabs, tabOrder: params.tabOrder,
+            paneHistories: params.paneHistories)
+        let daemon: PanelGetResult
+        do {
+            daemon = try await panelGetFetcher(worktreeID)
+        } catch {
+            shadowCompareLogger.error("panel.get failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+            return
+        }
+        let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
+        guard !mismatches.isEmpty else {
+            shadowCompareLogger.debug("\(worktreeID, privacy: .public): no divergence")
+            return
+        }
+        for mismatch in mismatches {
+            shadowCompareLogger.error("\(worktreeID, privacy: .public): \(mismatch, privacy: .public)")
+        }
+        shadowCompareLogger.info("\(worktreeID, privacy: .public): \(mismatches.count, privacy: .public) mismatch(es)")
     }
 
     // MARK: - Selection Persistence

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -703,6 +703,16 @@ final class AppState: ObservableObject {
         alert.buttons[1].keyEquivalent = "\r"
         return alert.runModal() == .alertFirstButtonReturn
     }
+    /// How the one-shot legacy panel import fires its RPC — injectable for the
+    /// same reason as `daemonCapabilitiesFetcher` (`DaemonClient` is concrete,
+    /// no protocol), so trigger tests can record calls without a real daemon.
+    lazy var panelImportTrigger: @MainActor (PanelImportParams) async throws -> PanelImportResult =
+        { [daemonClient] params in try await daemonClient.panelImportLegacy(params) }
+    /// Guards the one-shot legacy panel import to at most once per launch.
+    /// Deliberately NOT persisted — the daemon's create-if-absent import guard
+    /// (spec C §11.2) is the real idempotence boundary; this only avoids
+    /// redundant RPC fan-out as `loadTabStates` runs per worktree.
+    private var hasAttemptedPanelImport = false
 
     /// Best-effort re-fetch of `daemonCapabilities` (R7-minor). Used by the
     /// `.modelProfilesChanged` delta handler so a control-mode toggle from
@@ -980,18 +990,84 @@ final class AppState: ObservableObject {
 
     /// Drops histories for slot panes no longer present in any tab layout or
     /// tab root — closed panes and panes dropped by reconciliation. Keyed off
-    /// the GLOBAL layouts dict, so a per-worktree reconcile never prunes
-    /// another worktree's slots.
+    /// live TAB IDs (mirrors the `visibleTerminalIDs` fix, #478) rather than
+    /// `layouts.values` — the persisted `layouts` blob can carry stale
+    /// worktree-keyed entries left over from pre-#478 installs, which are not
+    /// tabs and must not keep their slot histories alive forever (#477).
+    /// `gridLayouts` (presentation-only, never persisted) is scanned
+    /// separately since its entries are legitimately live but not tab-keyed.
     func prunePaneHistories() {
         guard !paneHistories.isEmpty else { return }
         var liveIDs = Set<UUID>()
-        for layout in layouts.values { liveIDs.formUnion(layout.allPaneIDs()) }
         for tabList in tabs.values {
-            for tab in tabList { liveIDs.insert(tab.content.paneID) }
+            for tab in tabList {
+                liveIDs.insert(tab.content.paneID)
+                if let layout = layouts[tab.id] {
+                    liveIDs.formUnion(layout.allPaneIDs())
+                }
+            }
         }
+        for layout in gridLayouts.values { liveIDs.formUnion(layout.allPaneIDs()) }
         let pruned = paneHistories.filter { liveIDs.contains($0.key) }
         if pruned.count != paneHistories.count {
             paneHistories = pruned
+        }
+    }
+
+    // MARK: - Legacy panel import (spec C §11.2)
+
+    /// Builds the legacy-import payload for one worktree from AppState's
+    /// current in-memory tab/layout/history state. Grid-layout entries — the
+    /// persisted `layouts` blob's stale worktree-keyed rows from pre-#478
+    /// installs — are excluded BY CONSTRUCTION: only `layouts[tab.id]` is
+    /// ever consulted, never `layouts.values` (spec §11.2.2, "grid state is
+    /// not imported"). `paneHistories` is filtered to pane IDs that actually
+    /// appear in the included tabs' layouts, absorbing the #477
+    /// over-retention concern at the import boundary rather than trusting
+    /// the caller.
+    func buildPanelImportParams(worktreeID: UUID) -> PanelImportParams {
+        let wtTabs = tabs[worktreeID] ?? []
+        var includedPaneIDs = Set<UUID>()
+        let legacyTabs: [LegacyTabPayload] = wtTabs.map { tab in
+            let layout = layouts[tab.id]
+            includedPaneIDs.insert(tab.content.paneID)
+            if let layout { includedPaneIDs.formUnion(layout.allPaneIDs()) }
+            return LegacyTabPayload(tabID: tab.id, label: tab.label, content: tab.content, layout: layout)
+        }
+        let tabOrder = worktreeTabOrders[worktreeID] ?? wtTabs.map(\.id)
+        let activeTabID: UUID? = activeTabIndices[worktreeID].flatMap { idx in
+            wtTabs.indices.contains(idx) ? wtTabs[idx].id : nil
+        }
+        let includedPaneHistories = paneHistories.filter { includedPaneIDs.contains($0.key) }
+        return PanelImportParams(
+            worktreeID: worktreeID,
+            tabs: legacyTabs,
+            tabOrder: tabOrder,
+            activeTabID: activeTabID,
+            paneHistories: includedPaneHistories
+        )
+    }
+
+    /// Fires the one-shot legacy panel import once per launch, once the
+    /// daemon confirms panel-surface ownership is enabled (default OFF while
+    /// the feature soaks — this whole path is inert until then). Called from
+    /// the tail of `loadTabStates` for every worktree; imports every worktree
+    /// whose tabs are already loaded at that point. Failures are logged and
+    /// non-fatal — the daemon's create-if-absent guard means a skipped
+    /// worktree simply retries on the next launch.
+    func triggerPanelImportIfNeeded() {
+        guard !hasAttemptedPanelImport, daemonCapabilities?.panelSurfaceEnabled == true else { return }
+        hasAttemptedPanelImport = true
+        let worktreeIDs = Array(tabs.keys)
+        Task {
+            for worktreeID in worktreeIDs {
+                let params = buildPanelImportParams(worktreeID: worktreeID)
+                do {
+                    _ = try await panelImportTrigger(params)
+                } catch {
+                    logger.error("panelImportLegacy failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+                }
+            }
         }
     }
 

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1002,6 +1002,38 @@ actor DaemonClient {
         )
     }
 
+    /// Read daemon-owned panel-surface state for a worktree (ungated —
+    /// spec C §10.2). `tabID` narrows to one tab; nil returns every tab.
+    func panelGet(worktreeID: UUID, tabID: UUID? = nil) async throws -> PanelGetResult {
+        try await callAsync(
+            method: RPCMethod.panelGet,
+            params: PanelGetParams(worktreeID: worktreeID, tabID: tabID),
+            resultType: PanelGetResult.self
+        )
+    }
+
+    /// Apply one panel-surface operation. Gated daemon-side
+    /// (`daemon_panel_surface_enabled` / `agent_panel_control_enabled`,
+    /// spec C §7.2) — a gated rejection surfaces as `DaemonClientError.rpcError`
+    /// naming the flag.
+    func panelApply(_ envelope: PanelOperationEnvelope) async throws -> PanelApplyResult {
+        try await callAsync(
+            method: RPCMethod.panelApply,
+            params: PanelApplyParams(envelope: envelope),
+            resultType: PanelApplyResult.self
+        )
+    }
+
+    /// One-time legacy-tab import into the daemon-owned panel surface.
+    /// The daemon returns a "not implemented" error until Task 11 lands.
+    func panelImportLegacy(_ params: PanelImportParams) async throws -> PanelImportResult {
+        try await callAsync(
+            method: RPCMethod.panelImportLegacy,
+            params: params,
+            resultType: PanelImportResult.self
+        )
+    }
+
     /// Manually suspend a single Claude terminal.
     func terminalSuspend(terminalID: UUID) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/PanelSurface/PanelShadowCompare.swift
+++ b/Sources/TBDApp/PanelSurface/PanelShadowCompare.swift
@@ -8,42 +8,92 @@ import TBDShared
 /// shadow-compare trigger) logs them and does nothing else with them — this
 /// must never gate, block, or influence the import itself, and must never
 /// implement Approach A's broadcast-command/parked-ACK protocol.
-public enum PanelShadowCompare {
-    /// Normalizes both sides (sorts tabs by id so key/array ordering never
-    /// flags) and compares id/primary/label/layout equality per tab.
-    /// `revision` is deliberately excluded — the daemon copy may have
+enum PanelShadowCompare {
+    /// Normalizes both sides and compares primary/label/layout per matched
+    /// tab. `revision` is deliberately excluded — the daemon copy may have
     /// advanced since import (later applies, a later launch) and that is not
     /// a divergence this diagnostic cares about.
-    public static func mismatches(
+    ///
+    /// The local and daemon conversions come from two INDEPENDENT calls to
+    /// `LegacySurfaceImporter.convert` (the daemon's at import time, this
+    /// diagnostic's just now) — each mints its own fresh random IDs for
+    /// promoted-terminal-tab surfaces and note-panel slots
+    /// (`LegacySurfaceImporter.swift`'s two `makeID()` call sites). Those IDs
+    /// can never coincide across the two calls, so both tab-matching and
+    /// layout comparison key off STABLE content instead of minted identity:
+    /// - a tab is matched by its primary's `terminalID` when the primary is
+    ///   a terminal (true for both plain terminal tabs, whose surface `id`
+    ///   already IS the stable legacy tabID, and promoted tabs, whose surface
+    ///   `id` is minted) — terminalID is the one thing guaranteed stable
+    ///   there; otherwise by surface `id`, which is always the legacy tabID
+    ///   for every non-promoted tab (promotion only ever produces
+    ///   terminal-primary tabs).
+    /// - layouts compare via `normalize(_:)`, which drops every `PanelSlot`
+    ///   and `SplitNode` id and compares structure/direction/ratios/content
+    ///   only — so a minted note-panel slot id never flags, while a real
+    ///   content divergence (path changed, a viewer vanished, wrong split
+    ///   shape) still does.
+    static func mismatches(
         local: LegacySurfaceImporter.Conversion, daemon: PanelGetResult
     ) -> [String] {
         var results: [String] = []
-        let localByID = Dictionary(uniqueKeysWithValues: local.surfaces.map { ($0.id, $0) })
-        let daemonByID = Dictionary(uniqueKeysWithValues: daemon.tabs.map { ($0.id, $0) })
+        let localByKey = Dictionary(local.surfaces.map { (tabKey($0), $0) }, uniquingKeysWith: { first, _ in first })
+        let daemonByKey = Dictionary(daemon.tabs.map { (tabKey($0), $0) }, uniquingKeysWith: { first, _ in first })
 
-        let localIDs = localByID.keys.sorted { $0.uuidString < $1.uuidString }
-        let daemonIDs = daemonByID.keys.sorted { $0.uuidString < $1.uuidString }
+        let localKeys = localByKey.keys.sorted { $0.uuidString < $1.uuidString }
+        let daemonKeys = daemonByKey.keys.sorted { $0.uuidString < $1.uuidString }
 
-        for id in localIDs where daemonByID[id] == nil {
-            results.append("tab \(id): present in local conversion, missing from daemon surface")
+        for key in localKeys where daemonByKey[key] == nil {
+            results.append("tab \(key): present in local conversion, missing from daemon surface")
         }
-        for id in daemonIDs where localByID[id] == nil {
-            results.append("tab \(id): present in daemon surface, missing from local conversion")
+        for key in daemonKeys where localByKey[key] == nil {
+            results.append("tab \(key): present in daemon surface, missing from local conversion")
         }
 
-        for id in localIDs {
-            guard let localTab = localByID[id], let daemonTab = daemonByID[id] else { continue }
+        for key in localKeys {
+            guard let localTab = localByKey[key], let daemonTab = daemonByKey[key] else { continue }
             if localTab.primary != daemonTab.primary {
-                results.append("tab \(id): primary mismatch (local \(localTab.primary), daemon \(daemonTab.primary))")
+                results.append("tab \(key): primary mismatch (local \(localTab.primary), daemon \(daemonTab.primary))")
             }
             if localTab.label != daemonTab.label {
                 results.append(
-                    "tab \(id): label mismatch (local \(localTab.label ?? "nil"), daemon \(daemonTab.label ?? "nil"))")
+                    "tab \(key): label mismatch (local \(localTab.label ?? "nil"), daemon \(daemonTab.label ?? "nil"))")
             }
-            if localTab.layout != daemonTab.layout {
-                results.append("tab \(id): layout mismatch")
+            if normalize(localTab.layout) != normalize(daemonTab.layout) {
+                results.append("tab \(key): layout mismatch")
             }
         }
         return results
+    }
+
+    /// Stable cross-import matching key: terminalID for any terminal-primary
+    /// tab (covers both plain and promoted tabs uniformly), else the surface
+    /// id (the legacy tabID — never minted for a non-terminal-primary tab).
+    private static func tabKey(_ surface: WorkspaceTabSurface) -> UUID {
+        if case .terminal(let terminalID) = surface.primary {
+            return terminalID
+        }
+        return surface.id
+    }
+
+    /// Structural shape of a layout tree with every minted identity (split
+    /// id, panel slot id) dropped — only content, position, and ratios
+    /// remain, which is exactly what §11.3 means by "normalize away cosmetic
+    /// differences."
+    private indirect enum NormalizedNode: Equatable {
+        case primary
+        case panel(PanelContent)
+        case split(direction: SplitDirection, children: [NormalizedNode], ratios: [Double])
+    }
+
+    private static func normalize(_ node: PanelLayoutNode) -> NormalizedNode {
+        switch node {
+        case .primary:
+            return .primary
+        case .panel(let slot):
+            return .panel(slot.content)
+        case .split(let split):
+            return .split(direction: split.direction, children: split.children.map(normalize), ratios: split.ratios)
+        }
     }
 }

--- a/Sources/TBDApp/PanelSurface/PanelShadowCompare.swift
+++ b/Sources/TBDApp/PanelSurface/PanelShadowCompare.swift
@@ -1,0 +1,49 @@
+import Foundation
+import TBDShared
+
+/// Spec C §11.3 — migration-validation-only shadow comparator. Pure: no I/O,
+/// no daemon calls, no mutation. Compares a normalized view of the app's
+/// current legacy-derived conversion against the daemon's imported surface
+/// and returns human-readable mismatch strings; the caller (`AppState`'s
+/// shadow-compare trigger) logs them and does nothing else with them — this
+/// must never gate, block, or influence the import itself, and must never
+/// implement Approach A's broadcast-command/parked-ACK protocol.
+public enum PanelShadowCompare {
+    /// Normalizes both sides (sorts tabs by id so key/array ordering never
+    /// flags) and compares id/primary/label/layout equality per tab.
+    /// `revision` is deliberately excluded — the daemon copy may have
+    /// advanced since import (later applies, a later launch) and that is not
+    /// a divergence this diagnostic cares about.
+    public static func mismatches(
+        local: LegacySurfaceImporter.Conversion, daemon: PanelGetResult
+    ) -> [String] {
+        var results: [String] = []
+        let localByID = Dictionary(uniqueKeysWithValues: local.surfaces.map { ($0.id, $0) })
+        let daemonByID = Dictionary(uniqueKeysWithValues: daemon.tabs.map { ($0.id, $0) })
+
+        let localIDs = localByID.keys.sorted { $0.uuidString < $1.uuidString }
+        let daemonIDs = daemonByID.keys.sorted { $0.uuidString < $1.uuidString }
+
+        for id in localIDs where daemonByID[id] == nil {
+            results.append("tab \(id): present in local conversion, missing from daemon surface")
+        }
+        for id in daemonIDs where localByID[id] == nil {
+            results.append("tab \(id): present in daemon surface, missing from local conversion")
+        }
+
+        for id in localIDs {
+            guard let localTab = localByID[id], let daemonTab = daemonByID[id] else { continue }
+            if localTab.primary != daemonTab.primary {
+                results.append("tab \(id): primary mismatch (local \(localTab.primary), daemon \(daemonTab.primary))")
+            }
+            if localTab.label != daemonTab.label {
+                results.append(
+                    "tab \(id): label mismatch (local \(localTab.label ?? "nil"), daemon \(daemonTab.label ?? "nil"))")
+            }
+            if localTab.layout != daemonTab.layout {
+                results.append("tab \(id): layout mismatch")
+            }
+        }
+        return results
+    }
+}

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -33,6 +33,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var gc_enabled: Bool?
     var gc_grace_seconds: Int?
     var gc_snapshot_retention_days: Int?
+    var daemon_panel_surface_enabled: Bool?
+    var agent_panel_control_enabled: Bool?
 
     func toModel() -> Config {
         Config(
@@ -57,7 +59,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             autoCloseSetupEnabled: auto_close_setup_enabled ?? false,
             gcEnabled: gc_enabled ?? true,
             gcGraceSeconds: gc_grace_seconds ?? Config.defaultGCGraceSeconds,
-            gcSnapshotRetentionDays: gc_snapshot_retention_days ?? Config.defaultGCSnapshotRetentionDays
+            gcSnapshotRetentionDays: gc_snapshot_retention_days ?? Config.defaultGCSnapshotRetentionDays,
+            panelSurfaceEnabled: daemon_panel_surface_enabled ?? false,
+            agentPanelControlEnabled: agent_panel_control_enabled ?? false
         )
     }
 }
@@ -282,6 +286,29 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET gc_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the daemon panel-surface store master switch (spec C Phase 2
+    /// §8). Default OFF; the store stays inert until this flips on.
+    public func setPanelSurfaceEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET daemon_panel_surface_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the agent-originated panel-control gate. Default OFF and
+    /// independent of `daemon_panel_surface_enabled` — both must be true for
+    /// an agent to mutate panel layout.
+    public func setAgentPanelControlEnabled(_ enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET agent_panel_control_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -27,6 +27,7 @@ public final class TBDDatabase: Sendable {
     public let scheduledResumes: ScheduledResumeStore
     public let reapRecords: ReapRecordStore
     public let terminalHistory: TerminalHistoryStore
+    public let panelSurface: PanelSurfaceStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
@@ -66,6 +67,7 @@ public final class TBDDatabase: Sendable {
         self.scheduledResumes = ScheduledResumeStore(writer: pool)
         self.reapRecords = ReapRecordStore(writer: pool)
         self.terminalHistory = TerminalHistoryStore(writer: pool, historyDir: terminalHistoryDir)
+        self.panelSurface = PanelSurfaceStore(writer: pool)
 
         let migrator = Self.buildMigrator()
         if fileExisted {
@@ -105,6 +107,7 @@ public final class TBDDatabase: Sendable {
         self.scheduledResumes = ScheduledResumeStore(writer: queue)
         self.reapRecords = ReapRecordStore(writer: queue)
         self.terminalHistory = TerminalHistoryStore(writer: queue, historyDir: terminalHistoryDir)
+        self.panelSurface = PanelSurfaceStore(writer: queue)
         try Self.buildMigrator().migrate(queue)
     }
 
@@ -976,6 +979,59 @@ public final class TBDDatabase: Sendable {
             }
             try db.addIndexIfMissing(
                 "idx_terminal_history_worktree", on: "terminal_history", columns: ["worktreeID"])
+        }
+
+        // (Renumbered v57→v59 on rebase: main's #485 took v57 and v58.)
+        // Spec C Phase 2 (§8): daemon-owned panel-surface rows — one row per
+        // workspace tab (layout tree + primary + revision), per-panel MRU
+        // history, and bounded operation receipts for §7.4 idempotency. Both
+        // feature flags land default-OFF per the repo flag policy: the store
+        // is inert until `daemon_panel_surface_enabled` is turned on, and
+        // agent-originated mutations additionally require
+        // `agent_panel_control_enabled`. `worktree.panel_surface_imported_at`
+        // distinguishes "imported an empty layout" from "never imported".
+        migrator.registerMigration("v59_panel_surface") { db in
+            try db.createTableIfNotExists("workspace_tab_surface") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("worktreeID", .text).notNull()
+                    .references("worktree", onDelete: .cascade)
+                t.column("primaryContent", .text).notNull()   // PrimaryContent JSON
+                t.column("label", .text)
+                t.column("position", .integer).notNull()
+                t.column("layout", .text).notNull()           // PanelLayoutNode JSON
+                t.column("revision", .integer).notNull().defaults(to: 0)
+                t.column("updatedAt", .datetime).notNull()
+            }
+            try db.addIndexIfMissing("idx_workspace_tab_surface_worktree",
+                                     on: "workspace_tab_surface", columns: ["worktreeID", "position"])
+            // history rows cascade via tabID → workspace_tab_surface, which
+            // itself cascades to worktree — so deleting a worktree reaps its
+            // surfaces and their history rows in one chain.
+            try db.createTableIfNotExists("panel_history") { t in
+                t.primaryKey("panelID", .text).notNull()
+                t.column("tabID", .text).notNull()
+                    .references("workspace_tab_surface", onDelete: .cascade)
+                t.column("history", .text).notNull()          // PanelHistory JSON
+                t.column("updatedAt", .datetime).notNull()
+            }
+            try db.addIndexIfMissing("idx_panel_history_tab", on: "panel_history", columns: ["tabID"])
+            try db.createTableIfNotExists("panel_operation_receipt") { t in
+                t.primaryKey("operationID", .text).notNull()
+                t.column("worktreeID", .text).notNull()
+                    .references("worktree", onDelete: .cascade)
+                t.column("tabID", .text).notNull()
+                t.column("revision", .integer).notNull()
+                t.column("result", .text).notNull()           // PanelApplyResult JSON
+                t.column("appliedAt", .datetime).notNull()
+            }
+            try db.addIndexIfMissing("idx_panel_receipt_worktree",
+                                     on: "panel_operation_receipt", columns: ["worktreeID", "appliedAt"])
+            try db.addColumnIfMissing(table: "config", column: "daemon_panel_surface_enabled",
+                                      type: .boolean, defaults: false)
+            try db.addColumnIfMissing(table: "config", column: "agent_panel_control_enabled",
+                                      type: .boolean, defaults: false)
+            try db.addColumnIfMissing(table: "worktree", column: "panel_surface_imported_at",
+                                      type: .datetime)
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
+++ b/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
@@ -1,6 +1,23 @@
 import Foundation
 import GRDB
+import os
 import TBDShared
+
+private let decodeLogger = Logger(subsystem: "com.tbd.daemon", category: "database.decode")
+
+private func encodeJSONString<T: Encodable>(_ value: T) throws -> String {
+    let data = try JSONEncoder().encode(value)
+    guard let string = String(bytes: data, encoding: .utf8) else {
+        throw DecodingError.dataCorrupted(
+            .init(codingPath: [], debugDescription: "JSON-encoded data is not valid UTF-8"))
+    }
+    return string
+}
+
+private func decodeJSON<T: Decodable>(_ type: T.Type, from string: String) -> T? {
+    guard let data = string.data(using: .utf8) else { return nil }
+    return try? JSONDecoder().decode(T.self, from: data)
+}
 
 /// GRDB Record type for the `workspace_tab_surface` table: one row per
 /// workspace tab (layout tree + primary content + revision). See spec C §8.
@@ -14,6 +31,45 @@ struct WorkspaceTabSurfaceRecord: Codable, FetchableRecord, PersistableRecord, S
     var layout: String
     var revision: Int64
     var updatedAt: Date
+
+    init(from surface: WorkspaceTabSurface, position: Int, updatedAt: Date) throws {
+        self.id = surface.id.uuidString
+        self.worktreeID = surface.worktreeID.uuidString
+        self.primaryContent = try encodeJSONString(surface.primary)
+        self.label = surface.label
+        self.position = position
+        self.layout = try encodeJSONString(surface.layout)
+        self.revision = Int64(surface.revision)
+        self.updatedAt = updatedAt
+    }
+
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when a required field fails to parse — copies `TabRecord.toModel()`.
+    func toModel() -> WorkspaceTabSurface? {
+        guard let uuid = UUID(uuidString: id) else {
+            decodeLogger.warning("Skipping workspace_tab_surface row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        guard let wtID = UUID(uuidString: worktreeID) else {
+            decodeLogger.warning("Skipping workspace_tab_surface row \(id, privacy: .public): malformed worktreeID")
+            return nil
+        }
+        guard revision >= 0 else {
+            decodeLogger.warning("Skipping workspace_tab_surface row \(id, privacy: .public): negative revision")
+            return nil
+        }
+        guard let primary = decodeJSON(PrimaryContent.self, from: primaryContent) else {
+            decodeLogger.warning("Skipping workspace_tab_surface row \(id, privacy: .public): malformed primaryContent")
+            return nil
+        }
+        guard let layoutNode = decodeJSON(PanelLayoutNode.self, from: layout) else {
+            decodeLogger.warning("Skipping workspace_tab_surface row \(id, privacy: .public): malformed layout")
+            return nil
+        }
+        return WorkspaceTabSurface(
+            id: uuid, worktreeID: wtID, label: label,
+            primary: primary, layout: layoutNode, revision: UInt64(revision))
+    }
 }
 
 /// GRDB Record type for the `panel_history` table: per-panel MRU history
@@ -24,22 +80,57 @@ struct PanelHistoryRecord: Codable, FetchableRecord, PersistableRecord, Sendable
     var tabID: String
     var history: String
     var updatedAt: Date
+
+    init(panelID: PanelID, tabID: WorkspaceTabID, history: PanelHistory, updatedAt: Date) throws {
+        self.panelID = panelID.uuidString
+        self.tabID = tabID.uuidString
+        self.history = try encodeJSONString(history)
+        self.updatedAt = updatedAt
+    }
+
+    /// Failable decode of just the history payload: skips (logs) rather than
+    /// crashes on a malformed panel ID or history blob.
+    func toModel() -> (panelID: PanelID, history: PanelHistory)? {
+        guard let panelUUID = UUID(uuidString: panelID) else {
+            decodeLogger.warning("Skipping panel_history row: malformed panelID")
+            return nil
+        }
+        guard let history = decodeJSON(PanelHistory.self, from: history) else {
+            decodeLogger.warning("Skipping panel_history row \(panelID, privacy: .public): malformed history")
+            return nil
+        }
+        return (panelUUID, history)
+    }
 }
 
 /// GRDB Record type for the `panel_operation_receipt` table: bounded receipts
-/// used for §7.4 idempotency of agent-originated panel operations.
-struct PanelOperationReceiptRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
-    static let databaseTableName = "panel_operation_receipt"
-    var operationID: String
-    var worktreeID: String
-    var tabID: String
-    var revision: Int64
-    var result: String
-    var appliedAt: Date
+/// used for §7.4 idempotency of agent-originated panel operations. `public`
+/// because `PanelSurfaceStore.commit(receipt:)` takes it directly — callers
+/// (RPC handlers) construct the receipt themselves.
+public struct PanelOperationReceiptRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    public static let databaseTableName = "panel_operation_receipt"
+    public var operationID: String
+    public var worktreeID: String
+    public var tabID: String
+    public var revision: Int64
+    public var result: String
+    public var appliedAt: Date
+
+    public init(
+        operationID: String, worktreeID: String, tabID: String,
+        revision: Int64, result: String, appliedAt: Date
+    ) {
+        self.operationID = operationID
+        self.worktreeID = worktreeID
+        self.tabID = tabID
+        self.revision = revision
+        self.result = result
+        self.appliedAt = appliedAt
+    }
 }
 
 /// Store for the panel-surface schema (workspace tab layouts, panel history,
-/// operation receipts). Skeleton for Task 5 — full CRUD API lands in Task 6.
+/// operation receipts). See spec C §8.
 public struct PanelSurfaceStore: Sendable {
     let writer: any DatabaseWriter
 
@@ -54,6 +145,115 @@ public struct PanelSurfaceStore: Sendable {
             try WorkspaceTabSurfaceRecord
                 .filter(Column("worktreeID") == worktreeID.uuidString)
                 .fetchCount(db) == 0
+        }
+    }
+
+    /// All workspace-tab surfaces for a worktree, ordered by position.
+    public func surfaces(worktreeID: UUID) async throws -> [WorkspaceTabSurface] {
+        try await writer.read { db in
+            try WorkspaceTabSurfaceRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .order(Column("position"))
+                .fetchAll(db)
+                .compactMap { $0.toModel() }
+        }
+    }
+
+    /// A tab's surface plus its panels' navigation histories, or `nil` if
+    /// the tab has no persisted surface row.
+    public func state(tabID: UUID) async throws -> PanelSurfaceState? {
+        try await writer.read { db in
+            guard let surfaceRecord = try WorkspaceTabSurfaceRecord.fetchOne(db, key: tabID.uuidString),
+                  let surface = surfaceRecord.toModel() else {
+                return nil
+            }
+            let histories = try PanelHistoryRecord
+                .filter(Column("tabID") == tabID.uuidString)
+                .fetchAll(db)
+                .compactMap { $0.toModel() }
+            return PanelSurfaceState(
+                surface: surface,
+                histories: Dictionary(uniqueKeysWithValues: histories))
+        }
+    }
+
+    /// Per-panel `updatedAt` for a tab's persisted histories — feeds the
+    /// coordinator's §6.1 `.automatic` recency resolution.
+    public func historyRecency(tabID: UUID) async throws -> [PanelID: Date] {
+        try await writer.read { db in
+            let rows = try PanelHistoryRecord
+                .filter(Column("tabID") == tabID.uuidString)
+                .fetchAll(db)
+            var result: [PanelID: Date] = [:]
+            for row in rows {
+                guard let panelUUID = UUID(uuidString: row.panelID) else { continue }
+                result[panelUUID] = row.updatedAt
+            }
+            return result
+        }
+    }
+
+    /// Atomic §8 write: replace the tab's surface row + FULL history set for
+    /// that tab + record the receipt, in one transaction (all-or-nothing —
+    /// GRDB wraps a `write` closure in a SQLite transaction, so any thrown
+    /// error rolls back everything written so far in this call, including
+    /// the surface row and any history rows already saved). `position: nil`
+    /// keeps the row's existing position (or defaults to 0 for a brand-new
+    /// row). History rows for panels no longer in `state.histories` are
+    /// deleted (full replace); a history row's `updatedAt` only advances to
+    /// `now` when its decoded content actually changed — unchanged panels
+    /// keep their prior `updatedAt`.
+    public func commit(
+        state: PanelSurfaceState, position: Int?, receipt: PanelOperationReceiptRecord?,
+        now: Date = Date()
+    ) async throws {
+        _ = try await writer.write { db in
+            let existingPosition = try WorkspaceTabSurfaceRecord.fetchOne(db, key: state.surface.id.uuidString)?.position
+            let resolvedPosition = position ?? existingPosition ?? 0
+            let surfaceRecord = try WorkspaceTabSurfaceRecord(
+                from: state.surface, position: resolvedPosition, updatedAt: now)
+            try surfaceRecord.save(db)
+
+            let existingHistoryRows = try PanelHistoryRecord
+                .filter(Column("tabID") == state.surface.id.uuidString)
+                .fetchAll(db)
+            let existingByPanelID = Dictionary(uniqueKeysWithValues: existingHistoryRows.map { ($0.panelID, $0) })
+
+            // Full replace: drop rows for panels no longer present in the new state.
+            let newPanelIDStrings = Set(state.histories.keys.map(\.uuidString))
+            for row in existingHistoryRows where !newPanelIDStrings.contains(row.panelID) {
+                try PanelHistoryRecord.deleteOne(db, key: row.panelID)
+            }
+
+            for (panelID, history) in state.histories {
+                let existingRow = existingByPanelID[panelID.uuidString]
+                let unchanged = existingRow.flatMap { $0.toModel()?.history } == history
+                let updatedAt = unchanged ? (existingRow?.updatedAt ?? now) : now
+                let record = try PanelHistoryRecord(
+                    panelID: panelID, tabID: state.surface.id, history: history, updatedAt: updatedAt)
+                try record.save(db)
+            }
+
+            if let receipt {
+                try receipt.save(db)
+            }
+        }
+    }
+
+    /// Delete all surfaces (and, via `ON DELETE CASCADE`, their histories)
+    /// plus any operation receipts for a worktree. History rows cascade
+    /// automatically through the surface's FK; receipts reference the
+    /// worktree directly (not the surface), so they're deleted explicitly
+    /// here — used by callers re-writing a worktree's whole surface set so
+    /// a prior write's rows never linger as stale leftovers.
+    public func deleteSurfaces(worktreeID: UUID) async throws {
+        _ = try await writer.write { db in
+            try WorkspaceTabSurfaceRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .deleteAll(db)
+            try PanelOperationReceiptRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .deleteAll(db)
         }
     }
 }

--- a/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
+++ b/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
@@ -235,53 +235,131 @@ public struct PanelSurfaceStore: Sendable {
         now: Date = Date()
     ) async throws {
         _ = try await writer.write { db in
-            let existingPosition = try WorkspaceTabSurfaceRecord.fetchOne(db, key: state.surface.id.uuidString)?.position
-            let resolvedPosition = position ?? existingPosition ?? 0
-            let surfaceRecord = try WorkspaceTabSurfaceRecord(
-                from: state.surface, position: resolvedPosition, updatedAt: now)
-            try surfaceRecord.save(db)
-
-            let existingHistoryRows = try PanelHistoryRecord
-                .filter(Column("tabID") == state.surface.id.uuidString)
-                .fetchAll(db)
-            let existingByPanelID = Dictionary(uniqueKeysWithValues: existingHistoryRows.map { ($0.panelID, $0) })
-
-            // Full replace: drop rows for panels no longer present in the new state.
-            let newPanelIDStrings = Set(state.histories.keys.map(\.uuidString))
-            for row in existingHistoryRows where !newPanelIDStrings.contains(row.panelID) {
-                try PanelHistoryRecord.deleteOne(db, key: row.panelID)
-            }
-
-            // Loud-fail guard: `panel_history.panelID` is a table-wide PK, so a
-            // blind `save` would silently steal a row owned by another tab. Any
-            // panelID we're about to write that already exists under a DIFFERENT
-            // tab is a violation of the global-uniqueness invariant — throw
-            // instead of clobbering that tab's history.
-            for panelID in state.histories.keys {
-                if let owner = try PanelHistoryRecord.fetchOne(db, key: panelID.uuidString),
-                   owner.tabID != state.surface.id.uuidString {
-                    throw PanelSurfaceStoreError.panelHistoryOwnedByOtherTab(
-                        panelID: panelID,
-                        existingTabID: UUID(uuidString: owner.tabID) ?? UUID(),
-                        incomingTabID: state.surface.id)
-                }
-            }
-
-            for (panelID, history) in state.histories {
-                let existingRow = existingByPanelID[panelID.uuidString]
-                let unchanged = existingRow.flatMap { $0.toModel()?.history } == history
-                let updatedAt = unchanged ? (existingRow?.updatedAt ?? now) : now
-                let record = try PanelHistoryRecord(
-                    panelID: panelID, tabID: state.surface.id, history: history, updatedAt: updatedAt)
-                try record.save(db)
-            }
-
+            try Self.writeSurfaceAndHistory(state, position: position, db: db, now: now)
             if let receipt {
                 try receipt.save(db)
                 if let receiptWorktreeID = UUID(uuidString: receipt.worktreeID) {
-                    try pruneReceipts(db: db, worktreeID: receiptWorktreeID, now: now)
+                    try self.pruneReceipts(db: db, worktreeID: receiptWorktreeID, now: now)
                 }
             }
+        }
+    }
+
+    /// Writes ONE tab's surface row + its FULL history replace (drop-absent,
+    /// cross-tab clobber guard, changed-only `updatedAt`) against an
+    /// already-open write transaction. Shared by `commit` and the
+    /// transactional `applyReducing` so both honor the identical per-tab
+    /// contract (removed panels lose their row; no surface-row deletion needed
+    /// because a single op only ever mutates one tab, never removes it).
+    private static func writeSurfaceAndHistory(
+        _ state: PanelSurfaceState, position: Int?, db: GRDB.Database, now: Date
+    ) throws {
+        let existingPosition = try WorkspaceTabSurfaceRecord.fetchOne(db, key: state.surface.id.uuidString)?.position
+        let resolvedPosition = position ?? existingPosition ?? 0
+        let surfaceRecord = try WorkspaceTabSurfaceRecord(
+            from: state.surface, position: resolvedPosition, updatedAt: now)
+        try surfaceRecord.save(db)
+
+        let existingHistoryRows = try PanelHistoryRecord
+            .filter(Column("tabID") == state.surface.id.uuidString)
+            .fetchAll(db)
+        let existingByPanelID = Dictionary(uniqueKeysWithValues: existingHistoryRows.map { ($0.panelID, $0) })
+
+        // Full replace: drop rows for panels no longer present in the new state.
+        let newPanelIDStrings = Set(state.histories.keys.map(\.uuidString))
+        for row in existingHistoryRows where !newPanelIDStrings.contains(row.panelID) {
+            try PanelHistoryRecord.deleteOne(db, key: row.panelID)
+        }
+
+        // Loud-fail guard: `panel_history.panelID` is a table-wide PK, so a
+        // blind `save` would silently steal a row owned by another tab. Any
+        // panelID we're about to write that already exists under a DIFFERENT
+        // tab is a violation of the global-uniqueness invariant — throw
+        // instead of clobbering that tab's history.
+        for panelID in state.histories.keys {
+            if let owner = try PanelHistoryRecord.fetchOne(db, key: panelID.uuidString),
+               owner.tabID != state.surface.id.uuidString {
+                throw PanelSurfaceStoreError.panelHistoryOwnedByOtherTab(
+                    panelID: panelID,
+                    existingTabID: UUID(uuidString: owner.tabID) ?? UUID(),
+                    incomingTabID: state.surface.id)
+            }
+        }
+
+        for (panelID, history) in state.histories {
+            let existingRow = existingByPanelID[panelID.uuidString]
+            let unchanged = existingRow.flatMap { $0.toModel()?.history } == history
+            let updatedAt = unchanged ? (existingRow?.updatedAt ?? now) : now
+            let record = try PanelHistoryRecord(
+                panelID: panelID, tabID: state.surface.id, history: history, updatedAt: updatedAt)
+            try record.save(db)
+        }
+    }
+
+    /// Outcome of a transactional `applyReducing` call.
+    public enum ApplyOutcome: Sendable {
+        /// A fresh commit — the reducer ran and its result was persisted.
+        case applied(PanelApplyResult)
+        /// `operationID` already had a receipt — the stored result is replayed
+        /// (§7.4 idempotency), nothing was re-applied.
+        case replayed(PanelApplyResult)
+    }
+
+    /// Transactional §7.2 apply: idempotency check, state load, reducer run,
+    /// and persist ALL inside ONE write transaction, so concurrent same-tab
+    /// applies under a production `DatabasePool` cannot lose an update.
+    ///
+    /// Actor isolation does NOT span `await`, and a pool `read` sees a
+    /// pre-write WAL snapshot — so a coordinator that loaded state, reduced,
+    /// then `await`ed a separate `commit` could have a second apply load the
+    /// STALE pre-commit revision and clobber the first (silent lost update).
+    /// Doing the load inside the write transaction means the reducer runs
+    /// against the latest committed state — literally spec §7.4's "apply to
+    /// the current authoritative tree" — and the pool's single-writer lock
+    /// serializes the whole read-modify-write.
+    ///
+    /// `reduce` is the pure synchronous shared reducer (plus the caller's
+    /// baseRevision→staleTarget error mapping); it runs fine inside the
+    /// transaction. Returns `nil` when the tab has no surface row for
+    /// `worktreeID` (caller maps to its not-found error).
+    public func applyReducing(
+        operationID: UUID, tabID: UUID, worktreeID: UUID, now: Date,
+        reduce: @Sendable (PanelSurfaceState) throws -> PanelSurfaceState
+    ) async throws -> ApplyOutcome? {
+        try await writer.write { db -> ApplyOutcome? in
+            // Idempotency, authoritative under concurrency: a receipt committed
+            // by a racing duplicate is visible here (same write lock), so the
+            // second caller replays instead of double-applying.
+            if let existing = try PanelOperationReceiptRecord.fetchOne(db, key: operationID.uuidString),
+               let prior = decodeJSON(PanelApplyResult.self, from: existing.result) {
+                return .replayed(prior)
+            }
+
+            // Load current committed state INSIDE the transaction.
+            guard let surfaceRecord = try WorkspaceTabSurfaceRecord.fetchOne(db, key: tabID.uuidString),
+                  let surface = surfaceRecord.toModel(),
+                  surface.worktreeID == worktreeID else {
+                return nil
+            }
+            let histories = try PanelHistoryRecord
+                .filter(Column("tabID") == tabID.uuidString)
+                .fetchAll(db)
+                .compactMap { $0.toModel() }
+            let current = PanelSurfaceState(
+                surface: surface, histories: Dictionary(uniqueKeysWithValues: histories))
+
+            let newState = try reduce(current)
+
+            try Self.writeSurfaceAndHistory(newState, position: surfaceRecord.position, db: db, now: now)
+
+            let result = PanelApplyResult(tab: newState.surface, replayed: false)
+            let receipt = PanelOperationReceiptRecord(
+                operationID: operationID.uuidString, worktreeID: worktreeID.uuidString,
+                tabID: tabID.uuidString, revision: Int64(newState.surface.revision),
+                result: try encodeJSONString(result), appliedAt: now)
+            try receipt.save(db)
+            try self.pruneReceipts(db: db, worktreeID: worktreeID, now: now)
+            return .applied(result)
         }
     }
 

--- a/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
+++ b/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
@@ -319,12 +319,21 @@ public struct PanelSurfaceStore: Sendable {
     /// serializes the whole read-modify-write.
     ///
     /// `reduce` is the pure synchronous shared reducer (plus the caller's
-    /// baseRevision→staleTarget error mapping); it runs fine inside the
-    /// transaction. Returns `nil` when the tab has no surface row for
-    /// `worktreeID` (caller maps to its not-found error).
+    /// baseRevision→staleTarget error mapping and §6.1 `.automatic` recency
+    /// rewrite). It runs fine inside the transaction. Returns `nil` when the
+    /// tab has no surface row for `worktreeID` (caller maps to its
+    /// not-found error).
+    ///
+    /// `reduce` also receives a `[PanelID: Date]` recency map (`panel_history
+    /// .updatedAt`, keyed by panel) derived from the SAME `PanelHistoryRecord`
+    /// rows used to build `current.histories` — one fetch inside this
+    /// transaction feeds both. That is what keeps the coordinator's recency
+    /// rewrite coherent with the tree the reducer applies it to: there is no
+    /// separate pre-write recency query a concurrent commit could invalidate
+    /// between read and reduce.
     public func applyReducing(
         operationID: UUID, tabID: UUID, worktreeID: UUID, now: Date,
-        reduce: @Sendable (PanelSurfaceState) throws -> PanelSurfaceState
+        reduce: @Sendable (PanelSurfaceState, [PanelID: Date]) throws -> PanelSurfaceState
     ) async throws -> ApplyOutcome? {
         try await writer.write { db -> ApplyOutcome? in
             // Idempotency, authoritative under concurrency: a receipt committed
@@ -341,14 +350,19 @@ public struct PanelSurfaceStore: Sendable {
                   surface.worktreeID == worktreeID else {
                 return nil
             }
-            let histories = try PanelHistoryRecord
+            let historyRows = try PanelHistoryRecord
                 .filter(Column("tabID") == tabID.uuidString)
                 .fetchAll(db)
-                .compactMap { $0.toModel() }
+            let histories = historyRows.compactMap { $0.toModel() }
+            var recency: [PanelID: Date] = [:]
+            for row in historyRows {
+                guard let panelID = UUID(uuidString: row.panelID) else { continue }
+                recency[panelID] = row.updatedAt
+            }
             let current = PanelSurfaceState(
                 surface: surface, histories: Dictionary(uniqueKeysWithValues: histories))
 
-            let newState = try reduce(current)
+            let newState = try reduce(current, recency)
 
             try Self.writeSurfaceAndHistory(newState, position: surfaceRecord.position, db: db, now: now)
 
@@ -397,6 +411,21 @@ public struct PanelSurfaceStore: Sendable {
     public func pruneReceipts(worktreeID: UUID, now: Date) async throws {
         _ = try await writer.write { db in
             try self.pruneReceipts(db: db, worktreeID: worktreeID, now: now)
+        }
+    }
+
+    /// Persists a stand-alone receipt with NO surface/history write — used by
+    /// `PanelCoordinator`'s `selectTab` handling, which is worktree-scoped and
+    /// never mutates a `workspace_tab_surface`/`panel_history` row. Recording
+    /// the receipt still lets the generic idempotency check in `apply` (which
+    /// reads `receipt(operationID:)` before dispatching) replay a duplicate
+    /// `selectTab` without re-touching `worktree.activeTabID` or re-broadcasting.
+    public func saveReceipt(_ receipt: PanelOperationReceiptRecord, now: Date) async throws {
+        _ = try await writer.write { db in
+            try receipt.save(db)
+            if let worktreeID = UUID(uuidString: receipt.worktreeID) {
+                try self.pruneReceipts(db: db, worktreeID: worktreeID, now: now)
+            }
         }
     }
 

--- a/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
+++ b/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
@@ -138,6 +138,11 @@ public enum PanelSurfaceStoreError: Error, Equatable, Sendable {
     /// (fresh UUIDs + importer cross-tab dedup), so this should never fire —
     /// it exists to turn a silent data-loss path into a loud failure.
     case panelHistoryOwnedByOtherTab(panelID: PanelID, existingTabID: WorkspaceTabID, incomingTabID: WorkspaceTabID)
+    /// `commitImport` is create-if-absent: a worktree that already has a
+    /// `panel_surface_imported_at` stamp OR any `workspace_tab_surface` row
+    /// has already been imported (or is mid-import from a concurrent call),
+    /// and must not be silently overwritten.
+    case alreadyImported
 }
 
 /// Store for the panel-surface schema (workspace tab layouts, panel history,
@@ -273,7 +278,108 @@ public struct PanelSurfaceStore: Sendable {
 
             if let receipt {
                 try receipt.save(db)
+                if let receiptWorktreeID = UUID(uuidString: receipt.worktreeID) {
+                    try pruneReceipts(db: db, worktreeID: receiptWorktreeID, now: now)
+                }
             }
+        }
+    }
+
+    /// Keep at most this many receipts per worktree (spec C §7.4).
+    private static let receiptRetentionLimit = 100
+    /// Drop receipts older than this, regardless of count (spec C §7.4).
+    private static let receiptMaxAge: TimeInterval = 24 * 60 * 60
+
+    /// Shared prune body: runs INSIDE an already-open write transaction (used
+    /// by `commit`) or wrapped in its own (the public `pruneReceipts` below,
+    /// used directly by tests). Age-bound first, then count-bound — order
+    /// doesn't affect the final surviving set, both are applied together.
+    private func pruneReceipts(db: Database, worktreeID: UUID, now: Date) throws {
+        let cutoff = now.addingTimeInterval(-Self.receiptMaxAge)
+        try PanelOperationReceiptRecord
+            .filter(Column("worktreeID") == worktreeID.uuidString)
+            .filter(Column("appliedAt") < cutoff)
+            .deleteAll(db)
+
+        let keepIDs = try PanelOperationReceiptRecord
+            .filter(Column("worktreeID") == worktreeID.uuidString)
+            .order(Column("appliedAt").desc)
+            .limit(Self.receiptRetentionLimit)
+            .fetchAll(db)
+            .map(\.operationID)
+        try PanelOperationReceiptRecord
+            .filter(Column("worktreeID") == worktreeID.uuidString)
+            .filter(!keepIDs.contains(Column("operationID")))
+            .deleteAll(db)
+    }
+
+    /// Public entry point for `pruneReceipts` — same bounds as the private
+    /// helper `commit` runs automatically, exposed standalone for tests that
+    /// want to drive pruning without going through a full commit.
+    public func pruneReceipts(worktreeID: UUID, now: Date) async throws {
+        _ = try await writer.write { db in
+            try self.pruneReceipts(db: db, worktreeID: worktreeID, now: now)
+        }
+    }
+
+    /// Idempotency lookup (spec C §7.4): the previously committed result for
+    /// `operationID`, or `nil` if this operation never committed (or its
+    /// receipt has since been pruned).
+    public func receipt(operationID: UUID) async throws -> PanelApplyResult? {
+        try await writer.read { db in
+            guard let record = try PanelOperationReceiptRecord.fetchOne(db, key: operationID.uuidString) else {
+                return nil
+            }
+            return decodeJSON(PanelApplyResult.self, from: record.result)
+        }
+    }
+
+    /// Atomic §11.2 import: writes every converted surface + its histories +
+    /// stamps `worktree.panel_surface_imported_at`, all in one transaction.
+    /// Create-if-absent — throws `.alreadyImported` when the worktree already
+    /// has a stamp OR any existing surface row (covers a prior successful
+    /// import and a prior partial write alike).
+    ///
+    /// `conversion.histories` is keyed by `PanelID` across ALL tabs; each
+    /// surface's own subset is recovered via `surface.layout.allPanelIDs` —
+    /// the importer's cross-tab dedup guarantees those IDs are globally
+    /// unique, so the same `panelHistoryOwnedByOtherTab` guard `commit` uses
+    /// composes cleanly across this multi-tab write.
+    public func commitImport(
+        worktreeID: UUID, conversion: LegacySurfaceImporter.Conversion, now: Date
+    ) async throws {
+        _ = try await writer.write { db in
+            let alreadyStamped = try WorktreeRecord
+                .fetchOne(db, key: worktreeID.uuidString)?.panel_surface_imported_at != nil
+            let hasExistingSurfaces = try WorkspaceTabSurfaceRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .fetchCount(db) > 0
+            guard !alreadyStamped, !hasExistingSurfaces else {
+                throw PanelSurfaceStoreError.alreadyImported
+            }
+
+            for (index, surface) in conversion.surfaces.enumerated() {
+                let surfaceRecord = try WorkspaceTabSurfaceRecord(from: surface, position: index, updatedAt: now)
+                try surfaceRecord.save(db)
+
+                for panelID in surface.layout.allPanelIDs {
+                    guard let history = conversion.histories[panelID] else { continue }
+                    if let owner = try PanelHistoryRecord.fetchOne(db, key: panelID.uuidString),
+                       owner.tabID != surface.id.uuidString {
+                        throw PanelSurfaceStoreError.panelHistoryOwnedByOtherTab(
+                            panelID: panelID,
+                            existingTabID: UUID(uuidString: owner.tabID) ?? UUID(),
+                            incomingTabID: surface.id)
+                    }
+                    let historyRecord = try PanelHistoryRecord(
+                        panelID: panelID, tabID: surface.id, history: history, updatedAt: now)
+                    try historyRecord.save(db)
+                }
+            }
+
+            try db.execute(
+                sql: "UPDATE worktree SET panel_surface_imported_at = ? WHERE id = ?",
+                arguments: [now, worktreeID.uuidString])
         }
     }
 

--- a/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
+++ b/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import GRDB
+import TBDShared
+
+/// GRDB Record type for the `workspace_tab_surface` table: one row per
+/// workspace tab (layout tree + primary content + revision). See spec C §8.
+struct WorkspaceTabSurfaceRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "workspace_tab_surface"
+    var id: String
+    var worktreeID: String
+    var primaryContent: String
+    var label: String?
+    var position: Int
+    var layout: String
+    var revision: Int64
+    var updatedAt: Date
+}
+
+/// GRDB Record type for the `panel_history` table: per-panel MRU history
+/// (spec C §8), keyed by panel ID.
+struct PanelHistoryRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "panel_history"
+    var panelID: String
+    var tabID: String
+    var history: String
+    var updatedAt: Date
+}
+
+/// GRDB Record type for the `panel_operation_receipt` table: bounded receipts
+/// used for §7.4 idempotency of agent-originated panel operations.
+struct PanelOperationReceiptRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "panel_operation_receipt"
+    var operationID: String
+    var worktreeID: String
+    var tabID: String
+    var revision: Int64
+    var result: String
+    var appliedAt: Date
+}
+
+/// Store for the panel-surface schema (workspace tab layouts, panel history,
+/// operation receipts). Skeleton for Task 5 — full CRUD API lands in Task 6.
+public struct PanelSurfaceStore: Sendable {
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) {
+        self.writer = writer
+    }
+
+    /// Whether a worktree has no persisted workspace-tab-surface rows yet
+    /// (never imported / nothing saved).
+    public func isEmpty(worktreeID: UUID) async throws -> Bool {
+        try await writer.read { db in
+            try WorkspaceTabSurfaceRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .fetchCount(db) == 0
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
+++ b/Sources/TBDDaemon/Database/PanelSurfaceStore.swift
@@ -129,6 +129,17 @@ public struct PanelOperationReceiptRecord: Codable, FetchableRecord, Persistable
     }
 }
 
+public enum PanelSurfaceStoreError: Error, Equatable, Sendable {
+    /// A commit tried to write a panelID whose `panel_history` row already
+    /// belongs to a different tab. `panel_history.panelID` is a table-wide
+    /// primary key, so a blind upsert would silently steal the row (flip its
+    /// tabID, overwrite its history) and lose the other tab's panel history.
+    /// The invariant "panelID is globally unique across tabs" holds today
+    /// (fresh UUIDs + importer cross-tab dedup), so this should never fire —
+    /// it exists to turn a silent data-loss path into a loud failure.
+    case panelHistoryOwnedByOtherTab(panelID: PanelID, existingTabID: WorkspaceTabID, incomingTabID: WorkspaceTabID)
+}
+
 /// Store for the panel-surface schema (workspace tab layouts, panel history,
 /// operation receipts). See spec C §8.
 public struct PanelSurfaceStore: Sendable {
@@ -193,16 +204,27 @@ public struct PanelSurfaceStore: Sendable {
         }
     }
 
-    /// Atomic §8 write: replace the tab's surface row + FULL history set for
-    /// that tab + record the receipt, in one transaction (all-or-nothing —
+    /// Atomic §8 write for ONE tab: upsert the tab's surface row + its FULL
+    /// history set + record the receipt, in one transaction (all-or-nothing —
     /// GRDB wraps a `write` closure in a SQLite transaction, so any thrown
     /// error rolls back everything written so far in this call, including
-    /// the surface row and any history rows already saved). `position: nil`
-    /// keeps the row's existing position (or defaults to 0 for a brand-new
-    /// row). History rows for panels no longer in `state.histories` are
-    /// deleted (full replace); a history row's `updatedAt` only advances to
-    /// `now` when its decoded content actually changed — unchanged panels
-    /// keep their prior `updatedAt`.
+    /// the surface row and any history rows already saved).
+    ///
+    /// This is a PER-TAB upsert, NOT a worktree-level replace: it never
+    /// removes surfaces for OTHER tabs of the worktree that aren't in this
+    /// write. A caller wanting to replace a worktree's whole tab set must
+    /// `deleteSurfaces(worktreeID:)` first (history then cascades), then
+    /// commit each surviving tab. (Task 8's coordinator honors this contract.)
+    ///
+    /// `position: nil` keeps the row's existing position (or defaults to 0
+    /// for a brand-new row). History rows for panels no longer in
+    /// `state.histories` are deleted (full replace WITHIN this tab); a history
+    /// row's `updatedAt` only advances to `now` when its decoded content
+    /// actually changed — unchanged panels keep their prior `updatedAt`.
+    ///
+    /// Throws `PanelSurfaceStoreError.panelHistoryOwnedByOtherTab` if a
+    /// panelID being written already has a `panel_history` row under a
+    /// different tab (guards a silent cross-tab clobber — see the error doc).
     public func commit(
         state: PanelSurfaceState, position: Int?, receipt: PanelOperationReceiptRecord?,
         now: Date = Date()
@@ -223,6 +245,21 @@ public struct PanelSurfaceStore: Sendable {
             let newPanelIDStrings = Set(state.histories.keys.map(\.uuidString))
             for row in existingHistoryRows where !newPanelIDStrings.contains(row.panelID) {
                 try PanelHistoryRecord.deleteOne(db, key: row.panelID)
+            }
+
+            // Loud-fail guard: `panel_history.panelID` is a table-wide PK, so a
+            // blind `save` would silently steal a row owned by another tab. Any
+            // panelID we're about to write that already exists under a DIFFERENT
+            // tab is a violation of the global-uniqueness invariant — throw
+            // instead of clobbering that tab's history.
+            for panelID in state.histories.keys {
+                if let owner = try PanelHistoryRecord.fetchOne(db, key: panelID.uuidString),
+                   owner.tabID != state.surface.id.uuidString {
+                    throw PanelSurfaceStoreError.panelHistoryOwnedByOtherTab(
+                        panelID: panelID,
+                        existingTabID: UUID(uuidString: owner.tabID) ?? UUID(),
+                        incomingTabID: state.surface.id)
+                }
             }
 
             for (panelID, history) in state.histories {

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -31,6 +31,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var prStatus: String?  // JSON-encoded PRStatus, nil when never observed
     var promotedToRepoID: String?  // set only on promoted scratch rows
     var pr_number: Int?  // number of the PR this worktree was created from, nil otherwise
+    var panel_surface_imported_at: Date?  // stamped once the legacy layout is imported; nil = never imported
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -58,6 +59,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.prStatus = wt.prStatus.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         self.promotedToRepoID = wt.promotedToRepoID?.uuidString
         self.pr_number = wt.prNumber
+        self.panel_surface_imported_at = nil  // new worktrees start unimported; stamped via stampPanelSurfaceImported
     }
 
     /// Failable decode: skips (returns nil after a logged warning) only when the
@@ -716,6 +718,25 @@ public struct WorktreeStore: Sendable {
             try db.execute(
                 sql: "UPDATE worktree SET activeTabID = ? WHERE id = ?",
                 arguments: [tabID?.uuidString, worktreeID.uuidString]
+            )
+        }
+    }
+
+    /// Read the `panel_surface_imported_at` column for a worktree. `nil`
+    /// distinguishes "never imported" from "imported an empty layout"
+    /// (spec C Phase 2 §8). Returns nil for missing worktrees too.
+    public func panelSurfaceImportedAt(worktreeID: UUID) async throws -> Date? {
+        try await writer.read { db in
+            try WorktreeRecord.fetchOne(db, key: worktreeID.uuidString)?.panel_surface_imported_at
+        }
+    }
+
+    /// Stamp the legacy-layout-import timestamp for a worktree.
+    public func stampPanelSurfaceImported(worktreeID: UUID, at date: Date) async throws {
+        _ = try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE worktree SET panel_surface_imported_at = ? WHERE id = ?",
+                arguments: [date, worktreeID.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
+++ b/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
@@ -20,19 +20,6 @@ public enum PanelCoordinatorError: Error, Equatable, Sendable {
     case operation(PanelOperationError)
 }
 
-/// Encodes/decodes `PanelApplyResult` for the `panel_operation_receipt.result`
-/// column. Deliberately separate from `PanelSurfaceStore`'s private
-/// file-scoped JSON helpers — this is the coordinator's own encode of its own
-/// wire type, not a store-internal concern.
-private func encodeReceiptResult(_ result: PanelApplyResult) throws -> String {
-    let data = try JSONEncoder().encode(result)
-    guard let string = String(bytes: data, encoding: .utf8) else {
-        throw DecodingError.dataCorrupted(
-            .init(codingPath: [], debugDescription: "PanelApplyResult JSON is not valid UTF-8"))
-    }
-    return string
-}
-
 /// Vanished-target reducer errors — the only `PanelOperationError` cases a
 /// stale `baseRevision` can legitimately explain (§7.4: "target was removed
 /// or changed incompatibly").
@@ -93,8 +80,13 @@ public actor PanelCoordinator {
             throw PanelCoordinatorError.agentControlDisabled
         }
 
-        // 2. Idempotency: a prior commit for this operationID replays verbatim
-        // — no re-application, no re-persist, no broadcast.
+        // 2. Idempotency fast-path (§7.4): a prior committed result replays
+        // verbatim — no re-application, no re-persist, no broadcast, and it
+        // must NOT re-run resource validation below. The authoritative
+        // idempotency check also lives inside `applyReducing`'s transaction to
+        // cover a concurrent duplicate; this early read handles the common
+        // reconnect/retry replay and preserves the spec's replay-before-
+        // resource-check ordering.
         if let priorResult = try await db.panelSurface.receipt(operationID: envelope.operationID) {
             return PanelApplyResult(tab: priorResult.tab, replayed: true)
         }
@@ -104,54 +96,63 @@ public actor PanelCoordinator {
             throw PanelCoordinatorError.operation(.notTabScoped)
         }
 
-        // 4. Load current state. The tab must actually belong to the claimed
-        // worktree — otherwise a mismatched envelope would mutate one
-        // worktree's tab while broadcasting/receipting under another's id.
-        guard let state = try await db.panelSurface.state(tabID: envelope.tabID),
-              state.surface.worktreeID == envelope.worktreeID else {
+        // 4. §5.5 resource-existence check for open/navigate destinations.
+        // (Reads other tables, so it stays outside the apply transaction; a
+        // resource vanishing right after this is a separate, inherent race,
+        // not the surface-state lost-update the transaction closes.)
+        try await validateResourceExists(in: envelope.operation, worktreeID: envelope.worktreeID)
+
+        // 5. Placement rewrite (`.automatic` recency resolution) is Task 9 —
+        // pass the operation through unchanged until then.
+
+        // 6. Transactional load → reduce → persist. Doing the load inside the
+        // store's write transaction is what makes this safe under concurrent
+        // same-tab applies on a production DatabasePool: actor isolation does
+        // not span `await`, and a separate pre-write pool read would observe a
+        // stale revision and silently clobber a concurrent commit. The reduce
+        // closure is the pure shared reducer plus baseRevision→staleTarget
+        // mapping (evaluated against the state loaded INSIDE the transaction —
+        // i.e. "the current authoritative tree", §7.4).
+        let operation = envelope.operation
+        let baseRevision = envelope.baseRevision
+        let makeID = self.makeID
+        let reduce: @Sendable (PanelSurfaceState) throws -> PanelSurfaceState = { current in
+            do {
+                return try PanelSurfaceReducer.apply(operation, to: current, makeID: makeID)
+            } catch let error as PanelOperationError {
+                let baseIsStale = baseRevision.map { $0 != current.surface.revision } ?? false
+                if baseIsStale, isVanishedTarget(error) {
+                    throw PanelCoordinatorError.staleTarget(error)
+                }
+                throw PanelCoordinatorError.operation(error)
+            }
+        }
+
+        let outcome = try await db.panelSurface.applyReducing(
+            operationID: envelope.operationID, tabID: envelope.tabID,
+            worktreeID: envelope.worktreeID, now: now(), reduce: reduce)
+
+        guard let outcome else {
+            // No surface row for this tab under the claimed worktree.
             throw PanelCoordinatorError.tabNotFound(envelope.tabID)
         }
 
-        // 5. §5.5 resource-existence check for open/navigate destinations.
-        try await validateResourceExists(in: envelope.operation, worktreeID: envelope.worktreeID)
-
-        // 6. Placement rewrite (`.automatic` recency resolution) is Task 9 —
-        // pass the operation through unchanged until then.
-
-        // 7. Reduce.
-        let newState: PanelSurfaceState
-        do {
-            newState = try PanelSurfaceReducer.apply(envelope.operation, to: state, makeID: makeID)
-        } catch let error as PanelOperationError {
-            let baseIsStale = envelope.baseRevision.map { $0 != state.surface.revision } ?? false
-            if baseIsStale, isVanishedTarget(error) {
-                throw PanelCoordinatorError.staleTarget(error)
-            }
-            throw PanelCoordinatorError.operation(error)
+        switch outcome {
+        case .replayed(let prior):
+            // A concurrent duplicate committed first; return its result, no broadcast.
+            return PanelApplyResult(tab: prior.tab, replayed: true)
+        case .applied(let result):
+            // 7. Broadcast AFTER commit — never before (a rolled-back op must
+            // not reach subscribers; a thrown reduce/persist rolls the whole
+            // transaction back and returns before reaching here).
+            broadcast(.panelSurfaceChanged(PanelSurfaceDelta(
+                worktreeID: envelope.worktreeID,
+                tabs: [result.tab],
+                removedTabIDs: [],
+                activeTabID: nil,
+                originOperationID: envelope.operationID)))
+            return result
         }
-
-        // 8. Persist atomically (surface + histories + receipt in one transaction).
-        let result = PanelApplyResult(tab: newState.surface, replayed: false)
-        let receipt = PanelOperationReceiptRecord(
-            operationID: envelope.operationID.uuidString,
-            worktreeID: envelope.worktreeID.uuidString,
-            tabID: envelope.tabID.uuidString,
-            revision: Int64(newState.surface.revision),
-            result: try encodeReceiptResult(result),
-            appliedAt: now())
-        try await db.panelSurface.commit(state: newState, position: nil, receipt: receipt, now: now())
-
-        // 9. Broadcast AFTER commit — never before (a rolled-back op must not
-        // reach subscribers).
-        broadcast(.panelSurfaceChanged(PanelSurfaceDelta(
-            worktreeID: envelope.worktreeID,
-            tabs: [newState.surface],
-            removedTabIDs: [],
-            activeTabID: nil,
-            originOperationID: envelope.operationID)))
-
-        // 10. Return.
-        return result
     }
 
     /// §5.5: referenced notes and transcripts must belong to this worktree.

--- a/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
+++ b/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
@@ -32,6 +32,40 @@ private func isVanishedTarget(_ error: PanelOperationError) -> Bool {
     }
 }
 
+/// §6.1 rule 1 / Phase 1 decision record #3: rewrites `open(_, .automatic)`
+/// to `.replace(panelID:)`, targeting the most-recently-navigated viewer
+/// panel. `move`'s `.automatic` is deliberately left alone — the reducer
+/// itself rejects that combination with `.invalidPlacement`, and rewriting
+/// it here would silently paper over what should surface as a caller error.
+///
+/// `state` and `recency` MUST come from the same read — see
+/// `PanelSurfaceStore.applyReducing`, which derives both from one
+/// transaction-scoped fetch of `panel_history` so this rewrite can never
+/// disagree with the tree the reducer is about to apply it to.
+///
+/// Ties, and "no recency at all" (empty `recency` — panels seeded but never
+/// separately navigated), both fall back to the first panel in pre-order —
+/// the exact rule `PanelSurfaceReducer`'s own `.automatic` case uses for its
+/// no-rewrite default — so a present-vs-missing recency row never changes
+/// the outcome. Zero panels returns the operation untouched; the reducer's
+/// `.automatic` then splits right of the primary anchor.
+private func rewritingAutomaticPlacement(
+    _ operation: PanelOperation, in state: PanelSurfaceState, recency: [PanelID: Date]
+) -> PanelOperation {
+    guard case .open(let content, .automatic) = operation else { return operation }
+    let panelIDs = state.surface.layout.allPanelIDs
+    guard var winner = panelIDs.first else { return operation }
+    var winnerRecency = recency[winner]
+    for candidate in panelIDs.dropFirst() {
+        guard let candidateRecency = recency[candidate] else { continue }
+        if winnerRecency == nil || candidateRecency > winnerRecency! {
+            winner = candidate
+            winnerRecency = candidateRecency
+        }
+    }
+    return .open(content: content, placement: .replace(panelID: winner))
+}
+
 /// Daemon actor that owns committed panel-surface state. Serializes every
 /// `apply` call — one global actor for now (ponytail: global lock across all
 /// worktrees; shard per-worktree if cross-worktree apply throughput ever
@@ -91,9 +125,11 @@ public actor PanelCoordinator {
             return PanelApplyResult(tab: priorResult.tab, replayed: true)
         }
 
-        // 3. `.selectTab` is Task 9 — short-circuit until then.
-        if case .selectTab = envelope.operation {
-            throw PanelCoordinatorError.operation(.notTabScoped)
+        // 3. `.selectTab` is worktree-scoped, not tab-scoped (the reducer
+        // throws `.notTabScoped` for it) — the coordinator handles it
+        // directly: no surface mutation, no reducer call.
+        if case .selectTab(let selectedTabID) = envelope.operation {
+            return try await applySelectTab(selectedTabID: selectedTabID, envelope: envelope)
         }
 
         // 4. §5.5 resource-existence check for open/navigate destinations.
@@ -102,8 +138,12 @@ public actor PanelCoordinator {
         // not the surface-state lost-update the transaction closes.)
         try await validateResourceExists(in: envelope.operation, worktreeID: envelope.worktreeID)
 
-        // 5. Placement rewrite (`.automatic` recency resolution) is Task 9 —
-        // pass the operation through unchanged until then.
+        // 5. Placement rewrite (`.automatic` §6.1 recency resolution) happens
+        // INSIDE the `reduce` closure below, fed by the recency map
+        // `applyReducing` derives from the same transaction-scoped
+        // `panel_history` read it uses to build `current` — see
+        // `rewritingAutomaticPlacement`'s doc comment for why that's what
+        // keeps the rewrite coherent with the tree it's rewriting against.
 
         // 6. Transactional load → reduce → persist. Doing the load inside the
         // store's write transaction is what makes this safe under concurrent
@@ -116,9 +156,10 @@ public actor PanelCoordinator {
         let operation = envelope.operation
         let baseRevision = envelope.baseRevision
         let makeID = self.makeID
-        let reduce: @Sendable (PanelSurfaceState) throws -> PanelSurfaceState = { current in
+        let reduce: @Sendable (PanelSurfaceState, [PanelID: Date]) throws -> PanelSurfaceState = { current, recency in
             do {
-                return try PanelSurfaceReducer.apply(operation, to: current, makeID: makeID)
+                let resolvedOperation = rewritingAutomaticPlacement(operation, in: current, recency: recency)
+                return try PanelSurfaceReducer.apply(resolvedOperation, to: current, makeID: makeID)
             } catch let error as PanelOperationError {
                 let baseIsStale = baseRevision.map { $0 != current.surface.revision } ?? false
                 if baseIsStale, isVanishedTarget(error) {
@@ -153,6 +194,56 @@ public actor PanelCoordinator {
                 originOperationID: envelope.operationID)))
             return result
         }
+    }
+
+    /// `selectTab` is worktree-scoped: it updates which tab is active, not
+    /// any tab's panel layout. Reuses `worktree.activeTabID` via
+    /// `WorktreeStore` — the existing active-tab authority (already read by
+    /// non-panel-surface code) — rather than standing up a second one.
+    /// Validates the tab exists (has a persisted surface row) under the
+    /// claimed worktree, persists a stand-alone receipt (no surface/history
+    /// write) so the generic idempotency check in `apply` can replay a
+    /// duplicate without re-selecting/re-broadcasting, then broadcasts a
+    /// delta carrying only `activeTabID` — no `tabs`, no revision bump.
+    ///
+    /// ponytail: the idempotency check for `selectTab` is the early
+    /// `receipt(operationID:)` read in `apply` (step 2), not an
+    /// inside-one-transaction check like `applyReducing`'s — two concurrent
+    /// calls with the SAME `operationID` could both pass it and both write
+    /// (harmless: same `activeTabID` value, a redundant second broadcast).
+    /// Upgrade to a single cross-store transaction if that duplicate
+    /// broadcast ever matters; `selectTab` has no revision/lost-update risk
+    /// the way surface mutations do, so it wasn't worth one for this task.
+    private func applySelectTab(
+        selectedTabID: WorkspaceTabID, envelope: PanelOperationEnvelope
+    ) async throws -> PanelApplyResult {
+        guard let state = try await db.panelSurface.state(tabID: selectedTabID),
+              state.surface.worktreeID == envelope.worktreeID else {
+            throw PanelCoordinatorError.tabNotFound(selectedTabID)
+        }
+
+        try await db.worktrees.setActiveTabID(worktreeID: envelope.worktreeID, tabID: selectedTabID)
+
+        let result = PanelApplyResult(tab: state.surface, replayed: false)
+        let appliedAt = now()
+        let resultData = try JSONEncoder().encode(result)
+        guard let resultJSON = String(bytes: resultData, encoding: .utf8) else {
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: [], debugDescription: "JSON-encoded receipt result is not valid UTF-8"))
+        }
+        let receipt = PanelOperationReceiptRecord(
+            operationID: envelope.operationID.uuidString, worktreeID: envelope.worktreeID.uuidString,
+            tabID: selectedTabID.uuidString, revision: Int64(state.surface.revision),
+            result: resultJSON, appliedAt: appliedAt)
+        try await db.panelSurface.saveReceipt(receipt, now: appliedAt)
+
+        broadcast(.panelSurfaceChanged(PanelSurfaceDelta(
+            worktreeID: envelope.worktreeID,
+            tabs: [],
+            removedTabIDs: [],
+            activeTabID: selectedTabID,
+            originOperationID: envelope.operationID)))
+        return result
     }
 
     /// §5.5: referenced notes and transcripts must belong to this worktree.

--- a/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
+++ b/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
@@ -1,0 +1,180 @@
+import Foundation
+import TBDShared
+
+/// Errors `PanelCoordinator.apply` can throw. See spec C §7.2/§7.4.
+public enum PanelCoordinatorError: Error, Equatable, Sendable {
+    /// `daemon_panel_surface_enabled` is off — no mutating origin may proceed.
+    case surfaceDisabled
+    /// `origin == .agentCLI` while `agent_panel_control_enabled` is off.
+    case agentControlDisabled
+    /// The envelope's `tabID` has no persisted surface row.
+    case tabNotFound(UUID)
+    /// `baseRevision` was stale AND the reducer's target vanished/changed
+    /// incompatibly (§7.4 semantic rebase) — state is unchanged.
+    case staleTarget(PanelOperationError)
+    /// §5.5 daemon-half resource check: an `open`/`navigate` destination
+    /// referenced a note/transcript that doesn't exist or isn't in this worktree.
+    case invalidResource(String)
+    /// The reducer rejected the operation against a FRESH base (baseRevision
+    /// absent, current, or the error isn't a vanished-target case).
+    case operation(PanelOperationError)
+}
+
+/// Encodes/decodes `PanelApplyResult` for the `panel_operation_receipt.result`
+/// column. Deliberately separate from `PanelSurfaceStore`'s private
+/// file-scoped JSON helpers — this is the coordinator's own encode of its own
+/// wire type, not a store-internal concern.
+private func encodeReceiptResult(_ result: PanelApplyResult) throws -> String {
+    let data = try JSONEncoder().encode(result)
+    guard let string = String(bytes: data, encoding: .utf8) else {
+        throw DecodingError.dataCorrupted(
+            .init(codingPath: [], debugDescription: "PanelApplyResult JSON is not valid UTF-8"))
+    }
+    return string
+}
+
+/// Vanished-target reducer errors — the only `PanelOperationError` cases a
+/// stale `baseRevision` can legitimately explain (§7.4: "target was removed
+/// or changed incompatibly").
+private func isVanishedTarget(_ error: PanelOperationError) -> Bool {
+    switch error {
+    case .panelNotFound, .splitNotFound, .anchorNotFound:
+        return true
+    case .invalidRatios, .invalidPlacement, .historyUnavailable, .notTabScoped:
+        return false
+    }
+}
+
+/// Daemon actor that owns committed panel-surface state. Serializes every
+/// `apply` call — one global actor for now (ponytail: global lock across all
+/// worktrees; shard per-worktree if cross-worktree apply throughput ever
+/// matters, nothing here depends on the single-actor shape). Runs the
+/// gating → idempotency → resource-check → reduce → persist → broadcast
+/// pipeline in spec C §7.2/§7.4.
+public actor PanelCoordinator {
+    private let db: TBDDatabase
+    private let broadcast: @Sendable (StateDelta) -> Void
+    private let now: @Sendable () -> Date
+    private let makeID: @Sendable () -> UUID
+
+    public init(
+        db: TBDDatabase,
+        broadcast: @escaping @Sendable (StateDelta) -> Void,
+        now: @escaping @Sendable () -> Date = Date.init,
+        makeID: @escaping @Sendable () -> UUID = UUID.init
+    ) {
+        self.db = db
+        self.broadcast = broadcast
+        self.now = now
+        self.makeID = makeID
+    }
+
+    /// Ungated read (§10.2: `panel.get` is ungated). `tabID` present narrows
+    /// to that one tab; absent returns every tab in the worktree.
+    public func get(worktreeID: UUID, tabID: UUID?) async throws -> PanelGetResult {
+        if let tabID {
+            guard let state = try await db.panelSurface.state(tabID: tabID),
+                  state.surface.worktreeID == worktreeID else {
+                return PanelGetResult(tabs: [], activeTabID: nil)
+            }
+            return PanelGetResult(tabs: [state.surface], activeTabID: nil)
+        }
+        let surfaces = try await db.panelSurface.surfaces(worktreeID: worktreeID)
+        return PanelGetResult(tabs: surfaces, activeTabID: nil)
+    }
+
+    public func apply(_ envelope: PanelOperationEnvelope) async throws -> PanelApplyResult {
+        // 1. Gating (§10.2).
+        let config = try await db.config.get()
+        guard config.panelSurfaceEnabled else {
+            throw PanelCoordinatorError.surfaceDisabled
+        }
+        if envelope.origin == .agentCLI, !config.agentPanelControlEnabled {
+            throw PanelCoordinatorError.agentControlDisabled
+        }
+
+        // 2. Idempotency: a prior commit for this operationID replays verbatim
+        // — no re-application, no re-persist, no broadcast.
+        if let priorResult = try await db.panelSurface.receipt(operationID: envelope.operationID) {
+            return PanelApplyResult(tab: priorResult.tab, replayed: true)
+        }
+
+        // 3. `.selectTab` is Task 9 — short-circuit until then.
+        if case .selectTab = envelope.operation {
+            throw PanelCoordinatorError.operation(.notTabScoped)
+        }
+
+        // 4. Load current state.
+        guard let state = try await db.panelSurface.state(tabID: envelope.tabID) else {
+            throw PanelCoordinatorError.tabNotFound(envelope.tabID)
+        }
+
+        // 5. §5.5 resource-existence check for open/navigate destinations.
+        try await validateResourceExists(in: envelope.operation, worktreeID: envelope.worktreeID)
+
+        // 6. Placement rewrite (`.automatic` recency resolution) is Task 9 —
+        // pass the operation through unchanged until then.
+
+        // 7. Reduce.
+        let newState: PanelSurfaceState
+        do {
+            newState = try PanelSurfaceReducer.apply(envelope.operation, to: state, makeID: makeID)
+        } catch let error as PanelOperationError {
+            let baseIsStale = envelope.baseRevision.map { $0 != state.surface.revision } ?? false
+            if baseIsStale, isVanishedTarget(error) {
+                throw PanelCoordinatorError.staleTarget(error)
+            }
+            throw PanelCoordinatorError.operation(error)
+        }
+
+        // 8. Persist atomically (surface + histories + receipt in one transaction).
+        let result = PanelApplyResult(tab: newState.surface, replayed: false)
+        let receipt = PanelOperationReceiptRecord(
+            operationID: envelope.operationID.uuidString,
+            worktreeID: envelope.worktreeID.uuidString,
+            tabID: envelope.tabID.uuidString,
+            revision: Int64(newState.surface.revision),
+            result: try encodeReceiptResult(result),
+            appliedAt: now())
+        try await db.panelSurface.commit(state: newState, position: nil, receipt: receipt, now: now())
+
+        // 9. Broadcast AFTER commit — never before (a rolled-back op must not
+        // reach subscribers).
+        broadcast(.panelSurfaceChanged(PanelSurfaceDelta(
+            worktreeID: envelope.worktreeID,
+            tabs: [newState.surface],
+            removedTabIDs: [],
+            activeTabID: nil,
+            originOperationID: envelope.operationID)))
+
+        // 10. Return.
+        return result
+    }
+
+    /// §5.5: referenced notes and transcripts must belong to this worktree.
+    /// Only `open`/`navigate` carry a `PanelContent` destination that can
+    /// reference one; every other operation is a no-op here.
+    private func validateResourceExists(in operation: PanelOperation, worktreeID: UUID) async throws {
+        let content: PanelContent?
+        switch operation {
+        case .open(let destination, _): content = destination
+        case .navigate(_, let destination): content = destination
+        case .close, .move, .resize, .history, .selectTab: content = nil
+        }
+        guard let content else { return }
+        switch content {
+        case .transcript(let terminalID):
+            guard let terminal = try await db.terminals.get(id: terminalID),
+                  terminal.worktreeID == worktreeID else {
+                throw PanelCoordinatorError.invalidResource("terminal \(terminalID) not in worktree")
+            }
+        case .note(let noteID):
+            guard let note = try await db.notes.get(id: noteID),
+                  note.worktreeID == worktreeID else {
+                throw PanelCoordinatorError.invalidResource("note \(noteID) not in worktree")
+            }
+        case .file, .web:
+            break
+        }
+    }
+}

--- a/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
+++ b/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
@@ -104,8 +104,11 @@ public actor PanelCoordinator {
             throw PanelCoordinatorError.operation(.notTabScoped)
         }
 
-        // 4. Load current state.
-        guard let state = try await db.panelSurface.state(tabID: envelope.tabID) else {
+        // 4. Load current state. The tab must actually belong to the claimed
+        // worktree — otherwise a mismatched envelope would mutate one
+        // worktree's tab while broadcasting/receipting under another's id.
+        guard let state = try await db.panelSurface.state(tabID: envelope.tabID),
+              state.surface.worktreeID == envelope.worktreeID else {
             throw PanelCoordinatorError.tabNotFound(envelope.tabID)
         }
 

--- a/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
+++ b/Sources/TBDDaemon/PanelSurface/PanelCoordinator.swift
@@ -91,7 +91,11 @@ public actor PanelCoordinator {
     }
 
     /// Ungated read (§10.2: `panel.get` is ungated). `tabID` present narrows
-    /// to that one tab; absent returns every tab in the worktree.
+    /// to that one tab; absent returns every tab in the worktree plus the
+    /// worktree's active tab (the same `worktree.activeTabID` column that
+    /// `selectTab`/`importLegacy` write — no separate active-tab authority).
+    /// A tab-scoped get leaves `activeTabID` nil: it answers about one tab, and
+    /// active-tab is a worktree-level concept, not part of a single-tab query.
     public func get(worktreeID: UUID, tabID: UUID?) async throws -> PanelGetResult {
         if let tabID {
             guard let state = try await db.panelSurface.state(tabID: tabID),
@@ -101,7 +105,8 @@ public actor PanelCoordinator {
             return PanelGetResult(tabs: [state.surface], activeTabID: nil)
         }
         let surfaces = try await db.panelSurface.surfaces(worktreeID: worktreeID)
-        return PanelGetResult(tabs: surfaces, activeTabID: nil)
+        let activeTabID = try await db.worktrees.getActiveTabID(worktreeID: worktreeID)
+        return PanelGetResult(tabs: surfaces, activeTabID: activeTabID)
     }
 
     public func apply(_ envelope: PanelOperationEnvelope) async throws -> PanelApplyResult {

--- a/Sources/TBDDaemon/Server/RPCRouter+PanelHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+PanelHandlers.swift
@@ -1,0 +1,41 @@
+import Foundation
+import TBDShared
+
+/// RPC handlers for the daemon-owned panel surface (Task 10, spec C §10).
+/// `panel.get` is ungated (§10.2); `panel.apply` routes straight to
+/// `PanelCoordinator.apply`, which owns gating, idempotency, resource
+/// validation, and post-commit broadcast internally — these handlers only
+/// decode params and translate the coordinator's typed errors to RPC
+/// responses. Do NOT re-implement gating here.
+extension RPCRouter {
+    func handlePanelGet(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(PanelGetParams.self, from: paramsData)
+        let result = try await panelCoordinator.get(worktreeID: params.worktreeID, tabID: params.tabID)
+        return try RPCResponse(result: result)
+    }
+
+    func handlePanelApply(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(PanelApplyParams.self, from: paramsData)
+        do {
+            let result = try await panelCoordinator.apply(params.envelope)
+            return try RPCResponse(result: result)
+        } catch PanelCoordinatorError.surfaceDisabled {
+            // Stable string (spec §10.2) — names the flag so the app/CLI can
+            // surface an actionable message without matching this exactly.
+            return RPCResponse(error: "panel surface is disabled (daemon_panel_surface_enabled)")
+        } catch PanelCoordinatorError.agentControlDisabled {
+            return RPCResponse(error: "agent panel control is disabled (agent_panel_control_enabled)")
+        }
+        // Every other `PanelCoordinatorError` case (tabNotFound, staleTarget,
+        // invalidResource, operation) has no stable-string requirement — it
+        // propagates to `RPCRouter.handle`'s generic catch, which formats it
+        // via string interpolation.
+    }
+
+    /// Task 11 wires the real legacy-import migration. This route exists now
+    /// so dispatch is complete and testable ahead of that work.
+    func handlePanelImportLegacy(_ paramsData: Data) async throws -> RPCResponse {
+        _ = try decoder.decode(PanelImportParams.self, from: paramsData)
+        return RPCResponse(error: "panel.importLegacy is not implemented yet")
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+PanelHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+PanelHandlers.swift
@@ -1,12 +1,21 @@
 import Foundation
+import os
 import TBDShared
 
-/// RPC handlers for the daemon-owned panel surface (Task 10, spec C §10).
-/// `panel.get` is ungated (§10.2); `panel.apply` routes straight to
+private let panelHandlersLog = Logger(subsystem: "com.tbd.daemon", category: "panelHandlers")
+
+/// RPC handlers for the daemon-owned panel surface (Task 10/11, spec C §10,
+/// §11.2). `panel.get` is ungated (§10.2); `panel.apply` routes straight to
 /// `PanelCoordinator.apply`, which owns gating, idempotency, resource
 /// validation, and post-commit broadcast internally — these handlers only
 /// decode params and translate the coordinator's typed errors to RPC
-/// responses. Do NOT re-implement gating here.
+/// responses. Do NOT re-implement gating for `panel.apply` here.
+///
+/// `panel.importLegacy` (Task 11) is NOT routed through `PanelCoordinator` —
+/// it's a one-shot migration write (convert → commit → stamp), not a
+/// surface-mutation operation, so it drives `LegacySurfaceImporter` and
+/// `db.panelSurface.commitImport` directly and broadcasts through the same
+/// `subscriptions` channel the coordinator uses.
 extension RPCRouter {
     func handlePanelGet(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(PanelGetParams.self, from: paramsData)
@@ -32,10 +41,76 @@ extension RPCRouter {
         // via string interpolation.
     }
 
-    /// Task 11 wires the real legacy-import migration. This route exists now
-    /// so dispatch is complete and testable ahead of that work.
+    /// One-time §11.2 legacy-layout migration: gate → convert → commit →
+    /// stamp → (carry-forward) set active tab → broadcast. Create-if-absent
+    /// and idempotent: a worktree already imported (stamped OR holding any
+    /// surface row — `commitImport`'s guard) replays as a no-op result, not
+    /// an error, and does NOT broadcast again.
     func handlePanelImportLegacy(_ paramsData: Data) async throws -> RPCResponse {
-        _ = try decoder.decode(PanelImportParams.self, from: paramsData)
-        return RPCResponse(error: "panel.importLegacy is not implemented yet")
+        let params = try decoder.decode(PanelImportParams.self, from: paramsData)
+
+        let config = try await db.config.get()
+        guard config.panelSurfaceEnabled else {
+            // Stable string (mirrors `handlePanelApply`) — import is
+            // meaningless with the store off.
+            return RPCResponse(error: "panel surface is disabled (daemon_panel_surface_enabled)")
+        }
+
+        // Daemon-side hygiene defense: the app already filters, but never
+        // trust the wire — drop any paneHistories entry whose legacy pane ID
+        // appears in NO payload tab's tree before handing it to the importer.
+        var liveLegacyPaneIDs = Set<UUID>()
+        for tab in params.tabs {
+            let tree = tab.layout ?? .pane(tab.content)
+            liveLegacyPaneIDs.formUnion(tree.allPaneIDs())
+        }
+        let hygienicPaneHistories = params.paneHistories.filter { liveLegacyPaneIDs.contains($0.key) }
+
+        let conversion = LegacySurfaceImporter.convert(
+            worktreeID: params.worktreeID, tabs: params.tabs, tabOrder: params.tabOrder,
+            paneHistories: hygienicPaneHistories)
+
+        do {
+            try await db.panelSurface.commitImport(
+                worktreeID: params.worktreeID, conversion: conversion, now: Date())
+        } catch PanelSurfaceStoreError.alreadyImported {
+            return try RPCResponse(result: PanelImportResult(
+                imported: false, tabCount: 0, promotedTerminalTabs: 0, skipped: []))
+        }
+
+        // Carry-forward (spec §11.2.7): `LegacySurfaceImporter.convert` only
+        // preserves label/order, not the active tab — this import path owns
+        // setting it. Directly-converted tabs keep their legacy `tabID` as
+        // their new surface `id` (see `convertTab`), so the legacy
+        // `activeTabID` maps to "the same ID, if it survived conversion";
+        // when the active tab's own source was skipped (only its terminal(s)
+        // got promoted under fresh IDs), there's no surviving counterpart to
+        // point at, so the active tab is simply left unset.
+        let resolvedActiveTabID = params.activeTabID.flatMap { legacyActiveTabID in
+            conversion.surfaces.contains(where: { $0.id == legacyActiveTabID }) ? legacyActiveTabID : nil
+        }
+        if let resolvedActiveTabID {
+            try await db.worktrees.setActiveTabID(worktreeID: params.worktreeID, tabID: resolvedActiveTabID)
+        }
+
+        panelHandlersLog.info("""
+            panel.importLegacy worktree=\(params.worktreeID, privacy: .public) \
+            tabs=\(conversion.surfaces.count, privacy: .public) \
+            promoted=\(conversion.promotedTerminalTabs, privacy: .public) \
+            skipped=\(conversion.skipped.count, privacy: .public)
+            """)
+
+        // Broadcast AFTER commit, exactly once — never on the alreadyImported
+        // no-op path above (already returned).
+        subscriptions.broadcast(delta: .panelSurfaceChanged(PanelSurfaceDelta(
+            worktreeID: params.worktreeID,
+            tabs: conversion.surfaces,
+            removedTabIDs: [],
+            activeTabID: resolvedActiveTabID,
+            originOperationID: nil)))
+
+        return try RPCResponse(result: PanelImportResult(
+            imported: true, tabCount: conversion.surfaces.count,
+            promotedTerminalTabs: conversion.promotedTerminalTabs, skipped: conversion.skipped))
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -59,6 +59,11 @@ public final class RPCRouter: Sendable {
     /// Auto-`/login` typing + login-completion watching for profile login
     /// sessions. Injected so tests can zero out the trigger delays.
     public let loginSessions: LoginSessionCoordinator
+    /// Daemon-owned panel surface actor (spec C Phase 2). Gating lives inside
+    /// the coordinator (§7.2) — `panel.*` handlers route to it and must not
+    /// re-implement gating. Broadcasts through the same `subscriptions`
+    /// channel every other mutating handler uses.
+    public let panelCoordinator: PanelCoordinator
 
     /// Single-flights concurrent `pr.list` RPCs so a poll storm collapses into
     /// one git enumeration + gh fetch instead of N overlapping ones.
@@ -119,6 +124,8 @@ public final class RPCRouter: Sendable {
         self.controlMode = nil
         self.claudeCredentialsKeychain = claudeCredentialsKeychain
         self.loginSessions = loginSessions
+        self.panelCoordinator = PanelCoordinator(
+            db: db, broadcast: { [subscriptions] delta in subscriptions.broadcast(delta: delta) })
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.
@@ -381,6 +388,12 @@ public final class RPCRouter: Sendable {
                 return try await handleGCRestore(request.paramsData)
             case RPCMethod.gcSweepNow:
                 return try await handleGCSweepNow(request.paramsData)
+            case RPCMethod.panelGet:
+                return try await handlePanelGet(request.paramsData)
+            case RPCMethod.panelApply:
+                return try await handlePanelApply(request.paramsData)
+            case RPCMethod.panelImportLegacy:
+                return try await handlePanelImportLegacy(request.paramsData)
             default:
                 return RPCResponse(error: "Unknown method: \(request.method)")
             }
@@ -411,7 +424,8 @@ public final class RPCRouter: Sendable {
             tmuxVersion: version?.description,
             controlModeSupported: version.map { $0 >= TmuxVersion.controlModeMinimum } ?? false,
             hibernateInputVetoEnabled: config.hibernateInputVetoEnabled,
-            autoCloseSetupEnabled: config.autoCloseSetupEnabled))
+            autoCloseSetupEnabled: config.autoCloseSetupEnabled,
+            panelSurfaceEnabled: config.panelSurfaceEnabled))
     }
 
     // MARK: - PR Status

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -792,6 +792,15 @@ public struct Config: Codable, Sendable, Equatable {
     /// Days a reap snapshot (`refs/tbd/snapshots/...`) is retained before
     /// being pruned.
     public var gcSnapshotRetentionDays: Int
+    /// Master switch for the daemon-owned panel-surface store (spec C Phase
+    /// 2 §8). Default OFF: the store is inert (no reads/writes) until this
+    /// flips on. See `Database/CLAUDE.md` three-place migration rule for the
+    /// `v59_panel_surface` migration that backs this column.
+    public var panelSurfaceEnabled: Bool
+    /// Gate for agent-originated panel-surface mutations. Default OFF, and
+    /// independent of `panelSurfaceEnabled` — an agent may only mutate panel
+    /// layout once both flags are true.
+    public var agentPanelControlEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -819,7 +828,9 @@ public struct Config: Codable, Sendable, Equatable {
                 autoCloseSetupEnabled: Bool = false,
                 gcEnabled: Bool = true,
                 gcGraceSeconds: Int = Config.defaultGCGraceSeconds,
-                gcSnapshotRetentionDays: Int = Config.defaultGCSnapshotRetentionDays) {
+                gcSnapshotRetentionDays: Int = Config.defaultGCSnapshotRetentionDays,
+                panelSurfaceEnabled: Bool = false,
+                agentPanelControlEnabled: Bool = false) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -840,6 +851,8 @@ public struct Config: Codable, Sendable, Equatable {
         self.gcEnabled = gcEnabled
         self.gcGraceSeconds = gcGraceSeconds
         self.gcSnapshotRetentionDays = gcSnapshotRetentionDays
+        self.panelSurfaceEnabled = panelSurfaceEnabled
+        self.agentPanelControlEnabled = agentPanelControlEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -880,6 +893,9 @@ public struct Config: Codable, Sendable, Equatable {
             ?? Config.defaultGCGraceSeconds
         gcSnapshotRetentionDays = try c.decodeIfPresent(Int.self, forKey: .gcSnapshotRetentionDays)
             ?? Config.defaultGCSnapshotRetentionDays
+        panelSurfaceEnabled = try c.decodeIfPresent(Bool.self, forKey: .panelSurfaceEnabled) ?? false
+        agentPanelControlEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .agentPanelControlEnabled) ?? false
     }
 }
 

--- a/Sources/TBDShared/PanelSurface/LegacySurfaceImporter.swift
+++ b/Sources/TBDShared/PanelSurface/LegacySurfaceImporter.swift
@@ -1,11 +1,13 @@
 import Foundation
 import CoreGraphics
 
-/// Spec C §11.2 — pure, single-tab conversion from the legacy layout model
+/// Spec C §11.2 — pure conversion from the legacy layout model
 /// (`LayoutNode`/`PaneContent`/`Tab`) to the new panel-surface model
-/// (`WorkspaceTabSurface`/`PanelLayoutNode`). Multi-tab orchestration and
-/// terminal-leaf promotion to new tabs is Task 4; this only counts the
-/// terminals that need promoting.
+/// (`WorkspaceTabSurface`/`PanelLayoutNode`). Each legacy tab's primary
+/// content converts in place; every ADDITIONAL terminal leaf in its tree is
+/// promoted to its own new primary-terminal tab, spliced immediately after
+/// the source tab (spec §11.2 step 4 — a terminal is never dropped, even
+/// when the source tab itself fails validation and is skipped).
 public enum LegacySurfaceImporter {
     public struct Conversion: Sendable, Equatable {
         public var surfaces: [WorkspaceTabSurface]

--- a/Sources/TBDShared/PanelSurface/LegacySurfaceImporter.swift
+++ b/Sources/TBDShared/PanelSurface/LegacySurfaceImporter.swift
@@ -33,16 +33,45 @@ public enum LegacySurfaceImporter {
     ) -> Conversion {
         let byID = Dictionary(uniqueKeysWithValues: tabs.map { ($0.tabID, $0) })
         var result = Conversion()
-        for tabID in tabOrder {
+
+        // Final order (spec §11.2.7): tabOrder's sequence first (unknown IDs
+        // ignored), then any tabs missing from tabOrder appended in payload
+        // order — promoted tabs get spliced in below, after their source.
+        var orderedIDs: [UUID] = tabOrder.filter { byID[$0] != nil }
+        let known = Set(orderedIDs)
+        for tab in tabs where !known.contains(tab.tabID) {
+            orderedIDs.append(tab.tabID)
+        }
+
+        // Cross-tab dedup (corrupt-blob edge case): viewer-class leaves reuse
+        // their legacy pane ID as the new PanelID, but `result.histories` is
+        // keyed by PanelID across ALL tabs — a legacy pane ID reused across
+        // two different tabs would silently clobber the earlier tab's
+        // history entry. Track every PanelID handed out so a repeat mints a
+        // fresh one instead.
+        var usedPanelIDs = Set<PanelID>()
+
+        for tabID in orderedIDs {
             guard let payload = byID[tabID] else { continue }
-            switch convertTab(worktreeID: worktreeID, payload: payload,
-                               paneHistories: paneHistories, makeID: makeID) {
-            case .converted(let surface, let histories, let promoted):
+            let outcome = convertTab(
+                worktreeID: worktreeID, payload: payload, paneHistories: paneHistories,
+                makeID: makeID, usedPanelIDs: &usedPanelIDs)
+            switch outcome.result {
+            case .converted(let surface, let histories):
                 result.surfaces.append(surface)
                 for (id, history) in histories { result.histories[id] = history }
-                result.promotedTerminalTabs += promoted
             case .skipped(let reason):
                 result.skipped.append(reason)
+            }
+            // Terminal-leaf promotion (spec §11.2 step 4, "never kill or
+            // discard" a terminal): every additional terminal leaf becomes
+            // its own new primary-terminal tab, spliced immediately after
+            // its source in traversal order.
+            for terminalID in outcome.promotedTerminalIDs {
+                result.surfaces.append(WorkspaceTabSurface(
+                    id: makeID(), worktreeID: worktreeID, label: nil,
+                    primary: .terminal(terminalID: terminalID), layout: .primary, revision: 0))
+                result.promotedTerminalTabs += 1
             }
         }
         return result
@@ -109,8 +138,17 @@ public enum LegacySurfaceImporter {
     // MARK: - Per-tab conversion
 
     private enum TabOutcome {
-        case converted(WorkspaceTabSurface, [PanelID: PanelHistory], Int)
+        case converted(WorkspaceTabSurface, [PanelID: PanelHistory])
         case skipped(String)
+    }
+
+    /// `convertTab`'s full result: the single-tab outcome (converted or
+    /// skipped), plus every terminal ID from this tab that still needs its
+    /// own promoted tab. Populated in both branches — see the doc comment on
+    /// `convertTab` for why a skip must still promote.
+    private struct TabConversionOutcome {
+        var result: TabOutcome
+        var promotedTerminalIDs: [UUID]
     }
 
     /// A surviving panel slot, plus the legacy key under which its history
@@ -123,13 +161,24 @@ public enum LegacySurfaceImporter {
         var content: PanelContent
     }
 
+    /// Converts one legacy tab. Always reports every terminal ID that needs
+    /// promotion to its own new tab — not just when conversion succeeds.
+    /// Task 3 skipped a whole tab outright when its declared primary
+    /// (`payload.content.paneID`) matched no leaf in the tree (malformed
+    /// data): `primaryFound` never flips, the layout ends up with zero
+    /// `.primary` markers, and `PanelSurfaceValidator` rejects it. That skip
+    /// must not take the tab's terminals down with it (spec §11.2 step 4,
+    /// "never kill or discard" a terminal) — so on ANY validation failure we
+    /// fall back to promoting every terminal leaf found in the tree, plus the
+    /// declared primary itself if it's a terminal that was never matched.
     private static func convertTab(
         worktreeID: UUID, payload: LegacyTabPayload,
-        paneHistories: [UUID: MRUHistory<PaneContent>], makeID: () -> UUID
-    ) -> TabOutcome {
+        paneHistories: [UUID: MRUHistory<PaneContent>], makeID: () -> UUID,
+        usedPanelIDs: inout Set<PanelID>
+    ) -> TabConversionOutcome {
         let tree = payload.layout ?? .pane(payload.content)
         var primaryFound = false
-        var promotedCount = 0
+        var droppedTerminalIDs: [UUID] = []
         var panelSources: [PanelSource] = []
 
         func convertNode(_ node: LayoutNode) -> PanelLayoutNode? {
@@ -140,8 +189,8 @@ public enum LegacySurfaceImporter {
                     return .primary
                 }
                 switch leaf {
-                case .terminal:
-                    promotedCount += 1
+                case .terminal(let terminalID):
+                    droppedTerminalIDs.append(terminalID)
                     return nil
                 case .note(let noteID):
                     let newID = makeID()
@@ -150,8 +199,15 @@ public enum LegacySurfaceImporter {
                     return .panel(PanelSlot(id: newID, content: content))
                 case .webview, .codeViewer, .liveTranscript:
                     guard let content = panelContent(from: leaf) else { return nil }
-                    panelSources.append(PanelSource(newID: leaf.paneID, legacyHistoryKey: leaf.paneID, content: content))
-                    return .panel(PanelSlot(id: leaf.paneID, content: content))
+                    // Cross-tab dedup: a corrupt blob may reuse the same
+                    // legacy pane ID as a viewer leaf in two different tabs.
+                    // Reusing it here as the PanelID would collide in the
+                    // caller's global `histories` dict, clobbering whichever
+                    // tab converted first. Mint a fresh ID for any repeat.
+                    let panelID = usedPanelIDs.contains(leaf.paneID) ? makeID() : leaf.paneID
+                    usedPanelIDs.insert(panelID)
+                    panelSources.append(PanelSource(newID: panelID, legacyHistoryKey: leaf.paneID, content: content))
+                    return .panel(PanelSlot(id: panelID, content: content))
                 }
 
             case .split(let id, let direction, let children, let ratios):
@@ -190,9 +246,22 @@ public enum LegacySurfaceImporter {
         let state = PanelSurfaceState(surface: surface, histories: histories)
         let violations = PanelSurfaceValidator.violations(in: state)
         guard violations.isEmpty else {
-            return .skipped("tab \(payload.tabID): \(violations)")
+            // The tab's own surface never lands — but every terminal it
+            // references still must (spec §11.2 step 4). `droppedTerminalIDs`
+            // already holds every terminal leaf that wasn't the matched
+            // primary; if the declared primary itself is a terminal that was
+            // never found in the tree (why `primaryFound` is still false —
+            // the malformed case), it's not in that list yet, so add it.
+            var allTerminalIDs = droppedTerminalIDs
+            if case .terminal(let contentTerminalID) = payload.content,
+               !allTerminalIDs.contains(contentTerminalID) {
+                allTerminalIDs.insert(contentTerminalID, at: 0)
+            }
+            return TabConversionOutcome(
+                result: .skipped("tab \(payload.tabID): \(violations)"),
+                promotedTerminalIDs: allTerminalIDs)
         }
-        return .converted(surface, histories, promotedCount)
+        return TabConversionOutcome(result: .converted(surface, histories), promotedTerminalIDs: droppedTerminalIDs)
     }
 
     /// Re-keys a legacy `PaneContent` history onto the new `PanelContent`

--- a/Sources/TBDShared/PanelSurface/LegacySurfaceImporter.swift
+++ b/Sources/TBDShared/PanelSurface/LegacySurfaceImporter.swift
@@ -1,0 +1,228 @@
+import Foundation
+import CoreGraphics
+
+/// Spec C §11.2 — pure, single-tab conversion from the legacy layout model
+/// (`LayoutNode`/`PaneContent`/`Tab`) to the new panel-surface model
+/// (`WorkspaceTabSurface`/`PanelLayoutNode`). Multi-tab orchestration and
+/// terminal-leaf promotion to new tabs is Task 4; this only counts the
+/// terminals that need promoting.
+public enum LegacySurfaceImporter {
+    public struct Conversion: Sendable, Equatable {
+        public var surfaces: [WorkspaceTabSurface]
+        public var histories: [PanelID: PanelHistory]
+        public var promotedTerminalTabs: Int
+        public var skipped: [String]
+
+        public init(
+            surfaces: [WorkspaceTabSurface] = [], histories: [PanelID: PanelHistory] = [:],
+            promotedTerminalTabs: Int = 0, skipped: [String] = []
+        ) {
+            self.surfaces = surfaces
+            self.histories = histories
+            self.promotedTerminalTabs = promotedTerminalTabs
+            self.skipped = skipped
+        }
+    }
+
+    public static func convert(
+        worktreeID: UUID,
+        tabs: [LegacyTabPayload],
+        tabOrder: [UUID],
+        paneHistories: [UUID: MRUHistory<PaneContent>],
+        makeID: () -> UUID = { UUID() }
+    ) -> Conversion {
+        let byID = Dictionary(uniqueKeysWithValues: tabs.map { ($0.tabID, $0) })
+        var result = Conversion()
+        for tabID in tabOrder {
+            guard let payload = byID[tabID] else { continue }
+            switch convertTab(worktreeID: worktreeID, payload: payload,
+                               paneHistories: paneHistories, makeID: makeID) {
+            case .converted(let surface, let histories, let promoted):
+                result.surfaces.append(surface)
+                for (id, history) in histories { result.histories[id] = history }
+                result.promotedTerminalTabs += promoted
+            case .skipped(let reason):
+                result.skipped.append(reason)
+            }
+        }
+        return result
+    }
+
+    // MARK: - Content mapping
+
+    /// Maps a legacy viewer-class pane to its new-model `PanelContent`.
+    /// `.terminal` has no panel representation — terminals are promotion
+    /// candidates or the tab's primary, never a panel.
+    static func panelContent(from legacy: PaneContent) -> PanelContent? {
+        switch legacy {
+        case .terminal:
+            return nil
+        case .webview(_, let url):
+            return .web(url)
+        case .codeViewer(_, let path):
+            return .file(FileReference(path: path))
+        case .note(let noteID):
+            return .note(noteID: noteID)
+        case .liveTranscript(_, let terminalID):
+            return .transcript(terminalID: terminalID)
+        }
+    }
+
+    /// Maps a legacy pane (any variant, including `.terminal`) to the new
+    /// model's `PrimaryContent` — the superset `PanelContent` deliberately
+    /// excludes.
+    static func primaryContent(from legacy: PaneContent) -> PrimaryContent {
+        switch legacy {
+        case .terminal(let id):
+            return .terminal(terminalID: id)
+        case .webview(_, let url):
+            return .web(url)
+        case .codeViewer(_, let path):
+            return .file(FileReference(path: path))
+        case .note(let noteID):
+            return .note(noteID: noteID)
+        case .liveTranscript(_, let terminalID):
+            return .transcript(terminalID: terminalID)
+        }
+    }
+
+    /// Repairs malformed split ratios to equal shares. Falls back when the
+    /// count doesn't match, any value is non-finite or non-positive, or any
+    /// normalized share falls below `PanelSurfaceValidator.minShare`;
+    /// otherwise normalizes to sum 1.
+    static func normalizedRatios(_ ratios: [CGFloat], count: Int) -> [Double] {
+        guard count > 0 else { return [] }
+        let equalShare = Array(repeating: 1.0 / Double(count), count: count)
+        guard ratios.count == count else { return equalShare }
+
+        let values = ratios.map(Double.init)
+        guard values.allSatisfy({ $0.isFinite && $0 > 0 }) else { return equalShare }
+
+        let sum = values.reduce(0, +)
+        guard sum > 0 else { return equalShare }
+
+        let normalized = values.map { $0 / sum }
+        guard normalized.allSatisfy({ $0 >= PanelSurfaceValidator.minShare }) else { return equalShare }
+        return normalized
+    }
+
+    // MARK: - Per-tab conversion
+
+    private enum TabOutcome {
+        case converted(WorkspaceTabSurface, [PanelID: PanelHistory], Int)
+        case skipped(String)
+    }
+
+    /// A surviving panel slot, plus the legacy key under which its history
+    /// (if any) is stored: the reused pane ID for viewer-class leaves, or the
+    /// original (pre-mint) pane ID for note leaves — recorded so the note's
+    /// history can be re-keyed to the freshly minted `PanelID`.
+    private struct PanelSource {
+        var newID: PanelID
+        var legacyHistoryKey: UUID
+        var content: PanelContent
+    }
+
+    private static func convertTab(
+        worktreeID: UUID, payload: LegacyTabPayload,
+        paneHistories: [UUID: MRUHistory<PaneContent>], makeID: () -> UUID
+    ) -> TabOutcome {
+        let tree = payload.layout ?? .pane(payload.content)
+        var primaryFound = false
+        var promotedCount = 0
+        var panelSources: [PanelSource] = []
+
+        func convertNode(_ node: LayoutNode) -> PanelLayoutNode? {
+            switch node {
+            case .pane(let leaf):
+                if !primaryFound && leaf.paneID == payload.content.paneID {
+                    primaryFound = true
+                    return .primary
+                }
+                switch leaf {
+                case .terminal:
+                    promotedCount += 1
+                    return nil
+                case .note(let noteID):
+                    let newID = makeID()
+                    let content = PanelContent.note(noteID: noteID)
+                    panelSources.append(PanelSource(newID: newID, legacyHistoryKey: leaf.paneID, content: content))
+                    return .panel(PanelSlot(id: newID, content: content))
+                case .webview, .codeViewer, .liveTranscript:
+                    guard let content = panelContent(from: leaf) else { return nil }
+                    panelSources.append(PanelSource(newID: leaf.paneID, legacyHistoryKey: leaf.paneID, content: content))
+                    return .panel(PanelSlot(id: leaf.paneID, content: content))
+                }
+
+            case .split(let id, let direction, let children, let ratios):
+                var newChildren: [PanelLayoutNode] = []
+                var keptRatios: [CGFloat] = []
+                for (index, child) in children.enumerated() {
+                    guard let converted = convertNode(child) else { continue }
+                    newChildren.append(converted)
+                    if ratios.indices.contains(index) {
+                        keptRatios.append(ratios[index])
+                    }
+                }
+                if newChildren.isEmpty { return nil }
+                if newChildren.count == 1 { return newChildren[0] }
+                let normalized = normalizedRatios(keptRatios, count: newChildren.count)
+                return .split(SplitNode(id: id, direction: direction, children: newChildren, ratios: normalized))
+            }
+        }
+
+        // Nothing survived (no primary match, everything else a terminal) —
+        // deliberately invalid (0 primaries) so the validation gate below
+        // rejects it with a clear reason instead of us special-casing here.
+        let layout = convertNode(tree)
+            ?? .split(SplitNode(id: makeID(), direction: .horizontal, children: [], ratios: []))
+
+        let surface = WorkspaceTabSurface(
+            id: payload.tabID, worktreeID: worktreeID, label: payload.label,
+            primary: primaryContent(from: payload.content), layout: layout, revision: 0)
+
+        var histories: [PanelID: PanelHistory] = [:]
+        for source in panelSources {
+            histories[source.newID] = rekeyedHistory(
+                paneHistories[source.legacyHistoryKey], currentContent: source.content)
+        }
+
+        let state = PanelSurfaceState(surface: surface, histories: histories)
+        let violations = PanelSurfaceValidator.violations(in: state)
+        guard violations.isEmpty else {
+            return .skipped("tab \(payload.tabID): \(violations)")
+        }
+        return .converted(surface, histories, promotedCount)
+    }
+
+    /// Re-keys a legacy `PaneContent` history onto the new `PanelContent`
+    /// model: unmappable (`.terminal`) entries are dropped and the cursor is
+    /// clamped to the surviving index of the entry that was current. If the
+    /// current entry itself is unmappable, or the invariant
+    /// `entries[cursor] == currentContent` still doesn't hold afterward, the
+    /// whole history is replaced with a fresh seed of the panel's live
+    /// content — absent histories are seeded the same way.
+    private static func rekeyedHistory(
+        _ legacy: MRUHistory<PaneContent>?, currentContent: PanelContent
+    ) -> PanelHistory {
+        guard let legacy, legacy.entries.indices.contains(legacy.cursor),
+              panelContent(from: legacy.entries[legacy.cursor]) != nil else {
+            return .seeded(with: currentContent)
+        }
+
+        var newEntries: [PanelContent] = []
+        var newCursor = 0
+        for (index, entry) in legacy.entries.enumerated() {
+            guard let mapped = panelContent(from: entry) else { continue }
+            if index == legacy.cursor { newCursor = newEntries.count }
+            newEntries.append(mapped)
+        }
+
+        let rekeyed = PanelHistory(entries: newEntries, cursor: newCursor)
+        guard rekeyed.entries.indices.contains(rekeyed.cursor),
+              rekeyed.entries[rekeyed.cursor] == currentContent else {
+            return .seeded(with: currentContent)
+        }
+        return rekeyed
+    }
+}

--- a/Sources/TBDShared/PanelSurface/MRUHistory.swift
+++ b/Sources/TBDShared/PanelSurface/MRUHistory.swift
@@ -16,6 +16,15 @@ public struct MRUHistory<Element: Codable & Equatable & Sendable>: Codable, Equa
 
     public init() {}
 
+    /// Reconstructs a history from already-known entries/cursor — e.g.
+    /// re-keying a legacy history during import (`LegacySurfaceImporter`).
+    /// No validation performed; callers are responsible for consistency
+    /// (typically checked via `isWellFormed` / `PanelSurfaceValidator`).
+    public init(entries: [Element], cursor: Int) {
+        self.entries = entries
+        self.cursor = cursor
+    }
+
     /// A history whose single entry is the panel's initial content
     /// (`entries[cursor] == content` from birth — Spec C §6).
     public static func seeded(with element: Element) -> MRUHistory {

--- a/Sources/TBDShared/PanelSurface/MRUHistory.swift
+++ b/Sources/TBDShared/PanelSurface/MRUHistory.swift
@@ -16,11 +16,16 @@ public struct MRUHistory<Element: Codable & Equatable & Sendable>: Codable, Equa
 
     public init() {}
 
-    /// Reconstructs a history from already-known entries/cursor — e.g.
-    /// re-keying a legacy history during import (`LegacySurfaceImporter`).
-    /// No validation performed; callers are responsible for consistency
-    /// (typically checked via `isWellFormed` / `PanelSurfaceValidator`).
-    public init(entries: [Element], cursor: Int) {
+    /// Internal re-key seam for `LegacySurfaceImporter` (same module) and
+    /// `@testable` tests: rebuilds a history from already-known
+    /// entries/cursor to preserve order during import. Deliberately skips the
+    /// dedup/`maxEntries` cap and cursor-range guarantees that
+    /// `recordReplacement`/`seeded(with:)` enforce — callers own consistency
+    /// (checked via `isWellFormed` / `PanelSurfaceValidator`). `internal`, not
+    /// `public`, so this unvalidated constructor stays inside the module and
+    /// the `public private(set)` intent on `entries`/`cursor` holds for
+    /// external callers.
+    init(entries: [Element], cursor: Int) {
         self.entries = entries
         self.cursor = cursor
     }

--- a/Sources/TBDShared/PanelSurface/PanelSurfaceReducer.swift
+++ b/Sources/TBDShared/PanelSurface/PanelSurfaceReducer.swift
@@ -355,8 +355,8 @@ public enum PanelSurfaceReducer {
                         reason: "expected \(split.children.count) ratios, got \(ratios.count)")
                 }
                 let total = ratios.reduce(0, +)
-                guard total > 0 else {
-                    throw PanelOperationError.invalidRatios(reason: "ratios sum to zero")
+                guard total > 0, total.isFinite else {
+                    throw PanelOperationError.invalidRatios(reason: "ratios sum is non-positive or non-finite")
                 }
                 // Validate min-share on NORMALIZED ratios: raw values that pass
                 // the floor can still normalize below it (e.g. [0.1, 1.0]),

--- a/Sources/TBDShared/PanelSurface/PanelSurfaceValidator.swift
+++ b/Sources/TBDShared/PanelSurface/PanelSurfaceValidator.swift
@@ -64,11 +64,15 @@ public enum PanelSurfaceValidator {
         if split.ratios.count != split.children.count {
             found.append(.ratioCountMismatch(split.id))
         } else if split.children.count >= 2 {
-            if split.ratios.contains(where: { $0 < minShare - ratioSumTolerance }) {
-                found.append(.ratioBelowMinimum(split.id))
-            }
-            if abs(split.ratios.reduce(0, +) - 1.0) > ratioSumTolerance {
+            if split.ratios.contains(where: { !$0.isFinite }) {
                 found.append(.ratioSumInvalid(split.id))
+            } else {
+                if split.ratios.contains(where: { $0 < minShare - ratioSumTolerance }) {
+                    found.append(.ratioBelowMinimum(split.id))
+                }
+                if abs(split.ratios.reduce(0, +) - 1.0) > ratioSumTolerance {
+                    found.append(.ratioSumInvalid(split.id))
+                }
             }
         }
         for child in split.children {

--- a/Sources/TBDShared/PanelSurface/PanelSurfaceWire.swift
+++ b/Sources/TBDShared/PanelSurface/PanelSurfaceWire.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+// Spec C §10.1 wire surface. Full affected-tab snapshots, never structural
+// diffs — trees are small, IDs are stable, full payloads are self-healing.
+
+public struct PanelGetParams: Codable, Sendable, Equatable {
+    public let worktreeID: UUID
+    public let tabID: UUID?
+    public init(worktreeID: UUID, tabID: UUID? = nil) {
+        self.worktreeID = worktreeID
+        self.tabID = tabID
+    }
+}
+
+public struct PanelGetResult: Codable, Sendable, Equatable {
+    public let tabs: [WorkspaceTabSurface]
+    public let activeTabID: UUID?
+    public init(tabs: [WorkspaceTabSurface], activeTabID: UUID?) {
+        self.tabs = tabs
+        self.activeTabID = activeTabID
+    }
+}
+
+public struct PanelApplyParams: Codable, Sendable, Equatable {
+    public let envelope: PanelOperationEnvelope
+    public init(envelope: PanelOperationEnvelope) { self.envelope = envelope }
+}
+
+public struct PanelApplyResult: Codable, Sendable, Equatable {
+    public let tab: WorkspaceTabSurface
+    /// True when this operationID had already committed — the stored result
+    /// is being replayed (§7.4 idempotency), nothing was re-applied.
+    public let replayed: Bool
+    public init(tab: WorkspaceTabSurface, replayed: Bool) {
+        self.tab = tab
+        self.replayed = replayed
+    }
+}
+
+/// One legacy tab as the app knows it today: `Tab.content` (primary seed)
+/// plus the tab's `LayoutNode` tree when one exists in the layouts blob.
+public struct LegacyTabPayload: Codable, Sendable, Equatable {
+    public let tabID: UUID
+    public let label: String?
+    public let content: PaneContent
+    public let layout: LayoutNode?
+    public init(tabID: UUID, label: String?, content: PaneContent, layout: LayoutNode?) {
+        self.tabID = tabID
+        self.label = label
+        self.content = content
+        self.layout = layout
+    }
+}
+
+public struct PanelImportParams: Codable, Sendable, Equatable {
+    public let worktreeID: UUID
+    public let tabs: [LegacyTabPayload]
+    public let tabOrder: [UUID]
+    public let activeTabID: UUID?
+    /// PR #472's persisted per-slot histories (legacy `PaneContent` MRU),
+    /// keyed by legacy slot/pane ID.
+    public let paneHistories: [UUID: MRUHistory<PaneContent>]
+    public init(worktreeID: UUID, tabs: [LegacyTabPayload], tabOrder: [UUID],
+                activeTabID: UUID?, paneHistories: [UUID: MRUHistory<PaneContent>]) {
+        self.worktreeID = worktreeID
+        self.tabs = tabs
+        self.tabOrder = tabOrder
+        self.activeTabID = activeTabID
+        self.paneHistories = paneHistories
+    }
+}
+
+public struct PanelImportResult: Codable, Sendable, Equatable {
+    public let imported: Bool
+    public let tabCount: Int
+    public let promotedTerminalTabs: Int
+    public let skipped: [String]
+    public init(imported: Bool, tabCount: Int, promotedTerminalTabs: Int, skipped: [String]) {
+        self.imported = imported
+        self.tabCount = tabCount
+        self.promotedTerminalTabs = promotedTerminalTabs
+        self.skipped = skipped
+    }
+}
+
+public struct PanelSurfaceDelta: Codable, Sendable, Equatable {
+    public let worktreeID: UUID
+    public let tabs: [WorkspaceTabSurface]
+    public let removedTabIDs: [UUID]
+    public let activeTabID: UUID?
+    public let originOperationID: UUID?
+    public init(worktreeID: UUID, tabs: [WorkspaceTabSurface], removedTabIDs: [UUID],
+                activeTabID: UUID?, originOperationID: UUID?) {
+        self.worktreeID = worktreeID
+        self.tabs = tabs
+        self.removedTabIDs = removedTabIDs
+        self.activeTabID = activeTabID
+        self.originOperationID = originOperationID
+    }
+}

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1543,17 +1543,24 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// Whether the setup-hook tab auto-closes after a clean run (soak flag,
     /// default OFF). Re-evaluated by the daemon on every call.
     public let autoCloseSetupEnabled: Bool
+    /// Whether the daemon owns panel-surface state (`daemon_panel_surface_enabled`,
+    /// spec C Phase 2 §8/§10). Default OFF while the feature soaks — the app
+    /// uses this to decide whether `panel.get`/`panel.apply` are live or the
+    /// legacy client-owned layout path should still be used.
+    public let panelSurfaceEnabled: Bool
 
     public init(controlModeEnabled: Bool,
                 tmuxVersion: String? = nil,
                 controlModeSupported: Bool = false,
                 hibernateInputVetoEnabled: Bool = false,
-                autoCloseSetupEnabled: Bool = false) {
+                autoCloseSetupEnabled: Bool = false,
+                panelSurfaceEnabled: Bool = false) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
         self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
         self.autoCloseSetupEnabled = autoCloseSetupEnabled
+        self.panelSurfaceEnabled = panelSurfaceEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1567,6 +1574,8 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         hibernateInputVetoEnabled = try c.decodeIfPresent(Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
         // New field for setup-tab auto-close; absent from older daemons defaults to false (soaking).
         autoCloseSetupEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoCloseSetupEnabled) ?? false
+        // New field for the panel-surface flag; absent from older daemons defaults to false (soaking).
+        panelSurfaceEnabled = try c.decodeIfPresent(Bool.self, forKey: .panelSurfaceEnabled) ?? false
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -214,6 +214,9 @@ public enum RPCMethod {
     public static let gcRestore = "gc.restore"
     public static let gcSweepNow = "gc.sweepNow"
     public static let configSetGCEnabled = "config.setGCEnabled"
+    public static let panelGet = "panel.get"
+    public static let panelApply = "panel.apply"
+    public static let panelImportLegacy = "panel.importLegacy"
 }
 
 // MARK: - Branch Listing

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -31,6 +31,10 @@ public enum StateDelta: Codable, Sendable {
     /// payload (mirrors `.modelProfilesChanged`) — subscribers refetch via
     /// `gc.list`.
     case reapRecordsChanged
+    /// Committed panel-surface change for a worktree (Spec C §10.1). Carries
+    /// full affected-tab snapshots + the originating operation ID so the app
+    /// can dedupe its own RPC response against the subscription echo.
+    case panelSurfaceChanged(PanelSurfaceDelta)
 }
 
 /// Delta payload for a terminal's hibernation state change (hibernate / wake)

--- a/Tests/TBDAppTests/PaneHistoryAppStateTests.swift
+++ b/Tests/TBDAppTests/PaneHistoryAppStateTests.swift
@@ -145,6 +145,7 @@ struct PaneHistoryAppStateTests {
     @Test func prunePaneHistoriesDropsOrphansKeepsLiveSlots() {
         withIsolatedDefaults { defaults in
             let state = AppState(userDefaults: defaults)
+            let worktreeID = UUID()
             let tabID = UUID()
             let liveSlotID = UUID()
             let orphanID = UUID()
@@ -156,6 +157,9 @@ struct PaneHistoryAppStateTests {
                 ],
                 ratios: [0.5, 0.5]
             )
+            // #477 fix: retention is keyed off live TAB ids, so the layout
+            // above only counts as live because `tabID` is a real tab root.
+            state.tabs[worktreeID] = [TBDShared.Tab(id: tabID, content: .terminal(terminalID: tabID), label: nil)]
             var history = PaneHistory()
             history.recordReplacement(
                 outgoing: .codeViewer(id: liveSlotID, path: "/old"),
@@ -167,6 +171,52 @@ struct PaneHistoryAppStateTests {
 
             #expect(state.paneHistories[liveSlotID] == history)
             #expect(state.paneHistories[orphanID] == nil, "orphaned histories must not accumulate")
+        }
+    }
+
+    /// Grid-layout slots (worktree-keyed, presentation-only, never persisted)
+    /// are legitimately live even though they aren't tab-keyed — pruning must
+    /// consult `gridLayouts` alongside the tab-keyed scan.
+    @Test func prunePaneHistoriesKeepsGridLayoutSlotHistories() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            let worktreeID = UUID()
+            let gridSlotID = UUID()
+            state.gridLayouts[worktreeID] = .pane(.codeViewer(id: gridSlotID, path: "/grid"))
+            var history = PaneHistory()
+            history.recordReplacement(
+                outgoing: .codeViewer(id: gridSlotID, path: "/old"),
+                incoming: .codeViewer(id: gridSlotID, path: "/grid")
+            )
+            state.paneHistories = [gridSlotID: history]
+
+            state.prunePaneHistories()
+
+            #expect(state.paneHistories[gridSlotID] == history,
+                    "grid-layout slot histories must survive pruning")
+        }
+    }
+
+    /// #477 regression: a stale worktree-keyed entry left in the tab-keyed
+    /// `layouts` dict (pre-#478 pollution — not a real tab) must not keep its
+    /// history alive just because `layouts.values` used to include it.
+    @Test func prunePaneHistoriesDropsHistoryForStaleWorktreeKeyedLayoutsEntry() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+            let worktreeID = UUID()
+            let staleSlotID = UUID()
+            state.layouts[worktreeID] = .pane(.codeViewer(id: staleSlotID, path: "/stale"))
+            var history = PaneHistory()
+            history.recordReplacement(
+                outgoing: .codeViewer(id: staleSlotID, path: "/old"),
+                incoming: .codeViewer(id: staleSlotID, path: "/stale")
+            )
+            state.paneHistories = [staleSlotID: history]
+
+            state.prunePaneHistories()
+
+            #expect(state.paneHistories[staleSlotID] == nil,
+                    "a stale worktree-keyed layouts entry must not over-retain its history")
         }
     }
 }

--- a/Tests/TBDAppTests/PanelImportTriggerTests.swift
+++ b/Tests/TBDAppTests/PanelImportTriggerTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+// Spec C §11.2 — the app-side half of the gated legacy panel import.
+// DaemonClient is a concrete class (no protocol), so the trigger's RPC call
+// is exercised through the same injectable-closure seam other AppState tests
+// use (`daemonCapabilitiesFetcher`, `controlModeSetter`, ...): `panelImportTrigger`.
+
+@Suite("Panel import trigger")
+@MainActor
+struct PanelImportTriggerTests {
+
+    // MARK: - buildPanelImportParams (pure)
+
+    @Test func buildPanelImportParamsExcludesStaleWorktreeKeyedGridEntry() {
+        let suiteName = "PanelImportTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        let worktreeID = UUID()
+        let tabID = UUID()
+        let terminalID = UUID()
+        state.tabs[worktreeID] = [TBDShared.Tab(id: tabID, content: .terminal(terminalID: terminalID), label: "T1")]
+        state.layouts[tabID] = .pane(.terminal(terminalID: terminalID))
+        // Pollution: a stale worktree-keyed entry (pre-#478 grid state), not
+        // any real tab's ID — must never be sent as a tab payload.
+        state.layouts[worktreeID] = .pane(.codeViewer(id: UUID(), path: "/stale-grid"))
+
+        let params = state.buildPanelImportParams(worktreeID: worktreeID)
+
+        #expect(params.tabs.count == 1)
+        #expect(params.tabs.first?.tabID == tabID)
+        #expect(params.tabs.allSatisfy { $0.tabID != worktreeID },
+                "the stale worktree-keyed layouts entry must never surface as a tab payload")
+    }
+
+    @Test func buildPanelImportParamsFiltersOrphanedPaneHistories() {
+        let suiteName = "PanelImportTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        let worktreeID = UUID()
+        let tabID = UUID()
+        let liveSlotID = UUID()
+        let orphanSlotID = UUID()
+        state.tabs[worktreeID] = [TBDShared.Tab(id: tabID, content: .terminal(terminalID: tabID), label: nil)]
+        state.layouts[tabID] = .split(
+            id: UUID(), direction: .horizontal,
+            children: [.pane(.terminal(terminalID: tabID)), .pane(.codeViewer(id: liveSlotID, path: "/a"))],
+            ratios: [0.5, 0.5]
+        )
+        var history = PaneHistory()
+        history.recordReplacement(
+            outgoing: .codeViewer(id: liveSlotID, path: "/old"),
+            incoming: .codeViewer(id: liveSlotID, path: "/a")
+        )
+        state.paneHistories = [liveSlotID: history, orphanSlotID: history]
+
+        let params = state.buildPanelImportParams(worktreeID: worktreeID)
+
+        #expect(params.paneHistories[liveSlotID] != nil, "history for a slot in the included layout must flow through")
+        #expect(params.paneHistories[orphanSlotID] == nil, "orphaned histories must be dropped at the import boundary")
+    }
+
+    @Test func buildPanelImportParamsFlowsLabelOrderAndActiveTab() {
+        let suiteName = "PanelImportTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        let worktreeID = UUID()
+        let tabA = TBDShared.Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: "Alpha")
+        let tabB = TBDShared.Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: "Beta")
+        state.tabs[worktreeID] = [tabA, tabB]
+        state.worktreeTabOrders[worktreeID] = [tabB.id, tabA.id]
+        state.activeTabIndices[worktreeID] = 1
+
+        let params = state.buildPanelImportParams(worktreeID: worktreeID)
+
+        #expect(params.tabOrder == [tabB.id, tabA.id])
+        #expect(params.activeTabID == tabB.id)
+        #expect(params.tabs.first(where: { $0.tabID == tabA.id })?.label == "Alpha")
+        #expect(params.tabs.first(where: { $0.tabID == tabB.id })?.label == "Beta")
+    }
+
+    // MARK: - Trigger gating
+
+    @Test func flagOffFiresNoImportCall() async {
+        let suiteName = "PanelImportTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(controlModeEnabled: false, panelSurfaceEnabled: false)
+        var calls: [PanelImportParams] = []
+        state.panelImportTrigger = { params in
+            calls.append(params)
+            return PanelImportResult(imported: true, tabCount: 0, promotedTerminalTabs: 0, skipped: [])
+        }
+        state.tabs[UUID()] = [TBDShared.Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil)]
+
+        state.triggerPanelImportIfNeeded()
+        try? await Task.sleep(for: .milliseconds(200))
+
+        #expect(calls.isEmpty, "flag off must not call panel.importLegacy")
+    }
+
+    @Test func flagUnknownCapabilitiesFiresNoImportCall() async {
+        // Capabilities not yet fetched (nil) must behave like flag-off, not
+        // opt in by accident.
+        let suiteName = "PanelImportTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        #expect(state.daemonCapabilities == nil)
+        var calls: [PanelImportParams] = []
+        state.panelImportTrigger = { params in
+            calls.append(params)
+            return PanelImportResult(imported: true, tabCount: 0, promotedTerminalTabs: 0, skipped: [])
+        }
+        state.tabs[UUID()] = [TBDShared.Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil)]
+
+        state.triggerPanelImportIfNeeded()
+        try? await Task.sleep(for: .milliseconds(200))
+
+        #expect(calls.isEmpty, "nil capabilities must not call panel.importLegacy")
+    }
+
+    @Test func flagOnFiresImportOnceAcrossRepeatedCalls() async {
+        let suiteName = "PanelImportTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(controlModeEnabled: false, panelSurfaceEnabled: true)
+        var calls: [PanelImportParams] = []
+        state.panelImportTrigger = { params in
+            calls.append(params)
+            return PanelImportResult(imported: true, tabCount: params.tabs.count, promotedTerminalTabs: 0, skipped: [])
+        }
+        let worktreeID = UUID()
+        let tabID = UUID()
+        state.tabs[worktreeID] = [TBDShared.Tab(id: tabID, content: .terminal(terminalID: tabID), label: nil)]
+
+        state.triggerPanelImportIfNeeded()
+        state.triggerPanelImportIfNeeded() // must be a no-op — already attempted this launch
+
+        var recorded = false
+        for _ in 0..<200 {
+            if !calls.isEmpty { recorded = true; break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(recorded, "flag on must fire panel.importLegacy")
+        #expect(calls.count == 1, "import must fire at most once per launch")
+        #expect(calls.first?.worktreeID == worktreeID)
+    }
+
+    /// End-to-end wiring check: `loadTabStates` (the real call site) must
+    /// still reach the trigger at its tail even when the underlying
+    /// `listTabs` RPC fails (no daemon in the test environment) — the import
+    /// depends on AppState's already-loaded in-memory state, not on this
+    /// particular RPC's success.
+    @Test func loadTabStatesFiresImportOnceWhenFlagOn() async {
+        let suiteName = "PanelImportTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(controlModeEnabled: false, panelSurfaceEnabled: true)
+        var calls: [PanelImportParams] = []
+        state.panelImportTrigger = { params in
+            calls.append(params)
+            return PanelImportResult(imported: true, tabCount: params.tabs.count, promotedTerminalTabs: 0, skipped: [])
+        }
+        let worktreeID = UUID()
+        let tabID = UUID()
+        state.tabs[worktreeID] = [TBDShared.Tab(id: tabID, content: .terminal(terminalID: tabID), label: nil)]
+
+        await state.loadTabStates(worktreeID: worktreeID)
+        await state.loadTabStates(worktreeID: worktreeID) // second worktree-load must not re-fire
+
+        var recorded = false
+        for _ in 0..<200 {
+            if !calls.isEmpty { recorded = true; break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(recorded, "loadTabStates must reach the import trigger")
+        #expect(calls.count == 1, "import must fire at most once per launch")
+        #expect(calls.first?.worktreeID == worktreeID)
+    }
+}

--- a/Tests/TBDAppTests/ShadowCompareTests.swift
+++ b/Tests/TBDAppTests/ShadowCompareTests.swift
@@ -19,6 +19,28 @@ struct ShadowCompareTests {
         WorkspaceTabSurface(id: id, worktreeID: worktreeID, label: label, primary: primary, layout: layout, revision: revision)
     }
 
+    /// A tab exercising BOTH of `LegacySurfaceImporter`'s `makeID()` mint
+    /// sites at once: an extra terminal leaf (promotion mints a new surface
+    /// id) and a note leaf (mints a new panel slot id). Plus a codeViewer
+    /// leaf whose id is caller-supplied and stable — the one piece of real
+    /// content this helper can vary to prove genuine divergence still shows.
+    private func mixedPayload(
+        tabID: UUID, primaryTerminalID: UUID, extraTerminalID: UUID, noteID: UUID,
+        viewerLegacyID: UUID, viewerPath: String
+    ) -> LegacyTabPayload {
+        let layout = LayoutNode.split(
+            id: UUID(), direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: primaryTerminalID)),
+                .pane(.terminal(terminalID: extraTerminalID)),
+                .pane(.note(noteID: noteID)),
+                .pane(.codeViewer(id: viewerLegacyID, path: viewerPath)),
+            ],
+            ratios: [0.25, 0.25, 0.25, 0.25])
+        return LegacyTabPayload(
+            tabID: tabID, label: "Mixed", content: .terminal(terminalID: primaryTerminalID), layout: layout)
+    }
+
     @Test func identicalConversionAndGetProduceNoMismatches() {
         let tabID = UUID()
         let terminalID = UUID()
@@ -57,7 +79,9 @@ struct ShadowCompareTests {
         let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
 
         #expect(mismatches.count == 1)
-        #expect(mismatches.first?.contains(tabID.uuidString) == true)
+        // Matching key for a terminal-primary tab is the stable terminalID,
+        // not the (possibly minted) surface id.
+        #expect(mismatches.first?.contains(terminalID.uuidString) == true)
     }
 
     @Test func daemonExtraTabIsReported() {
@@ -65,70 +89,31 @@ struct ShadowCompareTests {
         // launch that the current live legacy state no longer has (e.g. the
         // app closed it locally since); create-if-absent import means the
         // daemon surface is never retroactively pruned.
-        let sharedTabID = UUID()
-        let terminalID = UUID()
-        let extraTabID = UUID()
-        let sharedTab = surface(id: sharedTabID, primary: .terminal(terminalID: terminalID))
-        let extraDaemonTab = surface(id: extraTabID, primary: .terminal(terminalID: UUID()))
+        let sharedTerminalID = UUID()
+        let extraTerminalID = UUID()
+        let sharedTab = surface(id: UUID(), primary: .terminal(terminalID: sharedTerminalID))
+        let extraDaemonTab = surface(id: UUID(), primary: .terminal(terminalID: extraTerminalID))
         let local = LegacySurfaceImporter.Conversion(surfaces: [sharedTab])
         let daemon = PanelGetResult(tabs: [sharedTab, extraDaemonTab], activeTabID: nil)
 
         let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
 
         #expect(mismatches.count == 1)
-        #expect(mismatches.first?.contains(extraTabID.uuidString) == true)
+        #expect(mismatches.first?.contains(extraTerminalID.uuidString) == true)
     }
 
     @Test func localExtraTabIsReported() {
-        let sharedTabID = UUID()
-        let terminalID = UUID()
-        let extraLocalTabID = UUID()
-        let sharedTab = surface(id: sharedTabID, primary: .terminal(terminalID: terminalID))
-        let extraLocalTab = surface(id: extraLocalTabID, primary: .terminal(terminalID: UUID()))
+        let sharedTerminalID = UUID()
+        let extraTerminalID = UUID()
+        let sharedTab = surface(id: UUID(), primary: .terminal(terminalID: sharedTerminalID))
+        let extraLocalTab = surface(id: UUID(), primary: .terminal(terminalID: extraTerminalID))
         let local = LegacySurfaceImporter.Conversion(surfaces: [sharedTab, extraLocalTab])
         let daemon = PanelGetResult(tabs: [sharedTab], activeTabID: nil)
 
         let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
 
         #expect(mismatches.count == 1)
-        #expect(mismatches.first?.contains(extraLocalTabID.uuidString) == true)
-    }
-
-    @Test func importerTransformsAreNotFlagged_terminalPromotionRatioRepairViewerToPanel() {
-        // The trigger builds `local` by running the SAME `LegacySurfaceImporter.convert`
-        // the daemon's import used — so terminal-leaf promotion, ratio repair, and
-        // viewer-leaf-to-panel conversion are already baked into `local`, not raw legacy
-        // state. Simulate the daemon side as exactly what that conversion produced
-        // (what a correct import would return) and confirm none of those legitimate
-        // transforms register as a mismatch.
-        let tabID = UUID()
-        let primaryTerminalID = UUID()
-        let extraTerminalID = UUID()
-        let viewerID = UUID()
-        let malformedRatioLayout = LayoutNode.split(
-            id: UUID(), direction: .horizontal,
-            children: [
-                .pane(.terminal(terminalID: primaryTerminalID)),
-                .pane(.terminal(terminalID: extraTerminalID)),
-                .pane(.codeViewer(id: viewerID, path: "/a")),
-            ],
-            ratios: [-1, 0, 999] // deliberately malformed — importer repairs to equal shares
-        )
-        let payload = LegacyTabPayload(
-            tabID: tabID, label: "Mixed", content: .terminal(terminalID: primaryTerminalID),
-            layout: malformedRatioLayout)
-
-        let conversion = LegacySurfaceImporter.convert(
-            worktreeID: worktreeID, tabs: [payload], tabOrder: [tabID], paneHistories: [:])
-
-        // Sanity: the importer really did promote the extra terminal and repair ratios.
-        #expect(conversion.promotedTerminalTabs == 1)
-        #expect(conversion.surfaces.count == 2)
-
-        let daemon = PanelGetResult(tabs: conversion.surfaces, activeTabID: nil)
-
-        #expect(PanelShadowCompare.mismatches(local: conversion, daemon: daemon).isEmpty,
-                "importer's own transforms (promotion, ratio repair, viewer→panel) must never be flagged")
+        #expect(mismatches.first?.contains(extraTerminalID.uuidString) == true)
     }
 
     @Test func labelMismatchIsReported() {
@@ -142,7 +127,76 @@ struct ShadowCompareTests {
         let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
 
         #expect(mismatches.count == 1)
-        #expect(mismatches.first?.contains(tabID.uuidString) == true)
+        #expect(mismatches.first?.contains(terminalID.uuidString) == true)
+    }
+
+    // MARK: - Independent-conversion mutation killers (the real trigger shape)
+
+    /// THE core regression test: `local` and `daemon` here are NOT the same
+    /// value reused twice — they come from two SEPARATE, independent
+    /// `LegacySurfaceImporter.convert` calls on identical legacy input,
+    /// exactly like production (the daemon converted once at import; this
+    /// diagnostic converts again later). Each call mints its OWN random IDs
+    /// at both `makeID()` sites (promoted-tab surface id, note panel slot
+    /// id) — a comparator that matches/compares by minted id instead of
+    /// stable content would report spurious mismatches here on virtually
+    /// every real launch that has a note panel or a multi-terminal tab.
+    @Test func independentConvertsOfIdenticalLegacyState_noSpuriousMismatches() {
+        let tabID = UUID()
+        let primaryTerminalID = UUID()
+        let extraTerminalID = UUID()
+        let noteID = UUID()
+        let viewerLegacyID = UUID()
+        let payload = mixedPayload(
+            tabID: tabID, primaryTerminalID: primaryTerminalID, extraTerminalID: extraTerminalID,
+            noteID: noteID, viewerLegacyID: viewerLegacyID, viewerPath: "/a")
+
+        let local = LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: [payload], tabOrder: [tabID], paneHistories: [:])
+        let daemonConversion = LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: [payload], tabOrder: [tabID], paneHistories: [:])
+
+        // Sanity: this really does exercise two independent random draws —
+        // otherwise the test proves nothing.
+        #expect(local.promotedTerminalTabs == 1)
+        #expect(daemonConversion.promotedTerminalTabs == 1)
+        #expect(local.surfaces[1].id != daemonConversion.surfaces[1].id,
+                "test setup must produce two genuinely independent minted promoted-tab ids")
+
+        let daemon = PanelGetResult(tabs: daemonConversion.surfaces, activeTabID: nil)
+        let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
+
+        #expect(mismatches.isEmpty,
+                "two independent conversions of identical legacy state must never diverge on minted ids alone")
+    }
+
+    /// Companion to the above: ID-normalization must not swallow REAL
+    /// divergence. Two independent conversions of legacy input that differs
+    /// in one meaningful way (a codeViewer's path) must still be reported.
+    @Test func independentConvertsWithRealContentDivergence_stillFlagged() {
+        let tabID = UUID()
+        let primaryTerminalID = UUID()
+        let extraTerminalID = UUID()
+        let noteID = UUID()
+        let viewerLegacyID = UUID()
+        let localPayload = mixedPayload(
+            tabID: tabID, primaryTerminalID: primaryTerminalID, extraTerminalID: extraTerminalID,
+            noteID: noteID, viewerLegacyID: viewerLegacyID, viewerPath: "/a")
+        let daemonPayload = mixedPayload(
+            tabID: tabID, primaryTerminalID: primaryTerminalID, extraTerminalID: extraTerminalID,
+            noteID: noteID, viewerLegacyID: viewerLegacyID, viewerPath: "/b")
+
+        let local = LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: [localPayload], tabOrder: [tabID], paneHistories: [:])
+        let daemonConversion = LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: [daemonPayload], tabOrder: [tabID], paneHistories: [:])
+        let daemon = PanelGetResult(tabs: daemonConversion.surfaces, activeTabID: nil)
+
+        let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
+
+        #expect(mismatches.count == 1)
+        #expect(mismatches.first?.contains(primaryTerminalID.uuidString) == true,
+                "the tab is keyed by its stable terminalID, not a minted id")
     }
 }
 

--- a/Tests/TBDAppTests/ShadowCompareTests.swift
+++ b/Tests/TBDAppTests/ShadowCompareTests.swift
@@ -1,0 +1,299 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+// Spec C §11.3 — the pure shadow-compare comparator. Migration-validation
+// diagnostic only: exercises `PanelShadowCompare.mismatches` directly, no
+// AppState/daemon involved (the impure trigger wiring lives in AppState and
+// is covered by PanelImportTriggerTests-style injection, not here).
+
+@Suite("PanelShadowCompare")
+struct ShadowCompareTests {
+    private let worktreeID = UUID()
+
+    private func surface(
+        id: UUID, primary: PrimaryContent, label: String? = nil,
+        layout: PanelLayoutNode = .primary, revision: UInt64 = 0
+    ) -> WorkspaceTabSurface {
+        WorkspaceTabSurface(id: id, worktreeID: worktreeID, label: label, primary: primary, layout: layout, revision: revision)
+    }
+
+    @Test func identicalConversionAndGetProduceNoMismatches() {
+        let tabID = UUID()
+        let terminalID = UUID()
+        let tab = surface(id: tabID, primary: .terminal(terminalID: terminalID), label: "Alpha")
+        let local = LegacySurfaceImporter.Conversion(surfaces: [tab])
+        let daemon = PanelGetResult(tabs: [tab], activeTabID: nil)
+
+        #expect(PanelShadowCompare.mismatches(local: local, daemon: daemon).isEmpty)
+    }
+
+    @Test func revisionDifferenceAloneIsNotReported() {
+        let tabID = UUID()
+        let terminalID = UUID()
+        let localTab = surface(id: tabID, primary: .terminal(terminalID: terminalID), label: "Alpha", revision: 0)
+        let daemonTab = surface(id: tabID, primary: .terminal(terminalID: terminalID), label: "Alpha", revision: 7)
+        let local = LegacySurfaceImporter.Conversion(surfaces: [localTab])
+        let daemon = PanelGetResult(tabs: [daemonTab], activeTabID: nil)
+
+        #expect(PanelShadowCompare.mismatches(local: local, daemon: daemon).isEmpty,
+                "daemon may have advanced the revision — that alone is not a divergence")
+    }
+
+    @Test func differingLayoutReportsOneMismatchNamingTheTab() {
+        let tabID = UUID()
+        let terminalID = UUID()
+        let viewerID = UUID()
+        let localTab = surface(id: tabID, primary: .terminal(terminalID: terminalID), layout: .primary)
+        let daemonLayout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: viewerID, content: .file(FileReference(path: "/a"))))],
+            ratios: [0.5, 0.5]))
+        let daemonTab = surface(id: tabID, primary: .terminal(terminalID: terminalID), layout: daemonLayout)
+        let local = LegacySurfaceImporter.Conversion(surfaces: [localTab])
+        let daemon = PanelGetResult(tabs: [daemonTab], activeTabID: nil)
+
+        let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
+
+        #expect(mismatches.count == 1)
+        #expect(mismatches.first?.contains(tabID.uuidString) == true)
+    }
+
+    @Test func daemonExtraTabIsReported() {
+        // Import-order drift: the daemon already imported a tab on a prior
+        // launch that the current live legacy state no longer has (e.g. the
+        // app closed it locally since); create-if-absent import means the
+        // daemon surface is never retroactively pruned.
+        let sharedTabID = UUID()
+        let terminalID = UUID()
+        let extraTabID = UUID()
+        let sharedTab = surface(id: sharedTabID, primary: .terminal(terminalID: terminalID))
+        let extraDaemonTab = surface(id: extraTabID, primary: .terminal(terminalID: UUID()))
+        let local = LegacySurfaceImporter.Conversion(surfaces: [sharedTab])
+        let daemon = PanelGetResult(tabs: [sharedTab, extraDaemonTab], activeTabID: nil)
+
+        let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
+
+        #expect(mismatches.count == 1)
+        #expect(mismatches.first?.contains(extraTabID.uuidString) == true)
+    }
+
+    @Test func localExtraTabIsReported() {
+        let sharedTabID = UUID()
+        let terminalID = UUID()
+        let extraLocalTabID = UUID()
+        let sharedTab = surface(id: sharedTabID, primary: .terminal(terminalID: terminalID))
+        let extraLocalTab = surface(id: extraLocalTabID, primary: .terminal(terminalID: UUID()))
+        let local = LegacySurfaceImporter.Conversion(surfaces: [sharedTab, extraLocalTab])
+        let daemon = PanelGetResult(tabs: [sharedTab], activeTabID: nil)
+
+        let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
+
+        #expect(mismatches.count == 1)
+        #expect(mismatches.first?.contains(extraLocalTabID.uuidString) == true)
+    }
+
+    @Test func importerTransformsAreNotFlagged_terminalPromotionRatioRepairViewerToPanel() {
+        // The trigger builds `local` by running the SAME `LegacySurfaceImporter.convert`
+        // the daemon's import used — so terminal-leaf promotion, ratio repair, and
+        // viewer-leaf-to-panel conversion are already baked into `local`, not raw legacy
+        // state. Simulate the daemon side as exactly what that conversion produced
+        // (what a correct import would return) and confirm none of those legitimate
+        // transforms register as a mismatch.
+        let tabID = UUID()
+        let primaryTerminalID = UUID()
+        let extraTerminalID = UUID()
+        let viewerID = UUID()
+        let malformedRatioLayout = LayoutNode.split(
+            id: UUID(), direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: primaryTerminalID)),
+                .pane(.terminal(terminalID: extraTerminalID)),
+                .pane(.codeViewer(id: viewerID, path: "/a")),
+            ],
+            ratios: [-1, 0, 999] // deliberately malformed — importer repairs to equal shares
+        )
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: "Mixed", content: .terminal(terminalID: primaryTerminalID),
+            layout: malformedRatioLayout)
+
+        let conversion = LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: [payload], tabOrder: [tabID], paneHistories: [:])
+
+        // Sanity: the importer really did promote the extra terminal and repair ratios.
+        #expect(conversion.promotedTerminalTabs == 1)
+        #expect(conversion.surfaces.count == 2)
+
+        let daemon = PanelGetResult(tabs: conversion.surfaces, activeTabID: nil)
+
+        #expect(PanelShadowCompare.mismatches(local: conversion, daemon: daemon).isEmpty,
+                "importer's own transforms (promotion, ratio repair, viewer→panel) must never be flagged")
+    }
+
+    @Test func labelMismatchIsReported() {
+        let tabID = UUID()
+        let terminalID = UUID()
+        let localTab = surface(id: tabID, primary: .terminal(terminalID: terminalID), label: "Old")
+        let daemonTab = surface(id: tabID, primary: .terminal(terminalID: terminalID), label: "New")
+        let local = LegacySurfaceImporter.Conversion(surfaces: [localTab])
+        let daemon = PanelGetResult(tabs: [daemonTab], activeTabID: nil)
+
+        let mismatches = PanelShadowCompare.mismatches(local: local, daemon: daemon)
+
+        #expect(mismatches.count == 1)
+        #expect(mismatches.first?.contains(tabID.uuidString) == true)
+    }
+}
+
+// MARK: - AppState wiring (spec C §11.3's "runs once after import" half)
+
+/// Exercises `AppState.triggerPanelImportIfNeeded`'s shadow-compare hook via
+/// the same injectable-closure seam `PanelImportTriggerTests` uses for the
+/// import RPC itself (`panelImportTrigger`) — `panelGetFetcher` here.
+@Suite("PanelShadowCompare AppState wiring")
+@MainActor
+struct ShadowCompareTriggerTests {
+
+    @Test func flagOnCallsPanelGetAfterSuccessfulImport() async {
+        let suiteName = "ShadowCompareTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(controlModeEnabled: false, panelSurfaceEnabled: true)
+        state.panelImportTrigger = { params in
+            PanelImportResult(imported: true, tabCount: params.tabs.count, promotedTerminalTabs: 0, skipped: [])
+        }
+        var getCalls: [UUID] = []
+        state.panelGetFetcher = { worktreeID in
+            getCalls.append(worktreeID)
+            return PanelGetResult(tabs: [], activeTabID: nil)
+        }
+        let worktreeID = UUID()
+        let tabID = UUID()
+        state.tabs[worktreeID] = [TBDShared.Tab(id: tabID, content: .terminal(terminalID: tabID), label: nil)]
+
+        state.triggerPanelImportIfNeeded()
+
+        var recorded = false
+        for _ in 0..<200 {
+            if !getCalls.isEmpty { recorded = true; break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(recorded, "shadow compare must fetch panel.get after a successful import")
+        #expect(getCalls == [worktreeID])
+    }
+
+    @Test func importedFalseStillRunsShadowCompare() async {
+        // "after a successful import (or imported == false)" — the daemon
+        // already having a surface (create-if-absent no-op) must still run
+        // the comparison, not just a fresh import.
+        let suiteName = "ShadowCompareTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(controlModeEnabled: false, panelSurfaceEnabled: true)
+        state.panelImportTrigger = { params in
+            PanelImportResult(imported: false, tabCount: params.tabs.count, promotedTerminalTabs: 0, skipped: [])
+        }
+        var getCalls: [UUID] = []
+        state.panelGetFetcher = { worktreeID in
+            getCalls.append(worktreeID)
+            return PanelGetResult(tabs: [], activeTabID: nil)
+        }
+        let worktreeID = UUID()
+        state.tabs[worktreeID] = [TBDShared.Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil)]
+
+        state.triggerPanelImportIfNeeded()
+
+        var recorded = false
+        for _ in 0..<200 {
+            if !getCalls.isEmpty { recorded = true; break }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(recorded, "imported == false must still run the shadow compare")
+    }
+
+    @Test func importFailureSkipsShadowCompare() async {
+        let suiteName = "ShadowCompareTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(controlModeEnabled: false, panelSurfaceEnabled: true)
+        struct Boom: Error {}
+        state.panelImportTrigger = { _ in throw Boom() }
+        var getCalls: [UUID] = []
+        state.panelGetFetcher = { worktreeID in
+            getCalls.append(worktreeID)
+            return PanelGetResult(tabs: [], activeTabID: nil)
+        }
+        let worktreeID = UUID()
+        state.tabs[worktreeID] = [TBDShared.Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil)]
+
+        state.triggerPanelImportIfNeeded()
+        try? await Task.sleep(for: .milliseconds(200))
+
+        #expect(getCalls.isEmpty, "a failed import must not run the shadow compare")
+    }
+
+    @Test func flagOffNeverCallsPanelGet() async {
+        let suiteName = "ShadowCompareTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(controlModeEnabled: false, panelSurfaceEnabled: false)
+        state.panelImportTrigger = { params in
+            PanelImportResult(imported: true, tabCount: params.tabs.count, promotedTerminalTabs: 0, skipped: [])
+        }
+        var getCalls: [UUID] = []
+        state.panelGetFetcher = { worktreeID in
+            getCalls.append(worktreeID)
+            return PanelGetResult(tabs: [], activeTabID: nil)
+        }
+        state.tabs[UUID()] = [TBDShared.Tab(id: UUID(), content: .terminal(terminalID: UUID()), label: nil)]
+
+        state.triggerPanelImportIfNeeded()
+        try? await Task.sleep(for: .milliseconds(200))
+
+        #expect(getCalls.isEmpty, "flag off must not run the shadow compare either")
+    }
+
+    @Test func shadowCompareNeverMutatesAppState() async {
+        // Log-only: even when the comparator finds real mismatches, AppState's
+        // own tab/layout/history state must be untouched.
+        let suiteName = "ShadowCompareTriggerTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let state = AppState(userDefaults: defaults)
+        state.daemonCapabilities = DaemonCapabilitiesResult(controlModeEnabled: false, panelSurfaceEnabled: true)
+        state.panelImportTrigger = { params in
+            PanelImportResult(imported: true, tabCount: params.tabs.count, promotedTerminalTabs: 0, skipped: [])
+        }
+        state.panelGetFetcher = { _ in
+            // Deliberately divergent from local state — forces mismatches.
+            PanelGetResult(
+                tabs: [WorkspaceTabSurface(
+                    id: UUID(), worktreeID: UUID(), label: "unexpected",
+                    primary: .terminal(terminalID: UUID()), layout: .primary, revision: 0)],
+                activeTabID: nil)
+        }
+        let worktreeID = UUID()
+        let tabID = UUID()
+        state.tabs[worktreeID] = [TBDShared.Tab(id: tabID, content: .terminal(terminalID: tabID), label: "T1")]
+        let tabsBefore = state.tabs
+        let layoutsBefore = state.layouts
+        let paneHistoriesBefore = state.paneHistories
+
+        state.triggerPanelImportIfNeeded()
+        try? await Task.sleep(for: .milliseconds(300))
+
+        #expect(state.tabs == tabsBefore)
+        #expect(state.layouts == layoutsBefore)
+        #expect(state.paneHistories == paneHistoriesBefore)
+    }
+}

--- a/Tests/TBDDaemonTests/PanelCoordinatorPlacementTests.swift
+++ b/Tests/TBDDaemonTests/PanelCoordinatorPlacementTests.swift
@@ -175,7 +175,8 @@ struct PanelCoordinatorPlacementTests {
         }
         #expect(split.children.count == 2)
         #expect(split.children.first == .primary)
-        #expect(split.ratios == [1 - PanelSurfaceReducer.defaultSideShare, PanelSurfaceReducer.defaultSideShare])
+        let side: Double = PanelSurfaceReducer.defaultSideShare
+        #expect(split.ratios == [1 - side, side])
         #expect(result.tab.layout.allPanelIDs.count == 1)
         #expect(result.tab.layout.panelSlot(id: result.tab.layout.allPanelIDs[0])?.content == newContent)
     }

--- a/Tests/TBDDaemonTests/PanelCoordinatorPlacementTests.swift
+++ b/Tests/TBDDaemonTests/PanelCoordinatorPlacementTests.swift
@@ -1,0 +1,274 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Task 9: the coordinator's `.automatic` recency rewrite (spec C §6.1 rule
+/// 1 / Phase 1 decision record #3) and `selectTab` handling. Both behaviors
+/// the reducer deliberately does NOT own — see `PanelCoordinator.swift`.
+@Suite("PanelCoordinatorPlacementTests")
+struct PanelCoordinatorPlacementTests {
+
+    private func makeWorktree(_ db: TBDDatabase, name: String = "w") async throws -> UUID {
+        let repo = try await db.repos.create(
+            path: "/tmp/pcp-\(UUID())", displayName: name, defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: "b",
+            path: "/tmp/pcp-wt-\(UUID())", tmuxServer: "srv")
+        return wt.id
+    }
+
+    private func makeCoordinator(
+        _ db: TBDDatabase, recorder: BroadcastRecorder,
+        now: @escaping @Sendable () -> Date = Date.init,
+        makeID: @escaping @Sendable () -> UUID = UUID.init
+    ) -> PanelCoordinator {
+        PanelCoordinator(db: db, broadcast: { recorder.record($0) }, now: now, makeID: makeID)
+    }
+
+    /// A tab with a primary-only layout (zero viewer panels).
+    private func seedZeroPanelTab(_ db: TBDDatabase, worktreeID: UUID, tabID: UUID = UUID()) async throws -> WorkspaceTabSurface {
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: worktreeID, label: "tab",
+            primary: .terminal(terminalID: UUID()), layout: .primary, revision: 0)
+        try await db.panelSurface.commit(
+            state: PanelSurfaceState(surface: surface, histories: [:]),
+            position: 0, receipt: nil, now: Date())
+        return surface
+    }
+
+    /// A tab whose layout has TWO viewer panels (pre-order: panelA, panelB)
+    /// beside the primary. Both histories are seeded in the SAME commit —
+    /// with no other write, both `panel_history` rows get an identical
+    /// `updatedAt`, i.e. a genuine tie.
+    private func seedTwoPanelTab(
+        _ db: TBDDatabase, worktreeID: UUID, tabID: UUID = UUID(),
+        panelA: PanelID, panelB: PanelID, now: Date
+    ) async throws -> WorkspaceTabSurface {
+        let contentA = PanelContent.file(FileReference(path: "/a.txt"))
+        let contentB = PanelContent.file(FileReference(path: "/b.txt"))
+        let layout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: panelA, content: contentA)),
+                       .panel(PanelSlot(id: panelB, content: contentB))],
+            ratios: [0.34, 0.33, 0.33]))
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: worktreeID, label: "tab",
+            primary: .terminal(terminalID: UUID()), layout: layout, revision: 0)
+        let state = PanelSurfaceState(surface: surface, histories: [
+            panelA: .seeded(with: contentA),
+            panelB: .seeded(with: contentB),
+        ])
+        try await db.panelSurface.commit(state: state, position: 0, receipt: nil, now: now)
+        return surface
+    }
+
+    /// Touches panel B's history with a NEW piece of content at `now`, so its
+    /// `panel_history.updatedAt` advances past panel A's (which is untouched
+    /// by this call — `writeSurfaceAndHistory` only bumps `updatedAt` for
+    /// rows whose decoded content actually changed).
+    private func bumpPanelBRecency(
+        _ db: TBDDatabase, surface: WorkspaceTabSurface, panelA: PanelID, panelB: PanelID, now: Date
+    ) async throws {
+        var historyB = MRUHistory<PanelContent>.seeded(with: .file(FileReference(path: "/b.txt")))
+        historyB.recordReplacement(
+            outgoing: .file(FileReference(path: "/b.txt")),
+            incoming: .file(FileReference(path: "/b2.txt")))
+        let state = PanelSurfaceState(surface: surface, histories: [
+            panelA: .seeded(with: .file(FileReference(path: "/a.txt"))),
+            panelB: historyB,
+        ])
+        try await db.panelSurface.commit(state: state, position: 0, receipt: nil, now: now)
+    }
+
+    // MARK: - §6.1 recency rewrite: recency winner beats pre-order-first
+
+    @Test func recencyWinnerChosenOverPreOrderFirst() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let panelA = UUID()
+        let panelB = UUID()
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        let t1 = Date(timeIntervalSince1970: 2_000)  // strictly later
+        let surface = try await seedTwoPanelTab(
+            db, worktreeID: wtID, panelA: panelA, panelB: panelB, now: t0)
+        // B becomes the more-recently-navigated panel.
+        try await bumpPanelBRecency(db, surface: surface, panelA: panelA, panelB: panelB, now: t1)
+
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let newContent = PanelContent.file(FileReference(path: "/new.txt"))
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: surface.id, baseRevision: nil,
+            origin: .appUser, operation: .open(content: newContent, placement: .automatic))
+
+        let result = try await coordinator.apply(envelope)
+
+        // Panel B (most-recently-navigated) got rewritten to, NOT panel A
+        // (pre-order-first).
+        #expect(result.tab.layout.panelSlot(id: panelB)?.content == newContent)
+        #expect(result.tab.layout.panelSlot(id: panelA)?.content == .file(FileReference(path: "/a.txt")))
+    }
+
+    // MARK: - §6.1 recency rewrite: no-history tie falls back to pre-order-first
+
+    @Test func noHistoryTieFallsBackToPreOrderFirstMatchingReducerDefault() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let panelA = UUID()
+        let panelB = UUID()
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        // Both panels seeded in ONE commit — identical updatedAt, a tie.
+        let surface = try await seedTwoPanelTab(
+            db, worktreeID: wtID, panelA: panelA, panelB: panelB, now: t0)
+
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let newContent = PanelContent.file(FileReference(path: "/new.txt"))
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: surface.id, baseRevision: nil,
+            origin: .appUser, operation: .open(content: newContent, placement: .automatic))
+
+        let result = try await coordinator.apply(envelope)
+
+        // Same outcome the UN-rewritten reducer default produces on a copy of
+        // the identical starting state (first panel in pre-order).
+        let unrewrittenState = try PanelSurfaceReducer.apply(
+            .open(content: newContent, placement: .automatic),
+            to: PanelSurfaceState(surface: surface, histories: [
+                panelA: .seeded(with: .file(FileReference(path: "/a.txt"))),
+                panelB: .seeded(with: .file(FileReference(path: "/b.txt"))),
+            ]))
+
+        #expect(result.tab.layout.panelSlot(id: panelA)?.content == newContent)
+        #expect(result.tab.layout.panelSlot(id: panelA)?.content
+                == unrewrittenState.surface.layout.panelSlot(id: panelA)?.content)
+        #expect(result.tab.layout.panelSlot(id: panelB)?.content
+                == unrewrittenState.surface.layout.panelSlot(id: panelB)?.content)
+    }
+
+    // MARK: - §6.1 recency rewrite: zero panels passes `.automatic` through
+
+    @Test func zeroPanelTabPassesAutomaticThroughToBesideSplit() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let surface = try await seedZeroPanelTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let newContent = PanelContent.file(FileReference(path: "/new.txt"))
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: surface.id, baseRevision: nil,
+            origin: .appUser, operation: .open(content: newContent, placement: .automatic))
+
+        let result = try await coordinator.apply(envelope)
+
+        // Reducer's own `.automatic` default: split right of primary at 0.35.
+        guard case .split(let split) = result.tab.layout else {
+            Issue.record("expected a split, got \(result.tab.layout)")
+            return
+        }
+        #expect(split.children.count == 2)
+        #expect(split.children.first == .primary)
+        #expect(split.ratios == [1 - PanelSurfaceReducer.defaultSideShare, PanelSurfaceReducer.defaultSideShare])
+        #expect(result.tab.layout.allPanelIDs.count == 1)
+        #expect(result.tab.layout.panelSlot(id: result.tab.layout.allPanelIDs[0])?.content == newContent)
+    }
+
+    // MARK: - selectTab: happy path
+
+    @Test func selectTabHappyPathPersistsActiveTabAndBroadcasts() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let surface = try await seedZeroPanelTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let opID = UUID()
+
+        let envelope = PanelOperationEnvelope(
+            operationID: opID, worktreeID: wtID, tabID: surface.id, baseRevision: nil,
+            origin: .appUser, operation: .selectTab(tabID: surface.id))
+
+        let result = try await coordinator.apply(envelope)
+        #expect(result.replayed == false)
+        #expect(result.tab == surface)
+
+        // activeTabID persisted via the EXISTING WorktreeStore column — no
+        // duplicate authority.
+        let activeTabID = try await db.worktrees.getActiveTabID(worktreeID: wtID)
+        #expect(activeTabID == surface.id)
+
+        #expect(recorder.count == 1)
+        guard case .panelSurfaceChanged(let delta) = recorder.deltas[0] else {
+            Issue.record("expected panelSurfaceChanged delta")
+            return
+        }
+        #expect(delta.worktreeID == wtID)
+        #expect(delta.tabs.isEmpty)
+        #expect(delta.removedTabIDs.isEmpty)
+        #expect(delta.activeTabID == surface.id)
+        #expect(delta.originOperationID == opID)
+
+        // No surface mutation: revision/layout unchanged.
+        let reloaded = try await db.panelSurface.state(tabID: surface.id)
+        #expect(reloaded?.surface.revision == surface.revision)
+        #expect(reloaded?.surface.layout == surface.layout)
+    }
+
+    // MARK: - selectTab: unknown tab
+
+    @Test func selectTabUnknownTabThrowsTabNotFound() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let surface = try await seedZeroPanelTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let missingTabID = UUID()
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: surface.id, baseRevision: nil,
+            origin: .appUser, operation: .selectTab(tabID: missingTabID))
+
+        await #expect(throws: PanelCoordinatorError.tabNotFound(missingTabID)) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+        let activeTabID = try await db.worktrees.getActiveTabID(worktreeID: wtID)
+        #expect(activeTabID == nil)
+    }
+
+    // MARK: - selectTab: idempotent by receipt
+
+    @Test func selectTabIsIdempotentByReceipt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let surface = try await seedZeroPanelTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let opID = UUID()
+
+        let envelope = PanelOperationEnvelope(
+            operationID: opID, worktreeID: wtID, tabID: surface.id, baseRevision: nil,
+            origin: .appUser, operation: .selectTab(tabID: surface.id))
+
+        let first = try await coordinator.apply(envelope)
+        #expect(first.replayed == false)
+        #expect(recorder.count == 1)
+
+        let second = try await coordinator.apply(envelope)
+        #expect(second.replayed == true)
+        #expect(second.tab == first.tab)
+        #expect(recorder.count == 1)  // no second broadcast
+
+        let activeTabID = try await db.worktrees.getActiveTabID(worktreeID: wtID)
+        #expect(activeTabID == surface.id)
+    }
+}

--- a/Tests/TBDDaemonTests/PanelCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PanelCoordinatorTests.swift
@@ -330,25 +330,7 @@ struct PanelCoordinatorTests {
         #expect(recorder.count == 0)
     }
 
-    // MARK: - selectTab is Task 9 — short-circuit until then
-
-    @Test func selectTabShortCircuitsAsNotTabScopedUntilTask9() async throws {
-        let db = try TBDDatabase(inMemory: true)
-        try await db.config.setPanelSurfaceEnabled(true)
-        let wtID = try await makeWorktree(db)
-        let tab = try await seedTab(db, worktreeID: wtID)
-        let recorder = BroadcastRecorder()
-        let coordinator = makeCoordinator(db, recorder: recorder)
-
-        let envelope = PanelOperationEnvelope(
-            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
-            origin: .appUser, operation: .selectTab(tabID: UUID()))
-
-        await #expect(throws: PanelCoordinatorError.operation(.notTabScoped)) {
-            _ = try await coordinator.apply(envelope)
-        }
-        #expect(recorder.count == 0)
-    }
+    // MARK: - selectTab coverage lives in PanelCoordinatorPlacementTests (Task 9)
 
     // MARK: - Carry-forward #1: a tab-removing op leaves no stale surface/history row
 

--- a/Tests/TBDDaemonTests/PanelCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PanelCoordinatorTests.swift
@@ -377,4 +377,116 @@ struct PanelCoordinatorTests {
             #expect(count == 0)
         }
     }
+
+    // MARK: - Actor-reentrancy lost update (production DatabasePool)
+
+    /// Regression for the reviewer's CRITICAL: actor isolation does NOT span
+    /// `await`, so a coordinator that loaded state, reduced, then awaited a
+    /// SEPARATE `commit` could have a concurrent same-tab apply read the stale
+    /// pre-commit revision (pool reads see a WAL snapshot) and silently clobber
+    /// the first. Only reproduces under a real `DatabasePool` (temp-file db) —
+    /// the in-memory `DatabaseQueue` used elsewhere serializes FIFO and hides
+    /// it. `applyReducing` closes the window by doing load→reduce→persist in
+    /// one write transaction; every concurrent apply then rebases on the last
+    /// committed tree, so all K increments and all K effects survive.
+    @Test func concurrentSameTabAppliesDoNotLoseUpdatesUnderPool() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pc-race-\(UUID()).sqlite")
+        let db = try TBDDatabase(path: tmp.path)
+        defer {
+            for suffix in ["", "-wal", "-shm"] {
+                try? FileManager.default.removeItem(atPath: tmp.path + suffix)
+            }
+        }
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let panelID = UUID()
+        let tab = try await seedTab(db, worktreeID: wtID, panelID: panelID, revision: 0)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+
+        // K concurrent navigates on the SAME panel, each a distinct destination
+        // and distinct operationID. navigate always increments revision by one
+        // and pushes history — additive without touching split ratios, so no
+        // reducer rejection muddies the lost-update signal.
+        let k = 6
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for i in 0..<k {
+                group.addTask {
+                    let env = PanelOperationEnvelope(
+                        operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+                        origin: .appUser,
+                        operation: .navigate(
+                            panelID: panelID,
+                            destination: .file(FileReference(path: "/f\(i).txt"))))
+                    _ = try await coordinator.apply(env)
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let finalState = try await db.panelSurface.state(tabID: tab.id)
+        // No lost update: each of the K applies incremented the revision.
+        #expect(finalState?.surface.revision == UInt64(k))
+        // Every navigate's destination survives in the panel's durable history.
+        let paths = Set((finalState?.histories[panelID]?.entries ?? []).compactMap {
+            content -> String? in
+            if case .file(let ref) = content { return ref.path }
+            return nil
+        })
+        for i in 0..<k {
+            #expect(paths.contains("/f\(i).txt"), "navigate to /f\(i).txt was lost")
+        }
+        #expect(recorder.count == k)
+    }
+
+    // MARK: - Broadcast ordering against a FAILED commit
+
+    /// The disable-broadcast check proves a broadcast fires on success; this
+    /// proves none fires when the persist THROWS after a successful reduce.
+    /// Trips Task 6's cross-tab `panelHistoryOwnedByOtherTab` guard by forcing
+    /// the reducer to mint a new panel whose id already belongs to another
+    /// tab's history row — the write transaction rolls back, so no broadcast
+    /// and the target tab is unchanged.
+    @Test func failedCommitAfterReduceLeavesStateUnchangedAndDoesNotBroadcast() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+
+        // Tab T2 owns a panel_history row for `collisionID`.
+        let collisionID = UUID()
+        _ = try await seedTab(db, worktreeID: wtID, panelID: collisionID)
+
+        // Tab T1: primary-only layout so `open .beside` mints a fresh panel.
+        let t1ID = UUID()
+        let t1 = WorkspaceTabSurface(
+            id: t1ID, worktreeID: wtID, label: "t1",
+            primary: .terminal(terminalID: UUID()), layout: .primary, revision: 0)
+        try await db.panelSurface.commit(
+            state: PanelSurfaceState(surface: t1, histories: [:]),
+            position: 1, receipt: nil, now: Date())
+
+        let recorder = BroadcastRecorder()
+        // makeID always returns the colliding id — the new panel slot's id will
+        // equal a panelID already owned by T2, tripping the store's guard.
+        let coordinator = makeCoordinator(db, recorder: recorder, makeID: { collisionID })
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: t1ID, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(
+                content: .file(FileReference(path: "/x.txt")),
+                placement: .beside(target: .primary, edge: .right, share: nil)))
+
+        await #expect(throws: (any Error).self) {
+            _ = try await coordinator.apply(envelope)
+        }
+        // No broadcast on a rolled-back commit.
+        #expect(recorder.count == 0)
+        // T1 is untouched: revision still 0, still primary-only, no phantom panel.
+        let reloaded = try await db.panelSurface.state(tabID: t1ID)
+        #expect(reloaded?.surface.revision == 0)
+        #expect(reloaded?.surface.layout == .primary)
+        #expect(reloaded?.histories.isEmpty == true)
+    }
 }

--- a/Tests/TBDDaemonTests/PanelCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PanelCoordinatorTests.swift
@@ -1,0 +1,338 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+/// Thread-safe broadcast sink. `PanelCoordinator.broadcast` is a synchronous
+/// `@Sendable` closure invoked from inside the actor's own method body
+/// (never concurrently with itself, since the actor serializes), so a plain
+/// lock-protected buffer is sufficient — no need for an actor recorder plus
+/// the cross-actor await dance that would introduce its own ordering risk.
+final class BroadcastRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _deltas: [StateDelta] = []
+
+    func record(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        _deltas.append(delta)
+    }
+
+    var deltas: [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return _deltas
+    }
+
+    var count: Int { deltas.count }
+}
+
+@Suite("PanelCoordinatorTests")
+struct PanelCoordinatorTests {
+
+    private func makeWorktree(_ db: TBDDatabase, name: String = "w") async throws -> UUID {
+        let repo = try await db.repos.create(
+            path: "/tmp/pc-\(UUID())", displayName: name, defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: "b",
+            path: "/tmp/pc-wt-\(UUID())", tmuxServer: "srv")
+        return wt.id
+    }
+
+    /// Seeds one tab directly via the store: a primary terminal plus a side
+    /// viewer panel at `panelID`.
+    @discardableResult
+    private func seedTab(
+        _ db: TBDDatabase, worktreeID: UUID, tabID: UUID = UUID(), panelID: PanelID = UUID(),
+        panelContent: PanelContent = .file(FileReference(path: "/a.txt")), revision: UInt64 = 0
+    ) async throws -> WorkspaceTabSurface {
+        let layout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: panelID, content: panelContent))],
+            ratios: [0.5, 0.5]))
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: worktreeID, label: "tab",
+            primary: .terminal(terminalID: UUID()), layout: layout, revision: revision)
+        let history = PanelHistory.seeded(with: panelContent)
+        let state = PanelSurfaceState(surface: surface, histories: [panelID: history])
+        try await db.panelSurface.commit(state: state, position: 0, receipt: nil, now: Date())
+        return surface
+    }
+
+    private func makeCoordinator(
+        _ db: TBDDatabase, recorder: BroadcastRecorder,
+        now: @escaping @Sendable () -> Date = Date.init,
+        makeID: @escaping @Sendable () -> UUID = UUID.init
+    ) -> PanelCoordinator {
+        PanelCoordinator(db: db, broadcast: { recorder.record($0) }, now: now, makeID: makeID)
+    }
+
+    private func receiptCount(_ db: TBDDatabase, worktreeID: UUID) async throws -> Int {
+        try await db.writerForTests.read { dbc in
+            try Int.fetchOne(
+                dbc, sql: "SELECT COUNT(*) FROM panel_operation_receipt WHERE worktreeID = ?",
+                arguments: [worktreeID.uuidString]) ?? 0
+        }
+    }
+
+    // MARK: - Gating (both branches of each flag)
+
+    @Test func surfaceDisabledRejectsEveryOriginZeroBroadcastsZeroReceipts() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        // Neither flag flipped on — daemon_panel_surface_enabled is off.
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+
+        await #expect(throws: PanelCoordinatorError.surfaceDisabled) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+        #expect(try await receiptCount(db, worktreeID: wtID) == 0)
+    }
+
+    @Test func agentCLIRejectedWhenAgentFlagOffEvenWithSurfaceFlagOn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        // agent_panel_control_enabled left off.
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .agentCLI,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+
+        await #expect(throws: PanelCoordinatorError.agentControlDisabled) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+        #expect(try await receiptCount(db, worktreeID: wtID) == 0)
+    }
+
+    @Test func appUserSucceedsWithOnlySurfaceFlagOn() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        // agent_panel_control_enabled stays off — appUser doesn't need it.
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+
+        let result = try await coordinator.apply(envelope)
+        #expect(result.replayed == false)
+        #expect(recorder.count == 1)
+    }
+
+    // MARK: - Happy path: open, revision +1, broadcast, receipt
+
+    @Test func happyPathOpenIncrementsRevisionBroadcastsAndPersistsReceipt() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        try await db.config.setAgentPanelControlEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID, revision: 3)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let opID = UUID()
+
+        let envelope = PanelOperationEnvelope(
+            operationID: opID, worktreeID: wtID, tabID: tab.id, baseRevision: 3,
+            origin: .agentCLI,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+
+        let result = try await coordinator.apply(envelope)
+        #expect(result.replayed == false)
+        #expect(result.tab.revision == 4)
+
+        #expect(recorder.count == 1)
+        guard case .panelSurfaceChanged(let delta) = recorder.deltas[0] else {
+            Issue.record("expected panelSurfaceChanged delta")
+            return
+        }
+        #expect(delta.worktreeID == wtID)
+        #expect(delta.tabs == [result.tab])
+        #expect(delta.originOperationID == opID)
+
+        let receipt = try await db.panelSurface.receipt(operationID: opID)
+        #expect(receipt == result)
+    }
+
+    // MARK: - Idempotent replay: no re-apply, no re-persist, one broadcast total
+
+    @Test func duplicateOperationIDReplaysWithoutReapplyingOrRebroadcasting() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let opID = UUID()
+
+        let envelope = PanelOperationEnvelope(
+            operationID: opID, worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+
+        let first = try await coordinator.apply(envelope)
+        #expect(first.replayed == false)
+        #expect(recorder.count == 1)
+
+        let second = try await coordinator.apply(envelope)
+        #expect(second.replayed == true)
+        #expect(second.tab == first.tab)
+        #expect(recorder.count == 1)  // no second broadcast
+
+        // State unchanged by the replay: still exactly first's revision.
+        let state = try await db.panelSurface.state(tabID: tab.id)
+        #expect(state?.surface.revision == first.tab.revision)
+    }
+
+    // MARK: - baseRevision semantic rebase
+
+    @Test func staleBaseRevisionWithVanishedPanelMapsToStaleTarget() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID, revision: 5)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let missingPanelID = UUID()
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: 1,  // stale
+            origin: .appUser,
+            operation: .close(panelID: missingPanelID))
+
+        await #expect(throws: PanelCoordinatorError.staleTarget(.panelNotFound(missingPanelID))) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+    }
+
+    @Test func freshBaseRevisionWithVanishedPanelMapsToOperationError() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID, revision: 5)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let missingPanelID = UUID()
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: 5,  // fresh
+            origin: .appUser,
+            operation: .close(panelID: missingPanelID))
+
+        await #expect(throws: PanelCoordinatorError.operation(.panelNotFound(missingPanelID))) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+    }
+
+    @Test func staleBaseRevisionWithSurvivingTargetAppliesSemanticRebase() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let panelID = UUID()
+        let tab = try await seedTab(db, worktreeID: wtID, panelID: panelID, revision: 5)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+
+        let envelope = PanelOperationEnvelope(
+            // stale relative to the tab's current revision (5), but the panel
+            // this operation targets still exists — must apply, not reject.
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: 1,
+            origin: .appUser,
+            operation: .navigate(panelID: panelID, destination: .file(FileReference(path: "/new.txt"))))
+
+        let result = try await coordinator.apply(envelope)
+        #expect(result.tab.revision == 6)
+        #expect(recorder.count == 1)
+    }
+
+    // MARK: - §5.5 resource existence
+
+    @Test func transcriptDestinationWithForeignTerminalIsInvalidResource() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let otherWtID = try await makeWorktree(db, name: "other")
+        let foreignTerminal = try await db.terminals.create(
+            worktreeID: otherWtID, tmuxWindowID: "1", tmuxPaneID: "%1")
+        let tab = try await seedTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(content: .transcript(terminalID: foreignTerminal.id), placement: .automatic))
+
+        await #expect(throws: PanelCoordinatorError.self) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+        #expect(try await receiptCount(db, worktreeID: wtID) == 0)
+    }
+
+    // MARK: - tabNotFound
+
+    @Test func tabNotFoundThrowsAndBroadcastsNothing() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+        let missingTabID = UUID()
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: missingTabID, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+
+        await #expect(throws: PanelCoordinatorError.tabNotFound(missingTabID)) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+    }
+
+    // MARK: - Carry-forward #1: a tab-removing op leaves no stale surface/history row
+
+    @Test func closeOperationLeavesNoStalePanelHistoryRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let panelID = UUID()
+        let tab = try await seedTab(db, worktreeID: wtID, panelID: panelID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser, operation: .close(panelID: panelID))
+
+        let result = try await coordinator.apply(envelope)
+        #expect(result.tab.layout.allPanelIDs.isEmpty)
+
+        let state = try await db.panelSurface.state(tabID: tab.id)
+        #expect(state?.histories.isEmpty == true)
+        try await db.writerForTests.read { dbc in
+            let count = try Int.fetchOne(
+                dbc, sql: "SELECT COUNT(*) FROM panel_history WHERE panelID = ?",
+                arguments: [panelID.uuidString])
+            #expect(count == 0)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/PanelCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PanelCoordinatorTests.swift
@@ -308,6 +308,48 @@ struct PanelCoordinatorTests {
         #expect(recorder.count == 0)
     }
 
+    @Test func tabBelongingToAnotherWorktreeIsTreatedAsNotFound() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let otherWtID = try await makeWorktree(db, name: "other")
+        let tab = try await seedTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+
+        // Envelope claims the tab lives in `otherWtID`, but it actually
+        // belongs to `wtID` — must not mutate/broadcast under the wrong id.
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: otherWtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+
+        await #expect(throws: PanelCoordinatorError.tabNotFound(tab.id)) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+    }
+
+    // MARK: - selectTab is Task 9 — short-circuit until then
+
+    @Test func selectTabShortCircuitsAsNotTabScopedUntilTask9() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+        let recorder = BroadcastRecorder()
+        let coordinator = makeCoordinator(db, recorder: recorder)
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser, operation: .selectTab(tabID: UUID()))
+
+        await #expect(throws: PanelCoordinatorError.operation(.notTabScoped)) {
+            _ = try await coordinator.apply(envelope)
+        }
+        #expect(recorder.count == 0)
+    }
+
     // MARK: - Carry-forward #1: a tab-removing op leaves no stale surface/history row
 
     @Test func closeOperationLeavesNoStalePanelHistoryRow() async throws {

--- a/Tests/TBDDaemonTests/PanelImportHandlerTests.swift
+++ b/Tests/TBDDaemonTests/PanelImportHandlerTests.swift
@@ -283,6 +283,14 @@ struct PanelImportHandlerTests {
         let broadcasts = panelSurfaceDeltas(deltas)
         #expect(broadcasts.count == 1)
         #expect(broadcasts[0].activeTabID == tabBID)
+
+        // A subsequent whole-worktree panel.get must report the active tab too
+        // (regression: get() previously always returned activeTabID: nil,
+        // handing a reconnecting renderer no active tab).
+        let getResponse = await router.handle(
+            try RPCRequest(method: RPCMethod.panelGet, params: PanelGetParams(worktreeID: wtID)))
+        let getResult = try getResponse.decodeResult(PanelGetResult.self)
+        #expect(getResult.activeTabID == tabBID)
     }
 
     @Test("an activeTabID that matches no imported tab (its source was skipped) leaves active tab unset")

--- a/Tests/TBDDaemonTests/PanelImportHandlerTests.swift
+++ b/Tests/TBDDaemonTests/PanelImportHandlerTests.swift
@@ -1,0 +1,376 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Task 11: `panel.importLegacy` handler tests. Router-level — exercises the
+/// full gating → convert → commitImport → broadcast pipeline. The pure
+/// conversion logic itself is covered exhaustively by
+/// `LegacySurfaceImporterTests`/`LegacySurfaceImporterFixtureTests`; here we
+/// check the RPC wiring, idempotency, and the two carry-forwards deferred
+/// from earlier reviews: active-tab preservation (spec §11.2.7) and
+/// dup-terminal-primary tolerance.
+@Suite("Panel import handler tests")
+struct PanelImportHandlerTests {
+
+    /// Router whose panel-surface broadcasts are captured in `deltas`
+    /// (mirrors `RPCRouterWorktreeCreateBroadcastTests`'s pattern).
+    private func makeRouterAndDB() throws -> (router: RPCRouter, db: TBDDatabase, deltas: BroadcastDeltas) {
+        let db = try TBDDatabase(inMemory: true)
+        let deltas = BroadcastDeltas()
+        let subs = StateSubscriptionManager()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subs
+        )
+        return (router, db, deltas)
+    }
+
+    private func makeWorktree(_ db: TBDDatabase, name: String = "w") async throws -> UUID {
+        let repo = try await db.repos.create(
+            path: "/tmp/pih-\(UUID())", displayName: name, defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: "b",
+            path: "/tmp/pih-wt-\(UUID())", tmuxServer: "srv")
+        return wt.id
+    }
+
+    private func panelSurfaceDeltas(_ deltas: BroadcastDeltas) -> [PanelSurfaceDelta] {
+        deltas.snapshot().compactMap {
+            if case .panelSurfaceChanged(let delta) = $0 { return delta }
+            return nil
+        }
+    }
+
+    // MARK: - Gate
+
+    @Test("import with the surface flag off returns the named gate error, no write")
+    func importWithFlagOffReturnsGateError() async throws {
+        let (router, db, deltas) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        let tabID = UUID()
+        let params = PanelImportParams(
+            worktreeID: wtID,
+            tabs: [LegacyTabPayload(tabID: tabID, label: nil, content: .terminal(terminalID: UUID()), layout: nil)],
+            tabOrder: [tabID], activeTabID: tabID, paneHistories: [:])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+
+        let response = await router.handle(request)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("daemon_panel_surface_enabled") == true)
+        #expect(try await db.panelSurface.isEmpty(worktreeID: wtID))
+        #expect(panelSurfaceDeltas(deltas).isEmpty)
+    }
+
+    // MARK: - Full round trip
+
+    /// Two legacy tabs: tabA has an extra terminal leaf (promotes to its own
+    /// tab), tabB is a plain terminal tab. Result: 3 surfaces (tabA, promoted,
+    /// tabB), 1 promotion, histories present, stamp set, one broadcast.
+    @Test("full round trip: convert, commit, stamp, one broadcast, panel.get reflects it")
+    func fullRoundTripImports() async throws {
+        let (router, db, deltas) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+
+        let tabAID = UUID()
+        let tabBID = UUID()
+        let mainTerm = UUID()
+        let extraTerm = UUID()
+        let viewerID = UUID()
+        let layoutA = LayoutNode.split(
+            id: UUID(), direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: mainTerm)),
+                .pane(.codeViewer(id: viewerID, path: "/one")),
+                .pane(.terminal(terminalID: extraTerm)),
+            ],
+            ratios: [0.34, 0.33, 0.33])
+        let payloadA = LegacyTabPayload(
+            tabID: tabAID, label: "A", content: .terminal(terminalID: mainTerm), layout: layoutA)
+        let payloadB = LegacyTabPayload(
+            tabID: tabBID, label: "B", content: .terminal(terminalID: UUID()), layout: nil)
+        let history = MRUHistory<PaneContent>.seeded(with: .codeViewer(id: viewerID, path: "/one"))
+
+        try await db.config.setPanelSurfaceEnabled(true)
+        let params = PanelImportParams(
+            worktreeID: wtID, tabs: [payloadA, payloadB], tabOrder: [tabAID, tabBID],
+            activeTabID: nil, paneHistories: [viewerID: history])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let result = try response.decodeResult(PanelImportResult.self)
+        #expect(result.imported == true)
+        #expect(result.tabCount == 3)
+        #expect(result.promotedTerminalTabs == 1)
+        #expect(result.skipped.isEmpty)
+
+        // panel.get reflects the converted surfaces in order.
+        let getResponse = await router.handle(
+            try RPCRequest(method: RPCMethod.panelGet, params: PanelGetParams(worktreeID: wtID)))
+        let getResult = try getResponse.decodeResult(PanelGetResult.self)
+        #expect(getResult.tabs.count == 3)
+        #expect(getResult.tabs[0].id == tabAID)
+        #expect(getResult.tabs[2].id == tabBID)
+
+        // History survives, re-keyed to the new panel ID under tabA.
+        let stateA = try await db.panelSurface.state(tabID: tabAID)
+        #expect(stateA?.histories.count == 1)
+
+        // Stamp set.
+        let stampedAt = try await db.worktrees.panelSurfaceImportedAt(worktreeID: wtID)
+        #expect(stampedAt != nil)
+
+        // Exactly one broadcast, carrying the full tab list.
+        let broadcasts = panelSurfaceDeltas(deltas)
+        #expect(broadcasts.count == 1)
+        #expect(broadcasts[0].tabs.count == 3)
+        #expect(broadcasts[0].worktreeID == wtID)
+    }
+
+    // MARK: - Idempotency: second call is a no-op, no second broadcast
+
+    @Test("second identical call returns imported:false, no DB change, no second broadcast")
+    func secondCallIsNoOpNoSecondBroadcast() async throws {
+        let (router, db, deltas) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let tabID = UUID()
+        let params = PanelImportParams(
+            worktreeID: wtID,
+            tabs: [LegacyTabPayload(tabID: tabID, label: nil, content: .terminal(terminalID: UUID()), layout: nil)],
+            tabOrder: [tabID], activeTabID: nil, paneHistories: [:])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+
+        let firstResponse = await router.handle(request)
+        #expect(firstResponse.success)
+        #expect(try firstResponse.decodeResult(PanelImportResult.self).imported == true)
+        #expect(panelSurfaceDeltas(deltas).count == 1)
+
+        let secondResponse = await router.handle(request)
+        #expect(secondResponse.success)
+        let secondResult = try secondResponse.decodeResult(PanelImportResult.self)
+        #expect(secondResult.imported == false)
+        #expect(secondResult.tabCount == 0)
+        #expect(secondResult.promotedTerminalTabs == 0)
+        #expect(secondResult.skipped.isEmpty)
+
+        // Nothing changed, and no second broadcast.
+        let surfaces = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(surfaces.map(\.id) == [tabID])
+        #expect(panelSurfaceDeltas(deltas).count == 1)
+    }
+
+    // MARK: - Payload hygiene: orphan history keys dropped
+
+    @Test("paneHistories entries keyed by IDs absent from every tab tree are dropped")
+    func orphanHistoryKeysDropped() async throws {
+        let (router, db, deltas) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let tabID = UUID()
+        let mainTerm = UUID()
+        let viewerID = UUID()
+        let orphanID = UUID()
+        let layout = LayoutNode.split(
+            id: UUID(), direction: .horizontal,
+            children: [.pane(.terminal(terminalID: mainTerm)), .pane(.codeViewer(id: viewerID, path: "/x"))],
+            ratios: [0.5, 0.5])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: mainTerm), layout: layout)
+        // orphanID appears in NO payload tab tree — daemon-side defense must
+        // drop it before conversion (it would otherwise be silently ignored
+        // by the importer anyway, but this pins the hygiene filter itself).
+        let orphanHistory = MRUHistory<PaneContent>.seeded(with: .codeViewer(id: orphanID, path: "/orphan"))
+        let liveHistory = MRUHistory<PaneContent>.seeded(with: .codeViewer(id: viewerID, path: "/x"))
+        _ = deltas
+
+        let params = PanelImportParams(
+            worktreeID: wtID, tabs: [payload], tabOrder: [tabID], activeTabID: nil,
+            paneHistories: [orphanID: orphanHistory, viewerID: liveHistory])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let result = try response.decodeResult(PanelImportResult.self)
+        #expect(result.tabCount == 1)
+
+        let state = try await db.panelSurface.state(tabID: tabID)
+        #expect(state?.histories.count == 1)
+    }
+
+    // MARK: - Skipped-tab reason propagates
+
+    @Test("a malformed tab's skip reason propagates into the result, its terminals still promote")
+    func skippedTabReasonPropagates() async throws {
+        let (router, db, deltas) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        try await db.config.setPanelSurfaceEnabled(true)
+        _ = deltas
+        let tabID = UUID()
+        let declaredPrimary = UUID()
+        let actualTerm = UUID()
+        // Declared primary (`declaredPrimary`) never appears as a leaf in the
+        // tree — malformed data the importer must skip the tab (0 primaries)
+        // while still promoting EVERY terminal it references: the tree's own
+        // leaf (`actualTerm`) AND the declared-but-unmatched primary itself
+        // (`LegacySurfaceImporter.convertTab`'s doc comment: "never kill or
+        // discard a terminal", covering both cases).
+        let layout = LayoutNode.pane(.terminal(terminalID: actualTerm))
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: declaredPrimary), layout: layout)
+
+        let params = PanelImportParams(
+            worktreeID: wtID, tabs: [payload], tabOrder: [tabID], activeTabID: nil, paneHistories: [:])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let result = try response.decodeResult(PanelImportResult.self)
+        #expect(result.skipped.count == 1)
+        #expect(result.skipped[0].contains(tabID.uuidString))
+        // The tab's own surface never lands; both its terminals are promoted.
+        #expect(result.tabCount == 2)
+        #expect(result.promotedTerminalTabs == 2)
+        let surfaces = try await db.panelSurface.surfaces(worktreeID: wtID)
+        let terminalIDs = surfaces.compactMap { surface -> UUID? in
+            if case .terminal(let id) = surface.primary { return id }
+            return nil
+        }
+        #expect(Set(terminalIDs) == Set([declaredPrimary, actualTerm]))
+    }
+
+    // MARK: - Carry-forward 1: active-tab metadata survives import (spec §11.2.7)
+
+    @Test("the imported worktree's active tab is set from the legacy payload's activeTabID")
+    func activeTabSurvivesImport() async throws {
+        let (router, db, deltas) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let tabAID = UUID()
+        let tabBID = UUID()
+        let payloadA = LegacyTabPayload(
+            tabID: tabAID, label: "A", content: .terminal(terminalID: UUID()), layout: nil)
+        let payloadB = LegacyTabPayload(
+            tabID: tabBID, label: "B", content: .terminal(terminalID: UUID()), layout: nil)
+
+        let params = PanelImportParams(
+            worktreeID: wtID, tabs: [payloadA, payloadB], tabOrder: [tabAID, tabBID],
+            activeTabID: tabBID, paneHistories: [:])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let persistedActive = try await db.worktrees.getActiveTabID(worktreeID: wtID)
+        #expect(persistedActive == tabBID)
+
+        let broadcasts = panelSurfaceDeltas(deltas)
+        #expect(broadcasts.count == 1)
+        #expect(broadcasts[0].activeTabID == tabBID)
+    }
+
+    @Test("an activeTabID that matches no imported tab (its source was skipped) leaves active tab unset")
+    func activeTabWithNoSurvivingSurfaceLeavesUnset() async throws {
+        let (router, db, deltas) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        try await db.config.setPanelSurfaceEnabled(true)
+        _ = deltas
+        let tabID = UUID()
+        let declaredPrimary = UUID()
+        let layout = LayoutNode.pane(.terminal(terminalID: UUID()))
+        // Malformed: declared primary never in the tree -> tab is skipped ->
+        // no surface exists under `tabID` for the active-tab pointer to match.
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: declaredPrimary), layout: layout)
+
+        let params = PanelImportParams(
+            worktreeID: wtID, tabs: [payload], tabOrder: [tabID], activeTabID: tabID, paneHistories: [:])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let persistedActive = try await db.worktrees.getActiveTabID(worktreeID: wtID)
+        #expect(persistedActive == nil)
+    }
+
+    // MARK: - Carry-forward 2: dup-terminal-primary blob is tolerated
+
+    /// A corrupt legacy blob where one tab's tree contains the SAME terminal
+    /// UUID twice: the first occurrence matches the declared primary, the
+    /// second is an "extra" terminal leaf that gets promoted into its own
+    /// new tab (spec §11.2 step 4, "never kill or discard a terminal"). Both
+    /// output tabs end up with `primary == .terminal(terminalID: dupTerm)` —
+    /// the importer over-promotes rather than drops. Neither
+    /// `commitImport`'s `panelHistoryOwnedByOtherTab` guard nor any DB
+    /// constraint may fire: terminal primaries are never `PanelContent`
+    /// panels, so they never appear in `panel_history`.
+    @Test("two output tabs sharing a primary terminalID (corrupt dup-terminal blob) commit without error")
+    func dupTerminalPrimaryBlobCommitsWithoutError() async throws {
+        let (router, db, deltas) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        try await db.config.setPanelSurfaceEnabled(true)
+        let tabID = UUID()
+        let dupTerm = UUID()
+        let layout = LayoutNode.split(
+            id: UUID(), direction: .horizontal,
+            children: [.pane(.terminal(terminalID: dupTerm)), .pane(.terminal(terminalID: dupTerm))],
+            ratios: [0.5, 0.5])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: dupTerm), layout: layout)
+
+        let params = PanelImportParams(
+            worktreeID: wtID, tabs: [payload], tabOrder: [tabID], activeTabID: nil, paneHistories: [:])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+        let response = await router.handle(request)
+
+        #expect(response.success)
+        let result = try response.decodeResult(PanelImportResult.self)
+        #expect(result.tabCount == 2, "the source tab + its promoted duplicate terminal")
+        #expect(result.promotedTerminalTabs == 1)
+        #expect(result.skipped.isEmpty)
+
+        let surfaces = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(surfaces.count == 2, "both tabs survive")
+        let terminalIDs = surfaces.compactMap { surface -> UUID? in
+            if case .terminal(let id) = surface.primary { return id }
+            return nil
+        }
+        #expect(terminalIDs == [dupTerm, dupTerm], "both surviving tabs claim the SAME primary terminalID")
+
+        let broadcasts = panelSurfaceDeltas(deltas)
+        #expect(broadcasts.count == 1)
+    }
+}
+
+/// Thread-safe collector for broadcast StateDeltas (mirrors the private
+/// helper in `RPCRouterWorktreeCreateBroadcastTests`).
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+}

--- a/Tests/TBDDaemonTests/PanelRPCTests.swift
+++ b/Tests/TBDDaemonTests/PanelRPCTests.swift
@@ -162,10 +162,10 @@ struct PanelRPCTests {
         #expect(!response.success)
     }
 
-    // MARK: - panel.importLegacy dispatch (Task 11 implements the real behavior)
+    // MARK: - panel.importLegacy dispatch (Task 11 implements the real behavior; see PanelImportHandlerTests)
 
-    @Test("panel.importLegacy route dispatches to a not-implemented error, not Unknown method")
-    func importLegacyDispatchesToStub() async throws {
+    @Test("panel.importLegacy route dispatches to the real handler (gate error with flag off), not Unknown method")
+    func importLegacyDispatchesToHandler() async throws {
         let (router, _) = try makeRouterAndDB()
         let params = PanelImportParams(
             worktreeID: UUID(), tabs: [], tabOrder: [], activeTabID: nil, paneHistories: [:])

--- a/Tests/TBDDaemonTests/PanelRPCTests.swift
+++ b/Tests/TBDDaemonTests/PanelRPCTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Router-level tests for `panel.get` / `panel.apply` / `panel.importLegacy`
+/// (Task 10, spec C §10). Exercises ROUTING only — `PanelCoordinator`'s
+/// internal gating/reduce/broadcast behavior is already covered exhaustively
+/// by `PanelCoordinatorTests`/`PanelCoordinatorPlacementTests`. Here we check:
+/// the RPC method reaches the coordinator, the two gate errors surface as the
+/// stable named-flag strings, a malformed payload decodes to an error
+/// response, and `daemon.capabilities` reports the new flag.
+@Suite("Panel RPC Tests")
+struct PanelRPCTests {
+
+    private func makeRouterAndDB() throws -> (RPCRouter, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+        return (router, db)
+    }
+
+    private func makeWorktree(_ db: TBDDatabase, name: String = "w") async throws -> UUID {
+        let repo = try await db.repos.create(
+            path: "/tmp/prpc-\(UUID())", displayName: name, defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: "b",
+            path: "/tmp/prpc-wt-\(UUID())", tmuxServer: "srv")
+        return wt.id
+    }
+
+    /// Seeds one tab directly via the store: a primary terminal plus a side
+    /// viewer panel — mirrors `PanelCoordinatorTests.seedTab`.
+    @discardableResult
+    private func seedTab(
+        _ db: TBDDatabase, worktreeID: UUID, tabID: UUID = UUID(), panelID: PanelID = UUID(),
+        panelContent: PanelContent = .file(FileReference(path: "/a.txt"))
+    ) async throws -> WorkspaceTabSurface {
+        let layout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: panelID, content: panelContent))],
+            ratios: [0.5, 0.5]))
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: worktreeID, label: "tab",
+            primary: .terminal(terminalID: UUID()), layout: layout, revision: 0)
+        let history = PanelHistory.seeded(with: panelContent)
+        let state = PanelSurfaceState(surface: surface, histories: [panelID: history])
+        try await db.panelSurface.commit(state: state, position: 0, receipt: nil, now: Date())
+        return surface
+    }
+
+    // MARK: - panel.get (ungated)
+
+    @Test("panel.get on an empty store returns an empty result, no error, both flags off")
+    func getOnEmptyStoreReturnsEmptyResult() async throws {
+        let (router, _) = try makeRouterAndDB()
+        let request = try RPCRequest(
+            method: RPCMethod.panelGet, params: PanelGetParams(worktreeID: UUID()))
+        let response = await router.handle(request)
+        #expect(response.success)
+        let result = try response.decodeResult(PanelGetResult.self)
+        #expect(result.tabs.isEmpty)
+    }
+
+    @Test("panel.get reflects a committed tab")
+    func getReflectsCommittedTab() async throws {
+        let (router, db) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+
+        let request = try RPCRequest(
+            method: RPCMethod.panelGet, params: PanelGetParams(worktreeID: wtID))
+        let response = await router.handle(request)
+        #expect(response.success)
+        let result = try response.decodeResult(PanelGetResult.self)
+        #expect(result.tabs.map(\.id) == [tab.id])
+    }
+
+    // MARK: - panel.apply gating surfaces as named-flag errors
+
+    @Test("panel.apply surfaces the surface-disabled gate by name")
+    func applySurfaceDisabledNamesFlag() async throws {
+        let (router, db) = try makeRouterAndDB()
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+        // Both flags off (default).
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+        let request = try RPCRequest(method: RPCMethod.panelApply, params: PanelApplyParams(envelope: envelope))
+        let response = await router.handle(request)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("daemon_panel_surface_enabled") == true)
+    }
+
+    @Test("panel.apply surfaces the agent-control gate by name")
+    func applyAgentControlDisabledNamesFlag() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await db.config.setPanelSurfaceEnabled(true)
+        // agent_panel_control_enabled left off.
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .agentCLI,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+        let request = try RPCRequest(method: RPCMethod.panelApply, params: PanelApplyParams(envelope: envelope))
+        let response = await router.handle(request)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("agent_panel_control_enabled") == true)
+    }
+
+    // MARK: - panel.apply happy path (flag on, appUser) + panel.get reflects it
+
+    @Test("panel.apply commits with the surface flag on and panel.get reflects it")
+    func applyHappyPathThenGetReflectsResult() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await db.config.setPanelSurfaceEnabled(true)
+        let wtID = try await makeWorktree(db)
+        let tab = try await seedTab(db, worktreeID: wtID)
+
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: wtID, tabID: tab.id, baseRevision: nil,
+            origin: .appUser,
+            operation: .open(content: .file(FileReference(path: "/b.txt")), placement: .automatic))
+        let applyRequest = try RPCRequest(
+            method: RPCMethod.panelApply, params: PanelApplyParams(envelope: envelope))
+        let applyResponse = await router.handle(applyRequest)
+        #expect(applyResponse.success)
+        let applyResult = try applyResponse.decodeResult(PanelApplyResult.self)
+        #expect(applyResult.replayed == false)
+        #expect(applyResult.tab.revision == 1)
+
+        let getRequest = try RPCRequest(method: RPCMethod.panelGet, params: PanelGetParams(worktreeID: wtID))
+        let getResponse = await router.handle(getRequest)
+        #expect(getResponse.success)
+        let getResult = try getResponse.decodeResult(PanelGetResult.self)
+        #expect(getResult.tabs.first?.revision == 1)
+    }
+
+    // MARK: - malformed params
+
+    @Test("panel.apply with malformed params JSON decodes to an error response")
+    func applyMalformedParamsDecodesToError() async throws {
+        let (router, _) = try makeRouterAndDB()
+        let request = RPCRequest(method: RPCMethod.panelApply, params: #"{"not":"an envelope"}"#)
+        let response = await router.handle(request)
+        #expect(!response.success)
+    }
+
+    // MARK: - panel.importLegacy dispatch (Task 11 implements the real behavior)
+
+    @Test("panel.importLegacy route dispatches to a not-implemented error, not Unknown method")
+    func importLegacyDispatchesToStub() async throws {
+        let (router, _) = try makeRouterAndDB()
+        let params = PanelImportParams(
+            worktreeID: UUID(), tabs: [], tabOrder: [], activeTabID: nil, paneHistories: [:])
+        let request = try RPCRequest(method: RPCMethod.panelImportLegacy, params: params)
+        let response = await router.handle(request)
+        #expect(!response.success)
+        #expect(response.error?.contains("Unknown method") == false)
+    }
+
+    // MARK: - daemon.capabilities
+
+    @Test("capabilities carries panelSurfaceEnabled")
+    func capabilitiesCarriesPanelSurfaceFlag() async throws {
+        let (router, db) = try makeRouterAndDB()
+
+        var response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        var result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.panelSurfaceEnabled == false)
+
+        try await db.config.setPanelSurfaceEnabled(true)
+        response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.panelSurfaceEnabled == true)
+    }
+
+    /// Codable back-compat: capabilities JSON from a daemon without the new
+    /// panelSurfaceEnabled key must still decode with a safe default.
+    @Test("capabilities JSON without panelSurfaceEnabled decodes with default false")
+    func capabilitiesDecodeBackCompat() throws {
+        let json = Data(#"{"controlModeEnabled":true,"controlModeSupported":false}"#.utf8)
+        let result = try JSONDecoder().decode(DaemonCapabilitiesResult.self, from: json)
+        #expect(result.panelSurfaceEnabled == false)
+    }
+}

--- a/Tests/TBDDaemonTests/PanelReceiptTests.swift
+++ b/Tests/TBDDaemonTests/PanelReceiptTests.swift
@@ -1,0 +1,312 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("PanelReceiptTests")
+struct PanelReceiptTests {
+
+    private func makeWorktree(_ db: TBDDatabase, name: String = "w") async throws -> UUID {
+        let repo = try await db.repos.create(
+            path: "/tmp/pr-\(UUID())", displayName: name, defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: "b",
+            path: "/tmp/pr-wt-\(UUID())", tmuxServer: "srv")
+        return wt.id
+    }
+
+    private func makeState(
+        worktreeID: UUID, tabID: UUID = UUID(), panelID: PanelID = UUID(),
+        panelContent: PanelContent = .file(FileReference(path: "/a.txt"))
+    ) -> PanelSurfaceState {
+        let layout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: panelID, content: panelContent))],
+            ratios: [0.5, 0.5]))
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: worktreeID, label: "tab",
+            primary: .terminal(terminalID: UUID()), layout: layout, revision: 1)
+        let history = PanelHistory.seeded(with: panelContent)
+        return PanelSurfaceState(surface: surface, histories: [panelID: history])
+    }
+
+    private func makeReceipt(
+        operationID: UUID = UUID(), worktreeID: UUID, tabID: UUID, appliedAt: Date,
+        result: PanelApplyResult
+    ) throws -> PanelOperationReceiptRecord {
+        let data = try JSONEncoder().encode(result)
+        let json = String(data: data, encoding: .utf8)!
+        return PanelOperationReceiptRecord(
+            operationID: operationID.uuidString, worktreeID: worktreeID.uuidString,
+            tabID: tabID.uuidString, revision: 1, result: json, appliedAt: appliedAt)
+    }
+
+    // MARK: - Idempotent replay
+
+    @Test func receiptRoundTripsThroughCommit() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let state = makeState(worktreeID: wtID)
+        let operationID = UUID()
+        let expectedResult = PanelApplyResult(tab: state.surface, replayed: false)
+        let receipt = try makeReceipt(
+            operationID: operationID, worktreeID: wtID, tabID: state.surface.id,
+            appliedAt: Date(), result: expectedResult)
+
+        try await db.panelSurface.commit(state: state, position: 0, receipt: receipt, now: Date())
+
+        let fetched = try await db.panelSurface.receipt(operationID: operationID)
+        #expect(fetched == expectedResult)
+    }
+
+    @Test func unknownOperationIDReturnsNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let fetched = try await db.panelSurface.receipt(operationID: UUID())
+        #expect(fetched == nil)
+    }
+
+    // MARK: - Bounded pruning
+
+    @Test func pruneByCountKeepsNewest100Of105() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let tabID = UUID()
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        let operationIDs: [UUID] = (0..<105).map { _ in UUID() }
+
+        try await db.writerForTests.write { dbc in
+            for i in 0..<105 {
+                let opID = operationIDs[i]
+                let result = PanelApplyResult(
+                    tab: WorkspaceTabSurface(
+                        id: tabID, worktreeID: wtID, primary: .terminal(terminalID: UUID()),
+                        layout: .primary, revision: 0),
+                    replayed: false)
+                let data = try JSONEncoder().encode(result)
+                let record = PanelOperationReceiptRecord(
+                    operationID: opID.uuidString, worktreeID: wtID.uuidString, tabID: tabID.uuidString,
+                    revision: 1, result: String(data: data, encoding: .utf8)!,
+                    appliedAt: base.addingTimeInterval(TimeInterval(i)))
+                try record.save(dbc)
+            }
+        }
+
+        // now is right after the last receipt — no receipt is 24h+ old yet.
+        try await db.panelSurface.pruneReceipts(worktreeID: wtID, now: base.addingTimeInterval(105))
+
+        let remainingCount = try await db.writerForTests.read { dbc in
+            try Int.fetchOne(
+                dbc, sql: "SELECT COUNT(*) FROM panel_operation_receipt WHERE worktreeID = ?",
+                arguments: [wtID.uuidString])
+        }
+        #expect(remainingCount == 100)
+
+        // The oldest 5 (indices 0..<5) must be gone; the newest 100 remain.
+        for opID in operationIDs[0..<5] {
+            #expect(try await db.panelSurface.receipt(operationID: opID) == nil)
+        }
+        for opID in operationIDs[5...] {
+            #expect(try await db.panelSurface.receipt(operationID: opID) != nil)
+        }
+    }
+
+    @Test func pruneByAgeDropsReceiptsOlderThan24Hours() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let tabID = UUID()
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        let operationIDs: [UUID] = (0..<3).map { _ in UUID() }
+
+        try await db.writerForTests.write { dbc in
+            for i in 0..<3 {
+                let opID = operationIDs[i]
+                let result = PanelApplyResult(
+                    tab: WorkspaceTabSurface(
+                        id: tabID, worktreeID: wtID, primary: .terminal(terminalID: UUID()),
+                        layout: .primary, revision: 0),
+                    replayed: false)
+                let data = try JSONEncoder().encode(result)
+                let record = PanelOperationReceiptRecord(
+                    operationID: opID.uuidString, worktreeID: wtID.uuidString, tabID: tabID.uuidString,
+                    revision: 1, result: String(data: data, encoding: .utf8)!,
+                    appliedAt: base.addingTimeInterval(TimeInterval(i)))
+                try record.save(dbc)
+            }
+        }
+
+        // 25h after the base — all 3 receipts (spanning only 2s) are older than 24h.
+        try await db.panelSurface.pruneReceipts(worktreeID: wtID, now: base.addingTimeInterval(25 * 60 * 60))
+
+        for opID in operationIDs {
+            #expect(try await db.panelSurface.receipt(operationID: opID) == nil)
+        }
+    }
+
+    // MARK: - Atomic import commit
+
+    private func makeConversion(worktreeID: UUID, tabID: UUID = UUID(), panelID: PanelID = UUID())
+        -> LegacySurfaceImporter.Conversion
+    {
+        let layout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: panelID, content: .file(FileReference(path: "/a.txt"))))],
+            ratios: [0.5, 0.5]))
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: worktreeID, primary: .terminal(terminalID: UUID()),
+            layout: layout, revision: 0)
+        return LegacySurfaceImporter.Conversion(
+            surfaces: [surface],
+            histories: [panelID: .seeded(with: .file(FileReference(path: "/a.txt")))])
+    }
+
+    @Test func commitImportWritesSurfacesHistoriesAndStampAtomically() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let conversion = makeConversion(worktreeID: wtID)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        try await db.panelSurface.commitImport(worktreeID: wtID, conversion: conversion, now: now)
+
+        let surfaces = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(surfaces == conversion.surfaces)
+        let state = try await db.panelSurface.state(tabID: conversion.surfaces[0].id)
+        #expect(state?.histories == conversion.histories)
+        let stampedAt = try await db.worktrees.panelSurfaceImportedAt(worktreeID: wtID)
+        #expect(stampedAt == now)
+    }
+
+    @Test func commitImportSecondCallIsNoOpAlreadyImportedGuard() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let conversion = makeConversion(worktreeID: wtID)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        try await db.panelSurface.commitImport(worktreeID: wtID, conversion: conversion, now: now)
+
+        // Second import call (e.g. a lost-response retry) must throw, never double-write.
+        let secondConversion = makeConversion(worktreeID: wtID)
+        await #expect(throws: PanelSurfaceStoreError.alreadyImported) {
+            try await db.panelSurface.commitImport(
+                worktreeID: wtID, conversion: secondConversion, now: now.addingTimeInterval(60))
+        }
+
+        // Only the FIRST import's surface must be present — no double-write.
+        let surfaces = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(surfaces.map(\.id) == [conversion.surfaces[0].id])
+    }
+
+    @Test func commitImportThrowsAlreadyImportedWhenSurfaceRowExistsButNoStamp() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        // A surface row exists (e.g. from an unrelated commit) but the
+        // worktree was never stamped as imported — must still guard.
+        let state = makeState(worktreeID: wtID)
+        try await db.panelSurface.commit(state: state, position: 0, receipt: nil, now: Date())
+        #expect(try await db.worktrees.panelSurfaceImportedAt(worktreeID: wtID) == nil)
+
+        let conversion = makeConversion(worktreeID: wtID)
+        await #expect(throws: PanelSurfaceStoreError.alreadyImported) {
+            try await db.panelSurface.commitImport(worktreeID: wtID, conversion: conversion, now: Date())
+        }
+    }
+
+    /// Atomicity: a conversion whose SECOND surface reuses a panelID already
+    /// owned by an unrelated tab (some other worktree's tab) trips the
+    /// `panelHistoryOwnedByOtherTab` guard partway through the write loop —
+    /// AFTER the first surface has already been `save`d in the same
+    /// transaction. Nothing from this failed import may land: not the first
+    /// surface, not its history, not the `panel_surface_imported_at` stamp.
+    @Test func commitImportRollsBackEntirelyOnMidLoopFailure() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let otherWtID = try await makeWorktree(db, name: "other")
+        let clobberedPanelID = UUID()
+        let ownerState = makeState(worktreeID: otherWtID, panelID: clobberedPanelID)
+        try await db.panelSurface.commit(state: ownerState, position: 0, receipt: nil, now: Date())
+
+        let wtID = try await makeWorktree(db)
+        let tab1 = makeConversion(worktreeID: wtID).surfaces[0]
+        // Second surface's panel reuses `clobberedPanelID`, which belongs to
+        // `ownerState`'s tab under a DIFFERENT worktree.
+        let tab2ID = UUID()
+        let layout2 = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: clobberedPanelID, content: .file(FileReference(path: "/b.txt"))))],
+            ratios: [0.5, 0.5]))
+        let tab2 = WorkspaceTabSurface(
+            id: tab2ID, worktreeID: wtID, primary: .terminal(terminalID: UUID()),
+            layout: layout2, revision: 0)
+        let conversion = LegacySurfaceImporter.Conversion(
+            surfaces: [tab1, tab2],
+            histories: [
+                tab1.layout.allPanelIDs[0]: .seeded(with: .file(FileReference(path: "/a.txt"))),
+                clobberedPanelID: .seeded(with: .file(FileReference(path: "/b.txt"))),
+            ])
+
+        await #expect(throws: PanelSurfaceStoreError.self) {
+            try await db.panelSurface.commitImport(worktreeID: wtID, conversion: conversion, now: Date())
+        }
+
+        // Nothing from the failed import landed for the target worktree.
+        let surfaces = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(surfaces.isEmpty)
+        #expect(try await db.worktrees.panelSurfaceImportedAt(worktreeID: wtID) == nil)
+        // The other worktree's tab still owns the panel untouched.
+        try await db.writerForTests.read { dbc in
+            let ownerTabID = try String.fetchOne(
+                dbc, sql: "SELECT tabID FROM panel_history WHERE panelID = ?",
+                arguments: [clobberedPanelID.uuidString])
+            #expect(ownerTabID == ownerState.surface.id.uuidString)
+        }
+    }
+
+    /// Multi-tab import: the importer's cross-tab dedup guarantees distinct
+    /// panelIDs across tabs, so `commitImport` writing MULTIPLE tabs' worth
+    /// of history in one transaction must never trip the
+    /// `panelHistoryOwnedByOtherTab` guard on its own legitimate writes.
+    @Test func commitImportMultiTabComposesWithCrossTabHistoryGuard() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let tab1ID = UUID()
+        let tab2ID = UUID()
+        let term1 = UUID()
+        let term2 = UUID()
+        let viewer1 = UUID()
+        let viewer2 = UUID()
+        let legacyHistory1 = MRUHistory<PaneContent>.seeded(with: .codeViewer(id: viewer1, path: "/one"))
+        let legacyHistory2 = MRUHistory<PaneContent>.seeded(with: .codeViewer(id: viewer2, path: "/two"))
+        // Each tab's primary is its terminal; the codeViewer is a SEPARATE
+        // leaf so it survives conversion as a panel (with history), not the
+        // tab's `.primary` — mirrors LegacySurfaceImporterTests's split shape.
+        let layout1 = LayoutNode.split(
+            id: UUID(), direction: .horizontal,
+            children: [.pane(.terminal(terminalID: term1)), .pane(.codeViewer(id: viewer1, path: "/one"))],
+            ratios: [0.5, 0.5])
+        let layout2 = LayoutNode.split(
+            id: UUID(), direction: .horizontal,
+            children: [.pane(.terminal(terminalID: term2)), .pane(.codeViewer(id: viewer2, path: "/two"))],
+            ratios: [0.5, 0.5])
+        let payload1 = LegacyTabPayload(
+            tabID: tab1ID, label: "one", content: .terminal(terminalID: term1), layout: layout1)
+        let payload2 = LegacyTabPayload(
+            tabID: tab2ID, label: "two", content: .terminal(terminalID: term2), layout: layout2)
+
+        let conversion = LegacySurfaceImporter.convert(
+            worktreeID: wtID, tabs: [payload1, payload2], tabOrder: [tab1ID, tab2ID],
+            paneHistories: [viewer1: legacyHistory1, viewer2: legacyHistory2])
+        #expect(conversion.skipped.isEmpty)
+        #expect(conversion.surfaces.count == 2)
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        try await db.panelSurface.commitImport(worktreeID: wtID, conversion: conversion, now: now)
+
+        let surfaces = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(surfaces.map(\.id) == [tab1ID, tab2ID])
+        let state1 = try await db.panelSurface.state(tabID: tab1ID)
+        let state2 = try await db.panelSurface.state(tabID: tab2ID)
+        #expect(state1?.histories.keys.first == viewer1)
+        #expect(state2?.histories.keys.first == viewer2)
+        let stampedAt = try await db.worktrees.panelSurfaceImportedAt(worktreeID: wtID)
+        #expect(stampedAt == now)
+    }
+}

--- a/Tests/TBDDaemonTests/PanelReceiptTests.swift
+++ b/Tests/TBDDaemonTests/PanelReceiptTests.swift
@@ -143,6 +143,37 @@ struct PanelReceiptTests {
         }
     }
 
+    /// Exact-boundary: a receipt whose `appliedAt` is EXACTLY `now - 24h`
+    /// (`appliedAt == cutoff`) is KEPT — prune uses strict `appliedAt < cutoff`,
+    /// so "older than 24h" excludes exactly-24h-old. Pins the direction so a
+    /// future refactor to `<=` can't silently prune a receipt one tick early
+    /// (a retry would then re-apply it — idempotency break).
+    @Test func pruneKeepsReceiptExactlyAtAgeBoundary() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let tabID = UUID()
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let operationID = UUID()
+        let result = PanelApplyResult(
+            tab: WorkspaceTabSurface(
+                id: tabID, worktreeID: wtID, primary: .terminal(terminalID: UUID()),
+                layout: .primary, revision: 0),
+            replayed: false)
+
+        try await db.writerForTests.write { dbc in
+            let data = try JSONEncoder().encode(result)
+            let record = PanelOperationReceiptRecord(
+                operationID: operationID.uuidString, worktreeID: wtID.uuidString, tabID: tabID.uuidString,
+                revision: 1, result: String(data: data, encoding: .utf8)!,
+                appliedAt: now.addingTimeInterval(-24 * 60 * 60))  // exactly the cutoff
+            try record.save(dbc)
+        }
+
+        try await db.panelSurface.pruneReceipts(worktreeID: wtID, now: now)
+
+        #expect(try await db.panelSurface.receipt(operationID: operationID) != nil)
+    }
+
     // MARK: - Atomic import commit
 
     private func makeConversion(worktreeID: UUID, tabID: UUID = UUID(), panelID: PanelID = UUID())

--- a/Tests/TBDDaemonTests/PanelSurfaceMigrationTests.swift
+++ b/Tests/TBDDaemonTests/PanelSurfaceMigrationTests.swift
@@ -1,0 +1,142 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("PanelSurfaceMigrationTests")
+struct PanelSurfaceMigrationTests {
+
+    @Test func v56CreatesTablesAndFlags() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let config = try await db.config.get()
+        #expect(config.panelSurfaceEnabled == false)
+        #expect(config.agentPanelControlEnabled == false)
+        try await db.writerForTests.read { dbConn in
+            #expect(try dbConn.tableExists("workspace_tab_surface"))
+            #expect(try dbConn.tableExists("panel_history"))
+            #expect(try dbConn.tableExists("panel_operation_receipt"))
+            let cols = try Row.fetchAll(dbConn, sql: "PRAGMA table_info(worktree)")
+                .compactMap { $0["name"] as String? }
+            #expect(cols.contains("panel_surface_imported_at"))
+        }
+    }
+
+    @Test func panelSurfaceStoreIsEmptyForFreshWorktree() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v56-\(UUID())", displayName: "v56", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v56-wt-\(UUID())", tmuxServer: "srv"
+        )
+        let isEmpty = try await db.panelSurface.isEmpty(worktreeID: wt.id)
+        #expect(isEmpty)
+    }
+
+    @Test func panelSurfaceImportedAtDefaultsNilAndCanBeStamped() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v56b-\(UUID())", displayName: "v56b", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w2", branch: "b2",
+            path: "/tmp/v56-wt2-\(UUID())", tmuxServer: "srv"
+        )
+        let before = try await db.worktrees.panelSurfaceImportedAt(worktreeID: wt.id)
+        #expect(before == nil)
+
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        try await db.worktrees.stampPanelSurfaceImported(worktreeID: wt.id, at: stamp)
+        let after = try await db.worktrees.panelSurfaceImportedAt(worktreeID: wt.id)
+        #expect(after == stamp)
+    }
+
+    /// Deleting a worktree must cascade-delete its workspace_tab_surface,
+    /// panel_history (via tabID → surface → worktree), and
+    /// panel_operation_receipt rows — no orphans. Relies on GRDB's
+    /// foreign-keys-on default (v55 precedent).
+    @Test func deletingWorktreeCascadesPanelSurfaceRows() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/v56cascade-\(UUID())", displayName: "v56c", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/v56c-wt-\(UUID())", tmuxServer: "srv")
+
+        let tabID = UUID().uuidString
+        let now = Date()
+        try await db.writerForTests.write { dbc in
+            try dbc.execute(sql: """
+                INSERT INTO workspace_tab_surface
+                    (id, worktreeID, primaryContent, position, layout, revision, updatedAt)
+                VALUES (?, ?, '{}', 0, '{}', 0, ?)
+                """, arguments: [tabID, wt.id.uuidString, now])
+            try dbc.execute(sql: """
+                INSERT INTO panel_history (panelID, tabID, history, updatedAt)
+                VALUES (?, ?, '[]', ?)
+                """, arguments: [UUID().uuidString, tabID, now])
+            try dbc.execute(sql: """
+                INSERT INTO panel_operation_receipt
+                    (operationID, worktreeID, tabID, revision, result, appliedAt)
+                VALUES (?, ?, ?, 0, '{}', ?)
+                """, arguments: [UUID().uuidString, wt.id.uuidString, tabID, now])
+        }
+
+        try await db.worktrees.delete(id: wt.id)
+
+        try await db.writerForTests.read { dbc in
+            let surfaces = try Int.fetchOne(dbc,
+                sql: "SELECT COUNT(*) FROM workspace_tab_surface WHERE worktreeID = ?",
+                arguments: [wt.id.uuidString])
+            let history = try Int.fetchOne(dbc,
+                sql: "SELECT COUNT(*) FROM panel_history WHERE tabID = ?",
+                arguments: [tabID])
+            let receipts = try Int.fetchOne(dbc,
+                sql: "SELECT COUNT(*) FROM panel_operation_receipt WHERE worktreeID = ?",
+                arguments: [wt.id.uuidString])
+            #expect(surfaces == 0)
+            #expect(history == 0)
+            #expect(receipts == 0)
+        }
+    }
+
+    /// Seeds a pre-v56 DB (migrated only through v55) with a real repo/worktree
+    /// row, then applies v56 and confirms the existing row survives untouched
+    /// and the new columns/tables show up alongside it — no data loss on
+    /// forward migration.
+    @Test func forwardMigrationFromPreV56DBPreservesExistingData() throws {
+        let queue = try DatabaseQueue()
+        let migrator = TBDDatabase.buildMigratorForTests()
+        try migrator.migrate(queue, upTo: "v55_oauth_usage_snapshot_cache")
+
+        let repoID = "33333333-3333-3333-3333-333333333333"
+        let wtID = "44444444-4444-4444-4444-444444444444"
+        try queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO repo (id, path, displayName, defaultBranch, createdAt)
+                VALUES (?, '/tmp/v56-pre-repo', 'V56', 'main', ?)
+                """, arguments: [repoID, Date()])
+            try db.execute(sql: """
+                INSERT INTO worktree (id, repoID, name, displayName, branch, path, status, createdAt, tmuxServer)
+                VALUES (?, ?, 'w', 'w', 'main', '/tmp/v56-pre-wt', 'active', ?, 'tbd-v56')
+                """, arguments: [wtID, repoID, Date()])
+        }
+
+        try migrator.migrate(queue)
+
+        try queue.read { db in
+            let count = try Int.fetchOne(
+                db, sql: "SELECT COUNT(*) FROM worktree WHERE id = ?", arguments: [wtID]) ?? -1
+            #expect(count == 1, "pre-existing worktree row must survive v56")
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM worktree WHERE id = ?", arguments: [wtID])
+            #expect(row?["panel_surface_imported_at"] == nil)
+            #expect(try db.tableExists("workspace_tab_surface"))
+            #expect(try db.tableExists("panel_history"))
+            #expect(try db.tableExists("panel_operation_receipt"))
+            let configCols = try Row.fetchAll(db, sql: "PRAGMA table_info(config)")
+                .compactMap { $0["name"] as String? }
+            #expect(configCols.contains("daemon_panel_surface_enabled"))
+            #expect(configCols.contains("agent_panel_control_enabled"))
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/PanelSurfaceMigrationTests.swift
+++ b/Tests/TBDDaemonTests/PanelSurfaceMigrationTests.swift
@@ -7,7 +7,7 @@ import TBDShared
 @Suite("PanelSurfaceMigrationTests")
 struct PanelSurfaceMigrationTests {
 
-    @Test func v56CreatesTablesAndFlags() async throws {
+    @Test func v59CreatesTablesAndFlags() async throws {
         let db = try TBDDatabase(inMemory: true)
         let config = try await db.config.get()
         #expect(config.panelSurfaceEnabled == false)
@@ -100,11 +100,11 @@ struct PanelSurfaceMigrationTests {
         }
     }
 
-    /// Seeds a pre-v56 DB (migrated only through v55) with a real repo/worktree
-    /// row, then applies v56 and confirms the existing row survives untouched
+    /// Seeds a pre-v59 DB (migrated only through v55) with a real repo/worktree
+    /// row, then applies the rest (including v59) and confirms the existing row survives untouched
     /// and the new columns/tables show up alongside it — no data loss on
     /// forward migration.
-    @Test func forwardMigrationFromPreV56DBPreservesExistingData() throws {
+    @Test func forwardMigrationFromPreV59DBPreservesExistingData() throws {
         let queue = try DatabaseQueue()
         let migrator = TBDDatabase.buildMigratorForTests()
         try migrator.migrate(queue, upTo: "v55_oauth_usage_snapshot_cache")
@@ -127,7 +127,7 @@ struct PanelSurfaceMigrationTests {
         try queue.read { db in
             let count = try Int.fetchOne(
                 db, sql: "SELECT COUNT(*) FROM worktree WHERE id = ?", arguments: [wtID]) ?? -1
-            #expect(count == 1, "pre-existing worktree row must survive v56")
+            #expect(count == 1, "pre-existing worktree row must survive v59")
             let row = try Row.fetchOne(db, sql: "SELECT * FROM worktree WHERE id = ?", arguments: [wtID])
             #expect(row?["panel_surface_imported_at"] == nil)
             #expect(try db.tableExists("workspace_tab_surface"))

--- a/Tests/TBDDaemonTests/PanelSurfaceStoreTests.swift
+++ b/Tests/TBDDaemonTests/PanelSurfaceStoreTests.swift
@@ -225,4 +225,33 @@ struct PanelSurfaceStoreTests {
             #expect(surfaceCount == 0)
         }
     }
+
+    /// `panel_history.panelID` is a table-wide PK. Committing tab2 with a
+    /// panelID already owned by tab1 must throw (not silently steal tab1's
+    /// row via upsert), and tab1's row must survive untouched.
+    @Test func commitRejectsPanelIDOwnedByAnotherTab() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let sharedPanel = UUID()
+        let content = PanelContent.file(FileReference(path: "/a.txt"))
+
+        let tab1 = makeState(worktreeID: wtID, panelID: sharedPanel, panelContent: content)
+        try await db.panelSurface.commit(state: tab1, position: 0, receipt: nil, now: Date())
+
+        // Tab2 (different tab id) carrying the SAME panelID.
+        let tab2 = makeState(worktreeID: wtID, panelID: sharedPanel, panelContent: content)
+        await #expect(throws: PanelSurfaceStoreError.self) {
+            try await db.panelSurface.commit(state: tab2, position: 1, receipt: nil, now: Date())
+        }
+
+        // Tab1's history row is still owned by tab1 and its surface intact.
+        try await db.writerForTests.read { dbc in
+            let ownerTabID = try String.fetchOne(
+                dbc, sql: "SELECT tabID FROM panel_history WHERE panelID = ?",
+                arguments: [sharedPanel.uuidString])
+            #expect(ownerTabID == tab1.surface.id.uuidString)
+        }
+        // Tab2 never landed.
+        #expect(try await db.panelSurface.state(tabID: tab2.surface.id) == nil)
+    }
 }

--- a/Tests/TBDDaemonTests/PanelSurfaceStoreTests.swift
+++ b/Tests/TBDDaemonTests/PanelSurfaceStoreTests.swift
@@ -1,0 +1,228 @@
+import Testing
+import Foundation
+import GRDB
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("PanelSurfaceStoreTests")
+struct PanelSurfaceStoreTests {
+
+    /// Builds a worktree row (via the real store, so FKs are satisfiable) and
+    /// returns its ID.
+    private func makeWorktree(_ db: TBDDatabase, name: String = "w") async throws -> UUID {
+        let repo = try await db.repos.create(
+            path: "/tmp/pss-\(UUID())", displayName: name, defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: name, branch: "b",
+            path: "/tmp/pss-wt-\(UUID())", tmuxServer: "srv")
+        return wt.id
+    }
+
+    private func makeState(
+        worktreeID: UUID, tabID: UUID = UUID(), panelID: PanelID = UUID(),
+        panelContent: PanelContent = .file(FileReference(path: "/a.txt"))
+    ) -> PanelSurfaceState {
+        let layout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: panelID, content: panelContent))],
+            ratios: [0.5, 0.5]))
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: worktreeID, label: "tab",
+            primary: .terminal(terminalID: UUID()), layout: layout, revision: 1)
+        let history = PanelHistory.seeded(with: panelContent)
+        return PanelSurfaceState(surface: surface, histories: [panelID: history])
+    }
+
+    @Test func commitRoundTripsSurfaceAndHistories() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let state = makeState(worktreeID: wtID)
+
+        try await db.panelSurface.commit(state: state, position: 0, receipt: nil, now: Date())
+
+        let fetched = try await db.panelSurface.state(tabID: state.surface.id)
+        #expect(fetched == state)
+    }
+
+    @Test func positionNilKeepsExistingPositionOrderingUnaffected() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let stateA = makeState(worktreeID: wtID)
+        let stateB = makeState(worktreeID: wtID)
+
+        // A at position 3, B at position 1 — deliberately out of insertion order.
+        try await db.panelSurface.commit(state: stateA, position: 3, receipt: nil, now: Date())
+        try await db.panelSurface.commit(state: stateB, position: 1, receipt: nil, now: Date())
+
+        // Recommit A with position: nil — must keep 3, not reset to 0/default.
+        try await db.panelSurface.commit(state: stateA, position: nil, receipt: nil, now: Date())
+
+        let ordered = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(ordered.map(\.id) == [stateB.surface.id, stateA.surface.id])
+    }
+
+    @Test func historiesFullyReplacedClosedPanelLosesRow() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let tabID = UUID()
+        let panelA = UUID()
+        let panelB = UUID()
+        let layout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [
+                .primary,
+                .panel(PanelSlot(id: panelA, content: .file(FileReference(path: "/a.txt")))),
+                .panel(PanelSlot(id: panelB, content: .file(FileReference(path: "/b.txt")))),
+            ],
+            ratios: [0.34, 0.33, 0.33]))
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: wtID, primary: .terminal(terminalID: UUID()),
+            layout: layout, revision: 1)
+        let bothHistories: [PanelID: PanelHistory] = [
+            panelA: .seeded(with: .file(FileReference(path: "/a.txt"))),
+            panelB: .seeded(with: .file(FileReference(path: "/b.txt"))),
+        ]
+        try await db.panelSurface.commit(
+            state: PanelSurfaceState(surface: surface, histories: bothHistories),
+            position: 0, receipt: nil, now: Date())
+
+        // Panel B closed: second commit's layout/histories omit it entirely.
+        let onlyA = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: panelA, content: .file(FileReference(path: "/a.txt"))))],
+            ratios: [0.5, 0.5]))
+        let narrowedSurface = WorkspaceTabSurface(
+            id: tabID, worktreeID: wtID, primary: .terminal(terminalID: UUID()),
+            layout: onlyA, revision: 2)
+        try await db.panelSurface.commit(
+            state: PanelSurfaceState(
+                surface: narrowedSurface,
+                histories: [panelA: .seeded(with: .file(FileReference(path: "/a.txt")))]),
+            position: nil, receipt: nil, now: Date())
+
+        let fetched = try await db.panelSurface.state(tabID: tabID)
+        #expect(fetched?.histories.keys.sorted() == [panelA].sorted())
+    }
+
+    @Test func historyRecencyOnlyAdvancesChangedPanel() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let tabID = UUID()
+        let panelA = UUID()
+        let panelB = UUID()
+        let layout = PanelLayoutNode.split(SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [
+                .panel(PanelSlot(id: panelA, content: .file(FileReference(path: "/a.txt")))),
+                .panel(PanelSlot(id: panelB, content: .file(FileReference(path: "/b.txt")))),
+            ],
+            ratios: [0.5, 0.5]))
+        let surface = WorkspaceTabSurface(
+            id: tabID, worktreeID: wtID, primary: .terminal(terminalID: UUID()),
+            layout: layout, revision: 1)
+        let now1 = Date(timeIntervalSince1970: 1_700_000_000)
+        let now2 = Date(timeIntervalSince1970: 1_700_000_500)
+
+        try await db.panelSurface.commit(
+            state: PanelSurfaceState(surface: surface, histories: [
+                panelA: .seeded(with: .file(FileReference(path: "/a.txt"))),
+                panelB: .seeded(with: .file(FileReference(path: "/b.txt"))),
+            ]),
+            position: 0, receipt: nil, now: now1)
+
+        // Second commit: only panelA's history value changes.
+        var changedA = PanelHistory.seeded(with: .file(FileReference(path: "/a.txt")))
+        changedA.recordReplacement(
+            outgoing: .file(FileReference(path: "/a.txt")), incoming: .file(FileReference(path: "/a2.txt")))
+        try await db.panelSurface.commit(
+            state: PanelSurfaceState(surface: surface, histories: [
+                panelA: changedA,
+                panelB: .seeded(with: .file(FileReference(path: "/b.txt"))),
+            ]),
+            position: nil, receipt: nil, now: now2)
+
+        let recency = try await db.panelSurface.historyRecency(tabID: tabID)
+        #expect(recency[panelA] == now2)
+        #expect(recency[panelB] == now1)
+    }
+
+    @Test func deleteSurfacesRemovesSurfacesHistoriesAndReceipts() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let stateA = makeState(worktreeID: wtID)
+        let stateB = makeState(worktreeID: wtID)
+        let receipt = PanelOperationReceiptRecord(
+            operationID: UUID().uuidString, worktreeID: wtID.uuidString,
+            tabID: stateA.surface.id.uuidString, revision: 1, result: "{}", appliedAt: Date())
+
+        try await db.panelSurface.commit(state: stateA, position: 0, receipt: receipt, now: Date())
+        try await db.panelSurface.commit(state: stateB, position: 1, receipt: nil, now: Date())
+
+        try await db.panelSurface.deleteSurfaces(worktreeID: wtID)
+
+        let remaining = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(remaining.isEmpty)
+        #expect(try await db.panelSurface.state(tabID: stateA.surface.id) == nil)
+        #expect(try await db.panelSurface.state(tabID: stateB.surface.id) == nil)
+        try await db.writerForTests.read { dbc in
+            let count = try Int.fetchOne(
+                dbc, sql: "SELECT COUNT(*) FROM panel_operation_receipt WHERE worktreeID = ?",
+                arguments: [wtID.uuidString])
+            #expect(count == 0)
+            let historyCount = try Int.fetchOne(
+                dbc, sql: "SELECT COUNT(*) FROM panel_history")
+            #expect(historyCount == 0)
+        }
+    }
+
+    @Test func surfacesOrderedByPosition() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let stateA = makeState(worktreeID: wtID)
+        let stateB = makeState(worktreeID: wtID)
+        let stateC = makeState(worktreeID: wtID)
+
+        try await db.panelSurface.commit(state: stateA, position: 2, receipt: nil, now: Date())
+        try await db.panelSurface.commit(state: stateB, position: 0, receipt: nil, now: Date())
+        try await db.panelSurface.commit(state: stateC, position: 1, receipt: nil, now: Date())
+
+        let ordered = try await db.panelSurface.surfaces(worktreeID: wtID)
+        #expect(ordered.map(\.id) == [stateB.surface.id, stateC.surface.id, stateA.surface.id])
+    }
+
+    /// Atomicity: a receipt whose `worktreeID` doesn't match any real
+    /// `worktree` row violates the FK constraint on `panel_operation_receipt`,
+    /// throwing partway through the single write transaction — AFTER the
+    /// surface row and history row have already been `save`d in the same
+    /// closure. If the transaction weren't atomic, those earlier writes
+    /// would still be visible. They must not be: everything rolls back.
+    @Test func commitRollsBackEntirelyWhenReceiptWriteFails() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let wtID = try await makeWorktree(db)
+        let state = makeState(worktreeID: wtID)
+        let danglingReceipt = PanelOperationReceiptRecord(
+            operationID: UUID().uuidString,
+            worktreeID: UUID().uuidString,  // no such worktree row — FK violation
+            tabID: state.surface.id.uuidString, revision: 1, result: "{}", appliedAt: Date())
+
+        await #expect(throws: (any Error).self) {
+            try await db.panelSurface.commit(
+                state: state, position: 0, receipt: danglingReceipt, now: Date())
+        }
+
+        // Nothing from this call must be visible: surface AND its history
+        // row, both written earlier in the same transaction, must be gone.
+        let fetched = try await db.panelSurface.state(tabID: state.surface.id)
+        #expect(fetched == nil)
+        try await db.writerForTests.read { dbc in
+            let historyCount = try Int.fetchOne(
+                dbc, sql: "SELECT COUNT(*) FROM panel_history WHERE tabID = ?",
+                arguments: [state.surface.id.uuidString])
+            #expect(historyCount == 0)
+            let surfaceCount = try Int.fetchOne(
+                dbc, sql: "SELECT COUNT(*) FROM workspace_tab_surface WHERE id = ?",
+                arguments: [state.surface.id.uuidString])
+            #expect(surfaceCount == 0)
+        }
+    }
+}

--- a/Tests/TBDSharedTests/LegacySurfaceImporterFixtureTests.swift
+++ b/Tests/TBDSharedTests/LegacySurfaceImporterFixtureTests.swift
@@ -1,0 +1,367 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// Spec C §13 migration fixtures + Task 4's multi-tab orchestration:
+/// terminal-leaf promotion to new primary-terminal tabs, cross-tab ordering,
+/// and cross-tab pane-ID dedup. Task 3 (`LegacySurfaceImporterTests`) covers
+/// the single-tab conversion core; this file exercises the layer built on
+/// top of it.
+@Suite("LegacySurfaceImporter fixtures (spec C §13)")
+struct LegacySurfaceImporterFixtureTests {
+    private let worktreeID = UUID()
+
+    private func file(_ p: String) -> PanelContent { .file(FileReference(path: p)) }
+
+    private func convert(
+        _ tabs: [LegacyTabPayload], tabOrder: [UUID]? = nil,
+        paneHistories: [UUID: MRUHistory<PaneContent>] = [:],
+        makeID: @escaping () -> UUID = { UUID() }
+    ) -> LegacySurfaceImporter.Conversion {
+        LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: tabs, tabOrder: tabOrder ?? tabs.map(\.tabID),
+            paneHistories: paneHistories, makeID: makeID)
+    }
+
+    // MARK: - One terminal only
+
+    @Test func oneTerminalOnlyTab_singleConvertedTab_noPromotion() {
+        let termID = UUID()
+        let tab = LegacyTabPayload(
+            tabID: UUID(), label: "shell", content: .terminal(terminalID: termID), layout: nil)
+
+        let result = convert([tab])
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.surfaces.count == 1)
+        #expect(result.surfaces[0].primary == .terminal(terminalID: termID))
+        #expect(result.surfaces[0].layout == .primary)
+        #expect(result.promotedTerminalTabs == 0)
+    }
+
+    // MARK: - Terminal + viewer
+
+    @Test func terminalPlusViewer_convertedTab_viewerSurvivesAsPanel_noPromotion() {
+        let termID = UUID()
+        let viewerID = UUID()
+        let splitID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [.pane(.terminal(terminalID: termID)), .pane(.codeViewer(id: viewerID, path: "/x"))],
+            ratios: [0.7, 0.3])
+        let tab = LegacyTabPayload(tabID: UUID(), label: nil, content: .terminal(terminalID: termID), layout: layout)
+
+        let result = convert([tab])
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.promotedTerminalTabs == 0)
+        #expect(result.surfaces.count == 1)
+        guard case .split(let split) = result.surfaces[0].layout else {
+            Issue.record("expected split"); return
+        }
+        #expect(split.children[0] == .primary)
+        #expect(split.children[1] == .panel(PanelSlot(id: viewerID, content: file("/x"))))
+    }
+
+    // MARK: - Nested mixed viewer splits, 3-deep, ratio preservation
+
+    @Test func nestedMixedViewerSplits_threeDeep_ratiosPreservedAtEveryLevel() {
+        let mainTerm = UUID()
+        let viewerA = UUID()
+        let viewerB = UUID()
+        let viewerC = UUID()
+        let outerID = UUID()
+        let innerID = UUID()
+        let inner2ID = UUID()
+        let tree = LayoutNode.split(
+            id: outerID, direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: mainTerm)),
+                .split(
+                    id: innerID, direction: .vertical,
+                    children: [
+                        .pane(.codeViewer(id: viewerA, path: "/a")),
+                        .split(
+                            id: inner2ID, direction: .horizontal,
+                            children: [
+                                .pane(.codeViewer(id: viewerB, path: "/b")),
+                                .pane(.codeViewer(id: viewerC, path: "/c")),
+                            ],
+                            ratios: [0.3, 0.7]),
+                    ],
+                    ratios: [0.5, 0.5]),
+            ],
+            ratios: [0.4, 0.6])
+        let tab = LegacyTabPayload(tabID: UUID(), label: nil, content: .terminal(terminalID: mainTerm), layout: tree)
+
+        let result = convert([tab])
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.promotedTerminalTabs == 0, "no extra terminal leaves in this tree")
+
+        guard case .split(let outer) = result.surfaces[0].layout, outer.id == outerID else {
+            Issue.record("expected outer split"); return
+        }
+        #expect(outer.ratios == [0.4, 0.6])
+        #expect(outer.children[0] == .primary)
+        guard case .split(let inner) = outer.children[1], inner.id == innerID else {
+            Issue.record("expected inner split"); return
+        }
+        #expect(inner.ratios == [0.5, 0.5])
+        #expect(inner.children[0] == .panel(PanelSlot(id: viewerA, content: file("/a"))))
+        guard case .split(let inner2) = inner.children[1], inner2.id == inner2ID else {
+            Issue.record("expected inner2 split"); return
+        }
+        #expect(inner2.ratios == [0.3, 0.7])
+        #expect(inner2.children[0] == .panel(PanelSlot(id: viewerB, content: file("/b"))))
+        #expect(inner2.children[1] == .panel(PanelSlot(id: viewerC, content: file("/c"))))
+    }
+
+    // MARK: - Multiple terminal leaves: promotion count, ordering, no loss
+
+    @Test func multipleTerminalLeaves_promotionCountOrderingAndNoTerminalLost() {
+        let mainTerm = UUID()
+        let extra1 = UUID()
+        let extra2 = UUID()
+        let viewerID = UUID()
+        let outerID = UUID()
+        let innerID = UUID()
+        let treeA = LayoutNode.split(
+            id: outerID, direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: mainTerm)),
+                .split(
+                    id: innerID, direction: .vertical,
+                    children: [.pane(.terminal(terminalID: extra1)), .pane(.codeViewer(id: viewerID, path: "/v"))],
+                    ratios: [0.5, 0.5]),
+                .pane(.terminal(terminalID: extra2)),
+            ],
+            ratios: [1.0 / 3, 1.0 / 3, 1.0 / 3])
+        let tabA = LegacyTabPayload(tabID: UUID(), label: nil, content: .terminal(terminalID: mainTerm), layout: treeA)
+
+        let termB = UUID()
+        let tabB = LegacyTabPayload(tabID: UUID(), label: nil, content: .terminal(terminalID: termB), layout: nil)
+
+        let result = convert([tabA, tabB], tabOrder: [tabA.tabID, tabB.tabID])
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.promotedTerminalTabs == 2)
+        #expect(result.surfaces.count == 4, "tabA, 2 promoted, tabB")
+
+        // Ordering: [tabA, promoted1, promoted2, tabB] — promoted tabs
+        // spliced immediately after their source, in tree traversal order.
+        #expect(result.surfaces[0].id == tabA.tabID)
+        #expect(result.surfaces[1].primary == .terminal(terminalID: extra1))
+        #expect(result.surfaces[1].layout == .primary)
+        #expect(result.surfaces[2].primary == .terminal(terminalID: extra2))
+        #expect(result.surfaces[2].layout == .primary)
+        #expect(result.surfaces[3].id == tabB.tabID)
+
+        // No terminal lost: union of primary terminal IDs across every
+        // output surface equals every terminal leaf across both input trees.
+        let expectedTerminals: Set<UUID> = [mainTerm, extra1, extra2, termB]
+        let survivingTerminals = Set(result.surfaces.compactMap { surface -> UUID? in
+            guard case .terminal(let id) = surface.primary else { return nil }
+            return id
+        })
+        #expect(survivingTerminals == expectedTerminals)
+    }
+
+    // MARK: - Note primary, with a secondary viewer panel
+
+    @Test func notePrimaryWithViewerPanel_notePreservedAsPrimaryNotPanel() {
+        let noteID = UUID()
+        let viewerID = UUID()
+        let splitID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [.pane(.note(noteID: noteID)), .pane(.codeViewer(id: viewerID, path: "/y"))],
+            ratios: [0.5, 0.5])
+        let tab = LegacyTabPayload(tabID: UUID(), label: nil, content: .note(noteID: noteID), layout: layout)
+
+        let result = convert([tab])
+
+        #expect(result.skipped.isEmpty)
+        let surface = result.surfaces[0]
+        #expect(surface.primary == .note(noteID: noteID), "note primary preserved by value, not re-minted")
+        guard case .split(let split) = surface.layout else { Issue.record("expected split"); return }
+        #expect(split.children[0] == .primary, "note-as-primary is a marker, never a panel slot")
+        #expect(split.children[1] == .panel(PanelSlot(id: viewerID, content: file("/y"))))
+        #expect(result.histories[noteID] == nil, "primary note never gets a panel history entry")
+    }
+
+    // MARK: - Viewer only
+
+    @Test func viewerOnlyTab_singleConvertedTab_primaryIsFile() {
+        let viewerID = UUID()
+        let tab = LegacyTabPayload(tabID: UUID(), label: nil, content: .codeViewer(id: viewerID, path: "/x"), layout: nil)
+
+        let result = convert([tab])
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.surfaces[0].layout == .primary)
+        #expect(result.surfaces[0].primary == .file(FileReference(path: "/x")))
+        #expect(result.promotedTerminalTabs == 0)
+    }
+
+    // MARK: - Transcript panes referencing primary AND promoted terminals
+
+    @Test func transcriptPanels_referencingPrimaryAndPromotedTerminal_bothSurvive() {
+        let mainTerm = UUID()
+        let extraTerm = UUID()
+        let transcriptOfMain = UUID()
+        let transcriptOfExtra = UUID()
+        let splitID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: mainTerm)),
+                .pane(.terminal(terminalID: extraTerm)),
+                .pane(.liveTranscript(id: transcriptOfMain, terminalID: mainTerm)),
+                .pane(.liveTranscript(id: transcriptOfExtra, terminalID: extraTerm)),
+            ],
+            ratios: [0.25, 0.25, 0.25, 0.25])
+        let tab = LegacyTabPayload(tabID: UUID(), label: nil, content: .terminal(terminalID: mainTerm), layout: layout)
+
+        let result = convert([tab])
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.promotedTerminalTabs == 1)
+        #expect(result.surfaces.count == 2)
+
+        guard case .split(let split) = result.surfaces[0].layout else { Issue.record("expected split"); return }
+        #expect(split.children.contains(.primary))
+        #expect(split.children.contains(.panel(PanelSlot(id: transcriptOfMain, content: .transcript(terminalID: mainTerm)))))
+        #expect(split.children.contains(.panel(PanelSlot(id: transcriptOfExtra, content: .transcript(terminalID: extraTerm)))))
+
+        #expect(result.surfaces[1].primary == .terminal(terminalID: extraTerm))
+    }
+
+    // MARK: - Malformed ratios still convert (multi-tab batch context)
+
+    @Test func malformedRatios_inBatch_fallsBackToEqualSharesAndStillConverts() {
+        let termID = UUID()
+        let viewerID = UUID()
+        let splitID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [.pane(.terminal(terminalID: termID)), .pane(.codeViewer(id: viewerID, path: "/a"))],
+            ratios: [0.9, 0.9])
+        let tab = LegacyTabPayload(tabID: UUID(), label: nil, content: .terminal(terminalID: termID), layout: layout)
+
+        let result = convert([tab])
+
+        #expect(result.skipped.isEmpty)
+        guard case .split(let split) = result.surfaces[0].layout else { Issue.record("expected split"); return }
+        #expect(split.ratios == [0.5, 0.5])
+    }
+
+    // MARK: - Label / order preservation
+
+    @Test func labelOrderPreservation_tabOrderRespected_unknownIgnored_missingAppendedInPayloadOrder() {
+        let tabA = LegacyTabPayload(tabID: UUID(), label: "Shell A", content: .terminal(terminalID: UUID()), layout: nil)
+        let tabB = LegacyTabPayload(tabID: UUID(), label: "Shell B", content: .terminal(terminalID: UUID()), layout: nil)
+        let tabC = LegacyTabPayload(tabID: UUID(), label: "Shell C", content: .terminal(terminalID: UUID()), layout: nil)
+        let unknownID = UUID()
+
+        // tabB deliberately omitted from tabOrder; unknownID is in tabOrder
+        // but has no matching payload.
+        let result = convert([tabA, tabB, tabC], tabOrder: [tabC.tabID, unknownID, tabA.tabID])
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.promotedTerminalTabs == 0)
+        #expect(result.surfaces.map(\.id) == [tabC.tabID, tabA.tabID, tabB.tabID],
+                "tabOrder sequence first (unknown ignored), stragglers appended in payload order")
+        #expect(result.surfaces.map(\.label) == ["Shell C", "Shell A", "Shell B"], "labels flow through")
+    }
+
+    // MARK: - Empty layout worktree
+
+    @Test func emptyLayoutWorktree_zeroTabs_emptyConversionNoSkips() {
+        let result = convert([], tabOrder: [])
+
+        #expect(result.surfaces.isEmpty)
+        #expect(result.histories.isEmpty)
+        #expect(result.skipped.isEmpty)
+        #expect(result.promotedTerminalTabs == 0)
+    }
+
+    // MARK: - Mandatory terminal preservation (malformed tab among valid ones)
+
+    @Test func terminalPreservation_malformedTabAmongValidOnes_noTerminalDropped() {
+        let termGood = UUID()
+        let tabGood = LegacyTabPayload(tabID: UUID(), label: nil, content: .terminal(terminalID: termGood), layout: nil)
+
+        // Malformed: declared primary (termMalformedPrimary) never appears
+        // as a leaf anywhere in the tree, so Task 3's single-tab converter
+        // never sets `primaryFound` — the tab as a whole fails validation
+        // (0 primaries) and would, pre-Task-4, silently drop every terminal
+        // it contains. All three of its terminal leaves/references must
+        // still survive as their own promoted tabs.
+        let termMalformedPrimary = UUID()
+        let termX = UUID()
+        let termY = UUID()
+        let splitID = UUID()
+        let malformedTree = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [.pane(.terminal(terminalID: termX)), .pane(.terminal(terminalID: termY))],
+            ratios: [0.5, 0.5])
+        let tabMalformed = LegacyTabPayload(
+            tabID: UUID(), label: nil, content: .terminal(terminalID: termMalformedPrimary), layout: malformedTree)
+
+        let result = convert([tabGood, tabMalformed], tabOrder: [tabGood.tabID, tabMalformed.tabID])
+
+        #expect(result.skipped.count == 1, "the malformed tab itself is skipped")
+        #expect(result.promotedTerminalTabs == 3, "all 3 of the malformed tab's terminals are promoted")
+
+        let survivingTerminals = Set(result.surfaces.compactMap { surface -> UUID? in
+            guard case .terminal(let id) = surface.primary else { return nil }
+            return id
+        })
+        #expect(survivingTerminals == [termGood, termMalformedPrimary, termX, termY],
+                "every input terminal ID survives as some output tab's primary — none dropped")
+        #expect(result.surfaces.count == 4, "1 converted (tabGood) + 3 promoted; the malformed tab's own surface never lands")
+    }
+
+    // MARK: - Cross-tab duplicate legacy pane ID (corrupt blob)
+
+    @Test func crossTabDuplicatePaneID_secondOccurrenceMintsFreshPanelID() {
+        let sharedID = UUID()
+        let termA = UUID()
+        let termB = UUID()
+        let tabA = LegacyTabPayload(
+            tabID: UUID(), label: nil, content: .terminal(terminalID: termA),
+            layout: .split(
+                id: UUID(), direction: .horizontal,
+                children: [.pane(.terminal(terminalID: termA)), .pane(.codeViewer(id: sharedID, path: "/a"))],
+                ratios: [0.5, 0.5]))
+        let tabB = LegacyTabPayload(
+            tabID: UUID(), label: nil, content: .terminal(terminalID: termB),
+            layout: .split(
+                id: UUID(), direction: .horizontal,
+                children: [.pane(.terminal(terminalID: termB)), .pane(.codeViewer(id: sharedID, path: "/b"))],
+                ratios: [0.5, 0.5]))
+
+        let result = convert([tabA, tabB])
+
+        #expect(result.skipped.isEmpty, "cross-tab duplicates are fine — only per-tab duplicates are validator errors")
+        #expect(result.surfaces.count == 2)
+
+        guard case .split(let splitA) = result.surfaces[0].layout,
+              case .panel(let slotA) = splitA.children[1] else {
+            Issue.record("expected tabA split+panel"); return
+        }
+        #expect(slotA.id == sharedID, "first occurrence keeps the original legacy pane ID")
+
+        guard case .split(let splitB) = result.surfaces[1].layout,
+              case .panel(let slotB) = splitB.children[1] else {
+            Issue.record("expected tabB split+panel"); return
+        }
+        #expect(slotB.id != sharedID, "second occurrence mints a fresh panel ID — avoids clobbering tabA's history entry")
+        #expect(slotB.content == file("/b"))
+
+        #expect(result.histories[sharedID] != nil)
+        #expect(result.histories[slotB.id] != nil)
+        #expect(result.histories.count == 2, "no history collision/clobber across tabs")
+    }
+}

--- a/Tests/TBDSharedTests/LegacySurfaceImporterTests.swift
+++ b/Tests/TBDSharedTests/LegacySurfaceImporterTests.swift
@@ -1,0 +1,304 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("LegacySurfaceImporter")
+struct LegacySurfaceImporterTests {
+    private let worktreeID = UUID()
+
+    private func file(_ p: String) -> PanelContent { .file(FileReference(path: p)) }
+
+    private func convertOne(
+        _ payload: LegacyTabPayload,
+        paneHistories: [UUID: MRUHistory<PaneContent>] = [:],
+        makeID: @escaping () -> UUID = { UUID() }
+    ) -> LegacySurfaceImporter.Conversion {
+        LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: [payload], tabOrder: [payload.tabID],
+            paneHistories: paneHistories, makeID: makeID)
+    }
+
+    // MARK: - Terminal-only tab
+
+    @Test func terminalOnlyTab_layoutNilBecomesPrimary_noPanelsNoHistory() {
+        let termID = UUID()
+        let tabID = UUID()
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: termID), layout: nil)
+
+        let result = convertOne(payload)
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.surfaces.count == 1)
+        let surface = result.surfaces[0]
+        #expect(surface.layout == .primary)
+        #expect(surface.primary == .terminal(terminalID: termID))
+        #expect(result.histories.isEmpty)
+        #expect(result.promotedTerminalTabs == 0)
+    }
+
+    // MARK: - Terminal + codeViewer split
+
+    @Test func terminalPlusViewerSplit_primaryReplacesTerminal_viewerKeepsID() {
+        let termID = UUID()
+        let viewerID = UUID()
+        let splitID = UUID()
+        let tabID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [.pane(.terminal(terminalID: termID)), .pane(.codeViewer(id: viewerID, path: "/a"))],
+            ratios: [0.6, 0.4])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: termID), layout: layout)
+        let legacyHistory = MRUHistory<PaneContent>.seeded(with: .codeViewer(id: viewerID, path: "/a"))
+
+        let result = convertOne(payload, paneHistories: [viewerID: legacyHistory])
+
+        #expect(result.skipped.isEmpty)
+        let surface = result.surfaces[0]
+        guard case .split(let split) = surface.layout else {
+            Issue.record("expected split"); return
+        }
+        #expect(split.id == splitID, "split ID reused")
+        #expect(split.direction == .horizontal)
+        #expect(split.children[0] == .primary)
+        #expect(split.children[1] == .panel(PanelSlot(id: viewerID, content: file("/a"))), "viewer keeps paneID")
+        #expect(split.ratios == [0.6, 0.4], "ratios preserved")
+        #expect(result.histories[viewerID]?.entries == [file("/a")], "history carried with same key")
+        #expect(result.promotedTerminalTabs == 0)
+    }
+
+    // MARK: - Note-leaf tab
+
+    @Test func noteLeafTab_freshPanelID_historyRekeyedToFreshID() {
+        let termID = UUID()
+        let noteID = UUID()
+        let splitID = UUID()
+        let tabID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .vertical,
+            children: [.pane(.terminal(terminalID: termID)), .pane(.note(noteID: noteID))],
+            ratios: [0.5, 0.5])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: termID), layout: layout)
+        let legacyHistory = MRUHistory<PaneContent>.seeded(with: .note(noteID: noteID))
+        let mintedID = UUID()
+
+        let result = convertOne(payload, paneHistories: [noteID: legacyHistory], makeID: { mintedID })
+
+        #expect(result.skipped.isEmpty)
+        let surface = result.surfaces[0]
+        guard case .split(let split) = surface.layout,
+              case .panel(let slot) = split.children[1] else {
+            Issue.record("expected split with panel"); return
+        }
+        #expect(slot.id == mintedID)
+        #expect(slot.id != noteID, "note pane ID is a resource ID, not slot identity")
+        #expect(slot.content == .note(noteID: noteID))
+        #expect(result.histories[mintedID]?.entries == [.note(noteID: noteID)], "re-keyed to fresh ID")
+        #expect(result.histories[noteID] == nil, "no leftover entry under the old key")
+    }
+
+    // MARK: - Viewer-only tab (primary IS a viewer)
+
+    @Test func viewerOnlyTab_primaryIsFile_layoutIsPrimaryWhenTreeIsSinglePane() {
+        let viewerID = UUID()
+        let tabID = UUID()
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .codeViewer(id: viewerID, path: "/x"), layout: nil)
+
+        let result = convertOne(payload)
+
+        #expect(result.skipped.isEmpty)
+        let surface = result.surfaces[0]
+        #expect(surface.layout == .primary)
+        #expect(surface.primary == .file(FileReference(path: "/x")))
+        #expect(result.histories.isEmpty, "primary leaf never becomes a panel slot")
+    }
+
+    // MARK: - Malformed ratios
+
+    @Test func malformedRatios_repeatedNonNormalizedValues_fallBackToEqualShares() {
+        let termID = UUID()
+        let viewerA = UUID()
+        let viewerB = UUID()
+        let splitID = UUID()
+        let tabID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: termID)),
+                .pane(.codeViewer(id: viewerA, path: "/a")),
+                .pane(.codeViewer(id: viewerB, path: "/b")),
+            ],
+            ratios: [0.9, 0.9, 0.9])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: termID), layout: layout)
+
+        let result = convertOne(payload)
+
+        #expect(result.skipped.isEmpty)
+        guard case .split(let split) = result.surfaces[0].layout else {
+            Issue.record("expected split"); return
+        }
+        #expect(split.ratios == [1.0 / 3, 1.0 / 3, 1.0 / 3])
+    }
+
+    @Test func malformedRatios_nonFiniteValue_fallsBackToEqualShares() {
+        let termID = UUID()
+        let viewerID = UUID()
+        let splitID = UUID()
+        let tabID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [.pane(.terminal(terminalID: termID)), .pane(.codeViewer(id: viewerID, path: "/a"))],
+            ratios: [CGFloat.nan, 1])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: termID), layout: layout)
+
+        let result = convertOne(payload)
+
+        #expect(result.skipped.isEmpty)
+        guard case .split(let split) = result.surfaces[0].layout else {
+            Issue.record("expected split"); return
+        }
+        #expect(split.ratios == [0.5, 0.5])
+    }
+
+    @Test func normalizedRatios_directUnit() {
+        #expect(LegacySurfaceImporter.normalizedRatios([0.6, 0.4], count: 2) == [0.6, 0.4])
+        #expect(LegacySurfaceImporter.normalizedRatios([0.9, 0.9, 0.9], count: 3) == [1.0 / 3, 1.0 / 3, 1.0 / 3])
+        #expect(LegacySurfaceImporter.normalizedRatios([.nan, 1], count: 2) == [0.5, 0.5])
+        #expect(LegacySurfaceImporter.normalizedRatios([0.6], count: 2) == [0.5, 0.5], "count mismatch")
+        #expect(LegacySurfaceImporter.normalizedRatios([0.05, 0.95], count: 2) == [0.5, 0.5], "sub-minShare")
+    }
+
+    // MARK: - History with terminal entries
+
+    @Test func historyWithTerminalEntries_droppedAndCursorClamped() {
+        let mainTerm = UUID()
+        let viewerID = UUID()
+        let webID = UUID()
+        let historyTermID = UUID()
+        let splitID = UUID()
+        let tabID = UUID()
+        let webURL = URL(string: "https://example.com")!
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [.pane(.terminal(terminalID: mainTerm)), .pane(.codeViewer(id: viewerID, path: "/a"))],
+            ratios: [0.6, 0.4])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: mainTerm), layout: layout)
+        let legacyHistory = MRUHistory<PaneContent>(
+            entries: [
+                .terminal(terminalID: historyTermID),
+                .codeViewer(id: viewerID, path: "/a"),
+                .webview(id: webID, url: webURL),
+            ],
+            cursor: 1)
+
+        let result = convertOne(payload, paneHistories: [viewerID: legacyHistory])
+
+        #expect(result.skipped.isEmpty)
+        let history = result.histories[viewerID]
+        #expect(history?.entries == [file("/a"), .web(webURL)], "terminal entry dropped")
+        #expect(history?.cursor == 0, "cursor clamped to surviving current entry")
+    }
+
+    @Test func historyWhereCurrentEntryIsTerminal_dropsWholeHistoryAndReseeds() {
+        let mainTerm = UUID()
+        let viewerID = UUID()
+        let splitID = UUID()
+        let tabID = UUID()
+        let layout = LayoutNode.split(
+            id: splitID, direction: .horizontal,
+            children: [.pane(.terminal(terminalID: mainTerm)), .pane(.codeViewer(id: viewerID, path: "/a"))],
+            ratios: [0.6, 0.4])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: mainTerm), layout: layout)
+        let legacyHistory = MRUHistory<PaneContent>(
+            entries: [.terminal(terminalID: UUID()), .codeViewer(id: viewerID, path: "/a")],
+            cursor: 0)
+
+        let result = convertOne(payload, paneHistories: [viewerID: legacyHistory])
+
+        #expect(result.histories[viewerID] == MRUHistory<PanelContent>.seeded(with: file("/a")))
+    }
+
+    // MARK: - Validator-clean assertion + nested split collapse + terminal promotion count
+
+    @Test func nestedSplitCollapsesAndConvertedSurfaceIsValidatorClean() {
+        let mainTerm = UUID()
+        let extraTerm = UUID()
+        let viewerID = UUID()
+        let outerID = UUID()
+        let innerID = UUID()
+        let tabID = UUID()
+        let layout = LayoutNode.split(
+            id: outerID, direction: .horizontal,
+            children: [
+                .pane(.terminal(terminalID: mainTerm)),
+                .split(
+                    id: innerID, direction: .vertical,
+                    children: [.pane(.terminal(terminalID: extraTerm)), .pane(.codeViewer(id: viewerID, path: "/b"))],
+                    ratios: [0.5, 0.5]),
+            ],
+            ratios: [0.5, 0.5])
+        let payload = LegacyTabPayload(
+            tabID: tabID, label: nil, content: .terminal(terminalID: mainTerm), layout: layout)
+
+        let result = convertOne(payload)
+
+        #expect(result.skipped.isEmpty)
+        let surface = result.surfaces[0]
+        guard case .split(let split) = surface.layout else {
+            Issue.record("expected split"); return
+        }
+        #expect(split.id == outerID)
+        #expect(split.children == [.primary, .panel(PanelSlot(id: viewerID, content: file("/b")))],
+                "inner split collapsed to its single surviving child")
+        #expect(result.promotedTerminalTabs == 1, "extraTerm counted for promotion")
+
+        let state = PanelSurfaceState(surface: surface, histories: result.histories)
+        #expect(PanelSurfaceValidator.violations(in: state).isEmpty)
+    }
+
+    @Test func allEmittedSurfacesAreValidatorClean() {
+        let fixtures: [LegacyTabPayload] = [
+            LegacyTabPayload(tabID: UUID(), label: nil, content: .terminal(terminalID: UUID()), layout: nil),
+            LegacyTabPayload(tabID: UUID(), label: nil, content: .codeViewer(id: UUID(), path: "/x"), layout: nil),
+        ]
+        let result = LegacySurfaceImporter.convert(
+            worktreeID: worktreeID, tabs: fixtures, tabOrder: fixtures.map(\.tabID), paneHistories: [:])
+
+        #expect(result.skipped.isEmpty)
+        #expect(result.surfaces.count == fixtures.count)
+        for surface in result.surfaces {
+            let state = PanelSurfaceState(surface: surface, histories: result.histories)
+            #expect(PanelSurfaceValidator.violations(in: state).isEmpty)
+        }
+    }
+
+    // MARK: - Direct helper unit tests
+
+    @Test func panelContent_mapsViewersAndRejectsTerminal() {
+        #expect(LegacySurfaceImporter.panelContent(from: .terminal(terminalID: UUID())) == nil)
+        let path = "/a"
+        #expect(LegacySurfaceImporter.panelContent(from: .codeViewer(id: UUID(), path: path)) == file(path))
+        let url = URL(string: "https://example.com")!
+        #expect(LegacySurfaceImporter.panelContent(from: .webview(id: UUID(), url: url)) == .web(url))
+        let noteID = UUID()
+        #expect(LegacySurfaceImporter.panelContent(from: .note(noteID: noteID)) == .note(noteID: noteID))
+        let terminalID = UUID()
+        #expect(LegacySurfaceImporter.panelContent(from: .liveTranscript(id: UUID(), terminalID: terminalID))
+                == .transcript(terminalID: terminalID))
+    }
+
+    @Test func primaryContent_mapsAllVariantsIncludingTerminal() {
+        let terminalID = UUID()
+        #expect(LegacySurfaceImporter.primaryContent(from: .terminal(terminalID: terminalID))
+                == .terminal(terminalID: terminalID))
+        let noteID = UUID()
+        #expect(LegacySurfaceImporter.primaryContent(from: .note(noteID: noteID)) == .note(noteID: noteID))
+    }
+}

--- a/Tests/TBDSharedTests/LegacySurfaceImporterTests.swift
+++ b/Tests/TBDSharedTests/LegacySurfaceImporterTests.swift
@@ -141,7 +141,11 @@ struct LegacySurfaceImporterTests {
         guard case .split(let split) = result.surfaces[0].layout else {
             Issue.record("expected split"); return
         }
-        #expect(split.ratios == [1.0 / 3, 1.0 / 3, 1.0 / 3])
+        // Hoisted + explicitly typed: an array literal of unresolved literal
+        // divisions inside #expect's macro expansion blows the type-checker's
+        // budget under CI's -j2 ("unable to type-check in reasonable time").
+        let third: Double = 1.0 / 3
+        #expect(split.ratios == [third, third, third])
     }
 
     @Test func malformedRatios_nonFiniteValue_fallsBackToEqualShares() {
@@ -166,8 +170,9 @@ struct LegacySurfaceImporterTests {
     }
 
     @Test func normalizedRatios_directUnit() {
+        let third: Double = 1.0 / 3  // see the hoist note above
         #expect(LegacySurfaceImporter.normalizedRatios([0.6, 0.4], count: 2) == [0.6, 0.4])
-        #expect(LegacySurfaceImporter.normalizedRatios([0.9, 0.9, 0.9], count: 3) == [1.0 / 3, 1.0 / 3, 1.0 / 3])
+        #expect(LegacySurfaceImporter.normalizedRatios([0.9, 0.9, 0.9], count: 3) == [third, third, third])
         #expect(LegacySurfaceImporter.normalizedRatios([.nan, 1], count: 2) == [0.5, 0.5])
         #expect(LegacySurfaceImporter.normalizedRatios([0.6], count: 2) == [0.5, 0.5], "count mismatch")
         #expect(LegacySurfaceImporter.normalizedRatios([0.05, 0.95], count: 2) == [0.5, 0.5], "sub-minShare")

--- a/Tests/TBDSharedTests/PanelSurfaceFiniteGuardTests.swift
+++ b/Tests/TBDSharedTests/PanelSurfaceFiniteGuardTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("PanelSurfaceFiniteGuardTests")
+struct PanelSurfaceFiniteGuardTests {
+    private func surface(ratios: [Double]) -> WorkspaceTabSurface {
+        let split = SplitNode(
+            id: UUID(), direction: .horizontal,
+            children: [.primary, .panel(PanelSlot(id: UUID(), content: .note(noteID: UUID())))],
+            ratios: ratios)
+        return WorkspaceTabSurface(
+            id: UUID(), worktreeID: UUID(), primary: .terminal(terminalID: UUID()),
+            layout: .split(split))
+    }
+
+    @Test func nanRatiosAreAViolation() {
+        let violations = PanelSurfaceValidator.violations(in: surface(ratios: [.nan, .nan]))
+        #expect(violations.contains { if case .ratioSumInvalid = $0 { return true }; return false })
+    }
+
+    @Test func infiniteRatioIsAViolation() {
+        let violations = PanelSurfaceValidator.violations(in: surface(ratios: [.infinity, 0.5]))
+        #expect(violations.contains { if case .ratioSumInvalid = $0 { return true }; return false })
+    }
+
+    @Test func finiteValidRatiosStayClean() {
+        #expect(PanelSurfaceValidator.violations(in: surface(ratios: [0.5, 0.5])).isEmpty)
+    }
+
+    @Test func resizeRejectsNonFiniteRatios() throws {
+        let base = surface(ratios: [0.5, 0.5])
+        guard case .split(let split) = base.layout else { Issue.record("expected split"); return }
+        let state = PanelSurfaceState(surface: base, histories: [:])
+        #expect(throws: PanelOperationError.self) {
+            _ = try PanelSurfaceReducer.apply(.resize(splitID: split.id, ratios: [.nan, 1.0]), to: state)
+        }
+    }
+}

--- a/Tests/TBDSharedTests/PanelSurfaceReducerTests.swift
+++ b/Tests/TBDSharedTests/PanelSurfaceReducerTests.swift
@@ -116,7 +116,10 @@ struct PanelSurfaceReducerOpenTests {
         #expect(split.children == [
             .primary, .panel(panelA), .panel(PanelSlot(id: newID, content: file("/n")))])
         // Exact arithmetic: siblings scaled by (1 - share), new panel gets share.
-        #expect(split.ratios == [0.6 * (1 - 0.3), 0.4 * (1 - 0.3), 0.3])
+        // Hoisted + explicitly typed — literal arithmetic inside an array
+        // literal inside #expect's expansion blows the type-checker's budget.
+        let scale: Double = 1 - 0.3
+        #expect(split.ratios == [0.6 * scale, 0.4 * scale, 0.3])
         #expect(out.histories[newID]?.entries == [file("/n")], "history seeded")
         #expect(PanelSurfaceValidator.violations(in: out).isEmpty)
     }

--- a/Tests/TBDSharedTests/PanelSurfaceWireTests.swift
+++ b/Tests/TBDSharedTests/PanelSurfaceWireTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite("PanelSurfaceWireTests")
+struct PanelSurfaceWireTests {
+    private func roundTrip<T: Codable & Equatable>(_ value: T) throws -> T {
+        try JSONDecoder().decode(T.self, from: JSONEncoder().encode(value))
+    }
+
+    @Test func panelGetRoundTrips() throws {
+        let result = PanelGetResult(
+            tabs: [WorkspaceTabSurface(id: UUID(), worktreeID: UUID(),
+                                       primary: .terminal(terminalID: UUID()), layout: .primary)],
+            activeTabID: UUID())
+        #expect(try roundTrip(result) == result)
+        let params = PanelGetParams(worktreeID: UUID(), tabID: nil)
+        #expect(try roundTrip(params) == params)
+    }
+
+    @Test func panelApplyRoundTrips() throws {
+        let envelope = PanelOperationEnvelope(
+            operationID: UUID(), worktreeID: UUID(), tabID: UUID(),
+            baseRevision: 3, origin: .agentCLI,
+            operation: .open(content: .file(FileReference(path: "docs/a.md")), placement: .automatic))
+        #expect(try roundTrip(PanelApplyParams(envelope: envelope)) == PanelApplyParams(envelope: envelope))
+    }
+
+    @Test func importParamsRoundTripWithLegacyTypes() throws {
+        let slotID = UUID()
+        let params = PanelImportParams(
+            worktreeID: UUID(),
+            tabs: [LegacyTabPayload(
+                tabID: UUID(), label: "claude",
+                content: .terminal(terminalID: UUID()),
+                layout: .split(id: UUID(), direction: .horizontal,
+                               children: [.pane(.terminal(terminalID: UUID())),
+                                          .pane(.codeViewer(id: slotID, path: "a.md"))],
+                               ratios: [0.6, 0.4]))],
+            tabOrder: [], activeTabID: nil,
+            paneHistories: [slotID: .seeded(with: .codeViewer(id: slotID, path: "a.md"))])
+        #expect(try roundTrip(params) == params)
+    }
+
+    @Test func panelSurfaceDeltaRoundTripsThroughStateDelta() throws {
+        let delta = StateDelta.panelSurfaceChanged(PanelSurfaceDelta(
+            worktreeID: UUID(), tabs: [], removedTabIDs: [UUID()],
+            activeTabID: nil, originOperationID: UUID()))
+        let decoded = try JSONDecoder().decode(StateDelta.self, from: JSONEncoder().encode(delta))
+        guard case .panelSurfaceChanged(let payload) = decoded,
+              case .panelSurfaceChanged(let original) = delta else {
+            Issue.record("wrong case"); return
+        }
+        #expect(payload == original)
+    }
+
+    @Test func rpcMethodConstants() {
+        #expect(RPCMethod.panelGet == "panel.get")
+        #expect(RPCMethod.panelApply == "panel.apply")
+        #expect(RPCMethod.panelImportLegacy == "panel.importLegacy")
+    }
+}


### PR DESCRIPTION
## What

Spec C Phase 2 (`docs/specs/2026-07-22-panel-agent-surface-c-primary-anchor-design.md`, now on main). The daemon-owned panel-surface layer:

- v56 schema (`workspace_tab_surface` / `panel_history` / `panel_operation_receipt` with `ON DELETE CASCADE` FKs)
- `PanelSurfaceStore` — atomic single-transaction writes, cross-tab clobber guard, idempotent receipts + bounded prune (100 / 24h)
- `PanelCoordinator` apply pipeline — transactional load→reduce→persist, gating, stale-target rebase, recency `.automatic` rewrite, `selectTab`
- `panel.get` / `panel.apply` / `panel.importLegacy` RPC + `DaemonClient` + capabilities
- `LegacySurfaceImporter` — single+multi-tab conversion with terminal-leaf promotion
- App-side gated one-shot import trigger
- Log-only shadow-compare diagnostic

## INERT — nothing runs until a flag flips

Everything is behind two default-off config flags: `daemon_panel_surface_enabled` gates the whole ownership path, `agent_panel_control_enabled` additionally gates agentCLI-origin mutations. `panel.get` is ungated (read-only). With flags off (default): app sends zero `panel.*` RPCs, coordinator apply/import reject, no always-on daemon path touches the new store/coordinator — verified end-to-end. No app rendering, no CLI mutation commands, no skill text — those are §12 step 6+, out of scope here.

## Two Criticals caught & fixed during the reviewed build

1. **Actor-reentrancy lost update** — the coordinator relied on actor isolation for per-worktree serialization, but isolation didn't span the `await` DB round-trips. Under the production `DatabasePool`/WAL, two concurrent same-tab applies could lose an update and leave a phantom receipt. Fixed by collapsing load→reduce→persist into one pool-serialized write transaction (`PanelSurfaceStore.applyReducing`), proven by a pool-backed concurrency test that fails pre-fix.
2. **Shadow-compare false positives** — it would flag the importer's own legitimate transforms (terminal promotion, note panels) as divergences on every launch, because independently-minted random IDs never matched. Fixed comparator-side: match by stable `terminalID`, normalize away minted slot IDs.

## Merged-code touches (Phase 1 code)

Task 1 added additive `isFinite` guards to the merged reducer/validator (rejects non-finite ratios; finite path unchanged). `MRUHistory` gained an `internal init(entries:cursor:)` re-key seam for the importer. Both additive, no existing behavior changed.

## Decision-record deviation

Import reuses legacy viewer-slot UUIDs as new panel IDs (spec §11.2.3 said "new IDs") so PR #472's `paneHistories` blob carries over without re-keying. Note-leaf IDs are minted fresh.

## Migration

v56 clean append after v55, three-place rule honored in one commit, cascade FKs, defaults false, existing DBs migrate without data loss.

## Soak & graduation

Enable for soak with `UPDATE config SET daemon_panel_surface_enabled = 1` (then the agent flag separately) — deliberately no UI toggle yet. Graduation: dogfood import + shadow-compare, fix any logged divergences, then Phase 3 (app rendering, step 6+). Flags graduate later via forcing `UPDATE` migrations per repo policy.

## Verification

- 3857 tests / 463 suites green (0 failures, clean run)
- `swiftlint --strict` — 0 violations / 580 files
- v56 max confirmed, inertness grep-verified
- Per-task review gates: every task independently reviewed; two Criticals + several Importants fixed and re-reviewed
- Final whole-branch review: "ready to merge" — its one Important (`panel.get` returning nil `activeTabID`) fixed in 811e80eb

## Follow-ups

Tracked minors + the Phase 3 requirement: #483

## Test plan

- [ ] `swift build`
- [ ] `swift test`
- [ ] `swiftlint --strict`
- [ ] Confirm flags default off in a fresh DB and existing DB migrates cleanly to v56
