### PR TITLE
fix(tests): a plain `throw` in a quarantined test pointed the reader at the trait's plumbing

### DIFF
--- a/Tests/TestSupport/FlakyTestSupport.swift
+++ b/Tests/TestSupport/FlakyTestSupport.swift
@@ -56,6 +56,16 @@ import Testing
 /// attempt looks clean, so a false-green attempt is recorded `passedFirstTry`
 /// while the run itself goes red — a green record for a red run.
 ///
+/// **Second limitation — a plain `throw` loses its throw site.** `#expect` and
+/// `#require` failures keep their exact location (they record at their own call
+/// site, before the trait ever sees them). A body that instead does a bare
+/// `throw someError` reaches this trait's generic `catch`, and Swift does not
+/// carry the throw site on an error, so the final attempt's failure is
+/// attributed to the `@Test` declaration rather than the throwing line. That is
+/// the closest true answer available, and it beats the default — which would
+/// point into this file's plumbing — but prefer `#require` in a quarantined
+/// test if you want the precise line.
+///
 /// Metrics: with `TBD_RETRY_METRICS_PATH` set (CI does this at the job level;
 /// unset locally, where the trait writes nothing and does no work), every
 /// execution appends one JSONL record — including clean first-try passes,
@@ -82,6 +92,7 @@ public struct FlakyTrait: TestTrait, TestScoping {
             let result = await Self.runAttempt(
                 comment: "flaky issue #\(issue), attempt \(attempt)",
                 suppressing: !isFinal,
+                attributingTo: test.sourceLocation,
                 function
             )
             if result.cancelled {
@@ -144,9 +155,19 @@ public struct FlakyTrait: TestTrait, TestScoping {
     /// indistinguishable, in the ledger, from a genuinely always-failing flake.
     /// It is "neither a failure nor a pass" only until an unsuppressed verdict
     /// has already been recorded; see the caller for that case.
+    ///
+    /// `attributingTo` is the `@Test` declaration site. It is only used for a
+    /// body that does a plain `throw` rather than failing through `#expect` or
+    /// `#require`: that error reaches the generic `catch`, and `Issue.record`
+    /// would otherwise default `sourceLocation` to *its own* call site in this
+    /// file, pointing the reader at the trait's plumbing on the one attempt
+    /// designed to surface honestly. The original throw site is not recoverable
+    /// — Swift does not carry it on the error — so the test declaration is the
+    /// closest true answer.
     private static func runAttempt(
         comment: Comment,
         suppressing: Bool,
+        attributingTo sourceLocation: SourceLocation,
         _ function: @Sendable () async throws -> Void
     ) async -> AttemptResult {
         let failed = FlagBox()
@@ -159,7 +180,7 @@ public struct FlakyTrait: TestTrait, TestScoping {
             } catch is CancellationError {
                 cancelled.set()
             } catch {
-                Issue.record(error)
+                Issue.record(error, sourceLocation: sourceLocation)
             }
         } matching: { _ in
             failed.set()


### PR DESCRIPTION
Follow-up to #500 (slice E), closing the one substantive minor from its review that landed after the merge.

## The problem

Slice E's design claim about the final retry attempt is that it surfaces the failure **at its real source location** — that's what separates a quarantine mechanism from a failure-swallowing one. For the two paths the self-tests exercise, it does: `#expect` and `#require` both record at their own call site before the trait ever sees them.

A body that instead does a bare `throw someError` reaches the trait's generic `catch`, where `Issue.record`'s `sourceLocation` defaults to *its own* call site — inside `FlakyTestSupport.swift`. So on the one attempt built to be honest, the first adopter who quarantined a test around a `throw`-based helper would have been pointed at the quarantine plumbing instead of their own test.

## The fix

Attribute the error to the `@Test` declaration site instead. Swift does not carry the throw site on an error, so the exact throwing line is not recoverable — the test declaration is the closest true answer, and it beats naming an unrelated file.

Verified with a throwaway probe (removed before commit): a body doing `throw ProbeError()` now reports at

```
Test plainThrowAttribution() recorded an issue at ZZThrowProbe.swift:9:6: Caught error: ProbeError()
```

— the `@Test` line in the test file, where before it would have named `FlakyTestSupport.swift`.

Also documented as a second known limitation next to the escaping-`Task` one, since it can only be narrowed and not eliminated, with the advice to prefer `#require` in a quarantined test when the precise line matters.

## Verification

- `swift build` green, `swiftlint --strict` 0 violations in 586 files.
- Both of slice E's proof paths re-run after the change and still hold: `retriesUntilPass` green with ledger `attempts:2 / passedOnRetry`; `alwaysFails` (gated) red after exactly 3 with `attempts:3 / failed`.
- No ledger impact — `file`/`line` in the metrics records come from `test.sourceLocation` (the `@Test` declaration), which this does not change.

Test infrastructure only; the default-off flag policy does not apply.

[20260724-spectacular-stoat](https://cheapsteak.github.io/tbd/open/?worktree=5146317A-1D34-45B7-891A-CBAE5F923A9D)