### PR TITLE
Fix: Desk prompts told every session to run a command that never existed (5 days, nothing respawned)

### DIFF
--- a/Sources/TBDDaemon/Lifecycle/PluginDirWriter.swift
+++ b/Sources/TBDDaemon/Lifecycle/PluginDirWriter.swift
@@ -100,11 +100,7 @@ struct PluginDirWriter {
         // Scripts ship executable. NOTE: the scheduler (scheduler.sh / tick-cron.sh)
         // is installed but NEVER auto-loaded — durable scheduling is opt-in via
         // `scheduler.sh enable`.
-        for (name, body) in [("tick.py", NightwatchSkillContent.tickPy),
-                             ("wake.py", NightwatchSkillContent.wakePy),
-                             ("judge.py", NightwatchSkillContent.judgePy),
-                             ("tick-cron.sh", NightwatchSkillContent.tickCronSh),
-                             ("scheduler.sh", NightwatchSkillContent.schedulerSh)] {
+        for (name, body) in NightwatchSkillContent.scripts {
             let path = scripts + "/" + name
             try body.write(toFile: path, atomically: true, encoding: .utf8)
             try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: path)

--- a/Sources/TBDShared/NightwatchDeskPrompts.swift
+++ b/Sources/TBDShared/NightwatchDeskPrompts.swift
@@ -33,7 +33,33 @@ public enum NightwatchDeskPrompts {
         • Single-driver rule: Before actioning any atlantis apply/merge, claim the item in queue/claims
         • Escalations in batches ≤4: Each question with exact PR#/command/recommendation
         • Capacity check: Before nudging others, verify profile usage <80% weekly cap
-        • Token ceiling: If ~200k tokens used, flag for session respawn instead of nudging
+        • Context ceiling: At ~200k tokens, run the handoff relay (below) — do NOT defer it and keep working
+        • The gate stops short of merging: get PRs *ready*, the human merges (never run `gh pr merge`)
+        • NEVER trigger `/closeout` — a finished-looking worktree is an archive question for the human
+
+        **Standing rules (set by Chang — these override anything else in this prompt):**
+
+        **NEVER trigger `/closeout`.** Not on a DONE pane, not on a "candidate for
+        /closeout" self-report, not because the composer already suggests it. A worktree
+        that looks finished is an *archive question for the human*, not a harvest to fire.
+        Report it and move on.
+
+        **Hand off at the context ceiling — never push through it.** There is no babysitter
+        daemon and no respawner; nothing will restart you. When this session passes ~200k
+        tokens it starts truncating its own shift, so use the relay:
+
+            python3 \(skillDir)/scripts/handoff.py --check
+                # exit 0 = under the ceiling · exit 10 = OVER
+
+            python3 \(skillDir)/scripts/handoff.py --act --notes-file <your-notes.md>
+                # writes the handoff doc and spawns a fresh successor in this worktree
+
+        The predecessor NEVER closes itself. The successor closes it, after it has read the
+        handoff:
+
+            python3 \(skillDir)/scripts/handoff.py --close-predecessor <predecessor-terminal-id>
+
+        If the spawn fails, you are still the only thing watching the desk — stay alive.
 
         **Next step:**
         Read the Nightwatch skill docs for the full merge-gate policy, clearance types, and acting procedures.
@@ -66,7 +92,7 @@ public enum NightwatchDeskPrompts {
         if mode == .daywatch {
             actionHint = "(daywatch: triage only; act on small_safe/preclear; batch rest for human review)"
         } else {
-            actionHint = "(nightwatch: act on everything the gate allows)"
+            actionHint = "(nightwatch: act on what the gate allows — the gate stops short of merging; the human merges)"
         }
 
         let queueDir = skillDir + "/queue"
@@ -81,8 +107,17 @@ public enum NightwatchDeskPrompts {
         2. Apply the policy per the skill docs
         3. For each decision:
            - Daywatch: act ONLY if clearanceKind in [preclear, small_safe]; otherwise batch for human review
-           - Nightwatch: act on everything the gate approves
+           - Nightwatch: act on what the gate allows — but NEVER merge (see the gate below)
         4. Write results to \(queueDir)/acted.jsonl (one JSON line per action taken)
+
+        **The gate (never automate past this):**
+        - A PR may only be enqueued when claude-review = APPROVED on the CURRENT SHA and
+          checks are clean. Human approval never substitutes for the bot verdict.
+        - NEVER run `gh pr merge`. It is not a safe wedge — it always escalates to the
+          human. Your job is to get PRs *ready*; the human merges.
+        - Re-read live PR state in the same breath as any send that asserts it
+          (`gh pr view N --json state,headRefOid,mergeStateStatus`); never dispatch a fact
+          older than the current tool call.
         5. Write a summary to \(queueDir)/judge-summary.txt
 
         **Field learnings — apply these rules:**
@@ -106,10 +141,23 @@ public enum NightwatchDeskPrompts {
         - Before invoking other workers (e.g., "nudge code-review worker"), verify profile usage is <80% weekly cap
         - If at/above 80%, skip nudging; instead, add to queue for next cycle
 
-        **Token ceiling for respawn:**
-        - If this session has used ~200k tokens, flag for respawn instead of nudging others
-        - Symptom: running slow, many retries, unclear LLM reasoning
-        - Remedy: call `tbd terminal close --all` on the desk, let daemon respawn fresh
+        **Context ceiling — hand off, never push through:**
+        - Symptom: running slow, many retries, unclear reasoning, truncated history
+        - Do NOT just mark the session for later recycling and keep working. That is a
+          no-op: there is no babysitter daemon and no respawner. Nothing will restart you.
+        - Check: `python3 \(skillDir)/scripts/handoff.py --check` (exit 0 = under, 10 = OVER)
+        - When OVER: write your handoff notes to a file, then
+          `python3 \(skillDir)/scripts/handoff.py --act --notes-file <your-notes.md>`
+          which writes the handoff doc and spawns a fresh successor in this worktree
+        - The predecessor NEVER closes itself. The successor closes it once it has read the
+          handoff: `python3 \(skillDir)/scripts/handoff.py --close-predecessor <tid>`
+        - If the spawn fails, stay alive — you are the only thing watching the desk
+
+        **NEVER trigger `/closeout`:**
+        - Not on a DONE pane, not on a "candidate for /closeout" self-report, not because
+          the composer already suggests it
+        - A worktree that looks finished is an *archive question for the human*, not a
+          harvest to fire. Report it and move on.
 
         **Act:** Use `tbd terminal send --submit` to confirm each action, or batch AskUserQuestion if unsure.
 
@@ -126,14 +174,21 @@ public enum NightwatchDeskPrompts {
             Triage decisions and act conservatively:
             - Act immediately only on small_safe/preclear clearances (safe, well-tested, low risk)
             - Batch everything else (experimental, novel, uncertain) into a human-review summary
-            - Use AskUserQuestion for uncertain calls; never force-merge uncertain PRs
+            - Use AskUserQuestion for uncertain calls
+            - NEVER run `gh pr merge` — no clearance kind authorizes a merge; the human merges
+            - Never trigger `/closeout` — a finished-looking worktree is an archive
+              question for the human
             """
 
         case .nightwatch:
             return """
-            Act on everything the gate approves:
-            - Merge PRs cleared by the policy (all clearance kinds)
+            Get PRs *ready* — the human merges:
+            - A PR may only be enqueued when claude-review = APPROVED on the current SHA
+              AND checks are clean. Human approval never substitutes for the bot verdict.
+            - NEVER run `gh pr merge`. It always escalates to the human, by design.
             - Escalate blockers (conflicts, status checks) with context
+            - Never trigger `/closeout` — a finished-looking worktree is an archive
+              question for the human
             - Write a morning summary of all actions taken
             """
 

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -631,6 +631,11 @@ DONE_PAT = re.compile(r"ready to archive|you're done|nothing (?:open|left)|windi
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 # Claude Code renders its OWN suggestions in the composer as dim (ESC[2m) ghost text.
+# KNOWN, ACCEPTED GAP: this requires `2` to be the LAST parameter of the SGR
+# sequence, so a compound escape like ESC[2;3m (dim+italic) would not match and
+# that ghost would be read as typed input. Not observed from Claude Code, and the
+# pattern was validated against the live fleet (STRANDED 14 -> 5, all five
+# survivors genuinely typed). Check here first if phantom strands ever return.
 DIM_RE = re.compile(r"\x1b\[(?:[0-9;]*;)?2m")
 # SGR mouse reports ("<65;61;31M") land in the composer on a stray click. Never input.
 MOUSE_RE = re.compile(r"^<\d+;\d+;\d+[Mm]$")
@@ -987,6 +992,7 @@ the SUCCESSOR closes the predecessor once it has actually read the handoff.
   handoff.py --check                      # exit 0 = under ceiling, 10 = over
   handoff.py --act --notes-file notes.md  # write handoff + spawn successor
   handoff.py --close-predecessor <tid>    # successor calls this when it's ready
+  handoff.py --selftest                   # offline ceiling / fail-closed test
 
 Ordering matters: the predecessor NEVER closes itself. If the spawn fails or the
 successor dies on boot, the old session is still there and the shift survives.
@@ -1065,11 +1071,24 @@ def resolve_self():
 
 
 def cmd_check(args):
+    """Exit 0 = under the ceiling · 10 = OVER (or unknowable).
+
+    FAILS CLOSED. An unreadable transcript, a `tbd terminal list` that errored,
+    or a row without a transcriptPath all report OVER. context_tokens() already
+    refuses to guess 0 because "a bogus low reading would silently disable the
+    ceiling" -- mapping its None to exit 0 here would have reinstated exactly
+    that, and the caller is told to trust "exit 0 = under the ceiling". The
+    asymmetry is decisive: a spurious handoff costs one relay cycle, a missed
+    one costs the shift to truncation, which is the failure this script exists
+    to prevent.
+    """
     *_, row = resolve_self()
-    used = context_tokens(row.get("transcriptPath", ""))
+    transcript = row.get("transcriptPath") or ""
+    used = context_tokens(transcript) if transcript else None
     if used is None:
-        print("context: UNKNOWN (transcript unreadable) — treating as under ceiling")
-        return 0
+        why = "no transcriptPath on the terminal row" if not transcript else "transcript unreadable"
+        print(f"context: UNKNOWN ({why}) — failing closed, treat as OVER")
+        return 10
     over = used >= args.threshold
     print(f"context: {used:,} / ceiling {args.threshold:,} — {'OVER' if over else 'ok'}")
     return 10 if over else 0
@@ -1159,12 +1178,16 @@ def cmd_close(args):
     """Close a predecessor terminal by killing its tmux window."""
     target = args.close_predecessor
     r = _run(["tbd", "terminal", "list", os.environ.get("TBD_WORKTREE_ID", ""), "--json"])
-    row = {}
-    if r.returncode == 0:
-        for candidate in json.loads(r.stdout or "[]"):
-            if candidate.get("id") == target:
-                row = candidate
-                break
+    # A FAILED lookup is not an absent terminal. Collapsing the two would report
+    # "already closed" for a predecessor that is still running and still holding
+    # the desk -- the same treat-unknown-as-benign shape as the old cmd_check.
+    if r.returncode != 0:
+        sys.exit(f"cannot verify terminal {target}: `tbd terminal list` failed: {r.stderr.strip()}")
+    try:
+        rows = json.loads(r.stdout or "[]")
+    except json.JSONDecodeError:
+        sys.exit(f"cannot verify terminal {target}: unparseable `tbd terminal list` output")
+    row = next((c for c in rows if c.get("id") == target), {})
     if not row:
         print(f"terminal {target} not found — already closed, nothing to do")
         return 0
@@ -1182,12 +1205,76 @@ def cmd_close(args):
     return 0
 
 
+def selftest():
+    """Offline test of the ceiling arithmetic and the fail-closed paths.
+
+    No subprocesses, no tbd, no tmux, no transcript on disk. Covers the two
+    behaviours that decide whether a shift survives: context_tokens() picking
+    the largest usage record, and cmd_check refusing to report "under" when it
+    cannot actually tell.
+    """
+    import tempfile
+    n = 0
+
+    def check(label, got, want):
+        nonlocal n
+        assert got == want, f"{label}: got {got!r}, want {want!r}"
+        n += 1
+
+    class Args:
+        threshold = DEFAULT_THRESHOLD
+
+    def with_row(row):
+        """Run cmd_check against a fixed terminal row, no tbd/env involved."""
+        g = globals()
+        real = g["resolve_self"]
+        g["resolve_self"] = lambda: ("T", "W", row)
+        try:
+            return cmd_check(Args())
+        finally:
+            g["resolve_self"] = real
+
+    # context_tokens: the reported figure is input + BOTH cache buckets, and the
+    # largest record in the tail wins (the tail holds smaller earlier turns).
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
+        for total in (10_000, 250_000, 40_000):
+            fh.write(json.dumps({"message": {"usage": {
+                "input_tokens": total - 30, "cache_creation_input_tokens": 20,
+                "cache_read_input_tokens": 10}}}) + "\n")
+        fh.write("not json at all\n")          # tolerated, not fatal
+        fh.write(json.dumps({"message": {}}) + "\n")   # no usage block
+        path = fh.name
+    check("largest usage record wins", context_tokens(path), 250_000)
+    check("over ceiling exits 10", with_row({"transcriptPath": path}), 10)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
+        fh.write(json.dumps({"message": {"usage": {"input_tokens": 1_000}}}) + "\n")
+        small = fh.name
+    check("under ceiling exits 0", with_row({"transcriptPath": small}), 0)
+
+    # FAIL CLOSED. Each of these once returned 0 ("under ceiling"), which is how
+    # a session runs past its ceiling with nobody ever telling it to hand off.
+    check("unreadable transcript fails closed",
+          with_row({"transcriptPath": "/nonexistent/transcript.jsonl"}), 10)
+    check("missing transcriptPath fails closed", with_row({}), 10)
+    check("empty transcriptPath fails closed", with_row({"transcriptPath": ""}), 10)
+    check("no usage records fails closed", context_tokens(os.devnull), None)
+
+    os.unlink(path)
+    os.unlink(small)
+    print(f"selftest: {n}/{n} handoff ceiling scenarios passed")
+
+
 def main():
+    if "--selftest" in sys.argv:
+        selftest()
+        return 0
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     g = p.add_mutually_exclusive_group(required=True)
     g.add_argument("--check", action="store_true", help="report context vs ceiling (exit 10 = over)")
     g.add_argument("--act", action="store_true", help="write handoff + spawn successor")
     g.add_argument("--close-predecessor", metavar="TID", help="successor closes the old session")
+    g.add_argument("--selftest", action="store_true", help="offline ceiling/fail-closed test")
     p.add_argument("--notes-file", help="markdown file holding the handoff body (required with --act)")
     p.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
     args = p.parse_args()

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -89,7 +89,7 @@ hibernation context (`hibernateReason` is a closed enum; the narrative, includin
 premises, lives in the `suspendedSnapshot` pane text, which wake.py scans ANSI-stripped;
 MERGED/CLOSED never yields a "fix your PR" wake), the checked-out branch's actual open PR +
 failing checks, and unmerged-commit state vs origin/main — then classifies
-(DONE → /closeout · RESUME_FAILING/OPEN · UNSUBMITTED_WORK · UNVERIFIED → neutral "verify
+(DONE → report-and-stop · RESUME_FAILING/OPEN · UNSUBMITTED_WORK · UNVERIFIED → neutral "verify
 first" prompt) and writes `queue/wake-plan.json`. First real sweep: 24/24 hibernated
 terminals verified DONE — every hand-composed "resume" wake would have been stale.
 
@@ -205,7 +205,8 @@ classifies the work, and composes the wake prompt from verified facts only.
 
 Rules it enforces:
   - A PR named in a wake premise is checked live (`gh pr view --json state`);
-    MERGED/CLOSED PRs never produce a "fix your PR" wake — they produce /closeout.
+    MERGED/CLOSED PRs never produce a "fix your PR" wake — they produce a done-report
+wake. No wake ever tells a session to run /closeout; archiving is the human's call.
   - A local branch name is NOT evidence of unfinished work: if the branch has no
     unmerged commits vs origin/main (or its PR merged), the work is DONE.
   - Anything unverifiable (gh failure, no repo, detached head) wakes NEUTRAL —
@@ -233,8 +234,10 @@ DB = f"{HOME}/tbd/state.db"
 SKILL = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 QUEUE = f"{SKILL}/queue"
 
-STANDING_RULE = ("If the task is complete, run /closeout. Resume only if genuinely "
-                 "unfinished. Do NOT merge — the human merges.")
+STANDING_RULE = ("If the task is complete, SAY SO AND STOP — do not run /closeout. "
+                 "A finished-looking worktree is an archive question for the human, "
+                 "not a harvest to fire. Resume only if genuinely unfinished. "
+                 "Do NOT merge — the human merges.")
 
 
 def sh(args, t=20, cwd=None):
@@ -382,7 +385,7 @@ def verify(item, fetch=True):
         # exact kind of unverified premise this script exists to eliminate.
         if v["dirty"]: facts.append("dirty working tree, merge state unknown")
     if v["dirty"] and v["classification"] == "DONE":
-        facts.append("note: dirty working tree — closeout should triage it")
+        facts.append("note: dirty working tree — needs triage before any archive decision")
     return v
 
 
@@ -392,18 +395,19 @@ def compose(v):
     c = v["classification"]
     if c == "DONE":
         return (f"Nightwatch wake (state verified live): your work here appears COMPLETE "
-                f"({facts}). Run /closeout now. {STANDING_RULE}")
+                f"({facts}). Report that in one line and stop. {STANDING_RULE}")
     if c == "RESUME_FAILING":
         return (f"Nightwatch wake (state verified live): PR #{v['pr']} on branch {v.get('branch')} "
                 f"has failing checks ({facts}). Diagnose, fix, push, drive to checks-green + "
                 f"claude-review approved on the current SHA. {STANDING_RULE}")
     if c == "RESUME_OPEN":
         return (f"Nightwatch wake (state verified live): PR #{v['pr']} on branch {v.get('branch')} "
-                f"is open ({facts}). Drive it to ready (checks green + claude-review approved) or "
-                f"/closeout if it's actually done. {STANDING_RULE}")
+                f"is open ({facts}). Drive it to ready (checks green + claude-review approved); "
+                f"if it is actually done, say so and stop. {STANDING_RULE}")
     if c == "UNSUBMITTED_WORK":
         return (f"Nightwatch wake (state verified live): branch {v.get('branch')} has {facts}. "
-                f"Decide: finish and open a PR, or /closeout and abandon. {STANDING_RULE}")
+                f"Decide: finish and open a PR, or report it to the human as an "
+                f"abandon candidate. {STANDING_RULE}")
     return (f"Nightwatch wake: live state could NOT be verified ({facts}). Before doing anything, "
             f"verify with git/gh what is actually outstanding — do not trust any earlier premise. "
             f"{STANDING_RULE}")
@@ -467,7 +471,31 @@ def selftest():
             snapshot="fix PR #14203 FAILING checks")
     assert any("stale" in f for f in v["facts"]), v
     assert v["classification"] == "DONE", v
-    print("selftest: 8/8 classification scenarios passed")
+    # 9. NO composed wake ever tells a session to run /closeout, in ANY branch.
+    #    These prompts are dispatched by `wake.py --act` with no human in the
+    #    loop, so a "Run /closeout now" is a harvest fired on the human's behalf.
+    #    Chang's standing rule: a finished-looking worktree is an archive
+    #    QUESTION for the human. Asserted on the composed output rather than on
+    #    the source text, so a future rephrasing that reintroduces the
+    #    instruction through STANDING_RULE or a new branch is still caught.
+    #    Whitelist the one permitted context rather than blacklisting imperative
+    #    phrasings: a blacklist is defeated from BOTH sides, since the sentence
+    #    that forbids "run /closeout" contains "run /closeout". Every mention of
+    #    /closeout in a dispatched prompt must be the prohibition itself.
+    PERMITTED = "do not run "
+    for classification in ("DONE", "RESUME_FAILING", "RESUME_OPEN",
+                           "UNSUBMITTED_WORK", "UNVERIFIED"):
+        prompt = compose({"classification": classification, "facts": ["f"],
+                          "pr": 1, "branch": "b"})
+        low, mentions = prompt.lower(), 0
+        i = low.find("/closeout")
+        while i != -1:
+            mentions += 1
+            assert low[max(0, i - len(PERMITTED)):i] == PERMITTED, \
+                f"{classification} wake mentions /closeout outside the prohibition: {prompt}"
+            i = low.find("/closeout", i + 1)
+        assert mentions == 1, f"{classification} wake lost the rule: {prompt}"
+    print("selftest: 9/9 classification scenarios passed")
 
 
 def main():

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -534,8 +534,8 @@ if __name__ == "__main__":
 """
 nightwatch tick — Tier-0 orchestrator. NO model in the hot path.
 
-Reads the whole TBD fleet across all tmux servers, the babysitter daemon health,
-and fleet-derived capacity, classifies every agent deterministically, and emits:
+Reads the whole TBD fleet across all tmux servers and fleet-derived capacity,
+classifies every agent deterministically, and emits:
   - a structured tick-report.json  (machine-readable)
   - a short human summary to stdout
   - queue/decisions.jsonl   (items that need Tier-2 / Opus judgment)
@@ -543,6 +543,7 @@ and fleet-derived capacity, classifies every agent deterministically, and emits:
 
 Exit code 0 = nothing needs Opus (silent-ok).  Exit code 10 = judgment items queued.
 Run with --prs to also gate open PRs (makes gh calls — skip during GitHub rate crunch).
+Run with --selftest for the offline classifier matrix (no DB, no tmux, no lock).
 """
 import subprocess, os, re, json, time, sys, fcntl
 
@@ -729,7 +730,94 @@ def fleet():
                     "ctx_pct": ctx_pct, "is_1m": is_1m, "burn_risk": burn})
     return out
 
+def _pane(*lines):
+    """Synthetic capture-pane output."""
+    return "\n".join(lines) + "\n"
+
+
+DIM, RESET = "\x1b[2m", "\x1b[0m"
+
+
+def selftest():
+    """Offline matrix for the composer ghost-guard. No DB, no tmux, no lock.
+
+    This guards the path that TYPES INTO LIVE PANES: whatever _composer()
+    returns is dispatched as though a human had written it, so every impostor
+    gets an explicit scenario rather than a string-presence check on the source.
+    Run from Swift by Tests/TBDDaemonTests/PluginDirWriterTests.swift.
+    """
+    n = 0
+
+    def check(label, got, want):
+        nonlocal n
+        assert got == want, f"{label}: got {got!r}, want {want!r}"
+        n += 1
+
+    def nonempty(text):
+        return [x for x in text.splitlines() if x.strip()]
+
+    def raws(text):
+        return [x for x in text.splitlines() if ANSI_RE.sub("", x).strip()]
+
+    # A genuinely typed line is the ONLY thing that may strand a pane.
+    typed = _pane("⏺ ran the build", "───────", "❯ please retry the deploy",
+                  "───────", "  bypass permissions on")
+    check("typed input strands", classify(typed, typed),
+          ("STRANDED", "please retry the deploy"))
+
+    # Claude Code's own suggestion: byte-identical to the above once ANSI is
+    # stripped. Dimness in the raw capture is the only thing telling them apart.
+    ghost_raw = _pane("⏺ ran the build", "───────",
+                      DIM + "❯ please retry the deploy" + RESET,
+                      "───────", "  bypass permissions on")
+    ghost = ANSI_RE.sub("", ghost_raw)
+    check("ghost text is not composer input",
+          _composer(nonempty(ghost), raws(ghost_raw)), "")
+    check("ghost text does not strand", classify(ghost, ghost_raw), ("IDLE", ""))
+
+    # An SGR mouse report from a stray click in the pane.
+    mouse = _pane("⏺ ran the build", "───────", "❯ <65;61;31M",
+                  "───────", "  bypass permissions on")
+    check("mouse report is not input", classify(mouse, mouse), ("IDLE", ""))
+
+    # Index alignment is load-bearing: raw_lines[j] must describe lines[j]. When
+    # the two filters disagree the lookup is abandoned rather than read off the
+    # wrong row — which FAILS OPEN (the ghost is treated as typed). Pinned here
+    # deliberately: a missed nudge costs a tick, but silently reading dimness
+    # from an unrelated row would suppress real input at random.
+    misaligned = ghost_raw + "an extra raw-only line\n"
+    check("misaligned raw capture is abandoned, not misread",
+          classify(ghost, misaligned)[0], "STRANDED")
+
+    # Same degrade when the caller passes no raw capture at all: the dim check
+    # is unavailable, but the mouse filter still holds.
+    check("no raw capture still filters mouse", classify(mouse)[0], "IDLE")
+    check("no raw capture cannot see dimness", classify(ghost)[0], "STRANDED")
+
+    # The TBD statusline is chrome, never a pane's last meaningful line.
+    check("statusline skipped",
+          _lastmeaning(["waiting on your call", "Opus 5(high)  494k/1000k  5h(65% →20:00)"]),
+          "waiting on your call")
+    check("bare prompt glyph skipped",
+          _lastmeaning(["waiting on your call", "❯"]), "waiting on your call")
+
+    # Precedence: an in-flight turn outranks whatever sits in the composer.
+    working = _pane("⏺ thinking", "❯ please retry the deploy",
+                    "  bypass permissions on", "esc to interrupt")
+    check("working outranks composer", classify(working, working)[0], "WORKING")
+    check("empty pane", classify("", ""), ("EMPTY", ""))
+
+    print(f"selftest: {n}/{n} composer ghost-guard scenarios passed")
+
+
 def main():
+    # --selftest must short-circuit BEFORE the machine-global lock below: a live
+    # tick holding it would otherwise make the selftest exit 0 silently, i.e.
+    # pass without running a single scenario.
+    if "--selftest" in sys.argv:
+        selftest()
+        return
+
     # Prevent concurrent tick runs across BOTH schedulers — the in-daemon DaywatchRunner
     # loop and the launchd scheduler.sh heartbeat. They execute DIFFERENT tick.py copies
     # from different install trees (AppSupport plugin dir vs ~/.claude), so a lock under

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -7,6 +7,26 @@ import Foundation
 /// Single source of truth, written by PluginDirWriter. Generated from the skill files.
 public enum NightwatchSkillContent {
 
+    /// Every script the daemon installs into `<skillDir>/scripts/`, in install
+    /// order. `PluginDirWriter.writeNightwatch` iterates this rather than
+    /// carrying its own list, so the set is visible to TBDShared tests — which
+    /// is what lets `NightwatchDeskPromptsTests` assert that every script a desk
+    /// prompt tells a session to run is actually shipped.
+    ///
+    /// That cross-check exists because the two drifted once: the judge prompt
+    /// spent five days naming `tbd terminal close --all` (a command that never
+    /// existed), and its replacement initially named `scripts/handoff.py` while
+    /// the writer shipped only five scripts, none of them that one. A prompt
+    /// naming an uninstalled path is the same defect wearing a different hat.
+    public static let scripts: [(name: String, body: String)] = [
+        ("tick.py", tickPy),
+        ("wake.py", wakePy),
+        ("judge.py", judgePy),
+        ("handoff.py", handoffPy),
+        ("tick-cron.sh", tickCronSh),
+        ("scheduler.sh", schedulerSh)
+    ]
+
     public static let skillMd: String = #"""
 ---
 name: nightwatch
@@ -21,7 +41,7 @@ Keep a fleet of TBD agent worktrees unblocked, productive, and gated while the h
 
 | Tier | Runs on | Does |
 |---|---|---|
-| **0** | `scripts/tick.py` — pure Python, $0 | sweep all panes (every tmux server), daemon health + fleet capacity, classify every agent, split into auto/judgment/human, write `queue/tick-report.json` |
+| **0** | `scripts/tick.py` — pure Python, $0 | sweep all panes (every tmux server), fleet capacity, classify every agent, split into auto/judgment/human, write `queue/tick-report.json` |
 | **1** | local model (Ollama) or Haiku — *future* | classify ambiguous panes, triage escalations, draft routine nudges. Off the Opus quota. |
 | **2** | **Opus — rare** | resolve genuinely ambiguous decisions, the deep review, any prod/security/CJI/access call. Wakes only when `queue/decisions.jsonl` has items. |
 | **Human** | Adam | merge PRs, proxy/IAM/prod restarts, Slack pings, access, the capacity (Bedrock) lever. |
@@ -36,7 +56,7 @@ python3 scripts/tick.py --prs  # also gate open PRs (wraps loop_perfect_sweep.py
 ```
 
 `tick.py` prints a short human summary AND writes:
-- `queue/tick-report.json` — full structured state (daemon, capacity, every agent, auto_actions, judgment_queue)
+- `queue/tick-report.json` — full structured state (capacity, every agent, auto_actions, judgment_queue)
 - `queue/decisions.jsonl` — append-only judgment items (decisions to resolve, maybe-archive)
 - `queue/for-adam.md` — human-only items
 
@@ -88,6 +108,40 @@ for.) And phrase gate outcomes honestly: nightwatch cannot deny a GitHub enqueue
 *stricter than the org's required checks* (AI Review is advisory until the ADR-0013 apply), so a
 bot-verdict shortfall on a human-approved PR is an **advisory heads-up**, not a "denied".
 
+## Standing rules (set by Chang — these override the tick prompt)
+
+**NEVER trigger `/closeout`.** Not on a DONE pane, not on a "candidate for /closeout"
+self-report, not because the composer already suggests it. A worktree that looks finished
+is an *archive question for the human*, not a harvest to fire. Report it and move on.
+(The tick prompt and older judge-summary passes treat `/closeout` as a small_safe action —
+they are wrong; this rule wins.)
+
+**Hand off at the context ceiling — never push through it.** A judge session that runs past
+~200k tokens starts truncating its own shift. Do not "flag for respawn" and keep working, and
+do NOT use `tbd terminal close --all` — **that command does not exist** (there is no
+`tbd terminal close` subcommand at all; the only real close is killing the tmux window).
+The working relay is `scripts/handoff.py`:
+
+```
+python3 scripts/handoff.py --check                       # exit 0 under · exit 10 OVER (reads
+                                                         # your own transcript's usage records)
+python3 scripts/handoff.py --act --notes-file notes.md   # writes queue/handoff-<ts>.md (+ the
+                                                         # HANDOFF-LATEST.md pointer) and spawns
+                                                         # a successor in THIS worktree on Opus,
+                                                         # briefed with the doc + this same rule
+python3 scripts/handoff.py --close-predecessor <tid>     # the SUCCESSOR runs this
+```
+
+**The predecessor never closes itself.** It writes notes → spawns → goes idle; the successor
+reads the doc and *then* kills the old terminal. If the spawn fails the script says so and
+stays alive — a half-completed relay must never leave the desk with nobody on it. The rule is
+recursive: the spawn prompt hands the successor the same ceiling instruction, so the relay
+continues without a human in the loop.
+
+*Tab caveat:* TBD has no "restart the session in this tab" command. `handoff.py` uses
+`tbd terminal create` on the **same worktree**, so the desk survives but the successor is a new
+tab; the old tab disappears when the successor closes it.
+
 ## Operating rules (hard-won via incidents)
 
 **REBALANCE FIRST on saturation** — A capacity crunch is usually too many sessions piled on ONE rate-capped account, not global scarcity. Swap stuck (STRANDED/RATE/ERROR) sessions onto an emptier account via `tbd terminal swap-profile --terminal <tid> --profile <name>` (parked=cold/cheap, awake=respawn). Passive holding just freezes them. *(Incident 2026-07-10: 14 of 19 stuck sessions were piled on one account; the watcher held instead of rebalancing and the whole fleet stalled overnight until rebalanced.)*
@@ -100,13 +154,23 @@ bot-verdict shortfall on a human-approved PR is an **advisory heads-up**, not a 
 
 ## Config (`config/`)
 - `priorities.txt` — must-keep-moving worktrees (flagged ★, reported first)
-- `safe_wedges.txt` — permission-wedge prefixes the daemon may auto-approve (never `gh pr merge`)
+- `safe_wedges.txt` — permission-wedge prefixes a future daemon may auto-approve (never `gh pr merge`)
 - `dont_touch.txt` — panes/names nightwatch must never nudge (human-driven, e.g. Adam's own session)
 
-## The durable spine (already on launchd, model-free)
-- `scripts/daemon.py` (babysitter) — auto-approves safe wedges, escalates real ones
-- `scripts/watchdog.sh` — restarts the daemon if its log goes >12min stale (hang/sleep)
-These keep the critical safety net running even when Opus is fully capped. (Currently live as `~/.fleet/babysitter_daemon.py` + `daemon_watchdog.sh`; copy in for a self-contained skill.)
+## There is no babysitter daemon (retired 2026-07-25)
+
+This section used to describe a "durable spine already on launchd": `scripts/daemon.py`
+auto-approving safe wedges, `scripts/watchdog.sh` restarting it, both "currently live as
+`~/.fleet/babysitter_daemon.py`". **None of it ever existed** — no scripts in this skill, no
+`~/.fleet/`, no launchd jobs, no plists, no log. Every tick dutifully reported
+`daemon: log-missing` as though a live service had crashed, and judge sessions burned five
+days escalating a *restart* for software with no install to restore.
+
+The fleet ran fine without it. `tick.py`'s `daemon_health()` is now a stub, `config/safe_wedges.txt`
+is the allowlist a future daemon *would* use (kept for that reason), and wedges route through
+judge ticks. If you ever build one: it types into ~96 live panes, so it MUST use the composer
+ghost-guard in `_composer()` — before that guard existed the dispatch path would have fired dim
+suggestions and raw mouse escape sequences as if a human had typed them.
 
 ## TBD integration
 - **Read:** `~/tbd/state.db` (worktrees/terminals/`tmuxServer` per pane — pane IDs collide across servers, always read the server, never hardcode)
@@ -487,7 +551,6 @@ DB = f"{HOME}/tbd/state.db"
 SKILL = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 QUEUE = f"{SKILL}/queue"
 CFG = f"{SKILL}/config"
-DAEMON_LOG = "/tmp/babysitter.log"
 
 # Fleet-wide backoff threshold. Post-ccflare (proxy removed 2026-07-01) there is no
 # shared account pool to saturate: every session talks to Anthropic directly over its
@@ -537,14 +600,33 @@ RATE_PAT = re.compile(r"rate.?limit|overloaded|usage limit|weekly limit|reset[s]
 ERR_PAT = re.compile(r"API error|503|ECONNRESET|inference gateway", re.I)
 DONE_PAT = re.compile(r"ready to archive|you're done|nothing (?:open|left)|winding down|wind down|/closeout|all merged", re.I)
 
-def classify(cap):
-    """Return state for a captured pane: WORKING / DECISION / RATE / ERROR / STRANDED / DONE / IDLE."""
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+# Claude Code renders its OWN suggestions in the composer as dim (ESC[2m) ghost text.
+DIM_RE = re.compile(r"\x1b\[(?:[0-9;]*;)?2m")
+# SGR mouse reports ("<65;61;31M") land in the composer on a stray click. Never input.
+MOUSE_RE = re.compile(r"^<\d+;\d+;\d+[Mm]$")
+# The TBD statusline ("Opus 5(high)  494k/1000k  5h(65% →20:00)  7d(21% →Thu 8pm)") is chrome,
+# not something an agent said — it must never be reported as a pane's last meaningful line.
+STATUS_RE = re.compile(r"\d+k/\d+k|\d+%\s*→|bypass permissions|Jump to bottom|^⧉ ")
+
+def classify(cap, cap_raw=None):
+    """Return state for a captured pane: WORKING / DECISION / RATE / ERROR / STRANDED / DONE / IDLE.
+
+    cap is ANSI-stripped; cap_raw (optional) keeps the escapes so the composer can tell
+    real typed input from dim ghost suggestions. Without cap_raw the ghost check degrades
+    to the mouse-sequence filter only.
+    """
     lines = [x for x in cap.splitlines() if x.strip()]
     if not lines: return "EMPTY", ""
+    raw_lines = None
+    if cap_raw is not None:
+        raw_lines = [x for x in cap_raw.splitlines() if ANSI_RE.sub("", x).strip()]
+        # Indices must line up 1:1 with `lines` or the dim lookup reads the wrong row.
+        if len(raw_lines) != len(lines): raw_lines = None
     tail = "\n".join(lines[-18:])
     if "esc to interrupt" in tail: return "WORKING", _lastmeaning(lines)
     if DECISION_PAT.search(tail): return "DECISION", _lastmeaning(lines)
-    comp = _composer(lines)
+    comp = _composer(lines, raw_lines)
     if RATE_PAT.search(tail): return "RATE", comp or _lastmeaning(lines)
     if ERR_PAT.search(tail): return "ERROR", comp or _lastmeaning(lines)
     if DONE_PAT.search(tail): return "DONE", _lastmeaning(lines)
@@ -555,6 +637,7 @@ def _lastmeaning(lines):
     for x in reversed(lines):
         s = x.strip()
         if any(k in s for k in ("bypass permissions","esc to interrupt","context used","auto-compact","/model")): continue
+        if STATUS_RE.search(s): continue
         if s.startswith(("─","✻","✳","✶","⏺","◯")): continue
         if not s or s == "❯": continue
         return s[:90]
@@ -577,20 +660,44 @@ def burn_risk(cap):
     risk = pct is not None and pct >= 85
     return pct, is_1m, risk
 
-def _composer(lines):
+def _composer(lines, raw_lines=None):
+    """Text a HUMAN actually left in the composer, or "" if there's nothing real there.
+
+    This feeds STRANDED, and STRANDED feeds the daemon's auto-dispatch — whatever
+    this returns gets typed into a live session as if a person had written it. So
+    two impostors are rejected:
+      · dim (ESC[2m) ghost text — Claude Code's own suggestion, identical to typed
+        input once ANSI is stripped. Dispatching one makes the agent "obey" a
+        suggestion nobody chose.
+      · SGR mouse reports from a stray click in the pane.
+    Rejecting is the safe direction: a missed nudge costs one tick, a bad dispatch
+    corrupts a session.
+    """
     for i, x in enumerate(lines):
         if "bypass permissions" in x and i > 0:
             for j in range(i-1, -1, -1):
                 s = lines[j].strip()
-                if s.startswith("❯"): return s[1:].strip()[:120]
+                if s.startswith("❯"):
+                    text = s[1:].strip()[:120]
+                    if not text or MOUSE_RE.match(text): return ""
+                    if raw_lines and DIM_RE.search(raw_lines[j]): return ""
+                    return text
                 if s.startswith("─"): continue
             break
     return ""
 
 def daemon_health():
-    if not os.path.exists(DAEMON_LOG): return {"ok": False, "age_s": None, "reason": "log-missing"}
-    age = int(time.time() - os.path.getmtime(DAEMON_LOG))
-    return {"ok": age <= 720, "age_s": age, "reason": ("stale" if age > 720 else "fresh")}
+    """Health of the babysitter daemon — which does not exist on this machine.
+
+    Retired 2026-07-25 (Chang's call). There is no daemon.py, no watchdog, no
+    launchd job and no log: the "durable spine" SKILL.md described was never
+    built. For five days every tick reported `daemon: log-missing` as if a live
+    service had fallen over, and judge sessions kept escalating a restart for
+    software that had no install to restore. The fleet ran fine without it.
+    Kept as a stub returning absent=True so anything still reading
+    tick-report.json["daemon"] gets a shape instead of a KeyError.
+    """
+    return {"ok": True, "absent": True, "age_s": None, "reason": "no-daemon (retired 2026-07-25)"}
 
 def fleet():
     rows = sh(["sqlite3","-separator","\t",DB,
@@ -602,8 +709,11 @@ def fleet():
         p = l.split("\t")
         if len(p) < 5: continue
         pane, name, srv, tid, rid = p
-        cap = sh(["tmux","-L",srv,"capture-pane","-p","-t",pane])
-        state, note = classify(cap)
+        # -e keeps the escapes: dimness is the only thing distinguishing a ghost
+        # suggestion from typed input, and it's gone by the time tmux strips ANSI.
+        cap_raw = sh(["tmux","-L",srv,"capture-pane","-p","-e","-t",pane])
+        cap = ANSI_RE.sub("", cap_raw)
+        state, note = classify(cap, cap_raw)
         ctx_pct, is_1m, burn = burn_risk(cap)
         hook = POLICIES.get(rid, {})
         pol = hook.get("policy", {})
@@ -698,15 +808,14 @@ def main():
             for j in judgment: f.write(json.dumps({**j,"ts":rep["ts"]})+"\n")
 
     # ---- human-readable summary ----
-    d, c = rep["daemon"], capacity
+    c = capacity
     print(f"=== nightwatch tick @ {time.strftime('%H:%M:%S')} ===")
     if rep["hooks"]:
         print("hooks: " + " · ".join(f"{n}[gate={h['gate'] or '-'},advance={h['advance_skill'] or '-'}]"
                                       for n,h in rep["hooks"].items()))
     else:
         print("hooks: (none — repos can ship .nightwatch/policy.json)")
-    print(f"daemon: {d['reason']} ({d['age_s']}s)   "
-          f"capacity: {c['status']} (rate-limited {c['rate_limited']}/{len(rep['agents'])})"
+    print(f"capacity: {c['status']} (rate-limited {c['rate_limited']}/{len(rep['agents'])})"
           f"{' ⚠ SATURATED — backoff, no nudging' if saturated else ''}")
     sm = rep["summary"]
     print(f"agents: {len(rep['agents'])}  working={sm['working']} idle={sm['idle']} "
@@ -742,6 +851,241 @@ def main():
 if __name__ == "__main__":
     main()
 """#
+
+    /// Context-ceiling relay for long-running desk sessions. A judge session past
+    /// its ceiling writes a handoff doc, spawns a successor in the same worktree,
+    /// and the SUCCESSOR closes the predecessor — never the reverse, so a failed
+    /// spawn leaves the desk still watched.
+    ///
+    /// Delimited with `##"""` because the script embeds `"""#` (an f-string opening
+    /// a markdown heading), which would otherwise close a `#"""` literal.
+    public static let handoffPy: String = ##"""
+#!/usr/bin/env python3
+"""Context-ceiling handoff for long-running desk sessions.
+
+A judge/watch session that runs past its context ceiling starts truncating its
+own history mid-shift ("I kept getting cut off"). The fix is a relay: the tiring
+session writes a handoff, spawns a fresh Opus session in the same worktree, and
+the SUCCESSOR closes the predecessor once it has actually read the handoff.
+
+  handoff.py --check                      # exit 0 = under ceiling, 10 = over
+  handoff.py --act --notes-file notes.md  # write handoff + spawn successor
+  handoff.py --close-predecessor <tid>    # successor calls this when it's ready
+
+Ordering matters: the predecessor NEVER closes itself. If the spawn fails or the
+successor dies on boot, the old session is still there and the shift survives.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+QUEUE = pathlib.Path(__file__).resolve().parent.parent / "queue"
+LATEST = QUEUE / "HANDOFF-LATEST.md"
+DEFAULT_THRESHOLD = 200_000
+SUCCESSOR_MODEL = "opus"
+
+
+def _run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def terminal_row(terminal_id, worktree_id):
+    """Live TBD record for a terminal (pane/window ids, transcript path)."""
+    r = _run(["tbd", "terminal", "list", worktree_id, "--json"])
+    if r.returncode != 0:
+        return {}
+    for row in json.loads(r.stdout or "[]"):
+        if row.get("id") == terminal_id:
+            return row
+    return {}
+
+
+def tmux_server():
+    """Server name from $TMUX — pane ids collide across servers, never guess."""
+    tmux = os.environ.get("TMUX", "")
+    return pathlib.PurePath(tmux.split(",")[0]).name if tmux else ""
+
+
+def context_tokens(transcript_path):
+    """Current context size, read off the transcript's own usage records.
+
+    Claude Code stamps every assistant message with the usage that produced it;
+    input + both cache buckets is what the statusline renders as `NNNk/1000k`.
+    Returns None when the transcript can't be read rather than guessing zero —
+    a bogus low reading would silently disable the ceiling.
+    """
+    try:
+        with open(transcript_path, "rb") as fh:
+            tail = fh.readlines()[-400:]
+    except OSError:
+        return None
+    best = None
+    for raw in tail:
+        try:
+            u = json.loads(raw).get("message", {}).get("usage") or {}
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        total = (
+            u.get("input_tokens", 0)
+            + u.get("cache_creation_input_tokens", 0)
+            + u.get("cache_read_input_tokens", 0)
+        )
+        if total and (best is None or total > best):
+            best = total
+    return best
+
+
+def resolve_self():
+    tid = os.environ.get("TBD_TERMINAL_ID")
+    wid = os.environ.get("TBD_WORKTREE_ID")
+    if not tid or not wid:
+        sys.exit("not inside a TBD terminal (TBD_TERMINAL_ID/TBD_WORKTREE_ID unset)")
+    return tid, wid, terminal_row(tid, wid)
+
+
+def cmd_check(args):
+    *_, row = resolve_self()
+    used = context_tokens(row.get("transcriptPath", ""))
+    if used is None:
+        print("context: UNKNOWN (transcript unreadable) — treating as under ceiling")
+        return 0
+    over = used >= args.threshold
+    print(f"context: {used:,} / ceiling {args.threshold:,} — {'OVER' if over else 'ok'}")
+    return 10 if over else 0
+
+
+def successor_prompt(doc_path, pred_tid, pred_window, server, threshold):
+    return f"""You are the successor Nightwatch/Daywatch judge session for this desk.
+The previous session hit its context ceiling ({threshold:,} tokens) and handed off
+to you rather than getting truncated mid-shift.
+
+FIRST, before anything else:
+1. Read the handoff document: {doc_path}
+2. Close the predecessor — it is idle and waiting for you to do this:
+     python3 "{pathlib.Path(__file__).resolve()}" --close-predecessor {pred_tid}
+   (predecessor terminal {pred_tid}, tmux window {pred_window} on server {server})
+3. Confirm in your first message what you picked up and what you closed.
+
+STANDING INSTRUCTION — this applies to YOU now, and to every session you spawn:
+When your own context passes {threshold:,} tokens, do not push through it. Run
+  python3 "{pathlib.Path(__file__).resolve()}" --check
+and when it reports OVER, write your own handoff notes to a file and run
+  python3 "{pathlib.Path(__file__).resolve()}" --act --notes-file <your-notes.md>
+That spawns your replacement on {SUCCESSOR_MODEL} in this same worktree with this
+same instruction, and your replacement closes you. Never close yourself first —
+if the spawn fails, you are still the only thing keeping the shift alive.
+
+Then continue the shift from the handoff.
+"""
+
+
+def cmd_act(args):
+    tid, wid, row = resolve_self()
+    server = tmux_server()
+    used = context_tokens(row.get("transcriptPath", ""))
+    ts = int(time.time())
+
+    notes = pathlib.Path(args.notes_file).read_text() if args.notes_file else ""
+    if not notes.strip():
+        sys.exit("refusing to hand off with empty notes — write the handoff first")
+
+    doc = QUEUE / f"handoff-{ts}.md"
+    QUEUE.mkdir(parents=True, exist_ok=True)
+    doc.write_text(
+        f"""# Desk handoff — {time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(ts))}
+
+Predecessor terminal: {tid} (pane {row.get('tmuxPaneID')}, window
+{row.get('tmuxWindowID')}, server {server})
+Context at handoff: {f'{used:,}' if used else 'unknown'} tokens
+Worktree: {wid}
+Transcript: {row.get('transcriptPath')}
+
+---
+
+{notes.strip()}
+"""
+    )
+    if LATEST.exists() or LATEST.is_symlink():
+        LATEST.unlink()
+    LATEST.symlink_to(doc.name)
+
+    prompt = successor_prompt(doc, tid, row.get("tmuxWindowID"), server, args.threshold)
+    spawn = _run(
+        [
+            "tbd", "terminal", "create", wid,
+            "--type", "claude",
+            "--claude-settings", json.dumps({"model": SUCCESSOR_MODEL}),
+            "--prompt-file", "-",
+            "--json",
+        ],
+        input=prompt,
+    )
+    if spawn.returncode != 0:
+        sys.exit(f"spawn FAILED, staying alive: {spawn.stderr.strip()}")
+
+    try:
+        new_id = json.loads(spawn.stdout).get("id", "?")
+    except json.JSONDecodeError:
+        new_id = spawn.stdout.strip() or "?"
+
+    print(f"handoff written: {doc}")
+    print(f"successor spawned: {new_id} (model={SUCCESSOR_MODEL})")
+    print("go idle now — the successor closes this terminal once it has read the doc.")
+    return 0
+
+
+def cmd_close(args):
+    """Close a predecessor terminal by killing its tmux window."""
+    target = args.close_predecessor
+    r = _run(["tbd", "terminal", "list", os.environ.get("TBD_WORKTREE_ID", ""), "--json"])
+    row = {}
+    if r.returncode == 0:
+        for candidate in json.loads(r.stdout or "[]"):
+            if candidate.get("id") == target:
+                row = candidate
+                break
+    if not row:
+        print(f"terminal {target} not found — already closed, nothing to do")
+        return 0
+    if target == os.environ.get("TBD_TERMINAL_ID"):
+        sys.exit("refusing to close myself — pass the PREDECESSOR's terminal id")
+
+    window = row.get("tmuxWindowID")
+    server = tmux_server()
+    if not window or not server:
+        sys.exit(f"cannot resolve tmux window/server for {target}")
+    kill = _run(["tmux", "-L", server, "kill-window", "-t", window])
+    if kill.returncode != 0 and "can't find" not in (kill.stderr or ""):
+        sys.exit(f"kill-window failed: {kill.stderr.strip()}")
+    print(f"closed predecessor {target} (window {window} on {server})")
+    return 0
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--check", action="store_true", help="report context vs ceiling (exit 10 = over)")
+    g.add_argument("--act", action="store_true", help="write handoff + spawn successor")
+    g.add_argument("--close-predecessor", metavar="TID", help="successor closes the old session")
+    p.add_argument("--notes-file", help="markdown file holding the handoff body (required with --act)")
+    p.add_argument("--threshold", type=int, default=DEFAULT_THRESHOLD)
+    args = p.parse_args()
+
+    if args.check:
+        return cmd_check(args)
+    if args.act:
+        return cmd_act(args)
+    return cmd_close(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+"""##
 
     public static let judgePy: String = #"""
 #!/usr/bin/env python3

--- a/Tests/TBDDaemonTests/PluginDirWriterTests.swift
+++ b/Tests/TBDDaemonTests/PluginDirWriterTests.swift
@@ -137,6 +137,28 @@ struct PluginDirWriterTests {
         #expect(output.contains("composer ghost-guard scenarios passed"), "unexpected output:\n\(output)")
     }
 
+    /// The relay decides whether a desk shift survives its context ceiling, so
+    /// its arithmetic and its fail-closed paths get executable coverage rather
+    /// than string-presence checks — same standard as `tick.py`/`wake.py`.
+    @Test("handoff.py --selftest passes: ceiling arithmetic + fail-closed paths")
+    func handoffPySelftest() throws {
+        let tempRoot = NSTemporaryDirectory() + "tbd-plugin-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tempRoot) }
+        try PluginDirWriter(applicationSupportRoot: tempRoot).writePlugin()
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["python3", tempRoot + "/TBD/plugin/skills/nightwatch/scripts/handoff.py", "--selftest"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+        try proc.run()
+        proc.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        #expect(proc.terminationStatus == 0, "handoff.py --selftest failed:\n\(output)")
+        #expect(output.contains("handoff ceiling scenarios passed"), "unexpected output:\n\(output)")
+    }
+
     @Test("handoff.py is installed alongside the other nightwatch scripts")
     func handoffPyInstalled() throws {
         let tempRoot = NSTemporaryDirectory() + "tbd-plugin-test-\(UUID().uuidString)"

--- a/Tests/TBDDaemonTests/PluginDirWriterTests.swift
+++ b/Tests/TBDDaemonTests/PluginDirWriterTests.swift
@@ -108,6 +108,50 @@ struct PluginDirWriterTests {
         #expect(output.contains("scenarios passed"))
     }
 
+    /// Executable coverage for the composer ghost-guard, which sits on the path
+    /// that types text into live tmux panes across the fleet. String-presence
+    /// assertions on `tickPy` (in TBDSharedTests) prove the guard is *shipped*;
+    /// only running it proves the guard *works* — a regex or an index-alignment
+    /// edit could leave every pinned substring intact and still fire ghost
+    /// suggestions as if a human had typed them.
+    ///
+    /// `--selftest` short-circuits before tick.py's machine-global flock, so a
+    /// live tick running concurrently can't turn this into a silent exit 0.
+    /// The `scenarios passed` assertion is the backstop for that regardless.
+    @Test("tick.py --selftest passes: composer ghost-guard matrix (no DB/tmux invoked)")
+    func tickPySelftest() throws {
+        let tempRoot = NSTemporaryDirectory() + "tbd-plugin-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tempRoot) }
+        try PluginDirWriter(applicationSupportRoot: tempRoot).writePlugin()
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["python3", tempRoot + "/TBD/plugin/skills/nightwatch/scripts/tick.py", "--selftest"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+        try proc.run()
+        proc.waitUntilExit()
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        #expect(proc.terminationStatus == 0, "tick.py --selftest failed:\n\(output)")
+        #expect(output.contains("composer ghost-guard scenarios passed"), "unexpected output:\n\(output)")
+    }
+
+    @Test("handoff.py is installed alongside the other nightwatch scripts")
+    func handoffPyInstalled() throws {
+        let tempRoot = NSTemporaryDirectory() + "tbd-plugin-test-\(UUID().uuidString)"
+        defer { try? FileManager.default.removeItem(atPath: tempRoot) }
+        try PluginDirWriter(applicationSupportRoot: tempRoot).writePlugin()
+
+        let scripts = tempRoot + "/TBD/plugin/skills/nightwatch/scripts"
+        for entry in NightwatchSkillContent.scripts {
+            let path = scripts + "/" + entry.name
+            #expect(FileManager.default.fileExists(atPath: path), "\(entry.name) not installed")
+            #expect(try String(contentsOfFile: path, encoding: .utf8) == entry.body)
+        }
+        #expect(FileManager.default.fileExists(atPath: scripts + "/handoff.py"))
+    }
+
     @Test("nightwatch SKILL.md has a valid skill name in frontmatter")
     func nightwatchSkillNamed() {
         #expect(NightwatchSkillContent.skillMd.contains("name: nightwatch"))

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -194,6 +194,35 @@ struct NightwatchDeskPromptsTests {
                     "handoff.py lost the self-close guard the relay depends on")
         }
 
+        /// The never-/closeout standing rule has to hold for the whole shipped
+        /// skill, not just the desk prompts. `wake.py --act` dispatches its
+        /// composed prompt into a hibernated session with no human in the loop,
+        /// so a "Run /closeout now" there is a harvest fired on the human's
+        /// behalf — the exact thing the rule forbids, reached by a different
+        /// door. Behavioural coverage lives in `wake.py --selftest` (scenario 9,
+        /// run by `PluginDirWriterTests.wakePySelftest`); this pins the prose
+        /// that documents it, which is what a reader consults.
+        @Test("SKILL.md does not advertise an automatic DONE → /closeout")
+        func skillMdDoesNotPromiseCloseout() {
+            let md = NightwatchSkillContent.skillMd
+            #expect(!md.contains("DONE → /closeout"),
+                    "SKILL.md still describes wake.py as auto-firing /closeout on DONE")
+            #expect(md.contains("NEVER trigger `/closeout`"))
+        }
+
+        @Test("wake.py's standing rule forbids /closeout rather than prescribing it")
+        func wakePyStandingRuleForbidsCloseout() {
+            let py = NightwatchSkillContent.wakePy
+            #expect(py.contains("do not run /closeout"),
+                    "wake.py's STANDING_RULE no longer carries the prohibition")
+            // The composed-prompt invariant itself is asserted executably in
+            // wake.py's own selftest, which whitelists the prohibition as the
+            // only permitted mention — a blacklist here would trip on that very
+            // sentence, as it did three times while writing this suite.
+            #expect(py.contains("9/9 classification scenarios passed"),
+                    "the selftest scenario pinning the rule was removed")
+        }
+
         @Test("Script names are unique")
         func scriptNamesUnique() {
             let names = NightwatchSkillContent.scripts.map(\.name)

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -37,19 +37,56 @@ struct NightwatchDeskPromptsTests {
         }
     }
 
-    @Test("No prompt tells the session to flag for respawn", arguments: liveModes)
-    func noRespawnFlagging(mode: NightwatchMode) {
-        // There is no babysitter daemon and no respawner — flagging is a no-op
-        // that leaves the session running past its ceiling.
+    /// The context ceiling has exactly one correct remedy: the handoff relay.
+    ///
+    /// Asserted as "the relay is named" rather than "the old wording is absent",
+    /// because the banned-substring form is defeated by any rephrasing — a
+    /// reintroduction reading "mark for respawn" or "the daemon will restart
+    /// you" sails past `!contains("flag for respawn")`. Pinning the positive
+    /// invariant catches every phrasing, including ones nobody has written yet.
+    @Test("The only context-ceiling remedy offered is the handoff relay", arguments: liveModes)
+    func ceilingRemedyIsTheRelay(mode: NightwatchMode) {
         for (label, text) in prompts(mode: mode, skillDir: "/skill") {
+            let mentionsCeiling = text.contains("200k") || text.lowercased().contains("context ceiling")
+            #expect(mentionsCeiling, "\(mode) \(label) never states the context ceiling")
+
             #expect(
-                !text.lowercased().contains("flag for respawn"),
-                "\(mode) \(label) tells the session to flag for respawn; nothing respawns it"
+                text.contains("handoff.py"),
+                "\(mode) \(label) raises the context ceiling without naming the handoff relay"
             )
-            #expect(
-                !text.lowercased().contains("daemon respawn"),
-                "\(mode) \(label) claims a daemon respawns the desk; no such daemon exists"
-            )
+            // No prompt may point at a recycler that does not exist. Asserted on
+            // concrete artifacts rather than on phrasing: a blacklist of wordings
+            // like "will restart you" is defeated from BOTH sides — a reworded
+            // reintroduction slips through, and the sentence that *forbids* the
+            // promise trips it, because a prohibition quotes what it prohibits.
+            // These names have no innocent reading in a prompt; none of them exist.
+            for phantom in ["daemon.py", "watchdog.sh", "~/.fleet", "babysitter_daemon"] {
+                #expect(
+                    !text.contains(phantom),
+                    "\(mode) \(label) points at \(phantom), which was never built"
+                )
+            }
+        }
+    }
+
+    /// The path a prompt tells a session to run must be a path the daemon
+    /// installs. This is the structural guard for the phantom-command class:
+    /// `tbd terminal close --all` was one, and a prompt naming an unshipped
+    /// `scripts/handoff.py` would have been the next.
+    @Test("Every script named in a desk prompt is actually shipped", arguments: liveModes)
+    func promptedScriptsAreShipped(mode: NightwatchMode) {
+        let shipped = Set(NightwatchSkillContent.scripts.map(\.name))
+        let pattern = /scripts\/([A-Za-z0-9_.-]+\.(?:py|sh))/
+
+        for (label, text) in prompts(mode: mode, skillDir: "/skill") {
+            let named = Set(text.matches(of: pattern).map { String($0.1) })
+            #expect(!named.isEmpty, "\(mode) \(label) names no script; the relay reference was lost")
+            for script in named {
+                #expect(
+                    shipped.contains(script),
+                    "\(mode) \(label) tells the session to run scripts/\(script), which PluginDirWriter does not install"
+                )
+            }
         }
     }
 
@@ -79,17 +116,88 @@ struct NightwatchDeskPromptsTests {
         }
     }
 
-    @Test("Every prompt carries the never-/closeout standing rule", arguments: liveModes)
+    /// Pins the *prohibition*, not the mere presence of the word. `contains("/closeout")`
+    /// is satisfied by a prompt that tells the session to fire `/closeout` — the
+    /// exact rule's opposite — so it proves nothing on its own.
+    @Test("Every prompt forbids /closeout, and says why", arguments: liveModes)
     func closeoutForbidden(mode: NightwatchMode) {
         for (label, text) in prompts(mode: mode, skillDir: "/skill") {
             #expect(
-                text.contains("/closeout"),
-                "\(mode) \(label) omits the never-/closeout rule"
+                text.contains("NEVER trigger `/closeout`") || text.contains("Never trigger `/closeout`")
+                    || text.contains("never trigger `/closeout`"),
+                "\(mode) \(label) does not forbid /closeout"
             )
             #expect(
                 text.lowercased().contains("archive question for the human"),
                 "\(mode) \(label) states the /closeout rule without the reason it exists"
             )
+            // A prohibition plus a licence elsewhere in the same prompt is not a
+            // prohibition. `/closeout` may appear only in the forbidding sense.
+            for licence in ["trigger `/closeout` on", "fire `/closeout`", "run `/closeout`",
+                            "small_safe action"] {
+                #expect(
+                    !text.contains(licence),
+                    "\(mode) \(label) forbids /closeout but also licenses it (\"\(licence)\")"
+                )
+            }
+        }
+    }
+
+    /// The compiled SKILL.md is what the daemon writes to disk on every start,
+    /// and `initialPrompt` sends the session there for its "full job description".
+    /// It must not contradict the prompt.
+    @Suite("Shipped nightwatch skill content")
+    struct SkillContentTests {
+        @Test("SKILL.md does not claim a babysitter daemon exists")
+        func noBabysitterDaemonClaim() {
+            let md = NightwatchSkillContent.skillMd
+            for claim in ["durable spine (already on launchd",
+                          "These keep the critical safety net running",
+                          "`scripts/daemon.py` (babysitter) — auto-approves"] {
+                #expect(!md.contains(claim), "SKILL.md still asserts a babysitter daemon: \(claim)")
+            }
+            #expect(md.contains("There is no babysitter daemon"))
+        }
+
+        @Test("SKILL.md carries the standing rules the prompts echo")
+        func standingRulesPresent() {
+            let md = NightwatchSkillContent.skillMd
+            #expect(md.contains("NEVER trigger `/closeout`"))
+            #expect(md.contains("handoff.py"))
+        }
+
+        @Test("tick.py ships the composer ghost-guard")
+        func tickShipsGhostGuard() {
+            // Without these, STRANDED counts dim ghost suggestions and SGR mouse
+            // reports as human input, and the dispatch path types them into live
+            // sessions. Measured on the fleet: STRANDED 14 -> 5, nine phantom.
+            let tick = NightwatchSkillContent.tickPy
+            for marker in ["ANSI_RE", "DIM_RE", "MOUSE_RE", "STATUS_RE",
+                           #""capture-pane","-p","-e""#,
+                           "def _composer(lines, raw_lines=None)",
+                           "DIM_RE.search(raw_lines[j])",
+                           "if len(raw_lines) != len(lines): raw_lines = None"] {
+                #expect(tick.contains(marker), "tick.py lost the ghost-guard: \(marker)")
+            }
+            // The retired babysitter's log path must not come back with it.
+            #expect(!tick.contains("DAEMON_LOG"))
+        }
+
+        @Test("handoff.py is shipped and exposes the three relay verbs")
+        func handoffShipped() {
+            #expect(NightwatchSkillContent.scripts.contains { $0.name == "handoff.py" })
+            let py = NightwatchSkillContent.handoffPy
+            for flag in ["--check", "--act", "--close-predecessor"] {
+                #expect(py.contains(flag), "handoff.py missing \(flag)")
+            }
+            #expect(py.contains("refusing to close myself"),
+                    "handoff.py lost the self-close guard the relay depends on")
+        }
+
+        @Test("Script names are unique")
+        func scriptNamesUnique() {
+            let names = NightwatchSkillContent.scripts.map(\.name)
+            #expect(Set(names).count == names.count, "duplicate script name would clobber a sibling")
         }
     }
 

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+import TBDShared
+
+/// Tier 1 — pure string construction, no external state.
+///
+/// These prompts are injected into every desk session on every tick, so a wrong
+/// instruction here is indistinguishable from a wrong policy: it silently drives
+/// agent behavior fleet-wide. Nothing asserted on their content until
+/// 2026-07-25, and by then the judge prompt had spent five days telling sessions
+/// to run `tbd terminal close --all` — a command that has never existed — as its
+/// context-ceiling remedy, and to merge PRs that the nightwatch gate reserves
+/// for the human.
+///
+/// Each expectation below therefore pins a *policy invariant*, not phrasing.
+@Suite("Nightwatch desk prompt policy invariants")
+struct NightwatchDeskPromptsTests {
+    /// Modes that actually reach a desk session. `.off` is a programmer-error
+    /// sentinel (`jobDescription` returns an ERROR string for it).
+    static let liveModes: [NightwatchMode] = [.daywatch, .nightwatch]
+
+    /// Every prompt string a desk session can receive, for one mode.
+    private func prompts(mode: NightwatchMode, skillDir: String) -> [(label: String, text: String)] {
+        [
+            ("initialPrompt", NightwatchDeskPrompts.initialPrompt(mode: mode, skillDir: skillDir)),
+            ("judgePrompt", NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir))
+        ]
+    }
+
+    @Test("No prompt references a `tbd terminal close` subcommand", arguments: liveModes)
+    func noPhantomCloseCommand(mode: NightwatchMode) {
+        for (label, text) in prompts(mode: mode, skillDir: "/skill") {
+            #expect(
+                !text.contains("terminal close"),
+                "\(mode) \(label) references `tbd terminal close`, which does not exist"
+            )
+        }
+    }
+
+    @Test("No prompt tells the session to flag for respawn", arguments: liveModes)
+    func noRespawnFlagging(mode: NightwatchMode) {
+        // There is no babysitter daemon and no respawner — flagging is a no-op
+        // that leaves the session running past its ceiling.
+        for (label, text) in prompts(mode: mode, skillDir: "/skill") {
+            #expect(
+                !text.lowercased().contains("flag for respawn"),
+                "\(mode) \(label) tells the session to flag for respawn; nothing respawns it"
+            )
+            #expect(
+                !text.lowercased().contains("daemon respawn"),
+                "\(mode) \(label) claims a daemon respawns the desk; no such daemon exists"
+            )
+        }
+    }
+
+    @Test("Judge prompt points the context ceiling at the handoff relay", arguments: liveModes)
+    func judgePromptNamesHandoffRelay(mode: NightwatchMode) {
+        let text = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: "/skill")
+        #expect(text.contains("/skill/scripts/handoff.py"), "handoff.py path not interpolated from skillDir")
+        #expect(text.contains("--check"))
+        #expect(text.contains("--act --notes-file"))
+        #expect(text.contains("--close-predecessor"))
+        // The ordering rule is the whole point of the relay: a predecessor that
+        // closes itself before the successor is up leaves the desk unwatched.
+        #expect(text.contains("NEVER closes itself"))
+    }
+
+    @Test("No prompt authorizes a merge — the human merges", arguments: liveModes)
+    func noMergeAuthorization(mode: NightwatchMode) {
+        for (label, text) in prompts(mode: mode, skillDir: "/skill") {
+            #expect(
+                text.contains("NEVER run `gh pr merge`") || text.contains("never run `gh pr merge`"),
+                "\(mode) \(label) does not forbid `gh pr merge`; the SKILL.md gate reserves merging for the human"
+            )
+            #expect(
+                !text.contains("Merge PRs cleared"),
+                "\(mode) \(label) authorizes merging cleared PRs, contradicting the gate"
+            )
+        }
+    }
+
+    @Test("Every prompt carries the never-/closeout standing rule", arguments: liveModes)
+    func closeoutForbidden(mode: NightwatchMode) {
+        for (label, text) in prompts(mode: mode, skillDir: "/skill") {
+            #expect(
+                text.contains("/closeout"),
+                "\(mode) \(label) omits the never-/closeout rule"
+            )
+            #expect(
+                text.lowercased().contains("archive question for the human"),
+                "\(mode) \(label) states the /closeout rule without the reason it exists"
+            )
+        }
+    }
+
+    @Test("Daywatch stays triage-only and nightwatch does not widen to merging")
+    func modeSpecificScope() {
+        let day = NightwatchDeskPrompts.judgePrompt(mode: .daywatch, skillDir: "/skill")
+        let night = NightwatchDeskPrompts.judgePrompt(mode: .nightwatch, skillDir: "/skill")
+
+        #expect(day.contains("triage only"))
+        // Nightwatch is the wider role, but "wider" must stop before merging.
+        #expect(night.contains("the human merges"))
+        #expect(!night.contains("act on everything the gate allows"))
+        #expect(!night.contains("act on everything the gate approves"))
+    }
+
+    @Test("The gate's enqueue precondition is stated, not just implied", arguments: liveModes)
+    func gatePreconditionStated(mode: NightwatchMode) {
+        let text = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: "/skill")
+        #expect(text.contains("claude-review = APPROVED"))
+        #expect(text.contains("CURRENT SHA") || text.contains("current SHA"))
+        #expect(text.contains("Human approval never substitutes"))
+    }
+}

