### PR TITLE
test: named quarantine — `.flaky(issue:)` trait + retry-metrics ledger (slice E)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,15 @@ jobs:
     # (docs/specs/2026-07-24-test-hardening-design.md §7), so one run produces
     # one artifact covering the fast and quiet passes together. Unset locally,
     # where the trait writes nothing.
+    #
+    # A LITERAL path, not `${{ runner.temp }}`: the `runner` context is not
+    # available in a job-level `env:` block, and GitHub resolves an unavailable
+    # context to the empty string instead of erroring — so that spelling would
+    # silently hand the tests `/retry-metrics.jsonl`, fail to open at the
+    # filesystem root, and upload an empty artifact forever. The existing test
+    # steps already `tee` to /tmp on these runners.
     env:
-      TBD_RETRY_METRICS_PATH: ${{ runner.temp }}/retry-metrics.jsonl
+      TBD_RETRY_METRICS_PATH: /tmp/retry-metrics.jsonl
     steps:
       - uses: actions/checkout@v4
         with:
@@ -182,7 +189,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: retry-metrics
-          path: ${{ runner.temp }}/retry-metrics.jsonl
+          path: /tmp/retry-metrics.jsonl
           if-no-files-found: warn
 
       - name: Build (verify TBDCLI and TBDDaemon executable targets compile)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,12 @@ jobs:
 
   test:
     runs-on: macos-26
+    # Both test steps below append their `.flaky(issue:)` retry records here
+    # (docs/specs/2026-07-24-test-hardening-design.md §7), so one run produces
+    # one artifact covering the fast and quiet passes together. Unset locally,
+    # where the trait writes nothing.
+    env:
+      TBD_RETRY_METRICS_PATH: ${{ runner.temp }}/retry-metrics.jsonl
     steps:
       - uses: actions/checkout@v4
         with:
@@ -122,6 +128,19 @@ jobs:
       # The floors sit well below those so ordinary test additions/removals never
       # trip them — they only fire when a pass collapses to near-nothing.
       - name: Test (fast parallel pass — tiers 1 and 2)
+        # A tier-1 test can still hang indefinitely: an over-long TestClock
+        # advance chain wedged for >10 min and `.clockDriven` did NOT bound it
+        # (the hung work sits where the time limit cannot cancel it). Without
+        # this the job falls back to the 6 h default.
+        #
+        # 30, not 10: this step runs the FIRST `swift test`, so it pays the
+        # whole test-target compile, not just the ~30 s of test runtime. Three
+        # consecutive warm-cache runs on main measured 2m22s / 3m33s / 6m02s —
+        # a 10-minute budget is under 2x the observed worst case and a cold
+        # cache (Package.resolved change, cache eviction) would blow through it
+        # and kill a healthy build. This bounds a hang at 1/12 of the default
+        # while staying far above any legitimate run.
+        timeout-minutes: 30
         run: |
           set -o pipefail
           swift test --parallel -j 2 --skip '^TBDDaemonLiveTests\.' 2>&1 | tee /tmp/fast-pass.log
@@ -155,6 +174,16 @@ jobs:
             exit 1
           fi
           echo "Quiet pass executed $count tests."
