### PR TITLE
Feat: tbd terminal close — the CLI surface a documented remedy pointed at for five days

### DIFF
--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -6,7 +6,7 @@ struct TerminalCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "terminal",
         abstract: "Manage terminals",
-        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalWake.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self, TerminalPin.self, TerminalUnpin.self, TerminalSwapProfile.self]
+        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalWake.self, TerminalClose.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self, TerminalPin.self, TerminalUnpin.self, TerminalSwapProfile.self]
     )
 }
 
@@ -192,6 +192,87 @@ struct TerminalWake: AsyncParsableCommand {
             print(result.woken
                 ? "Terminal woken."
                 : "Terminal already awake (no-op)\(prompt != nil ? " — prompt NOT delivered" : "").")
+        }
+    }
+}
+
+// MARK: - terminal close
+
+struct TerminalClose: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "close",
+        abstract: "Close a terminal: capture its scrollback to Closed Terminals history, kill its tmux window, remove it from TBD. Idempotent: closing an already-closed terminal is a no-op.",
+        discussion: """
+            Closing is immediate and final for the terminal row. The pane's
+            scrollback is captured into Session History → Closed Terminals
+            (best-effort), any pending session-limit auto-resume is cancelled,
+            and the tab disappears from the app. A Claude session's transcript
+            survives on disk, and a closed Claude terminal can be revived from
+            Closed Terminals history.
+
+            By default a terminal that is mid-turn or holding a permission
+            prompt is refused (exit 2) — pass --force to close it anyway. That
+            check applies only while the pane's window is alive, so a session
+            that died mid-turn stays closeable without --force.
+
+            A terminal cannot close itself: killing the window SIGHUPs the
+            calling shell, so this command could never report its own result.
+            Spawn a successor and have it close you.
+
+            Closing a worktree's last terminal does NOT archive the worktree —
+            it stays active with zero terminals. Use `tbd worktree archive`.
+            """
+    )
+
+    @Option(name: .long, help: "Terminal ID")
+    var terminal: String
+
+    @Flag(name: .long, help: "Close even if the terminal is mid-turn or waiting on a permission prompt")
+    var force = false
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        // Self-close is refused before the RPC, not skipped: with a single
+        // target, skipping would exit 0 having done nothing, which an
+        // autonomous caller reads as success.
+        if let selfID = ProcessInfo.processInfo.environment["TBD_TERMINAL_ID"],
+           UUID(uuidString: selfID) == terminalID {
+            FileHandle.standardError.write(Data("""
+                Refusing to close the calling terminal (\(terminalID)). A terminal cannot \
+                close itself — spawn a successor and have it close this one.\n
+                """.utf8))
+            throw ExitCode(2)
+        }
+
+        let client = SocketClient()
+        let response = try client.send(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            // --force drops the rails; otherwise the daemon applies them.
+            params: TerminalDeleteParams(
+                terminalID: terminalID,
+                respectActivityRails: force ? nil : true)
+        ))
+
+        guard response.success else {
+            // Branch on the machine-readable code, never the prose.
+            if response.errorCode == RPCErrorCode.terminalBusy.rawValue {
+                FileHandle.standardError.write(Data(((response.error ?? "Terminal is busy.") + "\n").utf8))
+                throw ExitCode(2)
+            }
+            throw CLIError.rpcError(response.error ?? "Unknown error")
+        }
+
+        let result = try response.decodeResult(TerminalDeleteResult.self)
+        if json {
+            printJSON(result)
+        } else {
+            print(result.alreadyGone ? "Terminal already closed (no-op)." : "Terminal closed.")
         }
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -445,8 +445,38 @@ extension RPCRouter {
     func handleTerminalDelete(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalDeleteParams.self, from: paramsData)
 
+        // Closing an already-closed terminal is a no-op SUCCESS, not an error —
+        // same contract as `terminal.wake`. Autonomous callers retry and race
+        // each other; making the second one fail would push every caller into
+        // string-matching this message to tell "already done" from "broken".
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
-            return RPCResponse(error: "Terminal not found: \(params.terminalID)")
+            return try RPCResponse(result: TerminalDeleteResult(closed: false, alreadyGone: true))
+        }
+
+        // Optional rails (CLI sets them; --force drops them; the app never
+        // does). Refuse to kill an in-flight turn or a raised permission hand,
+        // matching `isManuallyHibernatable`'s rails.
+        //
+        // Qualified on the window actually being ALIVE. `activityState` is
+        // hook-fed and carries no timestamp, so a session that died mid-turn
+        // (crash, OOM, killed pane) stays `.working` forever. An unqualified
+        // rail would then refuse forever on exactly the wedged terminal a
+        // caller most needs to close — turning the safety rail into a trap for
+        // this command's primary cleanup use case. A dead-window row cannot be
+        // mid-turn, so it stays closeable without --force.
+        if params.respectActivityRails == true,
+           terminal.activityState == .working || terminal.activityState == .waitingForUser,
+           let worktree = try await db.worktrees.get(id: terminal.worktreeID),
+           await tmux.windowExists(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID) {
+            let what = terminal.activityState == .working
+                ? "mid-turn"
+                : "waiting on a permission prompt"
+            return RPCResponse(
+                error: "Terminal \(params.terminalID) is \(what) "
+                    + "(activityState=\(terminal.activityState.rawValue)). "
+                    + "Closing now would kill in-flight work. Pass --force to close anyway.",
+                code: RPCErrorCode.terminalBusy.rawValue
+            )
         }
 
         // Terminal close cancels any pending auto-resume (spec §Cancellation).
