### PR TITLE
Feat: Drag to reorder pinned worktrees in the sidebar dock

### DIFF
--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -913,6 +913,66 @@ extension AppState {
         }
     }
 
+    /// Reorder the sidebar dock's pinned worktrees, triggered by SwiftUI
+    /// `.onMove` whose indices address the dock's PINNED ROOTS (the outer
+    /// ForEach), not the flattened row list.
+    ///
+    /// Optimistic, unlike `setPinned`: the client knows the entire resulting
+    /// order rather than depending on a daemon-assigned timestamp, so the row
+    /// can land under the cursor immediately and roll back if the RPC fails.
+    func reorderPins(fromOffsets source: IndexSet, toOffset destination: Int) {
+        // Snapshot BOTH collections — pinned worktrees span repo-keyed
+        // `worktrees` and repo-less `scratchWorktrees`, so a rollback that
+        // restored only one would leave the other half mutated.
+        let previousWorktrees = worktrees
+        let previousScratch = scratchWorktrees
+
+        // `children: { _ in [] }` collapses every subtree, which is exactly the
+        // root list the outer ForEach renders — so the indices line up by
+        // construction.
+        let currentRoots = PinnedDockContent
+            .rows(allWorktrees: allWorktrees, selectedIDs: [], children: { _ in [] })
+            .map(\.worktree.id)
+
+        guard let newOrder = PinnedDockReorder.reordered(
+            roots: currentRoots, fromOffsets: source, toOffset: destination) else {
+            logger.warning("reorderPins skipped: stale indices (roots=\(currentRoots.count, privacy: .public) source=\(Array(source), privacy: .public) destination=\(destination, privacy: .public))")
+            return
+        }
+
+        // Optimistic local update: assign contiguous orders in the new sequence.
+        for (index, id) in newOrder.enumerated() {
+            applyPinSortOrder(index, to: id)
+        }
+
+        Task {
+            do {
+                try await daemonClient.reorderPinnedWorktrees(worktreeIDs: newOrder)
+            } catch {
+                logger.error("reorderPins RPC failed: \(error.localizedDescription, privacy: .public)")
+                await MainActor.run {
+                    self.worktrees = previousWorktrees
+                    self.scratchWorktrees = previousScratch
+                }
+            }
+        }
+    }
+
+    /// Write `pinSortOrder` into whichever collection holds this worktree:
+    /// a pinned worktree can be a repo-keyed row or a repo-less scratch space,
+    /// and only one of the two ever holds it.
+    private func applyPinSortOrder(_ order: Int, to id: UUID) {
+        for (key, list) in worktrees {
+            if let idx = list.firstIndex(where: { $0.id == id }) {
+                worktrees[key]?[idx].pinSortOrder = order
+                return
+            }
+        }
+        if let idx = scratchWorktrees.firstIndex(where: { $0.id == id }) {
+            scratchWorktrees[idx].pinSortOrder = order
+        }
+    }
+
     /// Resolve the effective auto-hibernate-on-merge setting for a worktree.
     /// Returns the per-worktree override when explicitly set; otherwise falls
     /// back to the global default (`autoHibernateOnMergeDefault`).

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -790,6 +790,14 @@ actor DaemonClient {
         )
     }
 
+    /// Persist a new order for the sidebar dock's pinned worktrees.
+    func reorderPinnedWorktrees(worktreeIDs: [UUID]) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.worktreeReorderPins,
+            params: WorktreeReorderPinsParams(worktreeIDs: worktreeIDs)
+        )
+    }
+
     /// Set the global default for auto-hibernate-on-PR-merge.
     func setAutoHibernateOnMergeDefault(_ enabled: Bool) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Sidebar/PinnedDockContent.swift
+++ b/Sources/TBDApp/Sidebar/PinnedDockContent.swift
@@ -52,7 +52,18 @@ enum PinnedDockContent {
                      children: (UUID) -> [Worktree]) -> [PinnedDockRow] {
         let pinned = allWorktrees
             .filter { $0.pinnedAt != nil && $0.archivedAt == nil && !$0.isNightwatchDesk }
-            .sorted { ($0.pinnedAt ?? .distantPast) < ($1.pinnedAt ?? .distantPast) }
+            .sorted { lhs, rhs in
+                // Ordered pins first, by their explicit order. Pins that have
+                // never been dragged keep pinnedAt order and sort after —
+                // which is what lets the column ship with no backfill UPDATE.
+                switch (lhs.pinSortOrder, rhs.pinSortOrder) {
+                case let (l?, r?): return l < r
+                case (_?, nil):    return true
+                case (nil, _?):    return false
+                case (nil, nil):
+                    return (lhs.pinnedAt ?? .distantPast) < (rhs.pinnedAt ?? .distantPast)
+                }
+            }
 
         // Emit-once, which both prevents a worktree from appearing twice and
         // makes a cyclic parentWorktreeID chain terminate — so unlike
@@ -104,5 +115,22 @@ enum PinnedDockContent {
                               depth: depth + 1, children: children,
                               emitted: &emitted, into: &result)
         }
+    }
+
+    /// The contiguous run of rows belonging to one pinned root: the root itself
+    /// plus any expanded descendants beneath it.
+    ///
+    /// `PinnedDockView` renders a nested `ForEach` — outer over pinned roots,
+    /// inner over each root's rows — so that `.onMove`'s indices address ROOTS
+    /// rather than the flattened row list. Attaching `.onMove` to a flat
+    /// `ForEach` over `rows(...)` would move the wrong worktree whenever a
+    /// subtree was expanded.
+    static func subtree(of rootID: UUID, in rows: [PinnedDockRow]) -> [PinnedDockRow] {
+        guard let start = rows.firstIndex(where: { $0.worktree.id == rootID }) else { return [] }
+        var end = rows.index(after: start)
+        while end < rows.endIndex, rows[end].depth > rows[start].depth {
+            end = rows.index(after: end)
+        }
+        return Array(rows[start..<end])
     }
 }

--- a/Sources/TBDApp/Sidebar/PinnedDockContent.swift
+++ b/Sources/TBDApp/Sidebar/PinnedDockContent.swift
@@ -134,3 +134,24 @@ enum PinnedDockContent {
         return Array(rows[start..<end])
     }
 }
