### PR TITLE
Feat: Keep closed terminals recoverable -- capture + revive, setup auto-close, file-backed notes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -133,6 +133,12 @@ custom_rules:
       # Capture-for-replay: rebuilds a pane's display state verbatim for control-mode
       # attach/repair (replay bytes); never parses captured content for agent state.
       - "Sources/TBDDaemon/Tmux/ControlMode/PaneCaptureReplay\\.swift"
+      # Closed-terminal history: closeHookTerminal snapshots the dying pane's
+      # scrollback verbatim into ~/tbd/terminal-history for later READ-ONLY
+      # display (archival capture-for-display, the sanctioned use). The text is
+      # never parsed, matched, or used to infer agent/TUI state — exactly NOT
+      # the state-inference scraping the rule bans.
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+PreSession\\.swift"
       - "Sources/TBDShared/NightwatchSkillContent\\.swift"               # embedded Python babysitter (see rule above)
     regex: 'capturePane\w*\s*\(|capture-pane'
     match_kinds:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -139,6 +139,11 @@ custom_rules:
       # never parsed, matched, or used to infer agent/TUI state — exactly NOT
       # the state-inference scraping the rule bans.
       - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+PreSession\\.swift"
+      # Same sanctioned archival-capture use: captureThenKillWindow snapshots a
+      # live terminal's scrollback verbatim into terminal-history before the
+      # archive/reconcile-auto-archive paths kill its window (the archived row +
+      # history survive). Never parsed for agent/TUI state.
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\.swift"
       - "Sources/TBDShared/NightwatchSkillContent\\.swift"               # embedded Python babysitter (see rule above)
     regex: 'capturePane\w*\s*\(|capture-pane'
     match_kinds:

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -176,6 +176,25 @@ extension AppState {
         }
     }
 