@@ -481,7 +511,11 @@ extension RPCRouter {
             terminalID: terminal.id
         )))
 
-        return .ok()
+        return try RPCResponse(result: TerminalDeleteResult(
+            closed: true,
+            alreadyGone: false,
+            claudeSessionID: terminal.claudeSessionID
+        ))
     }
 
     /// Closed-terminal capture metadata for a worktree, newest first. Content

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -88,6 +88,10 @@ public enum RPCErrorCode: String, Sendable {
     /// refused. The app offers a default-account fallback retry
     /// (`TerminalWakeParams.fallbackToDefaultProfile`).
     case profileMissing
+    /// A `terminal.delete` with `respectActivityRails` was refused because the
+    /// terminal is mid-turn or holding a permission prompt AND its window is
+    /// still alive. The CLI maps this to exit 2; `--force` drops the rails.
+    case terminalBusy
 }
 
 // MARK: - RPC Method Names
@@ -1158,7 +1162,38 @@ public struct TerminalSendParams: Codable, Sendable {
 
 public struct TerminalDeleteParams: Codable, Sendable {
     public let terminalID: UUID
-    public init(terminalID: UUID) { self.terminalID = terminalID }
+    /// When true, refuse to close a terminal that is mid-turn or holding a
+    /// permission prompt, returning `RPCErrorCode.terminalBusy`. Optional and
+    /// defaulting to nil (= no rails) so the app's tab-close — a direct human
+    /// gesture on a visible tab — keeps its existing unconditional semantics,
+    /// and so older callers still decode.
+    ///
+    /// The CLI sets it; `--force` drops it. See `handleTerminalDelete` for why
+    /// the check is additionally qualified on the window being alive.
+    public let respectActivityRails: Bool?
+    public init(terminalID: UUID, respectActivityRails: Bool? = nil) {
+        self.terminalID = terminalID
+        self.respectActivityRails = respectActivityRails
+    }
+}
+
+/// Result for `terminal.delete`. Mirrors `TerminalWakeResult`'s shape: the call
+/// is idempotent, and the caller learns which of the two success paths it took.
+public struct TerminalDeleteResult: Codable, Sendable {
+    /// true — this call tore the terminal down; false — it was already gone.
+    public let closed: Bool
+    /// true when there was no such terminal row. Not an error: closing an
+    /// already-closed terminal is a no-op success, matching `terminal wake`.
+    public let alreadyGone: Bool
+    /// Echoed so an autonomous caller keeps a resume pointer after the row is
+    /// gone (the transcript survives on disk). nil for non-Claude terminals and
+    /// for the already-gone path.
+    public let claudeSessionID: String?
+    public init(closed: Bool, alreadyGone: Bool, claudeSessionID: String? = nil) {
+        self.closed = closed
+        self.alreadyGone = alreadyGone
+        self.claudeSessionID = claudeSessionID
+    }
 }
 
 /// Params for `terminalHistory.list` — closed-terminal capture metadata for a

--- a/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
+++ b/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 1 — in-memory DB, dry-run tmux, no real processes.
+///
+/// `terminal.delete`'s optional activity rails and its idempotent not-found
+/// path. Both branches of the rail conditional are covered per the repo rule,
+/// plus the liveness qualification that keeps the rail from becoming a trap.
+@Suite("terminal.delete activity rails")
+struct TerminalCloseRailsTests {
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let worktree: Worktree
+        let terminal: Terminal
+    }
+
+    private func makeFixture(
+        activityState: TerminalActivityState = .idle,
+        claudeSessionID: String? = "sess-abc"
+    ) async throws -> Fixture {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/tcr-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "b",
+            path: "/tmp/tcr-wt-\(UUID().uuidString)", tmuxServer: "tbd-tcr")
+        var terminal = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "Build", claudeSessionID: claudeSessionID, kind: .claude)
+        try await db.terminals.setActivityState(id: terminal.id, activityState: activityState)
+        terminal = try #require(try await db.terminals.get(id: terminal.id))
+        return Fixture(db: db, worktree: wt, terminal: terminal)
+    }
+
+    /// `windowIsDead: true` forces the row's window to read as gone, which is
+    /// what a crashed-mid-turn session looks like.
+    private func makeRouter(db: TBDDatabase, windowIsDead: Bool = false) -> RPCRouter {
+        var deadHook: (@Sendable (String) -> Bool)?
+        if windowIsDead { deadHook = { _ in true } }
+        let tmux = TmuxManager(dryRun: true, dryRunWindowIsDead: deadHook)
+        return RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date())
+    }
+
+    private func close(
+        _ router: RPCRouter, _ id: UUID, rails: Bool?
+    ) async throws -> RPCResponse {
+        await router.handle(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: id, respectActivityRails: rails)))
+    }
+
+    // MARK: - Rail OFF (the app's tab-close path, unchanged)
+
+    @Test("rails omitted: a mid-turn terminal still closes", arguments: [
+        TerminalActivityState.working, .waitingForUser
+    ])
+    func railsOffClosesBusyTerminal(state: TerminalActivityState) async throws {
+        let fx = try await makeFixture(activityState: state)
+        let router = makeRouter(db: fx.db)
+
+        let resp = try await close(router, fx.terminal.id, rails: nil)
+
+        #expect(resp.success, "app tab-close must keep its unconditional semantics")
+        let result = try resp.decodeResult(TerminalDeleteResult.self)
+        #expect(result.closed)
+        #expect(!result.alreadyGone)
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+    }
+
+    @Test("rails explicitly false behaves the same as omitted")
+    func railsFalseClosesBusyTerminal() async throws {
+        let fx = try await makeFixture(activityState: .working)
+        let router = makeRouter(db: fx.db)
+
+        let resp = try await close(router, fx.terminal.id, rails: false)
+
+        #expect(resp.success)
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+    }
+
+    // MARK: - Rail ON
+
+    @Test("rails on: a mid-turn terminal with a live window is refused", arguments: [
+        TerminalActivityState.working, .waitingForUser
+    ])
+    func railsOnRefusesBusyTerminal(state: TerminalActivityState) async throws {
+        let fx = try await makeFixture(activityState: state)
+        let router = makeRouter(db: fx.db)
+
+        let resp = try await close(router, fx.terminal.id, rails: true)
+
+        #expect(!resp.success)
+        #expect(resp.errorCode == RPCErrorCode.terminalBusy.rawValue,
+                "CLI maps the code to exit 2 without parsing prose")
+        #expect(resp.error?.contains("--force") == true, "the message must name the escape hatch")
+        // The refusal is total: nothing was torn down.
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) != nil)
+    }
+
+    @Test("rails on: an idle terminal closes", arguments: [
+        TerminalActivityState.idle, .unknown
+    ])
+    func railsOnClosesIdleTerminal(state: TerminalActivityState) async throws {
+        let fx = try await makeFixture(activityState: state)
+        let router = makeRouter(db: fx.db)
+
+        let resp = try await close(router, fx.terminal.id, rails: true)
+
+        #expect(resp.success)
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+    }
+
+    /// The qualification that keeps the rail from being a trap. `activityState`
+    /// is hook-fed and has no timestamp, so a session that died mid-turn stays
+    /// `.working` forever. Were the rail unqualified, the wedged terminal a
+    /// caller most needs to close would be the one it could never close.
+    @Test("rails on: a mid-turn terminal whose window is DEAD still closes")
+    func railsOnClosesBusyTerminalWithDeadWindow() async throws {
+        let fx = try await makeFixture(activityState: .working)
+        let router = makeRouter(db: fx.db, windowIsDead: true)
+
+        let resp = try await close(router, fx.terminal.id, rails: true)
+
+        #expect(resp.success, "a dead-window row cannot be mid-turn")
+        #expect(resp.errorCode == nil)
+        #expect(try await fx.db.terminals.get(id: fx.terminal.id) == nil)
+    }
+
+    // MARK: - Idempotency and result payload
+
+    @Test("closing an already-closed terminal is a no-op success")
+    func alreadyGoneIsSuccess() async throws {
+        let fx = try await makeFixture()
+        let router = makeRouter(db: fx.db)
+
+        let first = try await close(router, fx.terminal.id, rails: true)
+        #expect(try first.decodeResult(TerminalDeleteResult.self).closed)
+
+        let second = try await close(router, fx.terminal.id, rails: true)
+        #expect(second.success, "matches terminal.wake's documented idempotency")
+        let result = try second.decodeResult(TerminalDeleteResult.self)
+        #expect(!result.closed)
+        #expect(result.alreadyGone)
+    }
+
+    @Test("closing an unknown terminal is a no-op success, not an error")
+    func unknownTerminalIsSuccess() async throws {
+        let fx = try await makeFixture()
+        let router = makeRouter(db: fx.db)
+
+        let resp = try await close(router, UUID(), rails: true)
+
+        #expect(resp.success)
+        #expect(try resp.decodeResult(TerminalDeleteResult.self).alreadyGone)
+    }
+
+    @Test("the result echoes the Claude session id so a caller keeps a resume pointer")
+    func resultCarriesSessionID() async throws {
+        let fx = try await makeFixture(claudeSessionID: "sess-xyz")
+        let router = makeRouter(db: fx.db)
+
+        let resp = try await close(router, fx.terminal.id, rails: true)
+
+        #expect(try resp.decodeResult(TerminalDeleteResult.self).claudeSessionID == "sess-xyz")
+    }
+
+    @Test("a non-Claude terminal reports no session id")
+    func shellTerminalHasNoSessionID() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/tcr-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "wt", branch: "b",
+            path: "/tmp/tcr-wt-\(UUID().uuidString)", tmuxServer: "tbd-tcr")
+        let shell = try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: "shell", claudeSessionID: nil, kind: .shell)
+        let router = makeRouter(db: db)
+
+        let resp = try await close(router, shell.id, rails: true)
+
+        let result = try resp.decodeResult(TerminalDeleteResult.self)
+        #expect(result.closed)
+        #expect(result.claudeSessionID == nil)
+    }
+}