+
+/// Index maths for a dock drag, split out from `AppState` so the stale-index
+/// guard is testable without a live app.
+enum PinnedDockReorder {
+    /// The new root order after a `.onMove`, or nil when the offsets are stale.
+    ///
+    /// `source`/`destination` are captured against the `ForEach`'s snapshot and
+    /// can outlive it — a pin can be removed by another surface mid-drag. The
+    /// existing `reorderTopLevelWorktrees` guards the same way; this is not
+    /// theoretical.
+    static func reordered(roots: [UUID],
+                          fromOffsets source: IndexSet,
+                          toOffset destination: Int) -> [UUID]? {
+        guard !roots.isEmpty,
+              !source.contains(where: { $0 >= roots.count }),
+              destination <= roots.count else { return nil }
+        var next = roots
+        next.move(fromOffsets: source, toOffset: destination)
+        return next
+    }
+}

--- a/Sources/TBDApp/Sidebar/PinnedDockView.swift
+++ b/Sources/TBDApp/Sidebar/PinnedDockView.swift
@@ -16,20 +16,56 @@ struct PinnedDockView: View {
     let availableHeight: CGFloat
     @EnvironmentObject var appState: AppState
 
+    /// The pinned roots, in display order — the elements `.onMove` addresses.
+    private var roots: [PinnedDockRow] {
+        rows.filter { $0.depth == 0 }
+    }
+
+    /// One root's expanded descendants: its contiguous run of rows minus the
+    /// root itself, which `body` emits directly.
+    private func descendants(of root: PinnedDockRow) -> [PinnedDockRow] {
+        Array(PinnedDockContent.subtree(of: root.worktree.id, in: rows).dropFirst())
+    }
+
+    @ViewBuilder
+    private func dockRow(_ row: PinnedDockRow) -> some View {
+        WorktreeRowView(
+            worktree: row.worktree,
+            indentLevel: row.depth,
+            sectionRepoID: row.sectionRepoID
+        )
+        .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
+        .tag(row.worktree.id)
+    }
+
     var body: some View {
         if !rows.isEmpty {
             ScrollViewReader { proxy in
                 List(selection: $appState.selectedWorktreeIDs) {
-                    ForEach(rows) { row in
-                        WorktreeRowView(
-                            worktree: row.worktree,
-                            indentLevel: row.depth,
-                            sectionRepoID: row.sectionRepoID
-                        )
-                        .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(Color.clear)
-                        .tag(row.worktree.id)
+                    // Nested deliberately: `.onMove` hands back indices into its
+                    // OWN ForEach's elements, so the outer ForEach must iterate
+                    // pinned ROOTS. A flat ForEach over `rows` would move the
+                    // wrong worktree whenever a subtree was expanded, because
+                    // the indices would address the flattened list. This mirrors
+                    // RepoSectionView, whose ForEach iterates top-level
+                    // worktrees while WorktreeSubtreeView emits many rows each.
+                    ForEach(roots) { root in
+                        // The root row is emitted DIRECTLY, not through a
+                        // nested ForEach, and the descendants follow in one of
+                        // their own — exactly WorktreeSubtreeView's shape.
+                        // Verified live: wrapping the root in a ForEach too
+                        // makes the outer element's content a bare ForEach, and
+                        // AppKit then never starts a drag session, so `.onMove`
+                        // silently never fires.
+                        dockRow(root)
+                        ForEach(descendants(of: root)) { row in
+                            dockRow(row)
+                        }
+                    }
+                    .onMove { source, destination in
+                        appState.reorderPins(fromOffsets: source, toOffset: destination)
                     }
                 }
                 .onChange(of: appState.selectedWorktreeIDs) { _, ids in

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1099,6 +1099,16 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "worktree", column: "pinnedAt", type: .datetime)
         }
 
+        // Custom ordering for the sidebar's pinned dock. Nullable with NO
+        // default and NO backfill: `PinnedDockContent` falls back to `pinnedAt`
+        // order for rows that are still NULL, so existing pins keep their
+        // current visual order the moment this lands and the first drag assigns
+        // real values. Separate from `sortOrder`, which drives repo-section tree
+        // ordering — writing pin order there would scramble the sidebar.
+        migrator.registerMigration("v64_worktree_pin_sort_order") { db in
+            try db.addColumnIfMissing(table: "worktree", column: "pinSortOrder", type: .integer)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -850,9 +850,9 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Reorder the sidebar dock's pinned worktrees. Only affects the worktrees
-    /// in the provided list; any other worktree is pushed to values after the
-    /// reordered ones. Mirrors `ModelProfileStore.reorder` — the dock is one
-    /// flat cross-repo list, so there is no repo scoping.
+    /// in the provided list; any other PINNED worktree is pushed to values after
+    /// the reordered ones. Modelled on `ModelProfileStore.reorder` — the dock is
+    /// one flat cross-repo list, so there is no repo scoping.
     public func reorderPins(worktreeIDs: [UUID]) async throws {
         try await writer.write { db in
             for (index, worktreeID) in worktreeIDs.enumerated() {
@@ -861,15 +861,24 @@ public struct WorktreeStore: Sendable {
                     arguments: [index, worktreeID.uuidString]
                 )
             }
-            // Push any worktree not in the list to after the reordered ones, so
-            // rows the client did not know about never collide at one value.
+            // Push any PIN not in the list to after the reordered ones, so pins
+            // the client did not know about never collide at one value.
+            //
+            // The `pinnedAt IS NOT NULL` scoping is where this deliberately
+            // diverges from `ModelProfileStore.reorder`, which sweeps its whole
+            // table: every row in `model_profiles` IS a profile, but most rows in
+            // `worktree` are not pins. Sweeping unconditionally would stamp an
+            // order onto unpinned rows and destroy the invariant the no-backfill
+            // design rests on — `pinSortOrder IS NULL` means "never explicitly
+            // ordered", which is exactly what the dock's fallback sort reads.
+            // Do not "re-sync" this clause with the profile version.
             let idStrings = worktreeIDs.map(\.uuidString)
             let placeholders = idStrings.map { _ in "?" }.joined(separator: ",")
             let args: [any DatabaseValueConvertible] = [worktreeIDs.count] + idStrings
             try db.execute(
                 sql: """
                     UPDATE worktree SET pinSortOrder = ? + rowid
-                    WHERE id NOT IN (\(placeholders))
+                    WHERE pinnedAt IS NOT NULL AND id NOT IN (\(placeholders))
                     """,
                 arguments: StatementArguments(args)
             )
@@ -879,6 +888,10 @@ public struct WorktreeStore: Sendable {
     /// One past the highest assigned `pinSortOrder`, so a new pin appends to the
     /// end of the dock and never disturbs a curated order. Returns 0 when
     /// nothing has one yet.
+    ///
+    /// Only pins ever carry a non-NULL `pinSortOrder` (`reorderPins` scopes its
+    /// sweep, `setPinned` clears the field on unpin), so this MAX really is the
+    /// last pin's position rather than a number derived from unrelated rows.
     public func nextPinSortOrder() async throws -> Int {
         try await writer.read { db in
             let maxOrder = try Int.fetchOne(db, sql: "SELECT MAX(pinSortOrder) FROM worktree")

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -33,6 +33,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var pr_number: Int?  // number of the PR this worktree was created from, nil otherwise
     var panel_surface_imported_at: Date?  // stamped once the legacy layout is imported; nil = never imported
     var pinnedAt: Date?  // sidebar dock pin; nil = unpinned
+    var pinSortOrder: Int?  // sidebar dock ordering; nil = falls back to pinnedAt
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -62,6 +63,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.pr_number = wt.prNumber
         self.panel_surface_imported_at = nil  // new worktrees start unimported; stamped via stampPanelSurfaceImported
         self.pinnedAt = wt.pinnedAt
+        self.pinSortOrder = wt.pinSortOrder
     }
 
     /// Failable decode: skips (returns nil after a logged warning) only when the
@@ -119,7 +121,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             promotedToRepoID: promotedToRepoID.flatMap { UUID(uuidString: $0) },
             prStatus: pr,
             prNumber: pr_number,
-            pinnedAt: pinnedAt
+            pinnedAt: pinnedAt,
+            pinSortOrder: pinSortOrder
         )
     }
 }
@@ -833,12 +836,53 @@ public struct WorktreeStore: Sendable {
 
     /// Pin or unpin a worktree for the sidebar dock. `nil` clears the pin.
     /// Purely presentational — nothing in the daemon reads this value.
+    ///
+    /// Pinning appends to the end of the dock; unpinning clears both fields so a
+    /// re-pin appends again rather than reclaiming its old slot.
     public func setPinned(id: UUID, pinnedAt: Date?) async throws {
+        let order: Int? = pinnedAt == nil ? nil : try await nextPinSortOrder()
         try await writer.write { db in
             try db.execute(
-                sql: "UPDATE worktree SET pinnedAt = ? WHERE id = ?",
-                arguments: [pinnedAt, id.uuidString]
+                sql: "UPDATE worktree SET pinnedAt = ?, pinSortOrder = ? WHERE id = ?",
+                arguments: [pinnedAt, order, id.uuidString]
             )
+        }
+    }
+
+    /// Reorder the sidebar dock's pinned worktrees. Only affects the worktrees
+    /// in the provided list; any other worktree is pushed to values after the
+    /// reordered ones. Mirrors `ModelProfileStore.reorder` — the dock is one
+    /// flat cross-repo list, so there is no repo scoping.
+    public func reorderPins(worktreeIDs: [UUID]) async throws {
+        try await writer.write { db in
+            for (index, worktreeID) in worktreeIDs.enumerated() {
+                try db.execute(
+                    sql: "UPDATE worktree SET pinSortOrder = ? WHERE id = ?",
+                    arguments: [index, worktreeID.uuidString]
+                )
+            }
+            // Push any worktree not in the list to after the reordered ones, so
+            // rows the client did not know about never collide at one value.
+            let idStrings = worktreeIDs.map(\.uuidString)
+            let placeholders = idStrings.map { _ in "?" }.joined(separator: ",")
+            let args: [any DatabaseValueConvertible] = [worktreeIDs.count] + idStrings
+            try db.execute(
+                sql: """
+                    UPDATE worktree SET pinSortOrder = ? + rowid
+                    WHERE id NOT IN (\(placeholders))
+                    """,
+                arguments: StatementArguments(args)
+            )
+        }
+    }
+
+    /// One past the highest assigned `pinSortOrder`, so a new pin appends to the
+    /// end of the dock and never disturbs a curated order. Returns 0 when
+    /// nothing has one yet.
+    public func nextPinSortOrder() async throws -> Int {
+        try await writer.read { db in
+            let maxOrder = try Int.fetchOne(db, sql: "SELECT MAX(pinSortOrder) FROM worktree")
+            return (maxOrder ?? -1) + 1
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -336,4 +336,10 @@ extension RPCRouter {
                                          pinnedAt: params.pinned ? Date() : nil)
         return .ok()
     }
+
+    func handleWorktreeReorderPins(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(WorktreeReorderPinsParams.self, from: paramsData)
+        try await db.worktrees.reorderPins(worktreeIDs: params.worktreeIDs)
+        return .ok()
+    }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -356,6 +356,8 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeSetAutoHibernate(request.paramsData)
             case RPCMethod.worktreeSetPin:
                 return try await handleWorktreeSetPin(request.paramsData)
+            case RPCMethod.worktreeReorderPins:
+                return try await handleWorktreeReorderPins(request.paramsData)
             case RPCMethod.configGet:
                 return try await handleConfigGet()
             case RPCMethod.configSetAutoArchiveOnMergeDefault:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -163,6 +163,11 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// Ordering in the dock is ascending by this timestamp, so new pins append.
     public var pinnedAt: Date?
 
+    /// Position in the sidebar dock's pinned list, ascending. `nil` = never
+    /// explicitly ordered, in which case the dock falls back to `pinnedAt`
+    /// order — which is what lets the column ship with no backfill.
+    public var pinSortOrder: Int?
+
     /// A scratch space is a repo-less worktree. Derived — no separate column.
     public var isScratch: Bool { repoID == nil }
 
@@ -193,7 +198,8 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 promotedToRepoID: UUID? = nil,
                 prStatus: PRStatus? = nil,
                 prNumber: Int? = nil,
-                pinnedAt: Date? = nil) {
+                pinnedAt: Date? = nil,
+                pinSortOrder: Int? = nil) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -216,6 +222,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.prStatus = prStatus
         self.prNumber = prNumber
         self.pinnedAt = pinnedAt
+        self.pinSortOrder = pinSortOrder
     }
 
     enum CodingKeys: String, CodingKey {
@@ -224,7 +231,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         case archivedClaudeSessions, sortOrder, archivedHeadSHA
         case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge
         case autoHibernateOnMerge
-        case promotedToRepoID, prStatus, prNumber, pinnedAt
+        case promotedToRepoID, prStatus, prNumber, pinnedAt, pinSortOrder
     }
 
     public init(from decoder: Decoder) throws {
@@ -251,6 +258,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         prStatus = try c.decodeIfPresent(PRStatus.self, forKey: .prStatus)
         prNumber = try c.decodeIfPresent(Int.self, forKey: .prNumber)
         pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
+        pinSortOrder = try c.decodeIfPresent(Int.self, forKey: .pinSortOrder)
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -192,6 +192,7 @@ public enum RPCMethod {
     public static let worktreeSetAutoArchive = "worktree.setAutoArchive"
     public static let worktreeSetAutoHibernate = "worktree.setAutoHibernate"
     public static let worktreeSetPin = "worktree.setPin"
+    public static let worktreeReorderPins = "worktree.reorderPins"
     public static let configGet = "config.get"
     public static let configSetAutoArchiveOnMergeDefault = "config.setAutoArchiveOnMergeDefault"
     public static let configSetAutoHibernateOnMergeDefault = "config.setAutoHibernateOnMergeDefault"
@@ -1441,6 +1442,15 @@ public struct WorktreeSetPinParams: Codable, Sendable {
     public let pinned: Bool
     public init(worktreeID: UUID, pinned: Bool) {
         self.worktreeID = worktreeID; self.pinned = pinned
+    }
+}
+
+/// Params for `worktree.reorderPins`. The dock is one flat cross-repo list, so
+/// there is no repoID scoping (unlike `WorktreeReorderParams`).
+public struct WorktreeReorderPinsParams: Codable, Sendable {
+    public let worktreeIDs: [UUID]
+    public init(worktreeIDs: [UUID]) {
+        self.worktreeIDs = worktreeIDs
     }
 }
 

--- a/Tests/TBDAppTests/PinnedDockContentTests.swift
+++ b/Tests/TBDAppTests/PinnedDockContentTests.swift
@@ -13,12 +13,14 @@ struct PinnedDockContentTests {
                            parent: UUID? = nil,
                            pinnedAt: Date? = nil,
                            archivedAt: Date? = nil,
-                           displayName: String? = nil) -> Worktree {
+                           displayName: String? = nil,
+                           pinSortOrder: Int? = nil) -> Worktree {
         Worktree(id: id, repoID: repoID, name: name,
                  displayName: displayName ?? name,
                  branch: "b", path: "/tmp/\(name)",
                  archivedAt: archivedAt, tmuxServer: "s",
-                 parentWorktreeID: parent, pinnedAt: pinnedAt)
+                 parentWorktreeID: parent, pinnedAt: pinnedAt,
+                 pinSortOrder: pinSortOrder)
     }
 
     private static func at(_ seconds: TimeInterval) -> Date {
@@ -198,5 +200,66 @@ struct PinnedDockContentTests {
         let rows = PinnedDockContent.rows(allWorktrees: [p, c], selectedIDs: [pID],
                                           children: Self.noChildren)
         #expect(rows.map(\.worktree.name) == ["p"])
+    }
+
+    // MARK: rows — pinSortOrder
+
+    @Test("pins sort by pinSortOrder ascending when every pin has one")
+    func sortsByPinSortOrder() {
+        let a = Self.wt("a", pinnedAt: Self.at(0), pinSortOrder: 2)
+        let b = Self.wt("b", pinnedAt: Self.at(10), pinSortOrder: 0)
+        let c = Self.wt("c", pinnedAt: Self.at(20), pinSortOrder: 1)
+        let rows = PinnedDockContent.rows(allWorktrees: [a, b, c],
+                                          selectedIDs: [], children: Self.noChildren)
+        #expect(rows.map(\.worktree.name) == ["b", "c", "a"])
+    }
+
+    @Test("pins without an order sort after pins that have one")
+    func unorderedSortsLast() {
+        let ordered = Self.wt("ordered", pinnedAt: Self.at(100), pinSortOrder: 5)
+        let unordered = Self.wt("unordered", pinnedAt: Self.at(0))
+        let rows = PinnedDockContent.rows(allWorktrees: [unordered, ordered],
+                                          selectedIDs: [], children: Self.noChildren)
+        #expect(rows.map(\.worktree.name) == ["ordered", "unordered"])
+    }
+
+    @Test("two unordered pins fall back to pinnedAt — the no-backfill guarantee")
+    func fallsBackToPinnedAt() {
+        let older = Self.wt("older", pinnedAt: Self.at(0))
+        let newer = Self.wt("newer", pinnedAt: Self.at(50))
+        let rows = PinnedDockContent.rows(allWorktrees: [newer, older],
+                                          selectedIDs: [], children: Self.noChildren)
+        #expect(rows.map(\.worktree.name) == ["older", "newer"])
+    }
+
+    // MARK: subtree
+
+    @Test("subtree returns just the root when collapsed")
+    func subtreeCollapsed() {
+        let root = Self.wt("root", pinnedAt: Self.at(0), pinSortOrder: 0)
+        let rows = PinnedDockContent.rows(allWorktrees: [root],
+                                          selectedIDs: [], children: Self.noChildren)
+        #expect(PinnedDockContent.subtree(of: root.id, in: rows).map(\.worktree.name) == ["root"])
+    }
+
+    @Test("subtree returns the root plus its descendants, and nothing from a sibling")
+    func subtreeExpanded() {
+        let aID = UUID(), bID = UUID()
+        let a = Self.wt("a", id: aID, pinnedAt: Self.at(0), pinSortOrder: 0)
+        let aKid = Self.wt("aKid", parent: aID)
+        let b = Self.wt("b", id: bID, pinnedAt: Self.at(10), pinSortOrder: 1)
+        let all = [a, aKid, b]
+        let rows = PinnedDockContent.rows(allWorktrees: all, selectedIDs: [aID],
+                                          children: Self.childLookup(all))
+        #expect(PinnedDockContent.subtree(of: aID, in: rows).map(\.worktree.name) == ["a", "aKid"])
+        #expect(PinnedDockContent.subtree(of: bID, in: rows).map(\.worktree.name) == ["b"])
+    }
+
+    @Test("subtree of an id not in the rows is empty")
+    func subtreeMissing() {
+        let root = Self.wt("root", pinnedAt: Self.at(0))
+        let rows = PinnedDockContent.rows(allWorktrees: [root],
+                                          selectedIDs: [], children: Self.noChildren)
+        #expect(PinnedDockContent.subtree(of: UUID(), in: rows).isEmpty)
     }
 }

--- a/Tests/TBDAppTests/PinnedDockReorderTests.swift
+++ b/Tests/TBDAppTests/PinnedDockReorderTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import TBDApp
+
+@Suite("Pinned dock reorder index maths")
+struct PinnedDockReorderTests {
+    private func ids(_ n: Int) -> [UUID] { (0..<n).map { _ in UUID() } }
+
+    @Test("moving the last root to the front produces the expected order")
+    func moveLastToFront() throws {
+        let roots = ids(3)
+        let result = try #require(PinnedDockReorder.reordered(
+            roots: roots, fromOffsets: IndexSet(integer: 2), toOffset: 0))
+        #expect(result == [roots[2], roots[0], roots[1]])
+    }
+
+    @Test("moving the first root to the end produces the expected order")
+    func moveFirstToEnd() throws {
+        let roots = ids(3)
+        let result = try #require(PinnedDockReorder.reordered(
+            roots: roots, fromOffsets: IndexSet(integer: 0), toOffset: 3))
+        #expect(result == [roots[1], roots[2], roots[0]])
+    }
+
+    @Test("an out-of-range source index is rejected, not clamped")
+    func staleSourceRejected() {
+        let roots = ids(2)
+        #expect(PinnedDockReorder.reordered(
+            roots: roots, fromOffsets: IndexSet(integer: 5), toOffset: 0) == nil)
+    }
+
+    @Test("a destination beyond the count is rejected")
+    func staleDestinationRejected() {
+        let roots = ids(2)
+        #expect(PinnedDockReorder.reordered(
+            roots: roots, fromOffsets: IndexSet(integer: 0), toOffset: 99) == nil)
+    }
+
+    @Test("an empty root list is rejected rather than producing an empty write")
+    func emptyRejected() {
+        #expect(PinnedDockReorder.reordered(
+            roots: [], fromOffsets: IndexSet(integer: 0), toOffset: 0) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreePinnedAtStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreePinnedAtStoreTests.swift
@@ -57,7 +57,7 @@ import TBDShared
         #expect(try await db.worktrees.get(id: made[0].id)?.pinSortOrder == 2)
     }
 