+
+      # `warn`, not `ignore`: an absent file means the metrics wiring broke, and
+      # that must be visible rather than silently producing an empty dashboard.
+      - name: Upload retry metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: retry-metrics
+          path: ${{ runner.temp }}/retry-metrics.jsonl
+          if-no-files-found: warn
 
       - name: Build (verify TBDCLI and TBDDaemon executable targets compile)
         run: swift build -j 2

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -138,6 +138,13 @@ that a quarantine mechanism that silently stopped retrying cannot look
 identical to a working one. Its issue (#499) is a permanently-open fixture
 anchor. **The audit must exclude that exact test ID and no other.**
 
+The same file's `alwaysFails()` fixture shares issue #499 and is deliberately
+**not** excluded. It is gated off by `TBD_FLAKY_SELFTEST_FAILURE` and nothing in
+CI sets that, so it should contribute no records at all — if `failed` records
+for it ever appear in the ledger, the gate has leaked into CI, and the audit
+should **report that** rather than filter it away. An exclusion list that grew
+to cover it would turn a broken gate into silence.
+
 ## Assertion hygiene
 
 Four rules. Each traces to a real flake — provenance kept so the rule sticks.

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,20 +1,62 @@
 # Tests
 
-## Never reap background jobs with `jobs -p` in the tool shell
+## Shared-box hazards
 
-When simulating CI load to reproduce a flaky test, do NOT spawn background load
-and reap it with `kill $(jobs -p)`. Job control is OFF in the non-interactive
-tool shell, so `jobs -p` returns nothing, `kill` reaps nothing, and every
-backgrounded `&` child orphans to launchd and runs forever (this once leaked 22
-`yes` processes at ~850% CPU for a week).
+Reproducing a flake means inducing load, and this box runs several agent
+worktrees at once. Every entry below was paid for during the test-hardening
+program. They are one family, not four anecdotes — the next variant will be a
+fifth way to kill or mismeasure something you did not mean to.
 
-Instead, guard the whole script with `trap 'kill 0' EXIT` (kills the process
-group on exit), or capture each PID explicitly (`p=$!; ...; kill "$p"`) with
-`pkill -P $$` as a backstop. For a long-lived helper, prefer the Bash tool's
-`run_in_background` option, which the harness tracks and reaps.
+### The kill hazards
 
-This is also enforced mechanically by the `background-jobs` rule in
-`.claude/hooks/guardrails`, which blocks the broken shape at PreToolUse time.
+**One rule covers all of them: kill by captured PID or by your own process
+tree (`pkill -P $$`). Never by name pattern, never by process group.**
+
+- **`kill $(jobs -p)`** — job control is OFF in the non-interactive tool shell,
+  so `jobs -p` returns nothing, `kill` reaps nothing, and every backgrounded
+  `&` child orphans to launchd and runs forever. (Once leaked 22 `yes`
+  processes at ~850% CPU for a week.)
+- **`trap 'kill 0' EXIT`** — signals the whole process group, which includes
+  your own tool shell. This file used to recommend it; it does not any more.
+  It cost this program a stress run, and two slices had it in their plans.
+- **`pkill -f <pattern>`** — matches **across worktrees**. Every worktree
+  builds identically-named bundles, so `pkill -f TBDPackageTests` kills a
+  sibling agent's test run. Cost: ~70 minutes of someone else's work.
+- **Orphaned subagent subtrees** — stopping a parent *orphans* its children
+  rather than killing them, and the orphans keep obeying the rules that were
+  in force when they were spawned. An agent audited its own load, stopped the
+  subagent it knew about, verified `pgrep` was clean, and still contaminated
+  the box.
+
+That last one generalizes into three habits worth more than the rule itself:
+
+1. When a coordination rule lands, enumerate what is actually **running** —
+   processes, not your mental model of your agents.
+2. A stop is not a guarantee the subtree is gone. **Re-check after stopping.**
+3. Judge by **capability, not current behaviour**. An idle child that can fire
+   a build is a load generator that happens to be between jobs — `pgrep` came
+   back clean only because the children were momentarily between builds.
+
+For a long-lived helper, prefer the Bash tool's `run_in_background` option,
+which the harness tracks and reaps. The `jobs -p` shape is also blocked
+mechanically at PreToolUse time by the `background-jobs` rule in
+`.claude/hooks/guardrails`.
+
+### The same class, without a signal: the machine lying in your vocabulary
+
+A shared box also breaks builds in ways that read as broken code.
+
+- **Disk at 100%** surfaces as `generate-dSYM command failed` and `link
+  command failed` — errors that look exactly like a bad diff. **If a build or
+  link dies strangely, check `df` before debugging the diff.**
+- **Load average in the hundreds** turns clock-driven suites red on their
+  arming handshake, and CI-contention reds look like real assertion failures.
+
+Same family as the kill hazards and as the instrument-calibration failures
+below: the machine failing in the vocabulary of your own code. When your slice
+merges and you stand down, delete your own `.build` — and reclaim only your
+own, never a sibling's, because a rebuild costs them ~2 minutes and silently
+invalidates any measurement they are midway through.
 
 ## Test tiers
 
@@ -47,6 +89,54 @@ New tests should state their tier. Tier-1 tests put no real sleep in the
 *behaviour under test* — the code under test is driven entirely by virtual
 time. The scheduling handshake that observes it may still sleep; see "Clock and
 date seams" below for why that is not a tier violation.
+
+## Quarantine — `.flaky(issue:)`
+
+There is no blanket retry policy, in any tier, and there will not be one:
+a retry that nobody named hides a regression, because a test that started
+failing 40% of the time when someone broke the code is indistinguishable from
+one that was always 40% flaky. A tier-2 test that genuinely needs a retry gets
+named quarantine instead.
+
+```swift
+@Test(.flaky(issue: 512))
+func attachRacesSupersession() async { … }
+```
+
+The body re-runs up to 3 times total; the first two failures are suppressed as
+known issues and the third is surfaced normally, with its real source location.
+**The issue number is required — that is the entire honesty mechanism**, and it
+is what lets the nightly audit flag a `.flaky` whose issue is closed, or one
+that passed first-try all week, for removal. Anonymous quarantine is a
+permanent blind spot.
+
+Rules:
+
+- **Tier 2 only.** A red tier-1 test is a bug, full stop. Tier 3 already has
+  its own serial target. Never quarantine either.
+- **Open the issue first**, and put the diagnosis in it. Quarantine is a
+  deadline, not a resting place.
+- The trait is `TestTrait` only, never `SuiteTrait` — a quarantined *suite*
+  would let one annotation silence twenty tests.
+- **Do not quarantine a test that reports failures from an escaping `Task`.**
+  Suppression is scoped to the task tree, and it breaks in both directions
+  there. Full detail is in the trait's doc comment,
+  `Tests/TestSupport/FlakyTestSupport.swift`.
+
+Every execution of a `.flaky` test — including clean first-try passes, which
+are what prove a flake is fixed — appends one JSONL record to
+`$TBD_RETRY_METRICS_PATH` (set at the job level in CI, unset locally, where the
+trait does no work). Keys: `schema`, `testID`, `issue`, `attempts`, `outcome`
+(`passedFirstTry` | `passedOnRetry` | `failed`), `file`, `line`. **That schema
+is a consumed API** — the nightly quarantine audit reads it, so adding a key is
+fine and changing or removing one means bumping `schema`.
+
+One record in that ledger is *not* a flake report:
+`TBDDaemonTests.FlakyQuarantineSelfTests/retriesUntilPass()` is the mechanism's
+own self-test, which fails once and passes on retry by design on every run so
+that a quarantine mechanism that silently stopped retrying cannot look
+identical to a working one. Its issue (#499) is a permanently-open fixture
+anchor. **The audit must exclude that exact test ID and no other.**
 
 ## Assertion hygiene
 
@@ -115,6 +205,39 @@ other. If a clock-driven suite fails on the arming handshake, reach for
 suite rather than the target, and measured on the appearance suite it was both
 reliable *and* faster.
 
+**Keep advance chains short — single digits.** If crossing a threshold would
+take many production-sized intervals, **inject the pacing values** (that is
+what the interval init parameters are for) and cross it in 2–3 advances rather
+than 100.
+
+Measured: 100 tight `advanceWhenSuspended` iterations, accumulating a 5 s
+threshold out of 50 ms production intervals, passed in **0.626 s unloaded and
+hung past 10 minutes under 12 spinners**. The helper was behaving exactly as
+specified — it is non-throwing by design, so under load, if the code under test
+does not re-park within its yield budget, it records an `Issue` and *continues*;
+`advance` then moves `now` with no sleeper registered, and the sleep that
+arrives afterwards is scheduled against the new `now` and never fires.
+Permanent desync. The defect is emergent, not a helper bug: one advance has a
+small miss probability, one hundred makes it near-certain. That is a property
+of the *usage*, which is why it is a written rule rather than a helper fix.
+
+**The counter-rule, because following the above naively degrades coverage.**
+Shortening a chain silently buys a weaker assertion — and it degrades
+invisibly, because the test still passes. One migrated test named for having
+"no deadline" ended up running 4 iterations totalling 150 ms virtual and never
+reaching the 5 s threshold its own docstring claimed. Whenever you shorten a
+chain, check that the test still crosses the thresholds its name and docstring
+claim; if it does not, inject pacing sized to span them within the same 3–5
+advance budget. Short chain *and* strong claim — you do not have to trade them.
+
+**The failure signature is the part to internalize:** this did not present as a
+red test. It presented as a **hang**, and in the stress log as a silently
+truncated iteration with no `Test run with N tests` summary line — which a
+naive `rc == 0` check counts as a pass. It was caught only because the harness
+asserted the executed test count per iteration. **A truncated log or a missing
+summary line is a failure, not a pass.** Any harness, corpus runner, or stress
+loop must treat "no summary" as red.
+
 **The existential pins `Duration`, not `Instant`** — so it can express delays
 but not deadlines:
 
@@ -168,12 +291,31 @@ sleep that nobody advances hangs forever. Two mitigations, use both —
 failure. Convention: **put the advance immediately next to the assertion it
 unblocks**, not in a setup block far away.
 
+**`.clockDriven` is not a reliable backstop on its own** — known limitation,
+measured: a desynced advance chain hung past 10 minutes with the trait applied
+and the one-minute limit never fired (the hung work most likely sits in a
+detached task the time limit cannot cancel). It usually works and is worth
+keeping. Do not make it your *only* hang guard: stress harnesses, corpus
+runners and fuzzers need an outer timeout of their own.
+
 One caution on those two helpers: they record an `Issue` and continue rather
 than throwing, which is safe *only* because neither returns a value. A
 non-throwing waiter that does return something — `ControlModeTestSupport.waitFor`
 (PR #415) — also keeps going after recording, so anything you index out of its
 result must be `#require`-guarded or the test crashes instead of failing
 cleanly. Don't generalize "non-throwing" into "no `#require` needed".
+
+**And the crash is the *good* case.** The nastier one is that execution
+continues far enough to produce a second, plausible-looking assertion failure
+that misattributes the cause. A real instance: a waiter timed out having
+collected one event instead of two, the discarded `false` return let the test
+carry on, and the visible failure was `[42] == [42, 42]` — which reads as a
+generation-numbering bug and sends the reader to the wrong line entirely. A
+crash announces itself; this does not. **The tell was the duration**: 62 s for
+what should have been a fast assertion failure, i.e. two ~30 s bounded waits
+timing out back to back. When an assertion failure took far longer than an
+assertion failure should, suspect a swallowed waiter before you believe the
+message.
 
 `PollerClock` is **not** this seam and must not be copied as a template — see
 its doc comment. Full rationale:

--- a/Tests/TBDDaemonTests/FlakyQuarantineSelfTests.swift
+++ b/Tests/TBDDaemonTests/FlakyQuarantineSelfTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import TestSupport
+import Testing
+
+/// Proof that `.flaky(issue:)` actually re-runs a failing body.
+///
+/// Tier 1 — pure in-process counters, no sleeps, no filesystem, no subprocesses.
+///
+/// A retry mechanism that silently never retried would look exactly like a
+/// working one: every test would pass, the metrics file would fill with
+/// `passedFirstTry`, and the first real flake would go red anyway. These two
+/// fixtures are the only thing standing between that and us.
+@Suite("Flaky quarantine self-tests")
+struct FlakyQuarantineSelfTests {
+    private static let passCounter = RunCounter()
+    private static let failCounter = RunCounter()
+
+    /// **This is not a flaky test.** It is the mechanism's self-test: the body
+    /// fails by design on its first run in a process and passes on every
+    /// subsequent one, so the suite is permanently green *if and only if*
+    /// `.flaky` re-ran it. If quarantine ever stops working, this goes red.
+    ///
+    /// Issue #499 is a permanently-open **fixture anchor**, not a flake report —
+    /// nothing is wrong with this test, and closing the issue would only make
+    /// the nightly audit nag about a test that is doing its job. Slice G's
+    /// quarantine audit excludes exactly
+    /// `TBDDaemonTests.FlakyQuarantineSelfTests/retriesUntilPass()` by ID for
+    /// the same reason.
+    @Test(.flaky(issue: 499))
+    func retriesUntilPass() {
+        let run = Self.passCounter.next()
+        #expect(
+            run > 1,
+            """
+            self-test fixture: run \(run) fails by design. Seeing this as a *visible* \
+            failure means .flaky(issue:) did not re-run the body.
+            """
+        )
+    }
+
+    /// Proof of the *exactly three attempts* half: this body always fails, so
+    /// the run must go red with a visible failure naming attempt 3 — attempts 1
+    /// and 2 suppressed as known issues, attempt 3 surfaced.
+    ///
+    /// Gated off by default because a permanently-red test cannot live in CI.
+    /// Keeping it here rather than deleting it costs a PR nothing and keeps the
+    /// proof re-runnable on demand:
+    ///
+    /// ```
+    /// TBD_FLAKY_SELFTEST_FAILURE=1 swift test --filter FlakyQuarantineSelfTests
+    /// ```
+    @Test(
+        .enabled(if: ProcessInfo.processInfo.environment["TBD_FLAKY_SELFTEST_FAILURE"] == "1"),
+        .flaky(issue: 499)
+    )
+    func alwaysFails() {
+        let attempt = Self.failCounter.next()
+        Issue.record("self-test fixture: attempt \(attempt) of \(FlakyTrait.maxAttempts) — fails by design")
+    }
+}
+
+/// Lock-guarded run counter. Static because `.flaky` re-instantiates the suite
+/// type per attempt — stored properties would reset and the fixture would fail
+/// forever.
+private final class RunCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func next() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
+    }
+}