### PR DESCRIPTION
## Summary

The daemon has had this semantic all along — `terminal.delete`, which the app's tab-close has used since forever. Only the CLI never got a surface over it.

Without one, callers reach around the daemon with raw `tmux kill-window`. That does **not** close a Claude terminal: reconcile sees a dead window on a resumable row and *parks* it `.recovery`-hibernated with the session preserved (`WorktreeLifecycle+Reconcile.swift:282-289`), and focus-wake excludes only `.manual` parks (`AppState+Hibernation.swift:306-317`) — so navigating to the worktree respawns it. Meanwhile `captureOnClose` never runs, so the scrollback is gone. The predecessor isn't closed; it's zombified, and it can come back.

Companion to #506, which fixed the desk prompt that had been telling sessions to run `tbd terminal close --all` — a command that never existed — for five days.

## Surface

```
tbd terminal close --terminal <uuid> [--force] [--json]
```

Deliberately one target. `--all`/`--except`/`--dry-run` are not built; rationale is §2.1 and §6 D2 of the design doc landing in #506. Short version: `--all`'s only documented consumer was an instruction a working `--all` would have served *backwards*, because no close command can recycle the session that invokes it.

## Daemon changes (additive, decode-compatible)

- `terminal.delete` returns `TerminalDeleteResult{closed, alreadyGone, claudeSessionID}`, and an unknown terminal is a **no-op success** rather than an error — matching `terminal.wake`'s documented idempotency. Autonomous callers retry and race; making the loser fail pushes everyone into string-matching an error that embeds a UUID. App-invisible: it calls `callVoidAsync` and discards results.
- Optional `TerminalDeleteParams.respectActivityRails`. `nil`/`false` keeps today's unconditional close, so the app's tab-close — a direct human gesture on a visible tab — is unchanged. The CLI sets it; `--force` drops it.
- `RPCErrorCode.terminalBusy`, so the CLI maps the refusal to exit 2 without parsing prose.

