### PR TITLE
feat: searchable pane-history palette (replaces the undiscoverable right-click MRU dropdown)

### DIFF
--- a/Sources/TBDApp/Panes/PaneHistoryPalette.swift
+++ b/Sources/TBDApp/Panes/PaneHistoryPalette.swift
@@ -33,14 +33,6 @@ func paneHistorySearchText(for content: PaneContent) -> String {
     return paneHistoryLabel(for: content)
 }
 
-/// Parent directory shown dimmed under a file entry's basename; nil for
-/// every other pane type (and for a bare filename with no directory).
-func paneHistoryParentDirectory(for content: PaneContent) -> String? {
-    guard case .codeViewer(_, let path) = content else { return nil }
-    let dir = (path as NSString).deletingLastPathComponent
-    return dir.isEmpty ? nil : dir
-}
-
 /// Pure substring filter behind the palette's search field: case-insensitive,
 /// no fuzzy matching. Empty query matches everything, preserving MRU order.
 enum PaneHistoryPaletteFilter {
@@ -110,10 +102,11 @@ struct PaneHistoryPaletteView: View {
                         }
                     }
                 }
+                .padding(.vertical, 6)
             }
             .frame(maxHeight: 240)
         }
-        .frame(width: 280)
+        .frame(minWidth: 280, maxWidth: 460)
         .onAppear { searchFocused = true }
         .onChange(of: query) { _, _ in highlightedPosition = 0 }
     }
