### PR TITLE
DX: End the DaywatchRunner test flake by driving its loop on virtual time (slice C2)

### DIFF
--- a/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
+++ b/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
@@ -104,6 +104,7 @@ public actor DaywatchRunner {
     private let executor: DaywatchExecuting
     private let deskSessionManager: (any DeskSessionManaging)?
     private let interval: TimeInterval
+    private let clock: any Clock<Duration>
 
     // MARK: - State
 
@@ -142,11 +143,13 @@ public actor DaywatchRunner {
     public init(
         executor: DaywatchExecuting,
         deskSessionManager: (any DeskSessionManaging)? = nil,
-        interval: TimeInterval = DaywatchRunner.defaultInterval
+        interval: TimeInterval = DaywatchRunner.defaultInterval,
+        clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.executor = executor
         self.deskSessionManager = deskSessionManager
         self.interval = interval
+        self.clock = clock
     }
 
     // MARK: - Public API
@@ -274,13 +277,15 @@ public actor DaywatchRunner {
         // Then sleep and loop
         while !Task.isCancelled {
             do {
-                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
-                try await Task.sleep(for: .seconds(interval))
+                try await clock.sleep(for: .seconds(interval))
             } catch {
-                // Cancelled during sleep
+                // Any error from the clock ends the loop; for the clocks in use
+                // (ContinuousClock, TestClock) the only throw is cancellation.
                 return
             }
 
+            // A sleep that resumed *before* cancellation landed must not fall
+            // through to a tick — this re-check is what stops it.
             if Task.isCancelled { return }
 
             await runOnce()

--- a/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
+++ b/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
@@ -1,4 +1,6 @@
+import Clocks
 import Foundation
+import TestSupport
 import Testing
 @testable import TBDDaemonLib
 import TBDShared
@@ -124,7 +126,14 @@ actor FakeDeskSessionManager: DeskSessionManaging {
 
 // MARK: - Tests
 
-struct DaywatchRunnerTests {
+/// Tier 1 — single-tick and mode-transition behavior. Every assertion here is
+/// on a synchronous effect of `apply()`/`runOnce()`; the tests that start the
+/// background loop never assert on anything its asynchronous ticks touch, so
+/// the loop parking on a real 1000 s sleep is inert. These deliberately pass
+/// **no** clock, so they also cover the production default-clock construction
+/// path.
+@Suite("DaywatchRunner single tick")
+struct DaywatchRunnerSingleTickTests {
 
     // MARK: - Test: runOnce() with exit code 0 does not wake judge
 
@@ -195,66 +204,6 @@ struct DaywatchRunnerTests {
         // No ticks should have been called
         #expect(await executor.tickCallCount == 0)
         #expect(await executor.judgeWakeCalls.isEmpty)
-    }
-
-    // MARK: - Test: apply(.daywatch) twice is idempotent (one loop)
-
-    @Test("apply(.daywatch) twice is idempotent (one loop)")
-    func testApplyIdempotency() async {
-        let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let runner = DaywatchRunner(executor: executor, interval: 1000)
-
-        // Apply daywatch twice — should not start two loops
-        await runner.apply(mode: .daywatch)
-        await runner.apply(mode: .daywatch)
-
-        // Give a tiny bit of time for the loop to run its first tick
-        try? await Task.sleep(for: .milliseconds(50))
-
-        // Should have exactly one tick from the initial immediate tick
-        let count = await executor.tickCallCount
-        #expect(count == 1)
-    }
-
-    // MARK: - Test: loop runs first tick immediately (no wait)
-
-    @Test("loop runs first tick immediately (no wait for full interval)")
-    func testLoopRunsFirstTickImmediately() async {
-        let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        // Use a large interval so we can be sure the immediate tick happens before the sleep
-        let runner = DaywatchRunner(executor: executor, interval: 1000)
-
-        await runner.apply(mode: .daywatch)
-
-        // Small sleep to let the loop start and run first tick
-        try? await Task.sleep(for: .milliseconds(100))
-
-        // First tick should have been called immediately
-        let count = await executor.tickCallCount
-        #expect(count >= 1)
-    }
-
-    // MARK: - Test: apply(.off) cancels the loop
-
-    @Test("apply(.off) cancels the loop")
-    func testApplyOffCancelsLoop() async {
-        let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let runner = DaywatchRunner(executor: executor, interval: 0.05)
-
-        // Start the loop
-        await runner.apply(mode: .daywatch)
-        try? await Task.sleep(for: .milliseconds(100))
-
-        let countBefore = await executor.tickCallCount
-        #expect(countBefore >= 1)
-
-        // Stop the loop
-        await runner.apply(mode: .off)
-        try? await Task.sleep(for: .milliseconds(50))
-
-        let countAfter = await executor.tickCallCount
-        // Should not have increased much (at most one more tick if one was in progress)
-        #expect(countAfter <= countBefore + 1)
     }
 
     // MARK: - Test: mode switching (daywatch → nightwatch)
@@ -403,11 +352,118 @@ struct DaywatchRunnerTests {
         #expect(wakeCalls[0].act == false, "fallback wakeJudge should have act=false")
     }
 
-    @Test("concurrent same-mode apply() calls: one transition, loop running, desk set")
+}
+
+// MARK: - Loop tests (virtual time)
+
+/// Tier 1 — the background loop, driven entirely by a `TestClock`. Virtual time
+/// makes the *production* interval free, so these run `defaultInterval` rather
+/// than a shrunken test pacing: the timings asserted are the shipped ones.
+@Suite("DaywatchRunner loop", .clockDriven)
+struct DaywatchRunnerLoopTests {
+
+    @Test("loop runs its first tick immediately, before any time passes")
+    func testFirstTickIsImmediate() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let clock = TestClock<Duration>()
+        let runner = DaywatchRunner(
+            executor: executor, interval: DaywatchRunner.defaultInterval, clock: clock)
+
+        await runner.apply(mode: .daywatch)
+
+        // The loop parking on the interval sleep proves — sequentially, since
+        // the tick precedes the sleep in runLoop() — that tick 1 completed.
+        // Zero advance is the claim: "immediately" means no time passed.
+        await clock.waitForSuspension()
+        #expect(await executor.tickCallCount == 1)
+    }
+
+    @Test("loop ticks again at exactly the production interval")
+    func testSubsequentTicksAtInterval() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let clock = TestClock<Duration>()
+        let runner = DaywatchRunner(
+            executor: executor, interval: DaywatchRunner.defaultInterval, clock: clock)
+
+        await runner.apply(mode: .daywatch)
+        await clock.waitForSuspension()
+        #expect(await executor.tickCallCount == 1)
+
+        // One millisecond short of the interval must not fire.
+        await clock.advance(by: .seconds(DaywatchRunner.defaultInterval) - .milliseconds(1))
+        #expect(await executor.tickCallCount == 1)
+
+        // The final millisecond does. Wait for the re-park: that is tick 2 done.
+        await clock.advanceWhenSuspended(by: .milliseconds(1))
+        await clock.waitForSuspension()
+        #expect(await executor.tickCallCount == 2)
+
+        // And it keeps its cadence, not just the one extra tick.
+        await clock.advanceWhenSuspended(by: .seconds(DaywatchRunner.defaultInterval))
+        await clock.waitForSuspension()
+        #expect(await executor.tickCallCount == 3)
+    }
+
+    @Test("duplicate same-mode apply starts exactly one loop")
+    func testDuplicateApplyStartsOneLoop() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let clock = TestClock<Duration>()
+        let runner = DaywatchRunner(
+            executor: executor, interval: DaywatchRunner.defaultInterval, clock: clock)
+
+        await runner.apply(mode: .daywatch)
+        await runner.apply(mode: .daywatch)
+
+        // Two loops would each tick immediately; exactly one tick means one loop —
+        // but the second loop's first tick is async and a count read can miss it,
+        // so the cadence below is the discriminating assertion: over one interval
+        // a single loop ticks exactly once more, while two loops would reach 4.
+        await clock.waitForSuspension()
+        #expect(await executor.tickCallCount == 1)
+
+        await clock.advanceWhenSuspended(by: .seconds(DaywatchRunner.defaultInterval))
+        await clock.waitForSuspension()
+        #expect(await executor.tickCallCount == 2)
+    }
+
+    @Test("apply(.off) cancels the loop: no sleeper remains, no further ticks")
+    func testApplyOffCancelsLoop() async {
+        let executor = FakeDaywatchExecutor(tickExitCode: 0)
+        let clock = TestClock<Duration>()
+        let runner = DaywatchRunner(
+            executor: executor, interval: DaywatchRunner.defaultInterval, clock: clock)
+
+        await runner.apply(mode: .daywatch)
+        await clock.advanceWhenSuspended(by: .seconds(DaywatchRunner.defaultInterval))
+        await clock.waitForSuspension()
+        #expect(await executor.tickCallCount == 2)
+
+        await runner.apply(mode: .off)
+
+        // `checkSuspension()` throws while a sleeper IS registered, so no error
+        // is the assertion: the loop's timer is gone. Cancelling resumes the
+        // sleeper, which deregisters itself in TestClock.sleep's cancellation
+        // path; checkSuspension's opening megaYield is what gives that
+        // resumption its turn. This stops holding if cancel() ever moves off
+        // the apply() path onto something apply() doesn't await. Recorded via
+        // #expect (not a bare `try`) so a starved megaYield under load cannot
+        // abort the test before the deterministic count assertion below.
+        await #expect(throws: Never.self) { try await clock.checkSuspension() }
+
+        // Bare advance on purpose: nothing may be sleeping, so
+        // advanceWhenSuspended would wait for a sleeper that must never come.
+        await clock.advance(by: .seconds(DaywatchRunner.defaultInterval * 3))
+        #expect(await executor.tickCallCount == 2)
+    }
+
+    @Test("concurrent same-mode apply: one transition, loop intact")
     func testConcurrentSameModeApply() async {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
         let desker = FakeDeskSessionManager()
-        let runner = DaywatchRunner(executor: executor, deskSessionManager: desker, interval: 1000)
+        let clock = TestClock<Duration>()
+        let runner = DaywatchRunner(
+            executor: executor, deskSessionManager: desker,
+            interval: DaywatchRunner.defaultInterval, clock: clock)
 
         // Two racing apply(.daywatch) from .off — the gate serializes them; the
         // second must be a genuine no-op, not a false supersession that closes
@@ -420,6 +476,11 @@ struct DaywatchRunnerTests {
         let closeCalls = await desker.closeCalls
         #expect(ensureCalls.count == 1, "duplicate same-mode apply must not re-ensure")
         #expect(closeCalls == 0, "no orphan-close on duplicate apply")
+
+        // Pin the loop's first tick (exit 0, no nudge) as *completed* before
+        // restubbing the exit code. Otherwise the async first tick can observe
+        // exit 10 and nudge, making the count below 2 instead of 1.
+        await clock.waitForSuspension()
 
         // The transition really completed: a tick with exit 10 nudges the desk.
         await executor.setTickExitCode(10)


### PR DESCRIPTION
## Summary

**Slice C2** of the test-hardening program ([design](docs/specs/2026-07-24-test-hardening-design.md) §5, [slicing](docs/specs/2026-07-24-test-hardening-slicing.md) §2). Contracts consumed: §5.1 (clock signature — last param, named `clock`, defaulted, existential), §5.3 (TestSupport helpers only), §5.4 (suppression deletion). **Behavior-preserving by construction** (defaulted clock parameter, single production call site unchanged) — per slicing §1, no feature flag applies.

- **What was broken:** `DaywatchRunnerTests` is a long-standing flake-ledger entry. Four tests used bare `Task.sleep` grace windows (50–100 ms) as synchronization for the loop's *asynchronous* first tick, then asserted counts — under CI load the tick misses the window and the count reads 0. One test also pinned an incident-shaped tolerance (`countAfter <= countBefore + 1`) on a real 50 ms loop.
- **What this does:** `DaywatchRunner` takes `clock: any Clock<Duration> = ContinuousClock()`; the loop sleeps on it. The tests drive a `TestClock` at the **production** 900 s interval: the loop suites assert exact virtual timings (first tick with *zero* advance; a tick at exactly interval−1 ms → no, +1 ms → yes) instead of tolerance windows. The suppression at the loop site is deleted; `superfluous_disable_command` staying enabled is the mechanical proof the migration finished.
- **Scope ruling (channel #149):** `ProcessDaywatchExecutor`'s 5-minute kill deadline (`:67`) deliberately keeps its raw sleep + suppression. Its kill-path test would structurally inherit the fork/exec-before-sleeper-registration race C3 hit (#141), and fixing that requires an untestable-by-construction kill-on-arrival branch inside an executor whose own doc comment marks it interim pending the Phase A rewrite. Slice F inherits the site with this analysis (python3 presence verified for whenever F takes it).

## New coverage (not just determinism)

- The loop ticking a **second** time — and at the exact production cadence — had no test at all before; the old tests only ever observed the immediate first tick.
- `apply(.off)` is now proven by the **absence of a registered sleeper** (`checkSuspension`) plus an exact post-advance count, replacing the `<= +1` tolerance.
- A latent pre-existing race in `testConcurrentSameModeApply` (restubbing the exit code could beat the loop's async first tick and double the nudge count) is closed by handshake.

## The amended claim (program DoD, channel #81)

The wall-clock-**assertion** flake class is eliminated; residual scheduler-starvation is inherited from the dependency, named and quantified (issue #496, slice J). Not claimed: "cannot fail under load."

## Evidence

- **Mutations — 5 defects, 15/15 KILLED, 0 RED-OTHER** (defect written before each break; satisfiers enumerated by grep; baseline-green gate per mutation; kills matched against the predicted named assertion, not mere redness): off-fails-to-cancel (`SuspensionError`), duplicate-apply-second-loop (synchronous `ensureCalls` assertion — kill credit deliberately assigned to the deterministic satisfier, plus a cadence assertion that makes the count test deterministic too), loop-regresses-to-one-shot (helper's named no-sleeper diagnostic), interval fires early / late (boundary asserts).
- **Stress (interleaved, calibrated):** calibration warm-up-discarded U/L/U/L showed +33 % real pressure; 4 interleaved whole-target pairs with arm identity proven per switch by markers **and** by test-count delta (2033 → 2034 = exactly this branch's +1 net). AFTER arms 4/4 green (one run crawled to 1013 s under an ambient spike and still passed); BEFORE arms 2/4 red — **every red foreign** (the ledgered `isPipeWritable` flake, one `AutoCloseSetup` sighting, and #496-class 60 s wedges in sibling clock-driven suites). **Zero Daywatch failures in any arm of any run.**
- **Honest baseline statement:** the old flake did **not** reproduce on the BEFORE arm at the achievable operating point (run-start loads 17–54), so no measured before/after delta is claimed. The kill claim is structural — the four bare-sleep sync primitives are deleted, so the failing assertion shapes no longer exist — plus the flake ledger's history and the mutation results above.
- Gates: `swift build --build-tests` green; fast pass 3872 (1 known issue = slice E's permanent `.flaky` fixture) + quiet pass 54/17 green locally on the rebased head; `swiftlint --strict` 0/586 by hand; the `no_raw_task_sleep` rule proven to fire (raw sleep reintroduced → red → reverted); review loop: full read-only review (approve with minors) → all four findings addressed as prescribed → verification pass (approve, "fix 2 upgrades a probabilistic assertion into a deterministic one").
- Deliberately not `.serialized`: contract says reach for it when the arming handshake fails under load; this suite's 5 clock-driven tests did not fail in any loaded whole-target run tonight. First knob if it ever floods.

## Test plan

- [x] `swift test --filter DaywatchRunner` — 18/18 in 0.009 s (two suites: 13 single-tick tests passing **no** clock, covering the production default path; 5 loop tests on `TestClock`)
- [x] Both CI passes locally on the rebased head
- [x] Mutation suite 15/15 KILLED
- [x] `swiftlint --strict` clean; exactly one suppression remains in the file (the `:67` executor site ruled to slice F)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=2A5F0C01-1BE0-4328-9C9F-6EF76CBE2E2C)