+    /// Revive a closed terminal from its history entry into a new terminal tab
+    /// and switch focus to it. Claude entries resume their session; other kinds
+    /// open a fresh shell with the captured scrollback above the prompt.
+    func reviveClosedTerminal(_ entry: TerminalHistoryEntry, worktreeID: UUID) async {
+        do {
+            let size = mainAreaTerminalSize()
+            let terminal = try await daemonClient.reviveTerminalHistory(
+                worktreeID: worktreeID, id: entry.id, cols: size.cols, rows: size.rows)
+            terminals[worktreeID, default: []].append(terminal)
+            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
+            tabs[worktreeID, default: []].append(tab)
+            let index = (tabs[worktreeID]?.count ?? 1) - 1
+            setActiveTab(worktreeID: worktreeID, tabIndex: index)
+            historyActiveWorktrees.remove(worktreeID)
+        } catch {
+            handleConnectionError(error)
+        }
+    }
+
     /// Revive an archived worktree and resume the selected Claude session.
     /// Marks the row as `inFlight` immediately so the archived view can show
     /// a status pill, then flips to `.done` once the worktree is usable —

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -95,6 +95,10 @@ extension AppState {
         let current = historyLoadStates[worktreeID]?.currentSessions ?? []
         historyLoadStates[worktreeID] = current.isEmpty ? .loading : .loadingStale(current)
 
+        // Refresh closed-terminal history alongside sessions (metadata only —
+        // failures keep whatever was shown before).
+        await fetchClosedTerminals(worktreeID: worktreeID)
+
         do {
             let fresh = try await daemonClient.listSessions(worktreeID: worktreeID)
             historyLoadStates[worktreeID] = .loaded(fresh)
@@ -108,9 +112,35 @@ extension AppState {
         }
     }
 
+    /// Fetch closed-terminal capture metadata for the Closed Terminals
+    /// section. Best-effort: a failure keeps stale data visible.
+    func fetchClosedTerminals(worktreeID: UUID) async {
+        do {
+            closedTerminalHistories[worktreeID] =
+                try await daemonClient.listTerminalHistory(worktreeID: worktreeID)
+        } catch {
+            logger.warning("fetchClosedTerminals failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
+        }
+    }
+
+    /// Select a closed terminal and load its captured text off the main
+    /// thread (the content file can be ~10k lines). The right-hand pane shows
+    /// it read-only while this selection is set; selecting a session clears it.
+    func selectClosedTerminal(_ entry: TerminalHistoryEntry, worktreeID: UUID) async {
+        selectedClosedTerminalIDs[worktreeID] = entry.id
+        guard closedTerminalContents[entry.id] == nil else { return }
+        let path = TBDConstants.terminalHistoryPath(worktreeID: worktreeID, terminalID: entry.id)
+        let text = await Task.detached(priority: .userInitiated) {
+            (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+        }.value
+        // One-entry cache: drop any previously loaded scrollback.
+        closedTerminalContents = [entry.id: text]
+    }
+
     /// Select a session and load its transcript (stale-while-revalidate: skip if already loaded).
     func selectSession(_ summary: SessionSummary, worktreeID: UUID) async {
         selectedSessionIDs[worktreeID] = summary.sessionId
+        selectedClosedTerminalIDs.removeValue(forKey: worktreeID)
         guard sessionTranscripts[summary.sessionId] == nil else { return }
         sessionTranscriptLoading.insert(summary.sessionId)
         defer { sessionTranscriptLoading.remove(summary.sessionId) }

--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -131,7 +131,10 @@ extension AppState {
         guard closedTerminalContents[entry.id] == nil else { return }
         let path = TBDConstants.terminalHistoryPath(worktreeID: worktreeID, terminalID: entry.id)
         let text = await Task.detached(priority: .userInitiated) {
-            (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+            let raw = (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+            // The raw file keeps ANSI escapes (it's the replay source); the
+            // read-only viewer can't render them, so strip for display.
+            return ANSIEscape.strip(raw)
         }.value
         // One-entry cache: drop any previously loaded scrollback.
         closedTerminalContents = [entry.id: text]

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -291,6 +291,19 @@ extension AppState {
         }
     }
 
+    /// Persist the auto-close-setup-tab soak flag, then re-fetch capabilities
+    /// so the Settings toggle reflects the daemon's persisted state. Applies
+    /// to the next worktree creation.
+    func setAutoCloseSetupEnabled(_ enabled: Bool) async {
+        do {
+            try await autoCloseSetupSetter(enabled)
+            await refreshDaemonCapabilities()
+        } catch {
+            logger.error("Failed to set auto-close setup: \(error, privacy: .public)")
+            showAlert("Failed to set auto-close setup: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Set or clear a per-repo model profile override.
     func setRepoProfileOverride(repoID: UUID, profileID: UUID?) async {
         do {

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -147,6 +147,16 @@ extension AppState {
               arr.indices.contains(index) else { return }
 
         let tab = arr[index]
+
+        // Closing a note tab hard-deletes the note row. Confirm first when
+        // the note has content; an empty note closes silently as before.
+        if case .note(let noteID) = tab.content,
+           let note = notes[worktreeID]?.first(where: { $0.id == noteID }),
+           !note.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           !noteCloseConfirmer(note) {
+            return
+        }
+
         let layout = layouts[tab.id] ?? .pane(tab.content)
         let terminalIDsInTab = Set(layout.allTerminalIDs())
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -510,6 +510,12 @@ final class AppState: ObservableObject {
     @Published var selectedSessionIDs: [UUID: String] = [:]       // worktreeID → sessionId
     @Published var sessionTranscripts: [String: [TranscriptItem]] = [:]  // sessionId → items
     @Published var sessionTranscriptLoading: Set<String> = []
+    // Closed-terminal history (Session History → Closed Terminals).
+    @Published var closedTerminalHistories: [UUID: [TerminalHistoryEntry]] = [:]  // worktreeID → entries
+    @Published var selectedClosedTerminalIDs: [UUID: UUID] = [:]                  // worktreeID → entry id
+    /// Captured text of the currently selected closed terminal only —
+    /// deliberately a one-entry cache so large scrollbacks never accumulate.
+    @Published var closedTerminalContents: [UUID: String] = [:]                   // entry id → text
 
     /// Raw most-recent-first log of recently-visited worktrees, the recency
     /// input to the keep-alive policy. Bounded by `touchVisitedWorktree`, which

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -674,6 +674,10 @@ final class AppState: ObservableObject {
     /// the same reason as `controlModeSetter`.
     lazy var hibernateInputVetoSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setHibernateInputVeto(enabled: enabled) }
+    /// How `setAutoCloseSetupEnabled` persists the flag — injectable for the
+    /// same reason as `controlModeSetter`.
+    lazy var autoCloseSetupSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in try await daemonClient.setAutoCloseSetup(enabled: enabled) }
 
     /// Best-effort re-fetch of `daemonCapabilities` (R7-minor). Used by the
     /// `.modelProfilesChanged` delta handler so a control-mode toggle from

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -678,6 +678,23 @@ final class AppState: ObservableObject {
     /// same reason as `controlModeSetter`.
     lazy var autoCloseSetupSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setAutoCloseSetup(enabled: enabled) }
+    /// Asks the user to confirm closing a note tab whose note has content —
+    /// closing a note tab hard-deletes the note row (`closeTab` →
+    /// `deleteNote`). Injectable so tests can exercise both branches without
+    /// a real modal NSAlert.
+    lazy var noteCloseConfirmer: @MainActor (Note) -> Bool = { note in
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Delete note \u{201C}\(note.title)\u{201D}?"
+        alert.informativeText = "Closing this tab permanently deletes the note and its contents."
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+        // HIG: destructive action shouldn't be the Return-key default (same
+        // pattern as LegacyHooksCoordinator's migrate dialog).
+        alert.buttons[0].keyEquivalent = ""
+        alert.buttons[1].keyEquivalent = "\r"
+        return alert.runModal() == .alertFirstButtonReturn
+    }
 
     /// Best-effort re-fetch of `daemonCapabilities` (R7-minor). Used by the
     /// `.modelProfilesChanged` delta handler so a control-mode toggle from

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -683,11 +683,13 @@ final class AppState: ObservableObject {
     /// `deleteNote`). Injectable so tests can exercise both branches without
     /// a real modal NSAlert.
     lazy var noteCloseConfirmer: @MainActor (Note) -> Bool = { note in
+        let filePath = TBDConstants.noteContentPath(worktreeID: note.worktreeID, noteID: note.id)
+            .replacingOccurrences(of: NSHomeDirectory(), with: "~")
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = "Delete note \u{201C}\(note.title)\u{201D}?"
-        alert.informativeText = "Closing this tab permanently deletes the note and its contents."
-        alert.addButton(withTitle: "Delete")
+        alert.messageText = "Close note \u{201C}\(note.title)\u{201D}?"
+        alert.informativeText = "Closing this tab removes the note from TBD. Its contents are kept on disk at \(filePath)."
+        alert.addButton(withTitle: "Close Note")
         alert.addButton(withTitle: "Cancel")
         // HIG: destructive action shouldn't be the Return-key default (same
         // pattern as LegacyHooksCoordinator's migrate dialog).

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1241,6 +1241,17 @@ actor DaemonClient {
         )
     }
 
+    /// List closed-terminal capture metadata for a worktree (newest first).
+    /// Captured content is read directly from the file at
+    /// `TBDConstants.terminalHistoryPath` — not fetched over RPC.
+    func listTerminalHistory(worktreeID: UUID) async throws -> [TerminalHistoryEntry] {
+        return try await callAsync(
+            method: RPCMethod.terminalHistoryList,
+            params: TerminalHistoryListParams(worktreeID: worktreeID),
+            resultType: [TerminalHistoryEntry].self
+        )
+    }
+
     // MARK: - Model Profiles
     //
     // IMPORTANT: never log raw secret bytes. The `addModelProfile` wrapper is

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -872,6 +872,15 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the auto-close-setup-tab soak flag (default OFF). Applies to
+    /// the next worktree creation.
+    func setAutoCloseSetup(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetAutoCloseSetup,
+            params: ConfigSetAutoCloseSetupParams(enabled: enabled)
+        )
+    }
+
     /// Set or clear a repo's free-form env overrides.
     func setRepoEnvOverrides(repoID: UUID, overrides: [String: String]) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1252,6 +1252,16 @@ actor DaemonClient {
         )
     }
 
+    /// Revive a closed terminal from its history entry into a new terminal in
+    /// the same worktree. Returns the created terminal.
+    func reviveTerminalHistory(worktreeID: UUID, id: UUID, cols: Int? = nil, rows: Int? = nil) async throws -> Terminal {
+        return try await callAsync(
+            method: RPCMethod.terminalHistoryRevive,
+            params: TerminalHistoryReviveParams(worktreeID: worktreeID, id: id, cols: cols, rows: rows),
+            resultType: Terminal.self
+        )
+    }
+
     // MARK: - Model Profiles
     //
     // IMPORTANT: never log raw secret bytes. The `addModelProfile` wrapper is

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -124,9 +124,7 @@ struct HistoryPaneView: View {
                 if !closedTerminals.isEmpty {
                     Section("Closed Terminals") {
                         ForEach(closedTerminals) { entry in
-                            ClosedTerminalRowView(entry: entry) {
-                                Task { await appState.reviveClosedTerminal(entry, worktreeID: worktreeID) }
-                            }
+                            ClosedTerminalRowView(entry: entry)
                                 .contentShape(Rectangle())
                                 .onTapGesture {
                                     Task { await appState.selectClosedTerminal(entry, worktreeID: worktreeID) }
@@ -526,7 +524,6 @@ struct SessionTranscriptView: View {
 /// List row for one captured closed terminal (label/kind + close time).
 private struct ClosedTerminalRowView: View {
     let entry: TerminalHistoryEntry
-    let onRevive: () -> Void
 
     private var title: String {
         if let label = entry.label, !label.isEmpty { return label }
@@ -537,38 +534,24 @@ private struct ClosedTerminalRowView: View {
         }
     }
 
-    private var reviveHelp: String {
-        entry.kind == .claude && entry.claudeSessionID != nil
-            ? "Resume this Claude session in a new tab"
-            : "Open a new shell with this scrollback above the prompt"
-    }
-
     var body: some View {
-        HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 5) {
-                    Image(systemName: "terminal")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    Text(title)
-                        .font(.callout)
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                }
-                HStack(spacing: 4) {
-                    Text("closed \(entry.closedAt.smartFormatted)")
-                    Text("·").foregroundStyle(.quaternary)
-                    Text("\(entry.lineCount.formatted()) lines")
-                }
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 5) {
+                Image(systemName: "terminal")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(title)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-            Button("Revive", action: onRevive)
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .help(reviveHelp)
+            HStack(spacing: 4) {
+                Text("closed \(entry.closedAt.smartFormatted)")
+                Text("·").foregroundStyle(.quaternary)
+                Text("\(entry.lineCount.formatted()) lines")
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 3)
@@ -601,10 +584,15 @@ private struct ClosedTerminalDetailView: View {
                 Text("closed \(entry.closedAt.smartFormatted)")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
-                Spacer()
-                Text("Read-only")
+                Text("· Read-only")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+                Spacer()
+                Button("Revive") {
+                    Task { await appState.reviveClosedTerminal(entry, worktreeID: worktreeID) }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -124,7 +124,9 @@ struct HistoryPaneView: View {
                 if !closedTerminals.isEmpty {
                     Section("Closed Terminals") {
                         ForEach(closedTerminals) { entry in
-                            ClosedTerminalRowView(entry: entry)
+                            ClosedTerminalRowView(entry: entry) {
+                                Task { await appState.reviveClosedTerminal(entry, worktreeID: worktreeID) }
+                            }
                                 .contentShape(Rectangle())
                                 .onTapGesture {
                                     Task { await appState.selectClosedTerminal(entry, worktreeID: worktreeID) }
@@ -524,6 +526,7 @@ struct SessionTranscriptView: View {
 /// List row for one captured closed terminal (label/kind + close time).
 private struct ClosedTerminalRowView: View {
     let entry: TerminalHistoryEntry
+    let onRevive: () -> Void
 
     private var title: String {
         if let label = entry.label, !label.isEmpty { return label }
@@ -534,24 +537,38 @@ private struct ClosedTerminalRowView: View {
         }
     }
 
+    private var reviveHelp: String {
+        entry.kind == .claude && entry.claudeSessionID != nil
+            ? "Resume this Claude session in a new tab"
+            : "Open a new shell with this scrollback above the prompt"
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 5) {
-                Image(systemName: "terminal")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Text(title)
-                    .font(.callout)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 5) {
+                    Image(systemName: "terminal")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(title)
+                        .font(.callout)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                }
+                HStack(spacing: 4) {
+                    Text("closed \(entry.closedAt.smartFormatted)")
+                    Text("·").foregroundStyle(.quaternary)
+                    Text("\(entry.lineCount.formatted()) lines")
+                }
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
             }
-            HStack(spacing: 4) {
-                Text("closed \(entry.closedAt.smartFormatted)")
-                Text("·").foregroundStyle(.quaternary)
-                Text("\(entry.lineCount.formatted()) lines")
-            }
-            .font(.caption2)
-            .foregroundStyle(.tertiary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button("Revive", action: onRevive)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help(reviveHelp)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 3)

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -33,6 +33,15 @@ struct HistoryPaneView: View {
         return loadState.currentSessions.first { $0.sessionId == sid }
     }
 
+    private var closedTerminals: [TerminalHistoryEntry] {
+        appState.closedTerminalHistories[worktreeID] ?? []
+    }
+
+    private var selectedClosedTerminal: TerminalHistoryEntry? {
+        guard let id = appState.selectedClosedTerminalIDs[worktreeID] else { return nil }
+        return closedTerminals.first { $0.id == id }
+    }
+
     @State private var listWidth: CGFloat = 290
     @State private var dragStartWidth: CGFloat? = nil
 
@@ -62,8 +71,10 @@ struct HistoryPaneView: View {
                         .onEnded { _ in dragStartWidth = nil }
                 )
 
-            // Right panel: transcript or empty state
-            if let summary = selectedSummary {
+            // Right panel: closed-terminal capture, transcript, or empty state
+            if let entry = selectedClosedTerminal {
+                ClosedTerminalDetailView(entry: entry, worktreeID: worktreeID)
+            } else if let summary = selectedSummary {
                 SessionTranscriptView(
                     sessionId: summary.sessionId,
                     worktreeID: worktreeID,
@@ -79,7 +90,7 @@ struct HistoryPaneView: View {
     @ViewBuilder
     private var sessionList: some View {
         let sessions = loadState.currentSessions
-        if sessions.isEmpty && !loadState.isLoading {
+        if sessions.isEmpty && closedTerminals.isEmpty && !loadState.isLoading {
             VStack(spacing: 8) {
                 Image(systemName: "clock.arrow.circlepath")
                     .font(.system(size: 32))
@@ -90,24 +101,43 @@ struct HistoryPaneView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            List(sessions) { summary in
-                SessionRowView(summary: summary, isSelected: selectedSessionID == summary.sessionId)
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        Task { await appState.selectSession(summary, worktreeID: worktreeID) }
-                    }
-                    .contextMenu {
-                        Button("Copy Conversation Path") {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(summary.filePath, forType: .string)
+            List {
+                ForEach(sessions) { summary in
+                    SessionRowView(summary: summary, isSelected: selectedSessionID == summary.sessionId)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            Task { await appState.selectSession(summary, worktreeID: worktreeID) }
+                        }
+                        .contextMenu {
+                            Button("Copy Conversation Path") {
+                                NSPasteboard.general.clearContents()
+                                NSPasteboard.general.setString(summary.filePath, forType: .string)
+                            }
+                        }
+                        .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+                        .listRowBackground(
+                            selectedSessionID == summary.sessionId
+                                ? Color.accentColor.opacity(0.15)
+                                : Color.clear
+                        )
+                }
+                if !closedTerminals.isEmpty {
+                    Section("Closed Terminals") {
+                        ForEach(closedTerminals) { entry in
+                            ClosedTerminalRowView(entry: entry)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    Task { await appState.selectClosedTerminal(entry, worktreeID: worktreeID) }
+                                }
+                                .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
+                                .listRowBackground(
+                                    selectedClosedTerminal?.id == entry.id
+                                        ? Color.accentColor.opacity(0.15)
+                                        : Color.clear
+                                )
                         }
                     }
-                    .listRowInsets(EdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12))
-                    .listRowBackground(
-                        selectedSessionID == summary.sessionId
-                            ? Color.accentColor.opacity(0.15)
-                            : Color.clear
-                    )
+                }
             }
             .listStyle(.plain)
         }
@@ -486,6 +516,134 @@ struct SessionTranscriptView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Closed Terminals
+
+/// List row for one captured closed terminal (label/kind + close time).
+private struct ClosedTerminalRowView: View {
+    let entry: TerminalHistoryEntry
+
+    private var title: String {
+        if let label = entry.label, !label.isEmpty { return label }
+        switch entry.kind {
+        case .claude: return "Claude"
+        case .codex: return "Codex"
+        case .shell, .none: return "Terminal"
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 5) {
+                Image(systemName: "terminal")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(title)
+                    .font(.callout)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+            }
+            HStack(spacing: 4) {
+                Text("closed \(entry.closedAt.smartFormatted)")
+                Text("·").foregroundStyle(.quaternary)
+                Text("\(entry.lineCount.formatted()) lines")
+            }
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 3)
+        .contentShape(Rectangle())
+    }
+}
+
+/// Right-hand pane for a selected closed terminal: the captured scrollback,
+/// read-only, in a single monospaced NSTextView (no highlighting, no per-line
+/// rows — the capture can be ~10k lines and must stay cheap to display).
+private struct ClosedTerminalDetailView: View {
+    let entry: TerminalHistoryEntry
+    let worktreeID: UUID
+    @EnvironmentObject var appState: AppState
+
+    private var content: String? {
+        appState.closedTerminalContents[entry.id]
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 6) {
+                Image(systemName: "terminal")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text(entry.label ?? "Terminal")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Text("closed \(entry.closedAt.smartFormatted)")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+                Text("Read-only")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            if let content {
+                if content.isEmpty {
+                    VStack(spacing: 8) {
+                        Image(systemName: "terminal")
+                            .font(.system(size: 32))
+                            .foregroundStyle(.tertiary)
+                        Text("No captured output")
+                            .foregroundStyle(.secondary)
+                            .font(.callout)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ReadOnlyMonospacedTextView(text: content)
+                }
+            } else {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+/// Minimal scrollable read-only monospaced text view. One NSTextView for the
+/// whole capture — deliberately NOT a SwiftUI per-line list and NOT
+/// syntax-highlighted (both are proven main-thread hangs on large text in
+/// this app, see #129).
+private struct ReadOnlyMonospacedTextView: NSViewRepresentable {
+    let text: String
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        if let textView = scrollView.documentView as? NSTextView {
+            textView.isEditable = false
+            textView.isSelectable = true
+            textView.isRichText = false
+            textView.font = .monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+            textView.textColor = .textColor
+            textView.drawsBackground = false
+            textView.textContainerInset = NSSize(width: 8, height: 8)
+        }
+        scrollView.drawsBackground = false
+        scrollView.hasHorizontalScroller = false
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView,
+              textView.string != text else { return }
+        textView.string = text
     }
 }
 

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -14,12 +14,50 @@ struct NotePaneView: View {
         appState.notes[worktreeID]?.first { $0.id == noteID }
     }
 
+    /// Where this note's content lives on disk (daemon-written; the file
+    /// exists only once the note has non-empty content, but the would-be
+    /// path is shown regardless — file-backed settings convention, see
+    /// `RepoHooksSettingsView`).
+    private var contentFilePath: String {
+        TBDConstants.noteContentPath(worktreeID: worktreeID, noteID: noteID)
+    }
+
     var body: some View {
+        VStack(spacing: 0) {
+            editor
+            footer
+        }
+        .background(Color(nsColor: .textBackgroundColor))
+    }
+
+    private var footer: some View {
+        HStack(spacing: 4) {
+            Text(contentFilePath.replacingOccurrences(of: NSHomeDirectory(), with: "~"))
+                .font(.caption.monospaced())
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(contentFilePath, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .help("Copy full path")
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 6)
+    }
+
+    private var editor: some View {
         TextEditor(text: $text)
             .font(.system(.body, design: .monospaced))
             .padding(12)
             .scrollContentBackground(.hidden)
-            .background(Color(nsColor: .textBackgroundColor))
             .onChange(of: text) { _, newValue in
                 guard loaded else { return }
                 debounceSave(content: newValue)

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -235,6 +235,7 @@ struct GeneralSettingsTab: View {
                     """)
                 controlModeToggle
                 hibernateInputVetoToggle
+                autoCloseSetupToggle
             }
         }
         .formStyle(.grouped)
@@ -277,6 +278,19 @@ struct GeneralSettingsTab: View {
             set: { newValue in Task { await appState.setHibernateInputVetoEnabled(newValue) } }
         ))
         .help("Guard that prevents hibernation of sessions with typed-but-unsent input (machine-interface input detector). Off by default (soaking). Independent of the auto-hibernate idle sweep, which is also off by default.")
+    }
+
+    /// Auto-close the setup-hook tab after a clean run. Reads the persisted
+    /// flag from `daemon.capabilities` and writes via
+    /// `config.setAutoCloseSetup`. Off by default (soaking).
+    @ViewBuilder
+    private var autoCloseSetupToggle: some View {
+        let capabilities = appState.daemonCapabilities
+        Toggle("Auto-close the setup tab on success", isOn: Binding(
+            get: { capabilities?.autoCloseSetupEnabled ?? false },
+            set: { newValue in Task { await appState.setAutoCloseSetupEnabled(newValue) } }
+        ))
+        .help("When a repo's setup hook exits cleanly, close its tab automatically. A failed hook keeps the tab open with a shell for debugging. Off by default (soaking). Applies to newly created worktrees.")
     }
 
     private var primaryAgentPreferenceBinding: Binding<PrimaryAgentPreference> {

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -522,6 +522,13 @@ public final class Daemon: Sendable {
         // spawn landing before the sweep would miss a legacy column value.
         await database.repos.sweepClaudeSettingsOverlayColumnToFiles()
 
+        // 8c. One-time export of legacy DB note content to its file-backed
+        // home (`~/tbd/notes/<worktreeID>/<noteID>.md`). Unlike 8b the DB
+        // column is NOT cleared — it stays as a dormant fallback/backup; the
+        // file wins once it exists. Idempotent (file-exists guard), so no
+        // migration or marker is needed. Best-effort, never blocks startup.
+        await database.notes.exportContentColumnToFiles()
+
         // 9. Start socket server
         let sock = SocketServer(router: rpcRouter)
         self.socketServer = sock

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -29,6 +29,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var control_mode_enabled: Bool?
     var auto_resume_on_api_error: Bool?
     var hibernate_input_veto_enabled: Bool?
+    var auto_close_setup_enabled: Bool?
     var gc_enabled: Bool?
     var gc_grace_seconds: Int?
     var gc_snapshot_retention_days: Int?
@@ -53,6 +54,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             controlModeEnabled: control_mode_enabled ?? false,
             autoResumeOnApiError: auto_resume_on_api_error ?? false,
             hibernateInputVetoEnabled: hibernate_input_veto_enabled ?? false,
+            autoCloseSetupEnabled: auto_close_setup_enabled ?? false,
             gcEnabled: gc_enabled ?? true,
             gcGraceSeconds: gc_grace_seconds ?? Config.defaultGCGraceSeconds,
             gcSnapshotRetentionDays: gc_snapshot_retention_days ?? Config.defaultGCSnapshotRetentionDays
@@ -258,6 +260,18 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET hibernate_input_veto_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the auto-close-setup-tab opt-in (default OFF, soaking). Read
+    /// fresh at spawn time, so no daemon restart is required — applies to the
+    /// next worktree creation.
+    public func setAutoCloseSetup(enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_close_setup_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -26,13 +26,16 @@ public final class TBDDatabase: Sendable {
     public let audit: AuditStore
     public let scheduledResumes: ScheduledResumeStore
     public let reapRecords: ReapRecordStore
+    public let terminalHistory: TerminalHistoryStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
     /// `notesDir` overrides the note-content file directory (tests only; nil
     /// resolves `TBDConstants.noteContentDir`, which honors TBD_HOME).
-    public init(path: String, notesDir: String? = nil) throws {
+    /// `terminalHistoryDir` is the same seam for closed-terminal captures
+    /// (nil resolves `TBDConstants.terminalHistoryDir`).
+    public init(path: String, notesDir: String? = nil, terminalHistoryDir: String? = nil) throws {
         // Capture existence BEFORE DatabasePool opens the file — opening
         // creates an empty DB on the first launch, so we'd otherwise lose the
         // ability to distinguish "first launch" from "upgrade".
@@ -62,6 +65,7 @@ public final class TBDDatabase: Sendable {
         self.audit = AuditStore(writer: pool)
         self.scheduledResumes = ScheduledResumeStore(writer: pool)
         self.reapRecords = ReapRecordStore(writer: pool)
+        self.terminalHistory = TerminalHistoryStore(writer: pool, historyDir: terminalHistoryDir)
 
         let migrator = Self.buildMigrator()
         if fileExisted {
@@ -78,8 +82,9 @@ public final class TBDDatabase: Sendable {
     /// Create an in-memory database for testing using DatabaseQueue.
     /// `notesDir` overrides the note-content file directory so tests never
     /// touch the real `~/tbd/notes` (injection seam, like
-    /// `ThemeStore(themesDirectory:)`).
-    public init(inMemory: Bool, notesDir: String? = nil) throws {
+    /// `ThemeStore(themesDirectory:)`). `terminalHistoryDir` is the same seam
+    /// for closed-terminal captures (`~/tbd/terminal-history`).
+    public init(inMemory: Bool, notesDir: String? = nil, terminalHistoryDir: String? = nil) throws {
         precondition(inMemory, "Use init(path:) for file-backed databases")
         let queue = try DatabaseQueue()
         self.writer = queue
@@ -99,6 +104,7 @@ public final class TBDDatabase: Sendable {
         self.audit = AuditStore(writer: queue)
         self.scheduledResumes = ScheduledResumeStore(writer: queue)
         self.reapRecords = ReapRecordStore(writer: queue)
+        self.terminalHistory = TerminalHistoryStore(writer: queue, historyDir: terminalHistoryDir)
         try Self.buildMigrator().migrate(queue)
     }
 
@@ -949,6 +955,26 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(
                 table: "config", column: "auto_close_setup_enabled",
                 type: .boolean, defaults: false)
+        }
+
+        // Read-only closed-terminal history: metadata for scrollback captured
+        // at terminal close (content is file-backed at
+        // ~/tbd/terminal-history/<worktreeID>/<terminalID>.txt). Additive —
+        // close semantics are unchanged; capture is best-effort. Rows are
+        // pruned to the newest 50 per worktree on insert and removed (with
+        // their files) on worktree hard-delete; archive keeps them.
+        migrator.registerMigration("v57_terminal_history") { db in
+            try db.createTableIfNotExists("terminal_history") { t in
+                t.primaryKey("id", .text).notNull()
+                t.column("worktreeID", .text).notNull()
+                t.column("label", .text)
+                t.column("kind", .text)
+                t.column("closedAt", .datetime).notNull()
+                t.column("claudeSessionID", .text)
+                t.column("lineCount", .integer).notNull().defaults(to: 0)
+            }
+            try db.addIndexIfMissing(
+                "idx_terminal_history_worktree", on: "terminal_history", columns: ["worktreeID"])
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -963,7 +963,8 @@ public final class TBDDatabase: Sendable {
         // close semantics are unchanged; capture is best-effort. Rows are
         // pruned to the newest 50 per worktree on insert and removed (with
         // their files) on worktree hard-delete; archive keeps them.
-        migrator.registerMigration("v57_terminal_history") { db in
+        // (Renumbered v57→v58 on rebase: main's #482 took v56, shifting this branch's ids.)
+        migrator.registerMigration("v58_terminal_history") { db in
             try db.createTableIfNotExists("terminal_history") { t in
                 t.primaryKey("id", .text).notNull()
                 t.column("worktreeID", .text).notNull()

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -30,7 +30,9 @@ public final class TBDDatabase: Sendable {
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
     /// Create a production database at the given file path with WAL mode and a DatabasePool.
-    public init(path: String) throws {
+    /// `notesDir` overrides the note-content file directory (tests only; nil
+    /// resolves `TBDConstants.noteContentDir`, which honors TBD_HOME).
+    public init(path: String, notesDir: String? = nil) throws {
         // Capture existence BEFORE DatabasePool opens the file — opening
         // creates an empty DB on the first launch, so we'd otherwise lose the
         // ability to distinguish "first launch" from "upgrade".
@@ -48,7 +50,7 @@ public final class TBDDatabase: Sendable {
         self.worktrees = WorktreeStore(writer: pool)
         self.terminals = TerminalStore(writer: pool)
         self.notifications = NotificationStore(writer: pool)
-        self.notes = NoteStore(writer: pool)
+        self.notes = NoteStore(writer: pool, notesDir: notesDir)
         self.modelProfiles = ModelProfileStore(writer: pool)
         self.modelProfileUsage = ModelProfileUsageStore(writer: pool)
         self.oauthUsageSnapshots = OAuthUsageSnapshotStore(writer: pool)
@@ -74,7 +76,10 @@ public final class TBDDatabase: Sendable {
     }
 
     /// Create an in-memory database for testing using DatabaseQueue.
-    public init(inMemory: Bool) throws {
+    /// `notesDir` overrides the note-content file directory so tests never
+    /// touch the real `~/tbd/notes` (injection seam, like
+    /// `ThemeStore(themesDirectory:)`).
+    public init(inMemory: Bool, notesDir: String? = nil) throws {
         precondition(inMemory, "Use init(path:) for file-backed databases")
         let queue = try DatabaseQueue()
         self.writer = queue
@@ -82,7 +87,7 @@ public final class TBDDatabase: Sendable {
         self.worktrees = WorktreeStore(writer: queue)
         self.terminals = TerminalStore(writer: queue)
         self.notifications = NotificationStore(writer: queue)
-        self.notes = NoteStore(writer: queue)
+        self.notes = NoteStore(writer: queue, notesDir: notesDir)
         self.modelProfiles = ModelProfileStore(writer: queue)
         self.modelProfileUsage = ModelProfileUsageStore(writer: queue)
         self.oauthUsageSnapshots = OAuthUsageSnapshotStore(writer: queue)

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -933,6 +933,19 @@ public final class TBDDatabase: Sendable {
             try db.execute(sql: "UPDATE model_profiles SET sort_order = rowid")
         }
 
+        // Soak flag for auto-closing the setup-hook tab after a clean run
+        // (default OFF per the default-off-flag rule: it kills a pane and
+        // deletes terminal/tab rows without a user gesture). When on, a
+        // resolved setup hook's exit code is written to a marker file and a
+        // clean exit tears the tab down; nonzero keeps the tab open (execs
+        // the interactive shell) for debugging.
+        // (Renumbered v56→v57 on rebase: main's #482 took v56.)
+        migrator.registerMigration("v57_config_auto_close_setup") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "auto_close_setup_enabled",
+                type: .boolean, defaults: false)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/NoteStore.swift
+++ b/Sources/TBDDaemon/Database/NoteStore.swift
@@ -48,11 +48,63 @@ struct NoteRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
 }
 
 /// Provides CRUD operations for notes.
+///
+/// Note CONTENT is file-backed at `~/tbd/notes/<worktreeID>/<noteID>.md`
+/// (`TBDConstants.noteContentPath`); the DB row keeps tab identity + title.
+/// The DB `content` column is a dormant legacy fallback: reads prefer the
+/// file when it exists, writes go to the file only. Empty/whitespace-only
+/// content deletes the file (mirrors the app's `NotesFileStore` semantics),
+/// so a freshly auto-created empty note produces no file.
 public struct NoteStore: Sendable {
     let writer: any DatabaseWriter
+    /// Injection seam for tests (like `ThemeStore(themesDirectory:)`): nil
+    /// resolves `TBDConstants.noteContentDir` (which honors TBD_HOME) at
+    /// call time.
+    let notesDirOverride: String?
 
-    init(writer: any DatabaseWriter) {
+    init(writer: any DatabaseWriter, notesDir: String? = nil) {
         self.writer = writer
+        self.notesDirOverride = notesDir
+    }
+
+    // MARK: - Content files
+
+    func contentPath(worktreeID: UUID, noteID: UUID) -> String {
+        if let notesDirOverride {
+            return ((notesDirOverride as NSString)
+                .appendingPathComponent(worktreeID.uuidString) as NSString)
+                .appendingPathComponent("\(noteID.uuidString).md")
+        }
+        return TBDConstants.noteContentPath(worktreeID: worktreeID, noteID: noteID)
+    }
+
+    /// File content wins when the file exists; DB column is the fallback for
+    /// legacy rows that were never exported.
+    private func overlayContent(_ note: Note) -> Note {
+        let path = contentPath(worktreeID: note.worktreeID, noteID: note.id)
+        guard let fileContent = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return note
+        }
+        var overlaid = note
+        overlaid.content = fileContent
+        return overlaid
+    }
+
+    /// Writes `content` to the note's file (atomically, creating intermediate
+    /// directories). Empty/whitespace-only content deletes the file instead.
+    private func writeContentFile(_ content: String, worktreeID: UUID, noteID: UUID) throws {
+        let path = contentPath(worktreeID: worktreeID, noteID: noteID)
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            if FileManager.default.fileExists(atPath: path) {
+                try FileManager.default.removeItem(atPath: path)
+            }
+            return
+        }
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try content.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
     /// Create a new note. With no explicit `title`, uses a monotonically
@@ -75,32 +127,40 @@ public struct NoteStore: Sendable {
         }
     }
 
-    /// Get a note by ID.
+    /// Get a note by ID (content overlaid from its file when one exists).
     public func get(id: UUID) async throws -> Note? {
-        try await writer.read { db in
+        let note = try await writer.read { db in
             try NoteRecord.fetchOne(db, key: id.uuidString)?.toModel()
         }
+        return note.map(overlayContent)
     }
 
-    /// List notes, optionally filtered by worktree.
+    /// List notes, optionally filtered by worktree (content overlaid from
+    /// each note's file when one exists).
     public func list(worktreeID: UUID? = nil) async throws -> [Note] {
-        try await writer.read { db in
+        let notes = try await writer.read { db in
             var request = NoteRecord.all()
             if let worktreeID {
                 request = request.filter(Column("worktreeID") == worktreeID.uuidString)
             }
             return try request.fetchAll(db).compactMap { $0.toModel() }
         }
+        return notes.map(overlayContent)
     }
 
-    /// Update a note's title and/or content.
+    /// Update a note's title and/or content. Title goes to the DB row;
+    /// content goes to the file only. Exception: an explicit empty-content
+    /// update also clears the DB column — the file is deleted, and a stale
+    /// legacy column value would otherwise resurrect through the fallback.
     public func update(id: UUID, title: String? = nil, content: String? = nil) async throws -> Note {
-        try await writer.write { db in
+        let updated = try await writer.write { db -> Note in
             guard var record = try NoteRecord.fetchOne(db, key: id.uuidString) else {
                 throw DatabaseError(message: "Note not found")
             }
             if let title { record.title = title }
-            if let content { record.content = content }
+            if let content, content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                record.content = ""
+            }
             record.updatedAt = Date()
             try record.update(db)
             guard let model = record.toModel() else {
@@ -110,21 +170,59 @@ public struct NoteStore: Sendable {
             }
             return model
         }
+        if let content {
+            try writeContentFile(content, worktreeID: updated.worktreeID, noteID: updated.id)
+        }
+        return overlayContent(updated)
     }
 
-    /// Delete a note by ID.
+    /// Delete a note by ID. Deliberately does NOT delete the note's content
+    /// file — closing a note tab removes the row, the `.md` survives on disk.
+    /// (Orphan-file GC is out of scope; files are intentionally retained.)
     public func delete(id: UUID) async throws {
         _ = try await writer.write { db in
             try NoteRecord.deleteOne(db, key: id.uuidString)
         }
     }
 
-    /// Delete all notes for a worktree.
+    /// Delete all notes for a worktree. Content files are intentionally
+    /// retained (see `delete(id:)`).
     public func deleteForWorktree(worktreeID: UUID) async throws {
         _ = try await writer.write { db in
             try NoteRecord
                 .filter(Column("worktreeID") == worktreeID.uuidString)
                 .deleteAll(db)
+        }
+    }
+
+    /// One-time best-effort export of legacy DB note content to files, run at
+    /// daemon startup (sibling of `sweepClaudeSettingsOverlayColumnToFiles`).
+    /// For every row with non-empty content and no file yet, write the file.
+    /// The DB column is NOT cleared — it stays as a dormant fallback/backup;
+    /// the file simply wins once it exists. Idempotent by construction (the
+    /// file-exists guard also protects newer file edits from being clobbered
+    /// on later startups). Failures are logged and never block startup.
+    public func exportContentColumnToFiles() async {
+        let logger = Logger(subsystem: "com.tbd.daemon", category: "startup")
+        let rows: [Note]
+        do {
+            rows = try await writer.read { db in
+                try NoteRecord.fetchAll(db).compactMap { $0.toModel() }
+            }
+        } catch {
+            logger.error("note content export: read failed: \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        for note in rows
+        where !note.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let path = contentPath(worktreeID: note.worktreeID, noteID: note.id)
+            guard !FileManager.default.fileExists(atPath: path) else { continue }
+            do {
+                try writeContentFile(note.content, worktreeID: note.worktreeID, noteID: note.id)
+                logger.info("Exported note \(note.id, privacy: .public) content to \(path, privacy: .public)")
+            } catch {
+                logger.error("note content export failed for \(note.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 }

--- a/Sources/TBDDaemon/Database/NoteStore.swift
+++ b/Sources/TBDDaemon/Database/NoteStore.swift
@@ -55,8 +55,9 @@ public struct NoteStore: Sendable {
         self.writer = writer
     }
 
-    /// Create a new note with a monotonically increasing title ("Note 1", "Note 2", etc.).
-    public func create(worktreeID: UUID) async throws -> Note {
+    /// Create a new note. With no explicit `title`, uses a monotonically
+    /// increasing default ("Note 1", "Note 2", etc.).
+    public func create(worktreeID: UUID, title: String? = nil) async throws -> Note {
         try await writer.write { db in
             // Use MAX to avoid duplicate titles after deletions
             let maxNum = try Int.fetchOne(db, sql: """
@@ -66,7 +67,7 @@ public struct NoteStore: Sendable {
                 """, arguments: [worktreeID.uuidString]) ?? 0
             let note = Note(
                 worktreeID: worktreeID,
-                title: "Note \(maxNum + 1)"
+                title: title ?? "Note \(maxNum + 1)"
             )
             let record = NoteRecord(from: note)
             try record.insert(db)

--- a/Sources/TBDDaemon/Database/TerminalHistoryStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalHistoryStore.swift
@@ -1,0 +1,178 @@
+import Foundation
+import GRDB
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "terminalHistory")
+
+/// GRDB Record type for the `terminal_history` table.
+struct TerminalHistoryRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
+    static let databaseTableName = "terminal_history"
+
+    var id: String
+    var worktreeID: String
+    var label: String?
+    var kind: String?
+    var closedAt: Date
+    var claudeSessionID: String?
+    var lineCount: Int
+
+    init(from entry: TerminalHistoryEntry) {
+        self.id = entry.id.uuidString
+        self.worktreeID = entry.worktreeID.uuidString
+        self.label = entry.label
+        self.kind = entry.kind?.rawValue
+        self.closedAt = entry.closedAt
+        self.claudeSessionID = entry.claudeSessionID
+        self.lineCount = entry.lineCount
+    }
+
+    /// Failable decode: skips (returns nil after a logged warning) rather than
+    /// crashing when a required UUID fails to parse.
+    func toModel() -> TerminalHistoryEntry? {
+        guard let uuid = UUID(uuidString: id) else {
+            logger.warning("Skipping terminal_history row \(id, privacy: .public): malformed id")
+            return nil
+        }
+        guard let wtID = UUID(uuidString: worktreeID) else {
+            logger.warning("Skipping terminal_history row \(id, privacy: .public): malformed worktreeID \(worktreeID, privacy: .public)")
+            return nil
+        }
+        return TerminalHistoryEntry(
+            id: uuid,
+            worktreeID: wtID,
+            label: label,
+            kind: kind.flatMap(TerminalKind.init(rawValue:)),
+            closedAt: closedAt,
+            claudeSessionID: claudeSessionID,
+            lineCount: lineCount
+        )
+    }
+}
+
+/// Read-only closed-terminal history: at close time the daemon captures the
+/// pane's scrollback so the user can view it later.
+///
+/// Captured TEXT is file-backed at
+/// `~/tbd/terminal-history/<worktreeID>/<terminalID>.txt`
+/// (`TBDConstants.terminalHistoryPath`); the DB row keeps display metadata.
+/// Empty/whitespace-only captures store nothing (no file, no row).
+public struct TerminalHistoryStore: Sendable {
+    // ponytail: hard cap of the newest 50 captures per worktree; make it a
+    // config knob only if someone actually asks for more retention.
+    static let maxEntriesPerWorktree = 50
+
+    let writer: any DatabaseWriter
+    /// Injection seam for tests (like `NoteStore.notesDirOverride`): nil
+    /// resolves `TBDConstants.terminalHistoryDir` (which honors TBD_HOME)
+    /// at call time.
+    let historyDirOverride: String?
+
+    init(writer: any DatabaseWriter, historyDir: String? = nil) {
+        self.writer = writer
+        self.historyDirOverride = historyDir
+    }
+
+    // MARK: - Content files
+
+    func worktreeDir(worktreeID: UUID) -> String {
+        let base = historyDirOverride ?? TBDConstants.terminalHistoryDir.path
+        return (base as NSString).appendingPathComponent(worktreeID.uuidString)
+    }
+
+    func contentPath(worktreeID: UUID, terminalID: UUID) -> String {
+        (worktreeDir(worktreeID: worktreeID) as NSString)
+            .appendingPathComponent("\(terminalID.uuidString).txt")
+    }
+
+    // MARK: - Capture
+
+    /// Best-effort capture at terminal close. Runs `capture`, then stores the
+    /// text (file + metadata row) and prunes the worktree to the newest
+    /// `maxEntriesPerWorktree` records. NEVER throws — any failure is logged
+    /// and the close proceeds unchanged. Empty/whitespace-only captures store
+    /// nothing.
+    public func captureOnClose(terminal: Terminal, capture: () async throws -> String) async {
+        let text: String
+        do {
+            text = try await capture()
+        } catch {
+            logger.warning("scrollback capture failed for terminal \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        await store(terminal: terminal, text: text, closedAt: Date())
+    }
+
+    /// Store seam (internal so tests can control `closedAt` for deterministic
+    /// prune ordering). Best-effort: failures are logged, never thrown.
+    func store(terminal: Terminal, text: String, closedAt: Date) async {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let path = contentPath(worktreeID: terminal.worktreeID, terminalID: terminal.id)
+        do {
+            try FileManager.default.createDirectory(
+                atPath: (path as NSString).deletingLastPathComponent,
+                withIntermediateDirectories: true
+            )
+            try text.write(toFile: path, atomically: true, encoding: .utf8)
+
+            let entry = TerminalHistoryEntry(
+                id: terminal.id,
+                worktreeID: terminal.worktreeID,
+                label: terminal.label,
+                kind: terminal.kind,
+                closedAt: closedAt,
+                claudeSessionID: terminal.claudeSessionID,
+                lineCount: text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline).count
+            )
+            let record = TerminalHistoryRecord(from: entry)
+            let worktreeID = terminal.worktreeID
+            let pruned = try await writer.write { db -> [String] in
+                try record.save(db)
+                // Prune to the newest N; rowid breaks closedAt ties (insertion order).
+                let stale = try String.fetchAll(db, sql: """
+                    SELECT id FROM terminal_history WHERE worktreeID = ?
+                    ORDER BY closedAt DESC, rowid DESC LIMIT -1 OFFSET ?
+                    """, arguments: [worktreeID.uuidString, Self.maxEntriesPerWorktree])
+                if !stale.isEmpty {
+                    try TerminalHistoryRecord.filter(keys: stale).deleteAll(db)
+                }
+                return stale
+            }
+            for staleID in pruned {
+                guard let staleUUID = UUID(uuidString: staleID) else { continue }
+                let stalePath = contentPath(worktreeID: worktreeID, terminalID: staleUUID)
+                try? FileManager.default.removeItem(atPath: stalePath)
+            }
+        } catch {
+            logger.warning("failed to store closed-terminal history for \(terminal.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    // MARK: - Queries
+
+    /// List capture metadata for a worktree, newest first.
+    public func list(worktreeID: UUID) async throws -> [TerminalHistoryEntry] {
+        try await writer.read { db in
+            try TerminalHistoryRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .order(Column("closedAt").desc)
+                .fetchAll(db)
+                .compactMap { $0.toModel() }
+        }
+    }
+
+    /// Delete all history rows for a worktree AND its content directory.
+    /// Called from the worktree hard-delete paths (forget, scratch delete,
+    /// recovery cleanup) — archive deliberately keeps history.
+    public func deleteForWorktree(worktreeID: UUID) async throws {
+        _ = try await writer.write { db in
+            try TerminalHistoryRecord
+                .filter(Column("worktreeID") == worktreeID.uuidString)
+                .deleteAll(db)
+        }
+        let dir = worktreeDir(worktreeID: worktreeID)
+        if FileManager.default.fileExists(atPath: dir) {
+            try? FileManager.default.removeItem(atPath: dir)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -113,14 +113,12 @@ extension WorktreeLifecycle {
             archivedHeadSHA: capturedSHA
         )
 
-        // Kill all tmux windows for this worktree, reaping any wedged agent
-        // that survives kill-window's SIGHUP.
+        // Capture each terminal's scrollback into Closed Terminals history,
+        // then kill its tmux window, reaping any wedged agent that survives
+        // kill-window's SIGHUP. The archived worktree row and its history rows
+        // survive, so the captured output stays readable later.
         for terminal in terminals {
-            await killWindowAndReap(
-                server: worktree.tmuxServer,
-                windowID: terminal.tmuxWindowID,
-                paneID: terminal.tmuxPaneID
-            )
+            await captureThenKillWindow(terminal: terminal, server: worktree.tmuxServer)
         }
 
         // Delete terminals from db

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -781,6 +781,17 @@ extension WorktreeLifecycle {
             )
             createdTerminals.append((id: plannedTerminalID2, label: TerminalLabel.setup))
             if let setupMarkerPath, let setupHookPath {
+                // The auto-close wrapper lets the pane EXIT on hook success,
+                // and tmux destroys the window the instant it does — before
+                // the watcher's teardown can capture the scrollback for
+                // closed-terminal history. Keep the dead pane around; the
+                // teardown's killWindow removes it after capturing.
+                // Best-effort: a failure only costs the captured history.
+                do {
+                    try await tmux.setRemainOnExit(server: tmuxServer, windowID: window2.windowID)
+                } catch {
+                    logger.warning("setup auto-close: remain-on-exit failed for window \(window2.windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                }
                 setupAutoCloseSpawn = PreSessionSpawn(
                     terminalID: plannedTerminalID2,
                     windowID: window2.windowID,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -343,6 +343,12 @@ extension WorktreeLifecycle {
                         modelOverride: modelOverride,
                         claudeSettingsOverlay: claudeSettingsOverlay
                     )
+                    // Fresh creates get an initial note tab, appended after the
+                    // primary spawn set the tab order. Create path only — a
+                    // revive's surviving note rows re-materialize via the app's
+                    // reconcile instead. Best-effort: if the worktree row
+                    // vanished mid-wait, the note insert FK-fails and is logged.
+                    await createInitialNoteTab(worktreeID: worktree.id)
                 }
                 return .preSessionPending(phase3: phase3)
             }
@@ -364,6 +370,10 @@ extension WorktreeLifecycle {
             let terminalSpawnElapsedMs = terminalSpawnStart.duration(to: clock.now) / .milliseconds(1)
             timingLogger.debug("terminal-spawn \(worktreeID.uuidString, privacy: .public) \(Int(terminalSpawnElapsedMs))ms")
 
+            // 3c. Fresh repo-backed creates get an initial note tab (appended
+            // last; the primary terminal keeps focus).
+            await createInitialNoteTab(worktreeID: worktreeID)
+
             // 4. Update status to active
             let markActiveStart = clock.now
             try await db.worktrees.updateStatus(id: worktreeID, status: .active)
@@ -378,6 +388,24 @@ extension WorktreeLifecycle {
             // On failure, delete the DB row
             try? await db.worktrees.delete(id: worktreeID)
             throw error
+        }
+    }
+
+    /// Creates the initial "Notes" tab for a freshly created repo-backed
+    /// worktree: one empty note row appended to the tab order (last; the
+    /// primary terminal keeps focus). The app materializes the tab from the
+    /// note row via its `reconcileNoteTabs` poll — note tabs use the note
+    /// row's UUID as the tab ID. Best-effort: a failure (e.g. the worktree
+    /// row vanished mid-create, FK-failing the insert) must never fail the
+    /// create, whose checkout and terminals are already valid.
+    func createInitialNoteTab(worktreeID: UUID) async {
+        do {
+            let note = try await db.notes.create(worktreeID: worktreeID, title: "Notes")
+            var order = try await db.worktrees.getTabOrder(worktreeID: worktreeID)
+            order.append(note.id)
+            try await db.worktrees.setTabOrder(worktreeID: worktreeID, tabIDs: order)
+        } catch {
+            logger.warning("failed to create initial note tab for \(worktreeID, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -686,6 +686,7 @@ extension WorktreeLifecycle {
         // Create terminal 2: setup hook. Repo-backed worktrees only — scratch
         // spaces (repo == nil) have no repo path/setup hook and get just the
         // primary terminal, so the tab order stays `[primary]`.
+        var setupAutoCloseSpawn: PreSessionSpawn?
         if let repo {
             let plannedTerminalID2 = UUID()
             createdTerminalIDs.append(plannedTerminalID2)
@@ -696,7 +697,26 @@ extension WorktreeLifecycle {
                     TBDConstants.hookPath(repoID: $0, eventName: HookEvent.setup.rawValue)
                 }
             )
-            let setupCommand = shellWrapped(setupHookPath ?? defaultShell)
+            let setupCommand: String
+            var setupMarkerPath: String?
+            if config.autoCloseSetupEnabled, let setupHookPath {
+                // Auto-close soak flag ON with a resolved hook: wrap so the
+                // exit code lands in a marker (the watcher spawned below tears
+                // the tab down on exit 0). Delete any stale marker from a
+                // previous run of this worktree ID before the pane spawns.
+                let markerPath = Self.setupMarkerPath(worktreeID: worktreeID)
+                try? FileManager.default.removeItem(atPath: markerPath)
+                setupMarkerPath = markerPath
+                setupCommand = Self.setupAutoCloseCommand(
+                    hookPath: setupHookPath,
+                    runtimeDir: Self.setupRuntimeDir,
+                    markerPath: markerPath,
+                    shell: defaultShell
+                )
+            } else {
+                // Flag off (default) or no hook: today's behavior unchanged.
+                setupCommand = shellWrapped(setupHookPath ?? defaultShell)
+            }
             // Suppress the omz update prompt only when a setup hook actually
             // resolves — a hook-less "Setup" tab is just a regular shell and must
             // keep oh-my-zsh update checks (see `hookPaneEnv`).
@@ -732,6 +752,15 @@ extension WorktreeLifecycle {
                 kind: .shell
             )
             createdTerminals.append((id: plannedTerminalID2, label: TerminalLabel.setup))
+            if let setupMarkerPath, let setupHookPath {
+                setupAutoCloseSpawn = PreSessionSpawn(
+                    terminalID: plannedTerminalID2,
+                    windowID: window2.windowID,
+                    paneID: window2.paneID,
+                    markerPath: setupMarkerPath,
+                    hookPath: setupHookPath
+                )
+            }
         }
 
         // Restore any archived Claude sessions that were not consumed by the
@@ -828,6 +857,18 @@ extension WorktreeLifecycle {
         // Kill the untracked initial window that new-session created
         if let windowID = initialWindowID {
             try? await tmux.killWindow(server: tmuxServer, windowID: windowID)
+        }
+
+        // Flag-on setup spawn: arm the detached auto-close watcher. Started
+        // only AFTER the tab order above is persisted, so its teardown can
+        // never race the setTabOrder write and resurrect the closed tab.
+        if let setupAutoCloseSpawn {
+            let lifecycle = self
+            Task.detached {
+                await lifecycle.finishAutoCloseSetup(
+                    worktree: worktree, setup: setupAutoCloseSpawn
+                )
+            }
         }
 
         return createdTerminals

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
@@ -73,6 +73,8 @@ extension WorktreeLifecycle {
 
         try await db.terminals.deleteForWorktree(worktreeID: worktreeID)
         try await db.tabs.deleteForWorktree(worktreeID: worktreeID)
+        // Hard delete: closed-terminal history (rows + captured files) goes too.
+        try await db.terminalHistory.deleteForWorktree(worktreeID: worktreeID)
         for terminal in terminals {
             await pendingQuestions.clear(terminalID: terminal.id)
             ClaudeHookOverlay.removePerSessionOverlay(sessionKey: terminal.id.uuidString)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -420,17 +420,34 @@ extension WorktreeLifecycle {
     /// Best-effort: a failure here must never take down the worktree, whose
     /// checkout and agent terminals are already valid.
     func closePreSessionTerminal(worktree: Worktree, preSession: PreSessionSpawn) async {
-        try? await tmux.killWindow(
-            server: worktree.tmuxServer, windowID: preSession.windowID
+        await closeHookTerminal(
+            worktree: worktree,
+            terminalID: preSession.terminalID,
+            windowID: preSession.windowID
         )
+    }
+
+    /// Shared hook-tab teardown (pre-session and auto-closed setup tabs):
+    /// kill the tmux window, delete the terminal + tab rows, prune the tab
+    /// from the persisted tab order, broadcast `.terminalRemoved`. The prune
+    /// is a no-op on the create-success path (the primary spawn already set
+    /// an order without the hook tab) and keeps the stored order consistent
+    /// on the paths that appended the tab (manual re-run, setup auto-close).
+    func closeHookTerminal(worktree: Worktree, terminalID: UUID, windowID: String) async {
+        try? await tmux.killWindow(server: worktree.tmuxServer, windowID: windowID)
         do {
-            try await db.terminals.delete(id: preSession.terminalID)
-            try await db.tabs.delete(tabID: preSession.terminalID)
+            try await db.terminals.delete(id: terminalID)
+            try await db.tabs.delete(tabID: terminalID)
+            var order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
+            if order.contains(terminalID) {
+                order.removeAll { $0 == terminalID }
+                try await db.worktrees.setTabOrder(worktreeID: worktree.id, tabIDs: order)
+            }
             subscriptions?.broadcast(delta: .terminalRemoved(TerminalIDDelta(
-                terminalID: preSession.terminalID
+                terminalID: terminalID
             )))
         } catch {
-            logger.warning("failed to close pre-session terminal \(preSession.terminalID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            logger.warning("failed to close hook terminal \(terminalID, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -434,6 +434,16 @@ extension WorktreeLifecycle {
     /// an order without the hook tab) and keeps the stored order consistent
     /// on the paths that appended the tab (manual re-run, setup auto-close).
     func closeHookTerminal(worktree: Worktree, terminalID: UUID, windowID: String) async {
+        // Preserve the hook tab's output before the window dies so a user can
+        // read an auto-closed setup/pre-session run later (Session History →
+        // Closed Terminals). Best-effort: captureOnClose logs failures and
+        // the teardown proceeds unchanged.
+        if let terminal = try? await db.terminals.get(id: terminalID) {
+            await db.terminalHistory.captureOnClose(terminal: terminal) {
+                try await tmux.capturePaneScrollback(
+                    server: worktree.tmuxServer, paneID: terminal.tmuxPaneID)
+            }
+        }
         try? await tmux.killWindow(server: worktree.tmuxServer, windowID: windowID)
         do {
             try await db.terminals.delete(id: terminalID)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -167,15 +167,15 @@ extension WorktreeLifecycle {
         )
         let dbPaths = Set(dbWorktrees.map(\.path)).union(creatingPaths)
 
-        // Mark missing worktrees as archived — also kill their tmux windows
+        // Mark missing worktrees as archived — also capture each terminal's
+        // scrollback into Closed Terminals history, then kill its tmux window.
+        // The checkout is gone but the tmux server may still be live; capture
+        // is best-effort (a dead window/pane just logs and skips). The archived
+        // row and its history rows survive, so the output stays readable.
         for wt in dbWorktrees where !gitPaths.contains(wt.path) {
             let terminals = try await db.terminals.list(worktreeID: wt.id)
             for terminal in terminals {
-                await killWindowAndReap(
-                    server: wt.tmuxServer,
-                    windowID: terminal.tmuxWindowID,
-                    paneID: terminal.tmuxPaneID
-                )
+                await captureThenKillWindow(terminal: terminal, server: wt.tmuxServer)
             }
             try await db.terminals.deleteForWorktree(worktreeID: wt.id)
             try await db.tabs.deleteForWorktree(worktreeID: wt.id)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -54,6 +54,8 @@ extension WorktreeLifecycle {
                 do {
                     try await db.terminals.deleteForWorktree(worktreeID: worktree.id)
                     try await db.tabs.deleteForWorktree(worktreeID: worktree.id)
+                    // Hard delete: closed-terminal history (rows + files) goes too.
+                    try await db.terminalHistory.deleteForWorktree(worktreeID: worktree.id)
                     try await db.worktrees.delete(id: worktree.id)
                 } catch {
                     logger.warning("recovery: cleanup of missing-checkout worktree \(worktree.id, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
@@ -79,6 +81,8 @@ extension WorktreeLifecycle {
                 do {
                     try await db.terminals.deleteForWorktree(worktreeID: worktree.id)
                     try await db.tabs.deleteForWorktree(worktreeID: worktree.id)
+                    // Hard delete: closed-terminal history (rows + files) goes too.
+                    try await db.terminalHistory.deleteForWorktree(worktreeID: worktree.id)
                     try await db.worktrees.delete(id: worktree.id)
                 } catch {
                     logger.warning("recovery: failed to delete terminal-less worktree \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -91,6 +95,8 @@ extension WorktreeLifecycle {
                 do {
                     try await db.terminals.deleteForWorktree(worktreeID: worktree.id)
                     try await db.tabs.deleteForWorktree(worktreeID: worktree.id)
+                    // Hard delete: closed-terminal history (rows + files) goes too.
+                    try await db.terminalHistory.deleteForWorktree(worktreeID: worktree.id)
                     try await db.worktrees.delete(id: worktree.id)
                 } catch {
                     logger.warning("recovery: cleanup of repo-less worktree \(worktree.id, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SetupAutoClose.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+SetupAutoClose.swift
@@ -1,0 +1,76 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "setupHook")
+
+/// Auto-close for the setup-hook tab, gated on `config.auto_close_setup_enabled`
+/// (default OFF, soaking). When the flag is on AND a setup hook resolves, the
+/// hook command writes its exit code to a marker file; a detached watcher
+/// tears the tab down on a clean exit and leaves it open (with an interactive
+/// shell) on failure/timeout/killed pane. Flag off keeps today's behavior
+/// byte-for-byte (plain `shellWrapped`, no marker, no watcher).
+extension WorktreeLifecycle {
+
+    /// Directory holding setup-hook completion markers. Sibling of
+    /// `preSessionRuntimeDir`; TBD_HOME-relative so tests redirect automatically.
+    static var setupRuntimeDir: String {
+        TBDConstants.configDir
+            .appendingPathComponent("runtime")
+            .appendingPathComponent("setup")
+            .path
+    }
+
+    /// Marker file the wrapped setup-hook command writes its exit code to.
+    static func setupMarkerPath(worktreeID: UUID) -> String {
+        (setupRuntimeDir as NSString)
+            .appendingPathComponent(worktreeID.uuidString)
+    }
+
+    /// Wraps the setup hook so its exit code lands in the marker file.
+    /// Unlike `preSessionCommand` (which always execs the shell so the pane
+    /// stays usable), this execs the interactive shell ONLY on failure — a
+    /// clean run lets the pane exit so the watcher's teardown races nothing,
+    /// and a failed run keeps the pane alive for debugging. Single-quote
+    /// escaping matches `preSessionCommand` / `shellWrapped`.
+    static func setupAutoCloseCommand(
+        hookPath: String, runtimeDir: String, markerPath: String, shell: String
+    ) -> String {
+        func quoted(_ s: String) -> String {
+            "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        }
+        return "\(quoted(hookPath)); __tbd_rc=$?; "
+            + "/bin/mkdir -p \(quoted(runtimeDir)); "
+            + "/bin/echo $__tbd_rc > \(quoted(markerPath)); "
+            + "if [ $__tbd_rc -ne 0 ]; then exec \(shell); fi"
+    }
+
+    /// Detached tail of a flag-on setup spawn: await the marker (reusing the
+    /// pre-session polling, including its dead-window and deadline races),
+    /// then close the tab on exit 0. Any other outcome leaves the tab alone —
+    /// the wrapped command already exec'd a shell there on failure, and a
+    /// timeout/killed pane needs no daemon action.
+    func finishAutoCloseSetup(worktree: Worktree, setup: PreSessionSpawn) async {
+        let outcome = await waitForPreSessionCompletion(
+            preSession: setup, tmuxServer: worktree.tmuxServer
+        )
+        // The marker must never outlive the wait, whatever the outcome.
+        try? FileManager.default.removeItem(atPath: setup.markerPath)
+
+        switch outcome {
+        case .completed(exitCode: 0):
+            logger.info("setup hook completed cleanly for worktree \(worktree.id, privacy: .public) — closing its tab")
+            await closeHookTerminal(
+                worktree: worktree,
+                terminalID: setup.terminalID,
+                windowID: setup.windowID
+            )
+        case .completed(let exitCode):
+            logger.info("setup hook failed (exit \(exitCode, privacy: .public)) for worktree \(worktree.id, privacy: .public) — leaving its tab open")
+        case .timedOut:
+            logger.info("setup hook timed out for worktree \(worktree.id, privacy: .public) — leaving its tab open")
+        case .paneKilled:
+            logger.debug("setup hook pane closed before the marker was written for worktree \(worktree.id, privacy: .public)")
+        }
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -171,4 +171,24 @@ public struct WorktreeLifecycle: Sendable {
         // Escalate even if killWindow threw — the pane process may still be alive.
         if let panePID { await reaper.escalateAfterHangup(panePID) }
     }
+
+    /// Capture a live terminal's scrollback into Closed Terminals history
+    /// (best-effort), then kill its window and reap the pane. Used by the
+    /// archive paths (explicit archive + reconcile auto-archive), where the
+    /// worktree row and its `terminal_history` rows survive — unlike the
+    /// hard-delete paths (Forget/Recovery/scratch.delete) that wipe history
+    /// immediately after and so deliberately skip the capture. Capturing must
+    /// happen before the window dies; mirrors `closeHookTerminal`'s
+    /// never-throws capture (failures are logged inside `captureOnClose` and
+    /// never block the teardown).
+    func captureThenKillWindow(terminal: Terminal, server: String) async {
+        await db.terminalHistory.captureOnClose(terminal: terminal) {
+            try await tmux.capturePaneScrollback(server: server, paneID: terminal.tmuxPaneID)
+        }
+        await killWindowAndReap(
+            server: server,
+            windowID: terminal.tmuxWindowID,
+            paneID: terminal.tmuxPaneID
+        )
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -109,6 +109,17 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the auto-close-setup-tab soak flag. Read fresh at spawn time,
+    /// so it applies to the next worktree creation immediately — already-open
+    /// setup tabs are unaffected.
+    func handleConfigSetAutoCloseSetup(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetAutoCloseSetupParams.self, from: paramsData)
+        try await db.config.setAutoCloseSetup(enabled: params.enabled)
+        // Broadcast so the app reloads daemon capabilities.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the orphan-GC master switch. Turning it off does not cancel or
     /// undo any in-progress sweep — `OrphanGC.sweep` re-reads the flag itself
     /// on its next pass — this just flips the persisted gate.

--- a/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NoteHandlers.swift
@@ -41,6 +41,9 @@ extension RPCRouter {
         return try RPCResponse(result: note)
     }
 
+    /// Removes the note row + tab row only. The note's content file under
+    /// `~/tbd/notes/` is intentionally retained (orphan-file GC out of scope)
+    /// — closing a notes tab must never destroy content on disk.
     func handleNoteDelete(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(NoteDeleteParams.self, from: paramsData)
         try await db.notes.delete(id: params.noteID)

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -128,6 +128,9 @@ extension RPCRouter {
             await orphanGC.scratchpadCleanup(forRemovedWorktreePath: wt.path, repoPath: "")
         }
 
+        // Hard delete: closed-terminal history (rows + captured files) goes
+        // too. Archive (below) deliberately keeps it.
+        try? await db.terminalHistory.deleteForWorktree(worktreeID: wt.id)
         try await db.worktrees.delete(id: wt.id)
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: wt.id)))
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -454,8 +454,16 @@ extension RPCRouter {
             await limitResumeScheduler?.wake()
         }
 
-        // Kill the tmux window
+        // Capture the pane's scrollback just before the window dies so the
+        // user can view it read-only later (Session History → Closed
+        // Terminals). Strictly best-effort: any failure logs inside
+        // captureOnClose and the close proceeds unchanged.
         if let worktree = try await db.worktrees.get(id: terminal.worktreeID) {
+            await db.terminalHistory.captureOnClose(terminal: terminal) {
+                try await tmux.capturePaneScrollback(
+                    server: worktree.tmuxServer, paneID: terminal.tmuxPaneID)
+            }
+            // Kill the tmux window
             try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
         }
 
@@ -474,6 +482,15 @@ extension RPCRouter {
         )))
 
         return .ok()
+    }
+
+    /// Closed-terminal capture metadata for a worktree, newest first. Content
+    /// is not sent over RPC — the app reads the file at
+    /// `TBDConstants.terminalHistoryPath` directly.
+    func handleTerminalHistoryList(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalHistoryListParams.self, from: paramsData)
+        let entries = try await db.terminalHistory.list(worktreeID: params.worktreeID)
+        return try RPCResponse(result: entries)
     }
 
     func handleTerminalSetPin(_ paramsData: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -493,6 +493,218 @@ extension RPCRouter {
         return try RPCResponse(result: entries)
     }
 
+    /// Revive a closed terminal from its history entry into a NEW terminal in
+    /// the same (live) worktree. Claude entries with a session id resume that
+    /// Claude session (no scrollback replay — Claude repaints its transcript);
+    /// every other kind opens a fresh shell with the raw capture (colors
+    /// intact) printed above the prompt. The history row is kept.
+    func handleTerminalHistoryRevive(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(TerminalHistoryReviveParams.self, from: paramsData)
+
+        guard let worktree = try await db.worktrees.get(id: params.worktreeID) else {
+            return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
+        }
+        // A revived terminal must land in a live worktree — an archived row's
+        // tmux state is gone and nothing would ever show the tab.
+        if worktree.status == .archived {
+            return RPCResponse(error: "Worktree is archived: \(worktree.displayName). Revive it before reviving terminals.")
+        }
+        guard FileManager.default.fileExists(atPath: worktree.path) else {
+            return RPCResponse(error: "Worktree directory missing on disk: \(worktree.path). Cannot revive a terminal there.")
+        }
+        guard let entry = try await db.terminalHistory.list(worktreeID: params.worktreeID)
+            .first(where: { $0.id == params.id }) else {
+            return RPCResponse(error: "Closed-terminal history entry not found: \(params.id)")
+        }
+
+        let resolvedCols = params.cols ?? TmuxManager.defaultCols
+        let resolvedRows = params.rows ?? TmuxManager.defaultRows
+        let plannedTerminalID = UUID()
+        let defaultShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+
+        _ = try await tmux.ensureServer(
+            server: worktree.tmuxServer, session: "main", cwd: worktree.path,
+            cols: resolvedCols, rows: resolvedRows)
+        await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
+
+        // Claude-kind with a live session id → resume it. Mirrors the
+        // archived-session restore spawn in WorktreeLifecycle+Create.
+        if entry.kind == .claude, let sessionID = entry.claudeSessionID {
+            let repo: Repo?
+            if let rid = worktree.repoID {
+                repo = try await db.repos.get(id: rid)
+            } else {
+                repo = nil
+            }
+            let reviveConfig = try? await db.config.get()
+            var resolvedProfile: ResolvedModelProfile? = nil
+            do {
+                resolvedProfile = try await modelProfileResolver.resolve(repoID: worktree.repoID)
+            } catch {
+                logger.warning("revive: model profile resolution failed; falling back to keychain login")
+                resolvedProfile = nil
+            }
+            let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
+            ClaudeTrustSeeder.ensureTrustedForScratch(
+                worktree: worktree, profileConfigDir: profileConfigDir)
+            await TranscriptProjectDirSync.ensureSessionResumableDetached(
+                sessionID: sessionID,
+                worktreePath: worktree.path,
+                projectsRoot: claudeProjectsRoot(profileConfigDirPath: profileConfigDir),
+                storedTranscriptPath: nil
+            )
+            let claudeEnvOverrides = reviveConfig?.envSettingOverrides ?? [:]
+            let spawn = ClaudeSpawnCommandBuilder.build(
+                resumeID: sessionID,
+                freshSessionID: nil,
+                appendSystemPrompt: nil,
+                initialPrompt: nil,
+                profileSecret: resolvedProfile?.secret,
+                profileKind: resolvedProfile?.kind,
+                profileBaseURL: resolvedProfile?.baseURL,
+                profileModel: resolvedProfile?.model,
+                profileAwsRegion: resolvedProfile?.awsRegion,
+                profileAwsProfile: resolvedProfile?.awsProfile,
+                profileConfigDir: profileConfigDir,
+                cmd: nil,
+                shellFallback: defaultShell,
+                settingsOverlayPath: ClaudeHookOverlay.resolveOverlayPath(
+                    fallbackModels: resolvedProfile?.fallbackModels,
+                    sessionKey: plannedTerminalID.uuidString,
+                    repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
+                ),
+                pluginDirPath: PluginDirWriter.pluginDirPath,
+                envSettingOverrides: claudeEnvOverrides
+            )
+            let env: [String: String] = [
+                "TBD_WORKTREE_ID": worktree.id.uuidString,
+                "TBD_TERMINAL_ID": plannedTerminalID.uuidString,
+            ]
+            let mergedEnvOverrides = EnvOverrideResolver.merge(
+                global: reviveConfig?.envOverrides,
+                repo: repo?.envOverrides,
+                profile: resolvedProfile?.envOverrides
+            )
+            let terminal = try await spawnRevivedTerminal(
+                worktree: worktree,
+                plannedTerminalID: plannedTerminalID,
+                spawnCommand: spawn.command,
+                env: env,
+                sensitiveEnv: mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder },
+                label: TerminalLabel.claudeCode,
+                kind: .claude,
+                claudeSessionID: sessionID,
+                profileID: resolvedProfile?.profileID,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+            logger.info("revive: resumed claude session \(sessionID, privacy: .public) as terminal \(terminal.id, privacy: .public) in worktree \(worktree.id, privacy: .public)")
+            return try RPCResponse(result: terminal)
+        }
+
+        // Shell / codex / claude-with-nil-session → fresh shell with the
+        // capture visible above the prompt (the raw file keeps escapes, so
+        // `cat` renders its colors). Skip the `cat` if the file is gone.
+        let capturePath = db.terminalHistory.contentPath(
+            worktreeID: worktree.id, terminalID: entry.id)
+        let haveCapture = FileManager.default.fileExists(atPath: capturePath)
+        let command = Self.reviveShellCommand(
+            capturePath: haveCapture ? capturePath : nil,
+            closedAt: entry.closedAt,
+            shell: defaultShell
+        )
+        let env: [String: String] = [
+            "TBD_WORKTREE_ID": worktree.id.uuidString,
+            "TBD_TERMINAL_ID": plannedTerminalID.uuidString,
+        ]
+        let terminal = try await spawnRevivedTerminal(
+            worktree: worktree,
+            plannedTerminalID: plannedTerminalID,
+            spawnCommand: command,
+            env: env,
+            sensitiveEnv: [:],
+            label: nil,
+            kind: .shell,
+            claudeSessionID: nil,
+            profileID: nil,
+            cols: resolvedCols,
+            rows: resolvedRows
+        )
+        logger.info("revive: opened shell terminal \(terminal.id, privacy: .public) from history entry \(entry.id, privacy: .public) (capture present: \(haveCapture, privacy: .public))")
+        return try RPCResponse(result: terminal)
+    }
+
+    /// Shared plumbing for spawning an ADDITIONAL terminal into a live worktree
+    /// during revive: create the window, insert the row, append it to the
+    /// persisted tab order as the new active tab, and broadcast the same
+    /// `.terminalCreated` delta the normal create path emits.
+    private func spawnRevivedTerminal(
+        worktree: Worktree,
+        plannedTerminalID: UUID,
+        spawnCommand: String,
+        env: [String: String],
+        sensitiveEnv: [String: String],
+        label: String?,
+        kind: TerminalKind,
+        claudeSessionID: String?,
+        profileID: UUID?,
+        cols: Int,
+        rows: Int
+    ) async throws -> Terminal {
+        let window = try await tmux.createWindow(
+            server: worktree.tmuxServer,
+            session: "main",
+            cwd: worktree.path,
+            shellCommand: spawnCommand,
+            env: env,
+            sensitiveEnv: sensitiveEnv,
+            cols: cols,
+            rows: rows
+        )
+        let terminal = try await db.terminals.create(
+            id: plannedTerminalID,
+            worktreeID: worktree.id,
+            tmuxWindowID: window.windowID,
+            tmuxPaneID: window.paneID,
+            label: label,
+            claudeSessionID: claudeSessionID,
+            profileID: profileID,
+            kind: kind
+        )
+        var order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
+        if !order.contains(terminal.id) { order.append(terminal.id) }
+        try await db.worktrees.setTabOrder(worktreeID: worktree.id, tabIDs: order)
+        try await db.worktrees.setActiveTabID(worktreeID: worktree.id, tabID: terminal.id)
+        subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
+            terminalID: terminal.id, worktreeID: terminal.worktreeID, label: terminal.label
+        )))
+        return terminal
+    }
+
+    /// Build the fresh-shell revive command: a dimmed divider banner, an
+    /// optional `cat` of the raw capture file (escapes intact → colors render),
+    /// then `exec <shell>`. Single-quote escaping matches `preSessionCommand` /
+    /// `shellWrapped`, so a capture path containing a single quote is safe.
+    static func reviveShellCommand(capturePath: String?, closedAt: Date, shell: String) -> String {
+        func quoted(_ s: String) -> String {
+            "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+        }
+        let stamp = Self.reviveBannerDateFormatter.string(from: closedAt)
+        // Dim (SGR 2) divider; `\033`/`\n` interpreted by printf's format string.
+        var command = "printf \(quoted("\\033[2m── restored from close on %s ──\\033[0m\\n")) \(quoted(stamp)); "
+        if let capturePath {
+            command += "/bin/cat \(quoted(capturePath)); "
+        }
+        command += "exec \(shell)"
+        return command
+    }
+
+    private static let reviveBannerDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        return f
+    }()
+
     func handleTerminalSetPin(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSetPinParams.self, from: paramsData)
         let pinnedAt: Date? = params.pinned ? Date() : nil

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -258,6 +258,8 @@ public final class RPCRouter: Sendable {
                 return try await handleNoteDelete(request.paramsData)
             case RPCMethod.noteList:
                 return try await handleNoteList(request.paramsData)
+            case RPCMethod.terminalHistoryList:
+                return try await handleTerminalHistoryList(request.paramsData)
             case RPCMethod.terminalOutput:
                 return try await handleTerminalOutput(request.paramsData)
             case RPCMethod.terminalConversation:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -260,6 +260,8 @@ public final class RPCRouter: Sendable {
                 return try await handleNoteList(request.paramsData)
             case RPCMethod.terminalHistoryList:
                 return try await handleTerminalHistoryList(request.paramsData)
+            case RPCMethod.terminalHistoryRevive:
+                return try await handleTerminalHistoryRevive(request.paramsData)
             case RPCMethod.terminalOutput:
                 return try await handleTerminalOutput(request.paramsData)
             case RPCMethod.terminalConversation:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -367,6 +367,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetControlMode(request.paramsData)
             case RPCMethod.configSetHibernateInputVeto:
                 return try await handleConfigSetHibernateInputVeto(request.paramsData)
+            case RPCMethod.configSetAutoCloseSetup:
+                return try await handleConfigSetAutoCloseSetup(request.paramsData)
             case RPCMethod.configSetGCEnabled:
                 return try await handleConfigSetGCEnabled(request.paramsData)
             case RPCMethod.gcList:
@@ -404,7 +406,8 @@ public final class RPCRouter: Sendable {
             controlModeEnabled: enabled,
             tmuxVersion: version?.description,
             controlModeSupported: version.map { $0 >= TmuxVersion.controlModeMinimum } ?? false,
-            hibernateInputVetoEnabled: config.hibernateInputVetoEnabled))
+            hibernateInputVetoEnabled: config.hibernateInputVetoEnabled,
+            autoCloseSetupEnabled: config.autoCloseSetupEnabled))
     }
 
     // MARK: - PR Status

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -326,6 +326,13 @@ public struct TmuxManager: Sendable {
         ["-L", server, "capture-pane", "-p", "-J", "-S", "-10000", "-t", paneID]
     }
 
+    /// Keep a window's pane around (marked dead) after its process exits,
+    /// instead of destroying the window. Same option TmuxBridge sets
+    /// app-side when a viewer attaches.
+    public static func setRemainOnExitCommand(server: String, windowID: String) -> [String] {
+        ["-L", server, "set-option", "-wt", windowID, "remain-on-exit", "on"]
+    }
+
     public static func paneCurrentCommandQuery(server: String, paneID: String) -> [String] {
         ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_current_command}"]
     }
@@ -620,6 +627,19 @@ public struct TmuxManager: Sendable {
         if dryRun { return dryRunCapturePane?(server, paneID) ?? "" }
         let args = Self.capturePaneWithAnsiCommand(server: server, paneID: paneID)
         return try await runTmux(args)
+    }
+
+    /// Set `remain-on-exit on` for a window so its pane survives (dead) when
+    /// the process exits. The auto-close setup spawn needs this: its wrapper
+    /// lets the pane exit on hook success, and without remain-on-exit the
+    /// window is destroyed before the teardown can capture its scrollback.
+    public func setRemainOnExit(server: String, windowID: String) async throws {
+        let args = Self.setRemainOnExitCommand(server: server, windowID: windowID)
+        if dryRun {
+            dryRunRecorder?(args)
+            return
+        }
+        try await runTmux(args)
     }
 
     /// Archival snapshot of a closing pane's scrollback (plain text, last

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -319,6 +319,13 @@ public struct TmuxManager: Sendable {
         ["-L", server, "capture-pane", "-p", "-e", "-J", "-t", paneID]
     }
 
+    /// Plain-text scrollback capture (no `-e` escapes) bounded to roughly the
+    /// last 10k lines, wrapped lines joined. Used for the archival
+    /// closed-terminal-history snapshot taken just before a window is killed.
+    public static func capturePaneScrollbackCommand(server: String, paneID: String) -> [String] {
+        ["-L", server, "capture-pane", "-p", "-J", "-S", "-10000", "-t", paneID]
+    }
+
     public static func paneCurrentCommandQuery(server: String, paneID: String) -> [String] {
         ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_current_command}"]
     }
@@ -612,6 +619,16 @@ public struct TmuxManager: Sendable {
         // can exercise the park path's snapshot capture end-to-end.
         if dryRun { return dryRunCapturePane?(server, paneID) ?? "" }
         let args = Self.capturePaneWithAnsiCommand(server: server, paneID: paneID)
+        return try await runTmux(args)
+    }
+
+    /// Archival snapshot of a closing pane's scrollback (plain text, last
+    /// ~10k lines) for read-only closed-terminal history. Verbatim
+    /// pass-through for display — never parsed for agent/TUI state. dryRun
+    /// consults the shared `dryRunCapturePane` hook like the other captures.
+    public func capturePaneScrollback(server: String, paneID: String) async throws -> String {
+        if dryRun { return dryRunCapturePane?(server, paneID) ?? "" }
+        let args = Self.capturePaneScrollbackCommand(server: server, paneID: paneID)
         return try await runTmux(args)
     }
 

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -319,11 +319,14 @@ public struct TmuxManager: Sendable {
         ["-L", server, "capture-pane", "-p", "-e", "-J", "-t", paneID]
     }
 
-    /// Plain-text scrollback capture (no `-e` escapes) bounded to roughly the
-    /// last 10k lines, wrapped lines joined. Used for the archival
+    /// Scrollback capture with ANSI (`-e`) escapes preserved, bounded to
+    /// roughly the last 10k lines, wrapped lines joined. Used for the archival
     /// closed-terminal-history snapshot taken just before a window is killed.
+    /// The escapes are kept so the raw file is a faithful replay source (the
+    /// revive path `cat`s it back with colors intact); the read-only viewer
+    /// strips them for plain-text display.
     public static func capturePaneScrollbackCommand(server: String, paneID: String) -> [String] {
-        ["-L", server, "capture-pane", "-p", "-J", "-S", "-10000", "-t", paneID]
+        ["-L", server, "capture-pane", "-p", "-e", "-J", "-S", "-10000", "-t", paneID]
     }
 
     /// Keep a window's pane around (marked dead) after its process exits,

--- a/Sources/TBDShared/ANSIEscape.swift
+++ b/Sources/TBDShared/ANSIEscape.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Strips ANSI/OSC escape sequences from terminal capture text.
+///
+/// Closed-terminal history files are captured with escapes intact (`capture-pane
+/// -e`) so the raw file stays a faithful replay/fidelity source — the revive
+/// path `cat`s it back and colors render. The read-only history viewer, which
+/// cannot interpret escapes, strips them here for plain-text display.
+/// (Deliberate v1: colors in the viewer can come later.)
+public enum ANSIEscape {
+    /// CSI (`ESC [ … final-byte`) and OSC (`ESC ] … BEL|ST`) sequences.
+    /// Mirrors the scrubber pattern used elsewhere in TBD.
+    private static let regex = try! NSRegularExpression(
+        pattern: "\u{1B}\\[[0-9;?]*[ -/]*[@-~]|\u{1B}\\][^\u{07}\u{1B}]*(?:\u{07}|\u{1B}\\\\)"
+    )
+
+    /// Remove all ANSI/OSC escape sequences, leaving the visible text.
+    public static func strip(_ s: String) -> String {
+        let range = NSRange(s.startIndex..., in: s)
+        return regex.stringByReplacingMatches(in: s, range: range, withTemplate: "")
+    }
+}

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -133,6 +133,26 @@ public enum TBDConstants {
         claudeSettingsOverlayPath(repoID: repoID, environment: ProcessInfo.processInfo.environment)
     }
 
+    /// Base directory for per-note (tab) content files. Honors TBD_HOME.
+    public static func noteContentDir(environment: [String: String]) -> URL {
+        configDir(environment: environment).appendingPathComponent("notes")
+    }
+    public static var noteContentDir: URL { noteContentDir(environment: ProcessInfo.processInfo.environment) }
+
+    /// Path to one note tab's content file:
+    /// `~/tbd/notes/<worktreeID>/<noteID>.md`. Note content is file-backed
+    /// (the DB `content` column is a dormant legacy fallback); the DB note
+    /// row keeps tab identity + title. Honors TBD_HOME.
+    public static func noteContentPath(worktreeID: UUID, noteID: UUID, environment: [String: String]) -> String {
+        noteContentDir(environment: environment)
+            .appendingPathComponent(worktreeID.uuidString)
+            .appendingPathComponent("\(noteID.uuidString).md")
+            .path
+    }
+    public static func noteContentPath(worktreeID: UUID, noteID: UUID) -> String {
+        noteContentPath(worktreeID: worktreeID, noteID: noteID, environment: ProcessInfo.processInfo.environment)
+    }
+
     /// Path to a scratch worktree's notepad file:
     /// `~/tbd/worktrees/<worktreeID>/notes.md`. Honors TBD_HOME.
     public static func notesPath(worktreeID: UUID, environment: [String: String]) -> String {

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -153,6 +153,26 @@ public enum TBDConstants {
         noteContentPath(worktreeID: worktreeID, noteID: noteID, environment: ProcessInfo.processInfo.environment)
     }
 
+    /// Base directory for captured scrollback of closed terminals. Honors TBD_HOME.
+    public static func terminalHistoryDir(environment: [String: String]) -> URL {
+        configDir(environment: environment).appendingPathComponent("terminal-history")
+    }
+    public static var terminalHistoryDir: URL { terminalHistoryDir(environment: ProcessInfo.processInfo.environment) }
+
+    /// Path to one closed terminal's captured scrollback:
+    /// `~/tbd/terminal-history/<worktreeID>/<terminalID>.txt`. Content is
+    /// file-backed (the `terminal_history` DB row keeps metadata only); the
+    /// app reads this file directly. Honors TBD_HOME.
+    public static func terminalHistoryPath(worktreeID: UUID, terminalID: UUID, environment: [String: String]) -> String {
+        terminalHistoryDir(environment: environment)
+            .appendingPathComponent(worktreeID.uuidString)
+            .appendingPathComponent("\(terminalID.uuidString).txt")
+            .path
+    }
+    public static func terminalHistoryPath(worktreeID: UUID, terminalID: UUID) -> String {
+        terminalHistoryPath(worktreeID: worktreeID, terminalID: terminalID, environment: ProcessInfo.processInfo.environment)
+    }
+
     /// Path to a scratch worktree's notepad file:
     /// `~/tbd/worktrees/<worktreeID>/notes.md`. Honors TBD_HOME.
     public static func notesPath(worktreeID: UUID, environment: [String: String]) -> String {

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -962,6 +962,35 @@ public struct Note: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
+/// Metadata for a closed terminal whose scrollback was captured at close time.
+/// The captured text is file-backed at
+/// `~/tbd/terminal-history/<worktreeID>/<terminalID>.txt`
+/// (`TBDConstants.terminalHistoryPath`); the app reads the file directly and
+/// shows it read-only in Session History → Closed Terminals.
+public struct TerminalHistoryEntry: Codable, Sendable, Identifiable, Equatable {
+    /// The closed terminal's UUID (also names the content file).
+    public let id: UUID
+    public var worktreeID: UUID
+    public var label: String?
+    public var kind: TerminalKind?
+    public var closedAt: Date
+    public var claudeSessionID: String?
+    /// Line count of the captured text (display metadata).
+    public var lineCount: Int
+
+    public init(id: UUID, worktreeID: UUID, label: String? = nil,
+                kind: TerminalKind? = nil, closedAt: Date = Date(),
+                claudeSessionID: String? = nil, lineCount: Int = 0) {
+        self.id = id
+        self.worktreeID = worktreeID
+        self.label = label
+        self.kind = kind
+        self.closedAt = closedAt
+        self.claudeSessionID = claudeSessionID
+        self.lineCount = lineCount
+    }
+}
+
 /// Kind of reaped directory a `ReapRecord` describes.
 public enum ReapKind: String, Codable, Sendable { case agentWorktree, scratchpad }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -777,6 +777,13 @@ public struct Config: Codable, Sendable, Equatable {
     /// applies. The input veto is opt-in until it soaks and the v50 master
     /// default is reverted.
     public var hibernateInputVetoEnabled: Bool
+    /// Soak flag for auto-closing the setup-hook tab after a clean run.
+    /// When true AND a setup hook resolves, the hook's exit code is written
+    /// to a marker file; exit 0 closes the tab (kills the pane, deletes the
+    /// terminal/tab rows), nonzero leaves the tab open with an interactive
+    /// shell for debugging. Default OFF: this kills a pane and deletes rows
+    /// without a user gesture, so it is opt-in until it soaks.
+    public var autoCloseSetupEnabled: Bool
     /// Master switch for the daemon-owned orphan GC sweep. Default ON.
     public var gcEnabled: Bool
     /// Minimum age (seconds) an orphaned worktree/scratchpad must reach
@@ -809,6 +816,7 @@ public struct Config: Codable, Sendable, Equatable {
                 controlModeEnabled: Bool = false,
                 autoResumeOnApiError: Bool = false,
                 hibernateInputVetoEnabled: Bool = false,
+                autoCloseSetupEnabled: Bool = false,
                 gcEnabled: Bool = true,
                 gcGraceSeconds: Int = Config.defaultGCGraceSeconds,
                 gcSnapshotRetentionDays: Int = Config.defaultGCSnapshotRetentionDays) {
@@ -828,6 +836,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.controlModeEnabled = controlModeEnabled
         self.autoResumeOnApiError = autoResumeOnApiError
         self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
+        self.autoCloseSetupEnabled = autoCloseSetupEnabled
         self.gcEnabled = gcEnabled
         self.gcGraceSeconds = gcGraceSeconds
         self.gcSnapshotRetentionDays = gcSnapshotRetentionDays
@@ -864,6 +873,8 @@ public struct Config: Codable, Sendable, Equatable {
             Bool.self, forKey: .autoResumeOnApiError) ?? false
         hibernateInputVetoEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
+        autoCloseSetupEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .autoCloseSetupEnabled) ?? false
         gcEnabled = try c.decodeIfPresent(Bool.self, forKey: .gcEnabled) ?? true
         gcGraceSeconds = try c.decodeIfPresent(Int.self, forKey: .gcGraceSeconds)
             ?? Config.defaultGCGraceSeconds

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -139,6 +139,7 @@ public enum RPCMethod {
     public static let noteUpdate = "note.update"
     public static let noteDelete = "note.delete"
     public static let noteList = "note.list"
+    public static let terminalHistoryList = "terminalHistory.list"
     public static let terminalOutput = "terminal.output"
     public static let terminalConversation = "terminal.conversation"
     public static let terminalTranscript = "terminal.transcript"
@@ -1153,6 +1154,15 @@ public struct TerminalSendParams: Codable, Sendable {
 public struct TerminalDeleteParams: Codable, Sendable {
     public let terminalID: UUID
     public init(terminalID: UUID) { self.terminalID = terminalID }
+}
+
+/// Params for `terminalHistory.list` — closed-terminal capture metadata for a
+/// worktree, newest first. Result type: `[TerminalHistoryEntry]`. Content is
+/// NOT sent over RPC; the app reads the file at
+/// `TBDConstants.terminalHistoryPath` directly.
+public struct TerminalHistoryListParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
 }
 
 public struct TerminalSetPinParams: Codable, Sendable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -140,6 +140,7 @@ public enum RPCMethod {
     public static let noteDelete = "note.delete"
     public static let noteList = "note.list"
     public static let terminalHistoryList = "terminalHistory.list"
+    public static let terminalHistoryRevive = "terminalHistory.revive"
     public static let terminalOutput = "terminal.output"
     public static let terminalConversation = "terminal.conversation"
     public static let terminalTranscript = "terminal.transcript"
@@ -1163,6 +1164,20 @@ public struct TerminalDeleteParams: Codable, Sendable {
 public struct TerminalHistoryListParams: Codable, Sendable {
     public let worktreeID: UUID
     public init(worktreeID: UUID) { self.worktreeID = worktreeID }
+}
+
+/// Params for `terminalHistory.revive` — spawn a NEW terminal in `worktreeID`
+/// from the closed-terminal history entry `id`. Claude entries with a session
+/// id resume that session; every other kind opens a fresh shell with the raw
+/// capture (colors intact) printed above the prompt. Result type: `Terminal`.
+public struct TerminalHistoryReviveParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let id: UUID
+    public let cols: Int?
+    public let rows: Int?
+    public init(worktreeID: UUID, id: UUID, cols: Int? = nil, rows: Int? = nil) {
+        self.worktreeID = worktreeID; self.id = id; self.cols = cols; self.rows = rows
+    }
 }
 
 public struct TerminalSetPinParams: Codable, Sendable {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -207,6 +207,7 @@ public enum RPCMethod {
     public static let terminalCancelScheduledResume = "terminal.cancelScheduledResume"
     public static let configSetControlMode = "config.setControlMode"
     public static let configSetHibernateInputVeto = "config.setHibernateInputVeto"
+    public static let configSetAutoCloseSetup = "config.setAutoCloseSetup"
     public static let gcList = "gc.list"
     public static let gcRestore = "gc.restore"
     public static let gcSweepNow = "gc.sweepNow"
@@ -1362,6 +1363,14 @@ public struct ConfigSetHibernateInputVetoParams: Codable, Sendable {
     public init(enabled: Bool) { self.enabled = enabled }
 }
 
+/// Params for `config.setAutoCloseSetup` — the auto-close-setup-tab soak
+/// flag (default OFF). Read fresh at spawn time; applies to the next
+/// worktree creation, no daemon restart required.
+public struct ConfigSetAutoCloseSetupParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
 /// Params for `config.setGCEnabled` — the orphan-GC master switch.
 public struct ConfigSetGCEnabledParams: Codable, Sendable {
     public var enabled: Bool
@@ -1503,15 +1512,20 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// against hibernating sessions with typed-but-unsent input. Re-evaluated
     /// by the daemon on every call.
     public let hibernateInputVetoEnabled: Bool
+    /// Whether the setup-hook tab auto-closes after a clean run (soak flag,
+    /// default OFF). Re-evaluated by the daemon on every call.
+    public let autoCloseSetupEnabled: Bool
 
     public init(controlModeEnabled: Bool,
                 tmuxVersion: String? = nil,
                 controlModeSupported: Bool = false,
-                hibernateInputVetoEnabled: Bool = false) {
+                hibernateInputVetoEnabled: Bool = false,
+                autoCloseSetupEnabled: Bool = false) {
         self.controlModeEnabled = controlModeEnabled
         self.tmuxVersion = tmuxVersion
         self.controlModeSupported = controlModeSupported
         self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
+        self.autoCloseSetupEnabled = autoCloseSetupEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1523,6 +1537,8 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         controlModeSupported = try c.decodeIfPresent(Bool.self, forKey: .controlModeSupported) ?? false
         // New field for pending-input veto; absent from older daemons defaults to false (soaking).
         hibernateInputVetoEnabled = try c.decodeIfPresent(Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
+        // New field for setup-tab auto-close; absent from older daemons defaults to false (soaking).
+        autoCloseSetupEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoCloseSetupEnabled) ?? false
     }
 }
 

--- a/Tests/TBDAppTests/NoteCloseConfirmTests.swift
+++ b/Tests/TBDAppTests/NoteCloseConfirmTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Closing a note tab hard-deletes the note row, so `closeTab` asks for
+/// confirmation when the note has content (empty notes close silently).
+/// The confirmer is injectable (`AppState.noteCloseConfirmer`) so both
+/// branches run without a real modal NSAlert.
+///
+/// Constructs `AppState(userDefaults:)` against a throwaway suite —
+/// `UserDefaults.standard` on this unbundled executable is the developer's
+/// real TBDApp.plist (see TabUnreadCompletionTests).
+@MainActor
+@Suite("Note close confirmation")
+struct NoteCloseConfirmTests {
+
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "TBDAppTests.NoteCloseConfirm.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    private func makeNoteTab(
+        state: AppState, worktreeID: UUID, content: String
+    ) -> Note {
+        let note = Note(worktreeID: worktreeID, title: "Notes", content: content)
+        state.notes = [worktreeID: [note]]
+        state.tabs = [worktreeID: [
+            Tab(id: note.id, content: .note(noteID: note.id), label: nil)
+        ]]
+        return note
+    }
+
+    @Test func nonEmptyNoteDeclinedKeepsTab() {
+        withState { state in
+            let worktreeID = UUID()
+            let note = makeNoteTab(state: state, worktreeID: worktreeID, content: "important")
+            var asked = false
+            state.noteCloseConfirmer = { _ in
+                asked = true
+                return false
+            }
+
+            state.closeTab(worktreeID: worktreeID, index: 0)
+
+            #expect(asked, "a non-empty note must prompt before closing")
+            #expect(state.tabs[worktreeID]?.contains { $0.id == note.id } == true,
+                    "declining the prompt must keep the tab")
+        }
+    }
+
+    @Test func nonEmptyNoteConfirmedClosesTab() {
+        withState { state in
+            let worktreeID = UUID()
+            let note = makeNoteTab(state: state, worktreeID: worktreeID, content: "important")
+            state.noteCloseConfirmer = { _ in true }
+
+            state.closeTab(worktreeID: worktreeID, index: 0)
+
+            #expect(state.tabs[worktreeID]?.contains { $0.id == note.id } != true,
+                    "confirming the prompt must close the tab")
+        }
+    }
+
+    @Test func emptyNoteClosesSilently() {
+        withState { state in
+            let worktreeID = UUID()
+            let note = makeNoteTab(state: state, worktreeID: worktreeID, content: "  \n")
+            var asked = false
+            state.noteCloseConfirmer = { _ in
+                asked = true
+                return false
+            }
+
+            state.closeTab(worktreeID: worktreeID, index: 0)
+
+            #expect(!asked, "an empty (whitespace-only) note must not prompt")
+            #expect(state.tabs[worktreeID]?.contains { $0.id == note.id } != true,
+                    "an empty note tab must close silently as before")
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/AutoCloseSetupTests.swift
+++ b/Tests/TBDDaemonTests/AutoCloseSetupTests.swift
@@ -95,6 +95,10 @@ struct AutoCloseSetupTests {
                 "flag off must keep the pre-existing shellWrapped command")
         #expect(setupBody.contains("exec "))
 
+        // Flag off never touches remain-on-exit — the pane stays a normal
+        // interactive shell window.
+        #expect(!recorder.snapshot().contains { $0.contains("remain-on-exit") })
+
         // No watcher was armed: a marker written by hand is never consumed
         // and the setup terminal stays.
         try writeSetupMarker(worktreeID: wt.id, exitCode: 0)
@@ -135,6 +139,14 @@ struct AutoCloseSetupTests {
         )
         #expect(setupBody.contains("runtime/setup"))
         #expect(setupBody.contains("if [ $__tbd_rc -ne 0 ]"))
+
+        // Armed spawn must keep the dead pane around: the wrapper lets the
+        // pane exit on success, and without remain-on-exit the window dies
+        // with it before the teardown can capture scrollback history.
+        let remainCalls = recorder.snapshot().filter { $0.contains("remain-on-exit") }
+        #expect(remainCalls.count == 1)
+        #expect(remainCalls.first?.contains(setup.tmuxWindowID) == true,
+                "remain-on-exit must target the setup window")
 
         // dryRun tmux never runs the hook — stand in for its clean exit.
         // (The spawn deleted any stale marker, so write AFTER create returns.)
@@ -202,6 +214,8 @@ struct AutoCloseSetupTests {
         // with the flag on; no marker machinery, no watcher.
         let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
         #expect(!windowCalls.contains { ($0.last ?? "").contains("runtime/setup") })
+        // Hook-less setup tab is a plain interactive shell: no remain-on-exit.
+        #expect(!recorder.snapshot().contains { $0.contains("remain-on-exit") })
         let terminals = try await db.terminals.list(worktreeID: wt.id)
         #expect(terminals.contains { $0.label == TerminalLabel.setup })
     }

--- a/Tests/TBDDaemonTests/AutoCloseSetupTests.swift
+++ b/Tests/TBDDaemonTests/AutoCloseSetupTests.swift
@@ -145,8 +145,10 @@ struct AutoCloseSetupTests {
 
         #expect(try await db.terminals.get(id: setup.id) == nil,
                 "exit 0 must delete the setup terminal row")
-        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [primary.id],
+        let order = try await db.worktrees.getTabOrder(worktreeID: wt.id)
+        #expect(!order.contains(setup.id),
                 "the closed setup tab must be pruned from the stored tab order")
+        #expect(order.first == primary.id)
         #expect(try await db.worktrees.getActiveTabID(worktreeID: wt.id) == primary.id)
         let markerPath = WorktreeLifecycle.setupMarkerPath(worktreeID: wt.id)
         #expect(!FileManager.default.fileExists(atPath: markerPath), "marker must be consumed")

--- a/Tests/TBDDaemonTests/AutoCloseSetupTests.swift
+++ b/Tests/TBDDaemonTests/AutoCloseSetupTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import GRDB
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: these tests mutate the process-global
+// `TBD_HOME` env var (via `isolateTBDHome` from PreSessionTestSupport.swift)
+// to isolate hook resolution and the runtime/setup marker directory from the
+// developer's real ~/tbd. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+@Suite("Setup-tab auto-close")
+struct AutoCloseSetupTests {
+
+    /// Writes the completion marker the wrapped setup-hook command would write.
+    private func writeSetupMarker(worktreeID: UUID, exitCode: Int) throws {
+        let path = WorktreeLifecycle.setupMarkerPath(worktreeID: worktreeID)
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try "\(exitCode)\n".write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Command wrapper + marker path
+
+    @Test func setupMarkerPathRespectsTBDHome() {
+        let (home, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let id = UUID()
+        let path = WorktreeLifecycle.setupMarkerPath(worktreeID: id)
+        #expect(path.hasPrefix(home.path))
+        #expect(path.contains("runtime/setup"))
+        #expect(path.hasSuffix(id.uuidString))
+    }
+
+    @Test func setupAutoCloseCommandEscapesAndExecsShellOnlyOnFailure() {
+        let cmd = WorktreeLifecycle.setupAutoCloseCommand(
+            hookPath: "/tmp/it's here/setup",
+            runtimeDir: "/r/dir",
+            markerPath: "/r/dir/marker",
+            shell: "/bin/zsh"
+        )
+        // Quoting matches preSessionCommand's escaping.
+        #expect(cmd.contains("'/tmp/it'\\''s here/setup'"))
+        #expect(cmd.contains("__tbd_rc=$?"))
+        #expect(cmd.contains("/bin/mkdir -p '/r/dir'"))
+        #expect(cmd.contains("/bin/echo $__tbd_rc > '/r/dir/marker'"))
+        // Failure path execs the interactive shell for debugging …
+        #expect(cmd.hasSuffix("if [ $__tbd_rc -ne 0 ]; then exec /bin/zsh; fi"))
+        // … but success must let the pane exit: no unconditional exec.
+        #expect(!cmd.contains("fi; exec"))
+    }
+
+    // MARK: - Config flag plumbing
+
+    @Test func configFlagDefaultsOffAndRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        #expect(try await db.config.get().autoCloseSetupEnabled == false,
+                "auto_close_setup_enabled must default OFF")
+        try await db.config.setAutoCloseSetup(enabled: true)
+        #expect(try await db.config.get().autoCloseSetupEnabled == true)
+        try await db.config.setAutoCloseSetup(enabled: false)
+        #expect(try await db.config.get().autoCloseSetupEnabled == false)
+    }
+
+    // MARK: - Flag OFF (default): behavior byte-for-byte unchanged
+
+    @Test func flagOffSpawnsPlainShellWrappedSetupAndNoWatcher() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = PreSessionRecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installHook(named: "setup", repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        let setup = try #require(terminals.first { $0.label == TerminalLabel.setup })
+
+        // The setup window runs the plain shellWrapped hook — no marker
+        // machinery in the command.
+        let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        let setupBody = try #require(
+            windowCalls.compactMap(\.last).first { $0.contains(".worktree-hooks/setup") }
+        )
+        #expect(!setupBody.contains("runtime/setup"),
+                "flag off must not wire the marker file into the setup command")
+        #expect(!setupBody.contains("__tbd_rc"),
+                "flag off must keep the pre-existing shellWrapped command")
+        #expect(setupBody.contains("exec "))
+
+        // No watcher was armed: a marker written by hand is never consumed
+        // and the setup terminal stays.
+        try writeSetupMarker(worktreeID: wt.id, exitCode: 0)
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(try await db.terminals.get(id: setup.id) != nil,
+                "flag off must never auto-close the setup tab")
+        let markerPath = WorktreeLifecycle.setupMarkerPath(worktreeID: wt.id)
+        #expect(FileManager.default.fileExists(atPath: markerPath),
+                "flag off must not consume the marker (no watcher running)")
+        try? FileManager.default.removeItem(atPath: markerPath)
+    }
+
+    // MARK: - Flag ON: clean exit closes the tab, failure keeps it
+
+    @Test func flagOnCleanExitClosesSetupTab() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoCloseSetup(enabled: true)
+        let recorder = PreSessionRecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder, timeout: 5)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installHook(named: "setup", repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.count == 2)
+        let setup = try #require(terminals.first { $0.label == TerminalLabel.setup })
+        let primary = try #require(terminals.first { $0.id != setup.id })
+
+        // The setup window runs the marker-writing wrapper.
+        let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        let setupBody = try #require(
+            windowCalls.compactMap(\.last).first { $0.contains(".worktree-hooks/setup") }
+        )
+        #expect(setupBody.contains("runtime/setup"))
+        #expect(setupBody.contains("if [ $__tbd_rc -ne 0 ]"))
+
+        // dryRun tmux never runs the hook — stand in for its clean exit.
+        // (The spawn deleted any stale marker, so write AFTER create returns.)
+        try writeSetupMarker(worktreeID: wt.id, exitCode: 0)
+        try await waitFor("setup terminal auto-close") {
+            (try? await db.terminals.get(id: setup.id)) == nil
+        }
+
+        #expect(try await db.terminals.get(id: setup.id) == nil,
+                "exit 0 must delete the setup terminal row")
+        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [primary.id],
+                "the closed setup tab must be pruned from the stored tab order")
+        #expect(try await db.worktrees.getActiveTabID(worktreeID: wt.id) == primary.id)
+        let markerPath = WorktreeLifecycle.setupMarkerPath(worktreeID: wt.id)
+        #expect(!FileManager.default.fileExists(atPath: markerPath), "marker must be consumed")
+    }
+
+    @Test func flagOnFailureKeepsSetupTab() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoCloseSetup(enabled: true)
+        let lifecycle = makeLifecycle(db: db, timeout: 5)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installHook(named: "setup", repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        let setup = try #require(terminals.first { $0.label == TerminalLabel.setup })
+        let orderBefore = try await db.worktrees.getTabOrder(worktreeID: wt.id)
+
+        try writeSetupMarker(worktreeID: wt.id, exitCode: 3)
+        let markerPath = WorktreeLifecycle.setupMarkerPath(worktreeID: wt.id)
+        // Marker consumption is the observable signal that the watcher
+        // processed the failure outcome.
+        try await waitFor("setup marker consumed") {
+            !FileManager.default.fileExists(atPath: markerPath)
+        }
+
+        #expect(try await db.terminals.get(id: setup.id) != nil,
+                "a nonzero exit must keep the setup tab open")
+        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == orderBefore,
+                "a failed hook must leave the tab order untouched")
+    }
+
+    @Test func flagOnWithoutHookSpawnsPlainShell() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoCloseSetup(enabled: true)
+        let recorder = PreSessionRecordedCommands()
+        let lifecycle = makeLifecycle(db: db, recorder: recorder)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+        // No hook resolves → hook-less "Setup" tab stays a plain shell even
+        // with the flag on; no marker machinery, no watcher.
+        let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
+        #expect(!windowCalls.contains { ($0.last ?? "").contains("runtime/setup") })
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        #expect(terminals.contains { $0.label == TerminalLabel.setup })
+    }
+}
+}

--- a/Tests/TBDDaemonTests/DatabaseTests.swift
+++ b/Tests/TBDDaemonTests/DatabaseTests.swift
@@ -409,7 +409,12 @@ struct DatabaseTests {
     }
 
     @Test func updateNoteContent() async throws {
-        let db = try TBDDatabase(inMemory: true)
+        // Content writes are file-backed — inject a temp notes dir so the
+        // test never touches the real ~/tbd/notes.
+        let notesDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-notes-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: notesDir) }
+        let db = try TBDDatabase(inMemory: true, notesDir: notesDir.path)
         let repo = try await db.repos.create(path: "/tmp/test", displayName: "test", defaultBranch: "main")
         let wt = try await db.worktrees.create(
             repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",

--- a/Tests/TBDDaemonTests/NoteContentFileTests.swift
+++ b/Tests/TBDDaemonTests/NoteContentFileTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Note CONTENT is file-backed (`<notesDir>/<worktreeID>/<noteID>.md`); the
+/// DB row keeps identity + title, its `content` column surviving only as a
+/// dormant legacy fallback. These tests use the `TBDDatabase(inMemory:
+/// notesDir:)` injection seam with a per-test temp dir — no TBD_HOME setenv,
+/// so the suite runs fully parallel.
+@Suite("Note content files")
+struct NoteContentFileTests {
+
+    /// In-memory DB with an isolated notes dir and one (scratch-style)
+    /// worktree row to hang notes off. Caller removes `dir`.
+    private func makeFixture() async throws -> (db: TBDDatabase, dir: URL, worktree: Worktree) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-notes-\(UUID().uuidString)")
+        let db = try TBDDatabase(inMemory: true, notesDir: dir.path)
+        let wt = try await db.worktrees.createScratch(
+            name: "fixture", displayName: "fixture",
+            path: "/tmp/fixture-\(UUID().uuidString)", tmuxServer: "tbd-test"
+        )
+        return (db, dir, wt)
+    }
+
+    private func filePath(dir: URL, worktreeID: UUID, noteID: UUID) -> String {
+        dir.appendingPathComponent(worktreeID.uuidString)
+            .appendingPathComponent("\(noteID.uuidString).md").path
+    }
+
+    private func rawDBContent(db: TBDDatabase, noteID: UUID) async throws -> String? {
+        try await db.writerForTests.read { db in
+            try String.fetchOne(
+                db, sql: "SELECT content FROM note WHERE id = ?",
+                arguments: [noteID.uuidString]
+            )
+        }
+    }
+
+    @Test func updateWritesFileAndNotDBColumn() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let note = try await db.notes.create(worktreeID: wt.id)
+        let path = filePath(dir: dir, worktreeID: wt.id, noteID: note.id)
+        // A freshly created (empty) note must produce no file.
+        #expect(!FileManager.default.fileExists(atPath: path))
+
+        let updated = try await db.notes.update(id: note.id, content: "hello world")
+        #expect(updated.content == "hello world")
+        #expect(try String(contentsOfFile: path, encoding: .utf8) == "hello world")
+        #expect(try await rawDBContent(db: db, noteID: note.id) == "",
+                "content must not be written to the DB column")
+
+        #expect(try await db.notes.get(id: note.id)?.content == "hello world")
+    }
+
+    @Test func updateToEmptyDeletesFile() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let note = try await db.notes.create(worktreeID: wt.id)
+        _ = try await db.notes.update(id: note.id, content: "something")
+        let path = filePath(dir: dir, worktreeID: wt.id, noteID: note.id)
+        #expect(FileManager.default.fileExists(atPath: path))
+
+        let cleared = try await db.notes.update(id: note.id, content: "   \n")
+        #expect(!FileManager.default.fileExists(atPath: path),
+                "empty/whitespace-only content must delete the file")
+        #expect(cleared.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(try await db.notes.get(id: note.id)?.content == "")
+    }
+
+    @Test func fileWinsOverDBAndDBIsFallback() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Legacy row: content only in the DB column, no file.
+        let note = try await db.notes.create(worktreeID: wt.id)
+        try await db.writerForTests.write { db in
+            try db.execute(
+                sql: "UPDATE note SET content = 'legacy' WHERE id = ?",
+                arguments: [note.id.uuidString]
+            )
+        }
+        #expect(try await db.notes.get(id: note.id)?.content == "legacy",
+                "with no file, the DB column is the fallback")
+        #expect(try await db.notes.list(worktreeID: wt.id).first?.content == "legacy")
+
+        // File appears (e.g. external edit) → file wins over the stale column.
+        let path = filePath(dir: dir, worktreeID: wt.id, noteID: note.id)
+        try FileManager.default.createDirectory(
+            atPath: (path as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        try "from the file".write(toFile: path, atomically: true, encoding: .utf8)
+        #expect(try await db.notes.get(id: note.id)?.content == "from the file")
+        #expect(try await db.notes.list(worktreeID: wt.id).first?.content == "from the file")
+    }
+
+    @Test func clearingLegacyNoteDoesNotResurrectDBContent() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let note = try await db.notes.create(worktreeID: wt.id)
+        try await db.writerForTests.write { db in
+            try db.execute(
+                sql: "UPDATE note SET content = 'legacy' WHERE id = ?",
+                arguments: [note.id.uuidString]
+            )
+        }
+        // Explicitly clearing must stick: the file is deleted AND the legacy
+        // column is cleared, so the old content can't resurrect via fallback.
+        _ = try await db.notes.update(id: note.id, content: "")
+        #expect(try await db.notes.get(id: note.id)?.content == "")
+    }
+
+    @Test func startupExportWritesFilesOnceAndNeverClobbers() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Legacy rows: one with content, one empty.
+        let legacy = try await db.notes.create(worktreeID: wt.id)
+        let empty = try await db.notes.create(worktreeID: wt.id)
+        try await db.writerForTests.write { db in
+            try db.execute(
+                sql: "UPDATE note SET content = 'exported' WHERE id = ?",
+                arguments: [legacy.id.uuidString]
+            )
+        }
+
+        await db.notes.exportContentColumnToFiles()
+
+        let legacyPath = filePath(dir: dir, worktreeID: wt.id, noteID: legacy.id)
+        let emptyPath = filePath(dir: dir, worktreeID: wt.id, noteID: empty.id)
+        #expect(try String(contentsOfFile: legacyPath, encoding: .utf8) == "exported")
+        #expect(!FileManager.default.fileExists(atPath: emptyPath),
+                "empty rows must produce no file")
+        #expect(try await rawDBContent(db: db, noteID: legacy.id) == "exported",
+                "the export must NOT clear the DB column (dormant backup)")
+
+        // A newer file edit survives a second startup export untouched.
+        try "newer edit".write(toFile: legacyPath, atomically: true, encoding: .utf8)
+        await db.notes.exportContentColumnToFiles()
+        #expect(try String(contentsOfFile: legacyPath, encoding: .utf8) == "newer edit",
+                "a re-run must never clobber an existing file")
+    }
+
+    @Test func deleteKeepsContentFile() async throws {
+        let (db, dir, wt) = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let note = try await db.notes.create(worktreeID: wt.id)
+        _ = try await db.notes.update(id: note.id, content: "keep me")
+        let path = filePath(dir: dir, worktreeID: wt.id, noteID: note.id)
+
+        try await db.notes.delete(id: note.id)
+        #expect(try await db.notes.get(id: note.id) == nil, "the row must be gone")
+        #expect(try String(contentsOfFile: path, encoding: .utf8) == "keep me",
+                "closing/deleting a note must never destroy its content file")
+
+        // Worktree-level cleanup keeps files too.
+        let note2 = try await db.notes.create(worktreeID: wt.id)
+        _ = try await db.notes.update(id: note2.id, content: "also kept")
+        let path2 = filePath(dir: dir, worktreeID: wt.id, noteID: note2.id)
+        try await db.notes.deleteForWorktree(worktreeID: wt.id)
+        #expect(try String(contentsOfFile: path2, encoding: .utf8) == "also kept")
+    }
+}

--- a/Tests/TBDDaemonTests/NoteTabOnCreateTests.swift
+++ b/Tests/TBDDaemonTests/NoteTabOnCreateTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import GRDB
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: uses `isolateTBDHome` (process-global
+// TBD_HOME mutation) so hook resolution and runtime dirs never touch the
+// developer's real ~/tbd. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+@Suite("Initial note tab on worktree create")
+struct NoteTabOnCreateTests {
+
+    @Test func createAppendsNotesTabLast() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+        let notes = try await db.notes.list(worktreeID: wt.id)
+        #expect(notes.count == 1)
+        let note = try #require(notes.first)
+        #expect(note.title == "Notes")
+        #expect(note.content.isEmpty)
+
+        // The note tab rides last in the stored order; focus stays on the
+        // primary terminal.
+        let terminals = try await db.terminals.list(worktreeID: wt.id)
+        let order = try await db.worktrees.getTabOrder(worktreeID: wt.id)
+        #expect(order.last == note.id)
+        #expect(order.count == terminals.count + 1)
+        let active = try await db.worktrees.getActiveTabID(worktreeID: wt.id)
+        #expect(active != note.id)
+        #expect(terminals.map(\.id).contains(try #require(active)))
+    }
+
+    @Test func preSessionGatedCreateAlsoGetsNotesTab() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        let completion = try await lifecycle.completeCreateWorktree(
+            worktreeID: pending.id, skipClaude: true
+        )
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending when a preSession hook resolves")
+            return
+        }
+        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        await phase3.value
+
+        let notes = try await db.notes.list(worktreeID: pending.id)
+        #expect(notes.count == 1)
+        let order = try await db.worktrees.getTabOrder(worktreeID: pending.id)
+        #expect(order.last == notes.first?.id)
+    }
+
+    @Test func rowDeletedMidCreateLeavesNoOrphanNote() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        try await installPreSessionHook(repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        let completion = try await lifecycle.completeCreateWorktree(
+            worktreeID: pending.id, skipClaude: true
+        )
+        guard case .preSessionPending(let phase3) = completion else {
+            Issue.record("expected .preSessionPending")
+            return
+        }
+        // Repo removal mid-wait deletes the worktree row; the note FK must
+        // block a stray note insert (best-effort helper swallows the error).
+        try await db.worktrees.deleteForRepo(repoID: repo.id)
+        try writeMarker(worktreeID: pending.id, exitCode: 0)
+        await phase3.value
+
+        #expect(try await db.notes.list(worktreeID: pending.id).isEmpty,
+                "no note row may be created for a deleted worktree")
+    }
+}
+}

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -168,8 +168,9 @@ struct PreSessionHookTests {
         #expect(setupBody.contains("export TBD_REPO_PATH='\(repo.path)'"))
         #expect(setupBody.contains("export TBD_BRANCH='\(wt.branch)'"))
 
-        // Tab order [claude, setup], active = claude.
-        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [claude.id, setup.id])
+        // Tab order [claude, setup, initial note], active = claude.
+        let note = try #require(try await db.notes.list(worktreeID: wt.id).first)
+        #expect(try await db.worktrees.getTabOrder(worktreeID: wt.id) == [claude.id, setup.id, note.id])
         #expect(try await db.worktrees.getActiveTabID(worktreeID: wt.id) == claude.id)
         #expect(try await db.notifications.unread(worktreeID: wt.id).isEmpty)
     }
@@ -301,9 +302,10 @@ struct PreSessionHookTests {
                 "a clean hook run must delete its own terminal row")
         let claude = try #require(terminals.first { $0.label == "Claude Code" })
         let setup = try #require(terminals.first { $0.label == "setup" })
+        let note = try #require(try await db.notes.list(worktreeID: pending.id).first)
         #expect(try await db.worktrees.getTabOrder(worktreeID: pending.id)
-                == [claude.id, setup.id],
-                "tab order must be [claude, setup] once the pre-session tab is closed")
+                == [claude.id, setup.id, note.id],
+                "tab order must be [claude, setup, note] once the pre-session tab is closed")
         #expect(try await db.worktrees.getActiveTabID(worktreeID: pending.id) == claude.id)
         #expect(try await db.worktrees.get(id: pending.id)?.status == .active)
         // Exit 0 → no notification.

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GRDB
+import TestSupport
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -154,6 +155,70 @@ import Testing
         let path = fx.db.terminalHistory.contentPath(
             worktreeID: fx.worktree.id, terminalID: fx.terminal.id)
         #expect(try String(contentsOfFile: path, encoding: .utf8) == "setup hook output\n")
+    }
+
+    // MARK: - Capture on archive
+
+    @Test func archiveCapturesLiveTerminalScrollbackAndKeepsArchivedRow() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        let captured = "agent output before archive\nsecond line\n"
+        let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in captured })
+        let lifecycle = WorktreeLifecycle(
+            db: fx.db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+
+        _ = try await lifecycle.beginArchiveWorktree(worktreeID: fx.worktree.id)
+
+        // Terminal row torn down, but the worktree row survives as archived.
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+        #expect(try await fx.db.worktrees.get(id: fx.worktree.id)?.status == .archived)
+
+        // Scrollback captured into Closed Terminals history (row + file).
+        let entries = try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id)
+        #expect(entries.count == 1)
+        #expect(entries.first?.id == fx.terminal.id)
+        let path = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: fx.terminal.id)
+        #expect(try String(contentsOfFile: path, encoding: .utf8) == captured)
+    }
+
+    // MARK: - Capture on reconcile auto-archive
+
+    /// A worktree whose git checkout has vanished is auto-archived by reconcile;
+    /// its live terminal's scrollback must land in Closed Terminals history.
+    @Test func reconcileAutoArchiveCapturesTerminalScrollback() async throws {
+        let historyDir = try Self.makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: historyDir) }
+        let db = try TBDDatabase(inMemory: true, terminalHistoryDir: historyDir)
+
+        // Real git repo with no extra worktrees, so a DB worktree row pointing
+        // at a non-git path is auto-archived by reconcile.
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let captured = "reconcile scrollback\n"
+        let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in captured })
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "test", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "gone", branch: "gone-branch",
+            path: tempDir.appendingPathComponent("vanished").path, tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%0",
+            label: "Claude Code", claudeSessionID: UUID().uuidString, kind: .claude)
+
+        try await lifecycle.reconcile(repoID: repo.id)
+
+        // Worktree archived, terminal torn down, scrollback captured.
+        #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)
+        #expect(try await db.terminals.get(id: terminal.id) == nil)
+        let entries = try await db.terminalHistory.list(worktreeID: wt.id)
+        #expect(entries.count == 1)
+        #expect(entries.first?.id == terminal.id)
+        let path = db.terminalHistory.contentPath(worktreeID: wt.id, terminalID: terminal.id)
+        #expect(try String(contentsOfFile: path, encoding: .utf8) == captured)
     }
 
     // MARK: - Retention

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -220,6 +220,187 @@ import Testing
         #expect(!FileManager.default.fileExists(atPath: dir))
     }
 
+    // MARK: - Revive
+
+    /// Create the worktree's on-disk directory (revive requires a live dir)
+    /// and register cleanup.
+    private func makeLiveDir(_ path: String) throws {
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+    }
+
+    /// The `new-window` shell command recorded by a dryRun tmux (the last
+    /// element of the recorded args is the full command string).
+    private func newWindowCommand(_ recorded: [[String]]) -> String? {
+        recorded.first(where: { $0.contains("new-window") })?.last
+    }
+
+    @Test func shellReviveOpensFreshShellWithCapture() async throws {
+        let fx = try await makeFixture(label: "sh", kind: .shell, claudeSessionID: nil)
+        defer { fx.cleanup() }
+        try makeLiveDir(fx.worktree.path)
+        defer { try? FileManager.default.removeItem(atPath: fx.worktree.path) }
+
+        // A closed shell terminal with captured scrollback (file + row).
+        let shellTerm = Terminal(
+            worktreeID: fx.worktree.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
+            label: nil, kind: .shell)
+        await fx.db.terminalHistory.store(
+            terminal: shellTerm, text: "prior shell output\n", closedAt: Date())
+        let capturePath = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: shellTerm.id)
+        #expect(FileManager.default.fileExists(atPath: capturePath))
+
+        let recorder = PreSessionRecordedCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.append($0) },
+            dryRunCapturePane: { _, _ in "" })
+        let router = makeRouter(db: fx.db, tmux: tmux)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalHistoryRevive,
+            params: TerminalHistoryReviveParams(worktreeID: fx.worktree.id, id: shellTerm.id)))
+        #expect(resp.success)
+        let revived = try resp.decodeResult(Terminal.self)
+
+        // New terminal row, kind shell, in this worktree.
+        #expect(revived.kind == .shell)
+        #expect(revived.worktreeID == fx.worktree.id)
+        #expect(try await fx.db.terminals.get(id: revived.id) != nil)
+
+        // Tab order appended + active set to the new terminal.
+        #expect(try await fx.db.worktrees.getTabOrder(worktreeID: fx.worktree.id) == [revived.id])
+        #expect(try await fx.db.worktrees.getActiveTabID(worktreeID: fx.worktree.id) == revived.id)
+
+        // Spawn command: banner + cat of the capture file + exec shell.
+        let command = try #require(newWindowCommand(recorder.snapshot()))
+        #expect(command.contains("restored from close on"))
+        #expect(command.contains("/bin/cat"))
+        #expect(command.contains(capturePath))
+        #expect(command.contains("exec "))
+
+        // History row survives revive.
+        let entries = try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id)
+        #expect(entries.contains { $0.id == shellTerm.id })
+    }
+
+    @Test func claudeReviveResumesSession() async throws {
+        let fx = try await makeFixture(label: TerminalLabel.claudeCode, kind: .claude, claudeSessionID: "sess-xyz")
+        defer { fx.cleanup() }
+        try makeLiveDir(fx.worktree.path)
+        defer { try? FileManager.default.removeItem(atPath: fx.worktree.path) }
+
+        await fx.db.terminalHistory.store(
+            terminal: fx.terminal, text: "claude scrollback\n", closedAt: Date())
+
+        let recorder = PreSessionRecordedCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.append($0) },
+            dryRunCapturePane: { _, _ in "" })
+        let router = makeRouter(db: fx.db, tmux: tmux)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalHistoryRevive,
+            params: TerminalHistoryReviveParams(worktreeID: fx.worktree.id, id: fx.terminal.id)))
+        #expect(resp.success)
+        let revived = try resp.decodeResult(Terminal.self)
+
+        #expect(revived.kind == .claude)
+        #expect(revived.claudeSessionID == "sess-xyz")
+
+        // Spawn command resumes the session (no scrollback cat).
+        let command = try #require(newWindowCommand(recorder.snapshot()))
+        #expect(command.contains("claude --resume sess-xyz"))
+        #expect(!command.contains("/bin/cat"))
+    }
+
+    @Test func reviveWithMissingCaptureFileSkipsCat() async throws {
+        let fx = try await makeFixture(label: "sh", kind: .shell, claudeSessionID: nil)
+        defer { fx.cleanup() }
+        try makeLiveDir(fx.worktree.path)
+        defer { try? FileManager.default.removeItem(atPath: fx.worktree.path) }
+
+        // History row present, but the capture file is deleted underneath it.
+        let shellTerm = Terminal(
+            worktreeID: fx.worktree.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
+            label: nil, kind: .shell)
+        await fx.db.terminalHistory.store(
+            terminal: shellTerm, text: "gone soon\n", closedAt: Date())
+        let capturePath = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: shellTerm.id)
+        try FileManager.default.removeItem(atPath: capturePath)
+
+        let recorder = PreSessionRecordedCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.append($0) },
+            dryRunCapturePane: { _, _ in "" })
+        let router = makeRouter(db: fx.db, tmux: tmux)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalHistoryRevive,
+            params: TerminalHistoryReviveParams(worktreeID: fx.worktree.id, id: shellTerm.id)))
+        #expect(resp.success)
+
+        // Banner + shell, but no cat (file missing).
+        let command = try #require(newWindowCommand(recorder.snapshot()))
+        #expect(command.contains("restored from close on"))
+        #expect(!command.contains("/bin/cat"))
+        #expect(command.contains("exec "))
+    }
+
+    @Test func reviveUnknownWorktreeErrorsWithoutTerminal() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        let tmux = TmuxManager(dryRun: true)
+        let router = makeRouter(db: fx.db, tmux: tmux)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalHistoryRevive,
+            params: TerminalHistoryReviveParams(worktreeID: UUID(), id: fx.terminal.id)))
+        #expect(!resp.success)
+    }
+
+    @Test func reviveUnknownEntryErrorsWithoutTerminal() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        try makeLiveDir(fx.worktree.path)
+        defer { try? FileManager.default.removeItem(atPath: fx.worktree.path) }
+        let tmux = TmuxManager(dryRun: true)
+        let router = makeRouter(db: fx.db, tmux: tmux)
+
+        let before = try await fx.db.terminals.list(worktreeID: fx.worktree.id).count
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalHistoryRevive,
+            params: TerminalHistoryReviveParams(worktreeID: fx.worktree.id, id: UUID())))
+        #expect(!resp.success)
+        // No terminal created.
+        #expect(try await fx.db.terminals.list(worktreeID: fx.worktree.id).count == before)
+    }
+
+    @Test func reviveShellCommandQuotesSingleQuotePath() {
+        // Path with a single quote must be POSIX-escaped ('\'') for the cat.
+        let path = "/tmp/wei'rd/cap.txt"
+        let cmd = RPCRouter.reviveShellCommand(
+            capturePath: path,
+            closedAt: Date(timeIntervalSince1970: 0),
+            shell: "/bin/zsh")
+        #expect(cmd.contains("/bin/cat '/tmp/wei'\\''rd/cap.txt'"))
+        #expect(cmd.contains("restored from close on"))
+        #expect(cmd.hasSuffix("exec /bin/zsh"))
+    }
+
+    @Test func reviveShellCommandOmitsCatWhenNoCapture() {
+        let cmd = RPCRouter.reviveShellCommand(
+            capturePath: nil,
+            closedAt: Date(timeIntervalSince1970: 0),
+            shell: "/bin/zsh")
+        #expect(!cmd.contains("cat"))
+        #expect(cmd.contains("printf"))
+        #expect(cmd.hasSuffix("exec /bin/zsh"))
+    }
+
     // MARK: - Migration
 
     @Test func migrationCreatesTerminalHistoryTable() async throws {

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -1,0 +1,236 @@
+import Foundation
+import GRDB
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Closed-terminal history: scrollback captured at close time, file-backed
+/// content + `terminal_history` metadata rows, pruned to the newest 50 per
+/// worktree, removed on worktree hard-delete.
+@Suite struct TerminalHistoryTests {
+
+    private static func makeTempDir() throws -> String {
+        let dir = (NSTemporaryDirectory() as NSString)
+            .appendingPathComponent("tbd-term-history-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let historyDir: String
+        let worktree: Worktree
+        let terminal: Terminal
+
+        func cleanup() {
+            try? FileManager.default.removeItem(atPath: historyDir)
+        }
+    }
+
+    private func makeFixture(
+        label: String? = "Build",
+        kind: TerminalKind? = .claude,
+        claudeSessionID: String? = "sess-abc"
+    ) async throws -> Fixture {
+        let historyDir = try Self.makeTempDir()
+        let db = try TBDDatabase(inMemory: true, terminalHistoryDir: historyDir)
+        let repo = try await db.repos.create(
+            path: "/tmp/th-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "b",
+            path: "/tmp/th-wt-\(UUID().uuidString)", tmuxServer: "tbd-th")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: label, claudeSessionID: claudeSessionID, kind: kind)
+        return Fixture(db: db, historyDir: historyDir, worktree: wt, terminal: terminal)
+    }
+
+    private func makeRouter(db: TBDDatabase, tmux: TmuxManager) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date())
+    }
+
+    // MARK: - Capture on terminal.delete
+
+    @Test func deleteHandlerCapturesScrollbackToFileAndRow() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        let captured = "line one\nline two\nline three"
+        let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in captured })
+        let router = makeRouter(db: fx.db, tmux: tmux)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: fx.terminal.id)))
+        #expect(resp.success)
+
+        // Close semantics unchanged: terminal row is gone.
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+
+        // Metadata row present with correct fields.
+        let entries = try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id)
+        #expect(entries.count == 1)
+        let entry = try #require(entries.first)
+        #expect(entry.id == fx.terminal.id)
+        #expect(entry.worktreeID == fx.worktree.id)
+        #expect(entry.label == "Build")
+        #expect(entry.kind == .claude)
+        #expect(entry.claudeSessionID == "sess-abc")
+        #expect(entry.lineCount == 3)
+
+        // Content file written verbatim.
+        let path = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: fx.terminal.id)
+        #expect(try String(contentsOfFile: path, encoding: .utf8) == captured)
+
+        // RPC list returns it too.
+        let listResp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalHistoryList,
+            params: TerminalHistoryListParams(worktreeID: fx.worktree.id)))
+        #expect(listResp.success)
+        let listed = try listResp.decodeResult([TerminalHistoryEntry].self)
+        #expect(listed.map(\.id) == [fx.terminal.id])
+    }
+
+    @Test func emptyCaptureStoresNoFileAndNoRow() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in "  \n\t\n" })
+        let router = makeRouter(db: fx.db, tmux: tmux)
+
+        let resp = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: fx.terminal.id)))
+        #expect(resp.success)
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+
+        #expect(try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id).isEmpty)
+        let path = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: fx.terminal.id)
+        #expect(!FileManager.default.fileExists(atPath: path))
+    }
+
+    @Test func captureFailureIsSwallowedAndStoresNothing() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        struct CaptureError: Error {}
+
+        // Never throws out of captureOnClose; no row, no file.
+        await fx.db.terminalHistory.captureOnClose(terminal: fx.terminal) {
+            throw CaptureError()
+        }
+        #expect(try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id).isEmpty)
+        let path = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: fx.terminal.id)
+        #expect(!FileManager.default.fileExists(atPath: path))
+    }
+
+    // MARK: - Capture on hook-terminal auto-close
+
+    @Test func closeHookTerminalCapturesBeforeTeardown() async throws {
+        let fx = try await makeFixture(label: TerminalLabel.preSession, kind: .shell, claudeSessionID: nil)
+        defer { fx.cleanup() }
+        let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in "setup hook output\n" })
+        let lifecycle = WorktreeLifecycle(
+            db: fx.db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+
+        await lifecycle.closeHookTerminal(
+            worktree: fx.worktree,
+            terminalID: fx.terminal.id,
+            windowID: fx.terminal.tmuxWindowID)
+
+        // Teardown still ran.
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+
+        // Capture landed.
+        let entries = try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id)
+        #expect(entries.count == 1)
+        #expect(entries.first?.id == fx.terminal.id)
+        #expect(entries.first?.kind == .shell)
+        let path = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: fx.terminal.id)
+        #expect(try String(contentsOfFile: path, encoding: .utf8) == "setup hook output\n")
+    }
+
+    // MARK: - Retention
+
+    @Test func pruneKeepsNewestFiftyPerWorktree() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+        var ids: [UUID] = []
+        for i in 0..<51 {
+            let terminal = Terminal(
+                worktreeID: fx.worktree.id, tmuxWindowID: "@\(i)", tmuxPaneID: "%\(i)")
+            ids.append(terminal.id)
+            await fx.db.terminalHistory.store(
+                terminal: terminal, text: "output \(i)",
+                closedAt: base.addingTimeInterval(TimeInterval(i)))
+        }
+
+        let entries = try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id)
+        #expect(entries.count == 50)
+        // Oldest (index 0) is pruned — row and file.
+        #expect(!entries.contains { $0.id == ids[0] })
+        let oldestPath = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: ids[0])
+        #expect(!FileManager.default.fileExists(atPath: oldestPath))
+        // Newest survives — row and file.
+        #expect(entries.first?.id == ids[50])
+        let newestPath = fx.db.terminalHistory.contentPath(
+            worktreeID: fx.worktree.id, terminalID: ids[50])
+        #expect(FileManager.default.fileExists(atPath: newestPath))
+    }
+
+    // MARK: - Worktree hard-delete cleanup
+
+    @Test func deleteForWorktreeRemovesRowsAndDirectory() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        await fx.db.terminalHistory.store(
+            terminal: fx.terminal, text: "some output", closedAt: Date())
+        let dir = fx.db.terminalHistory.worktreeDir(worktreeID: fx.worktree.id)
+        #expect(FileManager.default.fileExists(atPath: dir))
+
+        try await fx.db.terminalHistory.deleteForWorktree(worktreeID: fx.worktree.id)
+
+        #expect(try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id).isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: dir))
+    }
+
+    @Test func forgetWorktreeCleansHistoryRowsAndDirectory() async throws {
+        let fx = try await makeFixture()
+        defer { fx.cleanup() }
+        await fx.db.terminalHistory.store(
+            terminal: fx.terminal, text: "some output", closedAt: Date())
+        let dir = fx.db.terminalHistory.worktreeDir(worktreeID: fx.worktree.id)
+        #expect(FileManager.default.fileExists(atPath: dir))
+
+        let lifecycle = WorktreeLifecycle(
+            db: fx.db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver())
+        try await lifecycle.forgetWorktree(worktreeID: fx.worktree.id)
+
+        #expect(try await fx.db.worktrees.get(id: fx.worktree.id) == nil)
+        #expect(try await fx.db.terminalHistory.list(worktreeID: fx.worktree.id).isEmpty)
+        #expect(!FileManager.default.fileExists(atPath: dir))
+    }
+
+    // MARK: - Migration
+
+    @Test func migrationCreatesTerminalHistoryTable() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let columns: [String] = try await db.writerForTests.read { sqlDB in
+            guard try sqlDB.tableExists("terminal_history") else { return [] }
+            return try Row.fetchAll(sqlDB, sql: "PRAGMA table_info(terminal_history)")
+                .compactMap { $0["name"] as String? }
+        }
+        #expect(Set(columns) == Set([
+            "id", "worktreeID", "label", "kind", "closedAt", "claudeSessionID", "lineCount"
+        ]))
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -71,7 +71,9 @@ import Testing
 
     #expect(primary.kind == .codex)
     #expect(primary.label == "Codex")
-    #expect(try await db.worktrees.getTabOrder(worktreeID: result.id) == terminals.map(\.id))
+    let noteIDs = try await db.notes.list(worktreeID: result.id).map(\.id)
+    #expect(try await db.worktrees.getTabOrder(worktreeID: result.id)
+            == terminals.map(\.id) + noteIDs)
     #expect(try await db.worktrees.getActiveTabID(worktreeID: result.id) == primary.id)
 }
 

--- a/Tests/TBDSharedTests/ANSIEscapeTests.swift
+++ b/Tests/TBDSharedTests/ANSIEscapeTests.swift
@@ -1,0 +1,24 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct ANSIEscapeTests {
+    @Test func stripsSGRColorSequences() {
+        // Red "error" + reset, dim divider — all escapes gone, text kept.
+        let raw = "\u{1B}[31merror\u{1B}[0m: something\n\u{1B}[2m── divider ──\u{1B}[0m"
+        #expect(ANSIEscape.strip(raw) == "error: something\n── divider ──")
+    }
+
+    @Test func stripsOSCTitleSequences() {
+        // OSC 0 (set window title) terminated by BEL, then by ST.
+        let bel = "\u{1B}]0;my title\u{07}prompt$ "
+        #expect(ANSIEscape.strip(bel) == "prompt$ ")
+        let st = "\u{1B}]0;t\u{1B}\\done"
+        #expect(ANSIEscape.strip(st) == "done")
+    }
+
+    @Test func leavesPlainTextUntouched() {
+        let plain = "no escapes here\njust text"
+        #expect(ANSIEscape.strip(plain) == plain)
+    }
+}


### PR DESCRIPTION
## Summary

Closing things in TBD used to be silently destructive: a closed terminal's output was gone forever, a closed notes tab hard-deleted the note, and the setup tab lingered after a successful hook run. This PR makes close recoverable across the board:

- **Closed-terminal history + revive** — on terminal close (and on hook-tab auto-close), the daemon captures the pane's last ~10k scrollback lines (with ANSI escapes) to `~/tbd/terminal-history/<worktreeID>/<terminalID>.txt` plus a metadata row (`terminal_history`, migration v57). A "Closed Terminals" section in Session History shows captures read-only (escapes stripped for display; raw file keeps them). **Revive** spawns a fresh terminal: Claude entries resume their session via `claude --resume`; shell entries get a dimmed "restored from close" divider, the colored capture replayed above, and a live prompt below. Env is recomputed by the daemon (nothing inherited from the dead process). Retention: newest 50 per worktree, deleted on worktree hard-delete, kept across archive.
- **Setup tab auto-closes on hook success** — behind a default-OFF flag (below). The hook's exit code lands in a marker file (preSession pattern); exit 0 tears the tab down after capturing its scrollback into history, nonzero drops into a debug shell and the tab stays. `remain-on-exit` is set on armed setup windows so the dead pane survives long enough to capture.
- **Notes: auto-open + content on disk** — repo-backed worktree creation auto-opens a "Notes" tab. Note content moved from the DB `content` column to `~/tbd/notes/<worktreeID>/<noteID>.md` (row remains as tab identity/title): no file until first non-empty write, file wins over the legacy column (kept as dormant backup; one-time idempotent export on daemon startup), closing/deleting a note keeps the file, and the pane shows its backing path with a copy button. Closing a non-empty note asks for confirmation.

## Feature flag

`auto_close_setup_enabled` (config column, migration `v56_config_auto_close_setup`, **default OFF**) gates the setup auto-close — it acts without a user gesture and kills a process, per the flag policy. Enable for soak via Settings > Experimental > "Auto-close the setup tab on success", or `UPDATE config SET auto_close_setup_enabled = 1;`, or the `config.setAutoCloseSetup` RPC. Both branches are tested (flag off = byte-for-byte prior spawn behavior, no marker, no watcher). Graduation plan: soak default-off; if it holds, flip the default with a forcing `UPDATE` migration (per the `auto_hibernate_enabled` lesson), then delete the flag.

History capture and revive ship unflagged: capture is additive and best-effort (close semantics unchanged; any capture failure logs and the close proceeds), and revive only runs on an explicit user gesture.

## capture-pane allowlist addition

`.swiftlint.yml`'s `capture_pane_allowlist` gains `WorktreeLifecycle+PreSession.swift`. Justification: this is **archival capture-for-display** — the bytes are stored verbatim and shown back to the user read-only / replayed on revive. Nothing is ever parsed to infer agent or TUI state, so it does not conflict with the no-screen-scraping rule's purpose (state must come from machine interfaces).

## Test plan

- [x] `swift build`, `swiftlint --strict` (0 violations), full `swift test --parallel -j 2` green (3774+ tests; only known load-flake suites, green in isolation)
- [x] New suites: `AutoCloseSetupTests`, `NoteTabOnCreateTests`, `NoteCloseConfirmTests`, `NoteContentFileTests`, `TerminalHistoryTests`, `ANSIEscapeTests` — both flag branches, marker success/failure/timeout, file-vs-DB precedence, export idempotence, prune-at-50, revive command quoting (incl. single-quote paths), claude-resume revive
- [x] Live-tested: setup tab auto-closes and appears in Closed Terminals with output (after the remain-on-exit fix); notes tab auto-opens; note file appears on first keystroke and survives close; revive replays colored scrollback above a fresh prompt

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=283CF3B2-9C82-4430-AF08-46D3A4C1942A)