### PR TITLE
DX: Virtualize the control-mode and attach ready-timer clocks — the precondition slice H is blocked on

### DIFF
--- a/Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
@@ -117,9 +117,21 @@ extension RPCRouter {
             // Generation-scoped so a timer outliving a superseded attach can't
             // kill the fresh attach that replaced it.
             let timeout = bridge.readyTimeout
-            Task { [supervisor = bridge.supervisor] in
-                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
-                try? await Task.sleep(for: timeout)
+            Task { [supervisor = bridge.supervisor, clock = bridge.clock] in
+                // `try?` is HEAD's shape, kept bit-for-bit. Note what it does
+                // NOT mean: on cancellation the sleep throws, `try?` swallows
+                // it, and control FALLS THROUGH to the detach below — so a
+                // cancelled timer runs the teardown IMMEDIATELY rather than
+                // skipping it. Latent today (nothing retains this Task handle,
+                // so nothing can cancel it), and harmless if it ever isn't —
+                // BECAUSE `detachIfNotReady` is generation-scoped and a no-op
+                // once the attach is acked. That "because" is the invariant
+                // this relies on, not a passing remark: if `detachIfNotReady`
+                // ever stops checking the generation, or a side effect is
+                // added AHEAD of that check, an early-fired timer starts
+                // tearing down a live attach. Spelled out because the opposite
+                // reading of `try?` is the natural one.
+                try? await clock.sleep(for: timeout)
                 await supervisor.detachIfNotReady(server: server, paneID: paneID, generation: generation)
             }
             // The generation rides the result so the app can echo it back in

--- a/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/PaneRepairCoordinator.swift
@@ -50,8 +50,11 @@ actor PaneRepairCoordinator {
     /// Recapture depth — matches the attach orchestrator's (see its note on
     /// the server-side `history-limit 50000`).
     private let historyDepth: Int
-    /// Reader-catch-up poll pacing (step 2) — injectable so tests can wedge
-    /// the reader on tiny intervals. The wait has NO deadline: pacing starts
+    /// Reader-catch-up poll pacing (step 2) — injectable so tests can choose
+    /// a pacing that reaches a threshold in a few clock advances (typically
+    /// LARGER than production: virtual time makes small intervals pointless,
+    /// and a long advance chain is a load-sensitivity hazard). The wait has
+    /// NO deadline: pacing starts
     /// at `writableCheckInterval` and relaxes to `writableSlowInterval` once
     /// the wait exceeds `writableEscalationThreshold`.
     private let writableCheckInterval: Duration
@@ -65,13 +68,18 @@ actor PaneRepairCoordinator {
     /// `repairing` flag already gates re-signaling at the fanout, but a
     /// duplicate signal for a key mid-repair must still be a no-op here.
     private var inFlight: Set<PaneKey> = []
+    /// Clock behind the reader-catch-up pacing below. Defaulted, so no call
+    /// site changes; tests pass a `TestClock` and drive virtual time.
+    private let clock: any Clock<Duration>
 
     init(supervisor: TmuxControlSupervisor,
          commandProvider: @escaping @Sendable (String) async -> TmuxControlCommandClient?,
          historyDepth: Int = 50_000,
          writableCheckInterval: Duration = .milliseconds(50),
          writableSlowInterval: Duration = .milliseconds(500),
-         writableEscalationThreshold: Duration = .seconds(5)) {
+         writableEscalationThreshold: Duration = .seconds(5),
+         clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
         self.supervisor = supervisor
         self.commandProvider = commandProvider
         self.historyDepth = historyDepth
@@ -182,7 +190,15 @@ actor PaneRepairCoordinator {
         // the viewer is gone or dying, the app-death detach path finishes the
         // job, and leaving the pane unpaused keeps it healthy for the next
         // attach.
-        let waitStart = ContinuousClock.now
+        //
+        // Elapsed is ACCUMULATED from the intervals this loop actually slept,
+        // not read off an `Instant` — `any Clock<Duration>` erases `Instant`,
+        // and both thresholds below are pure pacing/logging (neither gates a
+        // send, an unpause, or a generation decision), so excluding the
+        // nanosecond-scale writability check between slices is noise against
+        // a 5 s / 30 s mark, and makes both exactly advanceable on a
+        // `TestClock`.
+        var waited: Duration = .zero
         var loggedStall = false
         waitLoop: while true {
             switch supervisor.fanout.isPipeWritable(key: key, generation: generation) {
@@ -209,7 +225,6 @@ actor PaneRepairCoordinator {
                 }
                 return
             case .full?:
-                let waited = ContinuousClock.now - waitStart
                 if !loggedStall, waited >= Self.readerStallLogThreshold {
                     loggedStall = true
                     Self.logger.error("""
@@ -220,17 +235,17 @@ actor PaneRepairCoordinator {
                 let interval = waited >= writableEscalationThreshold
                     ? writableSlowInterval : writableCheckInterval
                 // Cancellation bail (latent — the bridge's dispatch Tasks are
-                // never cancelled today): in a cancelled task `Task.sleep`
+                // never cancelled today): in a cancelled task the sleep
                 // throws immediately, which would turn this deadline-free
                 // wait into an unbounded busy-spin. Exit silently, like the
                 // superseded `nil` case above: send nothing — the sink stays
                 // `repairing`, and a later overflow signal or attach heals it.
                 do {
-                    // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
-                    try await Task.sleep(for: interval)
+                    try await clock.sleep(for: interval)
                 } catch {
                     return
                 }
+                waited += interval
             }
         }
 

--- a/Sources/TBDDaemon/Tmux/ControlMode/TmuxControlModeBridge.swift
+++ b/Sources/TBDDaemon/Tmux/ControlMode/TmuxControlModeBridge.swift
@@ -49,6 +49,11 @@ struct TmuxControlModeBridge: Sendable {
     /// this value struct, wired to `PaneFanout.onOverflowRepair` in this
     /// init; injectable seam like `inputRouter`/`resizeCoordinator`.
     let repairCoordinator: PaneRepairCoordinator
+    /// Clock behind every delay in the control-mode subsystem: the attach
+    /// ready-timer below and (threaded down) the repair coordinator's
+    /// reader-catch-up pacing. Defaulted, so no call site changes; tests pass
+    /// a `TestClock` and drive virtual time instead of sleeping.
+    let clock: any Clock<Duration>
 
     init(supervisor: TmuxControlSupervisor,
          tmuxVersion: TmuxVersion?,
@@ -59,8 +64,10 @@ struct TmuxControlModeBridge: Sendable {
          resizeCoordinator: ControlModeResizeCoordinator? = nil,
          persistedFlagProvider: @escaping @Sendable () async -> Bool = { false },
          commandProvider: (@Sendable (String) async -> TmuxControlCommandClient?)? = nil,
-         repairCoordinator: PaneRepairCoordinator? = nil) {
+         repairCoordinator: PaneRepairCoordinator? = nil,
+         clock: any Clock<Duration> = ContinuousClock()) {
         self.supervisor = supervisor
+        self.clock = clock
         self.tmuxVersion = tmuxVersion
         self.environment = environment
         self.fdVending = fdVending
@@ -90,8 +97,13 @@ struct TmuxControlModeBridge: Sendable {
         // Wire the M3 overflow-repair signal, also BEFORE any connection
         // starts (same startup guarantee as the layout filter): the very
         // first routed byte can already overflow a wedged pipe.
+        // Only the default-constructed coordinator inherits our clock; an
+        // injected one carries whatever clock it was built with. (No call
+        // site injects one today — tests that need a fake-clocked coordinator
+        // construct it directly rather than going through the bridge.)
         self.repairCoordinator = repairCoordinator
-            ?? PaneRepairCoordinator(supervisor: supervisor, commandProvider: self.commandProvider)
+            ?? PaneRepairCoordinator(
+                supervisor: supervisor, commandProvider: self.commandProvider, clock: clock)
         let repair = self.repairCoordinator
         supervisor.fanout.onOverflowRepair = { key, generation in
             Task { await repair.repairIfNeeded(key: key, generation: generation) }

--- a/Tests/TBDDaemonTests/AttachRPCTests.swift
+++ b/Tests/TBDDaemonTests/AttachRPCTests.swift
@@ -108,7 +108,7 @@ struct AttachRPCStubTests {
     }
 }
 
-@Suite("Attach RPC orchestration", .clockDriven)
+@Suite("Attach RPC orchestration", .clockDriven, .serialized)
 struct AttachRPCOrchestrationTests {
 
     private func makeSocketPair() throws -> (Int32, Int32) {

--- a/Tests/TBDDaemonTests/AttachRPCTests.swift
+++ b/Tests/TBDDaemonTests/AttachRPCTests.swift
@@ -1,3 +1,4 @@
+import Clocks
 import Darwin
 import Foundation
 import TestSupport
@@ -107,7 +108,7 @@ struct AttachRPCStubTests {
     }
 }
 
-@Suite("Attach RPC orchestration")
+@Suite("Attach RPC orchestration", .clockDriven)
 struct AttachRPCOrchestrationTests {
 
     private func makeSocketPair() throws -> (Int32, Int32) {
@@ -134,7 +135,11 @@ struct AttachRPCOrchestrationTests {
         // that exercises the timeout, `unackedAttachTornDownAfterTimeout`,
         // passes its own short value explicitly.
         readyTimeout: Duration = .seconds(600),
-        commandProvider: (@Sendable (String) async -> TmuxControlCommandClient?)? = nil
+        commandProvider: (@Sendable (String) async -> TmuxControlCommandClient?)? = nil,
+        // The two tests that exercise the ready-timer pass a `TestClock` and
+        // advance it; everyone else keeps the real clock plus the sentinel
+        // timeout above, so the timer simply never fires.
+        clock: (any Clock<Duration>)? = nil
     ) -> TmuxControlModeBridge {
         TmuxControlModeBridge(
             supervisor: supervisor,
@@ -142,7 +147,8 @@ struct AttachRPCOrchestrationTests {
             environment: gateOn ? ["TBD_TMUX_CONTROL_MODE": "1"] : [:],
             fdVending: vending,
             readyTimeout: readyTimeout,
-            commandProvider: commandProvider)
+            commandProvider: commandProvider,
+            clock: clock ?? ContinuousClock())
     }
 
     /// Thread-safe monotonic counter — lets a commandProvider hand each
@@ -271,8 +277,10 @@ struct AttachRPCOrchestrationTests {
         await vending.adoptConnection(fd: serverSide)
         let (router, db) = try makeRouterAndDB()
         let worktreeID = try await makeWorktree(in: db)
+        let clock = TestClock<Duration>()
+        let readyTimeout: Duration = .seconds(5)
         router.controlMode = bridge(
-            supervisor: supervisor, vending: vending, readyTimeout: .milliseconds(100))
+            supervisor: supervisor, vending: vending, readyTimeout: readyTimeout, clock: clock)
 
         let request = try RPCRequest(
             method: RPCMethod.attachRequest,
@@ -282,9 +290,13 @@ struct AttachRPCOrchestrationTests {
         let (rxFD, _) = try SidecarTestSupport.receiveVend(from: clientSide)
         defer { Darwin.close(rxFD) }
 
-        // No attach.ready is ever sent. After the timeout, the daemon must
-        // detach — closing the write end, so the vended read fd sees EOF.
-        try await Task.sleep(for: .milliseconds(400))
+        // No attach.ready is ever sent. Advancing past the timeout fires the
+        // ready-timer — `advanceWhenSuspended` also proves the detached timer
+        // task actually armed, which the old wall-clock sleep only assumed.
+        // The daemon must then detach, closing the write end: EOF on the
+        // vended read fd (a blocking read, so it is the teardown itself that
+        // unblocks the assertion).
+        await clock.advanceWhenSuspended(by: readyTimeout)
         var buffer = [UInt8](repeating: 0, count: 8)
         let count = buffer.withUnsafeMutableBytes { Darwin.read(rxFD, $0.baseAddress, $0.count) }
         #expect(count == 0, "un-acked attach must be torn down (EOF on the vended fd)")
@@ -353,9 +365,11 @@ struct AttachRPCOrchestrationTests {
         let (router, db) = try makeRouterAndDB()
         let (client, recorder) = makeFakeClient()
         let worktreeID = try await makeWorktree(in: db, tmuxServer: "tbd-timeout-test")
+        let clock = TestClock<Duration>()
+        let readyTimeout: Duration = .seconds(5)
         router.controlMode = bridge(
             supervisor: supervisor, vending: vending,
-            readyTimeout: .milliseconds(100), commandProvider: { _ in client })
+            readyTimeout: readyTimeout, commandProvider: { _ in client }, clock: clock)
 
         let attach = try RPCRequest(
             method: RPCMethod.attachRequest,
@@ -371,9 +385,9 @@ struct AttachRPCOrchestrationTests {
         let readyTask = Task { await router.handle(ready) }
         try await waitFor("pause batch write") { recorder.writes.count >= 1 }
 
-        // Let the 100 ms ready-timeout fire while the replay is in flight:
-        // the acked attach must NOT be torn down (no EOF on the vended fd).
-        try await Task.sleep(for: .milliseconds(400))
+        // Let the ready-timeout fire while the replay is in flight: the acked
+        // attach must NOT be torn down (no EOF on the vended fd).
+        await clock.advanceWhenSuspended(by: readyTimeout)
         let flags = fcntl(rxFD, F_GETFL)
         _ = fcntl(rxFD, F_SETFL, flags | O_NONBLOCK)
         var probe = [UInt8](repeating: 0, count: 8)

--- a/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
@@ -34,7 +34,6 @@ struct ControlModeInputHealthTests {
     /// Poll until `recorder` has at least `count` health events (shared
     /// `waitFor`, which keeps the post-deadline re-check this suite needed
     /// under parallel-suite load).
-    @discardableResult
     private func waitForEvents(_ recorder: HealthRecorder, count: Int,
                                sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
         try await waitFor("\(count) health events", sourceLocation: sourceLocation) {
@@ -42,7 +41,6 @@ struct ControlModeInputHealthTests {
         }
     }
 
-    @discardableResult
     private func waitForWrites(_ recorder: LineRecorder, count: Int,
                                sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
         try await waitFor("\(count) stream writes", sourceLocation: sourceLocation) {
@@ -125,7 +123,7 @@ struct ControlModeInputHealthTests {
         router.enqueue(header: header, bytes: Data([0xff]))   // succeeds
         router.enqueue(header: header, bytes: Data([0xff]))   // steady healthy: no event
 
-        try await waitForEvents(health, count: 2)
+        try #require(await waitForEvents(health, count: 2))
         // Give the third completion time to land, then confirm no third event.
         try await Task.sleep(for: .milliseconds(50))
         #expect(health.events.map(\.healthy) == [false, true])
@@ -141,7 +139,7 @@ struct ControlModeInputHealthTests {
 
         for i in 0..<5 { router.enqueue(header: header, bytes: Data([UInt8(i)])) }
 
-        try await waitForWrites(recorder, count: 5)
+        try #require(await waitForWrites(recorder, count: 5))
         try await Task.sleep(for: .milliseconds(50))   // let completions drain
         #expect(health.events.isEmpty)
         router.shutdown()
@@ -160,7 +158,7 @@ struct ControlModeInputHealthTests {
         router.enqueue(header: SidecarInputHeader(worktreeID: worktreeID, paneID: "%0"),
                        bytes: Data([0x42]))
 
-        try await waitForWrites(recorder, count: 1)
+        try #require(await waitForWrites(recorder, count: 1))
         try await Task.sleep(for: .milliseconds(50))
         #expect(health.events.isEmpty)
         router.shutdown()
@@ -181,7 +179,7 @@ struct ControlModeInputHealthTests {
         router.enqueue(header: header, bytes: Data([0x41]))
         router.enqueue(header: header, bytes: Data([0x42]))   // steady failing: no 2nd event
 
-        try await waitForEvents(health, count: 1)
+        try #require(await waitForEvents(health, count: 1))
         try await Task.sleep(for: .milliseconds(50))
         #expect(health.events.map(\.healthy) == [false])
         router.shutdown()
@@ -200,7 +198,7 @@ struct ControlModeInputHealthTests {
         router.enqueuePaste(header: header, bytes: Data(repeating: 0x50, count: 1024))
         router.enqueue(header: header, bytes: Data([0x5a]))
 
-        try await waitForEvents(health, count: 2)
+        try #require(await waitForEvents(health, count: 2))
         #expect(health.events.map(\.healthy) == [false, true])
         router.shutdown()
     }
@@ -213,14 +211,14 @@ struct ControlModeInputHealthTests {
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
         router.enqueue(header: header, bytes: Data([0x41]))   // fails → event 1
-        try await waitForEvents(health, count: 1)
+        try #require(await waitForEvents(health, count: 1))
 
         // Detach then re-attach: state must reset WITHOUT a recovery event.
         router.unregister(worktreeID: worktreeID, paneID: "%0")
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
 
         router.enqueue(header: header, bytes: Data([0x41]))   // fails → event 2
-        try await waitForEvents(health, count: 2)
+        try #require(await waitForEvents(health, count: 2))
         #expect(health.events.map(\.healthy) == [false, false])
         router.shutdown()
     }
@@ -235,7 +233,7 @@ struct ControlModeInputHealthTests {
         router.enqueue(header: header, bytes: Data([0x41]))   // fails → failing event
         router.enqueue(header: header, bytes: Data([0xff]))   // succeeds → recovery event
 
-        try await waitForEvents(health, count: 2)
+        try #require(await waitForEvents(health, count: 2))
         // Both edges are stamped with the registered attach generation, so
         // the app can refuse a stale attach's failure against a fresh attach.
         #expect(health.events.map(\.generation) == [42, 42])
@@ -244,7 +242,7 @@ struct ControlModeInputHealthTests {
         // events carry it — never the stale one.
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv", generation: 43)
         router.enqueue(header: header, bytes: Data([0x41]))   // fails again → event 3
-        try await waitForEvents(health, count: 3)
+        try #require(await waitForEvents(health, count: 3))
         #expect(health.events.last?.generation == 43)
         router.shutdown()
     }
@@ -257,7 +255,7 @@ struct ControlModeInputHealthTests {
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
         router.enqueue(header: header, bytes: Data([0x41]))
-        try await waitForEvents(health, count: 1)
+        try #require(await waitForEvents(health, count: 1))
         #expect(health.events.map(\.generation) == [nil])
         router.shutdown()
     }
@@ -270,7 +268,7 @@ struct ControlModeInputHealthTests {
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
         router.enqueue(header: header, bytes: Data([0x41]))   // fails → event 1
-        try await waitForEvents(health, count: 1)
+        try #require(await waitForEvents(health, count: 1))
 
         // Re-attach WITHOUT the detach's unregister (the pane.detach RPC was
         // lost): the fresh attach must still start from a healthy baseline —
@@ -278,7 +276,7 @@ struct ControlModeInputHealthTests {
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
 
         router.enqueue(header: header, bytes: Data([0x41]))   // fails → event 2
-        try await waitForEvents(health, count: 2)
+        try #require(await waitForEvents(health, count: 2))
         #expect(health.events.map(\.healthy) == [false, false])
         router.shutdown()
     }

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -1,5 +1,7 @@
+import Clocks
 import Darwin
 import Foundation
+import TestSupport
 import Testing
 
 @testable import TBDDaemonLib
@@ -17,9 +19,15 @@ import Testing
 /// with recorded stream writes, reply blocks fed by hand, and a real
 /// supervisor + fanout so the gate/generation/fence/repair semantics under
 /// test are the production ones.
-@Suite("PaneRepairCoordinator")
+@Suite("PaneRepairCoordinator", .clockDriven)
 struct PaneRepairCoordinatorTests {
     private let server = "tbd-repair-unit"
+
+    /// The reader-catch-up pacing the coordinator actually ships with. Under
+    /// virtual time there is nothing to gain from shrinking them, so these
+    /// tests run the PRODUCTION constants and advance the `TestClock` by them.
+    private let checkInterval: Duration = .milliseconds(50)
+    private let slowInterval: Duration = .milliseconds(500)
 
     /// Thread-safe overflow-signal counter.
     private final class SignalCounter: @unchecked Sendable {
@@ -29,26 +37,24 @@ struct PaneRepairCoordinatorTests {
         var count: Int { lock.lock(); defer { lock.unlock() }; return _count }
     }
 
-    private func makeHarness(
-        writableCheckInterval: Duration = .milliseconds(10),
-        writableSlowInterval: Duration = .milliseconds(25),
-        writableEscalationThreshold: Duration = .milliseconds(50)
-    ) -> (TmuxControlSupervisor, PaneRepairCoordinator, LineRecorder, TmuxControlCommandClient, SignalCounter) {
+    private func makeHarness() -> (
+        TmuxControlSupervisor, PaneRepairCoordinator, LineRecorder,
+        TmuxControlCommandClient, SignalCounter, TestClock<Duration>
+    ) {
         let (client, recorder) = makeFakeClient()
         let supervisor = TmuxControlSupervisor()
+        let clock = TestClock()
         let coordinator = PaneRepairCoordinator(
             supervisor: supervisor,
             commandProvider: { [server] in $0 == server ? client : nil },
-            writableCheckInterval: writableCheckInterval,
-            writableSlowInterval: writableSlowInterval,
-            writableEscalationThreshold: writableEscalationThreshold)
+            clock: clock)
         // Wire the signal exactly as the bridge does, plus a call counter.
         let signals = SignalCounter()
         supervisor.fanout.onOverflowRepair = { key, generation in
             signals.increment()
             Task { await coordinator.repairIfNeeded(key: key, generation: generation) }
         }
-        return (supervisor, coordinator, recorder, client, signals)
+        return (supervisor, coordinator, recorder, client, signals, clock)
     }
 
     /// A 22-field primary-screen state line for `paneID` at 80x24 with the
@@ -125,7 +131,7 @@ struct PaneRepairCoordinatorTests {
 
     @Test("full repair: pause alone → wait for reader → captures+continue atomically → replay → fence flush → streaming resumes")
     func fullRepairHappyPath() async throws {
-        let (supervisor, coordinator, recorder, client, signals) = makeHarness()
+        let (supervisor, coordinator, recorder, client, signals, clock) = makeHarness()
         _ = coordinator
         let paneID = "%1"
         let key = PaneKey(server: server, paneID: paneID)
@@ -146,12 +152,15 @@ struct PaneRepairCoordinatorTests {
         await succeed(client, [[]])  // pause reply — the pane is now silent
 
         // The reader has NOT caught up (pipe still full): batch 2 must wait.
-        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
+        // Parking on the reader-wait sleep PROVES the loop is waiting —
+        // strictly stronger than inferring it from elapsed wall time.
+        await clock.waitForSuspension()
         #expect(recorder.writes.count == 1,
                 "captures+continue must not be sent while the reader is behind")
 
         // The app catches up — the pipe becomes writable.
         drainPipe(readFD)
+        await clock.advanceWhenSuspended(by: checkInterval)
         try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
         try #require(recorder.writes.count >= 2, "the captures+continue batch was never sent")
         #expect(recorder.writes[1] == """
@@ -201,7 +210,7 @@ struct PaneRepairCoordinatorTests {
 
     @Test("superseded between batch 1 and batch 2: nothing more sent, no unpause, successor untouched")
     func supersededMidRepairAbortsSilently() async throws {
-        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        let (supervisor, coordinator, recorder, client, _, _) = makeHarness()
         _ = coordinator
         let paneID = "%2"
         let key = PaneKey(server: server, paneID: paneID)
@@ -222,10 +231,12 @@ struct PaneRepairCoordinatorTests {
         defer { Darwin.close(read2) }
         await succeed(client, [[]])  // pause reply → post-pause re-check fires
 
+        // The repair task has provably EXITED (nothing is parked on the
+        // clock — the supersession is decided before the reader-wait), so the
+        // exit itself is the bound: no later write can appear.
         try await waitFor("repair exit") {
             await coordinator.isInFlight(key) == false
         }
-        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
         #expect(recorder.writes.count == 1, "a superseded repair must send NOTHING after the pause")
         #expect(!recorder.writes.contains { $0.contains("capture-pane") })
         #expect(!recorder.writes.contains { $0.contains(":continue'") })
@@ -247,7 +258,7 @@ struct PaneRepairCoordinatorTests {
 
     @Test("capture %error: unpause sent, repair aborted, pane not frozen")
     func captureFailureUnpausesAndAborts() async throws {
-        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        let (supervisor, coordinator, recorder, client, _, _) = makeHarness()
         _ = coordinator
         let paneID = "%3"
         let key = PaneKey(server: server, paneID: paneID)
@@ -258,8 +269,8 @@ struct PaneRepairCoordinatorTests {
 
         overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
         try await waitFor("pause write") { recorder.writes.count >= 1 }
-        await succeed(client, [[]])  // pause reply
-        drainPipe(readFD)            // reader catches up
+        drainPipe(readFD)            // reader catches up before the wait starts
+        await succeed(client, [[]])  // pause reply → writable on the first check
         try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
 
         // Scrollback capture %errors (tolerated at the correlator level);
@@ -289,9 +300,35 @@ struct PaneRepairCoordinatorTests {
 
     @Test("wedged reader: NO deadline — no continue, pane stays paused+repairing, and the SAME repair completes when the reader drains")
     func wedgedReaderWaitsOutTheStallThenHeals() async throws {
-        // Tiny injected intervals: escalation to slow polling happens within
-        // ~50 ms, so the wedged window below spans many slow intervals.
-        let (supervisor, coordinator, recorder, client, signals) = makeHarness()
+        // Injected pacing, for the same reason as
+        // `readerWaitEscalatesToTheSlowInterval` — but sized to span BOTH
+        // thresholds rather than just the escalation one. "NO deadline" is a
+        // claim about surviving an arbitrarily long stall, and the production
+        // 50 ms / 5 s / 30 s constants cannot express that in a short advance
+        // chain: 3 advances of 50 ms reach 150 ms and never leave the fast
+        // band, which proves far less than this test's name claims. With
+        // 2 s / 4 s / 15 s, FOUR advances reach 34 s of virtual wait — past
+        // the escalation threshold AND past the fixed 30 s
+        // `readerStallLogThreshold`, so the loop exercises the escalated
+        // pacing and the one-shot stall-log branch (nothing else covers the
+        // latter). Same short chain, strictly stronger claim.
+        let (client, recorder) = makeFakeClient()
+        let supervisor = TmuxControlSupervisor()
+        let clock = TestClock<Duration>()
+        let fast: Duration = .seconds(2)
+        let slow: Duration = .seconds(15)
+        let coordinator = PaneRepairCoordinator(
+            supervisor: supervisor,
+            commandProvider: { [server] in $0 == server ? client : nil },
+            writableCheckInterval: fast,
+            writableSlowInterval: slow,
+            writableEscalationThreshold: .seconds(4),
+            clock: clock)
+        let signals = SignalCounter()
+        supervisor.fanout.onOverflowRepair = { key, generation in
+            signals.increment()
+            Task { await coordinator.repairIfNeeded(key: key, generation: generation) }
+        }
         let paneID = "%4"
         let key = PaneKey(server: server, paneID: paneID)
         let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
@@ -304,12 +341,23 @@ struct PaneRepairCoordinatorTests {
         await succeed(client, [[]])  // pause reply — reader stays wedged
 
         // A TRANSIENTLY wedged reader (e.g. a long app main-thread hitch)
-        // must not kill the repair: with the pipe still full well past the
-        // escalation threshold (many slow poll intervals), the repair must
-        // NOT abort and must NOT send a continue — a continue would just
-        // re-overflow. It stays in flight; the pane stays paused (tmux
-        // buffers it server-side) and the sink stays `repairing`.
-        try await Task.sleep(for: .milliseconds(400))
+        // must not kill the repair: across many poll intervals with the pipe
+        // still full, the repair must NOT abort and must NOT send a continue
+        // — a continue would just re-overflow. It stays in flight; the pane
+        // stays paused (tmux buffers it server-side) and the sink stays
+        // `repairing`. Each advance drives exactly one more wait iteration:
+        // two fast (2 s + 2 s = the 4 s escalation threshold, so the loop
+        // switches to the slow interval) then two slow (+30 s = 34 s), which
+        // carries the wait past the fixed 30 s `readerStallLogThreshold` — so
+        // the stall-log branch runs exactly once and the loop keeps waiting
+        // rather than giving up. Four advances, 34 s of virtual stall. Do NOT
+        // lengthen this chain to "prove" more: a long chain of advances is
+        // itself a load-sensitivity hazard (see
+        // `readerWaitEscalatesToTheSlowInterval`) — reach further thresholds
+        // by injecting larger pacing, never by advancing more times.
+        for _ in 0..<2 { await clock.advanceWhenSuspended(by: fast) }
+        for _ in 0..<2 { await clock.advanceWhenSuspended(by: slow) }
+        await clock.waitForSuspension()  // re-armed on the slow interval, pipe still full
         #expect(recorder.writes.count == 1, "no captures and NO continue while the reader is wedged")
         #expect(await coordinator.isInFlight(key) == true, "the repair must keep waiting, not give up")
         let stats = try #require(supervisor.fanout.flowStats(key: key))
@@ -332,6 +380,7 @@ struct PaneRepairCoordinatorTests {
         // proceeds — batch 2 (captures + continue), replay behind the fence,
         // endRepair, streaming resumed. No new attach needed.
         drainPipe(readFD)
+        await clock.advanceWhenSuspended(by: slow)
         try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
         try #require(recorder.writes.count >= 2, "the captures+continue batch was never sent")
         #expect(recorder.writes[1].hasSuffix("refresh-client -A '%4:continue'"),
@@ -351,11 +400,79 @@ struct PaneRepairCoordinatorTests {
         #expect(live.hasSuffix("LIVE-AFTER-WEDGE"), "streaming must resume after the recovered repair")
     }
 
+    // MARK: - Pacing escalation
+
+    @Test("escalation: past the threshold the reader-wait paces on the SLOW interval, not the fast one")
+    func readerWaitEscalatesToTheSlowInterval() async throws {
+        // The `waited >= writableEscalationThreshold` branch was untestable on
+        // the real clock (5 s of wall time per run). Under virtual time it is
+        // free, and the root CLAUDE.md gated-branch rule applies.
+        //
+        // This is the ONE test that injects pacing values instead of running
+        // the production 50 ms / 5 s pair (every other test here keeps the
+        // production constants). Reason: that ratio needs 100 advances to
+        // accumulate the threshold, and a long chain of advances is itself a
+        // load-sensitivity hazard — `advanceWhenSuspended` gives the code
+        // under test 20 yields to re-park, and is non-throwing, so under load
+        // one missed re-park advances a sleeper-less clock and the test hangs
+        // forever (the failure mode ClockTestSupport's doc comment names).
+        // 100 draws makes that near-certain. A 1 s / 2 s / 10 s pacing proves
+        // exactly the same branch in THREE advances. Do not reintroduce a
+        // long advance chain here.
+        let (client, recorder) = makeFakeClient()
+        let supervisor = TmuxControlSupervisor()
+        let clock = TestClock<Duration>()
+        let fast: Duration = .seconds(1)
+        let slow: Duration = .seconds(10)
+        let coordinator = PaneRepairCoordinator(
+            supervisor: supervisor,
+            commandProvider: { [server] in $0 == server ? client : nil },
+            writableCheckInterval: fast,
+            writableSlowInterval: slow,
+            writableEscalationThreshold: .seconds(2),
+            clock: clock)
+        supervisor.fanout.onOverflowRepair = { key, generation in
+            Task { await coordinator.repairIfNeeded(key: key, generation: generation) }
+        }
+        let paneID = "%13"
+        let key = PaneKey(server: server, paneID: paneID)
+        let (readFD, generation) = try await supervisor.attach(server: server, paneID: paneID)
+        defer { Darwin.close(readFD) }
+        setNonblocking(readFD)
+        supervisor.fanout.markReady(key: key, generation: generation)
+
+        overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
+        try await waitFor("pause write") { recorder.writes.count >= 1 }
+        await succeed(client, [[]])  // pause reply — the reader stays wedged
+
+        // Two fast intervals accumulate exactly the escalation threshold, so
+        // the interval the loop picks NEXT is the slow one.
+        await clock.advanceWhenSuspended(by: fast)
+        await clock.advanceWhenSuspended(by: fast)
+        await clock.waitForSuspension()  // re-armed — on the slow interval now
+        #expect(await coordinator.isInFlight(key) == true, "the wait must still be running")
+
+        // The reader catches up, but the loop is parked on the SLOW interval:
+        // a fast-interval advance is not enough to wake it, so batch 2 stays
+        // unsent. (Before escalation, this same advance would have sent it —
+        // that is `fullRepairHappyPath`.)
+        drainPipe(readFD)
+        await clock.advanceWhenSuspended(by: fast)
+        #expect(recorder.writes.count == 1,
+                "past the escalation threshold the wait must sleep the SLOW interval")
+
+        // The rest of the slow interval does wake it, and the repair proceeds.
+        await clock.advanceWhenSuspended(by: slow - fast)
+        try await waitFor("captures+continue write after escalation") { recorder.writes.count >= 2 }
+        try #require(recorder.writes.count >= 2, "the escalated wait never sent batch 2")
+        #expect(recorder.writes[1].hasSuffix("refresh-client -A '%13:continue'"))
+    }
+
     // MARK: - Broken pipe
 
     @Test("broken pipe mid-wait: read end closed → continue sent, abortRepair, repairing cleared")
     func brokenPipeMidWaitUnpausesAndAborts() async throws {
-        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        let (supervisor, coordinator, recorder, client, _, clock) = makeHarness()
         _ = coordinator
         let paneID = "%5"
         let key = PaneKey(server: server, paneID: paneID)
@@ -369,8 +486,8 @@ struct PaneRepairCoordinatorTests {
         try await waitFor("pause write") { recorder.writes.count >= 1 }
         await succeed(client, [[]])  // pause reply — the reader wait begins
 
-        // A merely-full pipe keeps the repair waiting…
-        try await Task.sleep(for: .milliseconds(100))
+        // A merely-full pipe keeps the repair parked in the reader-wait…
+        await clock.waitForSuspension()
         #expect(recorder.writes.count == 1, "still waiting while the pipe is merely full")
 
         // …then the viewer dies: the READ end closes mid-wait. The pipe can
@@ -381,6 +498,7 @@ struct PaneRepairCoordinatorTests {
         Darwin.close(readFD)
         readClosed = true
 
+        await clock.advanceWhenSuspended(by: checkInterval)
         try await waitFor("trailing continue write") { recorder.writes.count >= 2 }
         #expect(recorder.writes.last == "refresh-client -A '%5:continue'",
                 "a broken pipe must unpause the pane")
@@ -406,10 +524,7 @@ struct PaneRepairCoordinatorTests {
         let supervisor = TmuxControlSupervisor()
         let coordinator = PaneRepairCoordinator(
             supervisor: supervisor,
-            commandProvider: { _ in nil },
-            writableCheckInterval: .milliseconds(10),
-            writableSlowInterval: .milliseconds(25),
-            writableEscalationThreshold: .milliseconds(50))
+            commandProvider: { _ in nil })
         supervisor.fanout.onOverflowRepair = { key, generation in
             Task { await coordinator.repairIfNeeded(key: key, generation: generation) }
         }
@@ -442,7 +557,7 @@ struct PaneRepairCoordinatorTests {
 
     @Test("superseded before the repair starts: nothing sent — not even the pause — successor untouched")
     func supersededBeforeRepairStartSendsNothing() async throws {
-        let (supervisor, coordinator, recorder, _, _) = makeHarness()
+        let (supervisor, coordinator, recorder, _, _, _) = makeHarness()
         let paneID = "%9"
         let key = PaneKey(server: server, paneID: paneID)
         // Capture-only wiring: the test dispatches the stale signal BY HAND
@@ -500,10 +615,7 @@ struct PaneRepairCoordinatorTests {
                     successorRead.set(fd)
                 }
                 return client
-            },
-            writableCheckInterval: .milliseconds(10),
-            writableSlowInterval: .milliseconds(25),
-            writableEscalationThreshold: .milliseconds(50))
+            })
         supervisor.fanout.onOverflowRepair = { _, _ in }
         defer { if successorRead.fd >= 0 { Darwin.close(successorRead.fd) } }
 
@@ -526,7 +638,7 @@ struct PaneRepairCoordinatorTests {
 
     @Test("superseded mid reader-wait: sink replaced while the pipe is full → silent exit, no continue, successor untouched")
     func supersededMidReaderWaitExitsSilently() async throws {
-        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        let (supervisor, coordinator, recorder, client, _, clock) = makeHarness()
         let paneID = "%11"
         let key = PaneKey(server: server, paneID: paneID)
         let (read1, gen1) = try await supervisor.attach(server: server, paneID: paneID)
@@ -540,7 +652,7 @@ struct PaneRepairCoordinatorTests {
         // The pause reply lands while gen-1 still owns the pane: the repair
         // enters the reader-wait (the pipe is full — read1 is never drained).
         await succeed(client, [[]])
-        try await Task.sleep(for: .milliseconds(100))
+        await clock.waitForSuspension()
         #expect(recorder.writes.count == 1, "still waiting while the pipe is merely full")
         #expect(await coordinator.isInFlight(key) == true, "the repair must be parked in the reader-wait")
 
@@ -550,10 +662,14 @@ struct PaneRepairCoordinatorTests {
         // the successor.
         let (read2, gen2) = try await supervisor.attach(server: server, paneID: paneID)
         defer { Darwin.close(read2) }
+        // Wake the parked wait loop so it re-checks writability and observes
+        // the supersession (`nil`). The exit itself then bounds the negative
+        // assertions below — the repair task is gone, so no later write can
+        // appear.
+        await clock.advanceWhenSuspended(by: checkInterval)
         try await waitFor("repair exit") {
             await coordinator.isInFlight(key) == false
         }
-        try await Task.sleep(for: .milliseconds(200))  // bounded negative check
         #expect(recorder.writes.count == 1, "a mid-wait supersession must send NOTHING after the pause")
         #expect(!recorder.writes.contains { $0.contains("capture-pane") })
         #expect(!recorder.writes.contains { $0.contains(":continue'") })
@@ -575,12 +691,14 @@ struct PaneRepairCoordinatorTests {
         // `onOverflowRepair` closure installed in the bridge's init.
         let (client, recorder) = makeFakeClient()
         let supervisor = TmuxControlSupervisor()
+        let clock = TestClock<Duration>()
         let bridge = TmuxControlModeBridge(
             supervisor: supervisor,
             tmuxVersion: TmuxVersion(major: 3, minor: 6),
             environment: [:],
             fdVending: FDVendingServer(),
-            commandProvider: { [server] in $0 == server ? client : nil })
+            commandProvider: { [server] in $0 == server ? client : nil },
+            clock: clock)
         let paneID = "%12"
         let key = PaneKey(server: server, paneID: paneID)
         let (readFD, generation) = try await bridge.supervisor.attach(server: server, paneID: paneID)
@@ -597,7 +715,11 @@ struct PaneRepairCoordinatorTests {
 
         // Complete the cycle so the repair task doesn't outlive the test.
         await succeed(client, [[]])
+        // The default coordinator parks on the BRIDGE's clock — proof the
+        // bridge threaded its clock into the coordinator it constructed.
+        await clock.waitForSuspension()
         drainPipe(readFD)
+        await clock.advanceWhenSuspended(by: checkInterval)
         try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
         await succeed(client, captureAndContinueReplies(paneID: paneID))
         try await waitFor("repair completion") {
@@ -610,7 +732,7 @@ struct PaneRepairCoordinatorTests {
 
     @Test("swallowed successor overflow: gen-2's signal deduped while gen-1 is parked → exit re-dispatch heals gen-2")
     func swallowedSuccessorOverflowIsReDispatched() async throws {
-        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        let (supervisor, coordinator, recorder, client, _, _) = makeHarness()
         let paneID = "%6"
         let key = PaneKey(server: server, paneID: paneID)
 
@@ -663,8 +785,8 @@ struct PaneRepairCoordinatorTests {
         try await waitFor("gen-2 pause write (re-dispatch)") { recorder.writes.count >= 2 }
         try #require(recorder.writes.count >= 2, "the swallowed gen-2 repair was never re-dispatched")
         #expect(recorder.writes[1] == "refresh-client -A '%6:pause'")
-        await succeed(client, [[]])  // gen-2 pause reply
-        drainPipe(read2)             // the reader catches up
+        drainPipe(read2)             // the reader catches up before the wait starts
+        await succeed(client, [[]])  // gen-2 pause reply → writable on the first check
         try await waitFor("gen-2 captures+continue write") { recorder.writes.count >= 3 }
         try #require(recorder.writes.count >= 3, "gen-2's captures+continue were never sent")
         #expect(recorder.writes[2].hasSuffix("refresh-client -A '%6:continue'"))
@@ -689,7 +811,7 @@ struct PaneRepairCoordinatorTests {
 
     @Test("%error'd batched continue: the repair completes AND retries one tolerate-errors continue")
     func erroredBatchedContinueRetriesAfterEndRepair() async throws {
-        let (supervisor, coordinator, recorder, client, _) = makeHarness()
+        let (supervisor, coordinator, recorder, client, _, _) = makeHarness()
         _ = coordinator
         let paneID = "%7"
         let key = PaneKey(server: server, paneID: paneID)
@@ -700,8 +822,8 @@ struct PaneRepairCoordinatorTests {
 
         overflowIntoRepair(supervisor.fanout, paneID: paneID, key: key)
         try await waitFor("pause write") { recorder.writes.count >= 1 }
-        await succeed(client, [[]])  // pause reply
-        drainPipe(readFD)            // reader catches up
+        drainPipe(readFD)            // reader catches up before the wait starts
+        await succeed(client, [[]])  // pause reply → writable on the first check
         try await waitFor("captures+continue write") { recorder.writes.count >= 2 }
 
         // All six captures succeed; the batched continue %errors (tolerated

--- a/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/PaneRepairCoordinatorTests.swift
@@ -19,7 +19,7 @@ import Testing
 /// with recorded stream writes, reply blocks fed by hand, and a real
 /// supervisor + fanout so the gate/generation/fence/repair semantics under
 /// test are the production ones.
-@Suite("PaneRepairCoordinator", .clockDriven)
+@Suite("PaneRepairCoordinator", .clockDriven, .serialized)
 struct PaneRepairCoordinatorTests {
     private let server = "tbd-repair-unit"
 


### PR DESCRIPTION
Slice D of the test-hardening program: migrate the control-mode / attach ready-timer machinery onto the injected clock seam, so the attach and pane-repair timers run on virtual time in tests instead of wall-clock sleeps.

**This is the sole precondition for slice H** (the seeded interleaving-invariant harness). See "What H can rely on" below — H's design rests on it.

## Behavior-preserving by construction — no feature flag applies

Every seam is a **defaulted last parameter** (`clock: any Clock<Duration> = ContinuousClock()`), so no production call site changes and the runtime behavior is identical. The root `CLAUDE.md` default-off flag policy covers new autonomous behavior; this is a refactor plus test changes, so no flag is warranted.

## Contracts consumed (not redefined)

- **Clock injection** (slicing §5.1): `init(..., clock: any Clock<Duration> = ContinuousClock())` — last parameter, named `clock`, defaulted, **existential not generic**. These are actors carrying `Sendable` conformances; a generic parameter would infect their types.
- **Test helpers** (§5.3): `@Suite(.clockDriven)`, `advanceWhenSuspended(by:)`, `waitForSuspension()` from `Tests/TestSupport/ClockTestSupport.swift`. Not edited — slice B owns it.
- **Names** (§5.5) and **`PollerClock` untouched** (§5.6).
- No `Package.swift` change: `Clocks` was already a dependency of both daemon test targets.

## Production changes (3 files)

**`TmuxControlModeBridge.swift`** — gains the `clock` parameter and threads it into the `PaneRepairCoordinator` it default-constructs. It already owned `readyTimeout`, so it is the natural single clock owner for the subsystem. An injected coordinator keeps its own clock (that is the seam tests reach).

**`RPCRouter+AttachHandlers.swift`** — the attach ready-timer now sleeps on the injected clock. Generation-scoping is unchanged: `detachIfNotReady` is generation-checked, so a timer outliving a superseded attach is still a no-op.

**`PaneRepairCoordinator.swift`** — the reader-catch-up wait now paces on the injected clock, and elapsed time is **accumulated from the intervals actually slept** rather than read off an `Instant`.

That last point is the one substantive change. `any Clock<Duration>` erases `Instant`, so `ContinuousClock.now - waitStart` is inexpressible. The rewrite accumulates `var waited: Duration = .zero`. The semantic delta is that `waited` no longer includes the nanosecond-scale non-blocking writability check between slices — measured against a 5 s escalation threshold and a 30 s stall-log mark, both of which are **pure pacing and logging**: neither gates a send, an unpause, nor a generation decision. Net effect is *more* determinism, since both thresholds become exactly advanceable. Unchanged: the wait still has no deadline, `.broken` still unpauses and aborts, supersession still returns silently sending nothing, and the stall log still fires exactly once.

## Suppressions deleted — the mechanical proof

Both `swiftlint:disable:next no_raw_task_sleep` suppressions in the subsystem are **gone**:

```
$ grep -rn "no_raw_task_sleep" Sources/TBDDaemon/Tmux/ControlMode/ Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
(no output)
```

The rule was proven to actually fire, not assumed to: re-introducing a raw `Task.sleep` at a migrated site makes `swiftlint --strict` red with `no_raw_task_sleep`, and it was then reverted. (Two earlier slices in this program shipped mechanisms that were named for something they did not do; this one was checked.)

## Deliberately NOT migrated — stated so the exclusions are reviewable

Adjudicated by the orchestrator under the principle *a time reference that measures what really elapsed stays on the concrete monotonic clock*:

1. **`PaneFanout.writeReplay(deadline:)`** — synchronous, waits on `Darwin.poll(2)` against a pipe fd. A `Clock<Duration>` cannot virtualize a syscall wait; substituting one would make the deadline lie about real IO.
2. **`TmuxControlConnection` teardown** `DispatchSemaphore.wait(timeout:)` — a real reader-thread join.
3. **`InputLatencyRecorder` / `ControlModeInputRouter`** `ContinuousClock.Instant` latency measurement — monotonic *observation*, not behavior. Nothing sleeps or gates on it. It already has its own injection seam (`now:` defaulted), so it is deterministically testable today; migrating it would mint a third seam shape, which the shared contract exists to prevent.

## Tests

`PaneRepairCoordinatorTests` and `AttachRPCOrchestrationTests` are tier 1 and now `.clockDriven`.

- `makeHarness()` **keeps the real production constants** (50 ms / 500 ms / 5 s) instead of the shrunk 10/25/50 ms values. Under virtual time shrinking buys nothing, so the tests now exercise production pacing — a coverage upgrade that fell out of the migration.
- Bounded negative checks (`Task.sleep(200ms)` then "batch 2 must not have been sent") became `waitForSuspension()`, which *proves* the repair task is parked on the reader-wait rather than inferring it from elapsed wall time. Where the repair had provably already exited, the sleep was deleted outright — the existing `waitFor("repair exit")` is a strictly stronger bound, since a terminated task cannot write later.
- The ready-timer tests advance virtual time instead of sleeping 400 ms. This also removes a latent race the old sleep papered over: the timer lives in a *detached* `Task` that might not have armed within 400 ms under load.
- `bridgeWiredCoordinatorRunsRepair` injects a `TestClock` into the real bridge and asserts the default-constructed coordinator parks on it — direct proof the bridge threads its clock down, rather than assuming it.

**New coverage:** the `waited >= writableEscalationThreshold` branch (slow-vs-fast pacing) had never been tested, because it cost 5 s of wall clock per run. `readerWaitEscalatesToTheSlowInterval` now covers it, per the root `CLAUDE.md` gated-branch rule.

**Tier 3 unchanged.** `Tests/TBDDaemonLiveTests/` suites drive a real tmux server, so their timing is externally owned; they stay on the real clock and needed zero edits. Quiet pass verified: 54 tests / 17 suites.

## A defect this PR's own stress requirement caught

The first version of the escalation test crossed the 5 s threshold in **~100** production-sized advances. Each `advanceWhenSuspended` does bounded yields; under CPU load a single miss desyncs the `TestClock` permanently, and 100 draws made that near-certain. It passed in 0.626 s unloaded and **wedged past 10 minutes** under load — a new instance of the very flake class this slice exists to remove.

Rewritten to **inject pacing** (1 s / 2 s / 10 s) and cross the threshold in **3** advances — same assertion strength, 0.048 s. An unrelated 8-advance loop was cut to 3. A full audit of the file leaves exactly one advance loop, `0..<3`.

Generalizable rule, now recorded for the program: **keep advance chains short, and inject pacing values rather than accumulating production-sized intervals.** Shortness is hygiene, not a cure — each advance is independently unsound in a large parallel target — but it reduces exposure while the shared helper is hardened separately (tracked as slice J).

## Advance-chain audit — shortening a chain can silently weaken a test

Shortening advance chains for load-safety has a mirror-image failure: the test still passes while proving less. A vacuity audit caught exactly that in my own work.

`wedgedReaderWaitsOutTheStallThenHeals` claims "**NO deadline**" in its name and docstring. Pre-migration it ran ~40 iterations past its (tiny, injected) escalation threshold. After my 8→3 reduction it ran 4 iterations totalling **150 ms virtual** and never reached the 5 s threshold at all — not vacuous (each advance forces a real loop iteration, and a premature abort still fails it), but materially weaker than its own name.

Fixed **within the same short-chain budget** by injecting larger pacing (2 s / 4 s / 15 s): four advances now span **34 virtual seconds**, crossing the escalation threshold *and* the fixed 30 s `readerStallLogThreshold`. That also picks up the one-shot stall-log branch, which nothing previously covered. Short chain *and* strong claim — the two are not a trade.

Audit of every advance chain in this diff, against what each test's name/docstring claims:

| Test | Advances | Virtual span | Claim crossed? |
|---|---|---|---|
| `wedgedReaderWaitsOutTheStallThenHeals` | 4 | 34 s | ✅ after fix (escalation + 30 s stall log) |
| `readerWaitEscalatesToTheSlowInterval` | 3 | 2 s + probes | ✅ crosses its 2 s threshold exactly |
| `fullRepairHappyPath`, `brokenPipeMidWait…`, `supersededMidReaderWait…`, `bridgeWiredCoordinatorRunsRepair` | 1 each | one interval | ✅ no threshold claim — each wakes the loop once |
| `unackedAttachTornDownAfterTimeout`, `ackedReplayInFlightSurvivesTimeout` | 1 each | `readyTimeout` | ✅ crosses exactly the timeout asserted |

One narrowing found, one fixed; every other chain's claim matches what it actually crosses.

## Non-throwing waiter hygiene (`ControlModeInputHealthTests`) — orchestrator-approved addition

A flake reported in this area turned out to be **misattributed by its own test**. The quoted failure was `health.events.map(\.generation) → [42] == [42, 42]`, which reads like a generation bug. It isn't. The preceding line waits via `ControlModeTestSupport.waitFor`, which is *non-throwing*: on deadline it records "timed out waiting for 2 health events", returns `false`, and the call site discarded that `Bool`. Execution then continued into an equality assertion against a half-filled array. The 62-second runtime is the tell — two ~30 s `ciSafeDeadline` waits, not a fast assertion failure.

`Tests/CLAUDE.md` documents this hazard for *indexing* out of a non-throwing waiter's result. This is one step further out and strictly nastier: a crash is obviously a crash, whereas `[42] == [42, 42]` sends the reader to the wrong line entirely.

Fix: all 12 previously-unguarded `waitFor*` call sites in that file are now `#require`-guarded, so a timeout fails **at the wait**, with its own message. One call site was already guarded — the pattern was already the intended one here. `@discardableResult` is also removed from both local helpers, so a future unguarded call is a compiler signal rather than a review rule.

**The underlying delivery starvation is NOT fixed and not in this slice** — filed as #494 with the analysis, per the orchestrator's ruling. That issue also records a second, independent intermittent flake found while verifying this change (`repeatedFailuresFireOnce` seeing three health transitions where the test's FIFO assumption predicts two).

## What slice H can rely on

- **Virtualized:** the attach ready-timer (`attach.request` → `detachIfNotReady`) and the repair reader-catch-up wait including its escalation threshold — one clock on `TmuxControlModeBridge`, threaded into `PaneRepairCoordinator`.
- **Already deterministic, no clock needed:** `AttachReplayOrchestrator` has **no** timer, task group, or continuation. Its whole sequence is awaits over the command correlator.
- **Therefore a seeded schedule over the fake-correlator seam is deterministic**, because ordering is decided by the correlator FIFO and the generation counter, not wall time. H's event vocabulary (attach, detach, `%pause`, replay-begin/complete, EOF, successor-attach) plus clock advances is fully covered: every event is a synchronous correlator injection or a `TestClock` advance. A given seed replays identically on any machine.
- **Three caveats H must design around:**
  1. `PaneFanout.writeReplay` blocks on `poll(2)` against a real pipe with a 5 s wall deadline. A schedule that wedges the reader hits real time there — drain the pipe in the harness, or treat the replay write as an atomic event rather than a schedulable window.
  2. `TmuxControlConnection` teardown joins its reader thread on a real semaphore timeout — relevant only if H schedules teardown.
  3. **A generated schedule is a long advance chain by construction.** Keep advances few and large; treat a truncated log or missing test-count summary as a *failure* (a wedge yields no seed and no step index, and a naive exit-code check scores it green); and put an outer timeout on the fuzz step rather than relying on `.clockDriven`.

## What this does and does not claim

Per the program's amended definition of done, these are two different claims and only the first is fully achieved:

- **Achieved — the wall-clock-*assertion* flake class is eliminated for these timers.** No wall clock times the behaviour under test. The attach ready-timer and the repair reader-wait are driven by an injected clock, and the tests assert exact virtual timings instead of tolerance windows. This is the flake class the program exists to kill.
- **Disclosed — a residual scheduler-starvation sensitivity remains, inherited from the dependency.** `TestClock.advance(to:)` calls `Task.megaYield()` internally, which serially awaits 20 detached *background-QoS* tasks; under heavy oversubscription macOS gives background QoS almost nothing, so an advance can stall. No change in this PR can reach it — the call is inside `swift-clocks`, on the hot path of every clock-driven test. Tracked for slice J (a `megaYield`-free virtual clock).

The distinction that matters, and the reason "tier-1 tests contain no real sleeps" needs reading carefully: **there is no real sleep in the behaviour under test; the real sleep is in the scheduling handshake that observes it.**

`@Suite(.clockDriven)` is doing real work against that residual rather than being ceremony: it converts what would otherwise be an unbounded wedge into a named 60-second failure with a suite attached. That is a result, not a caveat.

## `.serialized` — measured, not inherited

These two suites are their own contention source: every probe and advance costs a `megaYield` of 20 background-QoS tasks, so N clock-driven tests running in parallel flood the pool with exactly the low-priority work each one is waiting on. This slice has roughly **twice** the clock-driven population of the suite where that was first diagnosed (#497).

I deliberately measured **without** `.serialized` first rather than copying the remedy — otherwise I'd have shipped a green suite without knowing whether my population was over the line, or which tests sit closest to it.

Whole target, `--parallel -j 2 --skip '^TBDDaemonLiveTests\.'`, 8 spinners, 15 iterations, executed-test count asserted every run (3869 every time — nothing silently fell out):

| | green | red |
|---|---|---|
| without `.serialized` | 6/15 | 9 |
| with `.serialized` | 11/15 | 4 |

**The rate is directional only.** The arms ran as sequential batches, and the serialized arm saw **16% lower mean load** (83.1 vs 98.5) — the same methodology error this program corrected elsewhere, committed by me after quoting the rule. Stated rather than buried.

**The load-robust signal is qualitative**, and it is a change in kind rather than rate:

- **Without:** five of this slice's tests failed by name — both attach ready-timer tests, `fullRepairHappyPath`, `bridgeWiredCoordinatorRunsRepair`, `supersededMidReaderWaitExitsSilently`.
- **With:** exactly one does — `fullRepairHappyPath`, 2/15 at load ~90–120.

A failing set shrinking from five to one is not produced by a 16% load difference.

This narrows **two suites, not the target**, so `Tests/CLAUDE.md`'s asymmetry warning (a serial *pass* taxing every PR) does not apply.

**Residual, disclosed rather than claimed fixed:** `fullRepairHappyPath` still reddens ~13% at load ~90–120. That is the `megaYield`-inside-`advance(to:)` starvation inherited from `swift-clocks` (#496, slice J) — not a wall-clock assertion. CI runs 3–4 cores at `-j 2` on an otherwise idle box; this failure regime is loadavg ~90–120 on 12 cores.

## Tier-3 coverage claim — mutation-confirmed

"Real-clock coverage of the reader-wait concentrated in tier 3" is a claim about a file this PR does not touch, so it gets the same proof as any other claim.

**Satisfiers enumerated by grep, not by reasoning** (the audit that catches a claim built on an incomplete model): `repairs` is incremented in exactly one place — `PaneFanout.endRepair:518`. `abortRepair` deliberately does not increment it. `endRepair` has exactly one production caller, at step 6 of `PaneRepairCoordinator.repair()`, reachable only after the reader-catch-up wait exits on `.writable`. **One satisfier, no bypass.**

Mutation — make the wait give up and `abortRepair` on the first non-writable check (the faithful defect: the "NO deadline" property exists to prevent a transiently wedged reader becoming a permanently frozen pane):

| State | `ReplayLiveIntegrationMatrixTests` |
|---|---|
| baseline | 5 tests **passed** |
| mutated | **RED** — `(stats.repairs → 0) >= 1` at `:673` |
| reverted | 5 tests **passed** |

Red for the enumerated reason, terminating cleanly. (An earlier draft mutated a bare `return`, which leaves `repairing` set so `repairIfNeeded` re-dispatches and pause-spins — red for the *wrong* reason. Mutating the *defect* rather than the *diff* is what caught that.)

## Verification

- `swift build --build-tests` green (plain `swift build` does not compile test targets); `swiftlint --strict` 0 violations / 586 files.
- Fast pass: 3869 tests. Quiet pass `--no-parallel --filter '^TBDDaemonLiveTests\.'`: 54 tests / 17 suites, count-checked.
- Both `no_raw_task_sleep` suppressions deleted; `grep` over the subsystem returns nothing. Rule proven to fire by re-introducing a raw sleep and confirming `--strict` reds, then reverting.
- Rebased onto `6fcca058` (#497) and **re-verified** — every number above is measured against the fixed `waitForSuspension`, not the one that was proven to be measuring nothing.
- Reviewers: no significant findings. One comment corrected — `try?` on the ready-timer does **not** mean "cancellation skips the teardown"; cancellation makes the teardown run *immediately*. Behavior is bit-for-bit unchanged from HEAD (identical `try?` shape), but the comment now states the invariant it relies on *and* what breaks it.

[20260724-dead-worm](https://cheapsteak.github.io/tbd/open/?worktree=251EC043-7334-4A6D-9A3C-75DE101E5FEF)
