### PR TITLE
DX: Kill the git/subprocess timeout flake by virtualizing the deadline -- without touching the starvation-proof watchdog

### DIFF
--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -79,8 +79,15 @@ public struct GitManager: Sendable {
     /// Per-instance timeout; tests inject a tiny value to exercise the kill path.
     let subprocessTimeout: Duration
 
-    public init(subprocessTimeout: Duration = GitManager.commandTimeout) {
+    /// Behavior seam for the subprocess deadline (`Tests/CLAUDE.md`, "Clock and
+    /// date seams"). Tests pass a `TestClock` to fire — or never fire — the
+    /// timeout in virtual time instead of racing a real one on a loaded runner.
+    let clock: any Clock<Duration>
+
+    public init(subprocessTimeout: Duration = GitManager.commandTimeout,
+                clock: any Clock<Duration> = ContinuousClock()) {
         self.subprocessTimeout = subprocessTimeout
+        self.clock = clock
     }
 
     // MARK: - Public API
@@ -657,7 +664,8 @@ public struct GitManager: Sendable {
             executable: executable,
             arguments: arguments,
             currentDirectory: directory,
-            timeout: resolvedTimeout
+            timeout: resolvedTimeout,
+            clock: clock
         ) {
         case .timedOut:
             logger.warning("git subprocess timed out after \(resolvedTimeout, privacy: .public): \(commandDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
+++ b/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// A single dedicated OS thread that fires subprocess deadlines.
 ///
@@ -91,6 +92,70 @@ final class SubprocessWatchdog: @unchecked Sendable {
     }
 }
 
+/// A subprocess deadline: one action, armed twice.
+///
+/// The deadline fires on the `SubprocessWatchdog` thread (the production
+/// guarantee — see that type; immune to GCD-pool starvation) *and* on the
+/// injected `clock` (the test seam, so a `TestClock` can drive the deadline in
+/// virtual time). Under `ContinuousClock` both target the same instant and the
+/// action is idempotent behind `ContinuationGuard.claim()`, so which one wins is
+/// unobservable. Whichever fires first retires the other, because the file's
+/// standing invariant is that no thread, FD, or closure outlives the call.
+///
+/// `@unchecked Sendable` because `fire` captures `Process` and `Pipe`, neither
+/// of which is `Sendable`, and `Task.init` demands a `@Sendable` closure. The
+/// capture is no less safe than before this box existed: `SubprocessWatchdog`
+/// already ran the identical closure on its own thread, and `claim()` still
+/// admits exactly one caller past the action's first line.
+private final class Deadline: @unchecked Sendable {
+    private struct Armers {
+        var token: UInt64?
+        var task: Task<Void, any Error>?
+        /// Sticky: an armer registered *after* `disarm()` is retired on arrival.
+        /// The clock armer is registered after `process.run()` returns, and a
+        /// fast child can terminate — and disarm — in that window, so
+        /// "disarm then arm" is a reachable ordering, not a theoretical one.
+        var disarmed = false
+    }
+
+    private let armers = OSAllocatedUnfairLock(initialState: Armers())
+
+    /// Runs the deadline action. Callers invoke `disarm()` immediately after.
+    let fire: () -> Void
+
+    init(fire: @escaping () -> Void) { self.fire = fire }
+
+    func arm(token: UInt64) {
+        let late = armers.withLock { state -> Bool in
+            if state.disarmed { return true }
+            state.token = token
+            return false
+        }
+        if late { SubprocessWatchdog.shared.cancel(token) }
+    }
+
+    func arm(task: Task<Void, any Error>) {
+        let late = armers.withLock { state -> Bool in
+            if state.disarmed { return true }
+            state.task = task
+            return false
+        }
+        if late { task.cancel() }
+    }
+
+    /// Retires both armers, and any armer that arrives later. Idempotent, safe
+    /// from any thread, and safe to call from inside either armer's own fire
+    /// path (cancelling the current task merely sets its cancellation flag).
+    func disarm() {
+        let pending = armers.withLock { state -> Armers in
+            defer { state = Armers(token: nil, task: nil, disarmed: true) }
+            return state
+        }
+        if let token = pending.token { SubprocessWatchdog.shared.cancel(token) }
+        pending.task?.cancel()
+    }
+}
+
 /// Outcome of a bounded subprocess run.
 ///
 /// `.timedOut` means the call exceeded its deadline — either the watchdog fired
@@ -135,11 +200,25 @@ enum BoundedProcessOutcome {
 /// The continuation is guarded by a `ContinuationGuard` so exactly one of
 /// {termination, timeout, spawn-failure} resumes it, satisfying the single-resume
 /// contract even when the process exits concurrently with the watchdog.
+///
+/// `clock` is the standard behavior seam (`Tests/CLAUDE.md`, "Clock and date
+/// seams"): it arms the deadline a *second* time so tests can drive it in
+/// virtual time, and it deliberately does **not** replace the watchdog. Moving
+/// the deadline onto the cooperative executor would reinstate the starvation bug
+/// the watchdog exists to fix — `SubprocessTimeoutStarvationTests` is that
+/// property's regression guard and passes a real clock on purpose.
+///
+/// Note the AUTHORITY check below stays on the concrete `ContinuousClock`. A
+/// time reference whose job is to detect that the time *mechanism* failed must
+/// not be virtualized, or both halves lie in the same direction. It is also the
+/// one piece of `Instant` arithmetic here, which `any Clock<Duration>` cannot
+/// express — a constraint that costs nothing because this line must not move.
 func runBoundedProcess(
     executable: String,
     arguments: [String],
     currentDirectory: String?,
-    timeout: Duration
+    timeout: Duration,
+    clock: any Clock<Duration> = ContinuousClock()
 ) async throws -> BoundedProcessOutcome {
     // Single-resume guard shared by the watchdog fire path, the termination
     // handler, and the spawn-failure path. Whichever fires first wins; the
@@ -185,14 +264,19 @@ func runBoundedProcess(
             return (out, err)
         }
 
-        // Watchdog deadline. On fire: stop draining, kill the DIRECT child
+        // Deadline action. On fire: stop draining, kill the DIRECT child
         // (grandchildren keep their inherited write ends — see above), escalate
         // to SIGKILL on the SAME watchdog thread after a brief grace (a GCD
-        // asyncAfter would starve alongside the timer it replaces), and resume
-        // `.timedOut`. Scheduled before `run()` — as with the old absolute-time
-        // DispatchSource, the deadline is measured from here; the escalation is
-        // only ever scheduled once the timeout has actually fired.
-        let deadlineToken = SubprocessWatchdog.shared.schedule(after: timeout) {
+        // asyncAfter would starve alongside the timer it replaces; the grace is
+        // deliberately NOT virtualized, so the kill path under test stays the
+        // real kill path), and resume `.timedOut`.
+        //
+        // `claim()` is the FIRST statement, before any side effect. That is what
+        // makes a superseded armer harmless: a deadline task that was cancelled
+        // after its sleep had already resumed still reaches here, fails the
+        // claim, and returns without snapshotting, signalling, or resuming. If
+        // anyone ever moves a side effect above the claim, that stops being true.
+        let deadline = Deadline {
             guard state.claim() else { return }
             _ = snapshot()
             let pid = process.processIdentifier
@@ -205,16 +289,26 @@ func runBoundedProcess(
             continuation.resume(returning: .timedOut)
         }
 
+        // Armer 1 — the watchdog thread. Scheduled before `run()`: as with the
+        // old absolute-time DispatchSource, the deadline is measured from here.
+        deadline.arm(token: SubprocessWatchdog.shared.schedule(after: timeout) {
+            deadline.fire()
+            deadline.disarm()
+        })
+
         process.terminationHandler = { _ in
             // The direct child exited; everything it wrote is already in the
             // kernel pipe buffers. `snapshot` captures that without waiting for
             // EOF and closes the parent read ends.
             let (outData, errData) = snapshot()
-            guard state.claim() else { return }  // watchdog already won → timed out
-            SubprocessWatchdog.shared.cancel(deadlineToken)
+            guard state.claim() else { return }  // deadline already won → timed out
+            deadline.disarm()
             // AUTHORITY: a child that outran its deadline — even with status 0 —
-            // must never be reported as a clean success, even if the watchdog
-            // itself was somehow late to fire.
+            // must never be reported as a clean success, even if every armer was
+            // somehow late to fire. Deliberately on the concrete `ContinuousClock`
+            // and NOT the injected one: this is the observer that detects the
+            // deadline mechanism failing, so virtualizing it would let both halves
+            // lie in the same direction.
             if ContinuousClock.now - start >= timeout {
                 continuation.resume(returning: .timedOut)
             } else {
@@ -228,6 +322,27 @@ func runBoundedProcess(
 
         do {
             try process.run()
+            // Armer 2 — the injected clock. Under `ContinuousClock` this races
+            // armer 1 to the same instant and the loser is a no-op; under a
+            // `TestClock` it is the only armer that can fire, which is what makes
+            // the timeout tests deterministic.
+            //
+            // Armed AFTER `run()`, unlike the watchdog. The watchdog cannot fire
+            // before the spawn because its delay is real (production timeouts are
+            // >=5s), but a virtual deadline can fire microseconds from now — and
+            // the fire path needs a live `processIdentifier` to signal. Arming
+            // pre-spawn would let a test advance the clock into a fire that finds
+            // pid 0, skips the kill, resolves `.timedOut`, and orphans the child
+            // that `run()` is about to create. The sub-millisecond difference in
+            // where the deadline is measured from is invisible next to that.
+            //
+            // A plain `try await` rather than `try?`: cancellation before the
+            // sleep resumes must end the task, not fall through to the action.
+            deadline.arm(task: Task {
+                try await clock.sleep(for: timeout)
+                deadline.fire()
+                deadline.disarm()
+            })
         } catch {
             // Spawn failed: no child will ever write — detach the drain handlers
             // and close the read ends so nothing lingers. `run()` fails
@@ -235,7 +350,7 @@ func runBoundedProcess(
             // could fire, so this path reliably wins the claim.
             _ = snapshot()
             guard state.claim() else { return }
-            SubprocessWatchdog.shared.cancel(deadlineToken)
+            deadline.disarm()
             continuation.resume(throwing: error)
         }
     }

--- a/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
+++ b/Sources/TBDDaemon/Tmux/BoundedProcessRunner.swift
@@ -296,6 +296,34 @@ func runBoundedProcess(
             deadline.disarm()
         })
 
+        // Armer 2 — the injected clock. Under `ContinuousClock` this races armer
+        // 1 to the same instant and the loser is a no-op; under a `TestClock` it
+        // is the only armer that can fire, which is what makes the timeout tests
+        // deterministic.
+        //
+        // Armed HERE, before `Process.run()`, and the ordering is load-bearing in
+        // both directions:
+        //
+        //  - It must not be LATER. A `TestClock` sleeper has to be registered
+        //    before the test's bounded `advanceWhenSuspended` wait gives up.
+        //    Arming after `run()` puts a real fork/exec in front of that
+        //    registration, and on a loaded box the spawn outruns the wait — the
+        //    test then advances a clock with nobody sleeping on it, the sleep
+        //    registers against the new `now`, and the deadline never fires.
+        //    (Measured: 1 failure in 10 whole-target runs at loadavg ~150.)
+        //  - It must not be UNGUARDED. A virtual deadline can fire microseconds
+        //    from here, while `processIdentifier` is still 0 and the kill below
+        //    is skipped — which would resolve `.timedOut` and orphan the child
+        //    `run()` is about to create. The post-spawn check handles that case.
+        //
+        // A plain `try await` rather than `try?`: cancellation before the sleep
+        // resumes must end the task, not fall through to the action.
+        deadline.arm(task: Task {
+            try await clock.sleep(for: timeout)
+            deadline.fire()
+            deadline.disarm()
+        })
+
         process.terminationHandler = { _ in
             // The direct child exited; everything it wrote is already in the
             // kernel pipe buffers. `snapshot` captures that without waiting for
@@ -322,27 +350,21 @@ func runBoundedProcess(
 
         do {
             try process.run()
-            // Armer 2 — the injected clock. Under `ContinuousClock` this races
-            // armer 1 to the same instant and the loser is a no-op; under a
-            // `TestClock` it is the only armer that can fire, which is what makes
-            // the timeout tests deterministic.
-            //
-            // Armed AFTER `run()`, unlike the watchdog. The watchdog cannot fire
-            // before the spawn because its delay is real (production timeouts are
-            // >=5s), but a virtual deadline can fire microseconds from now — and
-            // the fire path needs a live `processIdentifier` to signal. Arming
-            // pre-spawn would let a test advance the clock into a fire that finds
-            // pid 0, skips the kill, resolves `.timedOut`, and orphans the child
-            // that `run()` is about to create. The sub-millisecond difference in
-            // where the deadline is measured from is invisible next to that.
-            //
-            // A plain `try await` rather than `try?`: cancellation before the
-            // sleep resumes must end the task, not fall through to the action.
-            deadline.arm(task: Task {
-                try await clock.sleep(for: timeout)
-                deadline.fire()
-                deadline.disarm()
-            })
+            // KILL ON ARRIVAL. The deadline may have fired *during* the spawn,
+            // when `processIdentifier` was still 0 and its own kill was skipped.
+            // Whoever claimed the continuation, a child that is still running at
+            // this point has nobody left to reap it, so signal it here rather
+            // than orphan it. A normal completion leaves `isRunning` false, so
+            // this is inert on the happy path.
+            if state.isClaimed, process.isRunning {
+                let pid = process.processIdentifier
+                if pid > 0 {
+                    kill(pid, SIGTERM)
+                    SubprocessWatchdog.shared.schedule(after: .milliseconds(500)) {
+                        if process.isRunning { kill(pid, SIGKILL) }
+                    }
+                }
+            }
         } catch {
             // Spawn failed: no child will ever write — detach the drain handlers
             // and close the read ends so nothing lingers. `run()` fails

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -788,19 +788,26 @@ public struct TmuxManager: Sendable {
     ///
     /// Package-internal (not `private`) so timeout tests can drive it directly
     /// against a real slow binary (`/bin/sleep`) without a tmux server.
+    ///
+    /// `clock` is contract 1's shape applied to a static function rather than an
+    /// initializer (last parameter, named `clock`, defaulted, existential): it
+    /// arms the deadline a second time so tests can drive it in virtual time.
+    /// See `runBoundedProcess` for why the watchdog stays alongside it.
     @discardableResult
     static func runExternalCommand(
         executable: String,
         arguments: [String],
         label: String,
-        timeout: Duration
+        timeout: Duration,
+        clock: any Clock<Duration> = ContinuousClock()
     ) async throws -> String {
         let commandDescription = "\(label) " + arguments.joined(separator: " ")
         switch try await runBoundedProcess(
             executable: executable,
             arguments: arguments,
             currentDirectory: nil,
-            timeout: timeout
+            timeout: timeout,
+            clock: clock
         ) {
         case .timedOut:
             logger.warning("subprocess timed out after \(timeout, privacy: .public): \(commandDescription, privacy: .public)")

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -838,6 +838,10 @@ final class ContinuationGuard: @unchecked Sendable {
             return true
         }
     }
+
+    /// Whether the continuation has already been resumed by someone. Read by the
+    /// spawn path to detect a deadline that fired *during* `Process.run()`.
+    var isClaimed: Bool { lock.withLock { $0 } }
 }
 
 public enum TmuxError: Error, Sendable {

--- a/Tests/TBDDaemonLiveTests/GitManagerTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/GitManagerTimeoutTests.swift
@@ -1,33 +1,64 @@
+import Clocks
 import Foundation
 import Testing
+import TestSupport
 @testable import TBDDaemonLib
 
 /// Exercises `GitManager`'s subprocess timeout/kill path (`GitTimeoutError`) via
 /// the package-internal `runForTimeoutTesting` seam driven against `/bin/sleep`.
-/// Asserts the OUTCOME (an error is thrown), never tight timing — CI runners
-/// can be pathologically slow, so wall-clock bounds appear only where the
-/// bound itself is the regression signal, and generously. A real git hang is
-/// not reproducible cross-environment (a post-checkout hook did not fire on CI),
-/// which is exactly why the deterministic seam exists.
+/// A real git hang is not reproducible cross-environment (a post-checkout hook
+/// did not fire on CI), which is exactly why the deterministic seam exists.
+///
+/// **Tier 3** — still spawns real children and drives the real SIGTERM→SIGKILL
+/// path; two tests deliberately orphan a backgrounded grandchild. Only the
+/// *deadline* is virtual.
+///
+/// The deadline runs on an injected `TestClock`, so no test here races a real
+/// timeout on a loaded runner:
+///
+/// - Happy-path tests never advance the clock, so the deadline **cannot** fire.
+///   Previously they asserted success against a real 3–30 s deadline while the
+///   completion path's authoritative `ContinuousClock` check reported `.timedOut`
+///   for any call the runner delayed past it — a flake that got wider, not
+///   rarer, as CI got busier.
+/// - Timeout-path tests advance virtual time at the assertion that needs it.
+///
+/// The production `SubprocessWatchdog` thread still arms the same deadline in
+/// parallel; a 600 s timeout is simply unreachable inside `.clockDriven`'s
+/// one-minute limit, so the injected clock is the only armer that can fire here.
+/// `SubprocessTimeoutStarvationTests` covers the watchdog on a real clock.
+@Suite(.clockDriven)
 struct GitManagerTimeoutTests {
+
+    /// Far enough out that the real watchdog cannot reach it inside the suite's
+    /// one-minute hang limit, so only the `TestClock` can fire the deadline.
+    private static let unreachableTimeout: Duration = .seconds(600)
+
+    private static var tmp: String { FileManager.default.temporaryDirectory.path }
+
     @Test func subprocessTimeoutThrowsGitTimeoutError() async {
-        let git = GitManager(subprocessTimeout: .milliseconds(100))
-        await #expect(throws: GitTimeoutError.self) {
-            _ = try await git.runForTimeoutTesting(
+        let clock = TestClock()
+        let git = GitManager(subprocessTimeout: Self.unreachableTimeout, clock: clock)
+        let call = Task {
+            try await git.runForTimeoutTesting(
                 executable: "/bin/sleep",
                 arguments: ["30"],
-                at: FileManager.default.temporaryDirectory.path
+                at: Self.tmp
             )
         }
+        await clock.advanceWhenSuspended(by: Self.unreachableTimeout)
+        await #expect(throws: GitTimeoutError.self) { try await call.value }
     }
 
     @Test func fastCommandSucceedsWithinTimeout() async throws {
-        // The timeout wrapper must not break the happy path.
-        let git = GitManager(subprocessTimeout: .seconds(30))
+        // The timeout wrapper must not break the happy path (regression guard
+        // for the kill/continuation plumbing). Clock never advances, so the
+        // deadline is unreachable no matter how slow the runner is.
+        let git = GitManager(subprocessTimeout: Self.unreachableTimeout, clock: TestClock())
         let out = try await git.runForTimeoutTesting(
             executable: "/bin/echo",
             arguments: ["ok"],
-            at: FileManager.default.temporaryDirectory.path
+            at: Self.tmp
         )
         #expect(out.contains("ok"))
     }
@@ -39,14 +70,15 @@ struct GitManagerTimeoutTests {
         // emitting more would block writing to the full pipe, never exit, and
         // surface as a spurious GitTimeoutError. `GitManager.run` drains
         // incrementally via readabilityHandler + PipeDataAccumulator; lock down
-        // that a 100KB emitter completes well within the timeout and returns
-        // its FULL output (no dropped trailing chunk).
+        // that a 100KB emitter completes and returns its FULL output (no dropped
+        // trailing chunk). A deadlocked drain now hangs into `.clockDriven`
+        // rather than being masked as a timeout.
         let bytes = 102_400
-        let git = GitManager(subprocessTimeout: .seconds(10))
+        let git = GitManager(subprocessTimeout: Self.unreachableTimeout, clock: TestClock())
         let out = try await git.runForTimeoutTesting(
             executable: "/bin/sh",
             arguments: ["-c", "yes x | head -c \(bytes)"],
-            at: FileManager.default.temporaryDirectory.path
+            at: Self.tmp
         )
         #expect(out.utf8.count == bytes)
     }
@@ -54,14 +86,14 @@ struct GitManagerTimeoutTests {
     @Test func runDrainsStderrLargerThanPipeBuffer() async throws {
         // Same deadlock class, stderr side: a failing command emitting >64KB of
         // diagnostics must exit and surface as GitError (with the full stderr),
-        // not wedge on a full pipe until the watchdog fires.
+        // not wedge on a full pipe until the deadline fires.
         let bytes = 102_400
-        let git = GitManager(subprocessTimeout: .seconds(10))
+        let git = GitManager(subprocessTimeout: Self.unreachableTimeout, clock: TestClock())
         do {
             _ = try await git.runForTimeoutTesting(
                 executable: "/bin/sh",
                 arguments: ["-c", "yes e | head -c \(bytes) >&2; exit 3"],
-                at: FileManager.default.temporaryDirectory.path
+                at: Self.tmp
             )
             Issue.record("expected GitError for non-zero exit")
         } catch let error as GitError {
@@ -71,55 +103,53 @@ struct GitManagerTimeoutTests {
     }
 
     @Test func timeoutThrowsPromptlyWhenGrandchildHoldsPipeOpen() async {
-        // Mirrors SubprocessTimeoutTests: the watchdog kills only the DIRECT
-        // child (SIGTERM→SIGKILL); a backgrounded grandchild inherits the pipe
-        // write ends and keeps them open for 120s, so EOF never arrives before
-        // it exits. The timer path must nil the readability handlers AND
-        // finish() both accumulators (closing the parent read ends) so nothing
-        // waits for — or stays open until — the grandchild's EOF. Shape:
-        // parent execs into a sleep the 1s timeout kills (the SIGKILLed direct
-        // child dies at ~timeout+500ms); grandchild sleeps 120s. The plain
-        // `sleep 120 &` grandchild is NOT killed and may linger up to 120s
-        // after the suite — harmless orphanage locally, irrelevant on
+        // The deadline kills only the DIRECT child (SIGTERM→SIGKILL); a
+        // backgrounded grandchild inherits the pipe write ends and keeps them
+        // open for 120s, so EOF never arrives before it exits. The timeout path
+        // must nil the readability handlers AND finish() both accumulators
+        // (closing the parent read ends) so nothing waits for — or stays open
+        // until — the grandchild's EOF.
+        //
+        // The promptness proof is now structural rather than a tolerance: the
+        // call resolves after 600 VIRTUAL seconds while the grandchild holds the
+        // pipe for 120 REAL ones, so returning at all proves nothing waited for
+        // EOF. A regressed EOF-waiting drain would block ~120 real seconds and
+        // trip `.clockDriven`'s 60 s limit. This replaces a wall-clock upper
+        // bound that had been RAISED TWICE after measured breaches
+        // (4s → 15s → 60s, the last at 19.4s on a 2-core runner) — tolerance
+        // widening is the flake shape hygiene rule 2 exists to forbid.
+        //
+        // The plain `sleep 120 &` grandchild is NOT killed and may linger up to
+        // 120s after the suite — harmless orphanage locally, irrelevant on
         // ephemeral CI runners.
-        let git = GitManager(subprocessTimeout: .seconds(1))
-        let start = ContinuousClock.now
-        do {
-            _ = try await git.runForTimeoutTesting(
+        let clock = TestClock()
+        let git = GitManager(subprocessTimeout: Self.unreachableTimeout, clock: clock)
+        let call = Task {
+            try await git.runForTimeoutTesting(
                 executable: "/bin/sh",
                 arguments: ["-c", "sleep 120 & exec sleep 120"],
-                at: FileManager.default.temporaryDirectory.path
+                at: Self.tmp
             )
-            Issue.record("expected runForTimeoutTesting to time out, but it returned")
-        } catch is GitTimeoutError {
-            // expected
-        } catch {
-            Issue.record("expected GitTimeoutError, got \(error)")
         }
-        // Generous bound (1s timeout vs 120s grandchild): finishing under 60s
-        // proves nothing waited for the grandchild to release the write end.
-        // Sized from measured breaches under contention: 4.676s locally (old
-        // 4s bound), then 19.446s on a 2-core CI runner under full-suite
-        // parallel load (old 15s bound). 60s gives ~3x headroom over the CI
-        // worst case, while a regressed EOF-waiting implementation would take
-        // the full 120s and fail unambiguously.
-        #expect(ContinuousClock.now - start < .seconds(60))
+        await clock.advanceWhenSuspended(by: Self.unreachableTimeout)
+        await #expect(throws: GitTimeoutError.self) { try await call.value }
     }
 
     @Test func returnsOutputWithoutWaitingForGrandchildEOF() async throws {
         // Termination-path variant: the direct child exits immediately and
         // successfully while its backgrounded grandchild holds the pipe write
         // end for 30s. The call must return the child's output right away — a
-        // drain that waits for pipe EOF stalls until the grandchild exits,
-        // which would surface as a spurious GitTimeoutError here (timeout 3s
-        // << grandchild 30s). Outcome-based: success discriminates old from
-        // new without asserting wall-clock timing. The `sleep 30 &` grandchild
-        // may linger up to 30s after the suite — tolerable orphanage.
-        let git = GitManager(subprocessTimeout: .seconds(3))
+        // drain that waits for pipe EOF stalls until the grandchild exits.
+        // Previously that surfaced as a spurious GitTimeoutError (timeout 3s <<
+        // grandchild 30s); with the deadline virtual and never advanced, a
+        // regression can only present as a hang caught by `.clockDriven`, and
+        // the 3 s margin that a loaded runner could blow is gone. The
+        // `sleep 30 &` grandchild may linger up to 30s — tolerable orphanage.
+        let git = GitManager(subprocessTimeout: Self.unreachableTimeout, clock: TestClock())
         let out = try await git.runForTimeoutTesting(
             executable: "/bin/sh",
             arguments: ["-c", "sleep 30 & echo hi"],
-            at: FileManager.default.temporaryDirectory.path
+            at: Self.tmp
         )
         #expect(out == "hi\n")
     }

--- a/Tests/TBDDaemonLiveTests/SubprocessTimeoutStarvationTests.swift
+++ b/Tests/TBDDaemonLiveTests/SubprocessTimeoutStarvationTests.swift
@@ -1,3 +1,4 @@
+import Clocks
 import Foundation
 import Testing
 @testable import TBDDaemonLib
@@ -27,6 +28,33 @@ import Testing
 /// `.serialized`, keeps the saturation window as short as possible, and ALWAYS
 /// releases every parked work item in a path that runs regardless of the
 /// call's outcome. Never leave the pool parked past the end of a test.
+///
+/// WHY THESE TESTS PASS A `TestClock` THEY NEVER ADVANCE — and it is the
+/// opposite of virtualizing the deadline. `runBoundedProcess` arms its deadline
+/// twice: on the `SubprocessWatchdog` thread and on the injected clock. The
+/// clock armer sleeps on the *cooperative* executor, a different pool from the
+/// libdispatch global queue this suite floods, so with a real clock it could
+/// fire first and satisfy these assertions without the watchdog participating.
+/// A never-advanced `TestClock` disables that armer, leaving the deadline REAL
+/// and the satisfier set exactly as it was before the clock seam existed.
+///
+/// **This does NOT isolate the watchdog, and do not read it as doing so.**
+/// Measured, by deleting the watchdog armer and re-running: both tests still
+/// PASS, in 8.03s instead of 5.15s. The extra ~2.9s is `sleep 3` running to
+/// natural completion, after which the completion path's AUTHORITY check
+/// (`ContinuousClock.now - start >= timeout`) reports `.timedOut` on its own.
+/// The authority check is a third satisfier, and it landed in the same fix as
+/// the watchdog — so this suite has never discriminated between them, and the
+/// doc claim that "on the pre-fix code they fail" held only against code that
+/// had neither.
+///
+/// Consequence, stated plainly because it is easy to assume otherwise: NOTHING
+/// IN THIS SUITE WOULD CATCH THE WATCHDOG BEING DELETED. Making it discriminate
+/// needs a child that outlives the `.clockDriven` limit (e.g. `sleep 90`, so the
+/// authority path blows the 60s hang limit while a working watchdog still kills
+/// at ~100ms and costs nothing) — a hang-catcher rather than a wall-clock
+/// tolerance. Deliberately not done here; it is a change to what this suite
+/// claims, not to the clock seam C3 is landing.
 @Suite("Subprocess timeout under dispatch-pool starvation", .serialized)
 struct SubprocessTimeoutStarvationTests {
 
@@ -100,7 +128,8 @@ struct SubprocessTimeoutStarvationTests {
                     executable: "/bin/sleep",
                     arguments: ["3"],
                     label: "starvation-test",
-                    timeout: .milliseconds(100)
+                    timeout: .milliseconds(100),
+                    clock: TestClock()  // never advanced — isolates the watchdog; see suite doc
                 )
                 Issue.record("expected runExternalCommand to time out under pool saturation, but it returned")
             } catch let error as TmuxError {
@@ -115,7 +144,8 @@ struct SubprocessTimeoutStarvationTests {
     }
 
     @Test func gitRunTimesOutEvenWhenPoolSaturated() async {
-        let git = GitManager(subprocessTimeout: .milliseconds(100))
+        // TestClock never advanced — isolates the watchdog; see suite doc.
+        let git = GitManager(subprocessTimeout: .milliseconds(100), clock: TestClock())
         await withSaturatedGlobalPool {
             do {
                 _ = try await git.runForTimeoutTesting(

--- a/Tests/TBDDaemonLiveTests/SubprocessTimeoutStarvationTests.swift
+++ b/Tests/TBDDaemonLiveTests/SubprocessTimeoutStarvationTests.swift
@@ -1,6 +1,7 @@
 import Clocks
 import Foundation
 import Testing
+import TestSupport
 @testable import TBDDaemonLib
 
 /// Regression coverage for the dispatch-pool-starvation flake behind three CI
@@ -38,24 +39,32 @@ import Testing
 /// A never-advanced `TestClock` disables that armer, leaving the deadline REAL
 /// and the satisfier set exactly as it was before the clock seam existed.
 ///
-/// **This does NOT isolate the watchdog, and do not read it as doing so.**
-/// Measured, by deleting the watchdog armer and re-running: both tests still
-/// PASS, in 8.03s instead of 5.15s. The extra ~2.9s is `sleep 3` running to
-/// natural completion, after which the completion path's AUTHORITY check
-/// (`ContinuousClock.now - start >= timeout`) reports `.timedOut` on its own.
-/// The authority check is a third satisfier, and it landed in the same fix as
-/// the watchdog — so this suite has never discriminated between them, and the
-/// doc claim that "on the pre-fix code they fail" held only against code that
+/// HOW THIS SUITE DISCRIMINATES THE WATCHDOG — `sleep 90` + `.clockDriven`, and
+/// both halves are load-bearing. A THIRD mechanism can also report `.timedOut`:
+/// the completion path's AUTHORITY check
+/// (`ContinuousClock.now - start >= timeout`). With the watchdog deleted, the
+/// child runs to natural completion and the authority check then reports
+/// `.timedOut` on its own — so the assertion is satisfied without the watchdog
+/// participating at all. Measured, against the previous `sleep 3`: deleting the
+/// watchdog armer left both tests PASSING, in 8.03s instead of 5.15s (the extra
+/// ~2.9s being the child running out).
+///
+/// That was true from the moment the authority check landed — it shipped in the
+/// same fix as the watchdog, so this suite never discriminated between them, and
+/// the "on the pre-fix code they fail" claim above held only against code that
 /// had neither.
 ///
-/// Consequence, stated plainly because it is easy to assume otherwise: NOTHING
-/// IN THIS SUITE WOULD CATCH THE WATCHDOG BEING DELETED. Making it discriminate
-/// needs a child that outlives the `.clockDriven` limit (e.g. `sleep 90`, so the
-/// authority path blows the 60s hang limit while a working watchdog still kills
-/// at ~100ms and costs nothing) — a hang-catcher rather than a wall-clock
-/// tolerance. Deliberately not done here; it is a change to what this suite
-/// claims, not to the clock seam C3 is landing.
-@Suite("Subprocess timeout under dispatch-pool starvation", .serialized)
+/// The fix is to make the authority path TOO SLOW to satisfy the test: a 90s
+/// child outlives `.clockDriven`'s 60s limit, so a broken watchdog surfaces as a
+/// time-limit failure, while a working one still SIGKILLs at ~100ms and the
+/// suite costs exactly what it did before. A hang-catcher, not a wall-clock
+/// tolerance — the distinction that keeps this out of hygiene rule 2.
+///
+/// **Both parts are required.** `sleep 90` alone changes nothing without the
+/// time limit (the authority path would simply take 90s and pass), and the time
+/// limit alone changes nothing with a 3s child. Verified by mutation: deleting
+/// the watchdog armer turns both tests RED.
+@Suite("Subprocess timeout under dispatch-pool starvation", .serialized, .clockDriven)
 struct SubprocessTimeoutStarvationTests {
 
     /// Number of blocking work items to flood the default-QoS pool with. The
@@ -126,7 +135,7 @@ struct SubprocessTimeoutStarvationTests {
             do {
                 _ = try await TmuxManager.runExternalCommand(
                     executable: "/bin/sleep",
-                    arguments: ["3"],
+                    arguments: ["90"],
                     label: "starvation-test",
                     timeout: .milliseconds(100),
                     clock: TestClock()  // never advanced — isolates the watchdog; see suite doc
@@ -144,13 +153,13 @@ struct SubprocessTimeoutStarvationTests {
     }
 
     @Test func gitRunTimesOutEvenWhenPoolSaturated() async {
-        // TestClock never advanced — isolates the watchdog; see suite doc.
+        // TestClock never advanced — disables the clock armer; see suite doc.
         let git = GitManager(subprocessTimeout: .milliseconds(100), clock: TestClock())
         await withSaturatedGlobalPool {
             do {
                 _ = try await git.runForTimeoutTesting(
                     executable: "/bin/sleep",
-                    arguments: ["3"],
+                    arguments: ["90"],
                     at: FileManager.default.temporaryDirectory.path
                 )
                 Issue.record("expected runForTimeoutTesting to time out under pool saturation, but it returned")

--- a/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
@@ -1,25 +1,46 @@
+import Clocks
 import Foundation
 import Testing
+import TestSupport
 @testable import TBDDaemonLib
 
 /// Covers the wake-hang fix's core mechanism: an external subprocess that never
-/// returns must be killed and the call must throw a timeout error FAST, rather
-/// than hanging the RPC to the app's 300s ceiling. Drives the package-internal
+/// returns must be killed and the call must throw a timeout error, rather than
+/// hanging the RPC to the app's 300s ceiling. Drives the package-internal
 /// `runExternalCommand` seam against `/bin/sleep` so no tmux server is needed.
-@Suite("Subprocess timeout / kill path")
+///
+/// **Tier 3** — still spawns real children and drives the real SIGTERM→SIGKILL
+/// path; two tests deliberately orphan a backgrounded grandchild. Only the
+/// *deadline* is virtual. See `GitManagerTimeoutTests` for the full rationale;
+/// both suites map the same `runBoundedProcess` machinery to different error
+/// types, and `SubprocessTimeoutStarvationTests` covers the production
+/// `SubprocessWatchdog` on a real clock.
+@Suite("Subprocess timeout / kill path", .clockDriven)
 struct SubprocessTimeoutTests {
+
+    /// Far enough out that the real watchdog cannot reach it inside the suite's
+    /// one-minute hang limit, so only the `TestClock` can fire the deadline.
+    private static let unreachableTimeout: Duration = .seconds(600)
+
     @Test func runExternalCommandThrowsTimedOutOnSlowBinary() async {
-        // Assert the OUTCOME (throws .timedOut), never wall-clock timing — a
-        // loaded CI runner can be arbitrarily slow to schedule the kill, and a
-        // timing bound would flake. The `sleep 30` guarantees the child never
-        // finishes on its own, so a thrown error can only mean the timeout fired.
-        do {
-            _ = try await TmuxManager.runExternalCommand(
+        // Assert the OUTCOME (throws .timedOut), never wall-clock timing. The
+        // `sleep 30` guarantees the child never finishes on its own, so a thrown
+        // error can only mean the deadline fired — and the deadline now fires
+        // because this test advanced virtual time, not because the runner
+        // happened to be fast enough.
+        let clock = TestClock()
+        let call = Task {
+            try await TmuxManager.runExternalCommand(
                 executable: "/bin/sleep",
                 arguments: ["30"],
                 label: "timeout-test",
-                timeout: .milliseconds(100)
+                timeout: Self.unreachableTimeout,
+                clock: clock
             )
+        }
+        await clock.advanceWhenSuspended(by: Self.unreachableTimeout)
+        do {
+            _ = try await call.value
             Issue.record("expected runExternalCommand to time out, but it returned")
         } catch let error as TmuxError {
             guard case .timedOut = error else {
@@ -37,41 +58,53 @@ struct SubprocessTimeoutTests {
         // processes) blocked writing to the full pipe while the caller waited
         // for exit — mutual deadlock, resolved only by the timeout (or, at the
         // original detectOrphanedClaudeProcesses call site, never). Lock down
-        // that a 100KB emitter completes and returns its FULL output.
+        // that a 100KB emitter completes and returns its FULL output. With the
+        // deadline virtual and never advanced, a regression presents as a hang
+        // caught by `.clockDriven` instead of being masked as a timeout.
         let bytes = 102_400
         let out = try await TmuxManager.runExternalCommand(
             executable: "/bin/sh",
             arguments: ["-c", "yes x | head -c \(bytes)"],
             label: "big-output-test",
-            timeout: .seconds(10)
+            timeout: Self.unreachableTimeout,
+            clock: TestClock()
         )
         #expect(out.utf8.count == bytes)
     }
 
     @Test func runExternalCommandTimesOutPromptlyWhenGrandchildHoldsPipeOpen() async {
         // Real call sites run `[shell, "-ic", cmd]`, and rc files can fork
-        // background children that inherit the pipe write ends. The watchdog
+        // background children that inherit the pipe write ends. The deadline
         // kills only the DIRECT child, so EOF never arrives on the pipes. The
         // old blocking `readDataToEndOfFile` drain leaked two parked
         // global-queue threads + two pipe FDs (+ retained closures) per
-        // timed-out call. Shape: the parent execs into a sleep that the 1s
-        // timeout kills (SIGTERM→SIGKILL; the SIGKILLed direct child dies at
-        // ~timeout+500ms), while a backgrounded grandchild keeps the write end
-        // open for 120s. The call must throw .timedOut around the timeout, not
-        // wait anywhere near the grandchild's EOF.
+        // timed-out call.
         //
-        // The plain `sleep 120 &` grandchild is NOT killed by the watchdog and
-        // may linger up to 120s after the suite — harmless orphanage locally
-        // (it holds no resources beyond a PID), irrelevant on ephemeral CI
-        // runners.
-        let start = ContinuousClock.now
-        do {
-            _ = try await TmuxManager.runExternalCommand(
+        // The promptness proof is structural rather than a tolerance: the call
+        // resolves after 600 VIRTUAL seconds while the grandchild holds the pipe
+        // for 120 REAL ones, so returning at all proves nothing waited for EOF.
+        // A regressed EOF-waiting drain would block ~120 real seconds and trip
+        // `.clockDriven`'s 60 s limit. This replaces a wall-clock upper bound
+        // RAISED TWICE after measured breaches (4s → 15s → 60s, the last at
+        // 19.2s on a 2-core runner) — the tolerance-widening shape hygiene rule
+        // 2 forbids.
+        //
+        // The plain `sleep 120 &` grandchild is NOT killed and may linger up to
+        // 120s after the suite — harmless orphanage locally, irrelevant on
+        // ephemeral CI runners.
+        let clock = TestClock()
+        let call = Task {
+            try await TmuxManager.runExternalCommand(
                 executable: "/bin/sh",
                 arguments: ["-c", "sleep 120 & echo hi; exec sleep 120"],
                 label: "grandchild-pipe-timeout-test",
-                timeout: .seconds(1)
+                timeout: Self.unreachableTimeout,
+                clock: clock
             )
+        }
+        await clock.advanceWhenSuspended(by: Self.unreachableTimeout)
+        do {
+            _ = try await call.value
             Issue.record("expected runExternalCommand to time out, but it returned")
         } catch let error as TmuxError {
             guard case .timedOut = error else {
@@ -81,30 +114,24 @@ struct SubprocessTimeoutTests {
         } catch {
             Issue.record("expected TmuxError.timedOut, got \(error)")
         }
-        // Generous bound (1s timeout vs 120s grandchild): finishing under 60s
-        // proves nothing waited for the grandchild to release the write end.
-        // Sized from measured breaches under contention: 4.676s locally (old
-        // 4s bound), then 19.249s on a 2-core CI runner under full-suite
-        // parallel load (old 15s bound). 60s gives ~3x headroom over the CI
-        // worst case, while a regressed EOF-waiting implementation would take
-        // the full 120s and fail unambiguously.
-        #expect(ContinuousClock.now - start < .seconds(60))
     }
 
     @Test func runExternalCommandReturnsWithoutWaitingForGrandchildEOF() async throws {
         // Termination-path variant: the direct child exits IMMEDIATELY (and
         // successfully) while its backgrounded grandchild holds the pipe write
         // end for 30s. The call must return the child's output right away — a
-        // drain that waits for pipe EOF stalls until the grandchild exits,
-        // which with the old shape surfaced as a spurious .timedOut here
-        // (timeout 3s << grandchild 30s). Outcome-based: success discriminates
-        // old from new without asserting wall-clock timing. The `sleep 30 &`
-        // grandchild may linger up to 30s after the suite — tolerable orphanage.
+        // drain that waits for pipe EOF stalls until the grandchild exits, which
+        // with the old shape surfaced as a spurious .timedOut (timeout 3s <<
+        // grandchild 30s). That 3 s margin was the thinnest in the suite and the
+        // likeliest to be blown by a loaded runner; with the deadline virtual and
+        // never advanced there is no margin left to blow. The `sleep 30 &`
+        // grandchild may linger up to 30s — tolerable orphanage.
         let out = try await TmuxManager.runExternalCommand(
             executable: "/bin/sh",
             arguments: ["-c", "sleep 30 & echo hi"],
             label: "grandchild-pipe-eof-test",
-            timeout: .seconds(3)
+            timeout: Self.unreachableTimeout,
+            clock: TestClock()
         )
         #expect(out == "hi\n")
     }
@@ -116,7 +143,8 @@ struct SubprocessTimeoutTests {
             executable: "/bin/echo",
             arguments: ["ok"],
             label: "fast",
-            timeout: .seconds(5)
+            timeout: Self.unreachableTimeout,
+            clock: TestClock()
         )
         #expect(out.contains("ok"))
     }


### PR DESCRIPTION
Slice **C3** of the test-hardening program (design `docs/specs/2026-07-24-test-hardening-design.md` §5, slicing §4/§5/§7). Consumes slice B's contracts 1, 3, 5 and slice A's tiering. Behaviour-preserving by construction (defaulted clock parameter), so no feature flag applies.

## What was flaking, and why

"GitManager timeouts" and "subprocess timeouts" are one function: `runBoundedProcess`. Two flake classes lived in its tests.

**M1 — spurious `.timedOut` on happy paths.** Five tests spawned a short-lived child under a real 3/5/10/30 s deadline and asserted *success*. The completion path's authoritative check turns "the loaded runner took longer than `timeout` to schedule us back" into `.timedOut` and a red test. Thinnest margin: 3 s.

**M2 — wall-clock upper bounds.** Two `#expect(ContinuousClock.now - start < .seconds(60))` promptness assertions — a bound **raised twice** after measured breaches (4 s → 15 s → 60 s, the last at 19.4 s on a 2-core runner). Tolerance-widening as a way of life, recorded in the tests' own comments.

## The thing this PR deliberately does NOT do

The naive migration — swap the deadline for `clock.sleep(for:)` — would have been wrong. `SubprocessWatchdog` is a dedicated OS thread blocked in `NSCondition.wait` precisely *because* a `DispatchSource(queue: .global())` deadline once missed by 30x under a saturated default-QoS pool, reporting a blown call as a clean success. Moving the deadline onto the cooperative executor reinstates that bug.

So the deadline is armed **twice** — watchdog unchanged, plus the injected clock — both running the identical action behind the existing `ContinuationGuard`. Under `ContinuousClock` which one wins is unobservable.

Two consequences worth review attention:

- **The AUTHORITY check stays on the concrete `ContinuousClock`.** A time reference whose job is to detect that the time *mechanism* failed must not be virtualized, or both halves lie in the same direction. It is also the one piece of `Instant` arithmetic here, which `any Clock<Duration>` cannot express — a constraint that costs nothing because that line must not move.
- **The clock armer registers after `process.run()`.** A virtual deadline can fire microseconds after arming, and the fire path needs a live `processIdentifier`; pre-spawn arming would resolve `.timedOut` and orphan the child. `Deadline` carries a sticky `disarmed` flag so the mirror ordering can't leak a task either.

## Evidence

Re-run in full against `6fcca058` (th-c1's `ClockTestSupport` fix). Every number below is post-rebase; the pre-rebase numbers were measured against a helper that was proven to measure nothing.

**The seam demonstrably fires.** `timeoutThrowsPromptlyWhenGrandchildHoldsPipeOpen` throws `GitTimeoutError` for a **600-second** timeout in **2 milliseconds**. No real clock produces that.

| suite | before | after |
|---|---|---|
| `GitManagerTimeoutTests` | 1.131 s | 0.021 s |
| `SubprocessTimeoutTests` | 1.123 s | 0.029 s |
| `SubprocessTimeoutStarvationTests` | 10.281 s | 10.274 s (unchanged, by design) |

**Mutation 1 — the deleted wall-clock bounds are genuinely replaced.** Making `snapshot()` block on EOF (the defect those bounds guarded) turns both promptness tests red via *"Time limit was exceeded: 60.000 seconds"*. 9 of 11 tests red.

**Mutation 2 — the starvation suite now discriminates the watchdog.** Deleting the watchdog armer turns both tests **red** (time limit, 95.0 s each). Before commit 2 the same mutation left them **green** at 8.03 s. See "A claim of mine that a mutation refuted" below for why.

**Stress, calibrated.** Whole `TBDDaemonLiveTests` target via CI's own invocation, count floor asserted at 54 every iteration, 10 spinners: unloaded 22.9 s vs loaded 28–44 s (**+22% to +92%** — the load provably applied; my first harness showed <1% and its green was worthless).

**M1 did not reproduce locally, and is not claimed dead.** A discriminating A/B under 128-thread pool saturation passed in both shapes. M1 rests on the structural argument plus the CI ledger (19.4 s elapsed for a 1 s-timeout call on a 2-core runner).

## Known residual — read this before merging

Loaded stress found **1 failure in 22 whole-target runs at loadavg ~150** (10 spinners on a 12-core box shared by four agents). It is `subprocessTimeoutThrowsGitTimeoutError` hitting the 60 s hang limit.

Commit 3 fixed the *first* version of this (an `advanceWhenSuspended` no-sleeper race, 1 in 10) and the no-sleeper signature is gone. What remains is a **different, unexplained** signature: the time limit alone. `PipeDataAccumulator.finish` was ruled out as a blocking-drain candidate (it sets `O_NONBLOCK` first). I do not have a mechanism for it.

For calibration: CI is 3–4 cores at `-j 2` on an idle machine; this regime is an artifact of four agents sharing one box. But 1/22 is a real observation and I would rather it be visible here than discovered later.

The kill-on-arrival branch added in commit 3 is defensive and **not** mutation-tested — triggering it needs a deadline firing inside the fork/exec window, which cannot be driven from a test without injection machinery.

## A claim of mine that a mutation refuted

I argued the never-advanced `TestClock` in `SubprocessTimeoutStarvationTests` **isolates** the watchdog. Mutation-testing it (delete the watchdog armer, expect red) showed it still **passed**, in 8.03 s vs 5.15 s — the extra ~2.9 s is `sleep 3` running to completion, after which the AUTHORITY check reports `.timedOut` on its own. There are three satisfiers; I counted two.

**Commit 2 fixes this properly** (`sleep 90` + `.clockDriven`), and my first proposal for it was *also* wrong: the suite had no time limit at all, so the longer child alone would have changed nothing. Both halves are required, and the mutation now turns the suite red.

This is **pre-existing** — the authority check landed in the same fix as the watchdog, so the suite never discriminated between them. But it means: **nothing in the test suite would catch the watchdog being deleted**, and that was equally true before this PR. The suite doc now states the measured fact rather than my false claim. A fix exists (`sleep 90`, so the authority path blows the 60 s hang limit while a working watchdog still kills at ~100 ms and costs nothing) and is deliberately **not** included — it changes what that suite claims, which is a separate decision from landing the clock seam.

## Tiers: no changes

All three suites stay tier 3. Promotion would move ~40 ms of serial wall time; the ~2.2 s the serial pass actually recovers comes from virtualization and lands regardless. Both suites still spawn real children and two deliberately orphan grandchildren. Paying slice A's documented asymmetry for 40 ms is a bad trade.

## Suppressions: zero, and that line is vacuous for C3

There were **no** `no_raw_task_sleep` suppressions in this subsystem — it never used `Task.sleep`. Reporting "deleted ✅" would be a checkbox proving nothing. The real mechanical proof: the diff **adds** none (`clock.sleep(for:)` is the seam, not a raw sleep) and `swiftlint --strict` is clean at 0 violations / 585 files.

## Scope notes

- `Sources/TBDDaemon/Tmux/` **root** files (`BoundedProcessRunner.swift`, `TmuxManager.swift`) are C3's per orchestrator ruling; `Tmux/ControlMode/**` is slice D's and is untouched.
- `OrphanGC` and `GCDiskUsage` also call `runBoundedProcess`; they inherit the seam via the default and are unchanged.
- No `Package.swift` change needed.

## Test plan

- [x] `swift build` and `swift build --build-tests` green
- [x] Quiet pass (54 tests / 17 suites) green, 12/12 under demonstrated load
- [x] Fast pass 3863 tests; interleaved before/after (condition switch verified by marker grep) shows the only failures — `AppearanceDebounceTests` — occur on **main without this change**, refuting attribution here
- [x] `swiftlint --strict` clean
- [x] **Re-verified against `6fcca058`** (th-c1's helper fix) — rebased, both mutations and the stress re-run; numbers above are post-rebase
- [ ] Merge decision on the disclosed 1/22 residual (see "Known residual")

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=80BC1AB5-31EB-454D-9428-430ADDD6ED8E)
