### PR TITLE
DX: Make the clock seam mechanical -- lint the 60 raw Task.sleep sites instead of trusting review

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -58,6 +58,17 @@ custom_rules:
     message: "Use os.Logger instead of print() in Sources/. See CLAUDE.md."
     severity: error
 
+  no_raw_task_sleep:
+    name: "No raw Task.sleep in Sources/"
+    # included/excluded HERE take REGEX (not glob), matched against file path.
+    included:
+      - "Sources/(TBDShared|TBDDaemon|TBDApp)/.*\\.swift"
+    regex: 'Task\.sleep\s*\('
+    match_kinds:
+      - identifier
+    message: "New delays/timers take an injected clock (`clock: any Clock<Duration> = ContinuousClock()`) — see Tests/CLAUDE.md \"Clock and date seams\" and docs/specs/2026-07-24-test-hardening-design.md §5."
+    severity: error
+
   no_scrollview_in_transcript_cards:
     name: "No direct ScrollView in transcript row cards"
     # included/excluded HERE take REGEX (not glob), matched against file path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,18 @@ Use `os.Logger` (`import os`) with one of the established subsystems (`com.tbd.a
 
 This rule is enforced mechanically by SwiftLint (custom rule `no_print_in_sources`) in the dedicated `lint` CI job and the pre-push git hook, both invoking a Homebrew-installed `swiftlint --strict` directly. To lint manually: `swiftlint --strict`. Prerequisite: `brew install swiftlint`. See `.swiftlint.yml`.
 
+### New delays and timers take an injected clock
+
+Anything that sleeps, debounces, polls, or times out takes the clock as its last initializer parameter, defaulted so no call site changes:
+
+```swift
+init(..., clock: any Clock<Duration> = ContinuousClock())
+```
+
+Existential, not generic — a generic parameter would infect the actor types these subsystems already carry `Sendable` conformances on. Timestamps that get *persisted or compared* use the separate date seam instead (`date: Date = Date()` on the method, or `now: @Sendable () -> Date` on the type): **`Duration` is behavior, `Date` is data.**
+
+Enforced mechanically by the SwiftLint rule `no_raw_task_sleep` (same `lint` job and pre-push hook as `no_print_in_sources`). Pre-existing sites carry a visible `// swiftlint:disable:next no_raw_task_sleep - legacy sleep, …` suppression and are being burned down; adding a new one draws review scrutiny. `PollerClock` is a sanctioned exception for suspend-aware *wall*-deadline sleeping and is not a template. Seam details, test helpers, and the existential's `Instant` limitation: [`Tests/CLAUDE.md`](Tests/CLAUDE.md) "Clock and date seams".
+
 ### No TUI screen-scraping
 
 Never infer an agent's state by parsing its rendered terminal screen — tmux `capture-pane` text, composer glyphs like `❯`, placeholder or status strings. Screen text is a display surface, not an API: scraping breaks *silently* when the TUI changes copy or rendering, couples TBD to one agent version, and sits at the wrong layer. Get agent state from machine interfaces instead: Claude Code hooks, transcript JSONL, tmux control-mode events, process exit codes, or TBD's own DB/RPC state. (Cautionary tale: PR #398 verified submits by scanning the composer line for `[Pasted text` — it defended an unreachable state and was removed as dead code.)

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2ac9f485880de6d74c504ea3a96b5b88b9829a2a8cc12c3a9da738ae8b99f55c",
+  "originHash" : "32946c529570441a44b2c80a923efd0ef5add54a256cbf6e72c5a1a8036b07b5",
   "pins" : [
     {
       "identity" : "coretextswift",
@@ -74,6 +74,15 @@
       }
     },
     {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "72d749bf341b78851203066ab421869b783ec42a",
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark",
@@ -88,6 +97,15 @@
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5fa253428866f2360c3754e88537f700ed2656b5",
         "version" : "1.4.1"
       }
     },