--- a/Tests/TestSupport/FlakyTestSupport.swift
+++ b/Tests/TestSupport/FlakyTestSupport.swift
@@ -1,0 +1,287 @@
+import Foundation
+import Testing
+
+// Named quarantine + retry metrics for the test-hardening program
+// (`docs/specs/2026-07-24-test-hardening-design.md` §7).
+//
+// §7's whole point is that quarantine must not become a landfill: a retry is
+// allowed only when it is attached to an open issue, and every retry (and every
+// clean first-try pass) is written to a machine-readable ledger so the nightly
+// audit can tell "still flaky" from "quietly fixed months ago".
+
+// MARK: - Trait
+
+/// Re-runs a test body up to three times, suppressing the failures of all but
+/// the last attempt, and records the outcome to the retry-metrics ledger.
+///
+/// ```swift
+/// @Test(.flaky(issue: 512))
+/// func attachRacesSupersession() async { … }
+/// ```
+///
+/// **The issue number is required, and that is the entire honesty mechanism.**
+/// A blanket retry policy hides regressions: a test that starts failing 40% of
+/// the time because someone broke the code under test is indistinguishable from
+/// one that has always been 40% flaky. Quarantine has to *name* what it hides
+/// so slice G's nightly audit can flag a `.flaky` whose issue is closed, or one
+/// that passed first-try all week, for removal. An anonymous retry is a
+/// permanent blind spot; a named one is a ticket.
+///
+/// **Tier 2 only.** A red tier-1 test is a bug — in the test or in the code —
+/// full stop; it is deterministic and in-process, so "sometimes it fails" means
+/// something is genuinely wrong. Never quarantine one. Tier 3 lives in its own
+/// serial target where the contention this papers over is already contained.
+///
+/// Costs and interactions to know before reaching for it:
+///
+/// - Retries multiply wall clock by up to 3x, and that lands on top of
+///   `.timeLimit` / `.clockDriven`, which bound **each attempt**, not the total.
+///   A quarantined suite that takes 40 s takes 2 minutes when it misbehaves.
+/// - The suite type is re-instantiated per attempt, so stored properties are
+///   fresh — but `static`/global state is **not** reset. A body that mutates a
+///   static sees attempt 1's residue on attempt 2. (The self-tests in
+///   `FlakyQuarantineSelfTests` rely on exactly that; most tests are hurt by it.)
+/// - `provideScope` runs once per test **case**, so a parameterized test retries
+///   per case, not per test function.
+///
+/// **Known limitation — escaping Tasks break suppression in both directions.**
+/// Swift Testing's known-issue matcher is scoped to the task tree that
+/// `provideScope` wraps. An issue recorded from a `Task.detached` bypasses the
+/// matcher entirely: the attempt looks like it *passed*, so no retry happens,
+/// while the run still fails — a false-green attempt. Conversely, an inheriting
+/// `Task { }` that outlives the scope keeps the matcher alive past the end of
+/// this test, so an issue it records during a **later** test gets silently
+/// swallowed as "known". Do not quarantine a test that reports failures from an
+/// escaping Task; fix the escape first.
+///
+/// Metrics: with `TBD_RETRY_METRICS_PATH` set (CI does this at the job level;
+/// unset locally, where the trait writes nothing and does no work), every
+/// execution appends one JSONL record — including clean first-try passes,
+/// because the audit needs "passed first-try all week" as much as it needs
+/// retries. **That schema is a consumed API** (slice G's nightly audit reads
+/// it): adding a key is fine, changing or removing one means bumping `schema`.
+///
+/// Deliberately `TestTrait` only, never `SuiteTrait`: a quarantined *suite* is
+/// precisely the landfill this mechanism exists to prevent.
+public struct FlakyTrait: TestTrait, TestScoping {
+    /// The open GitHub issue tracking this flake. Required — see the type doc.
+    public let issue: Int
+
+    /// Total attempts, including the final unsuppressed one.
+    public static let maxAttempts = 3
+
+    public func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        for attempt in 1...Self.maxAttempts {
+            let isFinal = attempt == Self.maxAttempts
+            let failed = await Self.runAttempt(
+                comment: "flaky issue #\(issue), attempt \(attempt)",
+                suppressing: !isFinal,
+                function
+            )
+            if !failed {
+                RetryMetrics.record(
+                    test: test,
+                    issue: issue,
+                    attempts: attempt,
+                    outcome: attempt == 1 ? .passedFirstTry : .passedOnRetry
+                )
+                return
+            }
+            if isFinal {
+                RetryMetrics.record(test: test, issue: issue, attempts: attempt, outcome: .failed)
+                return
+            }
+        }
+    }
+
+    /// Runs one attempt and reports whether it recorded any issue.
+    ///
+    /// The `withKnownIssue` scope is present on **every** attempt, including the
+    /// last, because its matcher is the only way to observe "did this attempt
+    /// fail" — a failing `#expect` does not throw, and Swift Testing exposes no
+    /// public per-case result. On the final attempt the matcher returns `false`,
+    /// which passes the issue straight through to be recorded for real, keeping
+    /// its original source location and comment. `isIntermittent: true` is what
+    /// stops the unmatched scope from adding a spurious "expected an issue"
+    /// failure of its own.
+    ///
+    /// The `do`/`catch` is not optional: the `matching:` overload is `rethrows`,
+    /// so `try await function()` cannot be called directly inside it. And
+    /// `#require` throws `ExpectationFailedError` *after* it has already
+    /// recorded its issue, so re-recording that specific error trips Swift
+    /// Testing's "An API was misused" diagnostic — it must be swallowed.
+    private static func runAttempt(
+        comment: Comment,
+        suppressing: Bool,
+        _ function: @Sendable () async throws -> Void
+    ) async -> Bool {
+        let failed = FlagBox()
+        await withKnownIssue(comment, isIntermittent: true) {
+            do {
+                try await function()
+            } catch is ExpectationFailedError {
+                // Already recorded by `#require`; re-recording misuses the API.
+            } catch {
+                Issue.record(error)
+            }
+        } matching: { _ in
+            failed.set()
+            return suppressing
+        }
+        return failed.isSet
+    }
+}
+
+public extension Trait where Self == FlakyTrait {
+    /// See ``FlakyTrait``. Tier 2 only; the issue number is required.
+    static func flaky(issue: Int) -> Self { FlakyTrait(issue: issue) }
+}
+
+// MARK: - Metrics ledger
+
+/// Appends one JSONL record per `.flaky` test-case execution to the path in
+/// `TBD_RETRY_METRICS_PATH`. Unset (the local default) means no file, no work.
+enum RetryMetrics {
+    enum Outcome: String, Encodable {
+        case passedFirstTry, passedOnRetry, failed
+    }
+
+    private struct Record: Encodable {
+        let schema = 1
+        let testID: String
+        let issue: Int
+        let attempts: Int
+        let outcome: Outcome
+        let file: String
+        let line: Int
+    }
+
+    static func record(test: Test, issue: Int, attempts: Int, outcome: Outcome) {
+        guard MetricsAppender.shared.isEnabled else { return }
+        let location = test.sourceLocation
+        let record = Record(
+            testID: stableID(test.id),
+            issue: issue,
+            attempts: attempts,
+            outcome: outcome,
+            file: repoRelativePath(location),
+            line: location.line
+        )
+        let encoder = JSONEncoder()
+        // Sanctioned by §7's brief: sorted keys give a stable order so the CI
+        // artifact diffs cleanly, and JSONEncoder handles escaping for free.
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(record), let json = String(data: data, encoding: .utf8) else {
+            MetricsAppender.shared.warnOnce("failed to encode a retry-metrics record")
+            return
+        }
+        MetricsAppender.shared.append(json)
+    }
+
+    /// `Test.ID.description` appends the declaration's source location
+    /// (`…/retriesUntilPass()/FlakyQuarantineSelfTests.swift:29:6`), which
+    /// churns every time someone adds a line above the test — useless as a
+    /// ledger key or as an audit exclusion. This rebuilds the stable
+    /// `Module.Suite/testName()` prefix instead, which is also the form
+    /// `swift test --filter` matches. Parameterized cases share one ID:
+    /// `provideScope` still runs (and records) once per case, so a
+    /// parameterized test contributes one record per case under the same key.
+    private static func stableID(_ id: Test.ID) -> String {
+        ([id.moduleName] + id.nameComponents.prefix(1)).joined(separator: ".")
+            + id.nameComponents.dropFirst().map { "/" + $0 }.joined()
+    }
+
+    /// `SourceLocation` carries an absolute path; the ledger wants
+    /// `Tests/TBDDaemonTests/Foo.swift` so records are comparable across
+    /// machines and CI checkouts. Falls back to reconstructing from `fileID`
+    /// (module + basename), which is exact for this repo's flat
+    /// `Tests/<Target>/<File>.swift` layout and only loses nested directories.
+    private static func repoRelativePath(_ location: SourceLocation) -> String {
+        let path = location._filePath
+        if let marker = path.range(of: "/Tests/") {
+            return "Tests/" + path[marker.upperBound...]
+        }
+        return "Tests/" + location.fileID
+    }
+}
+
+// MARK: - Plumbing
+
+/// Serializes appends across the in-process parallel test run, and opens the
+/// file exactly once.
+private final class MetricsAppender: @unchecked Sendable {
+    static let shared = MetricsAppender()
+
+    private let path: String?
+    private let lock = NSLock()
+    private var descriptor: Int32?
+    private var openFailed = false
+    private var warned = false
+
+    private init() {
+        let raw = ProcessInfo.processInfo.environment["TBD_RETRY_METRICS_PATH"]
+        path = (raw?.isEmpty == false) ? raw : nil
+    }
+
+    var isEnabled: Bool { path != nil }
+
+    func append(_ line: String) {
+        guard let path else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        if descriptor == nil, !openFailed {
+            let fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+            if fd < 0 {
+                openFailed = true
+                warnLocked("could not open \(path) (errno \(errno))")
+            } else {
+                descriptor = fd
+            }
+        }
+        guard let fd = descriptor else { return }
+        let bytes = Array((line + "\n").utf8)
+        let written = bytes.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
+        if written != bytes.count {
+            warnLocked("short write to \(path) (\(written) of \(bytes.count) bytes, errno \(errno))")
+        }
+    }
+
+    func warnOnce(_ message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        warnLocked(message)
+    }
+
+    /// An infra hiccup must never look like a code failure, so this never fails
+    /// a test — but it must not be silent either, or broken CI wiring shows up
+    /// as an empty artifact nobody questions. One line per process.
+    private func warnLocked(_ message: String) {
+        guard !warned else { return }
+        warned = true
+        let text = "warning: retry metrics disabled — \(message)\n"
+        FileHandle.standardError.write(Data(text.utf8))
+    }
+}
+
+/// Lock-guarded latch. The known-issue matcher runs on whatever task recorded
+/// the issue, so this crosses threads.
+private final class FlagBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    func set() {
+        lock.lock()
+        value = true
+        lock.unlock()
+    }
+
+    var isSet: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+}