-    @Test("a worktree absent from the list is pushed after the ordered ones")
+    @Test("a PIN absent from the list is pushed after the ordered ones")
     func reorderPinsPushesAbsentRows() async throws {
         let db = try TBDDatabase(inMemory: true)
         let repo = try await db.repos.create(path: "/tmp/r", displayName: "r", defaultBranch: "main")
@@ -65,10 +65,35 @@ import TBDShared
                                               branch: "b", path: "/tmp/a", tmuxServer: "s")
         let outsider = try await db.worktrees.create(repoID: repo.id, name: "z", displayName: "z",
                                                      branch: "b", path: "/tmp/z", tmuxServer: "s")
+        // The sweep only reaches PINNED rows, so the outsider must actually be a
+        // pin — it stands in for one created by another client mid-drag.
+        try await db.worktrees.setPinned(id: outsider.id, pinnedAt: Date())
         try await db.worktrees.reorderPins(worktreeIDs: [a.id])
         #expect(try await db.worktrees.get(id: a.id)?.pinSortOrder == 0)
         let outsiderOrder = try #require(await db.worktrees.get(id: outsider.id)?.pinSortOrder)
         #expect(outsiderOrder >= 1)   // after the single ordered row at index 0
+    }
+
+    /// Regression guard: `reorderPins` must NOT stamp unpinned worktrees. A
+    /// non-NULL `pinSortOrder` has to mean "this pin was explicitly ordered",
+    /// because the dock's fallback sort reads NULL as "never ordered, use
+    /// pinnedAt". `ModelProfileStore.reorder` sweeps its whole table — every row
+    /// there is a profile — and re-syncing this method with it would silently
+    /// reintroduce the spillover.
+    @Test("reordering pins leaves unpinned worktrees NULL")
+    func reorderPinsLeavesUnpinnedRowsNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r", displayName: "r", defaultBranch: "main")
+        let pinned = try await db.worktrees.create(repoID: repo.id, name: "p", displayName: "p",
+                                                   branch: "b", path: "/tmp/p", tmuxServer: "s")
+        let unpinned = try await db.worktrees.create(repoID: repo.id, name: "u", displayName: "u",
+                                                     branch: "b", path: "/tmp/u", tmuxServer: "s")
+        try await db.worktrees.setPinned(id: pinned.id, pinnedAt: Date())
+
+        try await db.worktrees.reorderPins(worktreeIDs: [pinned.id])
+
+        #expect(try await db.worktrees.get(id: pinned.id)?.pinSortOrder == 0)
+        #expect(try await db.worktrees.get(id: unpinned.id)?.pinSortOrder == nil)
     }
 
     @Test("nextPinSortOrder returns one past the current maximum")

