### PR TITLE
Fix: Transcript silently dropped every byte of hook- and CLAUDE.md-injected context (~88 KB per Read)

### DIFF
--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -1515,11 +1515,15 @@ actor DaemonClient {
     }
 
     /// Fetch the un-truncated body for a single transcript item (for
-    /// "Show full output" expansion).
-    func terminalTranscriptItemFullBody(terminalID: UUID, itemID: String) async throws -> TerminalTranscriptItemFullBodyResult {
+    /// "Show full output" expansion). Pass `includeBody: false` to fetch only
+    /// the injection metadata, leaving a potentially huge body off the wire.
+    func terminalTranscriptItemFullBody(
+        terminalID: UUID, itemID: String, includeBody: Bool = true
+    ) async throws -> TerminalTranscriptItemFullBodyResult {
         return try await callAsync(
             method: RPCMethod.terminalTranscriptItemFullBody,
-            params: TerminalTranscriptItemFullBodyParams(terminalID: terminalID, itemID: itemID),
+            params: TerminalTranscriptItemFullBodyParams(
+                terminalID: terminalID, itemID: itemID, includeBody: includeBody),
             resultType: TerminalTranscriptItemFullBodyResult.self
         )
     }

--- a/Sources/TBDApp/Diagnostics/TranscriptSignposts.swift
+++ b/Sources/TBDApp/Diagnostics/TranscriptSignposts.swift
@@ -56,14 +56,14 @@ enum TranscriptSignposts {
                  .assistantText(_, let t, _, _),
                  .thinking(_, let t, _):
                 return t.count
-            case .systemReminder(_, _, let t, _):
+            case .systemReminder(_, _, let t, _, _, _):
                 return t.count
             case .toolCall(_, _, let inputJSON, _, let result, _, _, _):
                 return inputJSON.count + (result?.text.count ?? 0)
             case .slashCommand(_, let name, let args, _):
                 return name.count + (args?.count ?? 0)
             }
-        case .systemReminder(_, _, let text, _),
+        case .systemReminder(_, _, let text, _, _, _),
              .skillBody(_, let text, _):
             return text.count
         case .toolCall(_, _, let inputJSON, _, let result, _):

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
@@ -44,10 +44,12 @@ struct SystemReminderRow: View {
                 // one another, and the size is the point.
                 if let source, !source.isEmpty {
                     Text(source)
-                        .truncationMode(.middle)
+                        // Paths head-truncate so the whole filename survives —
+                        // matches the table renderer's `titleTruncation`.
+                        .truncationMode(kind == .nestedMemory ? .head : .middle)
                         .lineLimit(1)
-                        // Middle-truncated paths need hover to reveal the whole
-                        // thing; hook names are short and need no tooltip.
+                        // Truncated paths need hover to reveal the whole thing;
+                        // hook names are short and need no tooltip.
                         .help(kind == .nestedMemory ? source : "")
                     Text("· \(ActivityRowFormatter.injectedSize(text: text, truncatedTo: truncatedTo))")
                         .foregroundStyle(.tertiary)

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
@@ -17,6 +17,7 @@ struct SystemReminderRow: View {
         case .slashEnvelope: return "command"
         case .skillBody: return "skill"
         case .taskNotification: return "background"
+        case .nestedMemory: return "file"
         case .other: return "info"
         }
     }

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
@@ -6,6 +6,11 @@ struct SystemReminderRow: View {
     let kind: SystemKind
     let text: String
     let timestamp: Date?
+    /// Where the injected context came from (CLAUDE.md path, hook name).
+    /// Nil for reminder kinds that carry no source.
+    var source: String? = nil
+    /// Original character count when `text` was capped by the parser.
+    var truncatedTo: Int? = nil
 
     @Environment(\.openTranscriptOverlay) private var openTranscriptOverlay
 
@@ -34,6 +39,16 @@ struct SystemReminderRow: View {
                     .padding(.horizontal, 5).padding(.vertical, 1)
                     .background(Color(nsColor: .quaternaryLabelColor).opacity(0.5))
                     .clipShape(Capsule())
+                // Same "<source> · <size>" readout the table renderer shows —
+                // injected-context rows are otherwise indistinguishable from
+                // one another, and the size is the point.
+                if let source, !source.isEmpty {
+                    Text(source)
+                        .truncationMode(.middle)
+                        .lineLimit(1)
+                    Text("· \(ActivityRowFormatter.injectedSize(text: text, truncatedTo: truncatedTo))")
+                        .foregroundStyle(.tertiary)
+                }
             }
         }
     }

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
@@ -46,6 +46,9 @@ struct SystemReminderRow: View {
                     Text(source)
                         .truncationMode(.middle)
                         .lineLimit(1)
+                        // Middle-truncated paths need hover to reveal the whole
+                        // thing; hook names are short and need no tooltip.
+                        .help(kind == .nestedMemory ? source : "")
                     Text("· \(ActivityRowFormatter.injectedSize(text: text, truncatedTo: truncatedTo))")
                         .foregroundStyle(.tertiary)
                 }

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRowBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRowBody.swift
@@ -2,15 +2,42 @@ import SwiftUI
 import TBDShared
 
 /// Overlay body for a `.systemReminder` item (non-skillBody kinds).
+///
+/// Injected-context rows (CLAUDE.md bodies, hook output) are capped at
+/// `TranscriptParser.bodyCharCap` like any other body, so this offers the same
+/// "Show full output" fetch the tool cards do. Only truncated items
+/// (`truncatedTo != nil`) get the affordance — short reminders never make the
+/// round-trip.
 struct SystemReminderRowBody: View {
+    let id: String
     let text: String
+    let truncatedTo: Int?
+    let terminalID: UUID?
+
+    @State private var fullText: String? = nil
+    @EnvironmentObject var appState: AppState
 
     var body: some View {
-        Text(text)
-            .font(.caption2)
-            .foregroundStyle(.tertiary)
-            .transcriptSelectableText()
-            .padding(.horizontal, 8)
-            .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(alignment: .leading, spacing: 4) {
+            Text(fullText ?? text)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .transcriptSelectableText()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if let cap = truncatedTo, fullText == nil, terminalID != nil {
+                TruncationFooter(truncatedTo: cap, currentLength: text.count) {
+                    Task { await fetchFull() }
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func fetchFull() async {
+        guard let terminalID else { return }
+        if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(terminalID: terminalID, itemID: id) {
+            await MainActor.run { fullText = r.text }
+        }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRowBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRowBody.swift
@@ -13,7 +13,15 @@ import TBDShared
 /// Injected rows additionally fetch their *injection metadata* (which hook,
 /// which command, which tool call triggered it) on appear. That rides the same
 /// `terminal.transcriptItemFullBody` RPC, so nothing is paid until a row is
-/// opened, and no field is added to `TranscriptItem`.
+/// opened, and no field is added to `TranscriptItem`. The on-appear fetch passes
+/// `includeBody: false` — it only reads `attachment`, and an injected CLAUDE.md
+/// body is routinely tens of KB.
+///
+/// Expanding a truncated row therefore re-reads the JSONL a second time. That
+/// is deliberate: the second read is user-initiated, bounded to one row, and
+/// caching the body from the metadata fetch would both defeat the truncation
+/// footer (the body would appear expanded unasked) and re-introduce the large
+/// payload on every open.
 struct SystemReminderRowBody: View {
     let id: String
     let kind: SystemKind
@@ -37,9 +45,12 @@ struct SystemReminderRowBody: View {
                 metadataBlock(metadata)
                 Divider()
             }
+            // `.caption`/`.primary` — this is the content the row was opened to
+            // read, matching `SkillBodyRow`'s injected body. `.caption2` +
+            // `.tertiary` is for small section labels, not a whole body.
             Text(fullText ?? text)
-                .font(.caption2)
-                .foregroundStyle(.tertiary)
+                .font(.caption)
+                .foregroundStyle(.primary)
                 .transcriptSelectableText()
                 .frame(maxWidth: .infinity, alignment: .leading)
             if let cap = truncatedTo, fullText == nil, terminalID != nil {
@@ -74,14 +85,26 @@ struct SystemReminderRowBody: View {
     @ViewBuilder
     private func field(_ label: String, _ value: String, monospaced: Bool = false) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
+            // One step up from the `.tertiary`/`.secondary` pair the rest of the
+            // file uses for section labels: the label/value contrast survives,
+            // but both stay legible against the overlay's light background.
             Text(label)
                 .font(.caption2)
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
             Text(value)
                 .font(monospaced ? .caption2.monospaced() : .caption2)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.primary)
                 .textSelection(.enabled)
         }
+    }
+
+    /// `$HOME` → `~`, on path-component boundaries. A plain substring replace
+    /// would turn `/Users/changelog-archive/x` into `~elog-archive/x` — a
+    /// different directory presented as living inside the user's home. Foundation
+    /// reads the same `NSHomeDirectory()`, so the daemon's `injectedPathSource`
+    /// abbreviates identically.
+    static func abbreviatedPath(_ path: String) -> String {
+        (path as NSString).abbreviatingWithTildeInPath
     }
 
     /// Tilde-abbreviated path + copy button, matching `RepoHooksSettingsView`'s
@@ -92,12 +115,14 @@ struct SystemReminderRowBody: View {
         HStack(alignment: .firstTextBaseline, spacing: 4) {
             Text("Path")
                 .font(.caption2)
-                .foregroundStyle(.tertiary)
-            Text(path.replacingOccurrences(of: NSHomeDirectory(), with: "~"))
-                .font(.caption.monospaced())
                 .foregroundStyle(.secondary)
+            Text(Self.abbreviatedPath(path))
+                .font(.caption.monospaced())
+                .foregroundStyle(.primary)
                 .lineLimit(1)
-                .truncationMode(.middle)
+                // Head, not middle: when the field is too narrow the filename
+                // must survive and the path prefix goes.
+                .truncationMode(.head)
                 .help(path)
 
             Button {
@@ -118,7 +143,7 @@ struct SystemReminderRowBody: View {
     private func fetchMetadata() async {
         guard carriesInjectionMetadata, metadata == nil, let terminalID else { return }
         if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(
-            terminalID: terminalID, itemID: id), let attachment = r.attachment {
+            terminalID: terminalID, itemID: id, includeBody: false), let attachment = r.attachment {
             await MainActor.run { metadata = attachment }
         }
     }

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRowBody.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRowBody.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import TBDShared
 
@@ -8,17 +9,34 @@ import TBDShared
 /// "Show full output" fetch the tool cards do. Only truncated items
 /// (`truncatedTo != nil`) get the affordance — short reminders never make the
 /// round-trip.
+///
+/// Injected rows additionally fetch their *injection metadata* (which hook,
+/// which command, which tool call triggered it) on appear. That rides the same
+/// `terminal.transcriptItemFullBody` RPC, so nothing is paid until a row is
+/// opened, and no field is added to `TranscriptItem`.
 struct SystemReminderRowBody: View {
     let id: String
+    let kind: SystemKind
     let text: String
     let truncatedTo: Int?
     let terminalID: UUID?
 
     @State private var fullText: String? = nil
+    @State private var metadata: TranscriptAttachmentMetadata? = nil
     @EnvironmentObject var appState: AppState
 
+    /// Only hook output and injected file bodies come from `attachment` rows;
+    /// every other reminder kind would round-trip for a guaranteed-nil result.
+    private var carriesInjectionMetadata: Bool {
+        kind == .hookOutput || kind == .nestedMemory
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 6) {
+            if let metadata {
+                metadataBlock(metadata)
+                Divider()
+            }
             Text(fullText ?? text)
                 .font(.caption2)
                 .foregroundStyle(.tertiary)
@@ -32,6 +50,77 @@ struct SystemReminderRowBody: View {
         }
         .padding(.horizontal, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .task(id: id) { await fetchMetadata() }
+    }
+
+    // MARK: Injection metadata
+
+    @ViewBuilder
+    private func metadataBlock(_ m: TranscriptAttachmentMetadata) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if let triggeredBy = m.triggeredBy { field("Triggered by", triggeredBy) }
+            if let hookName = m.hookName { field("Hook", hookName) }
+            if let hookEvent = m.hookEvent { field("Event", hookEvent) }
+            if let command = m.command { field("Command", command, monospaced: true) }
+            if let exitCode = m.exitCode { field("Exit code", "\(exitCode)") }
+            if let durationMs = m.durationMs { field("Duration", "\(durationMs) ms") }
+            if let memoryType = m.memoryType { field("Memory", memoryType) }
+            if let path = m.path { pathField(path) }
+            if let stderr = m.stderr { field("stderr", stderr, monospaced: true) }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func field(_ label: String, _ value: String, monospaced: Bool = false) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Text(value)
+                .font(monospaced ? .caption2.monospaced() : .caption2)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+        }
+    }
+
+    /// Tilde-abbreviated path + copy button, matching `RepoHooksSettingsView`'s
+    /// backing-path affordance. The abbreviation is display-only: the button
+    /// copies the full absolute path.
+    @ViewBuilder
+    private func pathField(_ path: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 4) {
+            Text("Path")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            Text(path.replacingOccurrences(of: NSHomeDirectory(), with: "~"))
+                .font(.caption.monospaced())
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .help(path)
+
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(path, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+                    .font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .help("Copy full path")
+        }
+    }
+
+    // MARK: Fetches
+
+    private func fetchMetadata() async {
+        guard carriesInjectionMetadata, metadata == nil, let terminalID else { return }
+        if let r = try? await appState.daemonClient.terminalTranscriptItemFullBody(
+            terminalID: terminalID, itemID: id), let attachment = r.attachment {
+            await MainActor.run { metadata = attachment }
+        }
     }
 
     private func fetchFull() async {

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowCellView.swift
@@ -185,6 +185,7 @@ final class ActivityRowCellView: NSTableCellView {
             presentation.titleSegments, truncation: presentation.titleTruncation)
         titleField.lineBreakMode = presentation.titleTruncation
         titleField.cell?.lineBreakMode = presentation.titleTruncation
+        titleField.toolTip = presentation.titleTooltip
 
         rebuildBadges(presentation.badges)
 

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -438,13 +438,23 @@ enum ActivityRowFormatter {
     /// which defeats the badge's whole purpose.
     static func injectedSize(text: String, truncatedTo: Int?) -> String {
         let count = truncatedTo ?? text.count
-        if count >= 1_000_000 {
-            return String(format: "%.1fM chars", Double(count) / 1_000_000)
+        if count < 1000 {
+            return "\(count) chars"
         }
-        if count >= 1000 {
-            return String(format: "%.1fK chars", Double(count) / 1000)
+        // Cascade smallest → largest, picking the first unit whose ROUNDED
+        // mantissa stays under 1000 — checking the raw count against a fixed
+        // threshold (the old `count >= 1_000_000` shape) lets values like
+        // 999_950 round up to "1000.0K" instead of bumping to "1.0M".
+        let units: [(divisor: Double, suffix: String)] = [
+            (1_000, "K"), (1_000_000, "M"), (1_000_000_000, "G"),
+        ]
+        for (index, unit) in units.enumerated() {
+            let mantissa = (Double(count) / unit.divisor * 10).rounded() / 10
+            if mantissa < 1000 || index == units.count - 1 {
+                return String(format: "%.1f\(unit.suffix) chars", mantissa)
+            }
         }
-        return "\(count) chars"
+        return "\(count) chars" // unreachable: loop always returns on its last iteration
     }
 
     // MARK: Task notification (background-task activity row)

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -97,8 +97,9 @@ enum ActivityRowFormatter {
         switch node.kind {
         case .chatBubble:
             return nil
-        case let .systemReminder(id, kind, text, ts):
-            return systemReminder(id: id, kind: kind, text: text, timestamp: ts)
+        case let .systemReminder(id, kind, text, ts, source, truncatedTo):
+            return systemReminder(id: id, kind: kind, text: text, timestamp: ts,
+                                  source: source, truncatedTo: truncatedTo)
         case let .skillBody(id, text, ts):
             return skillBody(id: id, text: text, timestamp: ts)
         case let .toolCall(id, name, inputJSON, inputTruncatedTo, result, ts):
@@ -381,7 +382,8 @@ enum ActivityRowFormatter {
     // MARK: System reminder (SystemReminderRow)
 
     private static func systemReminder(
-        id: String, kind: SystemKind, text: String, timestamp: Date?
+        id: String, kind: SystemKind, text: String, timestamp: Date?,
+        source: String?, truncatedTo: Int?
     ) -> ActivityRowPresentation {
         // Background-task notifications get a richer presentation: a
         // "Background · <summary>" title with the status surfaced as a badge.
@@ -397,17 +399,40 @@ enum ActivityRowFormatter {
             case .slashEnvelope: return "command"
             case .skillBody: return "skill"
             case .taskNotification: return "background"
+            // Covers both an injected CLAUDE.md and an @-mentioned file body;
+            // the source segment below carries the path that tells them apart.
+            case .nestedMemory: return "file"
             case .other: return "info"
             }
         }()
+
+        // Injected-context rows (hooks, CLAUDE.md) are otherwise near-identical
+        // re-injections of the same rule: the source name disambiguates them
+        // and the size is the whole point — one 15-line Read can pull 88 KB.
+        var segments: [ActivityRowSegment] = []
+        if let source, !source.isEmpty {
+            segments = [
+                ActivityRowSegment(text: source, style: .secondary),
+                ActivityRowSegment(text: "·", style: .tertiary),
+                ActivityRowSegment(text: injectedSize(text: text, truncatedTo: truncatedTo), style: .tertiary)
+            ]
+        }
+
         return ActivityRowPresentation(
             iconSystemName: "info.circle",
-            titleSegments: [],
+            titleSegments: segments,
             timestamp: timestamp,
             isError: false,
             badges: [ActivityRowBadge(text: label, kind: .neutral)],
-            openTargetID: id
+            openTargetID: id,
+            titleTruncation: .byTruncatingMiddle
         )
+    }
+
+    /// Human-readable size of an injected-context payload. `truncatedTo` holds
+    /// the ORIGINAL length when `text` was capped, so it wins when present.
+    static func injectedSize(text: String, truncatedTo: Int?) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(truncatedTo ?? text.count), countStyle: .file)
     }
 
     // MARK: Task notification (background-task activity row)

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -431,8 +431,20 @@ enum ActivityRowFormatter {
 
     /// Human-readable size of an injected-context payload. `truncatedTo` holds
     /// the ORIGINAL length when `text` was capped, so it wins when present.
+    ///
+    /// Both numbers are `String.count` — grapheme clusters, not bytes — so the
+    /// unit is spelled "chars". Feeding them to `ByteCountFormatter` understated
+    /// smart-quote / box-drawing / emoji-heavy CLAUDE.md bodies by up to 4x,
+    /// which defeats the badge's whole purpose.
     static func injectedSize(text: String, truncatedTo: Int?) -> String {
-        ByteCountFormatter.string(fromByteCount: Int64(truncatedTo ?? text.count), countStyle: .file)
+        let count = truncatedTo ?? text.count
+        if count >= 1_000_000 {
+            return String(format: "%.1fM chars", Double(count) / 1_000_000)
+        }
+        if count >= 1000 {
+            return String(format: "%.1fK chars", Double(count) / 1000)
+        }
+        return "\(count) chars"
     }
 
     // MARK: Task notification (background-task activity row)

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -59,7 +59,9 @@ struct ActivityRowPresentation: Equatable {
     let badges: [ActivityRowBadge]
     /// `openTranscriptOverlay(id)` target — most kinds.
     let openTargetID: String?
-    /// Title truncation: `.byTruncatingMiddle` for Read (file path), else tail.
+    /// Title truncation: `.byTruncatingMiddle` for Read (file path),
+    /// `.byTruncatingHead` for injected file paths (keep the whole filename),
+    /// else tail.
     let titleTruncation: NSLineBreakMode
     /// `NSView.toolTip` for the title field — set only where the visible title
     /// hides something (a middle-truncated path). Nil elsewhere: a tooltip that
@@ -431,10 +433,14 @@ enum ActivityRowFormatter {
             isError: false,
             badges: [ActivityRowBadge(text: label, kind: .neutral)],
             openTargetID: id,
-            titleTruncation: .byTruncatingMiddle,
-            // Paths get middle-truncated to fit the row, so hovering must be
-            // able to reveal the whole thing. Hook names are short and fully
-            // visible — no tooltip for those.
+            // Path sources head-truncate: the whole filename must survive, and
+            // middle truncation kept a short tail that cut into it
+            // (`/private/tmp/claude-5…pr-body.md` for `iam-pr-body.md`).
+            // Non-path sources keep middle truncation — head-truncating
+            // `PostToolUse:Read` would eat the informative front.
+            titleTruncation: (kind == .nestedMemory) ? .byTruncatingHead : .byTruncatingMiddle,
+            // Truncated paths need hovering to reveal the whole thing. Hook
+            // names are short and fully visible — no tooltip for those.
             titleTooltip: (kind == .nestedMemory) ? source.flatMap { $0.isEmpty ? nil : $0 } : nil
         )
     }

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -61,6 +61,10 @@ struct ActivityRowPresentation: Equatable {
     let openTargetID: String?
     /// Title truncation: `.byTruncatingMiddle` for Read (file path), else tail.
     let titleTruncation: NSLineBreakMode
+    /// `NSView.toolTip` for the title field — set only where the visible title
+    /// hides something (a middle-truncated path). Nil elsewhere: a tooltip that
+    /// merely repeats a fully-visible short title is noise.
+    let titleTooltip: String?
     let style: RowStyle
 
     init(
@@ -71,6 +75,7 @@ struct ActivityRowPresentation: Equatable {
         badges: [ActivityRowBadge],
         openTargetID: String?,
         titleTruncation: NSLineBreakMode = .byTruncatingTail,
+        titleTooltip: String? = nil,
         style: RowStyle = .chrome
     ) {
         self.iconSystemName = iconSystemName
@@ -80,6 +85,7 @@ struct ActivityRowPresentation: Equatable {
         self.badges = badges
         self.openTargetID = openTargetID
         self.titleTruncation = titleTruncation
+        self.titleTooltip = titleTooltip
         self.style = style
     }
 }
@@ -425,7 +431,11 @@ enum ActivityRowFormatter {
             isError: false,
             badges: [ActivityRowBadge(text: label, kind: .neutral)],
             openTargetID: id,
-            titleTruncation: .byTruncatingMiddle
+            titleTruncation: .byTruncatingMiddle,
+            // Paths get middle-truncated to fit the row, so hovering must be
+            // able to reveal the whole thing. Hook names are short and fully
+            // visible — no tooltip for those.
+            titleTooltip: (kind == .nestedMemory) ? source.flatMap { $0.isEmpty ? nil : $0 } : nil
         )
     }
 

--- a/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
@@ -140,8 +140,12 @@ struct TranscriptOverlayView: View {
             }
         case .thinking:
             return "brain"
-        case .systemReminder(_, let kind, _, _):
-            return kind == .skillBody ? "sparkles" : "info.circle"
+        case .systemReminder(_, let kind, _, _, _, _):
+            switch kind {
+            case .skillBody:    return "sparkles"
+            case .nestedMemory: return "doc.text"
+            default:            return "info.circle"
+            }
         case .userPrompt, .assistantText, .slashCommand:
             return "doc.text"
         }
@@ -154,16 +158,20 @@ struct TranscriptOverlayView: View {
             return toolCallLabel(name: name, inputJSON: inputJSON)
         case .thinking:
             return "Thinking"
-        case .systemReminder(_, let kind, _, _):
+        case .systemReminder(_, let kind, _, _, let source, _):
+            let label: String
             switch kind {
-            case .skillBody:          return "Skill"
-            case .toolReminder:       return "system-reminder"
-            case .hookOutput:         return "hook"
-            case .environmentDetails: return "env"
-            case .slashEnvelope:      return "command"
-            case .taskNotification:   return "Background"
-            case .other:              return "info"
+            case .skillBody:          label = "Skill"
+            case .toolReminder:       label = "system-reminder"
+            case .hookOutput:         label = "hook"
+            case .environmentDetails: label = "env"
+            case .slashEnvelope:      label = "command"
+            case .taskNotification:   label = "Background"
+            case .nestedMemory:       label = "file"
+            case .other:              label = "info"
             }
+            guard let source, !source.isEmpty else { return label }
+            return "\(label) · \(source)"
         case .userPrompt:   return "User"
         case .assistantText: return "Assistant"
         case .slashCommand(_, let name, _, _): return "/\(name)"
@@ -265,11 +273,11 @@ struct TranscriptOverlayView: View {
                         result: toolResult,
                         terminalID: f?.terminalID
                     )
-                case .systemReminder(_, let kind, let text, _) where kind == .skillBody:
+                case .systemReminder(_, let kind, let text, _, _, _) where kind == .skillBody:
                     SkillBodyRowBody(text: text)
                 case .thinking(_, let text, _):
                     ThinkingRowBody(text: text)
-                case .systemReminder(_, _, let text, _):
+                case .systemReminder(_, _, let text, _, _, _):
                     SystemReminderRowBody(text: text)
                 default:
                     Text(String(describing: item))

--- a/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
@@ -277,8 +277,13 @@ struct TranscriptOverlayView: View {
                     SkillBodyRowBody(text: text)
                 case .thinking(_, let text, _):
                     ThinkingRowBody(text: text)
-                case .systemReminder(_, _, let text, _, _, _):
-                    SystemReminderRowBody(text: text)
+                case .systemReminder(let itemID, _, let text, _, _, let truncatedTo):
+                    SystemReminderRowBody(
+                        id: itemID,
+                        text: text,
+                        truncatedTo: truncatedTo,
+                        terminalID: f?.terminalID
+                    )
                 default:
                     Text(String(describing: item))
                         .font(.system(.caption, design: .monospaced))

--- a/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptOverlayView.swift
@@ -277,9 +277,10 @@ struct TranscriptOverlayView: View {
                     SkillBodyRowBody(text: text)
                 case .thinking(_, let text, _):
                     ThinkingRowBody(text: text)
-                case .systemReminder(let itemID, _, let text, _, _, let truncatedTo):
+                case .systemReminder(let itemID, let kind, let text, _, _, let truncatedTo):
                     SystemReminderRowBody(
                         id: itemID,
+                        kind: kind,
                         text: text,
                         truncatedTo: truncatedTo,
                         terminalID: f?.terminalID

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRenderNode.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRenderNode.swift
@@ -79,7 +79,8 @@ struct TranscriptRenderNode: Identifiable, Equatable {
 
     enum Kind: Hashable {
         case chatBubble(TranscriptItem)
-        case systemReminder(id: String, kind: SystemKind, text: String, timestamp: Date?)
+        case systemReminder(id: String, kind: SystemKind, text: String, timestamp: Date?,
+                            source: String? = nil, truncatedTo: Int? = nil)
         case skillBody(id: String, text: String, timestamp: Date?)
         case toolCall(id: String, name: String, inputJSON: String,
                       inputTruncatedTo: Int?, result: ToolResult?, timestamp: Date?)
@@ -95,9 +96,9 @@ struct TranscriptRenderNode: Identifiable, Equatable {
             switch (lhs, rhs) {
             case (.chatBubble(let l), .chatBubble(let r)):
                 return l == r
-            case (.systemReminder(let li, let lk, let lt, let lts),
-                  .systemReminder(let ri, let rk, let rt, let rts)):
-                return li == ri && lk == rk && lt == rt && lts == rts
+            case (.systemReminder(let li, let lk, let lt, let lts, let lsrc, let ltr),
+                  .systemReminder(let ri, let rk, let rt, let rts, let rsrc, let rtr)):
+                return li == ri && lk == rk && lt == rt && lts == rts && lsrc == rsrc && ltr == rtr
             case (.skillBody(let li, let lt, let lts),
                   .skillBody(let ri, let rt, let rts)):
                 return li == ri && lt == rt && lts == rts
@@ -143,7 +144,7 @@ nonisolated func transcriptRenderNodes(from items: [TranscriptItem]) -> [Transcr
         case .userPrompt, .assistantText:
             out.append(TranscriptRenderNode(id: item.id, kind: .chatBubble(item), badgeUsage: badge))
 
-        case .systemReminder(let id, let kind, let text, let ts):
+        case .systemReminder(let id, let kind, let text, let ts, let source, let truncatedTo):
             if kind == .skillBody {
                 out.append(TranscriptRenderNode(
                     id: id,
@@ -153,7 +154,8 @@ nonisolated func transcriptRenderNodes(from items: [TranscriptItem]) -> [Transcr
             } else {
                 out.append(TranscriptRenderNode(
                     id: id,
-                    kind: .systemReminder(id: id, kind: kind, text: text, timestamp: ts),
+                    kind: .systemReminder(id: id, kind: kind, text: text, timestamp: ts,
+                                          source: source, truncatedTo: truncatedTo),
                     badgeUsage: badge
                 ))
             }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -77,7 +77,7 @@ struct TranscriptRow: View {
         switch node.kind {
         case .chatBubble(let item):
             ChatBubbleView(item: item)
-        case .systemReminder(let id, let kind, let text, let ts):
+        case .systemReminder(let id, let kind, let text, let ts, _, _):
             SystemReminderRow(id: id, kind: kind, text: text, timestamp: ts)
         case .skillBody(let id, let text, let ts):
             SkillBodyRow(id: id, text: text, timestamp: ts)

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -77,8 +77,9 @@ struct TranscriptRow: View {
         switch node.kind {
         case .chatBubble(let item):
             ChatBubbleView(item: item)
-        case .systemReminder(let id, let kind, let text, let ts, _, _):
-            SystemReminderRow(id: id, kind: kind, text: text, timestamp: ts)
+        case .systemReminder(let id, let kind, let text, let ts, let source, let truncatedTo):
+            SystemReminderRow(id: id, kind: kind, text: text, timestamp: ts,
+                              source: source, truncatedTo: truncatedTo)
         case .skillBody(let id, let text, let ts):
             SkillBodyRow(id: id, text: text, timestamp: ts)
         case .toolCall(let id, let name, let inputJSON, let inputTruncatedTo, let result, let ts):

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -363,9 +363,11 @@ enum TranscriptParser {
     }
 
     /// Extracts every injected-context payload from one JSONL row, in emission
-    /// order. Returns `[]` for non-attachment rows and for the payload-less
-    /// flavors (`task_reminder`, `command_permissions`, `queued_command`,
-    /// `*_delta`), which carry no content field at all.
+    /// order. Returns `[]` for non-attachment rows and for flavors that carry
+    /// no injected *prose* context: `*_delta`, `command_permissions`,
+    /// `queued_command`, `diagnostics`, and `edited_text_file` have no
+    /// `content` field at all, while `task_reminder`'s `content` is a
+    /// structured array of todo objects, not renderable text.
     ///
     /// `attachment.content` has a DIFFERENT native JSON type per flavor —
     /// object for `nested_memory`, array for `hook_additional_context`, string

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -395,9 +395,11 @@ enum TranscriptParser {
             // body is one level deeper.
             guard let inner = att["content"] as? [String: Any],
                   let body = inner["content"] as? String, !body.isEmpty else { return [] }
-            let source = (att["displayPath"] as? String)
-                ?? (att["path"] as? String)
-                ?? "CLAUDE.md"
+            let source = injectedPathSource(
+                displayPath: att["displayPath"] as? String,
+                absolutePath: (att["path"] as? String) ?? (inner["path"] as? String),
+                filename: nil
+            ) ?? "CLAUDE.md"
             return [AttachmentPayload(kind: .nestedMemory, source: source, text: body)]
 
         case "file":
@@ -412,10 +414,11 @@ enum TranscriptParser {
             guard let inner = att["content"] as? [String: Any],
                   let file = inner["file"] as? [String: Any],
                   let body = file["content"] as? String, !body.isEmpty else { return [] }
-            let source = (att["displayPath"] as? String)
-                ?? (att["filename"] as? String)
-                ?? (file["filePath"] as? String)
-                ?? "file"
+            let source = injectedPathSource(
+                displayPath: att["displayPath"] as? String,
+                absolutePath: file["filePath"] as? String,
+                filename: att["filename"] as? String
+            ) ?? "file"
             return [AttachmentPayload(kind: .nestedMemory, source: source, text: body)]
 
         case "hook_additional_context":
@@ -449,6 +452,101 @@ enum TranscriptParser {
         default:
             return []
         }
+    }
+
+    /// The path to show for an injected file body, in preference order:
+    ///
+    /// 1. A `displayPath` that stays inside the repo (`.github/CLAUDE.md`) —
+    ///    already the nicest form, and what the row has always rendered.
+    /// 2. The absolute path with `$HOME` collapsed to `~`, when `displayPath`
+    ///    is missing or *escapes* the repo. Claude Code writes escaping paths
+    ///    relative to the cwd, so a file in `/private/tmp` arrives as
+    ///    `../../../../../../private/tmp/…`, which truncates to nothing useful.
+    /// 3. The `filename`, or the display path's last component.
+    ///
+    /// Never returns a `../` prefix. The daemon runs as the same user as the
+    /// app, so `NSHomeDirectory()` abbreviates identically on either side.
+    static func injectedPathSource(
+        displayPath: String?, absolutePath: String?, filename: String?
+    ) -> String? {
+        if let displayPath, !displayPath.isEmpty, !displayPath.hasPrefix("../") { return displayPath }
+        if let absolutePath, !absolutePath.isEmpty {
+            return absolutePath.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+        }
+        if let filename, !filename.isEmpty { return filename }
+        if let displayPath, !displayPath.isEmpty { return (displayPath as NSString).lastPathComponent }
+        return nil
+    }
+
+    /// The injection mechanism behind one attachment row: which hook ran, with
+    /// what command and exit status, or which memory tier / file path was
+    /// loaded — plus the tool call that triggered it, resolved through
+    /// `attachment.toolUseID`.
+    ///
+    /// Deliberately NOT carried on `TranscriptItem`: it is only ever read when
+    /// a row is opened, so it rides the `terminal.transcriptItemFullBody`
+    /// round-trip the overlay already makes instead of costing a switch site
+    /// per associated value.
+    ///
+    /// `toolSummaries` maps `tool_use.id` → its short summary. Attribution is
+    /// resolved strictly through that map: `nil` when the row carries no
+    /// `toolUseID` (every `nested_memory` / `file` row) or when the id names a
+    /// `tool_use` the scan never saw. Position and proximity are never used —
+    /// no field links a CLAUDE.md load to the Read that touched its directory,
+    /// and guessing one would look authoritative while being wrong.
+    static func attachmentMetadata(
+        from json: [String: Any], toolSummaries: [String: String]
+    ) -> TranscriptAttachmentMetadata? {
+        guard json["type"] as? String == "attachment",
+              let att = json["attachment"] as? [String: Any],
+              let rawType = att["type"] as? String else {
+            return nil
+        }
+
+        func text(_ key: String) -> String? {
+            guard let s = att[key] as? String,
+                  !s.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+            return s
+        }
+
+        let inner = att["content"] as? [String: Any]
+        let file = inner?["file"] as? [String: Any]
+        let metadata = TranscriptAttachmentMetadata(
+            hookName: text("hookName"),
+            hookEvent: text("hookEvent"),
+            command: text("command"),
+            exitCode: att["exitCode"] as? Int,
+            durationMs: att["durationMs"] as? Int,
+            stderr: text("stderr"),
+            // Only meaningful for a memory row ("Project", "User", …); a
+            // `file` row's inner type is just "text".
+            memoryType: rawType == "nested_memory" ? inner?["type"] as? String : nil,
+            path: (att["path"] as? String) ?? (inner?["path"] as? String) ?? (file?["filePath"] as? String),
+            triggeredBy: (att["toolUseID"] as? String).flatMap { toolSummaries[$0] }
+        )
+        return metadata.isEmpty ? nil : metadata
+    }
+
+    /// `"Read ai-review-gate.yml"` — a tool call named by the scrap of input
+    /// that identifies it. Intentionally a small local summarizer: the richer
+    /// app-side one lives in `ActivityRowFormatter` (module `TBDApp`) and is
+    /// not reachable from the daemon.
+    static func toolInputSummary(name: String, input: [String: Any]) -> String {
+        func short(_ s: String, limit: Int = 40) -> String {
+            let oneLine = s.replacingOccurrences(of: "\n", with: " ")
+                .trimmingCharacters(in: .whitespaces)
+            return oneLine.count > limit ? "\(oneLine.prefix(limit))…" : oneLine
+        }
+        let detail: String? = {
+            if let p = input["file_path"] as? String, !p.isEmpty { return (p as NSString).lastPathComponent }
+            if let d = input["description"] as? String, !d.isEmpty { return short(d) }
+            if let c = input["command"] as? String, !c.isEmpty { return short(c) }
+            if let p = input["pattern"] as? String, !p.isEmpty { return short(p) }
+            if let p = input["path"] as? String, !p.isEmpty { return (p as NSString).lastPathComponent }
+            return nil
+        }()
+        guard let detail, !detail.isEmpty else { return name }
+        return name.isEmpty ? detail : "\(name) \(detail)"
     }
 
     // MARK: - helpers
@@ -539,9 +637,22 @@ enum TranscriptParser {
     ///  - bare `lineUUID` → returns the user message content, or the sole
     ///    injected payload of an attachment row
     static func lookupFullBody(filePath: String, itemID: String) -> String? {
+        lookupDetail(filePath: filePath, itemID: itemID).text
+    }
+
+    /// What one opened row can recover from the JSONL: its un-truncated body
+    /// plus, for `attachment` rows, how the context got injected.
+    struct ItemDetail {
+        let text: String?
+        let attachment: TranscriptAttachmentMetadata?
+    }
+
+    /// `lookupFullBody` plus the injection metadata. Same single pass, same id
+    /// forms — see `lookupFullBody` for the id grammar.
+    static func lookupDetail(filePath: String, itemID: String) -> ItemDetail {
         guard let data = FileManager.default.contents(atPath: filePath),
               let content = String(data: data, encoding: .utf8) else {
-            return nil
+            return ItemDetail(text: nil, attachment: nil)
         }
 
         // Detect the `#input` suffix variant first — when present, we ONLY scan
@@ -565,6 +676,12 @@ enum TranscriptParser {
             blockIndex = nil
         }
 
+        // `tool_use.id` → short summary, for resolving an attachment row's
+        // `toolUseID`. Accumulated as the scan walks down: a hook fires after
+        // the assistant emitted the tool call, so the triggering `tool_use`
+        // line is always already behind us when its attachment row appears.
+        var toolSummaries: [String: String] = [:]
+
         for line in content.components(separatedBy: "\n") where !line.isEmpty {
             guard let lineData = line.data(using: .utf8),
                   let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
@@ -580,7 +697,7 @@ enum TranscriptParser {
                             let input = block["input"] ?? [:]
                             if let data = try? JSONSerialization.data(withJSONObject: input, options: [.sortedKeys]),
                                let s = String(data: data, encoding: .utf8) {
-                                return s
+                                return ItemDetail(text: s, attachment: nil)
                             }
                         }
                     }
@@ -588,15 +705,28 @@ enum TranscriptParser {
                 continue
             }
 
-            // tool_use_id match — search tool_result blocks within user lines.
             if let message = json["message"] as? [String: Any],
                let array = message["content"] as? [[String: Any]] {
-                for block in array where block["type"] as? String == "tool_result" {
-                    if (block["tool_use_id"] as? String) == itemID {
-                        if let s = block["content"] as? String { return s }
-                        if let inner = block["content"] as? [[String: Any]] {
-                            return inner.compactMap { $0["text"] as? String }.joined(separator: "\n")
+                for block in array {
+                    switch block["type"] as? String {
+                    case "tool_use":
+                        guard let id = block["id"] as? String else { continue }
+                        toolSummaries[id] = toolInputSummary(
+                            name: (block["name"] as? String) ?? "",
+                            input: (block["input"] as? [String: Any]) ?? [:])
+                    case "tool_result":
+                        // tool_use_id match — the un-truncated result content.
+                        guard (block["tool_use_id"] as? String) == itemID else { continue }
+                        if let s = block["content"] as? String {
+                            return ItemDetail(text: s, attachment: nil)
                         }
+                        if let inner = block["content"] as? [[String: Any]] {
+                            return ItemDetail(
+                                text: inner.compactMap { $0["text"] as? String }.joined(separator: "\n"),
+                                attachment: nil)
+                        }
+                    default:
+                        continue
                     }
                 }
             }
@@ -605,31 +735,43 @@ enum TranscriptParser {
             if (json["uuid"] as? String) == lineUUID {
                 // Attachment rows carry no `message`, so the branches below
                 // can never recover their (truncated) body. Re-run the same
-                // extraction `buildItems` used and return it whole.
+                // extraction `buildItems` used and return it whole, alongside
+                // the injection metadata the overlay renders.
                 let payloads = attachmentPayloads(from: json)
-                if payloads.count > 1 {
-                    guard let blockIndex, blockIndex < payloads.count else { return nil }
-                    return payloads[blockIndex].text
+                if !payloads.isEmpty {
+                    let meta = attachmentMetadata(from: json, toolSummaries: toolSummaries)
+                    if payloads.count > 1 {
+                        guard let blockIndex, blockIndex < payloads.count else {
+                            return ItemDetail(text: nil, attachment: meta)
+                        }
+                        return ItemDetail(text: payloads[blockIndex].text, attachment: meta)
+                    }
+                    return ItemDetail(text: payloads[0].text, attachment: meta)
                 }
-                if let only = payloads.first { return only.text }
 
                 if let blockIndex,
                    let message = json["message"] as? [String: Any],
                    let blocks = message["content"] as? [[String: Any]],
                    blockIndex < blocks.count {
                     let block = blocks[blockIndex]
-                    return (block["text"] as? String) ?? (block["thinking"] as? String)
+                    return ItemDetail(
+                        text: (block["text"] as? String) ?? (block["thinking"] as? String),
+                        attachment: nil)
                 }
                 if let message = json["message"] as? [String: Any] {
-                    if let s = message["content"] as? String { return s }
+                    if let s = message["content"] as? String {
+                        return ItemDetail(text: s, attachment: nil)
+                    }
                     if let array = message["content"] as? [[String: Any]] {
-                        return array.first(where: { $0["type"] as? String == "text" })
-                            .flatMap { $0["text"] as? String }
+                        return ItemDetail(
+                            text: array.first(where: { $0["type"] as? String == "text" })
+                                .flatMap { $0["text"] as? String },
+                            attachment: nil)
                     }
                 }
             }
         }
-        return nil
+        return ItemDetail(text: nil, attachment: nil)
     }
 
     /// Parse `<command-name>foo</command-name><command-args>bar</command-args>` envelopes.

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -207,6 +207,13 @@ enum TranscriptParser {
         toolResultsByID: [String: ToolResult]
     ) -> [TranscriptItem] {
         var items: [TranscriptItem] = []
+        // Payload strings already emitted from a `hook_success` row. A hook's
+        // stdout (`hook_success`) and what was actually injected
+        // (`hook_additional_context`) are frequently the identical string, and
+        // hook_success always precedes its twin — so a forward-only set drops
+        // the duplicate. When the injected form DIFFERS (an oversized payload
+        // replaced by a `<persisted-output>` notice) both are kept.
+        var emittedHookPayloads: Set<String> = []
 
         for (i, json) in rawLines.enumerated() {
             // Subagent (sidechain) lines belong to a nested agent's own
@@ -216,6 +223,32 @@ enum TranscriptParser {
             let lineUUID = stableIDs[i]
             let timestamp = (json["timestamp"] as? String).flatMap { iso8601.date(from: $0) }
             let typeStr = json["type"] as? String
+
+            // Hook- and CLAUDE.md-injected context arrives as `type:"attachment"`
+            // rows, which carry no `message` and so match none of the branches
+            // below. Always `continue` — an attachment never falls through.
+            if typeStr == "attachment" {
+                let payloads = attachmentPayloads(from: json)
+                for (index, payload) in payloads.enumerated() {
+                    if payload.rawType == "hook_additional_context",
+                       emittedHookPayloads.contains(payload.text) {
+                        continue
+                    }
+                    if payload.rawType == "hook_success" {
+                        emittedHookPayloads.insert(payload.text)
+                    }
+                    let (truncated, originalCount) = truncate(payload.text)
+                    items.append(.systemReminder(
+                        id: payloads.count > 1 ? "\(lineUUID)#\(index)" : lineUUID,
+                        kind: payload.kind,
+                        text: truncated,
+                        timestamp: timestamp,
+                        source: payload.source,
+                        truncatedTo: originalCount == truncated.count ? nil : originalCount
+                    ))
+                }
+                continue
+            }
 
             if typeStr == "user", let kind = UserMessageClassifier.classify(json) {
                 let text = extractUserText(from: json) ?? ""
@@ -326,6 +359,114 @@ enum TranscriptParser {
         )
     }
 
+    // MARK: - attachments
+
+    /// One renderable payload extracted from a `type: "attachment"` JSONL row.
+    struct AttachmentPayload: Equatable {
+        /// The raw `attachment.type` — the dedup rule keys off it.
+        let rawType: String
+        let kind: SystemKind
+        /// Where the context came from: a CLAUDE.md display path, a hook name.
+        let source: String
+        let text: String
+    }
+
+    /// Extracts every injected-context payload from one JSONL row, in emission
+    /// order. Returns `[]` for non-attachment rows and for the payload-less
+    /// flavors (`task_reminder`, `command_permissions`, `queued_command`,
+    /// `*_delta`), which carry no content field at all.
+    ///
+    /// `attachment.content` has a DIFFERENT native JSON type per flavor —
+    /// object for `nested_memory`, array for `hook_additional_context`, string
+    /// for the rest — so a single `as? String` silently drops the two largest
+    /// sources of injected context.
+    ///
+    /// Shared by `buildItems` and `lookupFullBody` so the collapsed row and the
+    /// click-to-open overlay can never disagree about what a row contains.
+    static func attachmentPayloads(from json: [String: Any]) -> [AttachmentPayload] {
+        guard json["type"] as? String == "attachment",
+              let att = json["attachment"] as? [String: Any],
+              let rawType = att["type"] as? String else {
+            return []
+        }
+
+        func hookName() -> String { (att["hookName"] as? String) ?? "hook" }
+
+        switch rawType {
+        case "nested_memory":
+            // `content` is an object `{path, type, content}`; the CLAUDE.md
+            // body is one level deeper.
+            guard let inner = att["content"] as? [String: Any],
+                  let body = inner["content"] as? String, !body.isEmpty else { return [] }
+            let source = (att["displayPath"] as? String)
+                ?? (att["path"] as? String)
+                ?? "CLAUDE.md"
+            return [AttachmentPayload(rawType: rawType, kind: .nestedMemory, source: source, text: body)]
+
+        case "file":
+            // An @-mentioned file's body, injected verbatim into the context
+            // window. Same shape as `nested_memory` — `content` is an object,
+            // the body one level deeper at `content.file.content` — and the
+            // same *thing*: a file's text pasted into the prompt. Reusing
+            // `.nestedMemory` (not `.hookOutput`, which would badge a file
+            // body as hook stdout) rather than adding a case; the badge is now
+            // "file" for both, and the source segment carries the actual path,
+            // which is what distinguished a CLAUDE.md row anyway.
+            guard let inner = att["content"] as? [String: Any],
+                  let file = inner["file"] as? [String: Any],
+                  let body = file["content"] as? String, !body.isEmpty else { return [] }
+            let source = (att["displayPath"] as? String)
+                ?? (att["filename"] as? String)
+                ?? (file["filePath"] as? String)
+                ?? "file"
+            return [AttachmentPayload(rawType: rawType, kind: .nestedMemory, source: source, text: body)]
+
+        case "hook_additional_context":
+            // `content` is an array of strings — one entry per injected block.
+            let strings = (att["content"] as? [Any])?.compactMap { $0 as? String } ?? []
+            return strings.filter { !$0.isEmpty }.map {
+                AttachmentPayload(rawType: rawType, kind: .hookOutput, source: hookName(), text: $0)
+            }
+
+        case "hook_success":
+            // Two payload sources: `content` (plain-text hook stdout, usually
+            // empty) and a JSON `stdout` whose real text sits at
+            // `hookSpecificOutput.additionalContext`. A non-JSON `stdout` is
+            // the same text `content` already carries, so it is ignored.
+            var out: [AttachmentPayload] = []
+            if let s = att["content"] as? String, !s.isEmpty {
+                out.append(AttachmentPayload(rawType: rawType, kind: .hookOutput, source: hookName(), text: s))
+            }
+            for s in additionalContext(fromStdout: att["stdout"] as? String) {
+                out.append(AttachmentPayload(rawType: rawType, kind: .hookOutput, source: hookName(), text: s))
+            }
+            return out
+
+        case "skill_listing":
+            guard let s = att["content"] as? String, !s.isEmpty else { return [] }
+            return [AttachmentPayload(rawType: rawType, kind: .hookOutput, source: "skills", text: s)]
+
+        default:
+            return []
+        }
+    }
+
+    /// Pulls `hookSpecificOutput.additionalContext` out of a hook's stdout.
+    /// Most rows carry the literal `"{}\n"` and yield nothing. The field is
+    /// usually a String but may be an array of strings.
+    private static func additionalContext(fromStdout stdout: String?) -> [String] {
+        guard let stdout,
+              let data = stdout.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hookSpecific = obj["hookSpecificOutput"] as? [String: Any],
+              let raw = hookSpecific["additionalContext"] else {
+            return []
+        }
+        if let s = raw as? String { return s.isEmpty ? [] : [s] }
+        if let arr = raw as? [Any] { return arr.compactMap { $0 as? String }.filter { !$0.isEmpty } }
+        return []
+    }
+
     // MARK: - helpers
 
     static let bodyCharCap = 2000
@@ -409,8 +550,10 @@ enum TranscriptParser {
     /// itemID forms:
     ///  - `tool_use_id` (e.g. "toolu_abc") → returns the matching tool_result content
     ///  - `<tool_use_id>#input` → returns the un-truncated `tool_use.input` JSON
-    ///  - `<lineUUID>#<blockIndex>` → returns the assistant block's text/thinking
-    ///  - bare `lineUUID` → returns the user message content
+    ///  - `<lineUUID>#<blockIndex>` → returns the assistant block's text/thinking,
+    ///    or the Nth injected payload of a multi-payload attachment row
+    ///  - bare `lineUUID` → returns the user message content, or the sole
+    ///    injected payload of an attachment row
     static func lookupFullBody(filePath: String, itemID: String) -> String? {
         guard let data = FileManager.default.contents(atPath: filePath),
               let content = String(data: data, encoding: .utf8) else {
@@ -476,6 +619,16 @@ enum TranscriptParser {
 
             // line UUID match.
             if (json["uuid"] as? String) == lineUUID {
+                // Attachment rows carry no `message`, so the branches below
+                // can never recover their (truncated) body. Re-run the same
+                // extraction `buildItems` used and return it whole.
+                let payloads = attachmentPayloads(from: json)
+                if payloads.count > 1 {
+                    guard let blockIndex, blockIndex < payloads.count else { return nil }
+                    return payloads[blockIndex].text
+                }
+                if let only = payloads.first { return only.text }
+
                 if let blockIndex,
                    let message = json["message"] as? [String: Any],
                    let blocks = message["content"] as? [[String: Any]],

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -466,12 +466,17 @@ enum TranscriptParser {
     ///
     /// Never returns a `../` prefix. The daemon runs as the same user as the
     /// app, so `NSHomeDirectory()` abbreviates identically on either side.
+    ///
+    /// The abbreviation goes through `abbreviatingWithTildeInPath`, which only
+    /// matches on path-component boundaries. A substring replace would turn
+    /// `/Users/changelog-archive/x` into `~elog-archive/x` and
+    /// `/Volumes/T7/Users/me/x` into `/Volumes/T7~/x`.
     static func injectedPathSource(
         displayPath: String?, absolutePath: String?, filename: String?
     ) -> String? {
         if let displayPath, !displayPath.isEmpty, !displayPath.hasPrefix("../") { return displayPath }
         if let absolutePath, !absolutePath.isEmpty {
-            return absolutePath.replacingOccurrences(of: NSHomeDirectory(), with: "~")
+            return (absolutePath as NSString).abbreviatingWithTildeInPath
         }
         if let filename, !filename.isEmpty { return filename }
         if let displayPath, !displayPath.isEmpty { return (displayPath as NSString).lastPathComponent }

--- a/Sources/TBDDaemon/Claude/TranscriptParser.swift
+++ b/Sources/TBDDaemon/Claude/TranscriptParser.swift
@@ -201,19 +201,19 @@ enum TranscriptParser {
     /// tool_use_id→result index) into `[TranscriptItem]`. Both the full `parse`
     /// and the tail `parseTail` call this, guaranteeing the tail's items are
     /// byte-identical to the bottom of the full parse for the same lines.
+    ///
+    /// That guarantee holds only while this stays a pure function of the lines
+    /// it is handed: every item must be derivable from its own row. Do not add
+    /// cross-row state (a "have I already emitted this text?" set, say) — the
+    /// tail path passes only the lines inside its byte window, so any such
+    /// state starts empty there and the tail would emit rows the full parse
+    /// suppresses.
     private static func buildItems(
         rawLines: [[String: Any]],
         stableIDs: [String],
         toolResultsByID: [String: ToolResult]
     ) -> [TranscriptItem] {
         var items: [TranscriptItem] = []
-        // Payload strings already emitted from a `hook_success` row. A hook's
-        // stdout (`hook_success`) and what was actually injected
-        // (`hook_additional_context`) are frequently the identical string, and
-        // hook_success always precedes its twin — so a forward-only set drops
-        // the duplicate. When the injected form DIFFERS (an oversized payload
-        // replaced by a `<persisted-output>` notice) both are kept.
-        var emittedHookPayloads: Set<String> = []
 
         for (i, json) in rawLines.enumerated() {
             // Subagent (sidechain) lines belong to a nested agent's own
@@ -230,13 +230,6 @@ enum TranscriptParser {
             if typeStr == "attachment" {
                 let payloads = attachmentPayloads(from: json)
                 for (index, payload) in payloads.enumerated() {
-                    if payload.rawType == "hook_additional_context",
-                       emittedHookPayloads.contains(payload.text) {
-                        continue
-                    }
-                    if payload.rawType == "hook_success" {
-                        emittedHookPayloads.insert(payload.text)
-                    }
                     let (truncated, originalCount) = truncate(payload.text)
                     items.append(.systemReminder(
                         id: payloads.count > 1 ? "\(lineUUID)#\(index)" : lineUUID,
@@ -363,8 +356,6 @@ enum TranscriptParser {
 
     /// One renderable payload extracted from a `type: "attachment"` JSONL row.
     struct AttachmentPayload: Equatable {
-        /// The raw `attachment.type` — the dedup rule keys off it.
-        let rawType: String
         let kind: SystemKind
         /// Where the context came from: a CLAUDE.md display path, a hook name.
         let source: String
@@ -383,6 +374,10 @@ enum TranscriptParser {
     ///
     /// Shared by `buildItems` and `lookupFullBody` so the collapsed row and the
     /// click-to-open overlay can never disagree about what a row contains.
+    ///
+    /// Extraction is per-row and stateless — no cross-row dedup — which is what
+    /// keeps `buildItems` a pure function of the lines it is handed and
+    /// preserves `parseTail`'s identical-bottom guarantee.
     static func attachmentPayloads(from json: [String: Any]) -> [AttachmentPayload] {
         guard json["type"] as? String == "attachment",
               let att = json["attachment"] as? [String: Any],
@@ -401,7 +396,7 @@ enum TranscriptParser {
             let source = (att["displayPath"] as? String)
                 ?? (att["path"] as? String)
                 ?? "CLAUDE.md"
-            return [AttachmentPayload(rawType: rawType, kind: .nestedMemory, source: source, text: body)]
+            return [AttachmentPayload(kind: .nestedMemory, source: source, text: body)]
 
         case "file":
             // An @-mentioned file's body, injected verbatim into the context
@@ -419,52 +414,39 @@ enum TranscriptParser {
                 ?? (att["filename"] as? String)
                 ?? (file["filePath"] as? String)
                 ?? "file"
-            return [AttachmentPayload(rawType: rawType, kind: .nestedMemory, source: source, text: body)]
+            return [AttachmentPayload(kind: .nestedMemory, source: source, text: body)]
 
         case "hook_additional_context":
             // `content` is an array of strings — one entry per injected block.
             let strings = (att["content"] as? [Any])?.compactMap { $0 as? String } ?? []
             return strings.filter { !$0.isEmpty }.map {
-                AttachmentPayload(rawType: rawType, kind: .hookOutput, source: hookName(), text: $0)
+                AttachmentPayload(kind: .hookOutput, source: hookName(), text: $0)
             }
 
         case "hook_success":
-            // Two payload sources: `content` (plain-text hook stdout, usually
-            // empty) and a JSON `stdout` whose real text sits at
-            // `hookSpecificOutput.additionalContext`. A non-JSON `stdout` is
-            // the same text `content` already carries, so it is ignored.
-            var out: [AttachmentPayload] = []
-            if let s = att["content"] as? String, !s.isEmpty {
-                out.append(AttachmentPayload(rawType: rawType, kind: .hookOutput, source: hookName(), text: s))
-            }
-            for s in additionalContext(fromStdout: att["stdout"] as? String) {
-                out.append(AttachmentPayload(rawType: rawType, kind: .hookOutput, source: hookName(), text: s))
-            }
-            return out
+            // ONLY the plain-text `content` branch. `stdout`'s
+            // `hookSpecificOutput.additionalContext` is deliberately NOT read:
+            // measured across 120+ real sessions, every such payload is also
+            // present in a `hook_additional_context` row — either verbatim (130
+            // cases) or as the `<persisted-output>` notice that REPLACED an
+            // oversized payload (all 11 apparent orphans). `hook_additional_context`
+            // is what actually entered the context window; a hook's stdout is
+            // merely what it emitted. Rendering only the former is therefore
+            // both non-redundant and more truthful — and, because the rule is
+            // per-row rather than a cross-row dedup set, it keeps `buildItems`
+            // a pure function of its window (see `parseTail`'s identical-bottom
+            // guarantee). `content` itself is never mirrored in hac (221/221
+            // unique) so it stays.
+            guard let s = att["content"] as? String, !s.isEmpty else { return [] }
+            return [AttachmentPayload(kind: .hookOutput, source: hookName(), text: s)]
 
         case "skill_listing":
             guard let s = att["content"] as? String, !s.isEmpty else { return [] }
-            return [AttachmentPayload(rawType: rawType, kind: .hookOutput, source: "skills", text: s)]
+            return [AttachmentPayload(kind: .hookOutput, source: "skills", text: s)]
 
         default:
             return []
         }
-    }
-
-    /// Pulls `hookSpecificOutput.additionalContext` out of a hook's stdout.
-    /// Most rows carry the literal `"{}\n"` and yield nothing. The field is
-    /// usually a String but may be an array of strings.
-    private static func additionalContext(fromStdout stdout: String?) -> [String] {
-        guard let stdout,
-              let data = stdout.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let hookSpecific = obj["hookSpecificOutput"] as? [String: Any],
-              let raw = hookSpecific["additionalContext"] else {
-            return []
-        }
-        if let s = raw as? String { return s.isEmpty ? [] : [s] }
-        if let arr = raw as? [Any] { return arr.compactMap { $0 as? String }.filter { !$0.isEmpty } }
-        return []
     }
 
     // MARK: - helpers

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2120,9 +2120,10 @@ extension RPCRouter {
             }
             primaryPath = projectDir.appendingPathComponent("\(sessionID).jsonl").path
         }
-        let text = TranscriptParser.lookupFullBody(filePath: primaryPath, itemID: params.itemID)
-            ?? "Output no longer available."
+        let detail = TranscriptParser.lookupDetail(filePath: primaryPath, itemID: params.itemID)
 
-        return try RPCResponse(result: TerminalTranscriptItemFullBodyResult(text: text))
+        return try RPCResponse(result: TerminalTranscriptItemFullBodyResult(
+            text: detail.text ?? "Output no longer available.",
+            attachment: detail.attachment))
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2122,8 +2122,12 @@ extension RPCRouter {
         }
         let detail = TranscriptParser.lookupDetail(filePath: primaryPath, itemID: params.itemID)
 
+        // `includeBody: false` only keeps the body off the wire: the body string
+        // falls out of the very same single JSONL pass that produces the
+        // metadata (an attachment row's payloads must be extracted just to
+        // recognize it as one), so there is no parser work to skip.
         return try RPCResponse(result: TerminalTranscriptItemFullBodyResult(
-            text: detail.text ?? "Output no longer available.",
+            text: params.includeBody ? (detail.text ?? "Output no longer available.") : "",
             attachment: detail.attachment))
     }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1242,7 +1242,17 @@ public enum SystemKind: String, Codable, Sendable, Equatable, Hashable {
     case slashEnvelope
     case skillBody
     case taskNotification
+    case nestedMemory
     case other
+
+    /// Lenient decode: an unrecognized raw value degrades to `.other` rather
+    /// than throwing. Adding a case would otherwise make an OLD app binary
+    /// fail to decode a NEW daemon's payload — the schema-skew failure class
+    /// documented in CLAUDE.md. The encoder stays synthesized.
+    public init(from decoder: any Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = SystemKind(rawValue: raw) ?? .other
+    }
 }
 
 public struct ToolResult: Codable, Sendable, Equatable, Hashable {
@@ -1296,7 +1306,13 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable,
                   result: ToolResult?, subagent: Subagent?, timestamp: Date?,
                   usage: TokenUsage? = nil)
     case thinking(id: String, text: String, timestamp: Date?)
-    case systemReminder(id: String, kind: SystemKind, text: String, timestamp: Date?)
+    /// `source` names where injected context came from (a `displayPath` like
+    /// `.github/CLAUDE.md`, or a hook name like `PostToolUse:Read`) and
+    /// `truncatedTo` carries the ORIGINAL character count when `text` was
+    /// capped — same semantics as `toolCall.inputTruncatedTo`. Both default to
+    /// nil; only attachment-derived reminders populate them.
+    case systemReminder(id: String, kind: SystemKind, text: String, timestamp: Date?,
+                        source: String? = nil, truncatedTo: Int? = nil)
     case slashCommand(id: String, name: String, args: String?, timestamp: Date?)
 
     public var id: String {
@@ -1305,7 +1321,7 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable,
         case .assistantText(let id, _, _, _): return id
         case .toolCall(let id, _, _, _, _, _, _, _): return id
         case .thinking(let id, _, _): return id
-        case .systemReminder(let id, _, _, _): return id
+        case .systemReminder(let id, _, _, _, _, _): return id
         case .slashCommand(let id, _, _, _): return id
         }
     }
@@ -1316,7 +1332,7 @@ public indirect enum TranscriptItem: Codable, Sendable, Identifiable, Equatable,
              .assistantText(_, _, let t, _),
              .toolCall(_, _, _, _, _, _, let t, _),
              .thinking(_, _, let t),
-             .systemReminder(_, _, _, let t),
+             .systemReminder(_, _, _, let t, _, _),
              .slashCommand(_, _, _, let t):
             return t
         }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1761,10 +1761,69 @@ public struct TerminalTranscriptItemFullBodyParams: Codable, Sendable {
     }
 }
 
+/// How one injected-context row got into the context window: the hook that ran
+/// (name, event, command, exit status, timing, stderr), the memory tier / path
+/// of a loaded file, and the tool call that triggered it.
+///
+/// Rides the `terminal.transcriptItemFullBody` round-trip rather than living on
+/// `TranscriptItem`: it is only read when a row is opened, and every extra
+/// associated value on `TranscriptItem.systemReminder` costs ~15 switch sites.
+/// Every field is optional — only what a row actually carries is populated, and
+/// the overlay omits the rest rather than rendering placeholders.
+public struct TranscriptAttachmentMetadata: Codable, Sendable, Equatable {
+    public let hookName: String?
+    public let hookEvent: String?
+    public let command: String?
+    public let exitCode: Int?
+    public let durationMs: Int?
+    public let stderr: String?
+    /// `nested_memory`'s inner `content.type` — the memory tier, e.g. "Project".
+    /// Passed through verbatim; the set of values is Claude Code's, not ours.
+    public let memoryType: String?
+    /// Absolute path of the loaded file, for display (tilde-abbreviated) and
+    /// copy (verbatim).
+    public let path: String?
+    /// Short summary of the `tool_use` named by `attachment.toolUseID`, e.g.
+    /// "Read ai-review-gate.yml". Nil when the row carries no `toolUseID` or
+    /// the id resolves to nothing — never guessed from row position.
+    public let triggeredBy: String?
+
+    public var isEmpty: Bool {
+        hookName == nil && hookEvent == nil && command == nil && exitCode == nil
+            && durationMs == nil && stderr == nil && memoryType == nil
+            && path == nil && triggeredBy == nil
+    }
+
+    public init(
+        hookName: String? = nil,
+        hookEvent: String? = nil,
+        command: String? = nil,
+        exitCode: Int? = nil,
+        durationMs: Int? = nil,
+        stderr: String? = nil,
+        memoryType: String? = nil,
+        path: String? = nil,
+        triggeredBy: String? = nil
+    ) {
+        self.hookName = hookName
+        self.hookEvent = hookEvent
+        self.command = command
+        self.exitCode = exitCode
+        self.durationMs = durationMs
+        self.stderr = stderr
+        self.memoryType = memoryType
+        self.path = path
+        self.triggeredBy = triggeredBy
+    }
+}
+
 public struct TerminalTranscriptItemFullBodyResult: Codable, Sendable {
     public let text: String
-    public init(text: String) {
+    /// Present only for `attachment` rows (hook output, CLAUDE.md / file bodies).
+    public let attachment: TranscriptAttachmentMetadata?
+    public init(text: String, attachment: TranscriptAttachmentMetadata? = nil) {
         self.text = text
+        self.attachment = attachment
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1755,9 +1755,29 @@ public struct TerminalTranscriptResult: Codable, Sendable {
 public struct TerminalTranscriptItemFullBodyParams: Codable, Sendable {
     public let terminalID: UUID
     public let itemID: String
-    public init(terminalID: UUID, itemID: String) {
+    /// Whether the response carries the item's body text. `false` asks for the
+    /// injection metadata alone — the transcript opens *every* injected row on
+    /// appear just to read that metadata, and an injected CLAUDE.md body can be
+    /// tens of KB that the caller immediately discards.
+    ///
+    /// Defaults to `true`, and a payload that omits the key decodes as `true`,
+    /// so every existing caller and any older client keeps the body.
+    public let includeBody: Bool
+    public init(terminalID: UUID, itemID: String, includeBody: Bool = true) {
         self.terminalID = terminalID
         self.itemID = itemID
+        self.includeBody = includeBody
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case terminalID, itemID, includeBody
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        terminalID = try c.decode(UUID.self, forKey: .terminalID)
+        itemID = try c.decode(String.self, forKey: .itemID)
+        includeBody = try c.decodeIfPresent(Bool.self, forKey: .includeBody) ?? true
     }
 }
 
@@ -1818,6 +1838,8 @@ public struct TranscriptAttachmentMetadata: Codable, Sendable, Equatable {
 }
 
 public struct TerminalTranscriptItemFullBodyResult: Codable, Sendable {
+    /// The un-truncated body, or `""` when the request passed
+    /// `includeBody: false` (metadata-only fetch).
     public let text: String
     /// Present only for `attachment` rows (hook output, CLAUDE.md / file bodies).
     public let attachment: TranscriptAttachmentMetadata?

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -139,7 +139,10 @@ struct ActivityRowFormatterTests {
             id: "m2", kind: .nestedMemory, text: "# acme rules",
             source: "~/scratch/acme/very/deep/nesting/iam-pr-body.md")
         let p = try #require(ActivityRowFormatter.presentation(for: node))
-        #expect(p.titleTruncation == .byTruncatingMiddle)
+        // Head truncation: the ellipsis eats the path PREFIX so the whole
+        // filename survives. Middle truncation kept a short tail that cut into
+        // the filename itself (`…pr-body.md` for `iam-pr-body.md`).
+        #expect(p.titleTruncation == .byTruncatingHead)
         #expect(p.titleTooltip == "~/scratch/acme/very/deep/nesting/iam-pr-body.md")
     }
 
@@ -149,6 +152,9 @@ struct ActivityRowFormatterTests {
             id: "h2", kind: .hookOutput, text: "injected", source: "PostToolUse:Read")
         let p = try #require(ActivityRowFormatter.presentation(for: node))
         #expect(p.titleTooltip == nil)
+        // NOT head-truncated: the informative front of `PostToolUse:Read` is
+        // exactly what head truncation would drop.
+        #expect(p.titleTruncation == .byTruncatingMiddle)
     }
 
     @Test("Injected hook context → 'hook' badge + '<hookName> · <size>' title")

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -157,6 +157,22 @@ struct ActivityRowFormatterTests {
         #expect(ActivityRowFormatter.injectedSize(text: "short", truncatedTo: 44_312) == "44.3K chars")
     }
 
+    @Test("Injected size rounding never rolls a mantissa past its own unit")
+    func injectedSizeRoundingDoesNotRollPastItsUnit() {
+        // K boundary: 999_950...999_999 round to a K-mantissa of 1000.0 and
+        // must bump to M instead of printing "1000.0K chars".
+        #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 999_949) == "999.9K chars")
+        #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 999_950) == "1.0M chars")
+        #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 999_999) == "1.0M chars")
+        #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 1_000_000) == "1.0M chars")
+        // M boundary equivalent (same shape, x1000): must bump to G instead
+        // of printing "1000.0M chars".
+        #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 999_949_000) == "999.9M chars")
+        #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 999_950_000) == "1.0G chars")
+        #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 999_999_950) == "1.0G chars")
+        #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 1_000_000_000) == "1.0G chars")
+    }
+
     @Test("Task notification → clock icon, 'Background · <summary>' title, status badge")
     func taskNotification() throws {
         let node = TranscriptRenderNode.makeSystemReminder(

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -115,6 +115,35 @@ struct ActivityRowFormatterTests {
         #expect(p.openTargetID == "s1")
     }
 
+    @Test("Injected file body → 'file' badge + '<displayPath> · <original size>' title")
+    func nestedMemoryTitleCarriesSourceAndSize() throws {
+        // The size readout is the point: a collapsed row must show at a glance
+        // how much context a 15-line Read actually pulled in. `truncatedTo`
+        // holds the ORIGINAL length, so it wins over the capped `text`.
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "m1", kind: .nestedMemory, text: "# acme rules (truncated)",
+            source: ".github/CLAUDE.md", truncatedTo: 39_673)
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(p.badges == [ActivityRowBadge(text: "file", kind: .neutral)])
+        #expect(p.titleSegments.map(\.text).first == ".github/CLAUDE.md")
+        #expect(titleText(p).contains("KB"), "expected a human-readable size, got \(titleText(p))")
+        #expect(!titleText(p).contains("\(("# acme rules (truncated)").count)"),
+                "size must come from truncatedTo, not the capped text length")
+        #expect(p.openTargetID == "m1")
+    }
+
+    @Test("Injected hook context → 'hook' badge + '<hookName> · <size>' title")
+    func hookAdditionalContextTitleCarriesHookName() throws {
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "h1", kind: .hookOutput, text: String(repeating: "x", count: 300),
+            source: "PostToolUse:Read")
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(p.badges == [ActivityRowBadge(text: "hook", kind: .neutral)])
+        #expect(p.titleSegments.map(\.text).first == "PostToolUse:Read")
+        // Untruncated: size falls back to the text length.
+        #expect(titleText(p).contains("300"))
+    }
+
     @Test("Task notification → clock icon, 'Background · <summary>' title, status badge")
     func taskNotification() throws {
         let node = TranscriptRenderNode.makeSystemReminder(

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -133,6 +133,24 @@ struct ActivityRowFormatterTests {
         #expect(p.openTargetID == "m1")
     }
 
+    @Test("Injected file path gets a hover tooltip carrying the untruncated path")
+    func nestedMemoryTitleCarriesTooltip() throws {
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "m2", kind: .nestedMemory, text: "# acme rules",
+            source: "~/scratch/acme/very/deep/nesting/iam-pr-body.md")
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(p.titleTruncation == .byTruncatingMiddle)
+        #expect(p.titleTooltip == "~/scratch/acme/very/deep/nesting/iam-pr-body.md")
+    }
+
+    @Test("Hook rows get no tooltip — a short hook name is fully visible")
+    func hookRowHasNoTooltip() throws {
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "h2", kind: .hookOutput, text: "injected", source: "PostToolUse:Read")
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(p.titleTooltip == nil)
+    }
+
     @Test("Injected hook context → 'hook' badge + '<hookName> · <size>' title")
     func hookAdditionalContextTitleCarriesHookName() throws {
         let node = TranscriptRenderNode.makeSystemReminder(

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -126,7 +126,8 @@ struct ActivityRowFormatterTests {
         let p = try #require(ActivityRowFormatter.presentation(for: node))
         #expect(p.badges == [ActivityRowBadge(text: "file", kind: .neutral)])
         #expect(p.titleSegments.map(\.text).first == ".github/CLAUDE.md")
-        #expect(titleText(p).contains("KB"), "expected a human-readable size, got \(titleText(p))")
+        // Magnitude, not just "has a suffix": 39,673 chars → "39.7K chars".
+        #expect(titleText(p).contains("39.7K chars"), "got \(titleText(p))")
         #expect(!titleText(p).contains("\(("# acme rules (truncated)").count)"),
                 "size must come from truncatedTo, not the capped text length")
         #expect(p.openTargetID == "m1")
@@ -141,7 +142,19 @@ struct ActivityRowFormatterTests {
         #expect(p.badges == [ActivityRowBadge(text: "hook", kind: .neutral)])
         #expect(p.titleSegments.map(\.text).first == "PostToolUse:Read")
         // Untruncated: size falls back to the text length.
-        #expect(titleText(p).contains("300"))
+        #expect(titleText(p).contains("300 chars"), "got \(titleText(p))")
+    }
+
+    @Test("Injected size counts CHARACTERS, not bytes")
+    func injectedSizeIsCharactersNotBytes() {
+        // `truncatedTo` / `String.count` are grapheme clusters. Em-dashes are
+        // 3 UTF-8 bytes each, so a byte formatter would have reported ~3x —
+        // the unit label must match the number actually being counted.
+        let emDashes = String(repeating: "—", count: 1500)
+        #expect(emDashes.utf8.count == 4500)
+        #expect(ActivityRowFormatter.injectedSize(text: emDashes, truncatedTo: nil) == "1.5K chars")
+        #expect(ActivityRowFormatter.injectedSize(text: "abc", truncatedTo: nil) == "3 chars")
+        #expect(ActivityRowFormatter.injectedSize(text: "short", truncatedTo: 44_312) == "44.3K chars")
     }
 
     @Test("Task notification → clock icon, 'Background · <summary>' title, status badge")

--- a/Tests/TBDAppTests/SystemReminderPathAbbreviationTests.swift
+++ b/Tests/TBDAppTests/SystemReminderPathAbbreviationTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tier 1. The injected-row path field is the first place in the app fed an
+/// *arbitrary* absolute path out of a transcript, so its `~` abbreviation has to
+/// match whole path components — a substring replace of `NSHomeDirectory()`
+/// presented sibling and nested directories as living inside the user's home.
+@Suite("Injected row path abbreviation")
+struct SystemReminderPathAbbreviationTests {
+    private let home = NSHomeDirectory()
+    private var homeLeaf: String { (home as NSString).lastPathComponent }
+    private var homeParent: String { (home as NSString).deletingLastPathComponent }
+
+    @Test("a genuine home-prefixed path abbreviates to ~/…")
+    func abbreviatesHomePath() {
+        #expect(SystemReminderRowBody.abbreviatedPath("\(home)/acme-prod/.github/CLAUDE.md")
+            == "~/acme-prod/.github/CLAUDE.md")
+    }
+
+    @Test("a sibling directory sharing the home name's prefix is left alone")
+    func leavesSiblingDirectoryAlone() {
+        // e.g. home `/Users/me` must not turn `/Users/melog-archive/…` into `~log-archive/…`
+        let sibling = "\(homeParent)/\(homeLeaf)log-archive/CLAUDE.md"
+        #expect(SystemReminderRowBody.abbreviatedPath(sibling) == sibling)
+    }
+
+    @Test("home appearing mid-path on another volume is not spliced")
+    func leavesNestedHomePathAlone() {
+        let onVolume = "/Volumes/T7\(home)/notes.md"
+        #expect(SystemReminderRowBody.abbreviatedPath(onVolume) == onVolume)
+    }
+
+    @Test("an unrelated absolute path is unchanged")
+    func leavesUnrelatedPathAlone() {
+        #expect(SystemReminderRowBody.abbreviatedPath("/srv/acme-prod/deploy.swift")
+            == "/srv/acme-prod/deploy.swift")
+    }
+}

--- a/Tests/TBDAppTests/TableTranscriptHarness.swift
+++ b/Tests/TBDAppTests/TableTranscriptHarness.swift
@@ -1128,7 +1128,7 @@ struct TableTranscriptHarness {
         switch node.kind {
         case .chatBubble(let item):
             return TranscriptCompareRealSessions.itemText(item)
-        case .systemReminder(_, _, let text, _), .skillBody(_, let text, _):
+        case .systemReminder(_, _, let text, _, _, _), .skillBody(_, let text, _):
             return text
         case .toolCall(_, let name, let inputJSON, _, let result, _):
             return "\(name)\n\(inputJSON)\n\(result?.text ?? "")"

--- a/Tests/TBDAppTests/TranscriptCompareRealSessions.swift
+++ b/Tests/TBDAppTests/TranscriptCompareRealSessions.swift
@@ -286,7 +286,7 @@ enum TranscriptCompareRealSessions {
         case .userPrompt(_, let text, _),
              .assistantText(_, let text, _, _),
              .thinking(_, let text, _),
-             .systemReminder(_, _, let text, _):
+             .systemReminder(_, _, let text, _, _, _):
             return text
         case .toolCall(_, let name, let inputJSON, _, let result, _, _, _):
             return "\(name)\n\(inputJSON)\n\(result?.text ?? "")"

--- a/Tests/TBDAppTests/TranscriptRenderNodeEquatableTests.swift
+++ b/Tests/TBDAppTests/TranscriptRenderNodeEquatableTests.swift
@@ -65,11 +65,14 @@ struct TranscriptRenderNodeEquatableTests {
     private func makeSystemReminderNode(
         id: String = "sys-1",
         kind: SystemKind = .other,
-        text: String = "reminder"
+        text: String = "reminder",
+        source: String? = nil,
+        truncatedTo: Int? = nil
     ) -> TranscriptRenderNode {
         TranscriptRenderNode(
             id: id,
-            kind: .systemReminder(id: id, kind: kind, text: text, timestamp: nil),
+            kind: .systemReminder(id: id, kind: kind, text: text, timestamp: nil,
+                                  source: source, truncatedTo: truncatedTo),
             badgeUsage: nil
         )
     }
@@ -217,6 +220,21 @@ struct TranscriptRenderNodeEquatableTests {
         #expect(a != b)
     }
 
+    // systemReminder: source / truncatedTo feed contentVersion. Two rows can
+    // hold the SAME truncated prefix while coming from different files or
+    // different original sizes — the row must still re-render.
+    @Test func systemReminder_sourceChanges_isNotEqual() {
+        let a = makeSystemReminderNode(id: "s1", kind: .nestedMemory, text: "# rules", source: "CLAUDE.md")
+        let b = makeSystemReminderNode(id: "s1", kind: .nestedMemory, text: "# rules", source: ".github/CLAUDE.md")
+        #expect(a != b)
+    }
+
+    @Test func systemReminder_truncatedToChanges_isNotEqual() {
+        let a = makeSystemReminderNode(id: "s1", text: "# rules", source: "CLAUDE.md", truncatedTo: 5000)
+        let b = makeSystemReminderNode(id: "s1", text: "# rules", source: "CLAUDE.md", truncatedTo: 9000)
+        #expect(a != b)
+    }
+
     // skillBody: text changes
     @Test func skillBody_textChanges_isNotEqual() {
         let a = makeSkillBodyNode(id: "k1", text: "version A")
@@ -281,6 +299,10 @@ struct TranscriptRenderNodeEquatableTests {
         #expect(base != TranscriptRenderNode.Kind.systemReminder(id: "s1", kind: .skillBody, text: "msg", timestamp: ts))
         #expect(base != TranscriptRenderNode.Kind.systemReminder(id: "s1", kind: .other, text: "other", timestamp: ts))
         #expect(base != TranscriptRenderNode.Kind.systemReminder(id: "s1", kind: .other, text: "msg", timestamp: nil))
+        #expect(base != TranscriptRenderNode.Kind.systemReminder(
+            id: "s1", kind: .other, text: "msg", timestamp: ts, source: "CLAUDE.md"))
+        #expect(base != TranscriptRenderNode.Kind.systemReminder(
+            id: "s1", kind: .other, text: "msg", timestamp: ts, truncatedTo: 9000))
     }
 
     // skillBody: all three associated values contribute

--- a/Tests/TBDAppTests/TranscriptRenderNodeFixtures.swift
+++ b/Tests/TBDAppTests/TranscriptRenderNodeFixtures.swift
@@ -28,11 +28,13 @@ extension TranscriptRenderNode {
     }
 
     static func makeSystemReminder(
-        id: String, kind: SystemKind, text: String, timestamp: Date? = nil
+        id: String, kind: SystemKind, text: String, timestamp: Date? = nil,
+        source: String? = nil, truncatedTo: Int? = nil
     ) -> TranscriptRenderNode {
         TranscriptRenderNode(
             id: id,
-            kind: .systemReminder(id: id, kind: kind, text: text, timestamp: timestamp),
+            kind: .systemReminder(id: id, kind: kind, text: text, timestamp: timestamp,
+                                  source: source, truncatedTo: truncatedTo),
             badgeUsage: nil
         )
     }

--- a/Tests/TBDDaemonTests/TerminalTranscriptItemFullBodyHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalTranscriptItemFullBodyHandlerTests.swift
@@ -157,4 +157,113 @@ struct TerminalTranscriptItemFullBodyHandlerTests {
         #expect(result.text.count == 5000)
         #expect(result.text == bigPayload)
     }
+
+    // MARK: - includeBody
+
+    /// Plants a single-line JSONL fixture in the only place
+    /// `ClaudeProjectDirectory` looks (`~/.claude/projects/<encoded>/`) and
+    /// registers a terminal pointing at it. The caller removes `projectDir`.
+    private func plantFixture(line: [String: Any]) async throws -> (terminalID: UUID, projectDir: URL) {
+        let projectsBase = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".claude/projects")
+        try FileManager.default.createDirectory(at: projectsBase, withIntermediateDirectories: true)
+
+        let wtPath = "/private/tmp/tbd-fullbody-\(UUID().uuidString)"
+        let encoded = wtPath.map { "/.".contains($0) ? "-" : String($0) }.joined()
+        let projectDir = projectsBase.appendingPathComponent(encoded)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        let sessionID = UUID().uuidString
+        let lineData = try JSONSerialization.data(withJSONObject: line)
+        let lineStr = try #require(String(data: lineData, encoding: .utf8))
+        try (lineStr + "\n").write(
+            toFile: projectDir.appendingPathComponent("\(sessionID).jsonl").path,
+            atomically: true, encoding: .utf8)
+        ClaudeProjectDirectory.clearCache()
+
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "test-wt", branch: "tbd/test-wt",
+            path: wtPath, tmuxServer: "tbd-test")
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@mock-0", tmuxPaneID: "%mock-0",
+            claudeSessionID: sessionID)
+        return (terminal.id, projectDir)
+    }
+
+    /// A `nested_memory` attachment row: a large injected CLAUDE.md body plus
+    /// the injection metadata the overlay renders.
+    private func injectedMemoryLine(body: String, path: String) -> [String: Any] {
+        [
+            "type": "attachment",
+            "uuid": "att-acme",
+            "timestamp": "2026-07-24T10:00:00.000Z",
+            "attachment": [
+                "type": "nested_memory",
+                "displayPath": ".github/CLAUDE.md",
+                "path": path,
+                "content": ["path": path, "type": "Project", "content": body],
+            ],
+        ]
+    }
+
+    @Test("includeBody: false returns the metadata with no body text")
+    func metadataOnlyOmitsBody() async throws {
+        let body = String(repeating: "z", count: 43_000)
+        let planted = try await plantFixture(
+            line: injectedMemoryLine(body: body, path: "/srv/acme-prod/.github/CLAUDE.md"))
+        defer { try? FileManager.default.removeItem(at: planted.projectDir) }
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalTranscriptItemFullBody,
+            params: TerminalTranscriptItemFullBodyParams(
+                terminalID: planted.terminalID, itemID: "att-acme", includeBody: false)))
+
+        #expect(response.success)
+        let result = try response.decodeResult(TerminalTranscriptItemFullBodyResult.self)
+        #expect(result.text.isEmpty, "the 43 KB body must not cross the wire")
+        let attachment = try #require(result.attachment)
+        #expect(attachment.memoryType == "Project")
+        #expect(attachment.path == "/srv/acme-prod/.github/CLAUDE.md")
+    }
+
+    @Test("default (includeBody: true) still returns the body alongside the metadata")
+    func defaultIncludesBody() async throws {
+        let body = String(repeating: "z", count: 43_000)
+        let planted = try await plantFixture(
+            line: injectedMemoryLine(body: body, path: "/srv/acme-prod/.github/CLAUDE.md"))
+        defer { try? FileManager.default.removeItem(at: planted.projectDir) }
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalTranscriptItemFullBody,
+            params: TerminalTranscriptItemFullBodyParams(
+                terminalID: planted.terminalID, itemID: "att-acme")))
+
+        #expect(response.success)
+        let result = try response.decodeResult(TerminalTranscriptItemFullBodyResult.self)
+        #expect(result.text == body)
+        #expect(result.attachment?.memoryType == "Project")
+    }
+
+    /// Wire back-compat: params encoded by a client predating `includeBody`
+    /// (key absent) must still get the body.
+    @Test("params without includeBody behave as includeBody: true")
+    func legacyParamsIncludeBody() async throws {
+        let body = "acme guidance"
+        let planted = try await plantFixture(
+            line: injectedMemoryLine(body: body, path: "/srv/acme-prod/.github/CLAUDE.md"))
+        defer { try? FileManager.default.removeItem(at: planted.projectDir) }
+
+        let legacyParams = #"{"terminalID":"\#(planted.terminalID.uuidString)","itemID":"att-acme"}"#
+        let response = await router.handle(RPCRequest(
+            method: RPCMethod.terminalTranscriptItemFullBody, params: legacyParams))
+
+        #expect(response.success)
+        let result = try response.decodeResult(TerminalTranscriptItemFullBodyResult.self)
+        #expect(result.text == body)
+    }
 }

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -641,42 +641,73 @@ struct TranscriptParserTests {
         #expect(TranscriptParser.lookupFullBody(filePath: tmp, itemID: "att-hac#1") == "second injected block")
     }
 
-    @Test func attachment_hookSuccess_extracts_additionalContext_from_stdout_json() throws {
-        let stdout = #"{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"acme ADR applies here"}}"#
-        let line = try attachmentLine(uuid: "att-hs", [
-            "type": "hook_success",
-            "hookName": "PostToolUse:Read",
-            "content": "",
-            "stdout": stdout
-        ])
-        let tmp = try writeTempJSONL(line)
+    @Test func attachment_hookSuccess_ignores_additionalContext_in_stdout() throws {
+        // A hook's stdout is what it EMITTED; `hook_additional_context` is what
+        // was actually INJECTED. Measured across 120+ real sessions, the latter
+        // covers 100% of the former — so the stdout path is pure redundancy and
+        // emits nothing. The hac twin is the row that renders.
+        let injected = "acme ADR applies here"
+        let stdout = #"{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"\#(injected)"}}"#
+        let lines = [
+            try attachmentLine(uuid: "att-hs", [
+                "type": "hook_success",
+                "hookName": "PostToolUse:Read",
+                "content": "",
+                "stdout": stdout
+            ]),
+            try attachmentLine(uuid: "att-hac", [
+                "type": "hook_additional_context",
+                "hookName": "PostToolUse:Read",
+                "content": [injected]
+            ])
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
         defer { try? FileManager.default.removeItem(atPath: tmp) }
 
-        let row = try #require(reminders(TranscriptParser.parse(filePath: tmp)).first)
-        #expect(row.id == "att-hs")
+        let found = reminders(TranscriptParser.parse(filePath: tmp))
+        #expect(found.count == 1, "hook_success stdout must contribute nothing")
+        let row = try #require(found.first)
+        #expect(row.id == "att-hac")
         #expect(row.kind == .hookOutput)
         #expect(row.source == "PostToolUse:Read")
-        #expect(row.text == "acme ADR applies here")
+        #expect(row.text == injected)
     }
 
-    @Test func attachment_hookSuccess_accepts_array_additionalContext() throws {
-        let stdout = #"{"hookSpecificOutput":{"additionalContext":["one","two"]}}"#
-        let line = try attachmentLine(uuid: "att-arr", [
+    @Test func attachment_buildItems_is_window_independent_for_hookSuccess_pair() throws {
+        // `parseTail` hands `buildItems` only the lines inside its byte window.
+        // Any cross-row state (a dedup set, say) would make the same row parse
+        // differently depending on what preceded it — breaking parseTail's
+        // identical-bottom guarantee. Parse the pair, then parse the second row
+        // alone, and require the item to be identical.
+        let injected = "acme ADR applies here"
+        let stdout = #"{"hookSpecificOutput":{"additionalContext":"\#(injected)"}}"#
+        let hsLine = try attachmentLine(uuid: "att-hs", [
             "type": "hook_success", "hookName": "SessionStart", "content": "", "stdout": stdout
         ])
-        let tmp = try writeTempJSONL(line)
-        defer { try? FileManager.default.removeItem(atPath: tmp) }
+        let hacLine = try attachmentLine(uuid: "att-hac", [
+            "type": "hook_additional_context", "hookName": "SessionStart", "content": [injected]
+        ])
 
-        #expect(reminders(TranscriptParser.parse(filePath: tmp)).map(\.text) == ["one", "two"])
+        let both = try writeTempJSONL([hsLine, hacLine].joined(separator: "\n"))
+        defer { try? FileManager.default.removeItem(atPath: both) }
+        let windowOnly = try writeTempJSONL(hacLine)
+        defer { try? FileManager.default.removeItem(atPath: windowOnly) }
+
+        let fullTail = try #require(TranscriptParser.parse(filePath: both).last)
+        let windowed = try #require(TranscriptParser.parse(filePath: windowOnly).last)
+        #expect(fullTail == windowed)
     }
 
     @Test func attachment_hookSuccess_plain_content_emits_once() throws {
-        // Non-JSON stdout is the same text `content` already carries — one item.
+        // The plain-text branch survives — `hook_success.content` is never
+        // mirrored in a hook_additional_context row (221/221 unique across the
+        // corpus), so dropping it would lose the text entirely. `stdout` never
+        // contributes, JSON or not, so exactly one item comes out.
         let line = try attachmentLine(uuid: "att-plain", [
             "type": "hook_success",
             "hookName": "SessionStart:startup",
             "content": "Cleared: /tmp/acme-work-claimed",
-            "stdout": "Cleared: /tmp/acme-work-claimed\n"
+            "stdout": #"{"hookSpecificOutput":{"additionalContext":"something else entirely"}}"#
         ])
         let tmp = try writeTempJSONL(line)
         defer { try? FileManager.default.removeItem(atPath: tmp) }
@@ -698,11 +729,12 @@ struct TranscriptParserTests {
         #expect(TranscriptParser.parse(filePath: tmp).isEmpty)
     }
 
-    @Test func attachment_hookSuccess_payload_deduped_against_later_additionalContext() throws {
-        // The hook EMITS a payload (hook_success), then the same string is
-        // INJECTED (hook_additional_context) — one row, not two. A payload the
-        // injector REPLACED (an oversize `<persisted-output>` notice) is
-        // distinct and must survive.
+    @Test func attachment_injected_context_comes_only_from_additionalContext_row() throws {
+        // The hook EMITS a payload (hook_success stdout), and what actually
+        // entered the context window lands in the hook_additional_context row —
+        // sometimes verbatim, sometimes as the `<persisted-output>` notice that
+        // REPLACED an oversized payload. Only the hac row renders; every item
+        // stays addressable by `lookupFullBody`.
         let emitted = "acme skill rules apply"
         let stdout = try String(
             decoding: JSONSerialization.data(
@@ -723,9 +755,7 @@ struct TranscriptParserTests {
 
         let found = reminders(TranscriptParser.parse(filePath: tmp))
         #expect(found.map(\.text) == [emitted, "<persisted-output>\nOutput too large (22.2KB).\n</persisted-output>"])
-        // The surviving hac payload keeps the id it would have had regardless
-        // of dedup, so `lookupFullBody` can still find it.
-        #expect(found.map(\.id) == ["hs-1", "hac-1#1"])
+        #expect(found.map(\.id) == ["hac-1#0", "hac-1#1"])
         #expect(TranscriptParser.lookupFullBody(filePath: tmp, itemID: "hac-1#1")?.hasPrefix("<persisted-output>") == true)
     }
 

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -785,6 +785,279 @@ struct TranscriptParserTests {
         #expect(TranscriptParser.parse(filePath: tmp).isEmpty)
     }
 
+    // MARK: - injected path normalization
+    //
+    // Tier 1. Claude Code writes `displayPath` relative to the cwd, so a file
+    // outside the repo arrives as `../../../../../../private/tmp/…` — useless
+    // once the row middle-truncates it.
+
+    @Test func injectedPath_in_repo_displayPath_is_used_verbatim() throws {
+        // The nicest form already: no `../`, no home prefix. Must not change.
+        let line = try attachmentLine(uuid: "att-inrepo", [
+            "type": "nested_memory",
+            "displayPath": ".github/CLAUDE.md",
+            "path": "\(NSHomeDirectory())/acme-prod/.github/CLAUDE.md",
+            "content": ["type": "Project", "content": "# acme rules"]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(reminders(TranscriptParser.parse(filePath: tmp)).first?.source == ".github/CLAUDE.md")
+    }
+
+    @Test func injectedPath_escaping_displayPath_falls_back_to_tilde_absolute() throws {
+        let absolute = "\(NSHomeDirectory())/scratch/acme/iam-pr-body.md"
+        let line = try attachmentLine(uuid: "att-escape", [
+            "type": "file",
+            "displayPath": "../../../../../../scratch/acme/iam-pr-body.md",
+            "filename": "iam-pr-body.md",
+            "content": ["type": "text", "file": ["filePath": absolute, "content": "body"]]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let source = try #require(reminders(TranscriptParser.parse(filePath: tmp)).first?.source)
+        #expect(source == "~/scratch/acme/iam-pr-body.md")
+        #expect(!source.hasPrefix("../"), "an escaping relative path must never reach the row")
+    }
+
+    @Test func injectedPath_missing_displayPath_uses_absolute_path() throws {
+        // No `displayPath` at all: `attachment.path` is the only absolute form.
+        let line = try attachmentLine(uuid: "att-nodp", [
+            "type": "nested_memory",
+            "path": "/opt/acme/CLAUDE.md",
+            "content": ["type": "Project", "content": "# acme rules"]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        // Outside $HOME, so no tilde to collapse — the absolute path stands.
+        #expect(reminders(TranscriptParser.parse(filePath: tmp)).first?.source == "/opt/acme/CLAUDE.md")
+    }
+
+    @Test func injectedPath_escaping_with_no_absolute_falls_back_to_filename() throws {
+        let line = try attachmentLine(uuid: "att-fname", [
+            "type": "file",
+            "displayPath": "../../../tmp/acme/notes.md",
+            "filename": "notes.md",
+            "content": ["type": "text", "file": ["content": "body"]]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(reminders(TranscriptParser.parse(filePath: tmp)).first?.source == "notes.md")
+    }
+
+    @Test func injectedPath_last_resort_is_the_display_paths_last_component() {
+        // Neither an absolute path nor a filename: strip the escape prefix
+        // rather than rendering `../../..`.
+        #expect(TranscriptParser.injectedPathSource(
+            displayPath: "../../../tmp/acme/notes.md", absolutePath: nil, filename: nil) == "notes.md")
+        #expect(TranscriptParser.injectedPathSource(
+            displayPath: nil, absolutePath: nil, filename: nil) == nil)
+    }
+
+    // MARK: - injection metadata (overlay round-trip payload)
+    //
+    // Tier 1. Metadata rides `lookupDetail` — the same round-trip the overlay
+    // already makes for a full body — so nothing is added to `TranscriptItem`.
+
+    /// One assistant line carrying a single `tool_use` block.
+    private func toolUseLine(uuid: String, id: String, name: String, input: [String: Any]) throws -> String {
+        let row: [String: Any] = [
+            "type": "assistant",
+            "uuid": uuid,
+            "timestamp": "2026-07-24T09:59:59.000Z",
+            "message": ["role": "assistant", "content": [
+                ["type": "tool_use", "id": id, "name": name, "input": input]
+            ]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: row)
+        return try #require(String(bytes: data, encoding: .utf8))
+    }
+
+    @Test func metadata_hookSuccess_carries_hook_command_exit_duration_stderr() throws {
+        let line = try attachmentLine(uuid: "att-hs", [
+            "type": "hook_success",
+            "hookName": "PostToolUse:Read",
+            "hookEvent": "PostToolUse",
+            "command": #"python3 "${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.py""#,
+            "exitCode": 0,
+            "durationMs": 142,
+            "stderr": "acme: cache miss",
+            "content": "Injected acme guidance"
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let detail = TranscriptParser.lookupDetail(filePath: tmp, itemID: "att-hs")
+        #expect(detail.text == "Injected acme guidance")
+        let m = try #require(detail.attachment)
+        #expect(m.hookName == "PostToolUse:Read")
+        #expect(m.hookEvent == "PostToolUse")
+        #expect(m.command == #"python3 "${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.py""#)
+        #expect(m.exitCode == 0)
+        #expect(m.durationMs == 142)
+        #expect(m.stderr == "acme: cache miss")
+        #expect(m.memoryType == nil, "memory tier is meaningless for a hook row")
+    }
+
+    @Test func metadata_omits_blank_and_absent_fields() throws {
+        // Empty strings must read as absent so the overlay can omit the line
+        // instead of rendering an empty value.
+        let line = try attachmentLine(uuid: "att-blank", [
+            "type": "hook_additional_context",
+            "hookName": "SessionStart:compact",
+            "stderr": "   ",
+            "content": ["injected"]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let m = try #require(TranscriptParser.lookupDetail(filePath: tmp, itemID: "att-blank").attachment)
+        #expect(m.hookName == "SessionStart:compact")
+        #expect(m.stderr == nil)
+        #expect(m.command == nil)
+        #expect(m.exitCode == nil)
+        #expect(m.path == nil)
+    }
+
+    @Test func metadata_nestedMemory_carries_tier_and_absolute_path() throws {
+        let absolute = "\(NSHomeDirectory())/acme-prod/.github/CLAUDE.md"
+        let line = try attachmentLine(uuid: "att-mem", [
+            "type": "nested_memory",
+            "displayPath": ".github/CLAUDE.md",
+            "path": absolute,
+            "content": ["path": absolute, "type": "Project", "content": "# acme rules"]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let m = try #require(TranscriptParser.lookupDetail(filePath: tmp, itemID: "att-mem").attachment)
+        #expect(m.memoryType == "Project")
+        // The FULL absolute path — the overlay abbreviates for display and
+        // copies this verbatim.
+        #expect(m.path == absolute)
+        #expect(m.hookName == nil)
+    }
+
+    @Test func metadata_file_carries_path_but_no_memory_tier() throws {
+        let line = try attachmentLine(uuid: "att-file", [
+            "type": "file",
+            "displayPath": "src/acme/deploy.swift",
+            "filename": "deploy.swift",
+            "content": ["type": "text",
+                        "file": ["filePath": "/srv/acme-prod/src/acme/deploy.swift", "content": "func deployAcme() {}"]]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let m = try #require(TranscriptParser.lookupDetail(filePath: tmp, itemID: "att-file").attachment)
+        #expect(m.path == "/srv/acme-prod/src/acme/deploy.swift")
+        #expect(m.memoryType == nil, "a file row's inner type is just \"text\", not a memory tier")
+    }
+
+    @Test func metadata_is_nil_for_non_attachment_rows() throws {
+        let lines = [
+            try toolUseLine(uuid: "a1", id: "toolu_1", name: "Read",
+                            input: ["file_path": "/srv/acme-prod/.github/workflows/ai-review-gate.yml"]),
+            #"{"type":"user","uuid":"u1","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"file body"}]}}"#
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let detail = TranscriptParser.lookupDetail(filePath: tmp, itemID: "toolu_1")
+        #expect(detail.text == "file body")
+        #expect(detail.attachment == nil)
+    }
+
+    // MARK: - hook attribution (attachment.toolUseID → triggering tool call)
+
+    @Test func attribution_resolves_toolUseID_to_tool_name_and_input_summary() throws {
+        let lines = [
+            try toolUseLine(uuid: "a1", id: "toolu_1", name: "Read",
+                            input: ["file_path": "/srv/acme-prod/.github/workflows/ai-review-gate.yml"]),
+            try attachmentLine(uuid: "att-hac", [
+                "type": "hook_additional_context",
+                "hookName": "PostToolUse:Read",
+                "toolUseID": "toolu_1",
+                "content": ["acme review gate applies"]
+            ])
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let m = try #require(TranscriptParser.lookupDetail(filePath: tmp, itemID: "att-hac").attachment)
+        #expect(m.triggeredBy == "Read ai-review-gate.yml")
+    }
+
+    @Test func attribution_omitted_when_toolUseID_resolves_to_nothing() throws {
+        // ~3% of real hook rows name a tool_use that isn't in the file. Omit
+        // the line entirely — never "unknown", never a guess.
+        let lines = [
+            try toolUseLine(uuid: "a1", id: "toolu_1", name: "Read", input: ["file_path": "/srv/acme-prod/main.swift"]),
+            try attachmentLine(uuid: "att-orphan", [
+                "type": "hook_additional_context",
+                "hookName": "PostToolUse:Read",
+                "toolUseID": "toolu_missing",
+                "content": ["acme guidance"]
+            ])
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let m = try #require(TranscriptParser.lookupDetail(filePath: tmp, itemID: "att-orphan").attachment)
+        #expect(m.triggeredBy == nil)
+        #expect(m.hookName == "PostToolUse:Read", "the rest of the metadata still lands")
+    }
+
+    @Test func attribution_absent_for_nestedMemory_and_file_rows() throws {
+        // Neither flavor carries a `toolUseID`, and NOTHING in the JSONL links a
+        // CLAUDE.md load to the Read that touched its directory. Inferring one
+        // from row position would be positional guesswork — attribution is
+        // simply absent, even with a tool_use sitting immediately above.
+        let lines = [
+            try toolUseLine(uuid: "a1", id: "toolu_1", name: "Read",
+                            input: ["file_path": "/srv/acme-prod/.github/deploy.yml"]),
+            try attachmentLine(uuid: "att-mem", [
+                "type": "nested_memory",
+                "displayPath": ".github/CLAUDE.md",
+                "path": "/srv/acme-prod/.github/CLAUDE.md",
+                "content": ["type": "Project", "content": "# acme rules"]
+            ]),
+            try attachmentLine(uuid: "att-file", [
+                "type": "file",
+                "displayPath": "src/acme/deploy.swift",
+                "content": ["type": "text", "file": ["filePath": "/srv/acme-prod/src/acme/deploy.swift",
+                                                     "content": "func deployAcme() {}"]]
+            ])
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        for itemID in ["att-mem", "att-file"] {
+            let m = try #require(TranscriptParser.lookupDetail(filePath: tmp, itemID: itemID).attachment)
+            #expect(m.triggeredBy == nil, "\(itemID) must carry no attribution")
+        }
+    }
+
+    @Test func attribution_summary_shapes_per_tool() {
+        #expect(TranscriptParser.toolInputSummary(
+            name: "Read", input: ["file_path": "/srv/acme-prod/Sources/Deploy.swift"]) == "Read Deploy.swift")
+        #expect(TranscriptParser.toolInputSummary(
+            name: "Bash", input: ["command": "swift build", "description": "Build acme"]) == "Bash Build acme")
+        #expect(TranscriptParser.toolInputSummary(
+            name: "Bash", input: ["command": "swift build"]) == "Bash swift build")
+        #expect(TranscriptParser.toolInputSummary(
+            name: "Grep", input: ["pattern": "TODO", "path": "Sources"]) == "Grep TODO")
+        #expect(TranscriptParser.toolInputSummary(name: "TodoWrite", input: [:]) == "TodoWrite")
+        // Long inputs are clipped, one line, with an ellipsis.
+        let summary = TranscriptParser.toolInputSummary(
+            name: "Bash", input: ["command": String(repeating: "acme ", count: 40)])
+        #expect(summary.count <= "Bash ".count + 41)
+        #expect(summary.hasSuffix("…"))
+    }
+
     // MARK: - helpers
 
     private func writeTempJSONL(_ contents: String) throws -> String {

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -848,6 +848,30 @@ struct TranscriptParserTests {
         #expect(reminders(TranscriptParser.parse(filePath: tmp)).first?.source == "notes.md")
     }
 
+    // The `~` abbreviation must match whole path components. A substring
+    // replace of `NSHomeDirectory()` mangled sibling and nested paths.
+    @Test func injectedPath_tilde_abbreviation_is_component_boundary_aware() {
+        let home = NSHomeDirectory()
+        let leaf = (home as NSString).lastPathComponent
+        let parent = (home as NSString).deletingLastPathComponent
+
+        // A genuine home-prefixed path abbreviates.
+        #expect(TranscriptParser.injectedPathSource(
+            displayPath: nil, absolutePath: "\(home)/acme-prod/CLAUDE.md", filename: nil)
+            == "~/acme-prod/CLAUDE.md")
+
+        // A *sibling* directory whose name merely starts with the home leaf is
+        // a different directory and must be left alone.
+        let sibling = "\(parent)/\(leaf)log-archive/CLAUDE.md"
+        #expect(TranscriptParser.injectedPathSource(
+            displayPath: nil, absolutePath: sibling, filename: nil) == sibling)
+
+        // Home appearing mid-path (an external volume) must not be spliced.
+        let onVolume = "/Volumes/T7\(home)/notes.md"
+        #expect(TranscriptParser.injectedPathSource(
+            displayPath: nil, absolutePath: onVolume, filename: nil) == onVolume)
+    }
+
     @Test func injectedPath_last_resort_is_the_display_paths_last_component() {
         // Neither an absolute path nor a filename: strip the escape prefix
         // rather than rendering `../../..`.

--- a/Tests/TBDDaemonTests/TranscriptParserTests.swift
+++ b/Tests/TBDDaemonTests/TranscriptParserTests.swift
@@ -87,7 +87,7 @@ struct TranscriptParserTests {
 
         let items = TranscriptParser.parse(filePath: tmp)
         #expect(items.count == 1)
-        if case .systemReminder(_, let kind, _, _) = items[0] {
+        if case .systemReminder(_, let kind, _, _, _, _) = items[0] {
             #expect(kind == .toolReminder)
         } else {
             Issue.record("expected .systemReminder")
@@ -203,7 +203,7 @@ struct TranscriptParserTests {
 
         let items = TranscriptParser.parse(filePath: tmp)
         #expect(items.count == 1)
-        if case .systemReminder(_, let kind, let text, _) = items[0] {
+        if case .systemReminder(_, let kind, let text, _, _, _) = items[0] {
             #expect(kind == .skillBody)
             #expect(text.hasPrefix("Base directory for this skill:"))
         } else {
@@ -243,7 +243,7 @@ struct TranscriptParserTests {
         // Exactly one .systemReminder with kind .taskNotification preserving the
         // full original notification text.
         let reminders = items.compactMap { item -> (SystemKind, String)? in
-            if case .systemReminder(_, let kind, let text, _) = item { return (kind, text) }
+            if case .systemReminder(_, let kind, let text, _, _, _) = item { return (kind, text) }
             return nil
         }
         #expect(reminders.count == 1)
@@ -412,7 +412,7 @@ struct TranscriptParserTests {
         case .userPrompt(let id, let t, _): return "userPrompt|\(id)|\(t)"
         case .assistantText(let id, let t, _, _): return "assistantText|\(id)|\(t)"
         case .thinking(let id, let t, _): return "thinking|\(id)|\(t)"
-        case .systemReminder(let id, let kind, let t, _): return "systemReminder|\(id)|\(kind)|\(t)"
+        case .systemReminder(let id, let kind, let t, _, _, _): return "systemReminder|\(id)|\(kind)|\(t)"
         case .toolCall(let id, let name, _, _, let result, _, _, _):
             return "toolCall|\(id)|\(name)|\(result?.text ?? "<nil>")"
         case .slashCommand(let id, let name, let args, _):
@@ -527,6 +527,232 @@ struct TranscriptParserTests {
         let tail = TranscriptParser.parseTail(filePath: tmp, limit: 5)
         #expect(tail.count == 5)
         #expect(full.suffix(5).map(signature) == tail.map(signature))
+    }
+
+    // MARK: - attachments (hook- and CLAUDE.md-injected context)
+    //
+    // Tier 1. Fixture rows mirror the real shapes observed in a live Claude
+    // Code session JSONL (an `attachment` row per flavor); paths and hook
+    // payloads are rewritten to acme placeholders and shortened, except where
+    // a test needs to cross the 2000-char truncation cap.
+
+    /// Builds one `type:"attachment"` JSONL line from an attachment dict.
+    private func attachmentLine(uuid: String, _ attachment: [String: Any]) throws -> String {
+        let row: [String: Any] = [
+            "type": "attachment",
+            "uuid": uuid,
+            "timestamp": "2026-07-24T10:00:00.000Z",
+            "attachment": attachment
+        ]
+        let data = try JSONSerialization.data(withJSONObject: row)
+        return try #require(String(bytes: data, encoding: .utf8))
+    }
+
+    private func reminders(_ items: [TranscriptItem]) -> [(id: String, kind: SystemKind, text: String, source: String?, truncatedTo: Int?)] {
+        items.compactMap {
+            if case .systemReminder(let id, let kind, let text, _, let source, let truncatedTo) = $0 {
+                return (id, kind, text, source, truncatedTo)
+            }
+            return nil
+        }
+    }
+
+    @Test func attachment_nestedMemory_unwraps_nested_content_dict() throws {
+        // `attachment.content` is an OBJECT here; the CLAUDE.md body sits at
+        // `content.content`. A naive `content as? String` drops it entirely.
+        let line = try attachmentLine(uuid: "att-mem", [
+            "type": "nested_memory",
+            "displayPath": ".github/CLAUDE.md",
+            "path": "/Users/dev/acme-prod/.github/CLAUDE.md",
+            "content": ["path": "/Users/dev/acme-prod/.github/CLAUDE.md",
+                        "type": "nested_memory",
+                        "content": "# acme-prod workflow rules"]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let found = reminders(TranscriptParser.parse(filePath: tmp))
+        #expect(found.count == 1)
+        let row = try #require(found.first)
+        #expect(row.id == "att-mem")
+        #expect(row.kind == .nestedMemory)
+        #expect(row.text == "# acme-prod workflow rules")
+        #expect(row.source == ".github/CLAUDE.md")
+        #expect(row.truncatedTo == nil)
+    }
+
+    @Test func attachment_nestedMemory_long_body_records_original_length() throws {
+        let body = String(repeating: "acme rule line\n", count: 400)  // > 2000 chars, > 20 lines
+        let line = try attachmentLine(uuid: "att-big", [
+            "type": "nested_memory",
+            "displayPath": "CLAUDE.md",
+            "content": ["content": body]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let row = try #require(reminders(TranscriptParser.parse(filePath: tmp)).first)
+        #expect(row.text.count < body.count, "body must be truncated for the collapsed row")
+        #expect(row.truncatedTo == body.count, "truncatedTo carries the ORIGINAL character count")
+
+        // The click-to-open overlay must be able to recover the whole thing —
+        // attachment rows carry no `message`, so this needs its own branch.
+        #expect(TranscriptParser.lookupFullBody(filePath: tmp, itemID: "att-big") == body)
+    }
+
+    @Test func attachment_file_unwraps_dict_in_dict_body() throws {
+        // An @-mentioned file: `attachment.content` is an object whose `file`
+        // sub-object holds the body — one level deeper than `nested_memory`.
+        let line = try attachmentLine(uuid: "att-file", [
+            "type": "file",
+            "displayPath": "src/acme/deploy.swift",
+            "filename": "deploy.swift",
+            "content": ["type": "text",
+                        "file": ["filePath": "/Users/dev/acme-prod/src/acme/deploy.swift",
+                                 "content": "func deployAcme() {}\n"]]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let found = reminders(TranscriptParser.parse(filePath: tmp))
+        #expect(found.count == 1)
+        let row = try #require(found.first)
+        #expect(row.id == "att-file")
+        #expect(row.kind == .nestedMemory)
+        #expect(row.text == "func deployAcme() {}\n")
+        #expect(row.source == "src/acme/deploy.swift")
+    }
+
+    @Test func attachment_hookAdditionalContext_unwraps_string_array_and_suffixes_ids() throws {
+        // `attachment.content` is an ARRAY of strings — one item per element.
+        let line = try attachmentLine(uuid: "att-hac", [
+            "type": "hook_additional_context",
+            "hookName": "SessionStart",
+            "content": ["first injected block", "second injected block"]
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let found = reminders(TranscriptParser.parse(filePath: tmp))
+        #expect(found.map(\.id) == ["att-hac#0", "att-hac#1"])
+        #expect(found.map(\.text) == ["first injected block", "second injected block"])
+        #expect(found.allSatisfy { $0.kind == .hookOutput && $0.source == "SessionStart" })
+
+        #expect(TranscriptParser.lookupFullBody(filePath: tmp, itemID: "att-hac#1") == "second injected block")
+    }
+
+    @Test func attachment_hookSuccess_extracts_additionalContext_from_stdout_json() throws {
+        let stdout = #"{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"acme ADR applies here"}}"#
+        let line = try attachmentLine(uuid: "att-hs", [
+            "type": "hook_success",
+            "hookName": "PostToolUse:Read",
+            "content": "",
+            "stdout": stdout
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let row = try #require(reminders(TranscriptParser.parse(filePath: tmp)).first)
+        #expect(row.id == "att-hs")
+        #expect(row.kind == .hookOutput)
+        #expect(row.source == "PostToolUse:Read")
+        #expect(row.text == "acme ADR applies here")
+    }
+
+    @Test func attachment_hookSuccess_accepts_array_additionalContext() throws {
+        let stdout = #"{"hookSpecificOutput":{"additionalContext":["one","two"]}}"#
+        let line = try attachmentLine(uuid: "att-arr", [
+            "type": "hook_success", "hookName": "SessionStart", "content": "", "stdout": stdout
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(reminders(TranscriptParser.parse(filePath: tmp)).map(\.text) == ["one", "two"])
+    }
+
+    @Test func attachment_hookSuccess_plain_content_emits_once() throws {
+        // Non-JSON stdout is the same text `content` already carries — one item.
+        let line = try attachmentLine(uuid: "att-plain", [
+            "type": "hook_success",
+            "hookName": "SessionStart:startup",
+            "content": "Cleared: /tmp/acme-work-claimed",
+            "stdout": "Cleared: /tmp/acme-work-claimed\n"
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let found = reminders(TranscriptParser.parse(filePath: tmp))
+        #expect(found.count == 1)
+        #expect(found.first?.text == "Cleared: /tmp/acme-work-claimed")
+        #expect(found.first?.source == "SessionStart:startup")
+    }
+
+    @Test func attachment_hookSuccess_empty_stdout_object_emits_nothing() throws {
+        // The overwhelmingly common case: `stdout` is literally "{}\n".
+        let line = try attachmentLine(uuid: "att-empty", [
+            "type": "hook_success", "hookName": "PostToolUse:Bash", "content": "", "stdout": "{}\n"
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(TranscriptParser.parse(filePath: tmp).isEmpty)
+    }
+
+    @Test func attachment_hookSuccess_payload_deduped_against_later_additionalContext() throws {
+        // The hook EMITS a payload (hook_success), then the same string is
+        // INJECTED (hook_additional_context) — one row, not two. A payload the
+        // injector REPLACED (an oversize `<persisted-output>` notice) is
+        // distinct and must survive.
+        let emitted = "acme skill rules apply"
+        let stdout = try String(
+            decoding: JSONSerialization.data(
+                withJSONObject: ["hookSpecificOutput": ["additionalContext": emitted]]),
+            as: UTF8.self)
+        let lines = [
+            try attachmentLine(uuid: "hs-1", [
+                "type": "hook_success", "hookName": "SessionStart", "content": "", "stdout": stdout
+            ]),
+            try attachmentLine(uuid: "hac-1", [
+                "type": "hook_additional_context",
+                "hookName": "SessionStart",
+                "content": [emitted, "<persisted-output>\nOutput too large (22.2KB).\n</persisted-output>"]
+            ])
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let found = reminders(TranscriptParser.parse(filePath: tmp))
+        #expect(found.map(\.text) == [emitted, "<persisted-output>\nOutput too large (22.2KB).\n</persisted-output>"])
+        // The surviving hac payload keeps the id it would have had regardless
+        // of dedup, so `lookupFullBody` can still find it.
+        #expect(found.map(\.id) == ["hs-1", "hac-1#1"])
+        #expect(TranscriptParser.lookupFullBody(filePath: tmp, itemID: "hac-1#1")?.hasPrefix("<persisted-output>") == true)
+    }
+
+    @Test func attachment_skillListing_emits_hookOutput_named_skills() throws {
+        let line = try attachmentLine(uuid: "att-skills", [
+            "type": "skill_listing", "skillCount": 2, "content": "acme-deploy, acme-review"
+        ])
+        let tmp = try writeTempJSONL(line)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let row = try #require(reminders(TranscriptParser.parse(filePath: tmp)).first)
+        #expect(row.kind == .hookOutput)
+        #expect(row.source == "skills")
+        #expect(row.text == "acme-deploy, acme-review")
+    }
+
+    @Test func attachment_payloadless_flavors_emit_nothing() throws {
+        let lines = [
+            try attachmentLine(uuid: "att-tr", ["type": "task_reminder", "content": [], "itemCount": 0]),
+            try attachmentLine(uuid: "att-cp", ["type": "command_permissions", "allowedTools": ["Bash"]]),
+            try attachmentLine(uuid: "att-qc", ["type": "queued_command", "prompt": "go"]),
+            try attachmentLine(uuid: "att-dd", ["type": "deferred_tools_delta", "addedNames": ["X"]])
+        ].joined(separator: "\n")
+        let tmp = try writeTempJSONL(lines)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        #expect(TranscriptParser.parse(filePath: tmp).isEmpty)
     }
 
     // MARK: - helpers

--- a/Tests/TBDSharedTests/TerminalTranscriptRPCTests.swift
+++ b/Tests/TBDSharedTests/TerminalTranscriptRPCTests.swift
@@ -45,6 +45,26 @@ struct TerminalTranscriptRPCTests {
         let decoded = try JSONDecoder().decode(TerminalTranscriptItemFullBodyParams.self, from: data)
         #expect(decoded.terminalID == original.terminalID)
         #expect(decoded.itemID == "toolu_abc")
+        #expect(decoded.includeBody, "the body is included unless a caller opts out")
+    }
+
+    @Test func fullBody_params_roundtrip_metadata_only() throws {
+        let original = TerminalTranscriptItemFullBodyParams(
+            terminalID: UUID(), itemID: "att-acme", includeBody: false)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TerminalTranscriptItemFullBodyParams.self, from: data)
+        #expect(!decoded.includeBody)
+    }
+
+    /// A client predating the field omits it entirely — the daemon must decode
+    /// it as the body-carrying request it used to be.
+    @Test func fullBody_params_decode_without_includeBody_key_defaults_to_true() throws {
+        let id = UUID()
+        let json = Data(#"{"terminalID":"\#(id.uuidString)","itemID":"toolu_legacy"}"#.utf8)
+        let decoded = try JSONDecoder().decode(TerminalTranscriptItemFullBodyParams.self, from: json)
+        #expect(decoded.terminalID == id)
+        #expect(decoded.itemID == "toolu_legacy")
+        #expect(decoded.includeBody)
     }
 
     @Test func fullBody_result_codable_roundtrip() throws {

--- a/Tests/TBDSharedTests/TerminalTranscriptRPCTests.swift
+++ b/Tests/TBDSharedTests/TerminalTranscriptRPCTests.swift
@@ -52,5 +52,32 @@ struct TerminalTranscriptRPCTests {
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(TerminalTranscriptItemFullBodyResult.self, from: data)
         #expect(decoded.text == "complete content")
+        #expect(decoded.attachment == nil)
+    }
+
+    @Test func fullBody_result_carries_injection_metadata() throws {
+        let original = TerminalTranscriptItemFullBodyResult(
+            text: "injected",
+            attachment: TranscriptAttachmentMetadata(
+                hookName: "PostToolUse:Read", exitCode: 0, durationMs: 12,
+                path: "/srv/acme-prod/.github/CLAUDE.md", triggeredBy: "Read deploy.yml"))
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TerminalTranscriptItemFullBodyResult.self, from: data)
+        #expect(decoded.attachment == original.attachment)
+        #expect(decoded.attachment?.stderr == nil)
+    }
+
+    @Test func attachment_metadata_isEmpty_only_when_every_field_absent() {
+        #expect(TranscriptAttachmentMetadata().isEmpty)
+        #expect(!TranscriptAttachmentMetadata(exitCode: 0).isEmpty)
+        #expect(!TranscriptAttachmentMetadata(triggeredBy: "Read a.swift").isEmpty)
+    }
+
+    /// A daemon predating the field omits it entirely — the app must still decode.
+    @Test func fullBody_result_decodes_without_attachment_key() throws {
+        let json = Data(#"{"text":"legacy daemon"}"#.utf8)
+        let decoded = try JSONDecoder().decode(TerminalTranscriptItemFullBodyResult.self, from: json)
+        #expect(decoded.text == "legacy daemon")
+        #expect(decoded.attachment == nil)
     }
 }

--- a/Tests/TBDSharedTests/TranscriptItemTests.swift
+++ b/Tests/TBDSharedTests/TranscriptItemTests.swift
@@ -84,10 +84,42 @@ struct TranscriptItemTests {
         let original: TranscriptItem = .systemReminder(id: "s1", kind: .toolReminder, text: "hi", timestamp: nil)
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
-        guard case .systemReminder(_, let kind, _, _) = decoded else {
+        guard case .systemReminder(_, let kind, _, _, let source, let truncatedTo) = decoded else {
             Issue.record("expected .systemReminder"); return
         }
         #expect(kind == .toolReminder)
+        #expect(source == nil)
+        #expect(truncatedTo == nil)
+    }
+
+    @Test func roundtrip_systemReminder_nestedMemory_withSourceAndTruncation() throws {
+        let original: TranscriptItem = .systemReminder(
+            id: "s2", kind: .nestedMemory, text: "# acme rules", timestamp: nil,
+            source: ".github/CLAUDE.md", truncatedTo: 39_673)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(TranscriptItem.self, from: data)
+        guard case .systemReminder(let id, let kind, let text, _, let source, let truncatedTo) = decoded else {
+            Issue.record("expected .systemReminder"); return
+        }
+        #expect(id == "s2")
+        #expect(kind == .nestedMemory)
+        #expect(text == "# acme rules")
+        #expect(source == ".github/CLAUDE.md")
+        #expect(truncatedTo == 39_673)
+    }
+
+    /// An OLD binary decoding a NEW daemon's payload must not throw on a
+    /// SystemKind case it has never heard of — it degrades to `.other`.
+    @Test func systemKind_unknownRawValue_decodesToOther() throws {
+        let data = Data(#""someFutureKind""#.utf8)
+        let decoded = try JSONDecoder().decode(SystemKind.self, from: data)
+        #expect(decoded == .other)
+    }
+
+    @Test func systemKind_knownRawValue_stillRoundtrips() throws {
+        let data = try JSONEncoder().encode(SystemKind.nestedMemory)
+        #expect(String(bytes: data, encoding: .utf8) == #""nestedMemory""#)
+        #expect(try JSONDecoder().decode(SystemKind.self, from: data) == .nestedMemory)
     }
 
     @Test func roundtrip_slashCommand() throws {


### PR DESCRIPTION
## Summary

**What's broken.** Watching an agent in TBD showed a fraction of what it was actually told. Hooks and the harness inject context on every tool call — scoped rules, ADR pointers, skill listings, directory `CLAUDE.md` bodies, `@`-mentioned files — and none of it appeared in the transcript. Measured on one real session: a single 15-line `Read` pulled in ~88 KB (~22K tokens) that the viewer showed nothing of. Parsing that same session now surfaces **45 injected-context rows totalling ~370 KB** that were previously invisible.

**Why it happens.** `TranscriptParser.buildItems` branches on `user` and `assistant` rows. Injected context arrives on `type: "attachment"` rows, which matched no branch and fell through unrendered. `SystemKind` already had a `.hookOutput` case and `.systemReminder` already rendered — the vocabulary existed, attachments were just never wired into it.

**How it got broken.** Latent since the parser was written; attachment rows are a newer Claude Code transport, so there was never a branch to lose. Not caught because every test fixture was built from `user`/`assistant` rows, so the whole shape was untested.

## What this PR does

**1. Renders the injected context.** A per-flavor extraction seam shared by `buildItems` and `lookupFullBody`, so the collapsed row and the click-to-open overlay can't disagree.

The non-obvious part is that `attachment.content` has a **different native JSON type per flavor** — object for `nested_memory`, array for `hook_additional_context`, string for `hook_success`/`skill_listing`. A single `as? String` silently drops the two largest sources of injected context, which is exactly the trap that produced the original bug.

Only `hook_additional_context` is extracted for hook injections, not `hook_success`'s stdout. Measured across 120+ real sessions: `hook_additional_context` covers **100%** of `hook_success`'s stdout `additionalContext` — verbatim (130 cases) or as the `<persisted-output>` notice that replaced an oversized payload (all 11 apparent orphans had one; a 51,881-char payload became "Output too large (50.7KB)"). Meanwhile `hook_success.content` is never mirrored there (221/221 unique). So the stdout path was pure redundancy, and dropping it means **no cross-row dedup state is needed** — which keeps `buildItems` a pure function of its window and preserves `parseTail`'s identical-bottom guarantee. It's also more truthful: `hook_additional_context` is what actually entered the context window; a hook's stdout is merely what it emitted.

Collapsed rows carry the source and original size (`.github/CLAUDE.md · 44.3K chars`) — the signal that makes injection cost visible at a glance. Path rows truncate the *head*, so the filename always survives. Bodies reuse the existing 2000-char cap and are recoverable whole via `lookupFullBody`, which previously couldn't reach attachment rows because they carry no `message` key.

**2. Shows how the context got there.** The JSONL carries which hook fired, its literal command, exit code, duration, stderr, and a CLAUDE.md's memory tier — all of which we were discarding. The overlay now surfaces them through the full-body RPC it already calls, so nothing is paid until a row is opened and `TranscriptItem` gains no new fields. Paths get a tilde-abbreviated display plus a copy-full-path button.

**3. Attributes an injection to the tool call that caused it.** `attachment.toolUseID` resolves to a real `tool_use` in 2174/2232 hook rows on a real session, so the overlay can say `Triggered by: Read ai-review-gate.yml`.

**Attribution is deliberately absent where it cannot be known.** `nested_memory` and `file` rows carry no `toolUseID`, and nothing links a CLAUDE.md load to the Read that touched its directory. Inferring it from row position would be guesswork that reads as fact and breaks silently when rows are reordered or batched — the same family of inference this repo bans in its "No TUI screen-scraping" rule. An unresolvable id omits the line rather than printing "unknown".

**Deliberately excluded:** `task_reminder` (structured todo objects, not prose) and the 11 flavors carrying no `content` at all. The switch is an allowlist, not a generic fallback. Also out of scope: grouping injected rows under their triggering tool call, and aggregate per-tool-call cost badges.

**Schema skew:** `SystemKind` gains `.nestedMemory` plus a lenient decoder mapping unknown raw values to `.other`, so an app binary older than the daemon degrades instead of failing to decode. The two new `TranscriptItem.systemReminder` associated values are optional with defaults, and the new `includeBody` RPC param defaults to `true`, so older clients and persisted JSON are unaffected.

## Test plan

- [x] `swift build` clean; `swiftlint --strict` 0 violations
- [x] **Red-before-green verified by hand**: reverting only `TranscriptParser.swift` makes the new parser tests fail with 15 recorded issues; restoring it makes them pass
- [x] Parser tests built from real attachment row shapes cover each flavor, the dict/array unwrapping, `truncatedTo` on a >2000-char body, multi-payload ID suffixing, path-tier selection, metadata extraction, and attribution present/orphaned/absent
- [x] `attachment_buildItems_is_window_independent_for_hookSuccess_pair` pins the purity invariant the deleted dedup would have violated
- [x] **Verified live through the running daemon**, not just headless: `session.messages` over `~/tbd/sock` on a real 2.1 MB session returns 45 injected-context rows with correct source and size, and the 26,655-char SessionStart payload correctly renders as the 2,371-char `<persisted-output>` notice the model actually received
- [x] **Verified visually in the app** across two rounds; the maintainer drove the UI and reported back. Round 1 caught middle-truncation eating the filename and a gray-on-gray overlay body; both fixed in `a2bcc0d6` and re-confirmed live
- [x] Full suite green. A run taken while the machine was saturated (980s vs ~35s) failed 10 timing/tmux/subprocess suites; all 16 affected suites (131 tests) pass serially in ~29s, and no transcript/parser/RPC suite was among them

Rebased onto #505, which deleted the `Transcript/TextKit/` renderer this branch had also updated; those edits were dropped in favour of main's deletion, and `lastRenderedNodeID` went with it (deleted on main, no surviving callers).

Three review rounds were run against the branch. Known deferred nits: `stderr`/`command` render untruncated in the overlay, the metadata block is absent in Session History overlays (that RPC is terminal-scoped), and hook rows get no hover tooltip despite also truncating.

[20260724-amused-snake](https://cheapsteak.github.io/tbd/open/?worktree=0BC9328F-D012-4CCF-8EA1-1997CA7A6CF8)