### PR TITLE
Fix: Opus button in the worktree picker still spawns Opus 4.8 after Opus 5 shipped

### DIFF
--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -330,11 +330,17 @@ private struct ClaudeProfileRow: View {
 private struct ModelRailView: View {
     let onSelectModel: (String) -> Void
 
-    /// Per-spawn model buttons: label + exact model id.
+    /// Per-spawn model buttons: label + Claude Code model *alias*.
+    ///
+    /// Aliases, not pinned ids (`claude-opus-4-8`): the `claude` binary carries
+    /// the alias table (`opus` → latest opus, resolved per provider), so a CLI
+    /// auto-update picks up each new Opus/Sonnet/Fable with no TBD rebuild.
+    /// `ANTHROPIC_MODEL` — how the spawn delivers this (see
+    /// `ClaudeSpawnCommandBuilder`) — runs the same resolution as `--model`.
     private static let models: [(label: String, id: String, help: String)] = [
-        ("Fable", "claude-fable-5", "Spawn with Claude Fable 5"),
-        ("Opus", "claude-opus-4-8", "Spawn with Claude Opus 4.8"),
-        ("Sonnet", "claude-sonnet-5", "Spawn with Claude Sonnet 5"),
+        ("Fable", "fable", "Spawn with the latest Claude Fable"),
+        ("Opus", "opus", "Spawn with the latest Claude Opus"),
+        ("Sonnet", "sonnet", "Spawn with the latest Claude Sonnet"),
     ]
 
     var body: some View {

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -864,7 +864,8 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// existing precedence-based resolution. Not persisted — creation-time only.
     /// Optional/defaulted for backward compatibility with older clients.
     public let profileID: UUID?
-    /// Explicit per-creation Claude model override (e.g. "claude-fable-5"),
+    /// Explicit per-creation Claude model override — either a Claude Code alias
+    /// ("opus", what the model rail sends) or an exact id ("claude-opus-5"),
     /// injected as ANTHROPIC_MODEL for the new worktree's INITIAL Claude spawn
     /// only — later respawns (hibernation wake, new sessions) fall back to the
     /// profile default. nil preserves the profile's own model. Optional/


### PR DESCRIPTION
## Summary

**What's broken.** Clicking **Opus** in the new-worktree profile picker's model rail spawns **Opus 4.8**, not Opus 5. Same class of staleness waiting on the Fable and Sonnet buttons the next time either family ships a version.

**Why it happens.** The rail pinned exact model ids:

```swift
("Fable", "claude-fable-5", …), ("Opus", "claude-opus-4-8", …), ("Sonnet", "claude-sonnet-5", …)
```

Those strings are Swift source, so "the latest Opus" was only ever correct until the next release — every new model needed a TBD rebuild to catch up.

**How it got broken.** #464 introduced the rail with the ids pinned (`git log -S 'claude-opus-4-8'` fingers exactly that commit). It wasn't wrong at the time — `claude-opus-4-8` *was* the latest Opus — so nothing failed and no test could have caught it. It only started biting when Opus 5 shipped.

**What this PR does.** Passes the Claude Code **alias** (`opus`, `sonnet`, `fable`) instead of a pinned id. The `claude` binary carries the alias table itself:

```js
aliases: { opus: { default: "claude-opus-5", per_provider: { bedrock: "claude-opus-5", foundry: "claude-opus-4-6", gateway: "claude-opus-4-7" } }, … }
latest_per_family: { fable: "claude-fable-5", opus: "claude-opus-5", sonnet: "claude-sonnet-5", haiku: "claude-haiku-4-5" }
```

so a `claude` auto-update carries each new Opus/Sonnet/Fable with **no TBD rebuild**. This works because the rail's choice is delivered as `ANTHROPIC_MODEL` (`ClaudeSpawnCommandBuilder.swift:142`), which runs the same resolution path as `--model` (`hYn()` → `ZW()`) — aliases are first-class there, not just on the flag.

Two side effects worth calling out:

- **Bedrock/Vertex profiles are also fixed.** Aliases resolve *per provider*, so those profiles were previously handed a first-party id.
- **`opus` is not `opus[1m]`.** The CLI appends the `[1m]` suffix only when the 1M-context preference is on. Matching the previous pinned-id behavior, which never requested 1M either.

Help text drops the version number for the same reason the ids did (`"Spawn with the latest Claude Opus"`).

## Test plan

- [x] `swift build` — clean
- [x] `swiftlint --strict` — 0 violations in 585 files
- [ ] `scripts/restart.sh --app`, hover **+** in the sidebar, click **Opus** on a Claude profile row → new worktree's Claude reports Opus 5 (`/status`)
- [ ] Click **Sonnet** and **Fable** on the same row → Sonnet 5 / Fable 5, i.e. no regression from the previously-correct pins

No test added: the change is three string literals with no branching, and the behavior under test (alias → version) lives in the `claude` binary, not in TBD.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=80C792D1-1E03-4813-9340-52E28712F423)