--- a/docs/specs/2026-07-25-terminal-close-design.md
+++ b/docs/specs/2026-07-25-terminal-close-design.md
@@ -71,6 +71,36 @@ tbd terminal close --terminal <uuid> [--force] [--json]
 One target, named explicitly. `--all`, `--except` and `--dry-run` are deferred —
 see §2.1 and §6 D2.
 
+### On the noun
+
+"Terminal" here means **the row**, not a live pane. The two come apart, and the
+semantics table below depends on the distinction:
+
+- A **parked** terminal has no tmux window at all. `hibernatedAt` and
+  `claudeSessionID` survive, the window is dead, and the row is wakeable on
+  demand (`HibernationCoordinator.wake`).
+- A **closed** terminal survives as a Closed Terminals history entry — captured
+  scrollback plus a session id, with nothing running.
+
+So "close a terminal whose window is already gone" is coherent, not a typo: the
+row is the thing being closed, and killing the (already dead) window is one
+best-effort step of that. Rows §3 covering parked and recovery-parked terminals
+read as category errors only if "terminal" is taken to mean "a live pane".
+
+`terminal` is also **not** the app's "tab". A tab is a container that may hold
+several terminals in a split layout (`AppState.terminalIDs(in:)` walks
+`layout.allTerminalIDs()`), and the app's "Close Tab" deletes every terminal in
+it (`AppState+Tabs.swift:186`). This command is the finer-grained operation.
+
+The noun is imprecise in exactly one direction — the row outlives the terminal —
+but every alternative is worse: `session` collides with three existing meanings
+(Claude session, tmux session `"main"`, session events / Session History),
+`pane` is a tmux detail whose ids collide across servers, `tab` is taken and
+means something coarser, and `agent` is wrong for shell rows. It is also
+load-bearing across the CLI, the `terminal.*` RPC namespace, the DB table, and
+`TBD_TERMINAL_ID` (read by hooks and by `handoff.py`). Keep it; know what it
+means.
+
 ```swift
 struct TerminalClose: AsyncParsableCommand {
     static let configuration = CommandConfiguration(

--- a/docs/specs/2026-07-25-terminal-close-design.md
+++ b/docs/specs/2026-07-25-terminal-close-design.md
@@ -1,0 +1,371 @@
+# `tbd terminal close` — design
+
+**Status:** proposed, not implemented
+**Date:** 2026-07-25
+
+## 1. Why
+
+`tbd terminal` has no `close`. The daemon has had the semantic all along —
+`terminal.delete` (`RPCProtocol.swift:113`), handled by `handleTerminalDelete`
+(`RPCRouter+TerminalHandlers.swift:445-485`), which the SwiftUI app has been
+calling for tab-close since forever (`DaemonClient.swift:663-669`). Only the CLI
+never got a surface over it.
+
+The gap has been actively harmful, not merely absent.
+
+### 1.1 The phantom command
+
+`Sources/TBDShared/NightwatchDeskPrompts.swift:112` — a **compiled-in** desk tick
+prompt — instructs sessions:
+
+> Remedy: call `tbd terminal close --all` on the desk, let daemon respawn fresh
+
+Both halves are wrong: the command does not exist, and the daemon does not
+respawn desk sessions. This is the origin of the "RESPAWN FLAGGED" instruction
+that has sat inert in the nightwatch queue since 2026-07-20.
+
+### 1.2 The workaround is worse than a ghost row
+
+Lacking a CLI close, `handoff.py`'s `cmd_close()` reaches around the daemon:
+resolve the row via `tbd terminal list --json`, derive the tmux server from
+`$TMUX`, then `tmux -L <server> kill-window -t <windowID>`. That kills the window
+and leaves the DB row live. What follows is not a ghost — it is a resurrection:
+
+1. **The app's dead-window path parks it, within seconds.**
+   `terminal.recreateWindow` → `RPCRouter+TerminalHandlers.swift:737-759`: a
+   Claude-resumable row whose window is gone gets `setHibernated(id:sessionID:)`
+   — no `reason:` argument, so the reason is nil.
+2. **Reconcile does the same, later.** `WorktreeLifecycle+Reconcile.swift:282-289`
+   parks Claude-resumable rows with `reason: .recovery`, preserving the session
+   ID. Only plain shell/Codex rows get deleted (`:290-294`).
+3. **Focus-wake resurrects it.** `AppState+Hibernation.swift:306-317` excludes
+   only `hibernateReason == .manual`; the comment is explicit that "nil-reason
+   (legacy), auto, and recovery parks still focus-wake." Navigating to the
+   worktree respawns `claude --resume` on the retired session.
+
+So the relay can end with **predecessor and successor both live on the same
+desk**. It also loses the scrollback: `terminalHistory.captureOnClose` never
+runs, so the retired session never appears in Session History → Closed Terminals.
+
+### 1.3 Reconciliation verdict
+
+Asymmetric, and the asymmetry is deliberate:
+
+| Direction | Behavior | Evidence |
+| --- | --- | --- |
+| tmux window with no DB row | killed + reaped | `Reconcile.swift:373-381` |
+| DB row with no tmux window | Claude-resumable → **parked**; shell/Codex → deleted | `Reconcile.swift:282-294` |
+
+Reconcile is **not** on a timer. Its only callers are daemon startup
+(`Daemon.swift:200`), repo-add (`RPCRouter+RepoHandlers.swift:60`), and
+`tbd cleanup` (`RPCRouter+TerminalHandlers.swift:1744`). `tbd cleanup` therefore
+does **not** clean up an externally-killed Claude terminal in any useful sense —
+it parks it into the wakeable state described above.
+
+## 2. Command surface
+
+```
+tbd terminal close --terminal <uuid> [--force] [--json]
+tbd terminal close <worktree> --all [--force] [--dry-run] [--json]
+```
+
+```swift
+struct TerminalClose: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "close",
+        abstract: "Close a terminal: capture its scrollback to Closed Terminals history, kill its tmux window, remove it from TBD. Idempotent: closing an already-closed terminal is a no-op.",
+        discussion: """
+            Closing is immediate and final for the terminal row. The pane's
+            scrollback is captured into Session History → Closed Terminals
+            (best-effort), any pending session-limit auto-resume is cancelled,
+            and the tab disappears from the app. A Claude session's transcript
+            survives on disk, and a closed Claude terminal can be revived from
+            Closed Terminals history.
+
+            By default a Claude/Codex terminal that is mid-turn or holding a
+            permission prompt is refused — pass --force to close it anyway.
+
+            A terminal cannot close itself. Spawn a successor and have it close
+            you (see the nightwatch handoff relay).
+
+            `<worktree> --all` closes every terminal in ONE worktree; the
+            calling terminal is excluded and reported as skipped. This does NOT
+            archive the worktree — a worktree with zero terminals stays active.
+            Use `tbd worktree archive` for that.
+            """
+    )
+
+    @Argument(help: "Worktree name or ID (required with --all, forbidden otherwise)")
+    var worktree: String?
+
+    @Option(name: .long, help: "Terminal ID to close")
+    var terminal: String?
+
+    @Flag(name: .long, help: "Close ALL terminals in <worktree> (the calling terminal is excluded)")
+    var all = false
+
+    @Flag(name: .long, help: "Also close terminals that are mid-turn or waiting on a permission prompt")
+    var force = false
+
+    @Flag(name: .long, help: "List what would be closed without closing anything (--all only)")
+    var dryRun = false
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+}
+```
+
+`validate()` enforces exactly one of `--terminal` XOR (`worktree` + `--all`). A
+bare positional worktree with no `--all` is a `ValidationError` — a typo'd
+positional must never silently mean "close everything".
+
+`--terminal` is an `@Option`, matching the newer house pattern (`send`, `wake`,
+`focus`, `swap-profile` — `TerminalCommands.swift:122,161,207,391`) and freeing
+the positional for the worktree, matching `terminal list <worktree>`.
+
+There is **no** `TBD_TERMINAL_ID` default for `--terminal`. Other commands
+default to it (`NotifyCommand.swift:64-69`, `FakeRateLimitCommand.swift:31`), but
+here it would make a bare `tbd terminal close` mean "close myself" — the one
+thing this command refuses.
+
+### JSON schemas
+
+Single:
+```json
+{"terminalID": "…", "closed": true, "alreadyGone": false, "claudeSessionID": "…|null"}
+```
+
+`claudeSessionID` is echoed so an autonomous caller retains a resume pointer
+after the row is gone.
+
+Bulk:
+```json
+{"worktreeID": "…",
+ "closed":  [{"terminalID": "…", "claudeSessionID": "…|null"}],
+ "skipped": [{"terminalID": "…", "reason": "self|working|waiting_for_user"}],
+ "failed":  [{"terminalID": "…", "error": "…"}]}
+```
+
+`--dry-run` emits the same shape with `wouldClose` in place of `closed`.
+
+### Deliberately excluded
+
+- **Fleet-wide `--all`.** ~40 worktrees / ~93 panes. A shell-history replay would
+  decapitate the fleet. Anyone who genuinely wants it can loop
+  `tbd worktree list --json`, which at least forces them to write the loop.
+- **`--graceful` / typed `/exit`.** Knowing the composer is idle and empty
+  requires reading rendered screen text — banned by the no-TUI-scraping rule.
+  The hibernation subsystem already demonstrates that process-kill plus
+  `claude --resume` is lossless for a Claude session.
+- **A self-close override.** See §4.
+- **`--except <id>`.** See §6, D2 — deferred, not rejected.
+- **`--no-capture`.** Capture is already best-effort and cheap.
+- **A `delete` alias.** One user-facing verb: "close" (matching the app's "Close
+  Tab" and "Closed Terminals"). The RPC keeps its `terminal.delete` name.
+- **A default-off feature flag.** The flag rule targets features that act
+  *without a user gesture*. Every invocation here explicitly names its target —
+  the same category as `worktree archive`, which is unflagged and destructive —
+  and the underlying daemon capability has shipped for months behind the app's
+  tab-close. The rails in §3-§4 are the safety story. Per the branching-conditional
+  rule, the rail itself gets a test on both branches.
+
+## 3. Semantics
+
+| Terminal state | default | `--force` | under `--all` | under `--all --force` |
+| --- | --- | --- | --- | --- |
+| Idle Claude/Codex (`.idle`/`.unknown`) | closed | closed | closed | closed |
+| Working (`.working`), window alive | **refused**, exit 2 | closed | skipped, reported | closed |
+| Waiting on permission (`.waitingForUser`), window alive | **refused**, exit 2 | closed | skipped, reported | closed |
+| `.working`/`.waitingForUser` but **window dead** | closed (rail is liveness-qualified — see §6 D1) | closed | closed | closed |
+| Plain shell (`activityState` is agent-fed; shells stay `.unknown`) | closed | closed | closed | closed |
+| Hibernated-parked, window alive | closed; resumes cancelled; scrollback captured | same | closed | closed |
+| Recovery-parked, window already dead | closed; **capture stores nothing** (dead pane); session becomes unreachable from TBD, transcript survives on disk | same | closed | closed |
+| `keepWarm: true` | closed — keepWarm exempts from *auto-hibernation* only (`Models.swift:309-312`), it is not close protection | same | closed | closed |
+| Pinned (`pinnedAt`) | closed — pin is a dock affordance; the app closes pinned tabs too | same | closed | closed |
+| Pending scheduled resume | closed; resume cancelled (`RPCRouter+TerminalHandlers.swift:452-455`) | same | closed | closed |
+| Already gone (no DB row) | **no-op success**, exit 0, `alreadyGone: true` | same | n/a | n/a |
+| Self (`--terminal` == `$TBD_TERMINAL_ID`) | **refused**, exit 2 | **still refused** | skipped, `reason: "self"` | skipped |
+| Mid-`terminal send` race | close wins; a send arriving after row deletion errors "Terminal not found"; a send already in flight lands in a dying pane and is lost | same | same | same |
+| Scratch-worktree terminal | identical — the daemon reads `worktree.tmuxServer` from the row, satisfying the pane-ids-collide rule by construction | same | same | same |
+
+**Closing the last terminal is explicitly permitted and is not an archive.** The
+app already closes the last tab with no guard — `AppState+Tabs.swift:148-200`
+lets the tab count reach zero (`remaining > 0 ? min(index, remaining - 1) : 0`).
+The worktree row survives, and the tmux server survives because the server-kill
+sweep keys on live *worktree* rows, not terminal counts
+(`Reconcile.swift:348-361`). Close and archive stay distinct lifecycle events.
+
+## 4. Refusals
+
+All to stderr.
+
+| Refusal | Text | Exit |
+| --- | --- | --- |
+| Self-close | `Refusing to close the calling terminal (<uuid>). A terminal cannot close itself — spawn a successor and have it close this one.` | 2 |
+| Busy, no `--force` | `Terminal <uuid> is <mid-turn\|waiting on a permission prompt> (activityState=<working\|waiting_for_user>). Closing now would kill in-flight work. Pass --force to close anyway.` | 2 |
+| Bare worktree, no `--all` | `To close every terminal in a worktree, pass --all explicitly.` | 64 |
+| `--terminal` with `--all` | `Specify either --terminal <id> or <worktree> --all, not both.` | 64 |
+| Invalid UUID | `Invalid terminal ID: <s>` (matches `TerminalCommands.swift:136`) | 1 |
+
+`ExitCode(2)` has house precedent (`DoctorCommand.swift:34,39`).
+
+**Self-close is refused with no override flag.** The tmux window kill SIGHUPs the
+calling shell, so the `tbd` process dies mid-`recv` and can never report its own
+result; the agent's turn is chopped mid-tool-call. A daemon-side "reply first,
+tear down after a delay" deferral would work mechanically and is a legitimate
+future design — this is a scope call, not an impossibility. It is deferred
+because no consumer exists: `handoff.py` refuses self-close for an independent
+availability reason (if the spawn failed, the predecessor is the only thing still
+watching the desk), and successor-closes-predecessor is the documented standing
+rule. Build the deferral when a real consumer appears.
+
+Under `--all` the caller is excluded and **reported** as `reason: "self"` in both
+JSON and text — never silently dropped.
+
+## 5. Failure modes
+
+| Situation | Exit |
+| --- | --- |
+| Success / already gone / dry-run / bulk with only skips | 0 |
+| Daemon not running (`SocketClient.swift:19-21`) | 1 |
+| Bulk with any `failed` entries (partial results still printed) | 1 |
+| Refused (self, busy) | 2 |
+| Usage error | 64 |
+
+Best-effort, inherited from the daemon handler and acceptable:
+
+- **Scrollback capture failure** is swallowed inside `captureOnClose`; the close
+  proceeds with no history entry. Not surfaced per-call — the handler does not
+  know, and the result shape should not claim otherwise.
+- **`killWindow` failure** is `try?`-swallowed
+  (`RPCRouter+TerminalHandlers.swift:467`); the row is deleted regardless, and
+  the orphaned window is later reaped by reconcile's untracked-window sweep
+  (`Reconcile.swift:373-381`). Self-healing.
+- **A wedged process surviving SIGHUP.** `handleTerminalDelete` uses plain
+  `tmux.killWindow` (`TmuxManager.swift:508-515`), *not* the reaper-escalating
+  `killWindowAndReap` that reconcile uses (`WorktreeLifecycle.swift:164-171`).
+  This is a pre-existing gap shared with the app's tab-close, not something this
+  command introduces. Recommended as a separate follow-up PR.
+- **TOCTOU under `--all`**: a terminal closed between the list and the delete
+  resolves as `alreadyGone`. Harmless once idempotency lands.
+
+## 6. Reconciled disagreements
+
+The independent design (Fable) and this reading agree on the shape. Four points
+where they differ, and the call taken:
+
+**D1 — the busy rail must be liveness-qualified.** Refusing on
+`.working`/`.waitingForUser` has strong precedent: `isManuallyHibernatable`
+(`Models.swift:434-439`) refuses exactly those two states for manual "Hibernate
+now", and `worktree archive`'s `--force`-gates-a-safety-check shape matches
+(`WorktreeCommands.swift:374-404`). Adopted. **But** `activityState` is hook-fed
+and carries **no timestamp** — `Models.swift:296` is a bare enum with nothing to
+age it out. A session that dies mid-turn (crash, OOM, killed pane) stays
+`.working` forever, and an unqualified rail would then refuse forever on exactly
+the wedged terminal you most need to close, turning the safety rail into a trap
+for the command's primary cleanup use case. So the rail refuses only when the
+state is busy **and** `tmux.windowExists` confirms a live window. A dead-window
+row cannot be mid-turn — and that is precisely the zombified-predecessor state
+`handoff.py` creates today, which must remain closeable without `--force`.
+
+**D2 — `--except` deferred, not shipped.** The relay's real shape is "close
+everything but me", and self is already auto-excluded. The remaining
+justification (recycle a desk, keep the fresh session) is real but is expressible
+as N single-target closes, and the successor in the relay is spawned *after* the
+close decision. Ship the smaller surface; add `--except` when a second consumer
+appears.
+
+**D3 — self-close framing.** Both refuse it; recorded above with the deferral
+door explicitly left open rather than as a claim that it cannot be built.
+
+**D4 — the change is four pieces, not three.** `SocketClient` does not surface
+`errorCode` to CLI callers today (no references in `Sources/TBDCLI/`), so
+branching on `terminalBusy` requires a small addition there alongside the three
+daemon changes in §7.
+
+## 7. Required changes
+
+Not pure CLI. Three daemon changes plus one CLI plumbing change, all additive and
+decode-compatible.
+
+1. **Idempotent not-found.** `handleTerminalDelete` currently returns
+   `RPCResponse(error: "Terminal not found: …")`
+   (`RPCRouter+TerminalHandlers.swift:448-450`). Return a success
+   `TerminalDeleteResult(closed: false, alreadyGone: true)` instead. This matches
+   the idempotency contract `terminal wake` already sets
+   (`TerminalCommands.swift:158,190`). String-matching the error text in the CLI
+   is the fragile alternative, and the text embeds a UUID. App-invisible: the app
+   calls `callVoidAsync` and ignores results (`DaemonClient.swift:663-669`); the
+   only behavior change is that a double-close stops logging an error.
+2. **Rails, daemon-side.** Add optional `respectActivityRails: Bool?` to
+   `TerminalDeleteParams` (`RPCProtocol.swift:1159-1162`; optional per the
+   Models decode-compat rule). `nil`/`false` keeps today's unconditional close,
+   so the app's tab-close — a direct human gesture — is unchanged. `true` (the
+   CLI default, dropped by `--force`) applies the liveness-qualified rail from
+   §6 D1 and returns `RPCErrorCode.terminalBusy`. Daemon-side because the state
+   lives in the daemon's DB and a CLI-side check on a listed row would be
+   racier.
+3. **Structured error code.** Add `case terminalBusy` to `RPCErrorCode`
+   (`RPCProtocol.swift:86-91`, currently a single `profileMissing` case).
+   `RPCResponse(error:code:)` already carries it (`RPCProtocol.swift:50-55`).
+4. **CLI plumbing.** Surface `errorCode` through `SocketClient` so the command
+   maps `terminalBusy` → exit 2 without parsing prose.
+
+Result type: `TerminalDeleteResult(closed: Bool, alreadyGone: Bool,
+claudeSessionID: String?)`, mirroring wake's `{"woken": bool}` precedent.
+
+## 8. Migration
+
+**`handoff.py` `cmd_close()`** collapses to a single call:
+
+```python
+def cmd_close(args):
+    target = args.close_predecessor
+    if target == os.environ.get("TBD_TERMINAL_ID"):
+        sys.exit("refusing to close myself — pass the PREDECESSOR's terminal id")
+    r = _run(["tbd", "terminal", "close", "--terminal", target, "--json"])
+    if r.returncode == 0:
+        out = json.loads(r.stdout or "{}")
+        print(f"closed predecessor {target}" + (" (was already gone)" if out.get("alreadyGone") else ""))
+        return 0
+    sys.exit(f"close failed (exit {r.returncode}): {r.stderr.strip()}")
+```
+
+Deleted outright: the `$TMUX` server derivation, the `terminal list` row lookup,
+the raw `kill-window`, and the `"can't find"` stderr sniff. The local self-check
+stays as a belt — the CLI also refuses, but failing before the subprocess gives a
+clearer message. The predecessor now actually gets history capture, row deletion,
+and a `.terminalRemoved` broadcast.
+
+A predecessor that went idle per the relay protocol reads `.idle` and closes
+cleanly. One still finishing its last message reads `.working` and is correctly
+refused — the successor should retry briefly rather than lead with `--force`.
+
+The successor prompt's step 2 (`handoff.py:107-109`) should name the new command.
+
+**No other raw `kill-window` callers exist outside `Sources/`** — the only hits
+are `handoff.py` itself and prose in `docs/specs/`.
+
+**One-time fleet sweep.** Shipping this does not retroactively fix predecessors
+already zombified by the old path. Those rows are parked with `.recovery` (or nil
+reason) and will focus-wake. `tbd terminal close --terminal <id>` closes them
+correctly once available, but their scrollback is already unrecoverable — the
+pane is gone.
+
+## 9. Doc/reality mismatches found
+
+1. **`Sources/TBDShared/NightwatchDeskPrompts.swift:112`** — compiled-in desk
+   prompt instructs `tbd terminal close --all`, a command that does not exist,
+   and claims "let daemon respawn fresh", which the daemon does not do. Must be
+   rewritten to the handoff relay. Note that even after this ships the old text
+   stays wrong: `close --all` on the desk's own worktree excludes the caller by
+   design, so it would never recycle the desk session that ran it.
+2. **`docs/superpowers/specs/2026-05-09-pending-askuserquestion-rendering-design.md:228`**
+   — cites "`tbd terminal close` / explicit terminal close" as an existing CLI
+   trigger. The RPC half was real; the CLI half never existed.
+3. **nightwatch `SKILL.md:91-92`** — currently correct ("that command does not
+   exist"), becomes stale the moment this ships. Update in the same change that
+   migrates `handoff.py`, keeping the handoff relay as the documented
+   context-ceiling remedy; `close --all` was never the right tool for it.
+4. Queue records (`acted.jsonl:32,57`, `judge-summary.txt:118-119`) memorialize
+   the mismatch. Leave as-is — they are logs.

--- a/docs/specs/2026-07-25-terminal-close-design.md
+++ b/docs/specs/2026-07-25-terminal-close-design.md
@@ -15,8 +15,8 @@ The gap has been actively harmful, not merely absent.
 
 ### 1.1 The phantom command
 
-`Sources/TBDShared/NightwatchDeskPrompts.swift:112` — a **compiled-in** desk tick
-prompt — instructs sessions:
+`Sources/TBDShared/NightwatchDeskPrompts.swift` — a **compiled-in** desk tick
+prompt (at `33494d80:112`, before the fix in this branch) — instructed sessions:
 
 > Remedy: call `tbd terminal close --all` on the desk, let daemon respawn fresh
 
@@ -343,8 +343,12 @@ refused — the successor should retry briefly rather than lead with `--force`.
 
 The successor prompt's step 2 (`handoff.py:107-109`) should name the new command.
 
-**No other raw `kill-window` callers exist outside `Sources/`** — the only hits
-are `handoff.py` itself and prose in `docs/specs/`.
+**`handoff.py` is the only raw `kill-window` caller to migrate.** It now ships
+from `NightwatchSkillContent.handoffPy`, so the migration is a source edit in
+this repo rather than a hand-patch of the installed copy — and the daemon
+rewrites the installed copy on every start, so editing only the on-disk file
+would be reverted. Every other `kill-window` reference is either daemon code
+using `worktree.tmuxServer` correctly, or prose in `docs/specs/`.
 
 **One-time fleet sweep.** Shipping this does not retroactively fix predecessors
 already zombified by the old path. Those rows are parked with `.recovery` (or nil

--- a/docs/specs/2026-07-25-terminal-close-design.md
+++ b/docs/specs/2026-07-25-terminal-close-design.md
@@ -453,3 +453,44 @@ pane is gone.
    flag; the second does not.
 4. Queue records (`acted.jsonl:32,57`, `judge-summary.txt:118-119`) memorialize
    the mismatch. Leave as-is — they are logs.
+
+## 10. Known interaction: desk nudge targeting (real, owned elsewhere)
+
+Shipping the relay does not make the desk's judge loop correct, and this section
+exists so nobody reads §8 as claiming otherwise.
+
+**The defect.** `DeskSessionManager.nudgeDeskSession` resolves "the" desk judge
+with `terminals.list(worktreeID:).first(where: { $0.label == TerminalLabel.claudeCode })`
+(`DeskSessionManager.swift:272`). `TerminalStore.list` orders `createdAt ASC`
+(`TerminalStore.swift:153`), so `.first` is the *oldest* match. A relay handoff
+spawns the successor as a new terminal in the **same worktree**, carrying the
+same `TerminalLabel.claudeCode` (`RPCRouter+TerminalHandlers.swift:267`), so
+while both rows exist the daemon keeps nudging the predecessor. And because
+`--close-predecessor` currently only kills the tmux window, the predecessor's
+row is *parked*, not deleted (§1.2) — so it persists and keeps winning.
+
+**Root cause is label-matching, not ordering.** The ordering story is the
+visible half and is not sufficient: the resume/fork path assigns a hardcoded
+lowercase `label = "claude"` (`RPCRouter+TerminalHandlers.swift:258`), which
+never equals `TerminalLabel.claudeCode` (`"Claude Code"`). A resumed or forked
+desk judge is therefore invisible to that selector with no relay involved at
+all. Fixing the ordering alone would leave that case broken.
+
+**This is not a new or unnoticed gap.** It bit on 2026-07-25 for ~4.5 hours
+(judge ticks delivered to a stale predecessor; the decision queue reached 134
+unprocessed lines) — before this branch existed, on the hand-created relay. The
+approved fix is a single derived selector — `kind == .claude`, parked excluded,
+`windowExists`-qualified, newest-first — used at all four `DeskSessionManager`
+call sites. An explicit `activeJudgeTerminalID` pointer was considered and
+rejected: its own repair fallback is "newest live candidate", so it buys a
+second source of truth, and a pointer the successor must claim reproduces the
+original failure (a relay step owned by a model is a step a human question
+preempts forever).
+
+**Ownership and sequencing.** That work is slices A/B of the
+`desk-relay-targeting` worktree, greenlit with no dependency on this branch, and
+already built there. It touches only `DeskSessionManager.swift`; this branch
+touches none of it. The two are independent and may merge in either order — this
+branch makes the relay *survive daemon restarts* (the compiled-skill ingest),
+that one makes the daemon *address the right judge*. Neither substitutes for the
+other, and the relay is not fully trustworthy until both have landed.

--- a/docs/specs/2026-07-25-terminal-close-design.md
+++ b/docs/specs/2026-07-25-terminal-close-design.md
@@ -66,8 +66,10 @@ it parks it into the wakeable state described above.
 
 ```
 tbd terminal close --terminal <uuid> [--force] [--json]
