### PR TITLE
fix: scope viewer-batch PR branch matching to the worktree's own repo

### DIFF
--- a/Sources/TBDDaemon/PR/PRStatusManager.swift
+++ b/Sources/TBDDaemon/PR/PRStatusManager.swift
@@ -31,7 +31,7 @@ public actor PRStatusManager {
 
     private var onMergedTransition: (@Sendable (UUID, Int) async -> Void)?
 
-    private var onStatusPersist: (@Sendable (UUID, PRStatus) async -> Void)?
+    private var onStatusPersist: (@Sendable (UUID, PRStatus?) async -> Void)?
 
     private var onPRStatusComputed: (@Sendable (UUID, PRStatus, String) async -> Void)?
 
@@ -53,8 +53,11 @@ public actor PRStatusManager {
     }
 
     /// Register a callback fired whenever a worktree's cached PR status actually
-    /// changes, so the daemon can persist it to the DB.
-    public func setOnStatusPersist(_ cb: @escaping @Sendable (UUID, PRStatus) async -> Void) {
+    /// changes, so the daemon can persist it to the DB. A nil status means the
+    /// entry was cleared (cross-repo cache heal in `fetchAll`) and the DB row
+    /// must be cleared too, or `hydrate` would resurrect the stale value at the
+    /// next daemon start.
+    public func setOnStatusPersist(_ cb: @escaping @Sendable (UUID, PRStatus?) async -> Void) {
         self.onStatusPersist = cb
     }
 
@@ -128,8 +131,8 @@ public actor PRStatusManager {
 
         // Worktrees created from a PR row carry its number; resolve those
         // directly (a fork PR's head never appears in the viewer-authored batch).
-        // Everything else uses the legacy viewer-batch branch-name matching,
-        // byte-identical to before.
+        // Everything else uses the viewer-batch branch-name matching, scoped to
+        // each worktree's own repo (see `matchUnnumbered`).
         let (numbered, unnumbered) = Self.partitionByPRNumber(worktrees) { $0.prNumber }
 
         // Do NOT clear entries for missing worktrees — the batch query is
@@ -142,21 +145,51 @@ public actor PRStatusManager {
             matches += await fetchNumberedMatches(numbered)
         }
 
-        // Legacy path: viewer-authored batch + branch-name matching. On a fetch
-        // or parse failure it contributes no matches, but the numbered path above
-        // has already resolved independently.
+        // Legacy path: viewer-authored batch + branch-name matching, scoped to
+        // each worktree's own repo (the batch spans every repo the viewer
+        // authored PRs in, and the same branch name can exist in several). On a
+        // fetch or parse failure it contributes no matches, but the numbered
+        // path above has already resolved independently.
         var batchSucceeded = false
         if !unnumbered.isEmpty {
+            // Resolve each unnumbered worktree's own repo once, mirroring the
+            // numbered path's `resolved` dictionary. TTL-cached, so the poll
+            // doesn't spawn a `gh repo view` subprocess per worktree per tick.
+            var unnumberedRepos: [String: (owner: String, name: String)] = [:]
+            for path in Set(unnumbered.map(\.worktreePath)) {
+                if let ownerRepo = await cachedNameWithOwner(repoPath: path) {
+                    unnumberedRepos[path] = ownerRepo
+                } else {
+                    logger.debug("fetchAll: could not resolve owner/name for unnumbered worktree at \(path, privacy: .public)")
+                }
+            }
+
+            // Heal entries poisoned by the pre-repo-scoping branch match: a
+            // cached status whose PR URL belongs to a different repo than the
+            // worktree's own. This MUST run before `cachedNumberFallback` is
+            // computed below: a poisoned entry carries the OTHER repo's PR
+            // number, and the fallback would re-resolve that number scoped to
+            // the worktree's own repo, where it can land on an unrelated PR
+            // (worst case a MERGED one, firing auto-archive on the wrong
+            // worktree). Clearing the cache first makes that path unreachable.
+            // The clear is persisted (nil status) so `hydrate` can't resurrect
+            // it after a daemon restart. No `lastDirectUpdate` write: this runs
+            // inside fetchAll itself, and the worktree stays unmatched by
+            // construction, so no later apply() in this pass can touch it.
+            for entry in Self.poisonedCacheEntries(
+                unnumbered: unnumbered,
+                resolveRepo: { unnumberedRepos[$0] },
+                cachedStatus: { cache[$0] }) {
+                logger.debug("fetchAll: clearing cross-repo PR status for worktree \(entry.worktreeID, privacy: .public): cached PR is in \(entry.cachedRepo, privacy: .public) but worktree repo is \(entry.worktreeRepo, privacy: .public)")
+                cache.removeValue(forKey: entry.worktreeID)
+                await onStatusPersist?(entry.worktreeID, nil)
+            }
+
             if let jsonData = await runGHGraphQL(repoPath: repoPath) {
                 if let nodes = try? Self.parsePRNodes(from: jsonData) {
                     batchSucceeded = true   // empty nodes is still a valid answer (viewer has no PRs)
-                    let byBranch = Self.bestNodeByBranch(nodes)
-                    for wt in unnumbered {
-                        let candidates = Self.branchCandidates(localBranch: wt.branch, upstreamBranch: wt.upstreamBranch)
-                        if let node = candidates.compactMap({ byBranch[$0] }).first {
-                            matches.append((wt.id, node))
-                        }
-                    }
+                    matches += Self.matchUnnumbered(unnumbered, nodes: nodes,
+                                                    resolveRepo: { unnumberedRepos[$0] })
                 } else {
                     logger.warning("Failed to parse GraphQL response")
                 }
@@ -734,25 +767,96 @@ public actor PRStatusManager {
         }
     }
 
-    /// Build the branch → best-PR lookup used by the legacy (unnumbered) path.
-    /// When multiple PRs share a branch, pick the best: highest state priority
+    /// Lookup key scoping a branch name to one repo. Owner/name are lowercased
+    /// because GitHub treats them case-insensitively (URLs and `gh repo view`
+    /// may disagree on casing); the branch stays as-is (git refs are
+    /// case-sensitive). U+0001 cannot appear in a GitHub owner or repo name,
+    /// so keys can never collide across repos.
+    static func repoBranchKey(owner: String, name: String, branch: String) -> String {
+        "\(owner.lowercased())\u{1}\(name.lowercased())\u{1}\(branch)"
+    }
+
+    /// Build the (repo, branch) → best-PR lookup used by the legacy (unnumbered)
+    /// path. The viewer batch spans every repo the viewer authored PRs in, and
+    /// the same branch name can legitimately exist in several of them; keying on
+    /// branch alone handed one repo's PR to another repo's worktree (and
+    /// persisted it) — the cross-repo collision this fix removes. Nodes whose
+    /// URL doesn't parse to owner/name are dropped: they cannot be scoped, and
+    /// an unscoped match is exactly the bug. When multiple PRs share a
+    /// repo+branch, pick the best: highest state priority
     /// (OPEN > MERGED > CLOSED), then newest `createdAt` within the same state.
-    static func bestNodeByBranch(_ nodes: [PRNode]) -> [String: PRNode] {
-        var byBranch: [String: PRNode] = [:]
+    static func bestNodeByRepoBranch(_ nodes: [PRNode]) -> [String: PRNode] {
+        var byKey: [String: PRNode] = [:]
         for node in nodes {
-            if let existing = byBranch[node.headRefName] {
+            guard let repo = parseOwnerRepo(fromURL: node.url) else { continue }
+            let key = repoBranchKey(owner: repo.owner, name: repo.name, branch: node.headRefName)
+            if let existing = byKey[key] {
                 let nodePriority = prPriority(node.state)
                 let existingPriority = prPriority(existing.state)
                 if nodePriority > existingPriority {
-                    byBranch[node.headRefName] = node
+                    byKey[key] = node
                 } else if nodePriority == existingPriority && node.createdAt > existing.createdAt {
-                    byBranch[node.headRefName] = node
+                    byKey[key] = node
                 }
             } else {
-                byBranch[node.headRefName] = node
+                byKey[key] = node
             }
         }
-        return byBranch
+        return byKey
+    }
+
+    /// Match unnumbered worktrees against the viewer batch, scoped to each
+    /// worktree's own repo: a node only matches when its URL's owner/name
+    /// equals the worktree's resolved repo. Candidate order is preserved
+    /// (local branch first, then upstream — see `branchCandidates`). A worktree
+    /// whose repo can't be resolved gets NO match, so the caller keeps its
+    /// cached status — the same degrade behavior as the numbered path
+    /// (`groupNumberedByRepo`); matching it unscoped could apply another
+    /// repo's PR.
+    static func matchUnnumbered(
+        _ unnumbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)],
+        nodes: [PRNode],
+        resolveRepo: (String) -> (owner: String, name: String)?
+    ) -> [(worktreeID: UUID, node: PRNode)] {
+        let byRepoBranch = bestNodeByRepoBranch(nodes)
+        return unnumbered.compactMap { wt in
+            guard let repo = resolveRepo(wt.worktreePath) else { return nil }
+            let candidates = branchCandidates(localBranch: wt.branch, upstreamBranch: wt.upstreamBranch)
+            for candidate in candidates {
+                if let node = byRepoBranch[repoBranchKey(owner: repo.owner, name: repo.name, branch: candidate)] {
+                    return (wt.id, node)
+                }
+            }
+            return nil
+        }
+    }
+
+    /// Detect cache entries poisoned by the pre-repo-scoping branch match: an
+    /// unnumbered worktree whose cached PR URL belongs to a DIFFERENT repo than
+    /// the worktree's own. Without this heal a poisoned entry would display
+    /// forever (the repo-scoped match above never touches it again) and, worse,
+    /// feed its wrong-repo PR number into `cachedNumberFallback`.
+    ///
+    /// BOTH sides must resolve before an entry is judged: an unresolvable
+    /// worktree repo (gh offline/missing) or an unparseable cached URL is
+    /// absence of evidence, not proof of poisoning, so the entry is kept.
+    /// Owner/name compare case-insensitively (GitHub identifiers are).
+    /// Returns the poisoned entries with both repos rendered as
+    /// "owner/name" for the caller's log line.
+    static func poisonedCacheEntries(
+        unnumbered: [(id: UUID, branch: String, upstreamBranch: String?, worktreePath: String, prNumber: Int?)],
+        resolveRepo: (String) -> (owner: String, name: String)?,
+        cachedStatus: (UUID) -> PRStatus?
+    ) -> [(worktreeID: UUID, cachedRepo: String, worktreeRepo: String)] {
+        unnumbered.compactMap { wt in
+            guard let repo = resolveRepo(wt.worktreePath),
+                  let cached = cachedStatus(wt.id),
+                  let cachedRepo = parseOwnerRepo(fromURL: cached.url) else { return nil }
+            let sameRepo = cachedRepo.owner.lowercased() == repo.owner.lowercased()
+                && cachedRepo.name.lowercased() == repo.name.lowercased()
+            guard !sameRepo else { return nil }
+            return (wt.id, "\(cachedRepo.owner)/\(cachedRepo.name)", "\(repo.owner)/\(repo.name)")
+        }
     }
 
     /// The per-PR field selection shared by the viewer batch and the by-number

--- a/Tests/TBDDaemonTests/PRStatusManagerTests.swift
+++ b/Tests/TBDDaemonTests/PRStatusManagerTests.swift
@@ -1327,10 +1327,11 @@ struct PRStatusManagerTests {
         #expect(matches.isEmpty)
     }
 
-    @Test("unnumbered worktree still resolves via the legacy viewer-authored branch match (regression)")
+    @Test("unnumbered worktree still resolves via the viewer-authored branch match when the repo matches (regression)")
     func unnumberedResolvesViaLegacyBranchMatch() throws {
         // The viewer batch carries a node for the worktree's branch; a worktree
-        // with no stored number must still match it exactly as before.
+        // with no stored number must still match it when its own repo agrees
+        // with the node's URL repo.
         let json = """
         {
           "data": {
@@ -1356,10 +1357,201 @@ struct PRStatusManagerTests {
         """.data(using: .utf8)!
 
         let nodes = try PRStatusManager.parsePRNodes(from: json)
-        let byBranch = PRStatusManager.bestNodeByBranch(nodes)
-        let candidates = PRStatusManager.branchCandidates(localBranch: "feature-x", upstreamBranch: nil)
-        let node = candidates.compactMap { byBranch[$0] }.first
-        #expect(node?.number == 7)
+        let wt = UUID()
+        let matches = PRStatusManager.matchUnnumbered(
+            [(wt, "feature-x", nil, "/wt/acme", nil)],
+            nodes: nodes,
+            resolveRepo: { _ in ("acme", "acme") })
+        #expect(matches.count == 1)
+        #expect(matches.first?.worktreeID == wt)
+        #expect(matches.first?.node.number == 7)
+    }
+
+    // MARK: - Repo-scoped viewer-batch branch matching (cross-repo collision regression)
+
+    /// Convenience PRNode factory for the matching tests.
+    private func prNode(number: Int, url: String, branch: String, state: String = "OPEN",
+                        createdAt: String = "2026-07-01T00:00:00Z") -> PRStatusManager.PRNode {
+        PRStatusManager.PRNode(number: number, url: url, state: state, mergeStateStatus: "CLEAN",
+                               reviewDecision: "", headRefName: branch, createdAt: createdAt,
+                               isDraft: false, statusCheckRollupState: nil, mergeQueuePosition: nil)
+    }
+
+    @Test("matchUnnumbered gives each worktree its own repo's PR when two repos share a branch name")
+    func matchUnnumberedScopesSameBranchAcrossRepos() {
+        // The reported bug: identical branch name in mdg-private/monorepo and
+        // mdg-private/studio-ui; the studio-ui PR must not win both worktrees.
+        let branch = "Jephuff/BILL-149-remove-billingplan-userroles"
+        let monorepoWT = UUID(); let studioWT = UUID()
+        let nodes = [
+            prNode(number: 13113, url: "https://github.com/mdg-private/studio-ui/pull/13113", branch: branch),
+            prNode(number: 555, url: "https://github.com/mdg-private/monorepo/pull/555", branch: branch)
+        ]
+        let repos: [String: (owner: String, name: String)] = [
+            "/wt/monorepo": ("mdg-private", "monorepo"),
+            "/wt/studio-ui": ("mdg-private", "studio-ui")
+        ]
+        let matches = PRStatusManager.matchUnnumbered(
+            [(monorepoWT, branch, nil, "/wt/monorepo", nil),
+             (studioWT, branch, nil, "/wt/studio-ui", nil)],
+            nodes: nodes,
+            resolveRepo: { repos[$0] })
+        #expect(matches.count == 2)
+        let byID = Dictionary(uniqueKeysWithValues: matches.map { ($0.worktreeID, $0.node.number) })
+        #expect(byID[monorepoWT] == 555)
+        #expect(byID[studioWT] == 13113)
+    }
+
+    @Test("matchUnnumbered yields no match when the branch's only PR lives in another repo")
+    func matchUnnumberedNoMatchAcrossRepos() {
+        let nodes = [
+            prNode(number: 13113, url: "https://github.com/mdg-private/studio-ui/pull/13113",
+                   branch: "shared-branch")
+        ]
+        let matches = PRStatusManager.matchUnnumbered(
+            [(UUID(), "shared-branch", nil, "/wt/monorepo", nil)],
+            nodes: nodes,
+            resolveRepo: { _ in ("mdg-private", "monorepo") })
+        #expect(matches.isEmpty)
+    }
+
+    @Test("matchUnnumbered yields no match when the worktree's repo can't be resolved")
+    func matchUnnumberedNoMatchWhenRepoUnresolved() {
+        // Degrade like the numbered path: an unscoped match could apply another
+        // repo's PR, so an unresolvable repo means no match at all.
+        let nodes = [
+            prNode(number: 7, url: "https://github.com/acme/acme/pull/7", branch: "feature-x")
+        ]
+        let matches = PRStatusManager.matchUnnumbered(
+            [(UUID(), "feature-x", nil, "/wt/acme", nil)],
+            nodes: nodes,
+            resolveRepo: { _ in nil })
+        #expect(matches.isEmpty)
+    }
+
+    @Test("matchUnnumbered compares owner/name case-insensitively")
+    func matchUnnumberedCaseInsensitiveRepoCompare() {
+        let nodes = [
+            prNode(number: 8, url: "https://github.com/Acme/Widgets/pull/8", branch: "feature-y")
+        ]
+        let matches = PRStatusManager.matchUnnumbered(
+            [(UUID(), "feature-y", nil, "/wt/widgets", nil)],
+            nodes: nodes,
+            resolveRepo: { _ in ("acme", "widgets") })
+        #expect(matches.first?.node.number == 8)
+    }
+
+    @Test("matchUnnumbered still honors the upstream-branch candidate when the repo matches")
+    func matchUnnumberedUpstreamCandidate() {
+        // Local branch has no PR; the upstream branch does, in the same repo.
+        let nodes = [
+            prNode(number: 9, url: "https://github.com/acme/acme/pull/9", branch: "upstream-x")
+        ]
+        let matches = PRStatusManager.matchUnnumbered(
+            [(UUID(), "local-x", "upstream-x", "/wt/acme", nil)],
+            nodes: nodes,
+            resolveRepo: { _ in ("acme", "acme") })
+        #expect(matches.first?.node.number == 9)
+    }
+
+    @Test("bestNodeByRepoBranch keeps the tie-break within one repo: OPEN beats MERGED, newest wins within a state")
+    func bestNodeByRepoBranchTieBreakWithinRepo() {
+        let key = PRStatusManager.repoBranchKey(owner: "acme", name: "acme", branch: "reused")
+        // OPEN beats MERGED regardless of age.
+        let openVsMerged = PRStatusManager.bestNodeByRepoBranch([
+            prNode(number: 1, url: "https://github.com/acme/acme/pull/1", branch: "reused",
+                   state: "MERGED", createdAt: "2026-07-02T00:00:00Z"),
+            prNode(number: 2, url: "https://github.com/acme/acme/pull/2", branch: "reused",
+                   state: "OPEN", createdAt: "2026-07-01T00:00:00Z")
+        ])
+        #expect(openVsMerged[key]?.number == 2)
+        // Within the same state, newest createdAt wins.
+        let newestWins = PRStatusManager.bestNodeByRepoBranch([
+            prNode(number: 3, url: "https://github.com/acme/acme/pull/3", branch: "reused",
+                   state: "CLOSED", createdAt: "2026-07-01T00:00:00Z"),
+            prNode(number: 4, url: "https://github.com/acme/acme/pull/4", branch: "reused",
+                   state: "CLOSED", createdAt: "2026-07-03T00:00:00Z")
+        ])
+        #expect(newestWins[key]?.number == 4)
+    }
+
+    @Test("bestNodeByRepoBranch drops a node whose URL doesn't parse to owner/name")
+    func bestNodeByRepoBranchDropsUnparseableURL() {
+        let byKey = PRStatusManager.bestNodeByRepoBranch([
+            prNode(number: 5, url: "not a url", branch: "feature-z")
+        ])
+        #expect(byKey.isEmpty)
+    }
+
+    // MARK: - Poisoned-cache invalidation (cross-repo heal)
+
+    @Test("poisonedCacheEntries flags a cached status whose PR URL belongs to a different repo")
+    func poisonedCacheEntriesFlagsRepoMismatch() {
+        let wt = UUID()
+        let cached = PRStatus(number: 13113, url: "https://github.com/mdg-private/studio-ui/pull/13113",
+                              state: .mergeable)
+        let out = PRStatusManager.poisonedCacheEntries(
+            unnumbered: [(wt, "shared-branch", nil, "/wt/monorepo", nil)],
+            resolveRepo: { _ in ("mdg-private", "monorepo") },
+            cachedStatus: { _ in cached })
+        #expect(out.count == 1)
+        #expect(out.first?.worktreeID == wt)
+        #expect(out.first?.cachedRepo == "mdg-private/studio-ui")
+        #expect(out.first?.worktreeRepo == "mdg-private/monorepo")
+    }
+
+    @Test("poisonedCacheEntries keeps a cached status from the worktree's own repo")
+    func poisonedCacheEntriesKeepsSameRepo() {
+        let cached = PRStatus(number: 555, url: "https://github.com/mdg-private/monorepo/pull/555",
+                              state: .mergeable)
+        let out = PRStatusManager.poisonedCacheEntries(
+            unnumbered: [(UUID(), "shared-branch", nil, "/wt/monorepo", nil)],
+            resolveRepo: { _ in ("mdg-private", "monorepo") },
+            cachedStatus: { _ in cached })
+        #expect(out.isEmpty)
+    }
+
+    @Test("poisonedCacheEntries treats owner/name casing differences as the same repo")
+    func poisonedCacheEntriesCaseInsensitive() {
+        let cached = PRStatus(number: 1, url: "https://github.com/MDG-Private/Monorepo/pull/1",
+                              state: .pending)
+        let out = PRStatusManager.poisonedCacheEntries(
+            unnumbered: [(UUID(), "b", nil, "/wt/monorepo", nil)],
+            resolveRepo: { _ in ("mdg-private", "monorepo") },
+            cachedStatus: { _ in cached })
+        #expect(out.isEmpty)
+    }
+
+    @Test("poisonedCacheEntries keeps an entry whose cached URL doesn't parse")
+    func poisonedCacheEntriesKeepsUnparseableURL() {
+        let cached = PRStatus(number: 1, url: "not a pr url", state: .pending)
+        let out = PRStatusManager.poisonedCacheEntries(
+            unnumbered: [(UUID(), "b", nil, "/wt/monorepo", nil)],
+            resolveRepo: { _ in ("mdg-private", "monorepo") },
+            cachedStatus: { _ in cached })
+        #expect(out.isEmpty)
+    }
+
+    @Test("poisonedCacheEntries keeps an entry whose worktree repo can't be resolved")
+    func poisonedCacheEntriesKeepsUnresolvedRepo() {
+        // Absence of evidence is not proof of poisoning: never invalidate when
+        // either side fails to resolve.
+        let cached = PRStatus(number: 13113, url: "https://github.com/mdg-private/studio-ui/pull/13113",
+                              state: .mergeable)
+        let out = PRStatusManager.poisonedCacheEntries(
+            unnumbered: [(UUID(), "b", nil, "/wt/monorepo", nil)],
+            resolveRepo: { _ in nil },
+            cachedStatus: { _ in cached })
+        #expect(out.isEmpty)
+    }
+
+    @Test("poisonedCacheEntries skips a worktree with no cached status")
+    func poisonedCacheEntriesSkipsNoCache() {
+        let out = PRStatusManager.poisonedCacheEntries(
+            unnumbered: [(UUID(), "b", nil, "/wt/monorepo", nil)],
+            resolveRepo: { _ in ("mdg-private", "monorepo") },
+            cachedStatus: { _ in nil })
+        #expect(out.isEmpty)
     }
 
     @Test("cachedNumberFallback excludes a worktree the batch matched, even with a cached number")


### PR DESCRIPTION
## Problem

`PRStatusManager.fetchAll` matched worktrees without a stored PR number against the viewer-authored PR batch (which spans every repo the viewer has PRs in) by head branch name alone. Two worktrees in different repos on the identical branch name therefore both received whichever repo's PR won the branch key, and the wrong status was persisted to the DB.

Real case: a monorepo worktree and a studio-ui worktree both on branch `Jephuff/BILL-149-remove-billingplan-userroles`; the studio-ui PR (#13113 in `mdg-private/studio-ui`) was applied and persisted to the monorepo worktree.

## Fix

- **Repo-scoped matching**: `bestNodeByBranch` is replaced by `bestNodeByRepoBranch`, keyed on the node URL's owner/name (lowercased; GitHub identifiers are case-insensitive) plus branch, preserving the OPEN > MERGED > CLOSED then newest-createdAt tie-break within a repo. `matchUnnumbered` resolves each worktree's own repo (existing TTL-cached `gh repo view`, mirroring the numbered path) and only matches nodes from that repo. An unresolvable repo yields no match, keeping the cached status, the same degrade behavior as `groupNumberedByRepo`.
- **Cache heal**: `poisonedCacheEntries` flags unnumbered worktrees whose cached PR URL parses to a different repo than the worktree's own; `fetchAll` clears those entries and persists the clear (`onStatusPersist` now takes `PRStatus?`). The heal requires both sides to resolve (absence of evidence keeps the entry) and runs before `cachedNumberFallback`, so a stale wrong-repo PR number can never be re-resolved against the worktree's own repo, where a coincidental MERGED PR would have fired auto-archive on the wrong worktree.

## Testing

- 13 new pure-function tests (Swift Testing, no gh/network), including a regression test with the exact cross-repo branch collision, tie-break preservation, upstream-branch candidates, case-insensitive repo comparison, and every branch of the heal decision.
- `swift build` passes; full `swift test` run: 3758 tests in 449 suites, all passing; `swiftlint --strict`: 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)