**The rail is qualified on the window being alive**, which is the non-obvious part. `activityState` is hook-fed and carries no timestamp (`Models.swift` — a bare enum), so a session that died mid-turn stays `.working` forever. An unqualified rail would refuse forever on exactly the wedged terminal you most need to close — turning the safety rail into a trap for this command's primary cleanup use case, including the zombie rows the `kill-window` workaround leaves behind.

**Self-close is refused before the RPC** (exit 2, no override). Killing the window SIGHUPs the calling shell, so the process dies mid-`recv` and could never report its own result. With a single target, skipping instead of refusing would exit 0 having done nothing — which an autonomous caller reads as success.

## Test plan

- [x] `swift test` — 3877 tests / 460 suites green (1 known issue: the quarantine self-test fixture, red once by design)
- [x] `swiftlint --strict` — 0 violations
- [x] 9 new tests covering **both branches of the rail conditional** per the repo rule: rails off closes a busy terminal (app path unchanged), rails on refuses it, rails on with a **dead** window still closes, idle closes either way, plus idempotency and the result payload
- [x] Exit codes verified against the built binary, not assumed: `2` self-close (incl. a lowercase `TBD_TERMINAL_ID`), `64` missing `--terminal`, `1` invalid UUID
- [ ] Live end-to-end close against a daemon built from this branch — the currently-running daemon is from `main` and returns the old shape, so I only exercised the pre-RPC paths locally

## Notes for the reviewer

- **One design-doc correction.** §D4 of the doc in #506 says `SocketClient` needs a change to surface `errorCode`. That's wrong — `send()` already returns the full `RPCResponse`, as `CleanupCommand` does. No `SocketClient` change here; I'll fix the doc on #506.
- **Not included:** `handoff.py`'s migration off `kill-window`. It now lives in `NightwatchSkillContent` (#506) and a sibling worktree owns the next edit to it, so this rebases onto that rather than racing it. Until then `--close-predecessor` still uses the zombifying path.
- Merge order doesn't matter — this touches no file #506 touches.

[terminal-close-design](https://cheapsteak.github.io/tbd/open/?worktree=F97E72C1-E4F7-4D95-8080-82813621C056)