### PR TITLE
fix: stop first-launch reconcile from wiping pane back/forward history

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1894,6 +1894,14 @@ final class AppState: ObservableObject {
                     reconcileNoteTabs(worktreeID: wtID, notes: fetched)
                 }
             }
+
+            // Prune slot histories only after every visible worktree's tabs
+            // have been reconciled this cycle. Doing it inside the per-worktree
+            // `reconcileTabs` loop above would run against a partially-populated
+            // `tabs` on the first launch pass, deleting (and persisting as `[]`)
+            // histories for worktrees not yet loaded — the pane back/forward
+            // history was lost on every restart because of that.
+            prunePaneHistories()
         } catch {
             logger.error("Failed to list worktrees: \(error)")
             handleConnectionError(error)
@@ -1975,7 +1983,6 @@ final class AppState: ObservableObject {
 
         tabs[worktreeID] = currentTabs
         applyStoredOrder(worktreeID: worktreeID)
-        prunePaneHistories()
         if !alreadyLoadedOrder {
             Task { await loadTabStates(worktreeID: worktreeID) }
         }

--- a/Tests/TBDAppTests/PaneHistoryAppStateTests.swift
+++ b/Tests/TBDAppTests/PaneHistoryAppStateTests.swift
@@ -197,6 +197,57 @@ struct PaneHistoryAppStateTests {
         }
     }
 
+    /// Restart regression: on launch, worktrees reconcile one at a time as
+    /// their terminal lists arrive. Reconciling the FIRST worktree must not
+    /// delete a second worktree's slot history just because that worktree's
+    /// tabs haven't been loaded yet. Before the fix, `reconcileTabs` pruned
+    /// against the partially-populated `tabs`, wiping (and persisting as `[]`)
+    /// every other worktree's history on the first pass.
+    @Test func startupReconcileKeepsOtherWorktreesHistoriesUntilAllLoaded() {
+        withIsolatedDefaults { defaults in
+            let state = AppState(userDefaults: defaults)
+
+            // Two worktrees, each with a viewer slot recorded in a persisted
+            // layout + a persisted history — the on-disk state after a restart.
+            let wtA = UUID(), tabA = UUID(), slotA = UUID()
+            let wtB = UUID(), tabB = UUID(), slotB = UUID()
+
+            func viewerLayout(tabTerminal: UUID, slot: UUID) -> LayoutNode {
+                .split(
+                    id: UUID(), direction: .horizontal,
+                    children: [
+                        .pane(.terminal(terminalID: tabTerminal)),
+                        .pane(.codeViewer(id: slot, path: "/a")),
+                    ],
+                    ratios: [0.5, 0.5]
+                )
+            }
+            state.layouts[tabA] = viewerLayout(tabTerminal: tabA, slot: slotA)
+            state.layouts[tabB] = viewerLayout(tabTerminal: tabB, slot: slotB)
+
+            func history(for slot: UUID) -> PaneHistory {
+                var h = PaneHistory()
+                h.recordReplacement(
+                    outgoing: .codeViewer(id: slot, path: "/old"),
+                    incoming: .codeViewer(id: slot, path: "/a")
+                )
+                return h
+            }
+            state.paneHistories = [slotA: history(for: slotA), slotB: history(for: slotB)]
+
+            let terminalA = Terminal(id: tabA, worktreeID: wtA, tmuxWindowID: "@a",
+                                     tmuxPaneID: "%a", label: "A", kind: .shell)
+
+            // First loop iteration: only worktree A reconciles. Worktree B's
+            // tabs are still absent — its history must survive regardless.
+            state.reconcileTabs(worktreeID: wtA, terminals: [terminalA])
+
+            #expect(state.paneHistories[slotB] != nil,
+                    "a not-yet-reconciled worktree's history must not be wiped on the first startup pass")
+            #expect(state.paneHistories[slotA] != nil)
+        }
+    }
+
     /// #477 regression: a stale worktree-keyed entry left in the tab-keyed
     /// `layouts` dict (pre-#478 pollution — not a real tab) must not keep its
     /// history alive just because `layouts.values` used to include it.


### PR DESCRIPTION
## Root cause

`prunePaneHistories()` was called at the end of `reconcileTabs()`. The startup refresh loop (`refreshWorktrees`) calls `reconcileTabs` **once per worktree**, populating `tabs` one worktree at a time. On the first launch pass `tabs` starts empty, so the first worktree's reconcile builds `liveIDs` from only that worktree and prunes every history whose slot belongs to a worktree **not yet reconciled**. The prune is destructive and `paneHistories`'s `didSet` persists immediately, so those histories are deleted permanently and `com.tbd.app.paneHistories` is written as `[]` (the confirmed on-disk symptom: exactly 2 bytes, `0x5b5d`).

This is why layouts (`com.tbd.app.layouts`) survived restart fine while pane back/forward (`< >`) history and the history search palette always came back empty.

## The fix

Move the prune out of the per-worktree `reconcileTabs` and run it **once** at the end of the `refreshWorktrees` reconcile loop, after every visible worktree's tabs (and note tabs) have been reconciled — i.e. when `tabs` is fully populated. Pruning against the complete tab set can no longer mistake a not-yet-loaded worktree's live slot for an orphan.

The explicit prune on tab-close (`AppState+Tabs.swift`) is unchanged: it runs at runtime with fully-loaded tabs and is still needed to drop a closed tab's viewer history.

Scope: app-side legacy `Pane*` UserDefaults path only. The daemon panel surface (`PanelSurfaceStore`, `panel.*` RPCs, `v59_panel_surface`) is untouched.

## Regression test

`startupReconcileKeepsOtherWorktreesHistoriesUntilAllLoaded` in `PaneHistoryAppStateTests`: seeds two worktrees' persisted layouts + histories (the on-disk state after a restart), then calls `reconcileTabs` for only the first worktree (the first loop iteration). It asserts the second, not-yet-reconciled worktree's history survives. Fails on old code (`state.paneHistories[slotB] → nil`), passes with the fix. Uses an isolated `UserDefaults(suiteName:)` torn down with `removePersistentDomain`, per project test-isolation rules.

## Verification

- `swift build` — clean.
- `swift test --filter "PaneHistoryAppStateTests|AppStateTerminalReconciliationTests"` — 14 tests, all green (new regression test included; sibling reconciliation suite unaffected).
- `swiftlint --strict` on both changed files — 0 violations.