-tbd terminal close <worktree> --all [--force] [--dry-run] [--json]
 ```
+
+One target, named explicitly. `--all`, `--except` and `--dry-run` are deferred —
+see §2.1 and §6 D2.
 
 ```swift
 struct TerminalClose: AsyncParsableCommand {
@@ -88,49 +90,35 @@ struct TerminalClose: AsyncParsableCommand {
             A terminal cannot close itself. Spawn a successor and have it close
             you (see the nightwatch handoff relay).
 
-            `<worktree> --all` closes every terminal in ONE worktree; the
-            calling terminal is excluded and reported as skipped. This does NOT
-            archive the worktree — a worktree with zero terminals stays active.
-            Use `tbd worktree archive` for that.
+            Closing a worktree's last terminal does NOT archive it — the
+            worktree stays active with zero terminals. Use `tbd worktree
+            archive` for that.
             """
     )
 
-    @Argument(help: "Worktree name or ID (required with --all, forbidden otherwise)")
-    var worktree: String?
-
     @Option(name: .long, help: "Terminal ID to close")
-    var terminal: String?
+    var terminal: String
 
-    @Flag(name: .long, help: "Close ALL terminals in <worktree> (the calling terminal is excluded)")
-    var all = false
-
-    @Flag(name: .long, help: "Also close terminals that are mid-turn or waiting on a permission prompt")
+    @Flag(name: .long, help: "Also close a terminal that is mid-turn or waiting on a permission prompt")
     var force = false
-
-    @Flag(name: .long, help: "List what would be closed without closing anything (--all only)")
-    var dryRun = false
 
     @Flag(name: .long, help: "Output JSON")
     var json = false
 }
 ```
 
-`validate()` enforces exactly one of `--terminal` XOR (`worktree` + `--all`). A
-bare positional worktree with no `--all` is a `ValidationError` — a typo'd
-positional must never silently mean "close everything".
-
-`--terminal` is an `@Option`, matching the newer house pattern (`send`, `wake`,
-`focus`, `swap-profile` — `TerminalCommands.swift:122,161,207,391`) and freeing
-the positional for the worktree, matching `terminal list <worktree>`.
+`--terminal` is a required `@Option`, matching the newer house pattern (`send`,
+`wake`, `focus`, `swap-profile` — `TerminalCommands.swift:122,161,207,391`).
+There is no positional form: a bare `tbd terminal close` must not be one typo
+away from meaning anything at all.
 
 There is **no** `TBD_TERMINAL_ID` default for `--terminal`. Other commands
 default to it (`NotifyCommand.swift:64-69`, `FakeRateLimitCommand.swift:31`), but
 here it would make a bare `tbd terminal close` mean "close myself" — the one
 thing this command refuses.
 
-### JSON schemas
+### JSON schema
 
-Single:
 ```json
 {"terminalID": "…", "closed": true, "alreadyGone": false, "claudeSessionID": "…|null"}
 ```
@@ -138,27 +126,60 @@ Single:
 `claudeSessionID` is echoed so an autonomous caller retains a resume pointer
 after the row is gone.
 
-Bulk:
-```json
-{"worktreeID": "…",
- "closed":  [{"terminalID": "…", "claudeSessionID": "…|null"}],
- "skipped": [{"terminalID": "…", "reason": "self|working|waiting_for_user"}],
- "failed":  [{"terminalID": "…", "error": "…"}]}
-```
+## 2.1 Why `close --all` can never be a self-recycle remedy
 
-`--dry-run` emits the same shape with `wouldClose` in place of `closed`.
+Recorded at length because this was the *documented* remedy for five days, and
+the reason it can't work is structural rather than a missing feature. Anyone
+reading the nightwatch history will otherwise propose it again.
+
+The instruction shipped in `NightwatchDeskPrompts.swift` was:
+
+> Remedy: call `tbd terminal close --all` on the desk, let daemon respawn fresh
+
+It had **three** independent defects, and fixing any one of them leaves the
+other two:
+
+1. **The command did not exist.** No `close` subcommand of any shape.
+2. **Nothing respawns a desk session.** There is no babysitter daemon — see the
+   retraction in `NightwatchSkillContent.skillMd`.
+3. **Even a working `--all` does the opposite of what was intended.** This is
+   the interesting one.
+
+The intent was "this session is past its context ceiling; recycle it." But a
+process cannot close its own terminal: killing the tmux window SIGHUPs the
+calling shell, so `tbd` dies mid-`recv` and can never report a result, and the
+agent's turn is severed mid-tool-call. Any sane `--all` therefore excludes the
+caller (see §4). Which means, run by the tired desk session on its own worktree,
+`close --all` kills the desk's *other* panes and leaves the one session you
+wanted gone alive and still tired. **The remedy is precisely inverted.**
+
+The general principle: **"close everything here" is never a self-replacement
+primitive.** Self-replacement needs a second actor that outlives the first, so
+the ordering is necessarily
+*write handoff → spawn successor → successor closes predecessor*, and it must be
+that order — a predecessor that closes itself first leaves the desk unwatched if
+the spawn failed. That is exactly the shape of
+`NightwatchSkillContent.handoffPy`, and it is why the relay is the remedy rather
+than any flag on this command.
+
+Corollary for the flag design: `--all`'s only documented consumer was this
+incoherent instruction. Auditing what actually remains (§6 D2) left a need too
+narrow to justify a flag whose name lies whenever the caller is inside the
+target set — which is exactly when an autonomous caller would reach for it.
 
 ### Deliberately excluded
 
-- **Fleet-wide `--all`.** ~40 worktrees / ~93 panes. A shell-history replay would
-  decapitate the fleet. Anyone who genuinely wants it can loop
+- **`--all` (worktree-wide).** Deferred — §6 D2. Note that fleet-wide `--all`
+  is refused outright regardless: ~40 worktrees / ~93 panes, and a shell-history
+  replay would decapitate the fleet. Anyone who truly wants that can loop
   `tbd worktree list --json`, which at least forces them to write the loop.
+- **`--except <id>` and `--dry-run`.** Both existed only to make `--all` safe;
+  they leave with it.
 - **`--graceful` / typed `/exit`.** Knowing the composer is idle and empty
   requires reading rendered screen text — banned by the no-TUI-scraping rule.
   The hibernation subsystem already demonstrates that process-kill plus
   `claude --resume` is lossless for a Claude session.
 - **A self-close override.** See §4.
-- **`--except <id>`.** See §6, D2 — deferred, not rejected.
 - **`--no-capture`.** Capture is already best-effort and cheap.
 - **A `delete` alias.** One user-facing verb: "close" (matching the app's "Close
   Tab" and "Closed Terminals"). The RPC keeps its `terminal.delete` name.
@@ -171,22 +192,22 @@ Bulk:
 
 ## 3. Semantics
 
-| Terminal state | default | `--force` | under `--all` | under `--all --force` |
-| --- | --- | --- | --- | --- |
-| Idle Claude/Codex (`.idle`/`.unknown`) | closed | closed | closed | closed |
-| Working (`.working`), window alive | **refused**, exit 2 | closed | skipped, reported | closed |
-| Waiting on permission (`.waitingForUser`), window alive | **refused**, exit 2 | closed | skipped, reported | closed |
-| `.working`/`.waitingForUser` but **window dead** | closed (rail is liveness-qualified — see §6 D1) | closed | closed | closed |
-| Plain shell (`activityState` is agent-fed; shells stay `.unknown`) | closed | closed | closed | closed |
-| Hibernated-parked, window alive | closed; resumes cancelled; scrollback captured | same | closed | closed |
-| Recovery-parked, window already dead | closed; **capture stores nothing** (dead pane); session becomes unreachable from TBD, transcript survives on disk | same | closed | closed |
-| `keepWarm: true` | closed — keepWarm exempts from *auto-hibernation* only (`Models.swift:309-312`), it is not close protection | same | closed | closed |
-| Pinned (`pinnedAt`) | closed — pin is a dock affordance; the app closes pinned tabs too | same | closed | closed |
-| Pending scheduled resume | closed; resume cancelled (`RPCRouter+TerminalHandlers.swift:452-455`) | same | closed | closed |
-| Already gone (no DB row) | **no-op success**, exit 0, `alreadyGone: true` | same | n/a | n/a |
-| Self (`--terminal` == `$TBD_TERMINAL_ID`) | **refused**, exit 2 | **still refused** | skipped, `reason: "self"` | skipped |
-| Mid-`terminal send` race | close wins; a send arriving after row deletion errors "Terminal not found"; a send already in flight lands in a dying pane and is lost | same | same | same |
-| Scratch-worktree terminal | identical — the daemon reads `worktree.tmuxServer` from the row, satisfying the pane-ids-collide rule by construction | same | same | same |
+| Terminal state | default | `--force` |
+| --- | --- | --- |
+| Idle Claude/Codex (`.idle`/`.unknown`) | closed | closed |
+| Working (`.working`), window alive | **refused**, exit 2 | closed |
+| Waiting on permission (`.waitingForUser`), window alive | **refused**, exit 2 | closed |
+| `.working`/`.waitingForUser` but **window dead** | closed (rail is liveness-qualified — see §6 D1) | closed |
+| Plain shell (`activityState` is agent-fed; shells stay `.unknown`) | closed | closed |
+| Hibernated-parked, window alive | closed; resumes cancelled; scrollback captured | same |
+| Recovery-parked, window already dead | closed; **capture stores nothing** (dead pane); session becomes unreachable from TBD, transcript survives on disk | same |
+| `keepWarm: true` | closed — keepWarm exempts from *auto-hibernation* only (`Models.swift:309-312`), it is not close protection | same |
+| Pinned (`pinnedAt`) | closed — pin is a dock affordance; the app closes pinned tabs too | same |
+| Pending scheduled resume | closed; resume cancelled (`RPCRouter+TerminalHandlers.swift:452-455`) | same |
+| Already gone (no DB row) | **no-op success**, exit 0, `alreadyGone: true` | same |
+| Self (`--terminal` == `$TBD_TERMINAL_ID`) | **refused**, exit 2 | **still refused** |
+| Mid-`terminal send` race | close wins; a send arriving after row deletion errors "Terminal not found"; a send already in flight lands in a dying pane and is lost | same |
+| Scratch-worktree terminal | identical — the daemon reads `worktree.tmuxServer` from the row, satisfying the pane-ids-collide rule by construction | same |
 
 **Closing the last terminal is explicitly permitted and is not an archive.** The
 app already closes the last tab with no guard — `AppState+Tabs.swift:148-200`
@@ -203,8 +224,7 @@ All to stderr.
 | --- | --- | --- |
 | Self-close | `Refusing to close the calling terminal (<uuid>). A terminal cannot close itself — spawn a successor and have it close this one.` | 2 |
 | Busy, no `--force` | `Terminal <uuid> is <mid-turn\|waiting on a permission prompt> (activityState=<working\|waiting_for_user>). Closing now would kill in-flight work. Pass --force to close anyway.` | 2 |
-| Bare worktree, no `--all` | `To close every terminal in a worktree, pass --all explicitly.` | 64 |
-| `--terminal` with `--all` | `Specify either --terminal <id> or <worktree> --all, not both.` | 64 |
+| Missing `--terminal` | ArgumentParser's standard missing-required-option error | 64 |
 | Invalid UUID | `Invalid terminal ID: <s>` (matches `TerminalCommands.swift:136`) | 1 |
 
 `ExitCode(2)` has house precedent (`DoctorCommand.swift:34,39`).
@@ -219,16 +239,17 @@ availability reason (if the spawn failed, the predecessor is the only thing stil
 watching the desk), and successor-closes-predecessor is the documented standing
 rule. Build the deferral when a real consumer appears.
 
-Under `--all` the caller is excluded and **reported** as `reason: "self"` in both
-JSON and text — never silently dropped.
+Self-close is refused rather than silently skipped precisely because there is
+only one target: skipping it would exit 0 having done nothing, and an autonomous
+caller that doesn't inspect the payload would read that as success. §2.1 is the
+longer form of why no flag on this command can be a self-replacement primitive.
 
 ## 5. Failure modes
 
 | Situation | Exit |
 | --- | --- |
-| Success / already gone / dry-run / bulk with only skips | 0 |
+| Success / already gone | 0 |
 | Daemon not running (`SocketClient.swift:19-21`) | 1 |
-| Bulk with any `failed` entries (partial results still printed) | 1 |
 | Refused (self, busy) | 2 |
 | Usage error | 64 |
 
@@ -246,8 +267,8 @@ Best-effort, inherited from the daemon handler and acceptable:
   `killWindowAndReap` that reconcile uses (`WorktreeLifecycle.swift:164-171`).
   This is a pre-existing gap shared with the app's tab-close, not something this
   command introduces. Recommended as a separate follow-up PR.
-- **TOCTOU under `--all`**: a terminal closed between the list and the delete
-  resolves as `alreadyGone`. Harmless once idempotency lands.
+- **A terminal closed by someone else between the caller's `terminal list` and
+  this call** resolves as `alreadyGone`, exit 0. Harmless once idempotency lands.
 
 ## 6. Reconciled disagreements
 
@@ -268,12 +289,31 @@ state is busy **and** `tmux.windowExists` confirms a live window. A dead-window
 row cannot be mid-turn — and that is precisely the zombified-predecessor state
 `handoff.py` creates today, which must remain closeable without `--force`.
 
-**D2 — `--except` deferred, not shipped.** The relay's real shape is "close
-everything but me", and self is already auto-excluded. The remaining
-justification (recycle a desk, keep the fresh session) is real but is expressible
-as N single-target closes, and the successor in the relay is spawned *after* the
-close decision. Ship the smaller surface; add `--except` when a second consumer
-appears.
+**D2 — `--all` and `--except` both deferred, not shipped.** The independent
+design kept a worktree-scoped `--all` with the caller auto-excluded. Revised
+after review (Chang, 2026-07-25) to drop it, on the argument in §2.1: the flag's
+only documented consumer was an instruction that a working `--all` would have
+served *backwards*. Auditing the remainder:
+
+| Claimed need | Actually served by |
+| --- | --- |
+| Recycle a tired desk session | the handoff relay (§2.1) — `--all` cannot, by construction |
+| Retire the predecessor in a relay | single-target `--terminal` |
+| Clear a whole worktree | `tbd worktree archive`, which already capture-then-kills every terminal (`WorktreeLifecycle+Archive.swift:117-128`) |
+| Close every pane fleet-wide | refused outright; loop `tbd worktree list --json` |
+
+What survives is only "close every pane in this worktree but keep the worktree
+alive" — real, but rare, and not worth a flag whose name is false whenever the
+caller sits inside the target set. That is exactly the case an autonomous caller
+hits, and the failure is quiet: it exits 0 having left one terminal (its own)
+running, which a caller that doesn't inspect `skipped` reads as a clean sweep.
+
+The rejected alternative was keeping `--all` but refusing when the caller is in
+the target worktree. That is worse: it breaks the one legitimate use (sweeping a
+worktree you are *not* sitting in) while still not enabling self-recycling.
+
+`--except` and `--dry-run` existed only to make `--all` safe and leave with it.
+Add all three together if a second real consumer appears.
 
 **D3 — self-close framing.** Both refuse it; recorded above with the deferral
 door explicitly left open rather than as a claim that it cannot be built.
@@ -358,18 +398,22 @@ pane is gone.
 
 ## 9. Doc/reality mismatches found
 
-1. **`Sources/TBDShared/NightwatchDeskPrompts.swift:112`** — compiled-in desk
-   prompt instructs `tbd terminal close --all`, a command that does not exist,
-   and claims "let daemon respawn fresh", which the daemon does not do. Must be
-   rewritten to the handoff relay. Note that even after this ships the old text
-   stays wrong: `close --all` on the desk's own worktree excludes the caller by
-   design, so it would never recycle the desk session that ran it.
+1. **`Sources/TBDShared/NightwatchDeskPrompts.swift`** (at `33494d80:112`) —
+   compiled-in desk prompt instructing `tbd terminal close --all` on the desk.
+   Three independent defects, dissected in §2.1: the command never existed, no
+   daemon respawns a desk session, and a working `--all` would have inverted the
+   remedy. Fixed in this branch by pointing at the handoff relay. **Nothing this
+   design ships would have made the original sentence correct** — that is the
+   whole reason §2.1 exists.
 2. **`docs/superpowers/specs/2026-05-09-pending-askuserquestion-rendering-design.md:228`**
    — cites "`tbd terminal close` / explicit terminal close" as an existing CLI
    trigger. The RPC half was real; the CLI half never existed.
-3. **nightwatch `SKILL.md:91-92`** — currently correct ("that command does not
-   exist"), becomes stale the moment this ships. Update in the same change that
-   migrates `handoff.py`, keeping the handoff relay as the documented
-   context-ceiling remedy; `close --all` was never the right tool for it.
+3. **nightwatch `SKILL.md`, "Standing rules"** — says "that command does not
+   exist", correct today and stale the moment this ships. Update in the same
+   change that migrates `handoff.py`. Keep the relay as the documented
+   context-ceiling remedy and re-state the reason in the new terms: not "the
+   command doesn't exist" but "no close command can recycle the session that
+   invokes it" (§2.1). The first framing invites someone to fix it by adding the
+   flag; the second does not.
 4. Queue records (`acted.jsonl:32,57`, `judge-summary.txt:118-119`) memorialize
    the mismatch. Leave as-is — they are logs.

--- a/docs/specs/2026-07-25-terminal-close-design.md
+++ b/docs/specs/2026-07-25-terminal-close-design.md
@@ -348,15 +348,21 @@ Add all three together if a second real consumer appears.
 **D3 — self-close framing.** Both refuse it; recorded above with the deferral
 door explicitly left open rather than as a claim that it cannot be built.
 
-**D4 — the change is four pieces, not three.** `SocketClient` does not surface
-`errorCode` to CLI callers today (no references in `Sources/TBDCLI/`), so
-branching on `terminalBusy` requires a small addition there alongside the three
-daemon changes in §7.
+**D4 — ~~the change is four pieces, not three~~. Withdrawn: it is three.**
+This section claimed `SocketClient` needed a change to surface `errorCode`,
+inferred from there being no references to it in `Sources/TBDCLI/`. That
+inference was wrong. `SocketClient.send()` already returns the whole
+`RPCResponse`, `errorCode` included, and `CleanupCommand` already calls `send`
+directly for exactly that kind of access — the absence of references meant
+nobody had needed the field yet, not that it was unreachable. Verified while
+implementing: the command branches on `response.errorCode` with no change to
+`SocketClient`. Kept rather than deleted because "no references, therefore not
+available" is a tempting and wrong move to make twice.
 
 ## 7. Required changes
 
-Not pure CLI. Three daemon changes plus one CLI plumbing change, all additive and
-decode-compatible.
+Not pure CLI. Three daemon changes, all additive and decode-compatible. (No CLI
+plumbing change — see §6 D4, withdrawn.)
 
 1. **Idempotent not-found.** `handleTerminalDelete` currently returns
    `RPCResponse(error: "Terminal not found: …")`
@@ -378,8 +384,8 @@ decode-compatible.
 3. **Structured error code.** Add `case terminalBusy` to `RPCErrorCode`
    (`RPCProtocol.swift:86-91`, currently a single `profileMissing` case).
    `RPCResponse(error:code:)` already carries it (`RPCProtocol.swift:50-55`).
-4. **CLI plumbing.** Surface `errorCode` through `SocketClient` so the command
-   maps `terminalBusy` → exit 2 without parsing prose.
+   The CLI reads `response.errorCode` off `SocketClient.send()` and maps
+   `terminalBusy` → exit 2 without parsing prose. No `SocketClient` change.
 
 Result type: `TerminalDeleteResult(closed: Bool, alreadyGone: Bool,
 claudeSessionID: String?)`, mirroring wake's `{"woken": bool}` precedent.


### PR DESCRIPTION
## Summary

`NightwatchDeskPrompts` builds the prompt injected into every watch-desk agent session on every tick. It is not documentation — it is live instruction driving autonomous behavior across a ~40-worktree fleet. Nothing asserted on the strings, and they had drifted badly.

**What was broken.** The context-ceiling remedy read ``Remedy: call `tbd terminal close --all` on the desk, let daemon respawn fresh``. Both halves were false: there is no `tbd terminal close` subcommand (the daemon has `terminal.delete`, but no CLI surface was ever built over it), and there is no babysitter daemon — no `~/.fleet/`, no launchd job, no script. Sessions were told to mark themselves for respawn and keep working; for five days nothing recycled them. Separately, the prompts said "Merge PRs cleared by the policy (all clearance kinds)" and "act on everything the gate approves", contradicting the nightwatch gate, which reserves merging for the human and treats `gh pr merge` as an escalation.

**Why it wasn't caught.** No test read these strings. `swift test` was green throughout.

**The second-order problem.** `PluginDirWriter.writeNightwatch` rewrites the installed skill dir from string constants on every daemon start, `atomically: true`, no existence check. So fixing the on-disk `SKILL.md` and `tick.py` is ephemeral — the next `scripts/restart.sh` reverts them. The compiled source still described `scripts/daemon.py` + `watchdog.sh` as a "durable spine already on launchd", and the compiled `tick.py` lacked the composer ghost-guard entirely.

## What this PR does

- **Prompts** point the context ceiling at the handoff relay (`handoff.py --check` / `--act --notes-file` / `--close-predecessor`), including the ordering rule that the predecessor never closes itself — a failed successor spawn must leave the desk still watched. Both modes now state the gate's enqueue precondition and forbid `gh pr merge`. Adds the never-`/closeout` standing rule, so it no longer has to override the tick prompt from outside.
- **Ships `handoff.py`.** It was not in the installed set, so the relay path resolved only on a machine where it had been hand-created. A prompt naming an uninstalled path is the same defect as naming a nonexistent command, one layer down.
- **Retires the babysitter claim** from the compiled `SKILL.md` and ports the composer ghost-guard into the compiled `tick.py` (dim `ESC[2m` suggestions and SGR mouse reports are no longer read as human input — that path types what it finds into live sessions). `DAEMON_LOG` dropped with the stub it fed.
- **Removes the duplication that allowed the drift**: `PluginDirWriter` now iterates `NightwatchSkillContent.scripts` instead of carrying its own list, making the shipped set visible to `TBDShared` tests.
- **Tier-1 test suite** pinning each of these as a policy invariant — including the structural guard that every `scripts/*.py` named in a desk prompt is actually installed.

Also includes a design doc for `tbd terminal close` (`docs/specs/2026-07-25-terminal-close-design.md`). It is the rationale for this branch and specifies the follow-up slice; **it adds no code and the command does not exist yet.**

## Test plan

- [x] `swift test` — 3876 tests, 460 suites, green (1 known issue: the quarantine self-test fixture, red once by design)
- [x] `swiftlint --strict` — 0 violations
- [x] Ported `tick.py` verified against the live fleet, not just by inspection: extracted the compiled string to a temp tree (so its queue writes land there, not in the live queue) and ran it — reproduces `stranded=5`, down from 14 before the ghost-guard, with all five survivors genuinely typed input
- [x] Splice verified byte-exact: compiled `skillMd` / `tickPy` / `handoffPy` diffed against their on-disk sources (`tickPy` differing only by the intended `DAEMON_LOG` removal)
- [ ] Reviewer sanity-check on the `tick.py` port specifically — it is transcribed work, and the index alignment in `classify` (`len(raw_lines) != len(lines)` → bail) is load-bearing: a misaligned lookup reads dimness off the wrong row

## Notes for the reviewer

- Two assertions in the first commit pinned deleted wording rather than the invariant; the third commit tightens them. Worth internalizing: a banned-substring check is defeated from *both* sides — a reworded reintroduction slips past, and the sentence that forbids a promise contains the promise. It tripped twice here before being replaced with checks on artifacts that have no innocent reading.
- The shipped `SKILL.md` still states that `tbd terminal close` does not exist. True today; the follow-up slice that adds the command must update it in the same change.
- `handoff.py --close-predecessor` still uses raw `tmux kill-window`, which per the design doc §1.2 does not actually close a Claude terminal — reconcile parks it `.recovery`-hibernated and focus-wake resurrects it. Known and deliberately deferred to the follow-up slice.

[terminal-close-design](https://cheapsteak.github.io/tbd/open/?worktree=F97E72C1-E4F7-4D95-8080-82813621C056)