--- a/Tests/TBDDaemonTests/WorktreePinnedAtStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreePinnedAtStoreTests.swift
@@ -30,4 +30,55 @@ import TBDShared
         try await db.worktrees.setPinned(id: wt.id, pinnedAt: nil)
         #expect(try await db.worktrees.get(id: wt.id)?.pinnedAt == nil)
     }
+
+    @Test("a fresh worktree has no pin sort order")
+    func pinSortOrderDefaultsToNil() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r", displayName: "r", defaultBranch: "main")
+        let wt = try await db.worktrees.create(repoID: repo.id, name: "w", displayName: "w",
+                                               branch: "b", path: "/tmp/w", tmuxServer: "s")
+        #expect(wt.pinSortOrder == nil)
+        #expect(try await db.worktrees.get(id: wt.id)?.pinSortOrder == nil)
+    }
+
+    @Test("reorderPins writes 0..<n in list order")
+    func reorderPinsWritesIndices() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r", displayName: "r", defaultBranch: "main")
+        var made: [Worktree] = []
+        for name in ["a", "b", "c"] {
+            made.append(try await db.worktrees.create(repoID: repo.id, name: name, displayName: name,
+                                                      branch: "b", path: "/tmp/\(name)", tmuxServer: "s"))
+        }
+        // Reverse order: c, b, a
+        try await db.worktrees.reorderPins(worktreeIDs: [made[2].id, made[1].id, made[0].id])
+        #expect(try await db.worktrees.get(id: made[2].id)?.pinSortOrder == 0)
+        #expect(try await db.worktrees.get(id: made[1].id)?.pinSortOrder == 1)
+        #expect(try await db.worktrees.get(id: made[0].id)?.pinSortOrder == 2)
+    }
+
+    @Test("a worktree absent from the list is pushed after the ordered ones")
+    func reorderPinsPushesAbsentRows() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r", displayName: "r", defaultBranch: "main")
+        let a = try await db.worktrees.create(repoID: repo.id, name: "a", displayName: "a",
+                                              branch: "b", path: "/tmp/a", tmuxServer: "s")
+        let outsider = try await db.worktrees.create(repoID: repo.id, name: "z", displayName: "z",
+                                                     branch: "b", path: "/tmp/z", tmuxServer: "s")
+        try await db.worktrees.reorderPins(worktreeIDs: [a.id])
+        #expect(try await db.worktrees.get(id: a.id)?.pinSortOrder == 0)
+        let outsiderOrder = try #require(await db.worktrees.get(id: outsider.id)?.pinSortOrder)
+        #expect(outsiderOrder >= 1)   // after the single ordered row at index 0
+    }
+
+    @Test("nextPinSortOrder returns one past the current maximum")
+    func nextPinSortOrderAppends() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(path: "/tmp/r", displayName: "r", defaultBranch: "main")
+        #expect(try await db.worktrees.nextPinSortOrder() == 0)   // nothing pinned yet
+        let a = try await db.worktrees.create(repoID: repo.id, name: "a", displayName: "a",
+                                              branch: "b", path: "/tmp/a", tmuxServer: "s")
+        try await db.worktrees.reorderPins(worktreeIDs: [a.id])   // a → 0
+        #expect(try await db.worktrees.nextPinSortOrder() == 1)
+    }
 }

