### PR TITLE
feat: expose daemon-owned panel surface via tbd panel CLI

### DIFF
--- a/Sources/TBDCLI/Commands/PanelCommands.swift
+++ b/Sources/TBDCLI/Commands/PanelCommands.swift
@@ -354,6 +354,9 @@ struct PanelSelectTab: AsyncParsableCommand {
         let worktreeID = try resolveWorktreeArg(worktree, client: client)
         let tabID = try parseUUID(tab, label: "tab ID")
 
+        // baseRevision here is the SELECTED tab's own revision (there's no
+        // separate target panel/tab) — fine because selectTab never mutates
+        // a tab's layout, so staleness on that tab's tree can't apply.
         let result = try applyPanelOperation(
             client: client, worktreeID: worktreeID, tabID: tabID,
             operation: .selectTab(tabID: tabID))
@@ -435,21 +438,23 @@ func resolvePanelContent(_ opts: ContentOptions) throws -> PanelContent {
                 ? "Specify one of --file, --web, --transcript, --note"
                 : "Specify only one of --file, --web, --transcript, --note")
     }
-    return resolved[0]
+    let content = resolved[0]
+    if opts.render || opts.source {
+        guard case .file = content else {
+            throw CLIError.invalidArgument("--render/--source only apply to --file")
+        }
+    }
+    return content
 }
 
 /// Resolve `PlacementOptions` into a `PanelPlacement`. `--replace` and
 /// `--beside` are mutually exclusive; `--edge`/`--share` are only valid
 /// alongside `--beside`; no placement flags at all means `.automatic`.
 func resolvePanelPlacement(_ opts: PlacementOptions) throws -> PanelPlacement {
-    if let share = opts.share {
-        guard (0...1).contains(share) else {
-            throw CLIError.invalidArgument("--share must be between 0 and 1")
-        }
-    }
-
     switch (opts.replace, opts.beside) {
     case (nil, nil):
+        // "requires --beside" must win over the range check below — a bare
+        // --share with no placement target is missing --beside, not out of range.
         guard opts.edge == nil, opts.share == nil else {
             throw CLIError.invalidArgument("--edge/--share require --beside")
         }
@@ -464,6 +469,11 @@ func resolvePanelPlacement(_ opts: PlacementOptions) throws -> PanelPlacement {
     case (nil, let beside?):
         guard let edge = opts.edge else {
             throw CLIError.invalidArgument("--beside requires --edge")
+        }
+        if let share = opts.share {
+            guard (0...1).contains(share) else {
+                throw CLIError.invalidArgument("--share must be between 0 and 1")
+            }
         }
         let anchor: PanelAnchor = beside.lowercased() == "primary"
             ? .primary

--- a/Sources/TBDCLI/Commands/PanelCommands.swift
+++ b/Sources/TBDCLI/Commands/PanelCommands.swift
@@ -1,0 +1,623 @@
+import ArgumentParser
+import Foundation
+import TBDShared
+
+struct PanelCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "panel",
+        abstract: "Inspect and arrange a worktree's panels (agent See/Arrange)",
+        subcommands: [
+            PanelList.self,
+            PanelOpen.self,
+            PanelNavigate.self,
+            PanelClose.self,
+            PanelMove.self,
+            PanelResize.self,
+            PanelBack.self,
+            PanelForward.self,
+            PanelJump.self,
+            PanelSelectTab.self,
+        ]
+    )
+}
+
+// MARK: - ExpressibleByArgument conformance for CLI
+
+extension PanelEdge: ExpressibleByArgument {}
+
+// MARK: - panel list (See)
+
+struct PanelList: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "Show a worktree's tabs, panels, and layout — read-only, always available regardless of gating"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Limit to one tab ID")
+    var tab: String?
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try tab.map { try parseUUID($0, label: "tab ID") }
+
+        let result: PanelGetResult = try client.call(
+            method: RPCMethod.panelGet,
+            params: PanelGetParams(worktreeID: worktreeID, tabID: tabID),
+            resultType: PanelGetResult.self
+        )
+
+        if json {
+            printJSON(result)
+        } else {
+            if result.tabs.isEmpty {
+                print("No tabs found.")
+                return
+            }
+            for (index, tab) in result.tabs.enumerated() {
+                if index > 0 { print() }
+                for line in tabLines(tab, activeTabID: result.activeTabID) {
+                    print(line)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - panel open / navigate / close / move / resize / history / select-tab (Arrange)
+
+struct PanelOpen: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "open",
+        abstract: "Open a new panel in a tab's layout"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID")
+    var tab: String
+
+    @OptionGroup var content: ContentOptions
+    @OptionGroup var placement: PlacementOptions
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+        let panelContent = try resolvePanelContent(content)
+        let panelPlacement = try resolvePanelPlacement(placement)
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .open(content: panelContent, placement: panelPlacement))
+        printApplyResult(result, json: json)
+    }
+}
+
+struct PanelNavigate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "navigate",
+        abstract: "Change what an existing panel displays"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID")
+    var tab: String
+
+    @Option(name: .long, help: "Panel ID to navigate")
+    var panel: String
+
+    @OptionGroup var content: ContentOptions
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+        let panelID = try parseUUID(panel, label: "panel ID")
+        let destination = try resolvePanelContent(content)
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .navigate(panelID: panelID, destination: destination))
+        printApplyResult(result, json: json)
+    }
+}
+
+struct PanelClose: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "close",
+        abstract: "Close a panel"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID")
+    var tab: String
+
+    @Option(name: .long, help: "Panel ID to close")
+    var panel: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+        let panelID = try parseUUID(panel, label: "panel ID")
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .close(panelID: panelID))
+        printApplyResult(result, json: json)
+    }
+}
+
+struct PanelMove: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "move",
+        abstract: "Move a panel to a new placement in the layout"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID")
+    var tab: String
+
+    @Option(name: .long, help: "Panel ID to move")
+    var panel: String
+
+    @OptionGroup var placement: PlacementOptions
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+        let panelID = try parseUUID(panel, label: "panel ID")
+        let panelPlacement = try resolvePanelPlacement(placement)
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .move(panelID: panelID, placement: panelPlacement))
+        printApplyResult(result, json: json)
+    }
+}
+
+struct PanelResize: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "resize",
+        abstract: "Resize a split's children"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID")
+    var tab: String
+
+    @Option(name: .long, help: "Split ID to resize")
+    var split: String
+
+    @Option(name: .long, help: "Comma-separated ratios for the split's children, e.g. '0.5,0.5'")
+    var ratios: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+        let splitID = try parseUUID(split, label: "split ID")
+        let parsedRatios = try parseRatios(ratios)
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .resize(splitID: splitID, ratios: parsedRatios))
+        printApplyResult(result, json: json)
+    }
+}
+
+struct PanelBack: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "back",
+        abstract: "Step a panel back in its navigation history"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID")
+    var tab: String
+
+    @Option(name: .long, help: "Panel ID")
+    var panel: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+        let panelID = try parseUUID(panel, label: "panel ID")
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .history(panelID: panelID, action: .back))
+        printApplyResult(result, json: json)
+    }
+}
+
+struct PanelForward: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "forward",
+        abstract: "Step a panel forward in its navigation history"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID")
+    var tab: String
+
+    @Option(name: .long, help: "Panel ID")
+    var panel: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+        let panelID = try parseUUID(panel, label: "panel ID")
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .history(panelID: panelID, action: .forward))
+        printApplyResult(result, json: json)
+    }
+}
+
+struct PanelJump: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "jump",
+        abstract: "Jump a panel to a specific index in its navigation history"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID")
+    var tab: String
+
+    @Option(name: .long, help: "Panel ID")
+    var panel: String
+
+    @Option(name: .long, help: "History index to jump to")
+    var index: Int
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+        let panelID = try parseUUID(panel, label: "panel ID")
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .history(panelID: panelID, action: .jump(index: index)))
+        printApplyResult(result, json: json)
+    }
+}
+
+struct PanelSelectTab: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "select-tab",
+        abstract: "Make a tab the active tab"
+    )
+
+    @Argument(help: "Worktree name or ID")
+    var worktree: String
+
+    @Option(name: .long, help: "Tab ID to select")
+    var tab: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        let client = SocketClient()
+        let worktreeID = try resolveWorktreeArg(worktree, client: client)
+        let tabID = try parseUUID(tab, label: "tab ID")
+
+        let result = try applyPanelOperation(
+            client: client, worktreeID: worktreeID, tabID: tabID,
+            operation: .selectTab(tabID: tabID))
+        printApplyResult(result, json: json)
+    }
+}
+
+// MARK: - Shared flag groups (open/navigate share content; open/move share placement)
+
+/// The four `PanelContent` sources as CLI flags. Exactly one must be given.
+struct ContentOptions: ParsableArguments {
+    @Option(name: .long, help: "Open/navigate to a file")
+    var file: String?
+
+    @Flag(name: .long, help: "Force rendered presentation for --file")
+    var render = false
+
+    @Flag(name: .long, help: "Force source presentation for --file")
+    var source = false
+
+    @Option(name: .long, help: "Open/navigate to a URL")
+    var web: String?
+
+    @Option(name: .long, help: "Open/navigate to a terminal's transcript (terminal ID)")
+    var transcript: String?
+
+    @Option(name: .long, help: "Open/navigate to a note (note ID)")
+    var note: String?
+
+    init() {}
+}
+
+/// `PanelPlacement` as CLI flags. Neither `--replace` nor `--beside` given
+/// means `.automatic`.
+struct PlacementOptions: ParsableArguments {
+    @Option(name: .long, help: "Replace this panel's content in place (panel ID)")
+    var replace: String?
+
+    @Option(name: .long, help: "Place beside this anchor: 'primary' or a panel ID")
+    var beside: String?
+
+    @Option(name: .long, help: "Edge to place beside — required with --beside")
+    var edge: PanelEdge?
+
+    @Option(name: .long, help: "Share of space (0..1) for the new panel — optional with --beside")
+    var share: Double?
+
+    init() {}
+}
+
+/// Resolve `ContentOptions` into a `PanelContent`. Exactly one of
+/// --file/--web/--transcript/--note must be given.
+func resolvePanelContent(_ opts: ContentOptions) throws -> PanelContent {
+    var resolved: [PanelContent] = []
+
+    if let file = opts.file {
+        guard !(opts.render && opts.source) else {
+            throw CLIError.invalidArgument("Cannot use both --render and --source")
+        }
+        let presentation: FilePresentation = opts.render ? .rendered : (opts.source ? .source : .automatic)
+        resolved.append(.file(FileReference(path: resolvePath(file), presentation: presentation)))
+    }
+    if let web = opts.web {
+        guard let url = URL(string: web) else {
+            throw CLIError.invalidArgument("Invalid URL: \(web)")
+        }
+        resolved.append(.web(url))
+    }
+    if let transcript = opts.transcript {
+        resolved.append(.transcript(terminalID: try parseUUID(transcript, label: "terminal ID")))
+    }
+    if let note = opts.note {
+        resolved.append(.note(noteID: try parseUUID(note, label: "note ID")))
+    }
+
+    guard resolved.count == 1 else {
+        throw CLIError.invalidArgument(
+            resolved.isEmpty
+                ? "Specify one of --file, --web, --transcript, --note"
+                : "Specify only one of --file, --web, --transcript, --note")
+    }
+    return resolved[0]
+}
+
+/// Resolve `PlacementOptions` into a `PanelPlacement`. `--replace` and
+/// `--beside` are mutually exclusive; `--edge`/`--share` are only valid
+/// alongside `--beside`; no placement flags at all means `.automatic`.
+func resolvePanelPlacement(_ opts: PlacementOptions) throws -> PanelPlacement {
+    if let share = opts.share {
+        guard (0...1).contains(share) else {
+            throw CLIError.invalidArgument("--share must be between 0 and 1")
+        }
+    }
+
+    switch (opts.replace, opts.beside) {
+    case (nil, nil):
+        guard opts.edge == nil, opts.share == nil else {
+            throw CLIError.invalidArgument("--edge/--share require --beside")
+        }
+        return .automatic
+
+    case (let replace?, nil):
+        guard opts.edge == nil, opts.share == nil else {
+            throw CLIError.invalidArgument("--edge/--share are not valid with --replace")
+        }
+        return .replace(panelID: try parseUUID(replace, label: "panel ID"))
+
+    case (nil, let beside?):
+        guard let edge = opts.edge else {
+            throw CLIError.invalidArgument("--beside requires --edge")
+        }
+        let anchor: PanelAnchor = beside.lowercased() == "primary"
+            ? .primary
+            : .panel(try parseUUID(beside, label: "--beside target"))
+        return .beside(target: anchor, edge: edge, share: opts.share)
+
+    case (.some, .some):
+        throw CLIError.invalidArgument("Cannot use both --replace and --beside")
+    }
+}
+
+/// Parse a comma-separated ratio list, e.g. "0.5,0.5" -> [0.5, 0.5].
+func parseRatios(_ csv: String) throws -> [Double] {
+    let parts = csv.split(separator: ",", omittingEmptySubsequences: false)
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+    guard !parts.isEmpty, !parts.contains("") else {
+        throw CLIError.invalidArgument("Invalid --ratios: \(csv)")
+    }
+    return try parts.map { part in
+        guard let value = Double(part) else {
+            throw CLIError.invalidArgument("Invalid ratio: \(part)")
+        }
+        return value
+    }
+}
+
+// MARK: - Layout tree rendering (shared by `list` and Arrange result printing)
+
+func describe(_ content: PanelContent) -> String {
+    switch content {
+    case .file(let ref):
+        return "file \(ref.path)" + (ref.presentation == .automatic ? "" : " (\(ref.presentation.rawValue))")
+    case .web(let url):
+        return "web \(url.absoluteString)"
+    case .transcript(let terminalID):
+        return "transcript \(terminalID)"
+    case .note(let noteID):
+        return "note \(noteID)"
+    }
+}
+
+func describe(_ content: PrimaryContent) -> String {
+    switch content {
+    case .terminal(let terminalID):
+        return "terminal \(terminalID)"
+    case .note(let noteID):
+        return "note \(noteID)"
+    case .file(let ref):
+        return "file \(ref.path)" + (ref.presentation == .automatic ? "" : " (\(ref.presentation.rawValue))")
+    case .web(let url):
+        return "web \(url.absoluteString)"
+    case .transcript(let terminalID):
+        return "transcript \(terminalID)"
+    }
+}
+
+/// Render a layout tree indented, one line per node. Panel slots show their
+/// panelID + content; splits show their splitID, direction, and ratios;
+/// `.primary` marks where the tab's primary anchor sits in the tree — these
+/// IDs are the handles agents need to target Arrange mutations.
+func renderPanelTree(_ node: PanelLayoutNode, indent: String) -> [String] {
+    switch node {
+    case .primary:
+        return ["\(indent)[primary]"]
+    case .panel(let slot):
+        return ["\(indent)panel \(slot.id): \(describe(slot.content))"]
+    case .split(let split):
+        let ratios = split.ratios.map { String(format: "%.2f", $0) }.joined(separator: ",")
+        var lines = ["\(indent)split \(split.id) (\(split.direction.rawValue), ratios: \(ratios))"]
+        for child in split.children {
+            lines.append(contentsOf: renderPanelTree(child, indent: indent + "  "))
+        }
+        return lines
+    }
+}
+
+/// Full text rendering of one tab: header + primary + layout tree.
+func tabLines(_ tab: WorkspaceTabSurface, activeTabID: UUID?) -> [String] {
+    let marker = tab.id == activeTabID ? " [ACTIVE]" : ""
+    let label = tab.label.map { " — \($0)" } ?? ""
+    var lines = ["Tab \(tab.id)\(marker)\(label)"]
+    lines.append("  primary: \(describe(tab.primary))")
+    lines.append("  revision: \(tab.revision)")
+    lines.append(contentsOf: renderPanelTree(tab.layout, indent: "  "))
+    return lines
+}
+
+private func printApplyResult(_ result: PanelApplyResult, json: Bool) {
+    if json {
+        printJSON(result)
+    } else {
+        if result.replayed {
+            print("(replayed — operation was already applied)")
+        }
+        for line in tabLines(result.tab, activeTabID: nil) {
+            print(line)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private func parseUUID(_ raw: String, label: String) throws -> UUID {
+    guard let id = UUID(uuidString: raw) else {
+        throw CLIError.invalidArgument("Invalid \(label): \(raw)")
+    }
+    return id
+}
+
+/// Fetch a tab's current revision, then apply an operation against it as
+/// `origin: .agentCLI`. Every Arrange verb funnels through here so the
+/// `baseRevision` fetch-then-apply sequence lives in exactly one place.
+private func applyPanelOperation(
+    client: SocketClient, worktreeID: UUID, tabID: UUID, operation: PanelOperation
+) throws -> PanelApplyResult {
+    let current: PanelGetResult = try client.call(
+        method: RPCMethod.panelGet,
+        params: PanelGetParams(worktreeID: worktreeID, tabID: tabID),
+        resultType: PanelGetResult.self
+    )
+    guard let tab = current.tabs.first(where: { $0.id == tabID }) else {
+        throw CLIError.invalidArgument("Tab not found: \(tabID)")
+    }
+
+    let envelope = PanelOperationEnvelope(
+        operationID: UUID(), worktreeID: worktreeID, tabID: tabID,
+        baseRevision: tab.revision, origin: .agentCLI, operation: operation)
+    return try client.call(
+        method: RPCMethod.panelApply,
+        params: PanelApplyParams(envelope: envelope),
+        resultType: PanelApplyResult.self
+    )
+}
+
+/// Resolve a worktree argument that could be a UUID or a name. Duplicated
+/// from `TerminalCommands.swift` (that copy is `private` there) rather than
+/// promoted to a shared internal helper — see PR brief.
+private func resolveWorktreeArg(_ nameOrID: String, client: SocketClient) throws -> UUID {
+    if let id = UUID(uuidString: nameOrID) {
+        return id
+    }
+
+    let worktrees: [Worktree] = try client.call(
+        method: RPCMethod.worktreeList,
+        params: WorktreeListParams(),
+        resultType: [Worktree].self
+    )
+
+    let matches = worktrees.filter { $0.name == nameOrID || $0.displayName == nameOrID }
+    guard let match = matches.first else {
+        throw CLIError.invalidArgument("No worktree found with name or ID: \(nameOrID)")
+    }
+    if matches.count > 1 {
+        throw CLIError.invalidArgument("Multiple worktrees match '\(nameOrID)'. Use the full ID instead.")
+    }
+    return match.id
+}

--- a/Sources/TBDCLI/TBD.swift
+++ b/Sources/TBDCLI/TBD.swift
@@ -14,6 +14,7 @@ struct TBDCommand: AsyncParsableCommand {
             ConfigCommand.self,
             ProfileCommand.self,
             TerminalCommand.self,
+            PanelCommand.self,
             NotifyCommand.self,
             SessionEventCommand.self,
             TerminalActivityEventCommand.self,

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -29,7 +29,7 @@ TBD is a macOS app that manages git worktrees and terminal tabs (Claude Code, Co
 
 ## Discovering current commands
 
-Always run `tbd <subcommand> --help` for current flags — flag detail is not duplicated here. Top-level commands: `tbd worktree`, `tbd terminal`, `tbd link`, `tbd notify`.
+Always run `tbd <subcommand> --help` for current flags — flag detail is not duplicated here. Top-level commands: `tbd worktree`, `tbd terminal`, `tbd panel`, `tbd link`, `tbd notify`.
 
 ## Common workflows
 
@@ -141,6 +141,28 @@ tbd notify --type {response_complete|error|task_complete|attention_needed} --mes
 ```bash
 tbd link [<worktree>]   # no arg = current
 ```
+
+## Panels
+
+Each worktree tab has a **primary** anchor (its terminal, or a file/web/note/transcript) plus an optional layout tree of **viewer panels** beside it.
+
+### See
+
+```bash
+tbd panel list "$TBD_WORKTREE_ID"
+```
+
+Read-only and always available regardless of gating. Prints each tab's primary content plus its layout tree, including the **panelID**/**splitID** of every node — these are the handles Arrange commands target. Add `--tab <id>` to inspect one tab, `--json` for the raw result.
+
+### Arrange
+
+`open`, `navigate`, `close`, `move`, `resize`, `back`, `forward`, `jump`, `select-tab` rearrange panels in your own worktree — split a file open beside the terminal, swap what a panel shows, step through a panel's history, or switch the active tab. Run `tbd panel <verb> --help` for flags; most target a `--tab` plus a `--panel` or `--split` ID from `tbd panel list`.
+
+Terminals are **never** viewer panels — they only ever appear as a tab's primary anchor, so `open`/`navigate` content is always file, web, transcript, or note.
+
+### Gating
+
+Arrange requires the daemon's panel-surface flags, which default OFF during the current soak. If disabled, the command prints the daemon's error naming the flag and exits non-zero — ask the user to enable it rather than retrying. `list` works regardless.
 
 ## Scratch spaces & promotion
 

--- a/Tests/TBDCLITests/PanelCommandsTests.swift
+++ b/Tests/TBDCLITests/PanelCommandsTests.swift
@@ -79,6 +79,13 @@ struct PanelContentResolutionTests {
             _ = try resolvePanelContent(opts)
         }
     }
+
+    @Test func renderFlagOnNonFileContentIsInvalid() throws {
+        let opts = try ContentOptions.parse(["--web", "https://example.com", "--render"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelContent(opts)
+        }
+    }
 }
 
 @Suite("tbd panel placement resolution")
@@ -146,6 +153,16 @@ struct PanelPlacementResolutionTests {
         let opts = try PlacementOptions.parse(["--beside", "primary", "--edge", "left", "--share", "1.5"])
         #expect(throws: CLIError.self) {
             _ = try resolvePanelPlacement(opts)
+        }
+    }
+
+    @Test func bareShareWithoutBesideReportsMissingBesideNotRange() throws {
+        let opts = try PlacementOptions.parse(["--share", "1.5"])
+        do {
+            _ = try resolvePanelPlacement(opts)
+            Issue.record("expected resolvePanelPlacement to throw")
+        } catch let error as CLIError {
+            #expect("\(error)".contains("require --beside"))
         }
     }
 }

--- a/Tests/TBDCLITests/PanelCommandsTests.swift
+++ b/Tests/TBDCLITests/PanelCommandsTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+import Testing
+import ArgumentParser
+import TBDShared
+
+@testable import TBDCLI
+
+@Suite("tbd panel content resolution")
+struct PanelContentResolutionTests {
+    @Test func fileDefaultsToAutomaticPresentation() throws {
+        let opts = try ContentOptions.parse(["--file", "/tmp/a.txt"])
+        let content = try resolvePanelContent(opts)
+        guard case .file(let ref) = content else { Issue.record("expected .file"); return }
+        #expect(ref.path == "/tmp/a.txt")
+        #expect(ref.presentation == .automatic)
+    }
+
+    @Test func fileRenderFlagForcesRenderedPresentation() throws {
+        let opts = try ContentOptions.parse(["--file", "/tmp/a.md", "--render"])
+        let content = try resolvePanelContent(opts)
+        guard case .file(let ref) = content else { Issue.record("expected .file"); return }
+        #expect(ref.presentation == .rendered)
+    }
+
+    @Test func fileSourceFlagForcesSourcePresentation() throws {
+        let opts = try ContentOptions.parse(["--file", "/tmp/a.md", "--source"])
+        let content = try resolvePanelContent(opts)
+        guard case .file(let ref) = content else { Issue.record("expected .file"); return }
+        #expect(ref.presentation == .source)
+    }
+
+    @Test func fileRenderAndSourceTogetherIsInvalid() throws {
+        let opts = try ContentOptions.parse(["--file", "/tmp/a.md", "--render", "--source"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelContent(opts)
+        }
+    }
+
+    @Test func webResolvesToURL() throws {
+        let opts = try ContentOptions.parse(["--web", "https://example.com"])
+        let content = try resolvePanelContent(opts)
+        guard case .web(let url) = content else { Issue.record("expected .web"); return }
+        #expect(url.absoluteString == "https://example.com")
+    }
+
+    @Test func transcriptResolvesToTerminalID() throws {
+        let id = UUID()
+        let opts = try ContentOptions.parse(["--transcript", id.uuidString])
+        let content = try resolvePanelContent(opts)
+        guard case .transcript(let terminalID) = content else { Issue.record("expected .transcript"); return }
+        #expect(terminalID == id)
+    }
+
+    @Test func transcriptRejectsInvalidUUID() throws {
+        let opts = try ContentOptions.parse(["--transcript", "not-a-uuid"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelContent(opts)
+        }
+    }
+
+    @Test func noteResolvesToNoteID() throws {
+        let id = UUID()
+        let opts = try ContentOptions.parse(["--note", id.uuidString])
+        let content = try resolvePanelContent(opts)
+        guard case .note(let noteID) = content else { Issue.record("expected .note"); return }
+        #expect(noteID == id)
+    }
+
+    @Test func noContentSourceIsInvalid() throws {
+        let opts = try ContentOptions.parse([])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelContent(opts)
+        }
+    }
+
+    @Test func multipleContentSourcesIsInvalid() throws {
+        let opts = try ContentOptions.parse(["--file", "/tmp/a.txt", "--web", "https://example.com"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelContent(opts)
+        }
+    }
+}
+
+@Suite("tbd panel placement resolution")
+struct PanelPlacementResolutionTests {
+    @Test func noFlagsDefaultToAutomatic() throws {
+        let opts = try PlacementOptions.parse([])
+        #expect(try resolvePanelPlacement(opts) == .automatic)
+    }
+
+    @Test func replaceResolvesToReplacePlacement() throws {
+        let id = UUID()
+        let opts = try PlacementOptions.parse(["--replace", id.uuidString])
+        #expect(try resolvePanelPlacement(opts) == .replace(panelID: id))
+    }
+
+    @Test func replaceRejectsInvalidUUID() throws {
+        let opts = try PlacementOptions.parse(["--replace", "nope"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelPlacement(opts)
+        }
+    }
+
+    @Test func replaceWithEdgeIsInvalid() throws {
+        let opts = try PlacementOptions.parse(["--replace", UUID().uuidString, "--edge", "left"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelPlacement(opts)
+        }
+    }
+
+    @Test func besidePrimaryWithEdgeResolves() throws {
+        let opts = try PlacementOptions.parse(["--beside", "primary", "--edge", "right"])
+        #expect(try resolvePanelPlacement(opts) == .beside(target: .primary, edge: .right, share: nil))
+    }
+
+    @Test func besidePanelIDWithEdgeAndShareResolves() throws {
+        let id = UUID()
+        let opts = try PlacementOptions.parse(["--beside", id.uuidString, "--edge", "below", "--share", "0.3"])
+        #expect(try resolvePanelPlacement(opts) == .beside(target: .panel(id), edge: .below, share: 0.3))
+    }
+
+    @Test func besideWithoutEdgeIsInvalid() throws {
+        let opts = try PlacementOptions.parse(["--beside", "primary"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelPlacement(opts)
+        }
+    }
+
+    @Test func edgeWithoutBesideOrReplaceIsInvalid() throws {
+        let opts = try PlacementOptions.parse(["--edge", "left"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelPlacement(opts)
+        }
+    }
+
+    @Test func replaceAndBesideTogetherIsInvalid() throws {
+        let opts = try PlacementOptions.parse([
+            "--replace", UUID().uuidString, "--beside", "primary", "--edge", "left",
+        ])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelPlacement(opts)
+        }
+    }
+
+    @Test func shareOutOfRangeIsInvalid() throws {
+        let opts = try PlacementOptions.parse(["--beside", "primary", "--edge", "left", "--share", "1.5"])
+        #expect(throws: CLIError.self) {
+            _ = try resolvePanelPlacement(opts)
+        }
+    }
+}
+
+@Suite("tbd panel --ratios parsing")
+struct PanelRatiosParsingTests {
+    @Test func parsesTwoValues() throws {
+        #expect(try parseRatios("0.5,0.5") == [0.5, 0.5])
+    }
+
+    @Test func trimsWhitespaceAroundValues() throws {
+        #expect(try parseRatios("0.3, 0.7") == [0.3, 0.7])
+    }
+
+    @Test func parsesThreeValues() throws {
+        #expect(try parseRatios("0.2,0.3,0.5") == [0.2, 0.3, 0.5])
+    }
+
+    @Test func emptyStringIsInvalid() {
+        #expect(throws: CLIError.self) {
+            _ = try parseRatios("")
+        }
+    }
+
+    @Test func trailingCommaIsInvalid() {
+        #expect(throws: CLIError.self) {
+            _ = try parseRatios("0.5,")
+        }
+    }
+
+    @Test func nonNumericEntryIsInvalid() {
+        #expect(throws: CLIError.self) {
+            _ = try parseRatios("0.5,abc")
+        }
+    }
+}
+
+@Suite("tbd panel layout tree rendering")
+struct PanelTreeRenderingTests {
+    @Test func rendersPanelIDsSplitIDsAndRatiosAndPrimaryMarker() {
+        let terminalID = UUID()
+        let filePanelID = UUID()
+        let webPanelID = UUID()
+        let splitID = UUID()
+        let tabID = UUID()
+        let worktreeID = UUID()
+
+        let tab = WorkspaceTabSurface(
+            id: tabID,
+            worktreeID: worktreeID,
+            label: "My Tab",
+            primary: .terminal(terminalID: terminalID),
+            layout: .split(SplitNode(
+                id: splitID,
+                direction: .horizontal,
+                children: [
+                    .primary,
+                    .panel(PanelSlot(id: filePanelID, content: .file(FileReference(path: "/a.swift")))),
+                    .panel(PanelSlot(id: webPanelID, content: .web(URL(string: "https://example.com")!))),
+                ],
+                ratios: [0.5, 0.25, 0.25]
+            )),
+            revision: 7
+        )
+
+        let lines = tabLines(tab, activeTabID: tabID)
+        let joined = lines.joined(separator: "\n")
+
+        #expect(lines.first == "Tab \(tabID) [ACTIVE] — My Tab")
+        #expect(joined.contains("revision: 7"))
+        #expect(joined.contains("primary: terminal \(terminalID)"))
+        #expect(joined.contains("split \(splitID) (horizontal, ratios: 0.50,0.25,0.25)"))
+        #expect(joined.contains("[primary]"))
+        #expect(joined.contains("panel \(filePanelID): file /a.swift"))
+        #expect(joined.contains("panel \(webPanelID): web https://example.com"))
+    }
+
+    @Test func inactiveTabHasNoActiveMarker() {
+        let tabID = UUID()
+        let tab = WorkspaceTabSurface(
+            id: tabID, worktreeID: UUID(), label: nil,
+            primary: .terminal(terminalID: UUID()), layout: .primary, revision: 0)
+        let lines = tabLines(tab, activeTabID: UUID())
+        #expect(lines.first == "Tab \(tabID)")
+        #expect(!lines.first!.contains("ACTIVE"))
+    }
+
+    @Test func filePresentationShownWhenNonAutomatic() {
+        let content = PanelContent.file(FileReference(path: "/a.md", presentation: .rendered))
+        #expect(describe(content) == "file /a.md (rendered)")
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3a of the panel system: exposes the daemon-owned panel surface (RPCs shipped in Phase 2, `v59_panel_surface`) to agents through the `tbd` CLI, and documents the new surface in the bundled skill. No new subsystem, no flag, no migration — this is additive CLI surface over `panel.get`/`panel.apply`, which already exist and are tested.

## Command surface

**See** (calls `panel.get`, ungated):
```
tbd panel list <worktree> [--tab <tabID>] [--json]
```
Prints each tab's primary content, revision, and its layout tree indented — panel slots show `panelID: content`, splits show `splitID (direction, ratios: ...)`, and `.primary` marks where the primary anchor sits in the tree. These panelIDs/splitIDs are the handles Arrange commands target.

**Arrange** (each calls `panel.apply`, origin `.agentCLI`):
```
tbd panel open       <worktree> --tab <id> (--file <path> [--render|--source] | --web <url> | --transcript <terminalID> | --note <noteID>) [--replace <panelID> | --beside <primary|panelID> --edge <left|right|above|below> [--share <0..1>]] [--json]
tbd panel navigate   <worktree> --tab <id> --panel <panelID> (--file... | --web... | --transcript... | --note...) [--json]
tbd panel close      <worktree> --tab <id> --panel <panelID> [--json]
tbd panel move       <worktree> --tab <id> --panel <panelID> [--replace <panelID> | --beside <anchor> --edge <e> [--share <s>]] [--json]
tbd panel resize     <worktree> --tab <id> --split <splitID> --ratios <csv, e.g. "0.5,0.5"> [--json]
tbd panel back       <worktree> --tab <id> --panel <panelID> [--json]
tbd panel forward    <worktree> --tab <id> --panel <panelID> [--json]
tbd panel jump       <worktree> --tab <id> --panel <panelID> --index <n> [--json]
tbd panel select-tab <worktree> --tab <id> [--json]
```
Every Arrange verb fetches the target tab's current `revision` via `panel.get` first (erroring clearly if the tab isn't found), then builds a `PanelOperationEnvelope` with a fresh `operationID`, `origin: .agentCLI`, and that `baseRevision` before calling `panel.apply`. Placement defaults to `.automatic` when neither `--replace` nor `--beside` is given; `--replace`/`--beside` are mutually exclusive; `--edge`/`--share` are only valid with `--beside`.

## Gating

`panel.get` is ungated — `tbd panel list` always works. `panel.apply` is gated on two daemon flags that currently default OFF (pre-soak): when disabled, the daemon's stable error string (`"panel surface is disabled (daemon_panel_surface_enabled)"` or `"agent panel control is disabled (agent_panel_control_enabled)"`) surfaces verbatim via `CLIError.rpcError`, non-zero exit — not swallowed.

## Skill documentation

Added `tbd panel` to the "Top-level commands" line and a new `## Panels` section in `Sources/TBDShared/TBDSkillContent.swift`, covering See (read-only, always available), Arrange (the 9 verbs, noting terminals are never viewer panels — only ever the primary anchor), and gating. ~20 lines, defers flag detail to `--help`.

## Files changed
- `Sources/TBDCLI/Commands/PanelCommands.swift` (new) — `PanelCommand` + 10 subcommands, `ContentOptions`/`PlacementOptions` flag groups, pure resolvers (`resolvePanelContent`, `resolvePanelPlacement`, `parseRatios`, `renderPanelTree`/`tabLines`) kept `internal` for testability.
- `Sources/TBDCLI/TBD.swift` — registers `PanelCommand.self`.
- `Sources/TBDShared/TBDSkillContent.swift` — skill doc additions.
- `Tests/TBDCLITests/PanelCommandsTests.swift` (new) — 27 tests over the pure logic (content/placement flag resolution incl. mutual-exclusion validation and the `.automatic` default, ratios CSV parsing, layout-tree text rendering).

## Verification
- `swift build` — succeeds (whole package, all targets).
- `swiftlint --strict` — 0 violations, 564 files (Sources/TBDCLI is excluded from linting by existing repo config — CLI `print()` is intentional user output).
- `swift test --filter TBDCLITests` — full TBDCLITests target green (125 tests, includes new 27).
- `swift test --parallel -j 2` (full suite) — 3959 tests, all passed, 1 known issue (pre-existing, unrelated), no new reds.