@@ -151,6 +169,15 @@
       "state" : {
         "revision" : "ec6198d37d495efc6acd4dffbd262cdca7ff9b3f",
         "version" : "0.6.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,8 @@ let package = Package(
         .package(url: "https://github.com/LebJe/TOMLKit", from: "0.6.0"),
         .package(url: "https://github.com/apple/swift-markdown", from: "0.4.0"),
         .package(url: "https://github.com/krzyzanowskim/STTextView", from: "2.3.8"),
+        // Test-only: `TestClock` for tier-1 virtual-time tests. No `Sources/` target links it.
+        .package(url: "https://github.com/pointfreeco/swift-clocks", from: "1.0.0"),
     ],
     targets: [
         .target(
@@ -117,6 +119,7 @@ let package = Package(
             dependencies: [
                 "TBDDaemonLib",
                 "TBDShared",
+                .product(name: "Clocks", package: "swift-clocks"),
             ],
             path: "Tests/TestSupport"
         ),
@@ -131,6 +134,7 @@ let package = Package(
                 "TBDShared",
                 "TestSupport",
                 .product(name: "GRDB", package: "GRDB.swift"),
+                .product(name: "Clocks", package: "swift-clocks"),
             ]
         ),
         // Tier 3 (docs/specs/2026-07-24-test-hardening-design.md §3): suites whose
@@ -141,7 +145,12 @@ let package = Package(
         // slows every PR; the bar is the §3 criterion, not "it feels slow".
         .testTarget(
             name: "TBDDaemonLiveTests",
-            dependencies: ["TBDDaemonLib", "TBDShared", "TestSupport"]
+            dependencies: [
+                "TBDDaemonLib",
+                "TBDShared",
+                "TestSupport",
+                .product(name: "Clocks", package: "swift-clocks"),
+            ]
         ),
         .testTarget(
             name: "TBDAppTests",
@@ -151,6 +160,7 @@ let package = Package(
                 // assembles replay bytes, the app's SwiftTerm consumes them,
                 // and only this test target links the SwiftTerm product.
                 "TBDDaemonLib",
+                .product(name: "Clocks", package: "swift-clocks"),
             ],
             resources: [
                 .copy("Fixtures")

--- a/Sources/TBDApp/AppState+Toast.swift
+++ b/Sources/TBDApp/AppState+Toast.swift
@@ -31,6 +31,7 @@ extension AppState {
         let toastID = activeToast?.id
         let delay = toastTickDuration * 4
         toastDismissTask = Task { @MainActor [weak self] in
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: delay)
             guard !Task.isCancelled,
                   let self, self.activeToast?.id == toastID else { return }

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1750,6 +1750,7 @@ final class AppState: ObservableObject {
 
         // Wait for socket
         for _ in 0..<20 {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .milliseconds(200))
             if FileManager.default.fileExists(atPath: TBDConstants.socketPath) {
                 break
@@ -2353,6 +2354,7 @@ final class AppState: ObservableObject {
         // Skip noop broadcasts: same cell dims as the previous send.
         guard cols != lastBroadcastCols || rows != lastBroadcastRows else { return }
         mainAreaSizeBroadcastTask = Task { [weak self] in
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: 300_000_000) // 300ms debounce
             guard !Task.isCancelled, let self else { return }
             do {

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -165,6 +165,7 @@ struct ArchivedWorktreesView: View {
                             proxy.scrollTo(id, anchor: .center)
                         }
                         Task { @MainActor in
+                            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                             try? await Task.sleep(for: .milliseconds(900))
                             if appState.highlightedArchivedWorktreeID == id {
                                 appState.highlightedArchivedWorktreeID = nil

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -109,6 +109,7 @@ actor DaemonClient {
 
             // Wait for daemon to start (up to 4 seconds, polling every 0.5s)
             for attempt in 1...8 {
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds
                 if tryConnect() {
                     daemonClientLogger.info("Connected to daemon after \(attempt) attempts")

--- a/Sources/TBDApp/Notes/NotepadPopoverView.swift
+++ b/Sources/TBDApp/Notes/NotepadPopoverView.swift
@@ -106,6 +106,7 @@ struct NotepadPopoverView: View {
             loadedContent = disk
             loadedPath = path
             didLoad = true
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .milliseconds(200))
             editorFocused = true
         }
@@ -119,6 +120,7 @@ struct NotepadPopoverView: View {
     private func debounceSave(_ newValue: String) {
         saveTask?.cancel()
         saveTask = Task {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .milliseconds(500))
             guard !Task.isCancelled else { return }
             flushSave()

--- a/Sources/TBDApp/Panes/FileWatcher.swift
+++ b/Sources/TBDApp/Panes/FileWatcher.swift
@@ -202,6 +202,7 @@ private final class StreamState: @unchecked Sendable {
 
     private func scheduleDebouncedNotify() {
         let task = Task { [weak self] in
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .milliseconds(150))
             guard !Task.isCancelled, let self else { return }
             self.yieldIfActive()
@@ -218,6 +219,7 @@ private final class StreamState: @unchecked Sendable {
 
     private func scheduleReopen() {
         let task = Task { [weak self] in
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .milliseconds(50))
             guard !Task.isCancelled, let self else { return }
             self.performReopen()

--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -238,6 +238,7 @@ private struct HistoryHeaderRow: View {
         }
         statusClearTask?.cancel()
         statusClearTask = Task {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(2))
             guard !Task.isCancelled else { return }
             withAnimation { statusMessage = nil }

--- a/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/LiveTranscriptPaneView.swift
@@ -289,6 +289,7 @@ struct LiveTranscriptPaneView: View {
 
         for i in 0..<cfg.injectCount {
             if Task.isCancelled { break }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: UInt64(cfg.injectIntervalMs) * 1_000_000)
             if Task.isCancelled { break }
             let startIndex = cfg.preseed + i * batch
@@ -310,6 +311,7 @@ struct LiveTranscriptPaneView: View {
                 loadError = "Lost connection to the daemon."
                 return
             }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
         }
     }

--- a/Sources/TBDApp/Panes/NotePaneView.swift
+++ b/Sources/TBDApp/Panes/NotePaneView.swift
@@ -89,6 +89,7 @@ struct NotePaneView: View {
     private func debounceSave(content: String) {
         saveTask?.cancel()
         saveTask = Task {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .milliseconds(500))
             guard !Task.isCancelled else { return }
             await appState.updateNote(noteID: noteID, worktreeID: worktreeID, content: content)

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -583,6 +583,7 @@ struct PanePlaceholder: View {
         pasteboard.setString(urlString, forType: .string)
         didCopyURL = true
         Task { @MainActor in
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: 1_500_000_000)
             didCopyURL = false
         }

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -220,6 +220,7 @@ struct TableTranscriptPaneView: View {
                 loadError = "Lost connection to the daemon."
                 return
             }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
         }
     }

--- a/Sources/TBDApp/Panes/Transcript/TextKit/STTextViewTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TextKit/STTextViewTranscriptPaneView.swift
@@ -306,6 +306,7 @@ struct STTextViewTranscriptPaneView: View {
 
         for i in 0..<cfg.injectCount {
             if Task.isCancelled { break }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: UInt64(cfg.injectIntervalMs) * 1_000_000)
             if Task.isCancelled { break }
             let startIndex = cfg.preseed + i * batch
@@ -327,6 +328,7 @@ struct STTextViewTranscriptPaneView: View {
                 loadError = "Lost connection to the daemon."
                 return
             }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
         }
     }

--- a/Sources/TBDApp/RepoDetailView.swift
+++ b/Sources/TBDApp/RepoDetailView.swift
@@ -251,6 +251,7 @@ private struct ClaudeSettingsOverlayEditor: View {
         }
         withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
         Task {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(2))
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
         }

--- a/Sources/TBDApp/RepoInstructionsView.swift
+++ b/Sources/TBDApp/RepoInstructionsView.swift
@@ -119,6 +119,7 @@ struct RepoInstructionsView: View {
     private func scheduleSave() {
         saveTask?.cancel()
         saveTask = Task {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(1))
             guard !Task.isCancelled else { return }
 
@@ -141,6 +142,7 @@ struct RepoInstructionsView: View {
 
             guard success else { return }
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(2))
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
         }

--- a/Sources/TBDApp/ScratchInstructionsTabView.swift
+++ b/Sources/TBDApp/ScratchInstructionsTabView.swift
@@ -160,6 +160,7 @@ struct ScratchInstructionsTabView: View {
     private func scheduleSave() {
         saveTask?.cancel()
         saveTask = Task {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(1))
             guard !Task.isCancelled else { return }
 
@@ -171,6 +172,7 @@ struct ScratchInstructionsTabView: View {
 
             guard !Task.isCancelled else { return }
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(2))
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
         }

--- a/Sources/TBDApp/Settings/EnvOverridesEditor.swift
+++ b/Sources/TBDApp/Settings/EnvOverridesEditor.swift
@@ -114,6 +114,7 @@ struct EnvOverridesEditor: View {
             rows = overrides.sorted { $0.key < $1.key }.map { Row(key: $0.key, value: $0.value) }
             isSaving = false
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = true }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(2))
             withAnimation(.easeInOut(duration: 0.3)) { showSaved = false }
         }

--- a/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
+++ b/Sources/TBDApp/Settings/ModelProfilesSettingsView.swift
@@ -553,6 +553,7 @@ struct AddModelProfileSheet: View {
         .task(id: "\(preset)|\(awsRegion)|\(awsProfile)") {
             guard preset == .bedrock else { return }
             // Debounce so rapid keystrokes don't spam subprocess calls.
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: 500_000_000)
             if Task.isCancelled { return }
             modelDiscovery = .loading
@@ -1130,6 +1131,7 @@ struct EditBedrockSheet: View {
         .onAppear { awsProfileSuggestions = AWSProfiles.discover() }
         .task(id: "\(awsRegion)|\(awsProfile)") {
             // Debounce so rapid keystrokes don't spam subprocess calls.
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: 500_000_000)
             if Task.isCancelled { return }
             modelDiscovery = .loading

--- a/Sources/TBDApp/Settings/RepoHooksSettingsView.swift
+++ b/Sources/TBDApp/Settings/RepoHooksSettingsView.swift
@@ -141,6 +141,7 @@ struct RepoHooksSettingsView: View {
                     writeHook(content: draft.wrappedValue, to: filePath)
                     withAnimation(.easeInOut(duration: 0.3)) { showSaved.wrappedValue = true }
                     Task {
+                        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                         try? await Task.sleep(for: .seconds(2))
                         withAnimation(.easeInOut(duration: 0.3)) { showSaved.wrappedValue = false }
                     }

--- a/Sources/TBDApp/Sidebar/HoverMenuModel.swift
+++ b/Sources/TBDApp/Sidebar/HoverMenuModel.swift
@@ -85,6 +85,7 @@ final class HoverMenuModel: ObservableObject {
             openTaskGeneration += 1
             let generation = openTaskGeneration
             openTask = Task { [weak self] in
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: self?.openDelay ?? .zero)
                 guard let self else { return }
                 if self.openTaskGeneration == generation { self.openTask = nil }
@@ -97,6 +98,7 @@ final class HoverMenuModel: ObservableObject {
             closeTaskGeneration += 1
             let generation = closeTaskGeneration
             closeTask = Task { [weak self] in
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: self?.closeGrace ?? .zero)
                 guard let self else { return }
                 if self.closeTaskGeneration == generation { self.closeTask = nil }

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -47,6 +47,7 @@ struct RepoSectionView: View {
         } else {
             hoverDebounceTask?.cancel()
             hoverDebounceTask = Task { @MainActor in
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try await Task.sleep(nanoseconds: 80_000_000)
                 isSectionHovered = false
             }

--- a/Sources/TBDApp/Terminal/FDSidecarClient.swift
+++ b/Sources/TBDApp/Terminal/FDSidecarClient.swift
@@ -285,6 +285,7 @@ final class FDPromise: @unchecked Sendable {
     /// by the receive loop's no-waiter path.
     func value(timeout: Duration) async throws -> Int32 {
         let timeoutTask = Task { [weak self] in
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: timeout)
             self?.onCancelOrTimeout?()
             self?.settle(fd: nil, error: FDSidecarError.timedOut)

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -155,6 +155,7 @@ struct TerminalPanelView: View {
 
         didProbe = true   // gate further attempts only once we actually probe
 
+        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
         try? await Task.sleep(nanoseconds: 500_000_000)
         let result = await appState.healthCheckProfile(baseURL: baseURL)
         if !result.reachable {
@@ -1026,6 +1027,7 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
             resizeDebounceTask?.cancel()
             let daemonClient = appState?.daemonClient
             resizeDebounceTask = Task { [weak self] in
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: .milliseconds(100))
                 guard !Task.isCancelled, let self else { return }
                 guard var size = self.resizeSerializer.sizeToSend(cols: cols, rows: rows) else {

--- a/Sources/TBDDaemon/Claude/LoginSessionCoordinator.swift
+++ b/Sources/TBDDaemon/Claude/LoginSessionCoordinator.swift
@@ -144,6 +144,7 @@ public actor LoginSessionCoordinator {
                 activePumps.remove(terminalID)
                 pendingAutoLogin.remove(terminalID)
             }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: delays.pumpInitialDelay)
             var elapsed: Duration = .zero
             var sends = 0
@@ -157,9 +158,11 @@ public actor LoginSessionCoordinator {
                     sends += 1
                     logger.info("auto-login: typing /login into terminal \(terminalID, privacy: .public) (attempt \(sends, privacy: .public))")
                     await typeLogin()
+                    // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                     try? await Task.sleep(for: delays.pumpPostSendDelay)
                     elapsed += delays.pumpPostSendDelay
                 case .promptReady, .notReady:
+                    // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                     try? await Task.sleep(for: delays.pumpPollInterval)
                     elapsed += delays.pumpPollInterval
                 }
@@ -193,6 +196,7 @@ public actor LoginSessionCoordinator {
                     onLogin()
                     return
                 }
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: interval)
                 elapsed += interval
             }

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -114,6 +114,7 @@ public actor OAuthProfileUsagePoller {
         self.configDirPath = configDirPath
         self.fetcher = fetcher
         self.broadcast = broadcast
+        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
         self.sleeper = sleeper ?? { try await Task.sleep(for: .seconds($0)) }
         self.now = now ?? { Date() }
         // Default jitter: uniform in [0, span). Injectable for deterministic

--- a/Sources/TBDDaemon/Claude/PollerClock.swift
+++ b/Sources/TBDDaemon/Claude/PollerClock.swift
@@ -2,6 +2,13 @@ import Foundation
 
 /// Abstract clock used by `ClaudeUsagePoller` so tests can advance virtual time
 /// instead of sleeping. Production uses `SystemPollerClock`; tests use a fake.
+///
+/// This is NOT the standard clock seam and should not be copied as a template —
+/// new code that needs a delay/timer/debounce takes `clock: any Clock<Duration> =
+/// ContinuousClock()` (see `Tests/CLAUDE.md`, "Clock and date seams"). PollerClock
+/// exists only because Darwin's `Task.sleep` uses the suspending clock, so a single
+/// long sleep overshoots a wall-clock deadline by however long the machine slept —
+/// chunked re-checking is a genuinely different job.
 public protocol PollerClock: Sendable {
     func now() -> Date
     /// Sleep until `deadline`. May throw `CancellationError` to wake early.
@@ -16,6 +23,7 @@ public struct SystemPollerClock: PollerClock {
     /// `maxChunk`, `sleeper`, and `now` are injection seams for tests; production uses the defaults.
     public init(
         maxChunk: TimeInterval = 60,
+        // swiftlint:disable:next no_raw_task_sleep - sanctioned: suspend-aware wall-deadline chunking, see this file's docs
         sleeper: @escaping @Sendable (UInt64) async throws -> Void = { try await Task.sleep(nanoseconds: $0) },
         now: @escaping @Sendable () -> Date = { Date() }
     ) {

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -291,6 +291,7 @@ public final class Daemon: Sendable {
         // 4c. Start periodic SSH agent refresh (every 60s)
         self.sshRefreshTask = Task {
             while !Task.isCancelled {
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: .seconds(60))
                 if !(await sshResolver.isValid()) {
                     if await sshResolver.resolve() {
@@ -585,6 +586,7 @@ public final class Daemon: Sendable {
                 // Sweep once immediately (cold recovery), then every 60s.
                 await reaper.sweep(servers: await ownedServers())
                 while !Task.isCancelled {
+                    // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                     try? await Task.sleep(for: .seconds(60))
                     guard !Task.isCancelled else { break }
                     await reaper.sweep(servers: await ownedServers())
@@ -602,6 +604,7 @@ public final class Daemon: Sendable {
                     // Sweep once immediately (cold recovery), then every hour.
                     _ = await orphanGC.sweep()
                     while !Task.isCancelled {
+                        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                         try? await Task.sleep(for: .seconds(3600))
                         guard !Task.isCancelled else { break }
                         _ = await orphanGC.sweep()
@@ -697,6 +700,7 @@ public final class Daemon: Sendable {
                 tmux: tmux,
                 inspector: ProductionPaneProcessInspector(),
                 readTranscript: { path in FileManager.default.contents(atPath: path) },
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 waiter: { duration in _ = try? await Task.sleep(for: duration) }
             )
             let resumeScheduler = LimitResumeScheduler(
@@ -791,6 +795,7 @@ public final class Daemon: Sendable {
             let hibernationCoordinator = rpcRouter.hibernationCoordinator
             self.hibernationSweepTask = Task {
                 while !Task.isCancelled {
+                    // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                     try? await Task.sleep(for: .seconds(30))
                     guard !Task.isCancelled else { break }
                     await hibernationCoordinator.sweep()
@@ -813,6 +818,7 @@ public final class Daemon: Sendable {
     static func sleepThroughGatedInterval(_ interval: @Sendable () async -> Duration) async {
         var waited = Duration.zero
         while !Task.isCancelled {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: GitPollCadence.pollTick)
             waited += GitPollCadence.pollTick
             let due = await interval()

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -610,6 +610,7 @@ public actor HibernationCoordinator {
         // fresh id so subsequent hibernate/wake reference the live session.
         let termID = terminal.id
         Task {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(5))
             if let newID = await self.detector.captureSessionID(server: server, paneID: livePaneID) {
                 try? await self.db.terminals.updateSessionID(id: termID, sessionID: newID)
@@ -894,6 +895,7 @@ public actor HibernationCoordinator {
             return false
         }
         for _ in 0..<Self.exitPollAttempts {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: Self.exitPollInterval)
             if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: paneID),
                !ClaudeStateDetector.isClaudeProcess(cmd) {
@@ -908,9 +910,11 @@ public actor HibernationCoordinator {
     /// swap path so hibernate and account-switch interrupt identically.
     private func gracefullyInterruptPane(server: String, paneID: String) async {
         try? await tmux.sendKey(server: server, paneID: paneID, key: "Escape")
+        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
         try? await Task.sleep(for: .milliseconds(150))
         try? await tmux.sendKey(server: server, paneID: paneID, key: "C-c")
         try? await tmux.sendKey(server: server, paneID: paneID, key: "C-c")
+        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
         try? await Task.sleep(for: .milliseconds(150))
         if let pidStr = try? await tmux.panePID(server: server, paneID: paneID),
            let pid = Int32(pidStr), pid > 0 {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -252,6 +252,7 @@ extension WorktreeLifecycle {
                 }
                 return .paneKilled
             }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: pollNanos)
         }
         // Deadline race: the marker may have landed during the final poll

--- a/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
+++ b/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
@@ -64,6 +64,7 @@ public struct ProcessDaywatchExecutor: DaywatchExecuting {
             // Set up a 5-minute deadline. The timeout Task's check-and-set is also protected
             // by the lock, so only one of {termination, timeout} will successfully resume.
             Task {
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try await Task.sleep(for: .seconds(5 * 60))
                 state.lock.withLock { s in
                     if !s.finished {
@@ -273,6 +274,7 @@ public actor DaywatchRunner {
         // Then sleep and loop
         while !Task.isCancelled {
             do {
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try await Task.sleep(for: .seconds(interval))
             } catch {
                 // Cancelled during sleep

--- a/Sources/TBDDaemon/Process/AgentReaper.swift
+++ b/Sources/TBDDaemon/Process/AgentReaper.swift
@@ -75,6 +75,7 @@ public struct AgentReaper: Sendable {
         signaller.terminate(pid)
         for _ in 0..<graceAttempts {
             if !signaller.isAlive(pid) { return }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: pollInterval)
         }
         if signaller.isAlive(pid) {
@@ -89,6 +90,7 @@ public struct AgentReaper: Sendable {
     func escalateAfterHangup(_ pid: Int32) async {
         for _ in 0..<graceAttempts {
             if !signaller.isAlive(pid) { return }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: pollInterval)
         }
         guard signaller.isAlive(pid) else { return }

--- a/Sources/TBDDaemon/SSH/SSHAgentResolver.swift
+++ b/Sources/TBDDaemon/SSH/SSHAgentResolver.swift
@@ -103,6 +103,7 @@ public struct SSHAgentResolver: Sendable {
             }
 
             group.addTask {
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: .seconds(2))
                 if process.isRunning {
                     process.terminate()

--- a/Sources/TBDDaemon/Server/FDVendingServer.swift
+++ b/Sources/TBDDaemon/Server/FDVendingServer.swift
@@ -222,6 +222,7 @@ actor FDVendingServer {
                 try FDChannel.sendFD(fd, over: clientFD, frame: frame)
                 return
             }
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             if attempt < 9 { try? await Task.sleep(for: .milliseconds(50)) }
         }
         throw FDVendingServerError.notConnected

--- a/Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
@@ -118,6 +118,7 @@ extension RPCRouter {
             // kill the fresh attach that replaced it.
             let timeout = bridge.readyTimeout
             Task { [supervisor = bridge.supervisor] in
+                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: timeout)
                 await supervisor.detachIfNotReady(server: server, paneID: paneID, generation: generation)
             }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1544,10 +1544,12 @@ extension RPCRouter {
     private func gracefullyInterruptPane(server: String, paneID: String) async {
         // Escape: ask Claude to stop generating.
         try? await tmux.sendKey(server: server, paneID: paneID, key: "Escape")
+        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
         try? await Task.sleep(for: .milliseconds(150))
         // C-c C-c: interrupt / exit the TUI.
         try? await tmux.sendKey(server: server, paneID: paneID, key: "C-c")
         try? await tmux.sendKey(server: server, paneID: paneID, key: "C-c")
+        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
         try? await Task.sleep(for: .milliseconds(150))
         // SIGTERM the pane pid as a backstop (respawn -k is the real guarantee).
         if let pidStr = try? await tmux.panePID(server: server, paneID: paneID),
@@ -1566,6 +1568,7 @@ extension RPCRouter {
         let tmuxRef = self.tmux
         let dbRef = self.db
         Task {
+            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: .seconds(5))
             let detector = ClaudeStateDetector(tmux: tmuxRef)
             if let recaptured = await detector.captureSessionID(server: server, paneID: paneID) {

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
@@ -226,6 +226,7 @@ actor PaneRepairCoordinator {
                 // superseded `nil` case above: send nothing — the sink stays
                 // `repairing`, and a later overflow signal or attach heals it.
                 do {
+                    // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
                     try await Task.sleep(for: interval)
                 } catch {
                     return

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -59,9 +59,11 @@ Four rules. Each traces to a real flake — provenance kept so the rule sticks.
    blew a 5-second window by 0.11 s under CI load.)
 3. **No bare `Task.sleep(for:)` as a synchronization primitive in tests.**
    Tier 1 advances a test clock; tiers 2–3 use bounded polling with a
-   deadline (`waitFor` style). The clock seam and the `no_raw_task_sleep`
-   lint rule are landing in a later slice, so today this rule is enforced by
-   review, not mechanically.
+   deadline (`waitFor` style). In `Sources/` this is now mechanical — the
+   `no_raw_task_sleep` SwiftLint rule rejects any unsuppressed `Task.sleep`.
+   In `Tests/` it stays a review rule: the lint rule deliberately does not
+   cover test code, where tier-2/3 bounded polling is legitimate. See
+   "Clock and date seams" below for the seam the rule pushes you toward.
 4. **Timeout errors must report observed state, not just expected.**
    (`fileBytesMismatch(expected: 6150, actual: 6150)` re-read the file
    *after* the deadline and therefore lied about what it saw;
@@ -69,3 +71,88 @@ Four rules. Each traces to a real flake — provenance kept so the rule sticks.
    shape.)
 
 Full rationale: `docs/specs/2026-07-24-test-hardening-design.md` §6.
+
+## Clock and date seams
+
+Governing rule: **`Duration` is behavior, `Date` is data.** The two seams are
+not interchangeable — picking the wrong one is how a test ends up measuring
+elapsed wall time on a loaded runner instead of asserting behavior.
+
+### Behavior — delays, debounces, timers, polling intervals, timeouts
+
+```swift
+init(..., clock: any Clock<Duration> = ContinuousClock())
+```
+
+Last initializer parameter, named `clock`, defaulted so no call site changes
+and the migration is behavior-preserving by construction. **Existential, not
+generic**, and not named `scheduler`: these subsystems are actors carrying
+`Sendable` conformances, and a generic parameter would infect their types.
+
+Tests pass `TestClock` and drive time with `advanceWhenSuspended(by:)` — no
+sleeping, no load sensitivity, and exact virtual timings instead of tolerance
+windows.
+
+**The existential pins `Duration`, not `Instant`** — so it can express delays
+but not deadlines:
+
+| Compiles | Does **not** compile (`#ExistentialMemberAccess`) |
+|---|---|
+| `try await clock.sleep(for: .seconds(1))` | `clock.sleep(until:tolerance:)` |
+| `clock.now`, storage in an `actor` | `instant.duration(to:)` |
+
+Write timeout-shaped code duration-relative, as a task-group race:
+
+```swift
+group.addTask { try await work() }
+group.addTask { try await clock.sleep(for: limit); return nil }
+let first = try await group.next()
+group.cancelAll()
+```
+
+This is also the better *test* shape: "time out after X" is directly
+advanceable on a `TestClock`, while "sleep until instant Y" invites `Instant`
+arithmetic that drifts back toward wall-clock reasoning. If you hit a case
+that genuinely needs `Instant` math, raise it rather than switching the
+subsystem to a generic clock parameter.
+
+### Data — timestamps that get persisted or compared
+
+Two shapes, also not interchangeable:
+
+- **One-shot stamp** (`lastUsedAt`, hibernation stamps): a defaulted method
+  parameter, `func touchLastUsed(at date: Date = Date())`. Tests pass a
+  literal. No clock object needed to stamp a row.
+- **Repeated "what time is it now" reads**: `now: @Sendable () -> Date` on the
+  type. Tests back it with `TestDateSource`.
+
+### Shared test helpers — `Tests/TestSupport/ClockTestSupport.swift`
+
+Don't roll your own test clock wrapper, advance helper, `.timeLimit` default,
+or date box. This file is the whole shared surface:
+
+- `@Suite(.clockDriven)` — a one-minute time limit (Swift Testing's floor
+  granularity). A hang-catcher, not a perf budget.
+- `await clock.advanceWhenSuspended(by:)` — the one you want by default.
+- `await clock.waitForSuspension()` — the same wait without advancing.
+- `TestDateSource` — a lock-guarded box behind the `now: @Sendable () -> Date`
+  seam. Deliberately a class with a lock rather than an actor, because that
+  seam is a *synchronous* `() -> Date`.
+
+**The failure mode to design against:** a tier-1 test awaiting a `TestClock`
+sleep that nobody advances hangs forever. Two mitigations, use both —
+`.clockDriven` on the suite bounds the hang, and `advanceWhenSuspended` turns
+"the code under test never armed its timer" from an infinite hang into a named
+failure. Convention: **put the advance immediately next to the assertion it
+unblocks**, not in a setup block far away.
+
+One caution on those two helpers: they record an `Issue` and continue rather
+than throwing, which is safe *only* because neither returns a value. A
+non-throwing waiter that does return something — `ControlModeTestSupport.waitFor`
+(PR #415) — also keeps going after recording, so anything you index out of its
+result must be `#require`-guarded or the test crashes instead of failing
+cleanly. Don't generalize "non-throwing" into "no `#require` needed".
+
+`PollerClock` is **not** this seam and must not be copied as a template — see
+its doc comment. Full rationale:
+`docs/specs/2026-07-24-test-hardening-design.md` §5.

--- a/Tests/TBDDaemonTests/ClockTestSupportTests.swift
+++ b/Tests/TBDDaemonTests/ClockTestSupportTests.swift
@@ -1,0 +1,78 @@
+import Clocks
+import Foundation
+import Testing
+
+import TestSupport
+
+/// Tier 1 — deterministic, in-process, virtual time only.
+///
+/// Proves the shared clock seams in `Tests/TestSupport/ClockTestSupport.swift`
+/// behave as documented, and (by linking `Clocks` from a test target) that the
+/// test-only dependency wiring works.
+@Suite(.clockDriven)
+struct ClockTestSupportTests {
+    /// The exact shape production subsystems get migrated to: a defaulted
+    /// `clock: any Clock<Duration>` last parameter, a real `sleep(for:)`, and a
+    /// test that drives it with `advanceWhenSuspended` instead of waiting.
+    private actor DelayedFlag {
+        let clock: any Clock<Duration>
+        private(set) var fired = false
+
+        init(clock: any Clock<Duration> = ContinuousClock()) {
+            self.clock = clock
+        }
+
+        func run(after delay: Duration) async throws {
+            try await clock.sleep(for: delay)
+            fired = true
+        }
+    }
+
+    @Test func advanceWhenSuspendedUnblocksASleepingSubsystem() async throws {
+        let clock = TestClock()
+        let subject = DelayedFlag(clock: clock)
+
+        let task = Task { try await subject.run(after: .seconds(30)) }
+        let firedBeforeAdvance = await subject.fired
+        #expect(firedBeforeAdvance == false)
+
+        await clock.advanceWhenSuspended(by: .seconds(30))
+        try await task.value
+
+        let firedAfterAdvance = await subject.fired
+        #expect(firedAfterAdvance)
+    }
+
+    @Test func advanceWhenSuspendedMovesTheClockForward() async {
+        let clock = TestClock()
+        let before = clock.now
+
+        let task = Task { try await clock.sleep(for: .seconds(5)) }
+        await clock.advanceWhenSuspended(by: .seconds(5))
+        _ = try? await task.value
+
+        #expect(before.duration(to: clock.now) == .seconds(5))
+    }
+
+    @Test func testDateSourceReadsWritesAndAdvances() {
+        let source = TestDateSource(Date(timeIntervalSince1970: 1_000))
+        #expect(source.now == Date(timeIntervalSince1970: 1_000))
+
+        source.now = Date(timeIntervalSince1970: 2_000)
+        #expect(source.now == Date(timeIntervalSince1970: 2_000))
+
+        source.advance(by: 90)
+        #expect(source.now == Date(timeIntervalSince1970: 2_090))
+    }
+
+    @Test func testDateSourceProviderObservesLaterMutations() {
+        let source = TestDateSource(Date(timeIntervalSince1970: 1_000))
+        // Captured once, as a production seam would — it must still see the
+        // advance that happens after injection.
+        let now = source.provider
+        #expect(now() == Date(timeIntervalSince1970: 1_000))
+
+        source.advance(by: 60)
+        #expect(now() == Date(timeIntervalSince1970: 1_060))
+    }
+}

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -1,0 +1,134 @@
+import Clocks
+import Foundation
+import Testing
+
+// Shared clock seams for the test-hardening program
+// (`docs/specs/2026-07-24-test-hardening-design.md` §5).
+//
+// §5's governing rule is **`Duration` is behavior, `Date` is data**: production
+// types take `clock: any Clock<Duration> = ContinuousClock()` for delays,
+// debounces, timers and deadlines, and a `now: @Sendable () -> Date` (or
+// `date: Date = Date()`) parameter for timestamps that get persisted or
+// compared. This file is the *only* place those two seams get test-side
+// helpers. No slice should roll its own `TestClock` wrapper, advance helper, or
+// mutable-clock date source — if something here is missing or wrong, change it
+// here so all five consuming slices move together.
+
+// MARK: - Hang guard
+
+public extension Trait where Self == TimeLimitTrait {
+    /// Suite/test trait for anything driven by a `TestClock`.
+    ///
+    /// The known failure mode of virtual time (§5, "Known failure mode") is
+    /// that a tier-1 test awaiting a `TestClock` sleep nobody advances hangs
+    /// **forever** — no assertion fails, no output appears, the whole `swift
+    /// test` run just stops. That is far worse than a red test, because CI
+    /// burns its job timeout and the failure names no suite.
+    ///
+    /// This bounds it. `.minutes(1)` is not a performance budget — it is
+    /// Swift Testing's floor granularity (time limits are expressed in whole
+    /// minutes), and it is a hang-catcher. A clock-driven tier-1 test should
+    /// finish in milliseconds; if it takes a minute, it is wedged, and you
+    /// want the failure attributed to the test rather than to the runner.
+    static var clockDriven: Self { .timeLimit(.minutes(1)) }
+}
+
+// MARK: - TestClock
+
+public extension TestClock {
+    /// Waits until the code under test has actually registered a sleep on this
+    /// clock, then advances virtual time by `duration`.
+    ///
+    /// Why this exists: `advance(by:)` on a clock with **no registered
+    /// sleeper** merely moves `now` forward. The sleep that arrives afterwards
+    /// is scheduled against the new `now` and blocks forever — the exact hang
+    /// `.clockDriven` exists to catch. `TestClock.advance(to:)` calls
+    /// `megaYield()` internally, so a bare `advance(by:)` *usually* happens to
+    /// win the race against a task you just started. "Usually, on an unloaded
+    /// machine" is precisely the flake class this program exists to kill, so
+    /// don't rely on it — make the wait explicit.
+    ///
+    /// Convention that goes with it: **put the advance next to the assertion
+    /// it unblocks.** Batching advances at the top of a test re-creates the
+    /// same ordering ambiguity in a form that is harder to read.
+    ///
+    /// Non-throwing: a missing sleeper is reported via `Issue.record` at the
+    /// caller's source location rather than thrown, so call sites stay free of
+    /// `try` noise.
+    func advanceWhenSuspended(by duration: Duration,
+                              sourceLocation: SourceLocation = #_sourceLocation) async {
+        await waitForSuspension(sourceLocation: sourceLocation)
+        await advance(by: duration)
+    }
+
+    /// Yields until at least one task is suspended on this clock.
+    ///
+    /// Detection is inverted from how it reads: `checkSuspension()` **throws**
+    /// when a sleeper *is* registered (its job is to prove "no further
+    /// time-based asynchrony"), so catching its error is the success signal
+    /// here, and a normal return means nobody has reached their `sleep` yet.
+    ///
+    /// Budget-exhausted is a test bug, not a flake, so it records an Issue
+    /// naming the likely cause instead of hanging or throwing.
+    func waitForSuspension(maxYields: Int = 20,
+                           sourceLocation: SourceLocation = #_sourceLocation) async {
+        for _ in 0..<maxYields {
+            do {
+                try await checkSuspension()
+            } catch {
+                return  // A sleeper is registered — that is what we were waiting for.
+            }
+            await Task.yield()
+        }
+        Issue.record(
+            """
+            TestClock: no task was suspended on the clock after \(maxYields) yields — \
+            the code under test never reached its sleep. Did you start the task, or \
+            advance before it was armed?
+            """,
+            sourceLocation: sourceLocation
+        )
+    }
+}
+
+// MARK: - Date
+
+/// A mutable, thread-safe source of "now" for the `Date`-as-data seam.
+///
+/// Backs the `now: @Sendable () -> Date` parameter that §5 (shared contract 2)
+/// standardizes for timestamps that get persisted or compared (`lastUsedAt`,
+/// hibernation stamps). It replaces wall-clock freshness windows in
+/// assertions — the flake shape where `resolve_success_bumpsLastUsedAt` blew a
+/// 5-second tolerance by 0.11 s under CI load.
+///
+/// Deliberately a lock-guarded `final class`, not an `actor`: the seam it feeds
+/// is a **synchronous** `() -> Date`, which an actor cannot satisfy without
+/// making every timestamping call site `async`. The lock is uncontended in
+/// practice (a test sets it, production code reads it).
+public final class TestDateSource: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+
+    /// - Parameter start: default is a fixed, recognizable instant
+    ///   (2023-11-14T22:13:20Z) so failure output is stable and obviously
+    ///   synthetic rather than "whenever CI ran".
+    public init(_ start: Date = Date(timeIntervalSince1970: 1_700_000_000)) {
+        self.value = start
+    }
+
+    public var now: Date {
+        get { lock.withLock { value } }
+        set { lock.withLock { value = newValue } }
+    }
+
+    public func advance(by seconds: TimeInterval) {
+        lock.withLock { value += seconds }
+    }
+
+    /// The closure to hand to the production seam. It reads through to the
+    /// current value on every call, so mutations made *after* injection are
+    /// observed — that is the whole point.
+    public var provider: @Sendable () -> Date {
+        { [self] in now }
+    }
+}

--- a/docs/specs/2026-07-24-test-hardening-design.md
+++ b/docs/specs/2026-07-24-test-hardening-design.md
@@ -8,7 +8,7 @@
 
 The suite is healthy in the large (~3,100 tests, 15–20 s locally, strong seam culture), but CI flakes recur because three structural defects keep getting re-instantiated rather than fixed once:
 
-1. **No clock seam as a convention.** Production code stamps `Date()` and arms real timers internally, forcing tests into wall-clock assertions ("happened within 5 s") that measure elapsed time on a loaded runner, not behavior. Each instance gets patched ad hoc; any new `Task.sleep` mints the next flake. There are currently 64 raw `Task.sleep` call sites in `Sources/`.
+1. **No clock seam as a convention.** Production code stamps `Date()` and arms real timers internally, forcing tests into wall-clock assertions ("happened within 5 s") that measure elapsed time on a loaded runner, not behavior. Each instance gets patched ad hoc; any new `Task.sleep` mints the next flake. There are currently 60 raw `Task.sleep` call sites in `Sources/` (59 legacy + 1 sanctioned `PollerClock`; the "64" in earlier drafts was a naive grep that also counted `Task.sleep` mentions inside comments).
 2. **Deadline tests share a starved machine with heavyweight tests.** All test targets compile into one process and Swift Testing runs suites in parallel across all of them, so live-tmux suites, `ps` scans, and the replay firehose contend for the same 3–4 runner cores (at `-j 2`, the OOM floor) while timeout-sensitive tests tick. Nothing marks "needs real tmux and quiet CPU" vs "pure unit test", so CI cannot schedule them apart.
 3. **Assertions pin incidental facts.** `.last`-write ordering, exact counts, and freshness windows hold only when timing is quiet and were never guaranteed by the code under test.
 
@@ -72,7 +72,7 @@ Governing rule: **`Duration` is behavior, `Date` is data.**
 - **Data** — timestamps that get persisted or compared (`lastUsedAt`, hibernation stamps): the existing lightweight seam, a defaulted `date: Date = Date()` / `now: @Sendable () -> Date` parameter (the `touchLastUsed(at:)` pattern). No clock object needed to stamp a row.
 - **`PollerClock` stays untouched** — chunked, suspend-aware wall-deadline sleeping is a genuinely different job (Darwin's `Task.sleep` uses the suspending clock; see its doc comment) — but it stops being the template. A doc comment points new code at the standard seam.
 
-**Enforcement is a ratchet, not a flag day.** A SwiftLint custom rule `no_raw_task_sleep` (same shape as `no_print_in_sources`) forbids `Task.sleep` in `Sources/`. The 64 existing sites get explicit per-line `swiftlint:disable:this` suppressions in the ratchet PR, so every legacy site is greppable and the count only goes down. New code cannot add an unseamed sleep without a visible suppression, which the PR review gate treats as a finding.
+**Enforcement is a ratchet, not a flag day.** A SwiftLint custom rule `no_raw_task_sleep` (same shape as `no_print_in_sources`) forbids `Task.sleep` in `Sources/`. The existing sites get explicit per-line `swiftlint:disable:next` suppressions in the ratchet PR, so every legacy site is greppable and the count only goes down. (`:next`, not `:this`, per the slicing doc's fixed contract; it also matches the house style of every pre-existing suppression in `Sources/`. The trailing prose must be separated by an ASCII `" - "`, not an em-dash: SwiftLint tokenizes everything after the rule name as further rule names unless it sees that separator, which trips `superfluous_disable_command` on every site.) New code cannot add an unseamed sleep without a visible suppression, which the PR review gate treats as a finding.
 
 **Migration order (by flake payoff):**
 
@@ -153,4 +153,4 @@ Each stage is independently shippable; order front-loads flake payoff per unit e
 - **Quiet pass silently runs nothing** → executed-test count guard in CI (§4).
 - **Quarantine landfill** → required issue numbers + nightly audit (§7).
 - **Harness becomes its own flake source** → hard dependency on virtual time (Stage 2 before Stage 4); PR CI runs only pinned seeds.
-- **Lint ratchet friction** → suppressions are pre-seeded on all 64 legacy sites in one mechanical PR; developers only encounter the rule on genuinely new sleeps.
+- **Lint ratchet friction** → suppressions are pre-seeded on all 59 legacy sites in one mechanical PR; developers only encounter the rule on genuinely new sleeps.

--- a/docs/specs/2026-07-24-test-hardening-slicing.md
+++ b/docs/specs/2026-07-24-test-hardening-slicing.md
@@ -23,7 +23,7 @@ Slice IDs are stable handles (`A`, `B`, `C1`…) used in channels and branch nam
 | ID | Scope | Depends on | Module surface |
 |---|---|---|---|
 | **A** | Stage 0: `TBDDaemonLiveTests` target, live-suite move, CI two-step split, quiet-pass count guard, assertion-hygiene rules in `Tests/CLAUDE.md` | — | `Package.swift`, `.github/workflows/test.yml`, `Tests/` (moves), `Tests/CLAUDE.md` |
-| **B** | Ratchet: `swift-clocks` test-only dep, `no_raw_task_sleep` SwiftLint rule, 64 legacy suppressions, shared `TestSupport` clock helpers, clock-seam convention doc | A | `Package.swift`, `.swiftlint.yml`, all 64 sleep sites (one line each), `Tests/TestSupport/`, `docs/` |
+| **B** | Ratchet: `swift-clocks` test-only dep, `no_raw_task_sleep` SwiftLint rule, 59 legacy suppressions, shared `TestSupport` clock helpers, clock-seam convention doc | A | `Package.swift`, `.swiftlint.yml`, all 60 sleep sites (one line each), `Tests/TestSupport/`, `docs/` |
 | **C1** | Clock-seam migration: appearance debounce | B | `Sources/TBDApp` (appearance/settings) + its tests |
 | **C2** | Clock-seam migration: `DaywatchRunner` | B | `Sources/TBDDaemon/Nightwatch/` + its tests |
 | **C3** | Clock-seam migration: `GitManager` / subprocess timeout machinery | B | `Sources/TBDDaemon/Git/GitManager.swift`, subprocess timeout paths + their tests |
@@ -45,7 +45,7 @@ Wave 3:  F │ G                              (2-wide)
 Wave 4:  H  →  I                            (sequential)
 ```
 
-**Waves 0 and 1 are deliberately solo.** Both touch `Package.swift`, and B rewrites one line in 64 files across both modules — any concurrent slice would spend more time rebasing than working.
+**Waves 0 and 1 are deliberately solo.** Both touch `Package.swift`, and B rewrites one line in 39 files across both modules — any concurrent slice would spend more time rebasing than working.
 
 **Wave 2 is the parallelization payoff.** Six slices, mutually file-disjoint: C1/C4 are `TBDApp`, C2/C3/D are `TBDDaemon`, E is test-infrastructure only. Each removes only the suppressions inside files it already owns.
 
@@ -86,8 +86,13 @@ These exist so six agents produce one coherent codebase instead of six dialects.
 3. **Test clock helpers live in `Tests/TestSupport/`**, added by B. No slice rolls its own `TestClock` wrapper, advance helper, or `.timeLimit` default.
 4. **Suppression comment format** — exact and greppable, so F's burn-down is mechanical:
    ```swift
-   // swiftlint:disable:next no_raw_task_sleep — legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+   // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
    ```
+   The separator is an ASCII `" - "`, amended from the em-dash originally specced here.
+   SwiftLint tokenizes everything after the rule name as further rule names unless it
+   sees that exact separator, so the em-dash form raised `superfluous_disable_command`
+   on every site (verified: 304 violations). `PollerClock`'s single sanctioned sleep
+   carries `- sanctioned: …` instead, keeping it linted but outside F's burn-down grep.
 5. **Names are fixed:** target `TBDDaemonLiveTests`; lint rule `no_raw_task_sleep`; trait `.flaky(issue:)` taking a required `Int`.
 6. **`PollerClock` is not touched** by any slice. It stays for suspend-aware wall-deadline chunking; B adds a doc comment pointing new code at the standard seam.
 

--- a/docs/specs/2026-07-24-test-hardening-slicing.md
+++ b/docs/specs/2026-07-24-test-hardening-slicing.md
@@ -45,7 +45,7 @@ Wave 3:  F │ G                              (2-wide)
 Wave 4:  H  →  I                            (sequential)
 ```
 
-**Waves 0 and 1 are deliberately solo.** Both touch `Package.swift`, and B rewrites one line in 39 files across both modules — any concurrent slice would spend more time rebasing than working.
+**Waves 0 and 1 are deliberately solo.** Both touch `Package.swift`, and B rewrites one line in 35 files across both modules — any concurrent slice would spend more time rebasing than working.
 
 **Wave 2 is the parallelization payoff.** Six slices, mutually file-disjoint: C1/C4 are `TBDApp`, C2/C3/D are `TBDDaemon`, E is test-infrastructure only. Each removes only the suppressions inside files it already owns.
 


### PR DESCRIPTION
**Slice B** of the test-hardening program (`docs/specs/2026-07-24-test-hardening-slicing.md` §2). Wave 1, solo. Depends on slice A (#491). Unblocks C1–C4, D and E.

## Summary

Design §5's flake class #1 is production code that stamps `Date()` and arms real timers internally, which forces tests into wall-clock assertions that measure elapsed time on a loaded runner instead of behavior. This PR lands the seam and the ratchet that keeps it — **it migrates nothing**. C1–C4 and D do the actual migrations, and they consume the API defined here.

- **`swift-clocks` 1.1.0 as a test-only dependency.** `Clocks` is wired to `TestSupport`, `TBDDaemonTests`, `TBDAppTests` and `TBDDaemonLiveTests` only.
- **Shared test helpers** in `Tests/TestSupport/ClockTestSupport.swift` — the API five slices consume, so no slice rolls its own.
- **SwiftLint rule `no_raw_task_sleep`** over `Sources/`, modelled on `no_print_in_sources`.
- **59 legacy sleep sites pre-seeded with suppressions** in the fixed contract format, so slice F's burn-down is a grep. PollerClock's one sanctioned sleep carries a distinct suffix instead.
- **Convention docs** in `Tests/CLAUDE.md`, the root `CLAUDE.md`, and on `PollerClock` itself.

**Zero production behavior change, so no feature flag applies.** The only non-comment line added anywhere under `Sources/` is a doc comment on `PollerClock`. Every other `Sources/` hunk in this diff is a single `// swiftlint:disable:next` line.

## Contracts landed (slicing §5)

| # | Contract |
|---|---|
| 1 | `init(..., clock: any Clock<Duration> = ContinuousClock())` — last param, named `clock`, defaulted, existential not generic |
| 2 | Date seam is separate: `date: Date = Date()` for one-shot stamps, `now: @Sendable () -> Date` for repeated reads |
| 3 | Test helpers live in `Tests/TestSupport/` |
| 4 | Suppression format, exact and greppable (**amended** — see below) |
| 5 | Names fixed: `no_raw_task_sleep` |
| 6 | `PollerClock` not migrated; gets a doc comment pointing new code at the standard seam |

## Three findings that amend the spec

**1. `any Clock<Duration>` cannot express deadlines.** The existential pins `Duration` but not `Instant`, so `clock.sleep(until:tolerance:)` and `instant.duration(to:)` fail to compile with `#ExistentialMemberAccess`. `sleep(for:)`, `clock.now`, actor storage and task-group timeout races are all fine. C3 (subprocess/git *timeouts*) and D (attach ready-*timer*) are the deadline-shaped slices — they must express deadlines duration-relative, and `Tests/CLAUDE.md` documents the working pattern so they hit a documented constraint rather than a mystery diagnostic.

**2. The suppression separator is an ASCII `" - "`, not the em-dash originally specced.** SwiftLint tokenizes everything after the rule name as further rule names unless it sees that exact separator, so the em-dash form raised **304 `superfluous_disable_command` violations** — one per prose word, per site. The first implementation silenced that by disabling `superfluous_disable_command` repo-wide, which would have cost staleness enforcement on 11 pre-existing suppressions and every future one, to preserve one punctuation mark. The ASCII form keeps the default rule enabled, which additionally means **a suppression left behind after a migration now fails lint** — a free correctness check for slice F.

**3. The site count is 60, not 64.** 59 legacy + 1 sanctioned, across 35 files. The spec's 64 was a naive grep; five matches are `Task.sleep` mentions inside comments, correctly ignored by `match_kinds: [identifier]`. Corrected in both specs so F isn't hunting four phantoms.

Also corrected: design §5's justification for `:next` over `:this` was false (`:this` works fine as a trailing comment, and zero sites are multi-line). The decision stands — it's the fixed contract and matches house style — but the wrong reasoning is out of the spec rather than inherited by five slices.

## Handling the known hang

A tier-1 test awaiting a `TestClock` sleep nobody advances hangs **forever** — no assertion fails, no suite is named, CI burns its job timeout. Two mitigations ship here: `@Suite(.clockDriven)` bounds it, and `advanceWhenSuspended(by:)` turns "the code under test never armed its timer" into a named `Issue`. `advance(by:)` on a clock with no registered sleeper merely moves `now` forward; `TestClock.advance(to:)` megaYields internally so a bare advance *usually* wins the race — and "usually, on an unloaded machine" is precisely the flake class this program exists to kill.

## Test plan

Every gate measured, none assumed:

- [x] `swift build` green
- [x] Fast pass `--parallel -j 2 --skip '^TBDDaemonLiveTests\.'` — green **4/4 runs**, 3863 tests
- [x] Quiet pass `--filter '^TBDDaemonLiveTests\.' --no-parallel` — green, 54 tests
- [x] 3863 + 54 = 3917 = slice A's 3913 + the 4 new tests
- [x] `swiftlint --strict` clean (585 files) **with the new rule active**
- [x] **The rule actually fires**: a deliberate unsuppressed `Task.sleep` fails lint with exit 2 and the correct message
- [x] **Dependency is test-only**: no `Sources/` target edge in `swift package dump-package`; `nm` shows 0 `Clocks` symbols in `TBDApp`, `TBDDaemon`, `TBDCLI`
- [x] Independent code review (fresh context, 5 reviewers): no findings above threshold

One caveat not papered over: an early full-suite run showed 3 issues in `AppearanceDebounceTests` — the pre-existing real-timer flake slice A logged at 2/5 on main, and C1's first target. Four subsequent runs were clean, and this diff is provably comment-only under `Sources/`, so it isn't caused here.

Note on the `nm`/`dump-package` checks: a plain `import Clocks` from a `Sources/` file *succeeds* in a tree that has already built the test targets, because SwiftPM passes the shared `Modules/` dir as `-I` to every target. Module visibility is not gated by declared dependencies there, so the link-level checks are the load-bearing ones.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=46F16A3F-AE04-4FC5-91A4-BCD4C7B1A19F)