### PR TITLE
Fix: Stop stray repo files from blocking the full-install restart

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/TextKit/STTextViewTranscriptView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TextKit/STTextViewTranscriptView.swift
@@ -167,7 +167,7 @@ struct STTextViewTranscriptView: NSViewRepresentable {
         /// `scrollToTrueBottom(attempts:)` did, letting AppKit/TextKit2 perform a
         /// layout pass between attempts.
         ///
-        /// Each turn drives STTextView's own Apple-blessed cheap path
+        /// Each turn drives STTextView's own Apple-supported cheap path
         /// (`scrollToEndOfDocument` = `relocateViewport(to:endLocation)` →
         /// `layoutViewport` → `updateContentSizeIfNeeded` → scroll, all O(visible))
         /// then asks the viewport-relative question that actually matters: is the

--- a/docs/superpowers/specs/research-2026-05-06-zstack-event-leak.md
+++ b/docs/superpowers/specs/research-2026-05-06-zstack-event-leak.md
@@ -223,7 +223,7 @@ ZStack {
 
 ### Option C — Replace `ZStack` with `TabView`
 
-If Options A/B both miss subtle event paths (e.g., key event routing), use the OS-blessed mechanism. Wrap `NSTabViewController` directly to fully suppress the tab strip:
+If Options A/B both miss subtle event paths (e.g., key event routing), use the OS-sanctioned mechanism. Wrap `NSTabViewController` directly to fully suppress the tab strip:
 
 ```swift
 struct InvisibleTabContainer<Content: View>: NSViewControllerRepresentable {

--- a/scripts/restart-guard-lib.sh
+++ b/scripts/restart-guard-lib.sh
@@ -1,12 +1,28 @@
 #!/usr/bin/env bash
 # WIP-guard helpers for restart.sh — pure functions, no side effects, safe to
-# source. restart.sh sources this to decide whether a build is "blessed" (safe
+# source. restart.sh sources this to decide whether a build is "install-ready" (safe
 # to install to /Applications + restart the shared daemon); scripts/restart-guard-lib.test.sh
 # sources it to unit-test the helpers. All functions read the global REPO_ROOT.
 #
-# A blessed build must have:
-#  (a) A clean working tree — NO tracked changes AND no new untracked files
+# An install-ready build must have:
+#  (a) A working tree with no install-affecting changes — NO tracked changes AND
+#      no new untracked files within INSTALL_PATHSPECS
 #  (b) HEAD as an ancestor of main (upstream/main, origin/main, or main)
+
+# The set of paths that can affect the installed product: swift build compiles
+# Sources/ per Package.swift/Package.resolved; restart.sh copies
+# Resources/TBDApp.Info.plist and Resources/AppIcon.icns into the bundle; and
+# the two restart scripts themselves determine what lands in /Applications.
+# Nothing else (Tests/, docs/, other scripts, stray root files) can change the
+# installed product.
+INSTALL_PATHSPECS=(
+    Sources
+    Resources
+    Package.swift
+    Package.resolved
+    scripts/restart.sh
+    scripts/restart-guard-lib.sh
+)
 
 # Determine the main-branch ref to use for the ancestry check.
 resolve_main_ref() {
@@ -21,15 +37,18 @@ resolve_main_ref() {
     fi
 }
 
-# Check if the working tree is clean. Untracked files are INTENTIONALLY counted
-# as dirty: SwiftPM globs Sources/ by filesystem contents, so a brand-new,
-# not-yet-`git add`ed .swift file IS compiled into the build while being
-# invisible to a tracked-only check — exactly the WIP state this guard exists to
-# catch. Ignored paths (.build/, .DS_Store, …) never appear in --porcelain, so
-# the default untracked mode adds no build-artifact noise.
+# Check if the working tree is clean within the install-affecting paths.
+# Untracked files are INTENTIONALLY counted as dirty: SwiftPM globs Sources/ by
+# filesystem contents, so a brand-new, not-yet-`git add`ed .swift file IS
+# compiled into the build while being invisible to a tracked-only check —
+# exactly the WIP state this guard exists to catch. Dirt outside
+# INSTALL_PATHSPECS (e.g. a stray output.txt at the repo root) cannot change
+# the installed product and does not gate the install. Ignored paths (.build/,
+# .DS_Store, …) never appear in --porcelain, so the default untracked mode adds
+# no build-artifact noise.
 is_working_tree_clean() {
     local output
-    output=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null || echo "error")
+    output=$(git -C "$REPO_ROOT" status --porcelain -- "${INSTALL_PATHSPECS[@]}" 2>/dev/null || echo "error")
     if [ "$output" = "error" ]; then
         return 1  # not a git repo or error
     fi
@@ -45,8 +64,9 @@ is_head_ancestor_of() {
     git -C "$REPO_ROOT" merge-base --is-ancestor HEAD "$ref" 2>/dev/null
 }
 
-# Determine if the build is blessed (clean tree + HEAD on/before main).
-is_build_blessed() {
+# Determine if the build is install-ready (clean install-affecting paths + HEAD
+# on/before main).
+is_build_install_ready() {
     if ! is_working_tree_clean; then
         return 1
     fi
@@ -67,14 +87,16 @@ get_installed_worktree_path() {
     fi
 }
 
-# Print a loud warning when the build is not blessed.
+# Print a loud warning when the build is not install-ready.
 warn_wip_build() {
     local current_branch
     current_branch=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 
     local dirty_count=0
     if ! is_working_tree_clean; then
-        dirty_count=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+        # Count only install-affecting dirty files — same pathspec scope as the
+        # clean check above.
+        dirty_count=$(git -C "$REPO_ROOT" status --porcelain -- "${INSTALL_PATHSPECS[@]}" 2>/dev/null | wc -l | tr -d ' ')
     fi
 
     local installed_path
@@ -83,7 +105,7 @@ warn_wip_build() {
     cat >&2 << 'EOF'
 
 ===============================================================================
-WARNING: NOT BLESSED — WIP WORKTREE GUARD ACTIVE
+WARNING: NOT INSTALL-READY — WIP WORKTREE GUARD ACTIVE
 ===============================================================================
 
 This worktree is on a feature branch or has uncommitted/untracked changes. To
@@ -112,7 +134,7 @@ TO OVERRIDE (force full install):
   or
   TBD_INSTALL_WIP=1 scripts/restart.sh
 
-TO FIX (make it blessed):
+TO FIX (make it install-ready):
   • Commit your changes: git add -A && git commit -m "..."
   • Rebase onto upstream/main: git rebase upstream/main
   • Or push to a tracking branch

--- a/scripts/restart-guard-lib.test.sh
+++ b/scripts/restart-guard-lib.test.sh
@@ -11,72 +11,114 @@ assert_ok()   { local d="$1"; shift; if "$@" >/dev/null 2>&1; then echo "ok   - 
 assert_fail() { local d="$1"; shift; if "$@" >/dev/null 2>&1; then echo "FAIL - $d: expected failure"; FAIL=1; else echo "ok   - $d"; fi; }
 assert_eq()   { if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
 
-# Build a throwaway git repo with a `main` branch and one commit. Echoes its path.
+# Build a throwaway git repo with a `main` branch and one commit, including
+# tracked files inside the install-affecting paths (Sources/, Resources/,
+# Package.swift). Echoes its path.
 mkrepo() {
     local d; d="$(mktemp -d "${TMPDIR:-/tmp}/guard-test.XXXXXX")"
     git -C "$d" init -q -b main
     git -C "$d" config user.email t@t.t
     git -C "$d" config user.name t
     echo "seed" > "$d/README.md"
+    mkdir -p "$d/Sources" "$d/Resources"
+    echo "// seed" > "$d/Sources/Seed.swift"
+    echo "plist" > "$d/Resources/Info.plist"
+    echo "// package" > "$d/Package.swift"
     git -C "$d" add -A && git -C "$d" commit -q -m "seed"
     echo "$d"
 }
 
-test_clean_on_main_is_blessed() {
+test_clean_on_main_is_install_ready() {
     local REPO_ROOT; REPO_ROOT="$(mkrepo)"
     assert_ok "is_working_tree_clean on clean repo" is_working_tree_clean
     assert_eq "resolve_main_ref falls back to main" "main" "$(resolve_main_ref)"
-    assert_ok "is_build_blessed: clean + HEAD == main" is_build_blessed
+    assert_ok "is_build_install_ready: clean + HEAD == main" is_build_install_ready
     rm -rf "$REPO_ROOT"
 }
 
-test_dirty_tracked_file_not_blessed() {
+test_modified_source_file_not_install_ready() {
     local REPO_ROOT; REPO_ROOT="$(mkrepo)"
-    echo "change" >> "$REPO_ROOT/README.md"   # modify a tracked file
-    assert_fail "is_working_tree_clean with modified tracked file" is_working_tree_clean
-    assert_fail "is_build_blessed with dirty tracked file" is_build_blessed
+    echo "change" >> "$REPO_ROOT/Sources/Seed.swift"   # modify a tracked install-affecting file
+    assert_fail "is_working_tree_clean with modified Sources/ file" is_working_tree_clean
+    assert_fail "is_build_install_ready with modified Sources/ file" is_build_install_ready
+    rm -rf "$REPO_ROOT"
+}
+
+test_modified_resources_file_not_install_ready() {
+    local REPO_ROOT; REPO_ROOT="$(mkrepo)"
+    echo "change" >> "$REPO_ROOT/Resources/Info.plist"   # tracked, copied into the bundle
+    assert_fail "is_working_tree_clean with modified Resources/ file" is_working_tree_clean
+    assert_fail "is_build_install_ready with modified Resources/ file" is_build_install_ready
+    rm -rf "$REPO_ROOT"
+}
+
+test_modified_package_swift_not_install_ready() {
+    local REPO_ROOT; REPO_ROOT="$(mkrepo)"
+    echo "// change" >> "$REPO_ROOT/Package.swift"
+    assert_fail "is_working_tree_clean with modified Package.swift" is_working_tree_clean
+    assert_fail "is_build_install_ready with modified Package.swift" is_build_install_ready
     rm -rf "$REPO_ROOT"
 }
 
 # The High finding this PR fixes: a brand-new untracked .swift file is compiled
 # by SwiftPM but was invisible to the old --untracked-files=no check.
-test_untracked_new_file_not_blessed() {
+test_untracked_source_file_not_install_ready() {
     local REPO_ROOT; REPO_ROOT="$(mkrepo)"
-    echo "// wip" > "$REPO_ROOT/NewFeature.swift"   # untracked, never `git add`ed
-    assert_fail "is_working_tree_clean with untracked new file" is_working_tree_clean
-    assert_fail "is_build_blessed with untracked new file" is_build_blessed
+    echo "// wip" > "$REPO_ROOT/Sources/NewFeature.swift"   # untracked, never `git add`ed
+    assert_fail "is_working_tree_clean with untracked Sources/ file" is_working_tree_clean
+    assert_fail "is_build_install_ready with untracked Sources/ file" is_build_install_ready
+    rm -rf "$REPO_ROOT"
+}
+
+# Dirt OUTSIDE the install-affecting paths (stray root files, Tests/, docs/)
+# cannot change the installed product and must NOT gate the install.
+test_untracked_stray_files_stay_install_ready() {
+    local REPO_ROOT; REPO_ROOT="$(mkrepo)"
+    echo "stray" > "$REPO_ROOT/output.txt"               # stray file at repo root
+    mkdir -p "$REPO_ROOT/Tests"
+    echo "// test wip" > "$REPO_ROOT/Tests/WIPTests.swift"  # untracked test file
+    assert_ok "is_working_tree_clean ignores strays outside install paths" is_working_tree_clean
+    assert_ok "is_build_install_ready with only non-install-affecting strays" is_build_install_ready
+    rm -rf "$REPO_ROOT"
+}
+
+test_modified_readme_stays_install_ready() {
+    local REPO_ROOT; REPO_ROOT="$(mkrepo)"
+    echo "change" >> "$REPO_ROOT/README.md"   # tracked but not install-affecting
+    assert_ok "is_working_tree_clean ignores modified README.md" is_working_tree_clean
+    assert_ok "is_build_install_ready with modified README.md" is_build_install_ready
     rm -rf "$REPO_ROOT"
 }
 
 # Ignored paths (like .build/) must NOT trip the clean check.
-test_gitignored_path_stays_blessed() {
+test_gitignored_path_stays_install_ready() {
     local REPO_ROOT; REPO_ROOT="$(mkrepo)"
     printf '.build/\n' > "$REPO_ROOT/.gitignore"
     git -C "$REPO_ROOT" add .gitignore && git -C "$REPO_ROOT" commit -q -m "ignore build"
     mkdir -p "$REPO_ROOT/.build/debug"; echo x > "$REPO_ROOT/.build/debug/artifact"
     assert_ok "is_working_tree_clean ignores .build artifacts" is_working_tree_clean
-    assert_ok "is_build_blessed with only ignored artifacts" is_build_blessed
+    assert_ok "is_build_install_ready with only ignored artifacts" is_build_install_ready
     rm -rf "$REPO_ROOT"
 }
 
-test_head_ahead_of_main_not_blessed() {
+test_head_ahead_of_main_not_install_ready() {
     local REPO_ROOT; REPO_ROOT="$(mkrepo)"
     git -C "$REPO_ROOT" checkout -q -b feature
     echo "feat" > "$REPO_ROOT/f.txt"
     git -C "$REPO_ROOT" add -A && git -C "$REPO_ROOT" commit -q -m "feature commit"
     assert_fail "is_head_ancestor_of main when HEAD is ahead" is_head_ancestor_of "main"
-    assert_fail "is_build_blessed when HEAD ahead of main" is_build_blessed
+    assert_fail "is_build_install_ready when HEAD ahead of main" is_build_install_ready
     rm -rf "$REPO_ROOT"
 }
 
-test_no_main_ref_not_blessed() {
+test_no_main_ref_not_install_ready() {
     local d; d="$(mktemp -d "${TMPDIR:-/tmp}/guard-test.XXXXXX")"
     git -C "$d" init -q -b trunk   # no branch/ref named main
     git -C "$d" config user.email t@t.t; git -C "$d" config user.name t
     echo x > "$d/a"; git -C "$d" add -A; git -C "$d" commit -q -m x
     local REPO_ROOT="$d"
     assert_eq "resolve_main_ref empty when no main" "" "$(resolve_main_ref)"
-    assert_fail "is_build_blessed when no main ref resolvable" is_build_blessed
+    assert_fail "is_build_install_ready when no main ref resolvable" is_build_install_ready
     rm -rf "$d"
 }
 

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -9,7 +9,7 @@ set -e
 #   scripts/restart.sh --app    # restart app only (no rebuild, no daemon restart)
 #   scripts/restart.sh --daemon # restart daemon only (no rebuild, no app restart)
 #   scripts/restart.sh --quick  # skip rebuild, restart everything
-#   scripts/restart.sh --dry-run # print blessed/not-blessed decision, touch nothing
+#   scripts/restart.sh --dry-run # print install-ready/not-install-ready decision, touch nothing
 #   scripts/restart.sh --wip    # force install even if on a WIP branch
 #   TBD_INSTALL_WIP=1 scripts/restart.sh # same as --wip
 
@@ -39,31 +39,32 @@ fi
 
 # MARK: - WIP Guard
 #
-# Blessed builds (clean tree + HEAD on/before main) install to /Applications
-# and restart the shared daemon. WIP builds warn and launch from .build only.
-# Escape hatch: --wip / TBD_INSTALL_WIP=1. Helpers live in a sourceable lib so
-# they can be unit-tested (scripts/restart-guard-lib.test.sh).
+# Install-ready builds (clean install-affecting paths + HEAD on/before main)
+# install to /Applications and restart the shared daemon. WIP builds warn and
+# launch from .build only. Escape hatch: --wip / TBD_INSTALL_WIP=1. Helpers
+# live in a sourceable lib so they can be unit-tested
+# (scripts/restart-guard-lib.test.sh).
 source "$REPO_ROOT/scripts/restart-guard-lib.sh"
 
 # Determine install strategy and possibly print dry-run summary.
-build_is_blessed=false
+build_is_install_ready=false
 install_to_applications=true
 
-if ! is_build_blessed; then
-    build_is_blessed=false
+if ! is_build_install_ready; then
+    build_is_install_ready=false
     if [ "$force_wip" = false ]; then
         install_to_applications=false
     fi
 else
-    build_is_blessed=true
+    build_is_install_ready=true
 fi
 
 if [ "$dry_run" = true ]; then
-    if [ "$build_is_blessed" = true ]; then
-        echo "BLESSED: Working tree is clean and HEAD is on/before main."
+    if [ "$build_is_install_ready" = true ]; then
+        echo "INSTALL-READY: Install-affecting paths are clean and HEAD is on/before main."
         echo "Would install to /Applications and restart daemon."
     else
-        echo "NOT BLESSED: WIP branch or dirty working tree."
+        echo "NOT INSTALL-READY: WIP branch or dirty install-affecting paths."
         if [ "$force_wip" = true ]; then
             echo "Would install to /Applications and restart daemon (--wip override)."
         else
@@ -74,8 +75,8 @@ if [ "$dry_run" = true ]; then
     exit 0
 fi
 
-# Print warning if not blessed (unless --wip forces it).
-if [ "$build_is_blessed" = false ] && [ "$force_wip" = false ]; then
+# Print warning if not install-ready (unless --wip forces it).
+if [ "$build_is_install_ready" = false ] && [ "$force_wip" = false ]; then
     warn_wip_build
 fi
 
@@ -211,8 +212,8 @@ fi
 # exec path now that it runs from /Applications instead of .build/.
 printf '%s' "$REPO_ROOT" > "$BUNDLE_DIR/Contents/SourceWorktreePath.txt"
 
-# Conditionally sign + install to /Applications (only if blessed or --wip).
-# For WIP builds not blessed, we'll skip this and launch from .build/debug instead.
+# Conditionally sign + install to /Applications (only if install-ready or --wip).
+# For WIP builds not install-ready, we'll skip this and launch from .build/debug instead.
 INSTALLED_BUNDLE="/Applications/TBD.app"
 BUNDLED_EXEC_PATH="$INSTALLED_BUNDLE/Contents/MacOS/TBDApp"
 APP_EXEC_PATTERN=""
@@ -335,7 +336,7 @@ if [ "$daemon_only" = false ]; then
 
     echo "Starting app..."
     if [ "$install_to_applications" = true ]; then
-        # Launch from /Applications (blessed or --wip override)
+        # Launch from /Applications (install-ready or --wip override)
         open "$INSTALLED_BUNDLE" --stdout /tmp/tbdapp.log --stderr /tmp/tbdapp.log
     else
         # Launch from .build/debug (WIP worktree, no install to /Applications)


### PR DESCRIPTION
## Summary
- The restart script's WIP guard treated *any* working-tree dirt as a reason to block the full install — a stray `output.txt` at the repo root would stop a restart even though it can't affect the installed product.
- The guard now only considers paths that actually influence the build/install: `Sources/`, `Resources/`, `Package.swift`, `Package.resolved`, and the restart scripts themselves.
- Also renames the guard's internal vocabulary to "install-ready" to comply with the repo's banned-words rule.

## Test plan
- [x] `bash scripts/restart-guard-lib.test.sh` — all guard-lib tests pass, including new cases for strays inside vs. outside install-affecting paths
- [x] `swift build` — clean build