--- a/Tests/TestSupport/FlakyTestSupport.swift
+++ b/Tests/TestSupport/FlakyTestSupport.swift
@@ -52,7 +52,9 @@ import Testing
 /// `Task { }` that outlives the scope keeps the matcher alive past the end of
 /// this test, so an issue it records during a **later** test gets silently
 /// swallowed as "known". Do not quarantine a test that reports failures from an
-/// escaping Task; fix the escape first.
+/// escaping Task; fix the escape first. The ledger inherits that lie: the
+/// attempt looks clean, so a false-green attempt is recorded `passedFirstTry`
+/// while the run itself goes red — a green record for a red run.
 ///
 /// Metrics: with `TBD_RETRY_METRICS_PATH` set (CI does this at the job level;
 /// unset locally, where the trait writes nothing and does no work), every
@@ -77,7 +79,7 @@ public struct FlakyTrait: TestTrait, TestScoping {
     ) async throws {
         for attempt in 1...Self.maxAttempts {
             let isFinal = attempt == Self.maxAttempts
-            let failed = await Self.runAttempt(
+            let failed = try await Self.runAttempt(
                 comment: "flaky issue #\(issue), attempt \(attempt)",
                 suppressing: !isFinal,
                 function
@@ -114,17 +116,26 @@ public struct FlakyTrait: TestTrait, TestScoping {
     /// `#require` throws `ExpectationFailedError` *after* it has already
     /// recorded its issue, so re-recording that specific error trips Swift
     /// Testing's "An API was misused" diagnostic — it must be swallowed.
+    ///
+    /// Cancellation is neither a failure nor a pass, so it is rethrown rather
+    /// than retried. Swallowing it would green a cancelled test; recording it
+    /// as an issue would burn all three attempts and write
+    /// `attempts: 3, outcome: .failed` — indistinguishable, in the ledger, from
+    /// a genuinely always-failing flake. A cancelled run writes no record.
     private static func runAttempt(
         comment: Comment,
         suppressing: Bool,
         _ function: @Sendable () async throws -> Void
-    ) async -> Bool {
+    ) async throws -> Bool {
         let failed = FlagBox()
+        let cancelled = FlagBox()
         await withKnownIssue(comment, isIntermittent: true) {
             do {
                 try await function()
             } catch is ExpectationFailedError {
                 // Already recorded by `#require`; re-recording misuses the API.
+            } catch is CancellationError {
+                cancelled.set()
             } catch {
                 Issue.record(error)
             }
@@ -132,6 +143,7 @@ public struct FlakyTrait: TestTrait, TestScoping {
             failed.set()
             return suppressing
         }
+        if cancelled.isSet { throw CancellationError() }
         return failed.isSet
     }
 }
@@ -202,7 +214,9 @@ enum RetryMetrics {
     /// `Tests/<Target>/<File>.swift` layout and only loses nested directories.
     private static func repoRelativePath(_ location: SourceLocation) -> String {
         let path = location._filePath
-        if let marker = path.range(of: "/Tests/") {
+        // `.backwards`: a checkout path that itself contains `/Tests/` would
+        // otherwise be cut at the wrong occurrence.
+        if let marker = path.range(of: "/Tests/", options: .backwards) {
             return "Tests/" + path[marker.upperBound...]
         }
         return "Tests/" + location.fileID
@@ -244,9 +258,22 @@ private final class MetricsAppender: @unchecked Sendable {
         }
         guard let fd = descriptor else { return }
         let bytes = Array((line + "\n").utf8)
-        let written = bytes.withUnsafeBytes { write(fd, $0.baseAddress, $0.count) }
-        if written != bytes.count {
-            warnLocked("short write to \(path) (\(written) of \(bytes.count) bytes, errno \(errno))")
+        // Loop rather than one `write`: the consumer is a line parser, so a
+        // partial write would leave a fragment that the next record
+        // concatenates onto, yielding one unparseable line. Retries EINTR too.
+        bytes.withUnsafeBytes { buffer in
+            var offset = 0
+            while offset < buffer.count {
+                let written = write(fd, buffer.baseAddress! + offset, buffer.count - offset)
+                if written > 0 {
+                    offset += written
+                } else if written < 0, errno == EINTR {
+                    continue
+                } else {
+                    warnLocked("short write to \(path) (\(offset) of \(buffer.count) bytes, errno \(errno))")
+                    return
+                }
+            }
         }
     }
 

--- a/Tests/TestSupport/FlakyTestSupport.swift
+++ b/Tests/TestSupport/FlakyTestSupport.swift
@@ -79,12 +79,25 @@ public struct FlakyTrait: TestTrait, TestScoping {
     ) async throws {
         for attempt in 1...Self.maxAttempts {
             let isFinal = attempt == Self.maxAttempts
-            let failed = try await Self.runAttempt(
+            let result = await Self.runAttempt(
                 comment: "flaky issue #\(issue), attempt \(attempt)",
                 suppressing: !isFinal,
                 function
             )
-            if !failed {
+            if result.cancelled {
+                // Cancellation ends the sequence — there is nothing to retry.
+                // But `#expect` records without throwing, so an attempt can
+                // record a real failure and *then* be cancelled. On the final
+                // attempt that verdict was surfaced unsuppressed, so it is a
+                // genuine red and belongs in the ledger; leaving it out would
+                // make CI red and the audit data silent. On a non-final
+                // attempt the failure was suppressed and no verdict stands.
+                if isFinal, result.failed {
+                    RetryMetrics.record(test: test, issue: issue, attempts: attempt, outcome: .failed)
+                }
+                throw CancellationError()
+            }
+            if !result.failed {
                 RetryMetrics.record(
                     test: test,
                     issue: issue,
@@ -98,6 +111,14 @@ public struct FlakyTrait: TestTrait, TestScoping {
                 return
             }
         }
+    }
+
+    /// What one attempt did. `failed` and `cancelled` are independent: a body
+    /// can record a failing `#expect` (which does not throw) and then hit
+    /// cancellation in the same attempt.
+    private struct AttemptResult {
+        let failed: Bool
+        let cancelled: Bool
     }
 
     /// Runs one attempt and reports whether it recorded any issue.
@@ -117,16 +138,17 @@ public struct FlakyTrait: TestTrait, TestScoping {
     /// recorded its issue, so re-recording that specific error trips Swift
     /// Testing's "An API was misused" diagnostic — it must be swallowed.
     ///
-    /// Cancellation is neither a failure nor a pass, so it is rethrown rather
-    /// than retried. Swallowing it would green a cancelled test; recording it
-    /// as an issue would burn all three attempts and write
-    /// `attempts: 3, outcome: .failed` — indistinguishable, in the ledger, from
-    /// a genuinely always-failing flake. A cancelled run writes no record.
+    /// Cancellation is reported separately rather than retried. Swallowing it
+    /// would green a cancelled test; recording it as an issue would burn all
+    /// three attempts and write `attempts: 3, outcome: .failed` —
+    /// indistinguishable, in the ledger, from a genuinely always-failing flake.
+    /// It is "neither a failure nor a pass" only until an unsuppressed verdict
+    /// has already been recorded; see the caller for that case.
     private static func runAttempt(
         comment: Comment,
         suppressing: Bool,
         _ function: @Sendable () async throws -> Void
-    ) async throws -> Bool {
+    ) async -> AttemptResult {
         let failed = FlagBox()
         let cancelled = FlagBox()
         await withKnownIssue(comment, isIntermittent: true) {
@@ -143,8 +165,7 @@ public struct FlakyTrait: TestTrait, TestScoping {
             failed.set()
             return suppressing
         }
-        if cancelled.isSet { throw CancellationError() }
-        return failed.isSet
+        return AttemptResult(failed: failed.isSet, cancelled: cancelled.isSet)
     }
 }
 


### PR DESCRIPTION
**Slice E** of the test-hardening program (`docs/specs/2026-07-24-test-hardening-design.md` §7, slicing doc §4/§5). Replaces this repo's tribal rerun lore with quarantine that *names* what it hides. Slice G's nightly audit is the consumer, so the artifact format here is an API, not an implementation detail.

Test infrastructure only. The default-off flag policy in the root `CLAUDE.md` does not apply — this adds no autonomous behavior and is applied to nothing but its own self-test fixtures. No clock work in this slice.

## The trait

```swift
@Test(.flaky(issue: 512))
func attachRacesSupersession() async { … }
```

Body re-runs up to 3 times; the first two failures are suppressed as known issues, the third is surfaced normally **at its real source location and comment**. That last part is the difference between a quarantine mechanism and a failure-swallowing mechanism.

- **The required, non-defaulted issue number is the entire honesty mechanism.** Blanket retries hide regressions — a test that started failing 40% of the time because someone broke the code is indistinguishable from one that was always 40% flaky. This is why the program rejected "tier 2 gets one retry" from the original roadmap.
- **`TestTrait` only, never `SuiteTrait`** — a quarantined *suite* would let one annotation silence twenty tests against one issue number.
- **Tier 2 only.** A red tier-1 test is a bug, full stop; tier 3 already has its own serial target.

## Artifact schema — what slice G consumes

Every execution of a `.flaky` test appends one JSONL record to `$TBD_RETRY_METRICS_PATH` (set at the job level in CI; unset locally, where the trait does no work at all). **Including clean first-try passes** — G's "passed first-try all week" audit is impossible otherwise.

```json
{"attempts":2,"file":"Tests/TBDDaemonTests/FlakyQuarantineSelfTests.swift","issue":499,"line":29,"outcome":"passedOnRetry","schema":1,"testID":"TBDDaemonTests.FlakyQuarantineSelfTests/retriesUntilPass()"}
```

| key | meaning |
|---|---|
| `schema` | `1`. Adding a key is fine; changing or removing one bumps this. |
| `testID` | `Module.Suite/test()` — the `swift test --filter`-matchable form. Deliberately **not** `Test.ID.description`, which appends the declaration's source location and churns whenever a line is added above the test, making it useless as an audit exclusion key. |
| `issue` | the required issue number |
| `attempts` | `1...3`, how many times the body actually ran |
| `outcome` | `passedFirstTry` \| `passedOnRetry` \| `failed` |
| `file`, `line` | repo-relative `@Test` site, so G can point at the trait to delete **without parsing source or logs** |

Keys are alphabetically sorted so the artifact diffs cleanly. Both CI passes append to one file → one artifact per run. G needs no log parsing: `jq -s` gives per-issue pass/retry/fail counts keyed by `testID`, and the closed-issue half of the audit is a `gh issue view` per distinct `issue`.

### ⚠️ The one record G must exclude

`TBDDaemonTests.FlakyQuarantineSelfTests/retriesUntilPass()` — the mechanism's own self-test. It fails once and passes on retry **by design on every run**, so it would otherwise show as a permanently-flaky test in every nightly report forever, and a dashboard with a permanent false positive stops being read. Its issue #499 is a permanently-open **fixture anchor**, titled to say so. **Exclude that exact ID and no other.** This is stated here, in `Tests/CLAUDE.md`, and in #499 itself.

## How I proved it actually retries

A mechanism that silently never retried would be indistinguishable from a working one until the day it mattered. Both directions verified by running them, not by reading the code:

**Retry fires** — `retriesUntilPass` fails on attempt 1, passes on attempt 2, suite green:
```
Test retriesUntilPass() recorded a known issue at FlakyQuarantineSelfTests.swift:32:9: Expectation failed: (run → 1) > 1
Test retriesUntilPass() passed after 0.002 seconds with 1 known issue.
Test run with 2 tests in 1 suite passed with 1 known issue.
→ {"attempts":2,…,"outcome":"passedOnRetry",…}
```

**It gives up after exactly 3** — `TBD_FLAKY_SELFTEST_FAILURE=1`, gated off in CI:
```
… recorded a known issue …: attempt 1 of 3 — fails by design
… recorded a known issue …: attempt 2 of 3 — fails by design
… recorded an issue      …: attempt 3 of 3 — fails by design      ← visible, unsuppressed
Test alwaysFails() failed with 3 issues (including 2 known issues).
→ {"attempts":3,…,"outcome":"failed",…}
```

Also verified, because the obvious shortcut would have lied: a fixture that fails on 1 and 2 and **passes on 3** is recorded `attempts:3 / passedOnRetry`, not `failed`. And the suite type is confirmed re-instantiated per attempt (stored properties fresh; statics are not).

`alwaysFails` stays in the tree gated behind an env var rather than deleted — the proof costs a PR nothing and stays re-runnable.

## Two defects the review gate caught, both worth naming

1. **The feature was dead on CI.** `${{ runner.temp }}` is **not available in a job-level `env:` block**, and GitHub resolves an unavailable context to the *empty string* rather than erroring. Tests would have been handed `/retry-metrics.jsonl`, failed to open at the filesystem root, and uploaded an empty artifact on every run — while the upload step, being step-level, pointed at the real temp dir where nothing was ever written. `actionlint` confirms it: the first commit raises the context error, the fix does not. Now a literal `/tmp` path, which the existing steps already use. This is the program's recurring shape — a mechanism named for the thing you want that does not do it — and it would have shipped invisibly.
2. **A cancelled final attempt silenced a real verdict.** `#expect` records without throwing, so an attempt can record a genuine failure and *then* be cancelled (realistically: a `.timeLimit` expiry landing after an earlier failure — and `.clockDriven` applies a one-minute limit widely here). The rethrow skipped the ledger write: red in CI, silent in the audit data. Now a final attempt that both failed and was cancelled records `.failed`; a non-final one still records nothing, because its failure was suppressed and no verdict stands.

## `.github/workflows/test.yml` — additive, plus one authorized exception

- Job-level `env:` for the metrics path, and an `if: always()` upload step (`if-no-files-found: warn`, not `ignore` — an absent file means broken wiring and must be visible).
- **`timeout-minutes` on the fast pass**, which had none. Explicitly authorized by the orchestrator: a tier-1 test can hang indefinitely, `.clockDriven` did **not** bound it, and a hung fast pass currently eats the job's 6 h default.
- **30 minutes, not the suggested 10.** That step runs the first `swift test`, so it carries the whole test-target compile, not just the ~30 s of test runtime. Three consecutive warm-cache runs on `main` measured **2m22s / 3m33s / 6m02s** — a 10-minute budget is under 2x the observed worst case, and a cold cache would blow through it and kill a healthy build. 30 still bounds a hang at 1/12 of the default.

Slice A's two test steps are otherwise untouched: floors, `--skip`/`--filter`, `--no-parallel`, and the quiet step's `timeout-minutes: 15` are all as they were.

## `Tests/CLAUDE.md` — four rules earned by sibling slices

Ownership was granted for the duration of wave 2; rebased onto #497 (`6fcca058`), which lands ahead of these edits.

- **Advance-chain limit**, with the measured numbers: 100 tight `advanceWhenSuspended` iterations passed in **0.626 s unloaded and hung past 10 minutes under 12 spinners**. Plus the counter-rule, because following it naively degrades coverage invisibly — shorten the chain *and* keep the claim, by injecting pacing. Plus the failure signature: it presented as a **hang** and a truncated log with no summary line, which a naive `rc == 0` counts as a pass.
- **`.clockDriven` is not a reliable hang backstop on its own** — the existing text claimed it bounds the hang; measured, it did not fire. Corrected rather than left standing.
- **Shared-box hazards, written as the family it is**: `jobs -p`, `trap 'kill 0' EXIT`, `pkill -f` across worktrees, orphaned subagent subtrees — under one rule (kill by captured PID or your own process tree; never by name pattern or process group), plus the disk-at-100% class where `generate-dSYM`/`link command failed` reads as a broken diff. **Note this file previously *recommended* `trap 'kill 0' EXIT`**, which is hazard #2 and cost the program a stress run; that recommendation is now removed.
- **The non-throwing-waiter note extended**: the index crash is the *good* case. The nastier one is a plausible-looking second assertion that misattributes the cause — a real instance produced `[42] == [42, 42]`, sending the reader to the wrong line — and **the tell was the duration**, 62 s for what should have been a fast assertion failure.

## Verification

- `swift build` green; `swiftlint --strict` 0 violations in 586 files; `actionlint` clean apart from a pre-existing `SC2086` info.
- Both proof paths re-run after every code change, including after the two review fixes.
- Advance-chain audit (required of all slices): **N/A, reported clean** — this slice contains no clock work and shortened no chains.
- Rebased onto `6fcca058`; no numbers here were measured against the old `waitForSuspension`, since the slice takes no timing measurements.

Refs #499

[20260724-spectacular-stoat](https://cheapsteak.github.io/tbd/open/?worktree=5146317A-1D34-45B7-891A-CBAE5F923A9D)