### PR TITLE
fix(tests): kill the appearance-debounce flake at its root — clock seam + a shared helper that was measuring nothing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -160,6 +160,7 @@ let package = Package(
                 // assembles replay bytes, the app's SwiftTerm consumes them,
                 // and only this test target links the SwiftTerm product.
                 "TBDDaemonLib",
+                "TestSupport",
                 .product(name: "Clocks", package: "swift-clocks"),
             ],
             resources: [

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -59,6 +59,8 @@ final class AppState: ObservableObject {
     }
     /// Subscription to appearance.$schemeID changes for pushing COLORFGBG updates to running tmux servers.
     private var appearanceSubscription: AnyCancellable?
+    /// Owns the trailing-edge quiet window in front of that subscription.
+    private let appearanceDebouncer = AppearanceBroadcastDebouncer()
     /// Subscription to themeStore.$userThemes changes for reconciling the active scheme.
     private var themeStoreSubscription: AnyCancellable?
 
@@ -896,24 +898,24 @@ final class AppState: ObservableObject {
         // Debounce rapid changes (e.g., scrubbing through the scheme picker) to coalesce
         // multiple RPCs into a single request. The 200ms window is long enough to capture
         // rapid picker changes but short enough to feel responsive.
-        appearanceSubscription = appearance.$schemeID
-            // `@Published` delivers the current value at subscription time. Without
-            // `dropFirst()`, broadcastAppearanceColorFgBg runs on app launch before
-            // the daemon connection is even established — the RPC fails, the error
-            // gets logged and swallowed. Drop that subscriber-time emission so we
-            // only react to actual user-driven scheme changes.
-            .dropFirst()
-            .removeDuplicates()
-            // `DispatchQueue.main` rather than `RunLoop.main`: Combine's RunLoop
-            // scheduler fires its debounce Timer in `.default` mode only, so while
-            // the user scrubs the scheme picker (run loop in `.eventTracking` mode)
-            // the trailing emission stalls until the drag ends. The dispatch
-            // scheduler delivers regardless of run-loop mode — and is reliably
-            // serviced under structured concurrency, which the unit test depends on.
-            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.broadcastAppearanceColorFgBg(appearance)
-            }
+        // The debounce lives in `AppearanceBroadcastDebouncer` rather than in a
+        // Combine `.debounce` operator: that operator takes a `Scheduler`, which
+        // cannot be an `any Clock<Duration>`, so the delay was untestable except
+        // by reconstructing the whole chain in the test and waiting on a real
+        // 200ms timer. The debouncer keeps `dropFirst()`/`removeDuplicates()`
+        // (pure, no time) in Combine and replaces only the timed stage with
+        // cancel-and-replace on the injected clock. Run-loop-mode independence
+        // is unchanged, not new: the operator being replaced was already
+        // `DispatchQueue.main` for exactly that reason (a picker scrub puts the
+        // run loop in `.eventTracking`, which stalls a `RunLoop.main` timer).
+        //
+        // Drop any fire still pending from a previous `appearance`: this runs
+        // from that property's `didSet`, and releasing the old subscription no
+        // longer kills an armed timer the way tearing down a Combine chain did.
+        appearanceDebouncer.cancel()
+        appearanceSubscription = appearanceDebouncer.start(observing: appearance) { [weak self] _ in
+            self?.broadcastAppearanceColorFgBg(appearance)
+        }
 
         // When the theme store reloads (external file add/delete/edit), reconcile
         // the active schemeID so a deleted theme falls back to the default rather

--- a/Sources/TBDApp/Terminal/AppearanceBroadcastDebouncer.swift
+++ b/Sources/TBDApp/Terminal/AppearanceBroadcastDebouncer.swift
@@ -1,0 +1,94 @@
+import Combine
+import Foundation
+
+/// Trailing-edge debounce for appearance changes, built on the injectable clock
+/// seam instead of a Combine scheduler.
+///
+/// Why this type exists at all: the pipeline it owns used to be an inline
+/// `.dropFirst().removeDuplicates().debounce(for:scheduler: DispatchQueue.main)`
+/// chain inside `AppState.setupAppearanceSubscriptions`. Combine's `.debounce`
+/// takes a `Scheduler`, and `Scheduler` and `any Clock<Duration>` are unrelated
+/// protocols — there is no way to thread the project's clock seam
+/// (`docs/specs/2026-07-24-test-hardening-design.md` §5) through that operator.
+/// So the only test that covered the debounce contract *reconstructed* the
+/// chain in its own body and asserted against a copy: the production wiring had
+/// zero coverage, and the test waited on a real 200 ms timer against a wall
+/// clock, which made it load-sensitive and flaky.
+///
+/// The split here follows that constraint: the *pure* stages stay in Combine
+/// (`dropFirst`/`removeDuplicates` involve no time and are worth nobody's
+/// hand-rolled reimplementation), and only the time-dependent stage becomes
+/// cancel-and-replace on `clock.sleep(for:)` — the same shape as
+/// `AppState.scheduleMainAreaSizeBroadcast` and `NotePaneView.debounceSave`,
+/// but with the delay injectable so a `TestClock` can drive it in virtual time.
+@MainActor
+final class AppearanceBroadcastDebouncer {
+    private let interval: Duration
+    private let clock: any Clock<Duration>
+    private var pending: Task<Void, Never>?
+
+    /// - Parameter interval: quiet window before a change is broadcast. 200 ms
+    ///   is long enough to swallow a scheme-picker scrub, short enough to feel
+    ///   immediate.
+    /// - Parameter clock: last parameter, existential, defaulted — the shared
+    ///   seam contract. Existential rather than generic so this type doesn't
+    ///   have to become generic at every storage site.
+    init(interval: Duration = .milliseconds(200),
+         clock: any Clock<Duration> = ContinuousClock()) {
+        self.interval = interval
+        self.clock = clock
+    }
+
+    /// Wires `appearance.$schemeID` up and returns the subscription for the
+    /// caller to store.
+    ///
+    /// Releasing that subscription stops *new* values, but — unlike the Combine
+    /// `.debounce` this replaces, where the pending trailing emission died with
+    /// the chain — an already-armed fire is owned by this object, not by the
+    /// cancellable, and still lands. Call `cancel()` to drop it. `AppState` does
+    /// exactly that before re-subscribing.
+    ///
+    /// `onQuiet` fires once per quiet window with the most recent value.
+    /// `dropFirst()` matters: `@Published` replays the current value at
+    /// subscription time, and without it the very first broadcast would run at
+    /// app launch before the daemon connection exists — an RPC that fails and
+    /// gets swallowed.
+    func start(observing appearance: AppearanceSettings,
+               onQuiet: @escaping @MainActor (String) -> Void) -> AnyCancellable {
+        appearance.$schemeID
+            .dropFirst()
+            .removeDuplicates()
+            .sink { [weak self] value in
+                self?.schedule(value, onQuiet: onQuiet)
+            }
+    }
+
+    /// Cancels a pending fire, if any. Idempotent.
+    func cancel() {
+        pending?.cancel()
+        pending = nil
+    }
+
+    /// Trailing edge: every new value restarts the window, so a burst collapses
+    /// to one call with the last value.
+    private func schedule(_ value: String, onQuiet: @escaping @MainActor (String) -> Void) {
+        pending?.cancel()
+        pending = Task { @MainActor [clock, interval] in
+            // Cancellation while still asleep surfaces as a thrown error — the
+            // "a newer value superseded me" path.
+            guard (try? await clock.sleep(for: interval)) != nil else { return }
+            // Both checks are load-bearing; the throw alone is not enough.
+            // Cancellation that arrives *after* the sleep has already resumed
+            // cannot retroactively make that `await` throw. The window is real
+            // and reachable: the timer resumption is enqueued on the MainActor,
+            // and if the MainActor is mid-turn in something that sets
+            // `schemeID` (a picker drag, a SwiftUI pass), `schedule` runs first
+            // and cancels us — then our resumption executes anyway and
+            // broadcasts a superseded scheme, to be corrected 200ms later.
+            // Combine's `.debounce` could not do that, so omitting this would
+            // be a real behaviour change, not a tidiness nit.
+            guard !Task.isCancelled else { return }
+            onQuiet(value)
+        }
+    }
+}

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -43,7 +43,10 @@ in the parallel pass is merely the status quo, but moving a fast
 deterministic suite into the serial pass taxes every PR forever. When in
 doubt, leave it in the parallel pass.
 
-New tests should state their tier. Tier-1 tests contain no real sleeps.
+New tests should state their tier. Tier-1 tests put no real sleep in the
+*behaviour under test* — the code under test is driven entirely by virtual
+time. The scheduling handshake that observes it may still sleep; see "Clock and
+date seams" below for why that is not a tier violation.
 
 ## Assertion hygiene
 
@@ -89,9 +92,28 @@ and the migration is behavior-preserving by construction. **Existential, not
 generic**, and not named `scheduler`: these subsystems are actors carrying
 `Sendable` conformances, and a generic parameter would infect their types.
 
-Tests pass `TestClock` and drive time with `advanceWhenSuspended(by:)` — no
-sleeping, no load sensitivity, and exact virtual timings instead of tolerance
-windows.
+Tests pass `TestClock` and drive time with `advanceWhenSuspended(by:)`, which
+buys exact virtual timings instead of tolerance windows.
+
+**Where the real sleeps went — the distinction to keep straight.** "No real
+sleeps" applies to the *behaviour under test*: it never waits on wall time, so
+its assertions are exact and load-independent. It does **not** mean the process
+never sleeps. `advanceWhenSuspended` has to observe that the code under test
+has actually reached its `sleep`, and that is real task scheduling, not virtual
+time — so it polls with a real `Task.sleep` against a deadline (bounded
+polling, rule 3 above). Spinning `Task.yield()` there instead does not
+converge: it keeps the waiter runnable and re-queues it behind the very task it
+is waiting for, and raising the budget makes it worse, not better.
+
+Consequence to design around: clock-driven suites are load-**tolerant**, not
+load-**independent**. `TestClock.advance(to:)` calls `Task.megaYield()` twice
+per advance inside swift-clocks — 20 background-QoS tasks each — so a large
+population of clock-driven tests running in parallel floods the pool with
+exactly the low-priority work each one is waiting on, and they starve each
+other. If a clock-driven suite fails on the arming handshake, reach for
+`@Suite(.serialized)` before reaching for a longer timeout: it narrows that one
+suite rather than the target, and measured on the appearance suite it was both
+reliable *and* faster.
 
 **The existential pins `Duration`, not `Instant`** — so it can express delays
 but not deadlines:

--- a/Tests/TBDAppTests/AppearanceDebounceTests.swift
+++ b/Tests/TBDAppTests/AppearanceDebounceTests.swift
@@ -1,109 +1,268 @@
+import Clocks
 import Combine
 import Foundation
 import Testing
 @testable import TBDApp
 import TBDShared
+import TestSupport
 
-/// Tests that scheme changes are debounced before they turn into daemon RPCs.
+/// Tier 1. Debounce contract for scheme changes before they turn into daemon RPCs.
 ///
-/// These tests reconstruct the same Combine pipeline that
-/// `AppState.setupAppearanceSubscriptions` wires onto `appearance.$schemeID`
-/// (`dropFirst().removeDuplicates().debounce(for: .milliseconds(200),
-/// scheduler: DispatchQueue.main)`) and observe its emissions directly, so the
-/// debounce contract is verified without standing up a daemon connection.
+/// What changed and why: this suite used to *reconstruct*
+/// `AppState.setupAppearanceSubscriptions`' Combine chain inside its own body
+/// and assert against the copy, then wait on the real 200 ms
+/// `DispatchQueue.main` debounce by polling a 5 s wall-clock deadline. So the
+/// production wiring had no coverage at all, and the test failed under load
+/// (reproduced locally, 2 of 5 runs). Combine's `.debounce` takes a `Scheduler`,
+/// which can never be an `any Clock<Duration>`, so the fix was to move the
+/// timed stage out of Combine entirely — see `AppearanceBroadcastDebouncer`,
+/// which these tests now drive directly against a `TestClock`.
 ///
-/// Why `DispatchQueue.main` + condition-based waiting: a `RunLoop.main` Combine
-/// scheduler fires its debounce `Timer` in `.default` mode, which only advances
-/// while a `CFRunLoop` is actively spinning. Under `swift test` there is no
-/// `NSApplication.run()` pumping the main run loop, so those timers fire
-/// unreliably while the test is suspended in `Task.sleep` — the original flake.
-/// `DispatchQueue.main` blocks are serviced by the main-actor executor
-/// regardless, so the emission always lands; we then poll for it instead of
-/// sleeping a fixed window and asserting blind.
+/// Consequence: there is no wall clock anywhere below. Every timing is virtual
+/// and exact, so the assertions are boundary-precise rather than
+/// tolerance-windowed. The old doc comment's `DispatchQueue.main` vs
+/// `RunLoop.main` reasoning no longer applies — no Combine scheduler is
+/// involved.
+/// `.serialized` is load-bearing, not tidiness. Every test here drives a
+/// `TestClock`, and each probe/advance costs a `Task.megaYield()` — 20
+/// serially-awaited background-QoS detached tasks. Run in parallel, seven such
+/// tests flood the pool with exactly the low-priority work they are each
+/// waiting on, and they starve *each other*: measured in the full 1332-test
+/// target, the unserialized suite failed 4 of 6 runs on the arming handshake
+/// while taking ~12.6 s even when it passed. Serialized, the suite stops being
+/// its own contention source. This narrows one suite, not the target — other
+/// suites still run in parallel around it.
 @MainActor
-@Suite("AppState appearance debounce")
+@Suite("AppState appearance debounce", .clockDriven, .serialized)
 struct AppearanceDebounceTests {
-    @Test("rapid scheme changes within debounce window collapse to single emission")
-    func rapidSchemeChangesDebounce() async {
-        // Use isolated UserDefaults so the test never touches the developer's app preferences.
+    private static let interval = Duration.milliseconds(200)
+
+    /// Isolated `AppearanceSettings` + debouncer + fired-value recorder.
+    /// `UserDefaults.standard` on this unbundled executable is the developer's
+    /// real `TBDApp.plist`, so the suite name must be unique and torn down.
+    @MainActor
+    private final class Harness {
+        let suiteName: String
+        let defaults: UserDefaults
+        let appearance: AppearanceSettings
+        let clock = TestClock()
+        let debouncer: AppearanceBroadcastDebouncer
+        let fired = Box()
+        var subscription: AnyCancellable?
+
+        final class Box { var values: [String] = [] }
+
+        init() {
+            suiteName = "TBDAppTests.AppearanceDebounce.\(UUID().uuidString)"
+            defaults = UserDefaults(suiteName: suiteName)!
+            // `userThemesDirectory` is the injection seam named in the root
+            // CLAUDE.md; without it `init` stats the developer's real `~/tbd`.
+            // A non-existent temp path is the point — the lookup must miss
+            // deterministically rather than depend on what is on this machine.
+            appearance = AppearanceSettings(
+                defaults: defaults,
+                userThemesDirectory: FileManager.default.temporaryDirectory
+                    .appendingPathComponent("TBDAppTests.AppearanceDebounce.\(UUID().uuidString)")
+            )
+            debouncer = AppearanceBroadcastDebouncer(
+                interval: AppearanceDebounceTests.interval,
+                clock: clock
+            )
+        }
+
+        func subscribe() {
+            subscription = debouncer.start(observing: appearance) { [fired] value in
+                fired.values.append(value)
+            }
+        }
+
+        func tearDown() {
+            subscription?.cancel()
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+    }
+
+    /// A `Clock<Duration>` that delegates to a `TestClock` and then cancels the
+    /// sleeping task the instant its sleep resumes.
+    ///
+    /// This reproduces the one window a `try? await clock.sleep(...)` cannot
+    /// see: cancellation that arrives *after* the sleep completed, which cannot
+    /// retroactively make that `await` throw. `withUnsafeCurrentTask` is what
+    /// makes it exact — the hook runs inside the production debounce task
+    /// itself, so it cancels precisely that task, synchronously, between its
+    /// sleep returning and its next statement.
+    ///
+    /// (An earlier attempt called `debouncer.cancel()` through
+    /// `MainActor.assumeIsolated` here and crashed with SIGTRAP: `sleep` is a
+    /// `nonisolated` protocol requirement, so it runs on the generic executor
+    /// even when the calling task is `@MainActor`.)
+    ///
+    /// Delegating rather than reimplementing keeps virtual time exact —
+    /// `TestClock` still owns every suspension, so `advanceWhenSuspended` on the
+    /// base clock behaves normally.
+    fileprivate struct CancelOnResumeClock: Clock {
+        let base: TestClock<Swift.Duration>
+
+        var now: TestClock<Swift.Duration>.Instant { base.now }
+        var minimumResolution: Swift.Duration { base.minimumResolution }
+
+        func sleep(until deadline: TestClock<Swift.Duration>.Instant,
+                   tolerance: Swift.Duration?) async throws {
+            try await base.sleep(until: deadline, tolerance: tolerance)
+            withUnsafeCurrentTask { $0?.cancel() }
+        }
+    }
+
+    @MainActor
+    private static func withHarness(_ body: (Harness) async -> Void) async {
+        let harness = Harness()
+        harness.subscribe()
+        // `defer`, not a trailing call: `schemeID`'s `didSet` writes to the
+        // suite, so skipping teardown leaks a plist into the developer's real
+        // ~/Library/Preferences. Same length, one less coupling to `body`
+        // never throwing.
+        defer { harness.tearDown() }
+        await body(harness)
+    }
+
+    // Tier 1.
+    @Test("rapid scheme changes within one window collapse to a single fire")
+    func rapidChangesCollapse() async {
+        await Self.withHarness { h in
+            h.appearance.schemeID = "scheme-a"
+            h.appearance.schemeID = "scheme-b"
+            h.appearance.schemeID = "scheme-c"
+
+            await h.clock.advanceWhenSuspended(by: Self.interval)
+            #expect(h.fired.values == ["scheme-c"])
+        }
+    }
+
+    // Tier 1. The boundary the old wall-clock test structurally could not express.
+    @Test("nothing fires until the full interval has elapsed")
+    func firesExactlyOnTheBoundary() async {
+        await Self.withHarness { h in
+            h.appearance.schemeID = "scheme-a"
+
+            await h.clock.advanceWhenSuspended(by: Self.interval - .milliseconds(1))
+            #expect(h.fired.values.isEmpty, "one millisecond short of the window must not fire")
+
+            await h.clock.advance(by: .milliseconds(1))
+            #expect(h.fired.values == ["scheme-a"])
+        }
+    }
+
+    // Tier 1.
+    @Test("a late change restarts the quiet window")
+    func lateChangeRestartsWindow() async {
+        await Self.withHarness { h in
+            h.appearance.schemeID = "scheme-a"
+            await h.clock.advanceWhenSuspended(by: .milliseconds(150))
+            #expect(h.fired.values.isEmpty)
+
+            // Restarts the window: the first sleeper is cancelled, a fresh
+            // 200 ms one is armed. Note what the wait below can and cannot
+            // promise — `checkSuspension()` only asks "is anything suspended",
+            // so it can in principle be satisfied by the superseded sleeper
+            // whose entry is still being cleaned up, rather than by the new one.
+            // `advance(to:)` megaYields before touching `suspensions`, which is
+            // why the cleanup and the re-arm land first in practice. A
+            // "wait for a sleeper at/after deadline X" helper would make it a
+            // guarantee; that is a shared-helper change, not a C1 change.
+            h.appearance.schemeID = "scheme-b"
+            await h.clock.advanceWhenSuspended(by: .milliseconds(150))
+            #expect(h.fired.values.isEmpty, "only 150ms since the restart — must not fire yet")
+
+            await h.clock.advance(by: .milliseconds(50))
+            #expect(h.fired.values == ["scheme-b"])
+        }
+    }
+
+    // Tier 1.
+    @Test("changes separated by a full window fire twice, in order")
+    func separatedChangesFireTwice() async {
+        await Self.withHarness { h in
+            h.appearance.schemeID = "scheme-a"
+            await h.clock.advanceWhenSuspended(by: Self.interval)
+            #expect(h.fired.values == ["scheme-a"])
+
+            h.appearance.schemeID = "scheme-b"
+            await h.clock.advanceWhenSuspended(by: Self.interval)
+            #expect(h.fired.values == ["scheme-a", "scheme-b"])
+        }
+    }
+
+    // Tier 1.
+    @Test("dropFirst skips the subscriber-time value and removeDuplicates collapses repeats")
+    func dropFirstAndRemoveDuplicates() async {
+        await Self.withHarness { h in
+            // `dropFirst`: `@Published` replayed the current value at
+            // subscription time in `subscribe()`. Assert on the SLEEPER, not on
+            // `fired`: with no advance yet, `fired` is empty either way, so
+            // checking it would pass just as happily with `dropFirst()` deleted
+            // from production. `checkSuspension()` throws when a sleeper is
+            // registered, so "does not throw" is the real assertion — the
+            // subscriber-time replay never armed a timer at all.
+            await #expect(throws: Never.self) { try await h.clock.checkSuspension() }
+            #expect(h.fired.values.isEmpty)
+
+            // `removeDuplicates`: the second assignment is not a distinct value,
+            // so it never reaches the timer and cannot restart the window.
+            h.appearance.schemeID = "scheme-a"
+            await h.clock.advanceWhenSuspended(by: .milliseconds(100))
+            h.appearance.schemeID = "scheme-a"
+            await h.clock.advance(by: .milliseconds(100))
+
+            #expect(h.fired.values == ["scheme-a"], "a repeated value must neither fire twice nor restart the window")
+        }
+    }
+
+    /// Tier 1. Covers the branch that a plain `try? await clock.sleep(...)`
+    /// does **not**: cancellation arriving *after* the sleep has already
+    /// resumed, which cannot retroactively make that `await` throw.
+    ///
+    /// The other cancellation test below cancels while the timer is still
+    /// asleep, which the thrown-error path already handles — delete the
+    /// `Task.isCancelled` guard in production and that test stays green. This
+    /// one goes red, because `PostResumeCancelClock` lands the cancel in
+    /// exactly the window the guard exists for.
+    @Test("a cancel landing after the sleep resumes still suppresses the fire")
+    func cancelAfterSleepResumesSuppressesFire() async {
         let suiteName = "TBDAppTests.AppearanceDebounce.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
+        let appearance = AppearanceSettings(
+            defaults: defaults,
+            userThemesDirectory: FileManager.default.temporaryDirectory
+                .appendingPathComponent("TBDAppTests.AppearanceDebounce.\(UUID().uuidString)")
+        )
 
-        let appearance = AppearanceSettings(defaults: defaults)
+        let base = TestClock()
+        let debouncer = AppearanceBroadcastDebouncer(
+            interval: Self.interval,
+            clock: CancelOnResumeClock(base: base)
+        )
+        let fired = Harness.Box()
+        let subscription = debouncer.start(observing: appearance) { [fired] value in
+            fired.values.append(value)
+        }
+        defer { subscription.cancel() }
 
-        // Subscribe to the debounced schemeID emissions to count how many fire.
-        var debounceEmissions: [String] = []
-        let testSubscription = appearance.$schemeID
-            .dropFirst()
-            .removeDuplicates()
-            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
-            .sink { debounceEmissions.append($0) }
-
-        // Three changes with no suspension between them stay inside one debounce
-        // window, so the operator must coalesce them into a single trailing emission.
         appearance.schemeID = "scheme-a"
-        appearance.schemeID = "scheme-b"
-        appearance.schemeID = "scheme-c"
-
-        // Wait (condition-based) for the coalesced emission rather than sleeping a
-        // fixed window then asserting — no wall-clock dependency.
-        let landed = await poll { debounceEmissions.contains("scheme-c") }
-        #expect(landed, "Debounced emission of the final scheme should land within the deadline")
-
-        // The three rapid changes collapsed to exactly one emission of the last value;
-        // the intermediate values were never emitted on their own.
-        #expect(debounceEmissions == ["scheme-c"], "Rapid changes should coalesce to a single final emission")
-
-        testSubscription.cancel()
+        await base.advanceWhenSuspended(by: Self.interval)
+        #expect(fired.values.isEmpty, "a fire cancelled after its sleep resumed must not land")
     }
 
-    @Test("separated scheme changes produce separate emissions")
-    func separatedSchemeChangesProduceMultipleEmissions() async {
-        let suiteName = "TBDAppTests.AppearanceDebounceSpaced.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { defaults.removePersistentDomain(forName: suiteName) }
+    // Tier 1.
+    @Test("cancel() suppresses a pending fire")
+    func cancelSuppressesPendingFire() async {
+        await Self.withHarness { h in
+            h.appearance.schemeID = "scheme-a"
+            await h.clock.advanceWhenSuspended(by: .milliseconds(100))
 
-        let appearance = AppearanceSettings(defaults: defaults)
-
-        var debounceEmissions: [String] = []
-        let testSubscription = appearance.$schemeID
-            .dropFirst()
-            .removeDuplicates()
-            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
-            .sink { debounceEmissions.append($0) }
-
-        // First change: wait for its debounced emission to land.
-        appearance.schemeID = "scheme-a"
-        let first = await poll { debounceEmissions.count >= 1 }
-        #expect(first, "First separated change should produce an emission")
-        let countAfterFirst = debounceEmissions.count
-
-        // Second change after the first window settled: must emit again.
-        appearance.schemeID = "scheme-b"
-        let second = await poll { debounceEmissions.count > countAfterFirst }
-        #expect(second, "Second separated change should produce another emission")
-        #expect(debounceEmissions.count > countAfterFirst, "Separated changes should produce multiple emissions")
-
-        testSubscription.cancel()
+            h.debouncer.cancel()
+            await h.clock.advance(by: Self.interval)
+            #expect(h.fired.values.isEmpty)
+        }
     }
-}
-
-/// Polls `condition` on the main actor until it returns true or `timeout`
-/// elapses, returning the final result. Used instead of a fixed `Task.sleep`
-/// so the test proceeds the instant the asynchronous debounce emission arrives
-/// and never depends on a wall-clock window. The `Task.sleep` suspension points
-/// let `DispatchQueue.main` debounce blocks drain between checks.
-@MainActor
-private func poll(
-    timeout: Duration = .seconds(5),
-    interval: Duration = .milliseconds(10),
-    _ condition: () -> Bool
-) async -> Bool {
-    let deadline = ContinuousClock.now.advanced(by: timeout)
-    while ContinuousClock.now < deadline {
-        if condition() { return true }
-        try? await Task.sleep(for: interval)
-    }
-    return condition()
 }

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -61,29 +61,92 @@ public extension TestClock {
         await advance(by: duration)
     }
 
-    /// Yields until at least one task is suspended on this clock.
+    /// Waits until at least one task is suspended on this clock.
     ///
     /// Detection is inverted from how it reads: `checkSuspension()` **throws**
     /// when a sleeper *is* registered (its job is to prove "no further
     /// time-based asynchrony"), so catching its error is the success signal
     /// here, and a normal return means nobody has reached their `sleep` yet.
     ///
-    /// Budget-exhausted is a test bug, not a flake, so it records an Issue
-    /// naming the likely cause instead of hanging or throwing.
-    func waitForSuspension(maxYields: Int = 20,
+    /// ## Why this polls with a real sleep instead of yielding
+    ///
+    /// This waiter used to spin `await Task.yield()` up to a fixed budget of 20.
+    /// That budget was not merely too small — **the loop does not converge**, and
+    /// raising it makes things worse: measured on the 1331-test `TBDAppTests`
+    /// target, a budget of 5000 turned a 17 s run into a **577 s** run that still
+    /// failed. The contrast that identifies the variable: the same six tests are
+    /// 6/6 green under `--filter AppearanceDebounceTests`, 10/10 green under a
+    /// 24-test filter, and 0/3 in the full target *at the same machine load*. So
+    /// the failure scales with the number of runnable tasks in the process, not
+    /// with CPU load.
+    ///
+    /// The reason is what `Task.yield()` actually does: it keeps the calling task
+    /// **runnable** and re-enqueues it behind every other runnable task in the
+    /// process. In a large parallel target that queue is thousands deep, so the
+    /// waiter spends its whole budget cycling through the back of the queue while
+    /// the one task it is waiting for — the code under test, on its way to its
+    /// `sleep` — never gets a turn. Spinning harder enqueues more work and starves
+    /// it further, which is exactly the 577 s result.
+    ///
+    /// A real `Task.sleep` inverts that: it makes this task **non-runnable** and
+    /// hands the executor back, so the runtime schedules the code under test
+    /// normally instead of making it win a race against our own spin loop.
+    ///
+    /// This is bounded polling with a deadline — sanctioned by `Tests/CLAUDE.md`
+    /// assertion-hygiene rule 3 — and it is *not* a wall-clock assertion. What is
+    /// being waited on here is real task scheduling, which is genuinely real-time;
+    /// the behaviour under test stays on virtual time and its assertions stay
+    /// exact. The timeout is a hang-catcher, in the same family as `.clockDriven`,
+    /// not a timing budget.
+    ///
+    /// ## What this does NOT fix
+    ///
+    /// `checkSuspension()` opens with `Task.megaYield()` — 20 serially-awaited
+    /// **background-QoS** detached tasks — and `TestClock.advance(to:)` calls it
+    /// twice more per advance. That is inside swift-clocks, on the hot path of
+    /// every clock-driven test, and no change here can remove it. macOS starves
+    /// background QoS under saturation, so a residual load sensitivity remains:
+    /// this is load-*tolerant*, not load-*independent*. Measured healthy-path
+    /// cost is tens of microseconds to a few milliseconds, but a 6-test suite was
+    /// observed taking 8.4 s instead of 0.05 s — green, visibly stuck behind a
+    /// slow megaYield — at load average >= 200 on 12 cores. CI (3–4 cores, `-j 2`,
+    /// otherwise idle) is far from that regime. Making this load-independent
+    /// means a megaYield-free virtual clock replacing `TestClock`, which is a
+    /// shared-contract change and deliberately not bundled here.
+    ///
+    /// - Parameters:
+    ///   - timeout: hang guard, and the value is a two-sided constraint. It must
+    ///     stay well under `.clockDriven`'s one-minute limit (Swift Testing's
+    ///     floor granularity) — a test that waits twice has to afford both waits
+    ///     and still get this helper's diagnostic, rather than tripping the
+    ///     suite limit first and reporting an uninformative "wedged". But it
+    ///     must also clear the worst-case real arming latency: at 5 s, the
+    ///     appearance suite failed 4 of 6 full-target runs on this handshake.
+    ///     15 s is ~10x the observed healthy-path arming cost inside a
+    ///     1332-test target while still leaving half the per-test budget for a
+    ///     twice-waiting test. Only a genuinely un-armed timer ever pays it.
+    ///   - pollInterval: how long to step aside between probes. Each probe costs
+    ///     a megaYield, so probing tightly floods the pool with background tasks
+    ///     and starves the very task being waited for — lazier is better.
+    /// Note both are `Swift.Duration`, not this clock's generic `Duration`: they
+    /// are real wall-clock quantities for the scheduling handshake, deliberately
+    /// unrelated to the virtual time the clock hands out.
+    func waitForSuspension(timeout: Swift.Duration = .seconds(15),
+                           pollInterval: Swift.Duration = .milliseconds(25),
                            sourceLocation: SourceLocation = #_sourceLocation) async {
-        for _ in 0..<maxYields {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        repeat {
             do {
                 try await checkSuspension()
             } catch {
                 return  // A sleeper is registered — that is what we were waiting for.
             }
-            await Task.yield()
-        }
+            try? await Task.sleep(for: pollInterval)
+        } while ContinuousClock.now < deadline
         Issue.record(
             """
-            TestClock: no task was suspended on the clock after \(maxYields) yields — \
-            the code under test never reached its sleep. Did you start the task, or \
+            TestClock: no task was suspended on the clock within \(timeout) — the \
+            code under test never reached its sleep. Did you start the task, or \
             advance before it was armed?
             """,
             sourceLocation: sourceLocation

--- a/docs/specs/2026-07-24-test-hardening-design.md
+++ b/docs/specs/2026-07-24-test-hardening-design.md
@@ -68,7 +68,9 @@ Governing rule: **`Duration` is behavior, `Date` is data.**
   init(..., clock: any Clock<Duration> = ContinuousClock())
   ```
 
-  Tests inject `TestClock` from pointfree's `swift-clocks` (**test-target-only dependency**) and drive time with `await clock.advance(by:)` — no sleeping, no load sensitivity. A debounce test asserts *exact* virtual timings instead of tolerance windows.
+  Tests inject `TestClock` from pointfree's `swift-clocks` (**test-target-only dependency**) and drive time with `await clock.advance(by:)`. A debounce test asserts *exact* virtual timings instead of tolerance windows.
+
+  **Amended by slice C1 (measured):** "no sleeping, no load sensitivity" holds for the *behaviour under test*, not for the process. Observing that the code under test has reached its `sleep` is real task scheduling, so the shared `advanceWhenSuspended` helper polls with a real `Task.sleep` against a deadline; yield-spinning there provably does not converge (a budget of 5000 turned a 17 s run into 577 s and still failed). And because `TestClock.advance(to:)` calls `Task.megaYield()` twice per advance — 20 background-QoS tasks each — a large parallel population of clock-driven tests starves itself. Clock-driven suites are therefore load-**tolerant**, not load-**independent**; `@Suite(.serialized)` is the per-suite remedy. True independence would need a megaYield-free virtual clock replacing `TestClock`.
 - **Data** — timestamps that get persisted or compared (`lastUsedAt`, hibernation stamps): the existing lightweight seam, a defaulted `date: Date = Date()` / `now: @Sendable () -> Date` parameter (the `touchLastUsed(at:)` pattern). No clock object needed to stamp a row.
 - **`PollerClock` stays untouched** — chunked, suspend-aware wall-deadline sleeping is a genuinely different job (Darwin's `Task.sleep` uses the suspending clock; see its doc comment) — but it stops being the template. A doc comment points new code at the standard seam.
 


### PR DESCRIPTION
Slice **C1** of the test-hardening program ([design](docs/specs/2026-07-24-test-hardening-design.md) §5, [slicing](docs/specs/2026-07-24-test-hardening-slicing.md) §2). Migrates the appearance debounce to the injected clock seam — and fixes the shared clock helper that migration turned out to be standing on.

## The flake was hiding something bigger

`AppearanceDebounceTests` is the one flake in this program with independently reproduced evidence (2/5 runs for slice A, 1/5 for slice B, both on unrelated diffs). Reading it turned up the real problem: **it did not test production code at all.** It *reconstructed* `AppState.setupAppearanceSubscriptions`' Combine chain inside its own body and asserted against the copy, then waited on the real 200 ms `DispatchQueue` timer by polling a 5 s wall-clock deadline.

So the production wiring had zero coverage, and the "flaky test" was flaky about code that never ships.

**Controlled baseline, measured on `origin/main`** — the hardest number this program has for this flake, and it corrects the DoD's original instrument:

| baseline (origin/main), 20 iterations, under induced CPU load | result |
|---|---|
| the suite alone (`--filter AppearanceDebounceTests`), 10 spinners | **20 / 20 pass** |
| the whole target (`--filter TBDAppTests`), 6 spinners | **9 green / 11 RED** |

The reproducer is concurrent tests **and** CPU load together — neither alone. A filtered run under load proves nothing here.

## Why the operator had to be replaced

Combine's `.debounce` takes a `Scheduler`, and `Scheduler` and `any Clock<Duration>` are unrelated protocols — the seam cannot be threaded through it. So the timed stage moves into `AppearanceBroadcastDebouncer`: the pure stages (`dropFirst`/`removeDuplicates`, no time involved) stay in Combine, and only the debounce becomes cancel-and-replace on `clock.sleep(for:)` — the shape already used by `scheduleMainAreaSizeBroadcast` and `NotePaneView.debounceSave`.

Two behaviour differences vs the operator had to be closed explicitly, **both found in review**:

- A cancelled timer whose sleep had **already resumed** would still fire, because cancellation cannot retroactively make a completed `await` throw. Reachable whenever the MainActor is mid-turn in something that sets `schemeID` (a picker drag, a SwiftUI pass) — it would broadcast a superseded scheme. Guarded with `Task.isCancelled`.
- The pending timer is owned by the debouncer, not by the returned `AnyCancellable`, so releasing the subscription no longer kills an armed fire the way tearing down a Combine chain did. `AppState` now cancels explicitly before re-subscribing.

## The shared helper was measuring nothing

Migrating exposed a defect in slice B's `waitForSuspension`, which spun `await Task.yield()` against a fixed budget of 20. **The budget was not too small — the loop does not converge, and raising it makes things worse:** a budget of 5000 turned a 17 s run into a **577 s** run that still failed.

`Task.yield()` keeps the waiter *runnable* and re-queues it behind every other runnable task, so it competes with the very task it waits for. A real `Task.sleep` inverts that: the waiter becomes *non-runnable* and hands the executor back, so the runtime schedules the code under test normally. That is bounded polling with a deadline ([`Tests/CLAUDE.md`](Tests/CLAUDE.md) rule 3) — waiting on real task scheduling, which is genuinely real-time, while the behaviour under test stays on virtual time and its assertions stay exact.

| `--filter TBDAppTests` | before | after |
|---|---|---|
| result | **0 / 3** — all six tests hung the full 60 s `.clockDriven` limit | **6 / 6 green** |
| cost | ~6 minutes added to every CI run | ~8.5 s |

**What this does not fix, stated plainly:** `TestClock.advance(to:)` calls `Task.megaYield()` twice per advance *inside swift-clocks* — 20 serially-awaited background-QoS detached tasks each — and macOS starves background QoS under saturation. This is load-**tolerant**, not load-**independent**. Real independence means a megaYield-free virtual clock replacing `TestClock`: a shared-contract change, deliberately not bundled here.

## Tests

Seven tier-1 tests drive the **production type** against a `TestClock` — fires once at exactly T+interval, coalesces a burst, does not fire one millisecond early, restarts the window on a late input, honours `dropFirst`/`removeDuplicates`, obeys `cancel()`, and proves the post-resume cancellation guard suppresses the fire. Exact virtual timings instead of tolerance windows; no wall clock anywhere, and the old `poll()` helper and its `Task.sleep` are gone.

**Both repaired assertions were mutation-tested rather than eyeballed:**
- Delete `dropFirst()` from production → the dropFirst test fails. (The original "nothing fired yet" form passed with it deleted — it was vacuous.)
- Delete the `Task.isCancelled` guard → the new cancellation test fails with the stale value landing.

The suite is `@Suite(.serialized)`, which is load-bearing rather than tidiness. Every test drives a `TestClock`, and each probe and advance costs a megaYield; run in parallel, seven such tests flood the pool with exactly the low-priority work each is waiting on. **Unserialized they failed 4 of 6 full-target runs while taking ~12.6 s even when passing; serialized the suite is both reliable and faster (~8.5 s).** This narrows one suite, not the target — `Tests/CLAUDE.md`'s asymmetry warning is about serial *passes* taxing every PR, which this is not.

That regression was self-inflicted and worth recording: adding the seventh test to close a review finding *was itself* the extra contention, and `--filter` would have certified it 7/7 green in 0.05 s.

## No feature flag

Behaviour-preserving by construction — same 200 ms trailing edge, defaulted clock parameter, one call site — so the root `CLAUDE.md` default-off flag policy does not apply. The two behaviour differences above are corrections *toward* the replaced operator's semantics, not new behaviour.

`Package.swift`: `TestSupport` added to `TBDAppTests` so the target can reach the shared clock helpers (adjudicated; no cycle — `TestSupport` depends on `TBDDaemonLib`/`TBDShared`, never `TBDApp`).

## Docs corrected in the same PR

This branch made three committed statements false, and one would actively mislead:

> `Tests/CLAUDE.md` — "Tier-1 tests contain no real sleeps"

Read literally, that says this suite is no longer tier 1 — wrong, and it would push the next slice toward the yield-spinning shape that provably does not converge. The distinction the text collapsed is the deliverable: **no real sleep in the behaviour under test** (driven entirely by virtual time, assertions exact) versus **a real sleep in the scheduling handshake** that observes it. Only the second sleeps.

`Tests/CLAUDE.md` and the design spec now also record the consequence later slices need: clock-driven suites are load-tolerant, not load-independent, and `@Suite(.serialized)` is the per-suite remedy to reach for before a longer timeout.

Folded in here rather than split out — separating a doc fix from the change that invalidated the doc is how docs rot, and this branch has the measurements. (`Tests/CLAUDE.md` is slice E's file; this lands ~3 lines first and E rebases onto it.)

## Verification

- `swift build` green; `swiftlint --strict` 0 violations / 586 files
- `--filter AppearanceDebounceTests` — 3/3 green, ~0.05 s (7 tests)
- `--filter TBDAppTests` — 6/6 green (1332 tests)
- full `swift test --parallel -j 2` — 3/3 green, 3922 tests, ~31 s
### Stress, corrected protocol (whole target under induced CPU load — never the filter)

| | iterations | load | result |
|---|---|---|---|
| baseline `origin/main` | 20 | ~80 | **9 green / 11 red** (45%) |
| this branch | 20 | ~32-48 | **20 / 0** (100%) |
| this branch | 15 | ~90-100 | **13 green / 2 red** (87%) |

**The like-for-like comparison is row 1 vs row 3: 45% -> 87% at the same load band.** The middle row is shown because it exists, not because it is the claim — it was measured on a quieter box than the baseline, which is why the third batch was run at all.

**The claim this supports, precisely:** the wall-clock-**assertion** flake class is eliminated — the behaviour under test is now driven entirely by virtual time and its assertions are exact. What remains is a **residual scheduler-starvation sensitivity inherited from the dependency**, filed as #496. Both remaining failures were `.clockDriven` 60s time-limit trips, *not* the helper's 15s diagnostic: the suite wedged inside `TestClock.advance(to:)`, which calls `Task.megaYield()` (20 background-QoS tasks) twice per advance, inside swift-clocks, where nothing in this PR can reach it.

**That the failures are 60s time limits is itself a positive result.** One wedge ran 467 seconds; `.clockDriven` converted an unbounded hang that would name no suite into a named, attributed failure. The mitigation is provably doing its job.

CI is 3-4 cores at `-j 2` on an otherwise-idle runner (load ~2-4) versus a failure regime of load ~90+ on 12 cores, and at load ~32-48 this measured 20/20 — but that is a prediction about CI, not a measurement of it, so #496 stays open.

`TASK_MEGA_YIELD_COUNT` was measured as a possible mitigation and **refuted as a fix** (wedge survives at `count=1`); the frequency effect is unmeasured because load drift invalidated the comparison. Details in #496.

Residual filed as #496.

[20260724-moaning-octopus](https://cheapsteak.github.io/tbd/open/?worktree=24E32B59-8E9A-400D-B21C-9E541CB76044)