--- a/docs/specs/2026-07-26-pinned-dock-reorder-design.md
+++ b/docs/specs/2026-07-26-pinned-dock-reorder-design.md
@@ -1,0 +1,175 @@
+# Drag-and-drop reordering in the pinned worktree dock
+
+**Status:** design approved 2026-07-26, not yet implemented.
+**Depends on:** the pinned dock ([PR #517](https://github.com/cheapsteak/tbd/pull/517),
+spec [`2026-07-26-pinned-worktree-dock-design.md`](2026-07-26-pinned-worktree-dock-design.md)).
+Ships as a follow-up PR once #517 merges.
+
+## Problem
+
+The dock orders pins by `pinnedAt` ascending — oldest pin first, new pins append. That order
+records *when* you pinned things, which has nothing to do with how you want to see them. With
+the cap at five visible rows, the pins you use most can sit below the scroll line purely
+because you pinned them first.
+
+Drag-to-reorder was deliberately out of scope in the dock's original spec. This adds it.
+
+## Solution
+
+Drag a pinned row to reorder the dock. The order persists, survives restarts, and is never
+disturbed by pinning something new — a fresh pin still appends to the end.
+
+**Only top-level pinned rows are draggable.** Expanded children are derived from
+`parentWorktreeID`, not stored as pins; dragging one would either mean nothing or imply
+re-parenting, which is a different and much riskier feature. Children move with their parent.
+The Watch Desk slot is a separate view and is not draggable at all.
+
+## Architecture
+
+### Storage — a dedicated column
+
+Migration `v64_worktree_pin_sort_order` adds a nullable `pinSortOrder INTEGER` to `worktree`,
+through `addColumnIfMissing` per `Database/CLAUDE.md`.
+
+**Re-check that number at implementation time.** `v64` assumes #517's `v63_worktree_pinned_at`
+is the highest when this lands. Main is currently taking migration numbers faster than this
+branch can — #517's own migration was authored as `v60` and had to be renumbered to `v63` on
+rebase after three others landed first. Read the tail of `Database.swift` and take the next
+free number. This is cheap precisely because the body uses `addColumnIfMissing`: per
+`Database/CLAUDE.md`, renumbering an additive migration bricked the daemon twice before those
+helpers existed, and now just no-ops on a database that already ran it.
+
+`Worktree.sortOrder` already exists but is **not** reusable: it drives repo-section tree
+ordering via `worktree.reorder`, so writing pin order into it would scramble the sidebar every
+time you reordered the dock. The two are different orderings of different lists — the sidebar's
+is per-repo and hierarchical, the dock's is flat and global.
+
+Rewriting `pinnedAt` timestamps to encode order was rejected for the same class of reason: it
+would make `pinnedAt` a sort key wearing a timestamp's clothes, leaving "when did I pin this?"
+permanently unanswerable.
+
+Three changes in **one commit**, per the migration rule in the root `CLAUDE.md`:
+
+1. `Sources/TBDDaemon/Database/Database.swift` — the migration.
+2. `Sources/TBDDaemon/Database/WorktreeStore.swift` — `WorktreeRecord.pinSortOrder: Int?`,
+   threaded through `init(from:)` and `toModel()`.
+3. `Sources/TBDShared/Models.swift` — `Worktree.pinSortOrder: Int?`, optional so existing rows
+   and cached JSON still decode.
+
+### Ordering, and why there is no backfill
+
+`PinnedDockContent.rows` sorts by `pinSortOrder` ascending, **falling back to `pinnedAt`** for
+rows whose column is still `NULL`:
+
+```swift
+.sorted { lhs, rhs in
+    switch (lhs.pinSortOrder, rhs.pinSortOrder) {
+    case let (l?, r?):   return l < r
+    case (nil, _?):      return false          // unordered sorts after ordered
+    case (_?, nil):      return true
+    case (nil, nil):     return (lhs.pinnedAt ?? .distantPast) < (rhs.pinnedAt ?? .distantPast)
+    }
+}
+```
+
+Existing pins therefore keep their current visual order the moment the migration lands, with no
+backfill `UPDATE` and no flicker. The first drag assigns real values to everything.
+
+Pinning assigns `max(pinSortOrder) + 1` so a new pin appends and never disturbs a curated order.
+
+### RPC
+
+`worktree.reorderPins` with `WorktreeReorderPinsParams { worktreeIDs: [UUID] }` — the pinned
+worktrees in display order. The handler mirrors `ModelProfileStore.reorder` almost verbatim:
+write `index` for each id in the list, then push anything absent to `count + rowid` so rows the
+client did not know about land after the ordered ones rather than colliding at the same value.
+
+Global, no repo scoping — the dock is one flat cross-repo list, so this matches
+`modelProfile.reorder` rather than the repo-scoped `worktree.reorder`.
+
+### View — the nested `ForEach` this requires
+
+`.onMove` hands the handler indices into **its own `ForEach`'s elements**. `PinnedDockView`
+currently iterates a *flat* `[PinnedDockRow]` that already contains expanded children, so
+attaching `.onMove` there would move the wrong row whenever a subtree is expanded.
+
+`RepoSectionView` already solves this: its `ForEach` iterates top-level worktrees and each
+element renders a whole subtree via `WorktreeSubtreeView`, so move indices line up with roots.
+`PinnedDockView` adopts the same shape:
+
+```swift
+ForEach(pinnedRoots) { root in
+    ForEach(PinnedDockContent.subtree(of: root, in: rows)) { row in
+        WorktreeRowView(worktree: row.worktree,
+                        indentLevel: row.depth,
+                        sectionRepoID: row.sectionRepoID)
+            .tag(row.worktree.id)
+    }
+}
+.onMove { source, destination in
+    appState.reorderPins(fromOffsets: source, toOffset: destination)
+}
+```
+
+The outer `ForEach` carries `.onMove`; the inner emits the root plus its expanded descendants.
+`PinnedDockContent` keeps returning its flat `[PinnedDockRow]` — its existing tests stay valid —
+and gains a `subtree(of:in:)` helper that slices the contiguous run belonging to one root.
+
+### App state
+
+`AppState.reorderPins(fromOffsets:toOffset:)` mirrors `reorderTopLevelWorktrees`
+(`AppState+Worktrees.swift:785`):
+
+1. Snapshot the current pinned roots in display order — the same order the `ForEach` rendered.
+2. **Guard against stale indices.** `source`/`destination` can outlive the snapshot they were
+   captured against; if `source` contains an out-of-range index or `destination` exceeds the
+   count, log a warning and return rather than crashing. The existing method does exactly this,
+   and it is not theoretical — a pin can be removed by another surface mid-drag.
+3. Apply `move(fromOffsets:toOffset:)` to derive the new order.
+4. Update local state optimistically so the row lands under the cursor immediately.
+5. Persist via `worktree.reorderPins`; on failure, roll back to the snapshot and alert.
+
+Optimistic update is right here, unlike `setPinned`, because the client knows the entire
+resulting order rather than depending on a daemon-assigned timestamp.
+
+## Feature flag
+
+**None.** The root `CLAUDE.md` requires a default-off flag for behavior that acts without a user
+gesture, destroys state, or wholesale-replaces a load-bearing path. This is additive UI on an
+existing surface, driven entirely by an explicit drag, replacing nothing that carries load — the
+"small additive UI" exemption. Worst case for a bug is a wrong visual order, fixed by dragging
+again.
+
+## Testing
+
+**`PinnedDockContentTests`** (extend)
+- Rows sort by `pinSortOrder` ascending when every pin has one.
+- Rows with `pinSortOrder == nil` sort after rows that have one.
+- Two `nil` rows fall back to `pinnedAt` order — the no-backfill guarantee.
+- `subtree(of:in:)` returns exactly the root plus its descendants, and just the root when
+  collapsed.
+
+**`WorktreeStore` (daemon)**
+- `v64` adds the column; pre-existing rows read back `nil`.
+- `reorderPins` writes `0..<n` in list order.
+- A pinned worktree absent from the list is pushed after the ordered ones, not left colliding.
+- Round-trip of a non-nil and a nil `pinSortOrder`.
+
+**`AppState.reorderPins`**
+- A move produces the expected resulting order.
+- An out-of-range `source` index returns without mutating state (the stale-index guard).
+- A `destination` beyond the count returns without mutating state.
+
+**Live**
+- Drag a pin from bottom to top; order holds across an app restart.
+- Drag with a subtree expanded — the parent moves with its children, and the correct row moves.
+- Pin something new: it appends at the end, leaving the curated order untouched.
+- Drag with more than five pins, so the dock is scrolled and capped.
+
+## Out of scope
+
+- Reordering expanded children, or drag-to-re-parent.
+- Dragging a worktree *into* the dock from the repo list to pin it. Pinning stays the gutter
+  button and the context menu.
+- Dragging the Watch Desk slot.
+- A CLI equivalent. The RPC makes one trivial later.

--- a/docs/specs/2026-07-26-pinned-dock-reorder-design.md
+++ b/docs/specs/2026-07-26-pinned-dock-reorder-design.md
@@ -98,22 +98,26 @@ element renders a whole subtree via `WorktreeSubtreeView`, so move indices line 
 `PinnedDockView` adopts the same shape:
 
 ```swift
-ForEach(pinnedRoots) { root in
-    ForEach(PinnedDockContent.subtree(of: root, in: rows)) { row in
-        WorktreeRowView(worktree: row.worktree,
-                        indentLevel: row.depth,
-                        sectionRepoID: row.sectionRepoID)
-            .tag(row.worktree.id)
-    }
+ForEach(roots) { root in
+    dockRow(root)                                  // emitted DIRECTLY
+    ForEach(descendants(of: root)) { dockRow($0) } // descendants follow
 }
 .onMove { source, destination in
     appState.reorderPins(fromOffsets: source, toOffset: destination)
 }
 ```
 
-The outer `ForEach` carries `.onMove`; the inner emits the root plus its expanded descendants.
-`PinnedDockContent` keeps returning its flat `[PinnedDockRow]` — its existing tests stay valid —
-and gains a `subtree(of:in:)` helper that slices the contiguous run belonging to one root.
+The outer `ForEach` carries `.onMove`; each element emits its root row plus that root's expanded
+descendants. `PinnedDockContent` keeps returning its flat `[PinnedDockRow]` — its existing tests
+stay valid — and gains a `subtree(of:in:)` helper slicing the contiguous run belonging to one
+root.
+
+**The root row must be emitted directly, not wrapped in a `ForEach` of its own.** Verified live,
+the hard way: if the outer element's content is a *bare* `ForEach`, AppKit never starts a drag
+session and `.onMove` silently never fires — no reorder, no error, no log. The working shape is
+exactly `WorktreeSubtreeView`'s: one row, then a `ForEach` for the children. Symptom to
+recognise if this regresses: dragging appears to do nothing at all, rather than doing the wrong
+thing.
 
 ### App state
 


### PR DESCRIPTION
Follow-up to #517, which added the pinned dock. That PR ordered pins by `pinnedAt`; this one lets you choose the order.

## Summary

The dock ordered pins oldest-first, new pins appending. That records *when* you pinned things, which has nothing to do with how you want to see them — and with the dock capped at five visible rows, the pins you reach for most can sit below the scroll line purely because you pinned them first.

This adds drag-to-reorder. The order persists, survives restarts, and a fresh pin still appends to the end rather than disturbing it.

**Only top-level pinned rows are draggable.** Expanded children are derived from `parentWorktreeID`, not stored as pins — dragging one would either mean nothing or imply re-parenting, a different and much riskier feature. Children move with their parent. The Watch Desk slot is a separate view and isn't draggable at all.

## Storage

Migration `v64_worktree_pin_sort_order` adds a nullable `pinSortOrder INTEGER` to `worktree`, via `addColumnIfMissing`. All three parts in one commit per the migration rule: migration, `WorktreeRecord`, `TBDShared.Worktree`.

**`sortOrder` could not be reused** — it drives repo-section tree ordering via `worktree.reorder`, so writing pin order into it would scramble the sidebar every time you reordered the dock. Two different orderings of two different lists: the sidebar's is per-repo and hierarchical, the dock's is flat and global.

Rewriting `pinnedAt` timestamps to encode order was rejected for the same class of reason — it would make `pinnedAt` a sort key wearing a timestamp's clothes, leaving "when did I pin this?" permanently unanswerable.

## No backfill

`PinnedDockContent.rows` sorts by `pinSortOrder` ascending and **falls back to `pinnedAt`** when both values are `nil`. Existing pins therefore keep their exact current visual order the moment the migration lands — no `UPDATE`, no reshuffle, no flicker. The first drag assigns real values.

That fallback is only meaningful because `reorderPins` **leaves unpinned worktrees `NULL`**, a deliberate divergence from `ModelProfileStore.reorder` which this otherwise copies almost verbatim: every row in `model_profiles` is a profile, but most rows in `worktree` are not pins. Without the `pinnedAt IS NOT NULL` guard on the sweep clause, one reorder would stamp `pinSortOrder` across the whole table and destroy the "NULL means never explicitly ordered" invariant. Regression test `reorderPinsLeavesUnpinnedRowsNil` covers it, mutation-checked by stripping the guard and confirming exactly that test — and only it — failed.

## The view change, and a trap worth knowing

`.onMove` hands its closure indices into **its own `ForEach`'s elements**. `PinnedDockView` iterated a *flat* row list that already contained expanded children, so attaching `.onMove` there would move the wrong worktree whenever a subtree was expanded. It now uses a nested shape — outer `ForEach` over pinned roots carrying `.onMove`, descendants emitted beneath — mirroring `RepoSectionView`.

**The root row must be emitted directly, not wrapped in a `ForEach` of its own.** If the outer element's content is a *bare* `ForEach`, AppKit never starts a drag session and `.onMove` silently never fires — no reorder, no error, no log. Found by shipping the wrong shape, watching drags do nothing, then proving the harness sound against `RepoSectionView`'s known-good `.onMove`. The working shape is exactly `WorktreeSubtreeView`'s. Recorded in the spec and in a code comment, because "nothing happens" is easy to misdiagnose.

## App state

`AppState.reorderPins` is optimistic with rollback, unlike `setPinned` — the client knows the entire resulting order rather than depending on a daemon-assigned timestamp, so the row lands under the cursor immediately.

One thing it does that `reorderTopLevelWorktrees` doesn't need to: pinned worktrees span **both** `worktrees` (repo-keyed) and `scratchWorktrees` (scratch spaces are pinnable), so it snapshots and restores both. A rollback touching only one would silently leave the other half mutated.

## No feature flag

`CLAUDE.md` requires a default-off flag for behaviour that acts without a user gesture, destroys state, or wholesale-replaces a load-bearing path. This is additive UI on an existing surface, driven entirely by an explicit drag, replacing nothing load-bearing — the "small additive UI" exemption. Worst case for a bug is a wrong visual order, fixed by dragging again.

Design doc: `docs/specs/2026-07-26-pinned-dock-reorder-design.md`.

## Test plan

- [x] `swiftlint --strict` 0 violations in 603 files; full suite **4365 tests / 492 suites passed**, 1 known issue (`FlakyQuarantineSelfTests`, by design)
- [x] Daemon: `v64` column defaults to `nil`; `reorderPins` writes `0..<n`; a *pin* absent from the list is pushed after the ordered ones; an *unpinned* row stays `NULL`; `nextPinSortOrder` returns one past the max
- [x] `PinnedDockContent`: sorts by `pinSortOrder`; unordered pins sort last; two unordered pins fall back to `pinnedAt`; `subtree(of:in:)` returns root-only when collapsed, root+descendants when expanded, empty for an unknown id
- [x] `PinnedDockReorder`: move-to-front, move-to-end, out-of-range source rejected, destination-beyond-count rejected, empty list rejected
- [x] Live, with real CGEvent drags: order survives restart; **with a subtree expanded, dragging root index 3 / flat index 4 moved the correct row** — not the neighbour a flat-index bug would have grabbed; dragging a child is inert; a new pin appends; dragging still targets correctly with the dock capped and scrolled

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A3227F57-9BF9-427D-A915-D90AD0C037BF)