@@ -127,17 +120,9 @@ struct PaneHistoryPaletteView: View {
                 .opacity(entryIndex == history.cursor ? 1 : 0)
                 .frame(width: 12)
 
-            VStack(alignment: .leading, spacing: 0) {
-                Text(paneHistoryLabel(for: content))
-                    .font(.caption)
-                    .lineLimit(1)
-                if let parentDir = paneHistoryParentDirectory(for: content) {
-                    Text(parentDir)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
+            Text(paneHistoryLabel(for: content))
+                .font(.caption)
+                .lineLimit(1)
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 8)

--- a/Sources/TBDApp/Panes/PaneHistoryPalette.swift
+++ b/Sources/TBDApp/Panes/PaneHistoryPalette.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+import TBDShared
+
+// MARK: - Label / search-text helpers
+//
+// Single source of truth for how a pane-history entry reads, reused by
+// `PaneHistoryPaletteView` below. This is exactly the labeling the old
+// right-click history dropdown used (PR #472) before the palette replaced it.
+
+/// Display label for a pane-history entry.
+func paneHistoryLabel(for content: PaneContent) -> String {
+    switch content {
+    case .codeViewer(_, let path):
+        return URL(fileURLWithPath: path).lastPathComponent
+    case .webview(_, let url):
+        return (url.host ?? "") + url.path
+    case .liveTranscript:
+        return "Transcript"
+    case .terminal:
+        return "Terminal"
+    case .note:
+        return "Note"
+    }
+}
+
+/// Text the palette's search field matches against. Same as the display
+/// label, except file entries match on their full path — not just the
+/// basename — so a query like `foo/bar` finds a file at that path.
+func paneHistorySearchText(for content: PaneContent) -> String {
+    if case .codeViewer(_, let path) = content {
+        return path
+    }
+    return paneHistoryLabel(for: content)
+}
+
+/// Parent directory shown dimmed under a file entry's basename; nil for
+/// every other pane type (and for a bare filename with no directory).
+func paneHistoryParentDirectory(for content: PaneContent) -> String? {
+    guard case .codeViewer(_, let path) = content else { return nil }
+    let dir = (path as NSString).deletingLastPathComponent
+    return dir.isEmpty ? nil : dir
+}
+
+/// Pure substring filter behind the palette's search field: case-insensitive,
+/// no fuzzy matching. Empty query matches everything, preserving MRU order.
+enum PaneHistoryPaletteFilter {
+    static func filteredIndices(entries: [PaneContent], query: String) -> [Int] {
+        guard !query.isEmpty else { return Array(entries.indices) }
+        let needle = query.lowercased()
+        return entries.indices.filter {
+            paneHistorySearchText(for: entries[$0]).lowercased().contains(needle)
+        }
+    }
+}
+
+/// Pure gate behind the search icon: disabled when there's one entry or
+/// fewer — nothing else to jump to. Extracted from the view so it's
+/// unit-testable without SwiftUI (same pattern as `ParkedPaneWakeModel`).
+enum PaneHistoryPaletteButtonModel {
+    static func isEnabled(entryCount: Int) -> Bool {
+        entryCount > 1
+    }
+}
+
+// MARK: - PaneHistoryPaletteView
+
+/// Searchable palette over a pane's MRU history (PR #472/#478's
+/// `PaneHistory` / `MRUHistory<PaneContent>`). Replaces the old right-click
+/// dropdown on the history chevrons, which was undiscoverable. Read-only over
+/// the passed-in `history`; selecting an entry calls back with its index so
+/// the caller can drive the SAME `go(to:)` cursor-jump the old menu used —
+/// this view never mutates history itself.
+struct PaneHistoryPaletteView: View {
+    let history: PaneHistory
+    let onSelect: (Int) -> Void
+
+    @State private var query = ""
+    @State private var highlightedPosition = 0
+    @FocusState private var searchFocused: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    private var filteredIndices: [Int] {
+        PaneHistoryPaletteFilter.filteredIndices(entries: history.entries, query: query)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            TextField("Search history", text: $query)
+                .textFieldStyle(.plain)
+                .padding(8)
+                .focused($searchFocused)
+                .onKeyPress(.downArrow) { move(by: 1); return .handled }
+                .onKeyPress(.upArrow) { move(by: -1); return .handled }
+                .onKeyPress(.return) { selectHighlighted(); return .handled }
+                .onKeyPress(.escape) { dismiss(); return .handled }
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if filteredIndices.isEmpty {
+                        Text("No matches")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(8)
+                    } else {
+                        ForEach(Array(filteredIndices.enumerated()), id: \.element) { position, entryIndex in
+                            row(entryIndex: entryIndex, isHighlighted: position == highlightedPosition)
+                                .onTapGesture { select(entryIndex) }
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: 240)
+        }
+        .frame(width: 280)
+        .onAppear { searchFocused = true }
+        .onChange(of: query) { _, _ in highlightedPosition = 0 }
+    }
+
+    @ViewBuilder
+    private func row(entryIndex: Int, isHighlighted: Bool) -> some View {
+        let content = history.entries[entryIndex]
+        HStack(spacing: 6) {
+            Image(systemName: "checkmark")
+                .font(.caption2)
+                .opacity(entryIndex == history.cursor ? 1 : 0)
+                .frame(width: 12)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(paneHistoryLabel(for: content))
+                    .font(.caption)
+                    .lineLimit(1)
+                if let parentDir = paneHistoryParentDirectory(for: content) {
+                    Text(parentDir)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(isHighlighted ? Color.accentColor.opacity(0.15) : Color.clear)
+        .contentShape(Rectangle())
+    }
+
+    private func move(by delta: Int) {
+        guard !filteredIndices.isEmpty else { return }
+        let count = filteredIndices.count
+        highlightedPosition = ((highlightedPosition + delta) % count + count) % count
+    }
+
+    private func selectHighlighted() {
+        guard filteredIndices.indices.contains(highlightedPosition) else { return }
+        select(filteredIndices[highlightedPosition])
+    }
+
+    private func select(_ entryIndex: Int) {
+        onSelect(entryIndex)
+        dismiss()
+    }
+}

--- a/Sources/TBDApp/Panes/PaneHistoryPalette.swift
+++ b/Sources/TBDApp/Panes/PaneHistoryPalette.swift
@@ -45,12 +45,13 @@ enum PaneHistoryPaletteFilter {
     }
 }
 
-/// Pure gate behind the search icon: disabled when there's one entry or
-/// fewer — nothing else to jump to. Extracted from the view so it's
-/// unit-testable without SwiftUI (same pattern as `ParkedPaneWakeModel`).
+/// Pure gate behind the search icon: disabled only at zero entries — a live
+/// viewer slot always has at least its current content, so in practice this
+/// button is always enabled. Extracted from the view so it's unit-testable
+/// without SwiftUI (same pattern as `ParkedPaneWakeModel`).
 enum PaneHistoryPaletteButtonModel {
     static func isEnabled(entryCount: Int) -> Bool {
-        entryCount > 1
+        entryCount > 0
     }
 }
 
@@ -79,7 +80,9 @@ struct PaneHistoryPaletteView: View {
         VStack(alignment: .leading, spacing: 0) {
             TextField("Search history", text: $query)
                 .textFieldStyle(.plain)
-                .padding(8)
+                .padding(.horizontal, 8)
+                .padding(.top, 16)
+                .padding(.bottom, 8)
                 .focused($searchFocused)
                 .onKeyPress(.downArrow) { move(by: 1); return .handled }
                 .onKeyPress(.upArrow) { move(by: -1); return .handled }
@@ -102,7 +105,7 @@ struct PaneHistoryPaletteView: View {
                         }
                     }
                 }
-                .padding(.vertical, 6)
+                .padding(.bottom, 6)
             }
             .frame(maxHeight: 240)
         }

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -51,6 +51,7 @@ struct PanePlaceholder: View {
     @State private var isHeaderHovering = false
     @State private var showSourceCode = false
     @State private var hasRenderableContent = false
+    @State private var showHistoryPalette = false
     @StateObject private var webviewState = WebviewState()
     @State private var didCopyURL = false
     @AppStorage(AppState.enableTranscriptKey)
@@ -238,15 +239,17 @@ struct PanePlaceholder: View {
 
     // MARK: - Slot History Navigation
 
-    /// Back/forward chevrons for viewer-class slot panes. Left-click steps
-    /// one entry; right-click either chevron shows the SAME full MRU list
-    /// (newest first, checkmark on the current entry) for direct jumps.
+    /// Search icon + back/forward chevrons for viewer-class slot panes. The
+    /// search icon opens the MRU history palette (searchable replacement for
+    /// the old right-click dropdown — see `historySearchButton`); the
+    /// chevrons still left-click step one entry at a time.
     @ViewBuilder
     private var historyNavigation: some View {
         let history = appState.paneHistories[content.paneID] ?? PaneHistory()
 
+        historySearchButton(history: history)
+
         historyButton(
-            history: history,
             icon: "chevron.left",
             help: "Back",
             action: { navigateHistory { $0.goBack() } }
@@ -254,7 +257,6 @@ struct PanePlaceholder: View {
         .disabled(!history.canGoBack)
 
         historyButton(
-            history: history,
             icon: "chevron.right",
             help: "Forward",
             action: { navigateHistory { $0.goForward() } }
@@ -262,11 +264,32 @@ struct PanePlaceholder: View {
         .disabled(!history.canGoForward)
     }
 
-    /// Plain Button + .contextMenu — NOT Menu(primaryAction:), whose label
-    /// right-click fell through to the header's context menu, and never
-    /// .onTapGesture, which blocks .contextMenu on macOS.
+    /// Search icon opening the searchable MRU-history palette (replaces the
+    /// former right-click dropdown on the chevrons, which was
+    /// undiscoverable). Disabled when there's nothing to browse — a single
+    /// entry means no other place to jump to.
+    private func historySearchButton(history: PaneHistory) -> some View {
+        Button(action: { showHistoryPalette = true }) {
+            Image(systemName: "text.magnifyingglass")
+                .font(.system(size: 8, weight: .bold))
+                .frame(width: 16, height: 16)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.borderless)
+        .help("Search pane history")
+        .disabled(!PaneHistoryPaletteButtonModel.isEnabled(entryCount: history.entries.count))
+        .popover(isPresented: $showHistoryPalette, arrowEdge: .bottom) {
+            PaneHistoryPaletteView(history: history) { index in
+                navigateHistory { $0.go(to: index) }
+            }
+        }
+    }
+
+    /// Plain Button — no `.contextMenu` (that dropdown is now the palette
+    /// above); never `.onTapGesture`, which blocks `.contextMenu` on macOS
+    /// (moot here since there's none left, but keeping the plain-Button
+    /// shape avoids reintroducing the trap).
     private func historyButton(
-        history: PaneHistory,
         icon: String,
         help: String,
         action: @escaping () -> Void
@@ -281,21 +304,6 @@ struct PanePlaceholder: View {
         }
         .buttonStyle(.borderless)
         .help(help)
-        .contextMenu {
-            ForEach(Array(history.entries.enumerated()), id: \.offset) { index, entry in
-                Button {
-                    navigateHistory { $0.go(to: index) }
-                } label: {
-                    // Explicit checkmark symbol on the cursor entry — renders
-                    // reliably in a .contextMenu, unlike Toggle state.
-                    if index == history.cursor {
-                        Label(historyEntryLabel(entry), systemImage: "checkmark")
-                    } else {
-                        Text(historyEntryLabel(entry))
-                    }
-                }
-            }
-        }
     }
 
     /// Applies a history navigation to this slot: mutate the slot's history,
@@ -309,21 +317,6 @@ struct PanePlaceholder: View {
         else { return }
         appState.paneHistories[content.paneID] = history
         layout = updated
-    }
-
-    private func historyEntryLabel(_ content: PaneContent) -> String {
-        switch content {
-        case .codeViewer(_, let path):
-            return URL(fileURLWithPath: path).lastPathComponent
-        case .webview(_, let url):
-            return (url.host ?? "") + url.path
-        case .liveTranscript:
-            return "Transcript"
-        case .terminal:
-            return "Terminal"
-        case .note:
-            return "Note"
-        }
     }
 
     // MARK: - Pane Body

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -270,7 +270,7 @@ struct PanePlaceholder: View {
     /// entry means no other place to jump to.
     private func historySearchButton(history: PaneHistory) -> some View {
         Button(action: { showHistoryPalette = true }) {
-            Image(systemName: "text.magnifyingglass")
+            Image(systemName: "line.3.horizontal")
                 .font(.system(size: 8, weight: .bold))
                 .frame(width: 16, height: 16)
                 .contentShape(Rectangle())

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -245,7 +245,12 @@ struct PanePlaceholder: View {
     /// chevrons still left-click step one entry at a time.
     @ViewBuilder
     private var historyNavigation: some View {
-        let history = appState.paneHistories[content.paneID] ?? PaneHistory()
+        // A pane that hasn't navigated yet has no recorded history — but it
+        // always has its current content, so fall back to a single-entry
+        // history seeded with it rather than an empty one. Otherwise the
+        // search button would wrongly read as "nothing to show" for the
+        // common case of a freshly opened viewer slot.
+        let history = appState.paneHistories[content.paneID] ?? PaneHistory.seeded(with: content)
 
         historySearchButton(history: history)
 
@@ -266,12 +271,19 @@ struct PanePlaceholder: View {
 
     /// Search icon opening the searchable MRU-history palette (replaces the
     /// former right-click dropdown on the chevrons, which was
-    /// undiscoverable). Disabled when there's nothing to browse — a single
-    /// entry means no other place to jump to.
+    /// undiscoverable). Always enabled for a live viewer slot — it always
+    /// has at least its current entry to show, checkmarked, even before any
+    /// navigation has happened. Disabled only at zero entries, which in
+    /// practice never happens here.
     private func historySearchButton(history: PaneHistory) -> some View {
         Button(action: { showHistoryPalette = true }) {
+            // A couple points larger and a lighter weight than the 8pt/bold
+            // chevrons/close glyph: at 8pt bold, "line.3.horizontal"'s three
+            // bars crowd into a smudge. Regular weight + a touch more size
+            // gives the bars air while still reading as the lightest glyph
+            // in the row (not heavier than its neighbors).
             Image(systemName: "line.3.horizontal")
-                .font(.system(size: 8, weight: .bold))
+                .font(.system(size: 10, weight: .regular))
                 .frame(width: 16, height: 16)
                 .contentShape(Rectangle())
         }

--- a/Tests/TBDAppTests/PaneHistoryPaletteTests.swift
+++ b/Tests/TBDAppTests/PaneHistoryPaletteTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDApp
+
+// MARK: - PaneHistoryPaletteFilter / labels
+//
+// The palette's popover, auto-focus, and keyboard navigation are SwiftUI/
+// AppKit interaction and are NOT exercised here — they need LIVE
+// verification (restart the app and check: icon appears left of the
+// chevrons and is disabled at ≤1 history entry, popover opens with the
+// search field focused, ↑/↓ move the highlight, Enter navigates + closes,
+// Esc closes without navigating, and a mouse click on a row does the same
+// as Enter). What IS covered below is the pure logic: substring filtering
+// (including full-path matching for file entries), the disabled-when-≤1
+// gate, and that a filtered row's index still drives the same MRU
+// `go(to:)` cursor-jump the old right-click dropdown used.
+
+@Suite("PaneHistoryPaletteFilter")
+struct PaneHistoryPaletteFilterTests {
+    private func entries() -> [PaneContent] {
+        [
+            .codeViewer(id: UUID(), path: "/repo/Sources/TBDApp/AppState.swift"),
+            .webview(id: UUID(), url: URL(string: "https://github.com/foo/bar")!),
+            .liveTranscript(id: UUID(), terminalID: UUID()),
+        ]
+    }
+
+    @Test func emptyQueryReturnsEveryEntryInOrder() {
+        let indices = PaneHistoryPaletteFilter.filteredIndices(entries: entries(), query: "")
+        #expect(indices == [0, 1, 2])
+    }
+
+    @Test func matchesLabelCaseInsensitively() {
+        // "TRANSCRIPT" should match the liveTranscript entry's "Transcript" label.
+        let indices = PaneHistoryPaletteFilter.filteredIndices(entries: entries(), query: "TRANSCRIPT")
+        #expect(indices == [2])
+    }
+
+    @Test func matchesWebviewHostAndPath() {
+        let indices = PaneHistoryPaletteFilter.filteredIndices(entries: entries(), query: "github.com/foo")
+        #expect(indices == [1])
+    }
+
+    @Test func matchesFileEntryOnFullPathNotJustBasename() {
+        // "AppState.swift" alone is the basename shown; "Sources/TBDApp" is
+        // only in the full path — must still match (requirement 3 in the
+        // spec: file entries match on their full path).
+        let indices = PaneHistoryPaletteFilter.filteredIndices(entries: entries(), query: "Sources/TBDApp")
+        #expect(indices == [0])
+    }
+
+    @Test func noMatchReturnsEmpty() {
+        let indices = PaneHistoryPaletteFilter.filteredIndices(entries: entries(), query: "nonexistent-zzz")
+        #expect(indices.isEmpty)
+    }
+
+    @Test func labelForCodeViewerIsBasenameOnly() {
+        #expect(paneHistoryLabel(for: .codeViewer(id: UUID(), path: "/a/b/c.swift")) == "c.swift")
+    }
+
+    @Test func parentDirectoryIsNilForNonFileEntries() {
+        #expect(paneHistoryParentDirectory(for: .liveTranscript(id: UUID(), terminalID: UUID())) == nil)
+    }
+
+    @Test func parentDirectoryIsDimmedDirectoryForFileEntries() {
+        #expect(paneHistoryParentDirectory(for: .codeViewer(id: UUID(), path: "/a/b/c.swift")) == "/a/b")
+    }
+}
+
+@Suite("PaneHistoryPaletteButtonModel")
+struct PaneHistoryPaletteButtonModelTests {
+    @Test func disabledWithZeroOrOneEntry() {
+        #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 0) == false)
+        #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 1) == false)
+    }
+
+    @Test func enabledWithTwoOrMoreEntries() {
+        #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 2) == true)
+        #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 10) == true)
+    }
+}
+
+// MARK: - Selection reuses the same MRU cursor-jump
+
+@Suite("PaneHistoryPalette selection drives MRUHistory.go(to:)")
+struct PaneHistoryPaletteSelectionTests {
+    /// A filtered row's position in the visible list is NOT the same as its
+    /// index in `history.entries` once a query has narrowed the list. This
+    /// reproduces exactly what `PaneHistoryPaletteView.select(_:)` does:
+    /// resolve the row back to its absolute `entries` index via
+    /// `filteredIndices`, then jump with the same `go(to:)` the old
+    /// right-click dropdown used — never a parallel navigation path.
+    @Test func selectingAFilteredRowJumpsToItsAbsoluteEntry() {
+        let slotID = UUID()
+        var history = PaneHistory()
+        // Build up an MRU order: /old, /middle, /keep (cursor lands on /keep).
+        history.recordReplacement(
+            outgoing: .codeViewer(id: slotID, path: "/old"),
+            incoming: .codeViewer(id: slotID, path: "/middle")
+        )
+        history.recordReplacement(
+            outgoing: .codeViewer(id: slotID, path: "/middle"),
+            incoming: .codeViewer(id: slotID, path: "/keep")
+        )
+        // entries is now MRU order: [/keep, /middle, /old], cursor == 0.
+        #expect(history.entries == [
+            .codeViewer(id: slotID, path: "/keep"),
+            .codeViewer(id: slotID, path: "/middle"),
+            .codeViewer(id: slotID, path: "/old"),
+        ])
+
+        // Query "old" narrows the visible list to just entry index 2.
+        let filtered = PaneHistoryPaletteFilter.filteredIndices(entries: history.entries, query: "old")
+        #expect(filtered == [2])
+
+        // Selecting that (only) visible row must land on absolute index 2.
+        let target = filtered[0]
+        let jumped = history.go(to: target)
+
+        #expect(jumped == .codeViewer(id: slotID, path: "/old"))
+        #expect(history.cursor == 2)
+    }
+}

--- a/Tests/TBDAppTests/PaneHistoryPaletteTests.swift
+++ b/Tests/TBDAppTests/PaneHistoryPaletteTests.swift
@@ -57,15 +57,9 @@ struct PaneHistoryPaletteFilterTests {
     }
 
     @Test func labelForCodeViewerIsBasenameOnly() {
+        // Row display drops the full path entirely (single-line, basename
+        // only) — this is the same helper the row view calls for its label.
         #expect(paneHistoryLabel(for: .codeViewer(id: UUID(), path: "/a/b/c.swift")) == "c.swift")
-    }
-
-    @Test func parentDirectoryIsNilForNonFileEntries() {
-        #expect(paneHistoryParentDirectory(for: .liveTranscript(id: UUID(), terminalID: UUID())) == nil)
-    }
-
-    @Test func parentDirectoryIsDimmedDirectoryForFileEntries() {
-        #expect(paneHistoryParentDirectory(for: .codeViewer(id: UUID(), path: "/a/b/c.swift")) == "/a/b")
     }
 }
 

--- a/Tests/TBDAppTests/PaneHistoryPaletteTests.swift
+++ b/Tests/TBDAppTests/PaneHistoryPaletteTests.swift
@@ -9,11 +9,12 @@ import TBDShared
 // The palette's popover, auto-focus, and keyboard navigation are SwiftUI/
 // AppKit interaction and are NOT exercised here — they need LIVE
 // verification (restart the app and check: icon appears left of the
-// chevrons and is disabled at ≤1 history entry, popover opens with the
-// search field focused, ↑/↓ move the highlight, Enter navigates + closes,
-// Esc closes without navigating, and a mouse click on a row does the same
-// as Enter). What IS covered below is the pure logic: substring filtering
-// (including full-path matching for file entries), the disabled-when-≤1
+// chevrons and is enabled whenever there's at least one entry (always true
+// for a live viewer slot), popover opens with the search field focused,
+// ↑/↓ move the highlight, Enter navigates + closes, Esc closes without
+// navigating, and a mouse click on a row does the same as Enter). What IS
+// covered below is the pure logic: substring filtering (including
+// full-path matching for file entries), the disabled-at-zero-entries
 // gate, and that a filtered row's index still drives the same MRU
 // `go(to:)` cursor-jump the old right-click dropdown used.
 
@@ -65,12 +66,12 @@ struct PaneHistoryPaletteFilterTests {
 
 @Suite("PaneHistoryPaletteButtonModel")
 struct PaneHistoryPaletteButtonModelTests {
-    @Test func disabledWithZeroOrOneEntry() {
+    @Test func disabledWithZeroEntries() {
         #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 0) == false)
-        #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 1) == false)
     }
 
-    @Test func enabledWithTwoOrMoreEntries() {
+    @Test func enabledWithOneOrMoreEntries() {
+        #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 1) == true)
         #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 2) == true)
         #expect(PaneHistoryPaletteButtonModel.isEnabled(entryCount: 10) == true)
     }


### PR DESCRIPTION
- **What**: the viewer pane header's back/forward history (the MRU list from #472/#478) was only reachable by right-clicking the chevrons — undiscoverable. This adds a visible hamburger button (`line.3.horizontal`, left of the `< >` chevrons) that opens a searchable popover of the slot's recently-viewed entries: auto-focused search field, case-insensitive substring filter (matches file paths too), ↑/↓ + Enter to jump, Esc to close, click to jump. The right-click dropdown on the chevrons is removed (now a no-op).
- **Scope**: app-side only. Read-only over the existing `MRUHistory`/`PaneHistory` (shipped #472/#478) — no new store, no daemon/RPC/schema/flag changes. Independent of the Phase 1/2 panel-surface work.
- **Behavior notes**: the button is always enabled for a viewer slot (a never-navigated pane opens showing its single current entry, checkmarked — no dead click); file rows show filename only (path dropped to avoid clutter); popover grows to fit long filenames (up to ~460pt).
- **Verification**: full suite 3872 tests green, swiftlint --strict clean; the popover/focus/keyboard-nav/icon were verified live via restart + user eyeball across three iterations (icon un-squished to 10pt/regular, list padding above the search field, always-open behavior).
- Note it was built + iterated behind the usual live-UI loop; no feature flag (small additive gesture-driven UI, nothing autonomous or destructive).