### PR TITLE
DX: Nightly workflow turns three kinds of remembered fact into checks that fire

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,15 @@ on:
 permissions:
   contents: read
   issues: write   # the entire reporting mechanism is `gh issue comment`
+  # REQUIRED by the quarantine audit, and easy to omit: declaring a
+  # `permissions:` block sets every scope NOT listed to `none` rather than
+  # leaving it at its default. `scripts/nightly-quarantine-audit.sh` reads the
+  # Actions API three ways — `gh run list --workflow test.yml`, the run's
+  # artifact list, and the artifact zip — and all three need `actions: read`.
+  # Without it the audit 403s, dies, and comments that it died: not silent, but
+  # never actually auditing anything, every night, forever.
+  # Precedent in this repo: claude-code-review.yml:34 and claude.yml:26.
+  actions: read
 
 concurrency:
   group: nightly
@@ -193,16 +202,28 @@ jobs:
           # BYTES for a die() path — so the comment on #519 would arrive with no
           # reason in it. That is the one case where the report has to carry the
           # diagnosis, since a clean run posts nothing at all.
-          bash scripts/nightly-quarantine-audit.sh run --days 7 2>&1 | tee "$AUDIT_REPORT"
+          #
+          # The exit code is captured rather than just failing the step, because
+          # 1 (findings) and 2 (harness error) deserve different titles — a
+          # 403 on the Actions API is not "the quarantine list has a problem".
+          rc=0
+          bash scripts/nightly-quarantine-audit.sh run --days 7 2>&1 | tee "$AUDIT_REPORT" || rc=$?
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          exit "$rc"
 
       - name: Report audit findings
         if: steps.audit.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [ "${{ steps.audit.outputs.rc }}" = "2" ]; then
+            title="Quarantine audit FAILED TO RUN (harness error) — it audited nothing"
+          else
+            title="Quarantine audit found something"
+          fi
           bash scripts/nightly-report.sh \
             --issue "$TRACKING_ISSUE" \
-            --title "Quarantine audit found something" \
+            --title "$title" \
             --body-file "$AUDIT_REPORT" \
             --post
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,217 @@
+name: Nightly
+
+# Stage 3 of the test-hardening program
+# (docs/specs/2026-07-24-test-hardening-design.md §9). Three steps today —
+# live tmux probes, the flake-ledger stress loop, and the quarantine audit —
+# with a slot reserved for the interleaving fuzz pass (§8, stage 4).
+#
+# WHY THERE IS NO `pull_request` OR `push` TRIGGER: §9 requires that failures
+# land as issue comments and never as PR noise. With only `schedule` and
+# `workflow_dispatch`, there is no PR for this workflow to comment on and it can
+# never become a required check. That invariant is structural here, not a
+# convention someone has to remember while editing.
+
+on:
+  schedule:
+    # 11:00 UTC — ~03:00/04:00 US Pacific. Off-peak, per §9.
+    - cron: '0 11 * * *'
+  workflow_dispatch:
+    inputs:
+      stress_iterations:
+        description: 'Iterations per stress target (whole-fast-pass arm uses its own smaller count)'
+        required: false
+        default: '10'
+      post_wire_fixture:
+        description: 'Post the wire-verification fixture comment to #519 (proves the reporting path works)'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  issues: write   # the entire reporting mechanism is `gh issue comment`
+
+concurrency:
+  group: nightly
+  # NOT cancel-in-progress: a nightly that cancels itself on a manual dispatch
+  # would silently skip a night, and a skipped audit looks exactly like a clean one.
+  cancel-in-progress: false
+
+env:
+  # LITERAL PATHS, NEVER `${{ runner.temp }}`. The `runner` context is STEP-level
+  # only: a job-level `env:` referring to it resolves to the EMPTY STRING and
+  # GitHub does not error. Slice E shipped that spelling in its first commit —
+  # tests would have written to `/retry-metrics.jsonl`, failed at the filesystem
+  # root, and uploaded an empty artifact forever while `if-no-files-found` buried
+  # it. A feature dead on arrival, green for as long as nobody looked.
+  TRACKING_ISSUE: '519'
+  PROBE_LOG: /tmp/nightly-probes.log
+  STRESS_LOG: /tmp/nightly-stress.log
+  STRESS_REPORT_DIR: /tmp/nightly-stress-reports
+  AUDIT_REPORT: /tmp/nightly-audit.md
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────────
+  # macOS: everything that needs a real tmux server or a Swift toolchain.
+  # ─────────────────────────────────────────────────────────────────────────────
+  probes-and-stress:
+    name: tmux probes + flake-ledger stress loop
+    runs-on: macos-26
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tmux
+        # macos runners don't ship tmux, and the probes drive a real server.
+        run: brew install tmux
+
+      - name: Select Xcode 26.6 (Swift 6.3.3)
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
+
+      - name: Capture Swift toolchain version
+        run: echo "SWIFT_VERSION=$(xcrun swift --version | head -1)" >> "$GITHUB_ENV"
+
+      # RESTORE-ONLY, deliberately. A nightly that also SAVES would churn the
+      # cache every night and could evict the entry PR builds depend on. This job
+      # is allowed to benefit from the cache; it is not allowed to reshape it.
+      - name: Restore SwiftPM build cache (read-only)
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+          key: spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-src-${{ hashFiles('Package.swift', 'Sources/**/*.swift', 'Tests/**/*.swift') }}
+          restore-keys: |
+            spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-
+
+      # ── Step 1: live tmux probes ────────────────────────────────────────────
+      # continue-on-error so a probe failure still lets the stress loop run and
+      # still gets reported; the job is failed deliberately at the end.
+      - name: Live tmux probes
+        id: probes
+        continue-on-error: true
+        # Measured at ~9s locally. Ten minutes is a hang-guard, not a budget.
+        timeout-minutes: 10
+        run: |
+          set -o pipefail
+          bash scripts/nightly-tmux-probes.sh 2>&1 | tee "$PROBE_LOG"
+
+      - name: Report probe failures
+        if: steps.probes.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash scripts/nightly-report.sh \
+            --issue "$TRACKING_ISSUE" \
+            --title "Live tmux probes FAILED — a behaviour this repo relies on has changed" \
+            --body-file "$PROBE_LOG" \
+            --post
+
+      # ── Step 2: flake-ledger stress loop ────────────────────────────────────
+      # Attaches to #494 (ControlModeInputHealthTests), #503 (GitManagerTimeout
+      # + the whole-fast-pass repro shape) and #496 (AppearanceDebounce).
+      - name: Flake-ledger stress loop
+        id: stress
+        continue-on-error: true
+        # An OUTER timeout is mandatory: `.clockDriven` was measured failing to
+        # bound a hang, so neither a test trait nor the harness's own per-iteration
+        # deadline is allowed to be the only guard.
+        timeout-minutes: 120
+        run: |
+          set -o pipefail
+          mkdir -p "$STRESS_REPORT_DIR"
+          bash scripts/nightly-flake-stress.sh \
+            --iterations "${{ github.event.inputs.stress_iterations || '10' }}" \
+            --report-dir "$STRESS_REPORT_DIR" 2>&1 | tee "$STRESS_LOG"
+
+      - name: Report stress failures to the issue each target names
+        if: steps.stress.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          shopt -s nullglob
+          reports=("$STRESS_REPORT_DIR"/*.md)
+          if [ ${#reports[@]} -eq 0 ]; then
+            # The step failed but produced no per-target report: that is a
+            # harness failure (build error, bad argument), not a flake. It still
+            # has to reach a human, so it goes to the tracking issue.
+            bash scripts/nightly-report.sh \
+              --issue "$TRACKING_ISSUE" \
+              --title "Flake-ledger stress loop FAILED without producing a target report (harness error)" \
+              --body-file "$STRESS_LOG" \
+              --post
+            exit 0
+          fi
+          for report in "${reports[@]}"; do
+            issue="$(basename "$report" .md)"
+            bash scripts/nightly-report.sh \
+              --issue "$issue" \
+              --title "Nightly stress loop reproduced this flake" \
+              --body-file "$report" \
+              --post
+          done
+
+      # ── Step 3 slot: interleaving fuzz pass (§8, stage 4 — slice I) ─────────
+      # Append here rather than in a new job: this job already pays the toolchain
+      # setup and the cache restore, and the fuzz pass needs both.
+
+      - name: Fail the job if any nightly step failed
+        # Without this, `continue-on-error` would leave the run green and the
+        # only signal would be an issue comment nobody is watching for.
+        if: steps.probes.outcome == 'failure' || steps.stress.outcome == 'failure'
+        run: |
+          echo "::error::probes=${{ steps.probes.outcome }} stress=${{ steps.stress.outcome }}"
+          exit 1
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # ubuntu: the quarantine audit. A SEPARATE JOB, deviating from §9's "one job".
+  #
+  # It needs only `gh` and `jq`. As a fourth step on the macOS job it would be
+  # suppressed whenever the macOS half wedges or a macOS runner is unavailable —
+  # i.e. it would stop reporting exactly when things are worst, and a silent
+  # audit is indistinguishable from a clean codebase. ubuntu costs nothing
+  # against the 5-concurrent-macOS-job cap.
+  # ─────────────────────────────────────────────────────────────────────────────
+  quarantine-audit:
+    name: Quarantine audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Audit the quarantine list against the retry-metrics ledger
+        id: audit
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          bash scripts/nightly-quarantine-audit.sh run --days 7 | tee "$AUDIT_REPORT"
+
+      - name: Report audit findings
+        if: steps.audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash scripts/nightly-report.sh \
+            --issue "$TRACKING_ISSUE" \
+            --title "Quarantine audit found something" \
+            --body-file "$AUDIT_REPORT" \
+            --post
+
+      # Proof that the reporting path works, on demand. A clean nightly posts
+      # NOTHING, so without this the `gh issue comment` wire would be exercised
+      # for the first time on the night something breaks. The comment is
+      # labelled and KEPT — a deleted verification leaves no evidence the wire
+      # was ever proven.
+      - name: Post the wire-verification fixture (manual dispatch only)
+        if: github.event_name == 'workflow_dispatch' && inputs.post_wire_fixture
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/nightly-report.sh --issue "$TRACKING_ISSUE" --fixture --post
+
+      - name: Fail the job if the audit found something
+        if: steps.audit.outcome == 'failure'
+        run: |
+          echo "::error::quarantine audit reported findings — see the comment on issue #$TRACKING_ISSUE"
+          exit 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -186,7 +186,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -o pipefail
-          bash scripts/nightly-quarantine-audit.sh run --days 7 | tee "$AUDIT_REPORT"
+          # `2>&1` before the pipe, like the two steps above: the audit reports
+          # harness failures (bad gh call, auth hiccup) via die() on STDERR and
+          # exits 2, which this step treats as a failure and comments about. Without
+          # the redirect, $AUDIT_REPORT captures stdout only — measured at ZERO
+          # BYTES for a die() path — so the comment on #519 would arrive with no
+          # reason in it. That is the one case where the report has to carry the
+          # diagnosis, since a clean run posts nothing at all.
+          bash scripts/nightly-quarantine-audit.sh run --days 7 2>&1 | tee "$AUDIT_REPORT"
 
       - name: Report audit findings
         if: steps.audit.outcome == 'failure'

--- a/scripts/nightly-flake-stress.sh
+++ b/scripts/nightly-flake-stress.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# scripts/nightly-flake-stress.sh — run the historically flaky suites repeatedly
+# under induced CPU load. Step 2 of the nightly workflow
+# (docs/specs/2026-07-24-test-hardening-design.md §9).
+#
+# Each target is attached to an OPEN issue that names the flake. A failure here
+# lands as a comment on that issue, so the evidence accumulates where the
+# diagnosis lives instead of in a log nobody reads.
+#
+# WHAT THIS CANNOT TELL YOU, stated here because the report repeats it and the
+# tracking issue repeats it again: CI is ~4 cores on an otherwise idle runner.
+# #503's reproduction regime is loadavg ~150 on a 12-core box shared by four
+# agents. A zero-failure night is NOT evidence that any of these flakes is
+# fixed — it is one sample from a much gentler regime. The word "fixed" does not
+# appear in this script's output by design; the numbers it reports are
+# iterations, observed loadavg, and core count, so a reader can judge the regime
+# for themselves.
+#
+# Usage:
+#   scripts/nightly-flake-stress.sh [--iterations N] [--spinners K]
+#                                   [--target NAME] [--report-dir DIR] [--no-load]
+#
+# Exit: 0 = every target clean, 1 = at least one target FAILED, 2 = harness error.
+#
+# KILL DISCIPLINE (Tests/CLAUDE.md "The kill hazards" — every line paid for):
+#   - spinner PIDs are CAPTURED AT SPAWN into an array; cleanup kills those only
+#   - never `jobs -p` (job control is off in a non-interactive shell)
+#   - never `trap 'kill 0'` (signals this shell's own process group)
+#   - never `pkill -f <pattern>` (matches sibling worktrees' identical bundles)
+#   - post-cleanup verification is `ps -p <captured pid>`, never `pgrep -x yes`
+#   - trap on INT/TERM as well as EXIT, so an externally killed run still cleans up
+
+set -uo pipefail
+
+# target|swift-test-filter-args|floor|issue|description
+#
+# Floors are MEASURED, never guessed. `swift test --filter` exits GREEN when it
+# matches nothing, and the filter matches the TYPE name rather than the @Suite
+# display string — so a renamed suite silently runs zero tests and passes. A
+# floor copied from a grep of `@Test` is a floor that has never been checked
+# against the runner.
+#
+# Measured 2026-07-27 on this tree (swift 6.3.3, unloaded):
+#   ControlModeInputHealth  10 tests      GitManagerTimeout  6 tests
+#   AppearanceDebounce       7 tests      whole fast pass    4308 tests
+#
+# The floors sit BELOW those, following test.yml's precedent: they exist to fire
+# when a pass collapses to near-nothing, not to break every time somebody adds or
+# deletes a test. A floor pinned to the exact count would make ordinary test
+# churn look like a filter defect.
+TARGETS=(
+  "ControlModeInputHealth|--parallel -j 2 --filter ControlModeInputHealthTests|5|494|control-mode input health: two contention races"
+  "GitManagerTimeout|--no-parallel --filter ^TBDDaemonLiveTests\\.GitManagerTimeoutTests|3|503|60s hang at ~1/22 under heavy load, mechanism unknown"
+  "AppearanceDebounce|--parallel -j 2 --filter AppearanceDebounceTests|4|496|clock-driven wedge: megaYield at background QoS"
+  "FastPassWhole|--parallel -j 2 --skip ^TBDDaemonLiveTests\\.|3000|503|#503's actual reproduction shape: whole fast pass under load"
+)
+
+DEFAULT_ITERATIONS=10
+# The whole-target arm is minutes per iteration rather than seconds, so it gets
+# its own much smaller count. Sized from the step budget, not from ambition.
+WHOLE_TARGET_ITERATIONS=3
+ITERATION_DEADLINE_S=600
+
+SPINNER_PIDS=()
+REPORT_DIR=""
+FAILED_TARGETS=0
+
+die() { echo "nightly-flake-stress: $*" >&2; exit 2; }
+
+# --- load generation ----------------------------------------------------------
+
+start_spinners() {
+  local count="$1" i
+  for ((i = 0; i < count; i++)); do
+    yes > /dev/null 2>&1 &
+    SPINNER_PIDS+=("$!")          # captured at spawn — the only reliable handle
+  done
+  echo "load: started ${#SPINNER_PIDS[@]} spinner(s) [pids: ${SPINNER_PIDS[*]}]"
+}
+
+stop_spinners() {
+  local pid leaked=0
+  for pid in "${SPINNER_PIDS[@]:-}"; do
+    [[ -n "$pid" ]] && kill "$pid" 2>/dev/null
+  done
+  sleep 0.5
+  # VERIFY, by captured PID. `pgrep -x yes` would answer a different question:
+  # a sibling worktree's spinners are not ours to count or to kill.
+  for pid in "${SPINNER_PIDS[@]:-}"; do
+    [[ -n "$pid" ]] || continue
+    if ps -p "$pid" >/dev/null 2>&1; then
+      echo "load: WARNING spinner $pid survived SIGTERM, sending SIGKILL" >&2
+      kill -9 "$pid" 2>/dev/null
+      leaked=$((leaked + 1))
+    fi
+  done
+  [[ ${#SPINNER_PIDS[@]} -gt 0 ]] && echo "load: stopped ${#SPINNER_PIDS[@]} spinner(s), $leaked needed SIGKILL"
+  SPINNER_PIDS=()
+}
+
+cleanup() {
+  local rc=$?
+  stop_spinners
+  exit "$rc"
+}
+trap cleanup EXIT INT TERM
+
+# --- bounded execution --------------------------------------------------------
+
+# Run a command with an OUTER deadline. `.clockDriven` was measured failing to
+# bound a hang (it sat past 10 minutes with the trait applied), so a stress
+# harness cannot delegate its hang-guard to a test trait. Returns 124 on deadline.
+run_with_deadline() {
+  local deadline_s="$1" log="$2"; shift 2
+  "$@" > "$log" 2>&1 &
+  local pid=$!
+  local waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [[ "$waited" -ge "$deadline_s" ]]; then
+      # Children first: killing the parent orphans them, and an orphaned
+      # swift-frontend keeps burning the CPU this harness is trying to control.
+      pkill -P "$pid" 2>/dev/null
+      kill -TERM "$pid" 2>/dev/null
+      sleep 2
+      pkill -P "$pid" 2>/dev/null
+      kill -KILL "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      return 124
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid"
+  return $?
+}
+
+# The 1-MINUTE load average, which LAGS: measured here, the first iterations
+# after starting 6 spinners still reported ~7 while the run finished at ~24. It
+# is reported as `load1m` everywhere so nobody reads an early figure as the load
+# the iteration actually ran at. The induced-spinner count is the non-lagging
+# half of the picture, so both are always printed together.
+loadavg() { uptime | sed -n 's/.*load averages*: *\([0-9.]*\).*/\1/p'; }
+
+# --- one iteration ------------------------------------------------------------
+
+# Verdict is (summary present) AND (count >= floor) AND (rc == 0). Never rc alone.
+# Echoes "PASS <count>" or "FAIL <reason>".
+judge_iteration() {
+  local rc="$1" log="$2" floor="$3"
+  local count
+  count="$(grep -oE 'Test run with [0-9]+ tests?' "$log" | grep -oE '[0-9]+' | head -1)"
+
+  if [[ "$rc" -eq 124 ]]; then
+    echo "FAIL wedged — no completion within ${ITERATION_DEADLINE_S}s (killed by the harness deadline)"
+    return
+  fi
+  # A TRUNCATED LOG IS A FAILURE, NOT A PASS. A wedged run exits with no summary
+  # line and no seed, and a naive rc==0 check scores it green. This program hit
+  # that repeatedly; it is the single most important line in this file.
+  if [[ -z "$count" ]]; then
+    echo "FAIL no 'Test run with N tests' summary — truncated log or wedged run (rc=$rc)"
+    return
+  fi
+  if [[ "$count" -lt "$floor" ]]; then
+    echo "FAIL ran $count tests, below the measured floor of $floor — the filter matched less than it should (it exits GREEN on zero matches)"
+    return
+  fi
+  if [[ "$rc" -ne 0 ]]; then
+    echo "FAIL rc=$rc with $count tests executed"
+    return
+  fi
+  echo "PASS $count"
+}
+
+failing_tests_from() {
+  # Swift Testing's failure lines, deduplicated, capped so one bad run cannot
+  # produce a comment nobody will read.
+  grep -E '✘|Expectation failed|Issue recorded|Test .* failed' "$1" 2>/dev/null \
+    | sed 's/^[[:space:]]*//' | sort -u | head -12
+}
+
+# --- one target ---------------------------------------------------------------
+
+run_target() {
+  local spec="$1" iterations="$2" work_dir="$3"
+  local name filter floor issue description
+  IFS='|' read -r name filter floor issue description <<< "$spec"
+
+  [[ "$name" == "FastPassWhole" ]] && iterations="$WHOLE_TARGET_ITERATIONS"
+
+  echo
+  echo "═══ $name — issue #$issue — $iterations iteration(s), floor $floor"
+  echo "    $description"
+
+  local failures=0 pass_counts=() signatures=() i verdict log load_before
+  for ((i = 1; i <= iterations; i++)); do
+    log="$work_dir/$name-$i.log"
+    load_before="$(loadavg)"
+    local rc=0
+    # shellcheck disable=SC2086 # $filter is a deliberately word-split arg list
+    run_with_deadline "$ITERATION_DEADLINE_S" "$log" swift test $filter || rc=$?
+    verdict="$(judge_iteration "$rc" "$log" "$floor")"
+    if [[ "$verdict" == PASS* ]]; then
+      pass_counts+=("${verdict#PASS }")
+      printf '    %2d/%d  pass (%s tests, load1m %s at start, %d spinners)\n' "$i" "$iterations" "${verdict#PASS }" "$load_before" "${#SPINNER_PIDS[@]}"
+    else
+      failures=$((failures + 1))
+      printf '    %2d/%d  *** %s (load1m %s at start, %d spinners)\n' "$i" "$iterations" "${verdict#FAIL }" "$load_before" "${#SPINNER_PIDS[@]}"
+      signatures+=("iteration $i (load1m $load_before at start, ${#SPINNER_PIDS[@]} spinners): ${verdict#FAIL }")
+      local detail; detail="$(failing_tests_from "$log")"
+      [[ -n "$detail" ]] && signatures+=("$(printf '%s' "$detail" | sed 's/^/      /')")
+    fi
+  done
+
+  echo "    result: $failures/$iterations failed"
+  [[ "$failures" -eq 0 ]] && return 0
+
+  FAILED_TARGETS=$((FAILED_TARGETS + 1))
+  # One report file per FAILING target, named by the issue it attaches to.
+  {
+    echo "**\`$name\` failed $failures of $iterations iteration(s) under induced load.**"
+    echo
+    echo "- Machine: $(sysctl -n hw.ncpu 2>/dev/null || nproc) cores, ${#SPINNER_PIDS[@]} induced spinners, load1m now: $(loadavg)"
+    echo "  (\`load1m\` is the 1-minute average and LAGS the induced load — early iterations under-report it. The spinner count is the reliable half.)"
+    echo "- Filter: \`swift test $filter\`, executed-test floor $floor"
+    echo "- Iteration deadline: ${ITERATION_DEADLINE_S}s (an outer timeout — \`.clockDriven\` was measured NOT bounding a hang)"
+    echo
+    echo "Signatures:"
+    echo
+    local s
+    for s in "${signatures[@]}"; do echo "$s"; done
+    echo
+    echo "> This is one night's sample from CI's regime (a few idle cores), not the"
+    echo "> regime this flake was characterised in (loadavg ~150 on 12 shared cores)."
+    echo "> Treat it as evidence the flake is still live, not as a rate."
+  } >> "$REPORT_DIR/$issue.md"
+  return 1
+}
+
+# --- main ---------------------------------------------------------------------
+
+main() {
+  local iterations="$DEFAULT_ITERATIONS" spinners="" only_target="" induce_load=1
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --iterations) iterations="${2:-}"; shift 2 ;;
+      --spinners)   spinners="${2:-}"; shift 2 ;;
+      --target)     only_target="${2:-}"; shift 2 ;;
+      --report-dir) REPORT_DIR="${2:-}"; shift 2 ;;
+      --no-load)    induce_load=0; shift ;;
+      *) die "unknown argument $1" ;;
+    esac
+  done
+
+  command -v swift >/dev/null 2>&1 || die "swift not found"
+  [[ -n "$REPORT_DIR" ]] || REPORT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/flake-stress-reports.XXXXXX")"
+  mkdir -p "$REPORT_DIR" || die "cannot create report dir $REPORT_DIR"
+  local work_dir; work_dir="$(mktemp -d "${TMPDIR:-/tmp}/flake-stress.XXXXXX")" || die "cannot create work dir"
+
+  local ncpu; ncpu="$(sysctl -n hw.ncpu 2>/dev/null || nproc)"
+  [[ -n "$spinners" ]] || spinners="$ncpu"
+
+  echo "nightly-flake-stress: $ncpu cores, baseline load $(loadavg)"
+  echo "logs: $work_dir   reports: $REPORT_DIR"
+
+  # Build ONCE up front so the first iteration's timing is not dominated by the
+  # compile. `swift build` alone does NOT build test targets — `--build-tests` does.
+  echo
+  echo "building test targets (swift build --build-tests -j 2)…"
+  if ! run_with_deadline 1800 "$work_dir/build.log" swift build --build-tests -j 2; then
+    echo "nightly-flake-stress: BUILD FAILED — see $work_dir/build.log" >&2
+    tail -30 "$work_dir/build.log" >&2
+    exit 2
+  fi
+  echo "build ok."
+
+  [[ "$induce_load" -eq 1 ]] && start_spinners "$spinners"
+
+  local spec name
+  for spec in "${TARGETS[@]}"; do
+    name="${spec%%|*}"
+    [[ -n "$only_target" && "$name" != "$only_target" ]] && continue
+    run_target "$spec" "$iterations" "$work_dir"
+  done
+
+  stop_spinners
+
+  echo
+  if [[ "$FAILED_TARGETS" -eq 0 ]]; then
+    echo "═══ every target clean this run."
+    echo "    NOT evidence that these flakes are fixed — see the note in this script's header."
+    return 0
+  fi
+  echo "═══ $FAILED_TARGETS target(s) FAILED; reports written to $REPORT_DIR"
+  return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/nightly-flake-stress.test.sh
+++ b/scripts/nightly-flake-stress.test.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Tests for scripts/nightly-flake-stress.sh — run: bash scripts/nightly-flake-stress.test.sh
+#
+# ZERO BUILDS, ZERO CPU LOAD. Everything proven here is proven against synthetic
+# `swift test` logs and against `sleep` processes, so this runs safely on a shared
+# box while other agents are working.
+#
+# What matters most in the stress loop is not that it runs tests — it is how it
+# JUDGES a run. A wedged run exits with no summary line, and a harness that
+# checks `rc == 0` scores it green; that mistake has been made repeatedly in this
+# program, and it is the reason a nightly can report "clean" while a suite is
+# hanging every night. So the judgment is tested first and mutation-checked.
+# shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F` below
+# shellcheck disable=SC2034 # SPINNER_PIDS is owned by the sourced script under test
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/nightly-flake-stress.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT"   # source-guard prevents main() from running
+
+FAIL=0
+assert_eq()       { if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: [$2] lacks [$3]"; FAIL=1; fi; }
+mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/stress-test.XXXXXX"; }
+
+mk_log() { local f="$1"; shift; printf '%s\n' "$@" > "$f"; }
+
+# Run judge_iteration inside a MUTATED copy of the script, to prove a given
+# verdict is actually produced by the guard it is attributed to.
+judge_mutated() {
+  local sed_expr="$1" rc="$2" log="$3" floor="$4"
+  local mutant; mutant="$(mktmpd)/mutant.sh"
+  sed -E "$sed_expr" "$SCRIPT" > "$mutant"
+  bash -c "source '$mutant'; judge_iteration '$rc' '$log' '$floor'"
+}
+
+# ---------------------------------------------------------------------------
+# The verdict rules
+# ---------------------------------------------------------------------------
+
+test_a_clean_run_passes_with_its_count() {
+  local d; d="$(mktmpd)"
+  mk_log "$d/ok.log" "Test run started." "Test run with 42 tests passed after 3.1 seconds."
+  assert_eq "clean run -> PASS with the executed count" "PASS 42" "$(judge_iteration 0 "$d/ok.log" 10)"
+  rm -rf "$d"
+}
+
+test_a_truncated_log_is_a_failure_not_a_pass() {
+  # THE RULE THIS FILE EXISTS FOR. A wedged run produces no summary line, and
+  # `rc == 0` alone scores it green.
+  local d; d="$(mktmpd)"
+  mk_log "$d/trunc.log" "Test run started." "Suite \"ControlModeInputHealth\" started."
+  local verdict; verdict="$(judge_iteration 0 "$d/trunc.log" 10)"
+  assert_contains "no summary line -> FAIL even with rc=0" "$verdict" "FAIL"
+  # The DIAGNOSIS matters as much as the verdict: "it wedged" and "your filter
+  # under-matched" send a reader to completely different places.
+  assert_contains "and the reason names the missing summary" "$verdict" "no 'Test run with N tests' summary"
+
+  # MUTATION, and it did not do what I expected — recorded rather than tidied
+  # away. Removing the summary guard alone does NOT produce a pass: the count is
+  # empty, so the floor guard catches it next and the run still fails. That is
+  # defense in depth, and it is worth locking in as its own assertion.
+  local without_summary_guard
+  # shellcheck disable=SC2016 # the sed expression must reach sed unexpanded
+  without_summary_guard="$(judge_mutated 's/if \[\[ -z "\$count" \]\]/if [[ -z "NEVER" ]]/' 0 "$d/trunc.log" 10)"
+  assert_contains "mutation: with the summary guard gone, the FLOOR guard still catches a wedge" \
+    "$without_summary_guard" "FAIL"
+  # And the set as a whole IS load-bearing: remove both and the wedge scores green,
+  # which is precisely the "rc == 0 means pass" mistake this harness exists to avoid.
+  local without_both
+  # shellcheck disable=SC2016 # the sed expression must reach sed unexpanded
+  without_both="$(judge_mutated 's/if \[\[ -z "\$count" \]\]/if [[ -z "NEVER" ]]/; s/if \[\[ "\$count" -lt "\$floor" \]\]/if [[ "$count" -lt -1 ]]/' 0 "$d/trunc.log" 10)"
+  assert_contains "mutation: with BOTH guards gone, a wedged run scores PASS" "$without_both" "PASS"
+  rm -rf "$d"
+}
+
+test_a_deadline_kill_is_reported_as_wedged() {
+  local d; d="$(mktmpd)"
+  mk_log "$d/wedged.log" "Test run started."
+  local verdict; verdict="$(judge_iteration 124 "$d/wedged.log" 10)"
+  assert_contains "rc=124 -> wedged" "$verdict" "FAIL wedged"
+  assert_contains "and says it was the harness deadline" "$verdict" "killed by the harness deadline"
+  rm -rf "$d"
+}
+
+test_running_fewer_tests_than_the_floor_is_a_failure() {
+  # `swift test --filter` exits GREEN on zero matches — five payouts in this
+  # program so far. A renamed suite must not read as a clean run.
+  local d; d="$(mktmpd)"
+  mk_log "$d/thin.log" "Test run with 0 tests passed after 0.1 seconds."
+  local verdict; verdict="$(judge_iteration 0 "$d/thin.log" 10)"
+  assert_contains "zero matches -> FAIL despite rc=0" "$verdict" "FAIL ran 0 tests"
+  assert_contains "and explains the green-on-zero-matches trap" "$verdict" "exits GREEN on zero matches"
+  # shellcheck disable=SC2016 # the sed expression must reach sed unexpanded
+  assert_contains "mutation: without the floor guard, zero tests scores PASS" \
+    "$(judge_mutated 's/if \[\[ "\$count" -lt "\$floor" \]\]/if [[ "$count" -lt -1 ]]/' 0 "$d/thin.log" 10)" "PASS"
+  rm -rf "$d"
+}
+
+test_a_nonzero_rc_with_a_full_count_still_fails() {
+  local d; d="$(mktmpd)"
+  mk_log "$d/red.log" "Test run with 42 tests failed after 3.1 seconds."
+  assert_contains "real test failure -> FAIL with the count" "$(judge_iteration 1 "$d/red.log" 10)" "FAIL rc=1 with 42 tests"
+  rm -rf "$d"
+}
+
+test_the_three_verdicts_are_independent() {
+  # A log can satisfy two rules and violate the third. Each must be able to fail
+  # on its own, or the "three independent verdicts" claim is decorative.
+  local d; d="$(mktmpd)"
+  mk_log "$d/a.log" "Test run with 3 tests passed after 1s."
+  assert_contains "summary present + rc 0 + below floor -> still fails" \
+    "$(judge_iteration 0 "$d/a.log" 10)" "below the measured floor"
+  mk_log "$d/b.log" "Test run with 42 tests failed after 1s."
+  assert_contains "summary present + above floor + rc 1 -> still fails" \
+    "$(judge_iteration 1 "$d/b.log" 10)" "FAIL rc=1"
+  rm -rf "$d"
+}
+
+test_failure_signatures_are_extracted_and_capped() {
+  local d; d="$(mktmpd)"
+  : > "$d/many.log"
+  local i
+  for i in $(seq 1 30); do echo "✘ Test example$i() recorded an issue" >> "$d/many.log"; done
+  local sigs count; sigs="$(failing_tests_from "$d/many.log")"
+  count="$(printf '%s\n' "$sigs" | grep -c .)"
+  assert_contains "failure lines are extracted" "$sigs" "example1()"
+  assert_eq "and capped so one bad run cannot flood an issue comment" "12" "$count"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# Kill discipline — proven with `sleep`, which costs zero CPU
+# ---------------------------------------------------------------------------
+
+test_stop_spinners_kills_only_its_captured_pids() {
+  # `sleep` stands in for `yes`: same process-lifecycle question, none of the
+  # load. A bystander process proves the cleanup is targeted rather than broad.
+  local bystander mine1 mine2
+  sleep 30 & bystander=$!
+  sleep 30 & mine1=$!
+  sleep 30 & mine2=$!
+  SPINNER_PIDS=("$mine1" "$mine2")
+  stop_spinners >/dev/null 2>&1
+  sleep 0.3
+  assert_eq "captured pid 1 is gone" "gone" "$(ps -p "$mine1" >/dev/null 2>&1 && echo live || echo gone)"
+  assert_eq "captured pid 2 is gone" "gone" "$(ps -p "$mine2" >/dev/null 2>&1 && echo live || echo gone)"
+  assert_eq "an uncaptured bystander is UNTOUCHED" "live" "$(ps -p "$bystander" >/dev/null 2>&1 && echo live || echo gone)"
+  kill "$bystander" 2>/dev/null
+  wait "$bystander" 2>/dev/null
+  # shellcheck disable=SC2034 # SPINNER_PIDS belongs to the sourced script under test
+  SPINNER_PIDS=()
+}
+
+test_stop_spinners_verifies_by_captured_pid_and_reports_survivors() {
+  # The verification must be able to SEE a survivor. A check that always reports
+  # zero survivors is a check that cannot fail — the exact defect this program
+  # found in a spinner-survival check that cleared its PID array first.
+  local stubborn
+  sleep 30 & stubborn=$!
+  SPINNER_PIDS=("$stubborn")
+  # Make SIGTERM a no-op for the process by trapping it in a subshell we control:
+  # simpler and more honest here is to assert the reporting path directly.
+  local out; out="$(stop_spinners 2>&1)"
+  assert_contains "stop_spinners reports how many it stopped" "$out" "stopped 1 spinner(s)"
+  kill -9 "$stubborn" 2>/dev/null
+  wait "$stubborn" 2>/dev/null
+  SPINNER_PIDS=()
+}
+
+test_run_with_deadline_kills_an_overrunning_command() {
+  local d; d="$(mktmpd)" rc=0
+  local start elapsed
+  start=$SECONDS
+  run_with_deadline 2 "$d/out.log" sleep 60 || rc=$?
+  elapsed=$((SECONDS - start))
+  assert_eq "an overrunning command returns the deadline code" "124" "$rc"
+  assert_eq "and is actually killed rather than waited out" "yes" \
+    "$(if [[ $elapsed -lt 20 ]]; then echo yes; else echo "no ($elapsed s)"; fi)"
+  rm -rf "$d"
+}
+
+test_run_with_deadline_passes_through_a_fast_commands_status() {
+  local d; d="$(mktmpd)" rc=0
+  run_with_deadline 30 "$d/out.log" true || rc=$?
+  assert_eq "a fast success passes through rc 0" "0" "$rc"
+  rc=0
+  run_with_deadline 30 "$d/out.log" false || rc=$?
+  assert_eq "a fast failure passes through its rc" "1" "$rc"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# Target table
+# ---------------------------------------------------------------------------
+
+test_every_target_names_an_issue_and_a_floor() {
+  local spec name filter floor issue desc bad=0
+  for spec in "${TARGETS[@]}"; do
+    # shellcheck disable=SC2034 # desc is read to consume the field, not used
+    IFS='|' read -r name filter floor issue desc <<< "$spec"
+    [[ -n "$name" && -n "$filter" && -n "$issue" ]] || { echo "     malformed: $spec"; bad=$((bad + 1)); }
+    [[ "$floor" =~ ^[0-9]+$ ]] || { echo "     non-numeric floor: $spec"; bad=$((bad + 1)); }
+    [[ "$issue" =~ ^[0-9]+$ ]] || { echo "     non-numeric issue: $spec"; bad=$((bad + 1)); }
+  done
+  assert_eq "every stress target carries a numeric floor and an issue number" "0" "$bad"
+  assert_eq "and there are the four targets the PR describes" "4" "${#TARGETS[@]}"
+}
+
+test_targets_reference_only_open_ledger_issues() {
+  # The issues this loop comments on are #494, #503 and #496 — stated in the PR
+  # and asserted here so the two cannot drift apart silently.
+  local spec issue seen=""
+  for spec in "${TARGETS[@]}"; do
+    issue="$(printf '%s' "$spec" | cut -d'|' -f4)"
+    case " $seen " in *" $issue "*) ;; *) seen="$seen $issue" ;; esac
+  done
+  assert_eq "the loop attaches to exactly the documented issue set" " 494 503 496" "$seen"
+}
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_' | sort); do
+  echo "== $t"
+  "$t"
+done
+if [[ $FAIL -eq 0 ]]; then echo "ALL PASS"; else echo "FAILURES"; fi
+exit $FAIL

--- a/scripts/nightly-quarantine-audit.sh
+++ b/scripts/nightly-quarantine-audit.sh
@@ -1,0 +1,449 @@
+#!/usr/bin/env bash
+# scripts/nightly-quarantine-audit.sh — audit the `.flaky(issue:)` quarantine list
+# against the retry-metrics ledger. Step 3 of the nightly workflow
+# (docs/specs/2026-07-24-test-hardening-design.md §7 and §9).
+#
+# Quarantine is a deadline, not a resting place. Two things make it rot silently:
+# a `.flaky` whose issue was closed months ago, and a `.flaky` whose test has
+# passed first-try every run since someone quietly fixed it. Neither is visible
+# from a green CI badge. This reads the ledger and says so.
+#
+# THE INPUT IS THE LEDGER, NEVER A LOG. Every `.flaky` execution — including
+# clean first-try passes, which are what prove a flake is fixed — appends one
+# JSONL record to `$TBD_RETRY_METRICS_PATH`, uploaded as the `retry-metrics`
+# artifact by the `test` job. Keys: schema/testID/issue/attempts/outcome/file/line.
+# That schema is a consumed API; this script is the consumer. Parsing `swift test`
+# output instead would re-introduce exactly the fragility the ledger removed.
+#
+# Usage:
+#   scripts/nightly-quarantine-audit.sh run                      # CI: fetch + analyze
+#   scripts/nightly-quarantine-audit.sh fetch     --out-dir DIR [--days N]
+#   scripts/nightly-quarantine-audit.sh states    --ledger-dir DIR --out FILE
+#   scripts/nightly-quarantine-audit.sh inventory --out FILE
+#   scripts/nightly-quarantine-audit.sh analyze   --ledger-dir DIR --runs-file F \
+#                                                 --issue-states F [--inventory F]
+#
+# The split exists so `analyze` is a PURE FUNCTION of its input files and can be
+# proven against known-positive fixtures with no network — see
+# scripts/nightly-quarantine-audit.test.sh. An audit that has only ever been run
+# against a healthy codebase is indistinguishable from one that never fires.
+#
+# Exit: 0 = no findings, 1 = findings (report on stdout either way), 2 = usage/input error.
+#
+# Test seams (env):
+#   AUDIT_GH_CMD    command standing in for `gh`   (default: gh)
+#   AUDIT_REPO      owner/repo for gh queries      (default: cheapsteak/tbd)
+#   AUDIT_TODAY     ISO date used in the header    (default: today, UTC)
+
+set -uo pipefail
+
+# --- Contract constants -------------------------------------------------------
+
+# THE EXCLUSION LIST IS EXACTLY ONE ENTRY, and growing it is a contract change.
+# `retriesUntilPass()` fails once and passes on retry BY DESIGN on every run, so
+# that a quarantine mechanism which silently stopped retrying cannot look
+# identical to a working one. Its issue (#499) is a permanently-open fixture
+# anchor, so F1/F2 would nag about a test that is doing its job.
+readonly EXCLUDED_TEST_ID="TBDDaemonTests.FlakyQuarantineSelfTests/retriesUntilPass()"
+
+# `alwaysFails()` shares issue #499 and is DELIBERATELY NOT EXCLUDED. It is gated
+# off by TBD_FLAKY_SELFTEST_FAILURE, which nothing in CI sets, so it must
+# contribute zero records. If records appear, the gate leaked into CI and F3
+# reports it. An exclusion list grown to cover a broken gate turns the gate into
+# silence — slice E was asked to add this entry in review and refused. Honoured.
+readonly GATE_LEAK_SUFFIX="/alwaysFails()"
+
+readonly EXPECTED_SCHEMA=1
+readonly DEFAULT_WINDOW_DAYS=7
+# F2 needs enough observations that "all green" means something. One clean run is
+# not evidence a flake is gone; five is a week of nightlies-plus-merges.
+readonly DEFAULT_MIN_RUNS=5
+
+GH_CMD="${AUDIT_GH_CMD:-gh}"
+REPO="${AUDIT_REPO:-cheapsteak/tbd}"
+
+die() { echo "nightly-quarantine-audit: $*" >&2; exit 2; }
+
+# --- fetch: CI runs -> ledger dir + runs.tsv ----------------------------------
+
+# Downloads every `retry-metrics` artifact from `main` runs of the Test workflow
+# inside the window. Writes:
+#   $out/ledger/<runId>.jsonl   one file per run that produced an artifact
+#   $out/runs.tsv               runId \t createdAt \t yes|no|unreadable|skipped:<conclusion>
+# The runs.tsv "no" rows are the whole point of F5: `test.yml` uploads with
+# `if-no-files-found: warn`, which is invisible unless something looks for it.
+#
+# ONLY success/failure runs are eligible. A CANCELLED run never reaches the
+# upload step, so counting it as "no artifact" reports a concurrency cancellation
+# as a broken ledger — measured, not theorised: the first live run of this audit
+# reported 30 missing artifacts, of which the three post-feature ones were all
+# `cancel-in-progress` cancellations. Ineligible runs are recorded as
+# `skipped:<conclusion>` so they stay visible without being counted.
+fetch() {
+  local out_dir="" days="$DEFAULT_WINDOW_DAYS"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --out-dir) out_dir="${2:-}"; shift 2 ;;
+      --days)    days="${2:-}"; shift 2 ;;
+      *) die "fetch: unknown argument $1" ;;
+    esac
+  done
+  [[ -n "$out_dir" ]] || die "fetch: --out-dir is required"
+  mkdir -p "$out_dir/ledger" || die "fetch: cannot create $out_dir/ledger"
+  : > "$out_dir/runs.tsv"
+
+  local since
+  since="$(iso_days_ago "$days")"
+
+  local runs
+  runs="$("$GH_CMD" run list --repo "$REPO" --workflow test.yml --branch main \
+            --status completed --limit 100 \
+            --json databaseId,createdAt,conclusion --jq \
+            ".[] | select(.createdAt >= \"$since\") | [.databaseId, .createdAt, .conclusion] | @tsv")" \
+    || die "fetch: gh run list failed"
+
+  if [[ -z "$runs" ]]; then
+    echo "fetch: no completed main runs of test.yml since $since" >&2
+    return 0
+  fi
+
+  local run_id created conclusion artifact_id
+  while IFS=$'\t' read -r run_id created conclusion; do
+    [[ -n "$run_id" ]] || continue
+    case "$conclusion" in
+      success|failure) ;;
+      *) printf '%s\t%s\tskipped:%s\n' "$run_id" "$created" "${conclusion:-unknown}" >> "$out_dir/runs.tsv"
+         continue ;;
+    esac
+    artifact_id="$("$GH_CMD" api "repos/$REPO/actions/runs/$run_id/artifacts" \
+                     --jq '.artifacts[] | select(.name == "retry-metrics" and .expired == false) | .id' \
+                     2>/dev/null | head -1)"
+    if [[ -z "$artifact_id" ]]; then
+      printf '%s\t%s\tno\n' "$run_id" "$created" >> "$out_dir/runs.tsv"
+      continue
+    fi
+    local tmp_zip="$out_dir/ledger/$run_id.zip"
+    if "$GH_CMD" api "repos/$REPO/actions/artifacts/$artifact_id/zip" > "$tmp_zip" 2>/dev/null \
+       && unzip -p "$tmp_zip" > "$out_dir/ledger/$run_id.jsonl" 2>/dev/null; then
+      printf '%s\t%s\tyes\n' "$run_id" "$created" >> "$out_dir/runs.tsv"
+    else
+      # The artifact exists but could not be read. That is not "no artifact" —
+      # reporting it as such would blame the test job for a download failure.
+      printf '%s\t%s\tunreadable\n' "$run_id" "$created" >> "$out_dir/runs.tsv"
+    fi
+    rm -f "$tmp_zip"
+  done <<< "$runs"
+}
+
+iso_days_ago() {
+  local days="$1"
+  # BSD date (macOS) and GNU date (ubuntu) disagree on relative-date syntax, and
+  # this script runs on both: locally for its tests, on ubuntu in CI.
+  date -u -v-"${days}"d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "${days} days ago" +%Y-%m-%dT%H:%M:%SZ
+}
+
+# --- states: distinct issues in the ledger -> issue \t OPEN|CLOSED ------------
+
+states() {
+  local ledger_dir="" out=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --ledger-dir) ledger_dir="${2:-}"; shift 2 ;;
+      --out)        out="${2:-}"; shift 2 ;;
+      *) die "states: unknown argument $1" ;;
+    esac
+  done
+  [[ -n "$ledger_dir" && -n "$out" ]] || die "states: --ledger-dir and --out are required"
+  : > "$out"
+
+  local issue state
+  for issue in $(distinct_issues "$ledger_dir"); do
+    state="$("$GH_CMD" issue view "$issue" --repo "$REPO" --json state --jq .state 2>/dev/null)"
+    # An unreadable issue is recorded as UNKNOWN rather than assumed OPEN: a
+    # lookup failure must not silently read as "quarantine is still justified".
+    printf '%s\t%s\n' "$issue" "${state:-UNKNOWN}" >> "$out"
+  done
+}
+
+distinct_issues() {
+  ledger_cat "$1" | jq -r 'select(.issue != null) | .issue' 2>/dev/null | sort -un
+}
+
+# `cat` over the ledger dir that tolerates an empty/absent dir (jq -s [] is the
+# correct answer for "no records", and must not be an error).
+ledger_cat() {
+  local dir="$1"
+  [[ -d "$dir" ]] || return 0
+  find "$dir" -name '*.jsonl' -type f -exec cat {} + 2>/dev/null
+}
+
+# --- inventory: source-tree `.flaky(issue:)` sites ----------------------------
+
+# Emits: file \t funcName \t issue — one row per quarantined test in the tree.
+# Feeds F6 (informational): a quarantine the ledger has never seen.
+inventory() {
+  local out="" root="."
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --out)  out="${2:-}"; shift 2 ;;
+      --root) root="${2:-}"; shift 2 ;;
+      *) die "inventory: unknown argument $1" ;;
+    esac
+  done
+  [[ -n "$out" ]] || die "inventory: --out is required"
+  : > "$out"
+
+  local file line_no issue func rest
+  # `.flaky(issue: N)` on a trait line, then the next `func NAME(` below it.
+  grep -rn '\.flaky(issue: *[0-9]\+)' "$root/Tests" --include='*.swift' 2>/dev/null \
+    | grep -v 'FlakyTestSupport.swift' \
+    | while IFS=: read -r file line_no rest; do
+        issue="$(printf '%s' "$rest" | sed -n 's/.*\.flaky(issue: *\([0-9]*\)).*/\1/p')"
+        [[ -n "$issue" ]] || continue
+        func="$(tail -n "+$line_no" "$file" 2>/dev/null \
+                  | sed -n 's/^[[:space:]]*func \([A-Za-z0-9_]*\)(.*/\1/p' | head -1)"
+        [[ -n "$func" ]] || continue
+        printf '%s\t%s\t%s\n' "${file#"$root"/}" "$func" "$issue" >> "$out"
+      done
+}
+
+# --- analyze: pure function of its input files --------------------------------
+
+# One aggregate object per testID, in exactly slice E's verified shape:
+#   jq -s 'group_by(.testID)[] | {testID, issue, records, outcomes}'
+aggregate() {
+  ledger_cat "$1" | jq -s -c '
+    map(select(.testID != null))
+    | group_by(.testID)[]
+    | {
+        testID:   .[0].testID,
+        issue:    .[0].issue,
+        file:     .[0].file,
+        line:     .[0].line,
+        records:  length,
+        outcomes: (group_by(.outcome) | map({key: (.[0].outcome // "null"), value: length}) | from_entries),
+        schemas:  (map(.schema) | unique)
+      }
+  ' 2>/dev/null
+}
+
+# `grep -c` prints 0 AND exits 1 when nothing matches, so the obvious
+# `x=$(grep -c ... || echo 0)` yields the string "0\n0" and every later arithmetic
+# test on it is a syntax error. Measured on the first live run.
+count_matching() {
+  local n; n="$(grep -c -- "$(printf '%b' "$1")" "$2" 2>/dev/null)"
+  [[ "$n" =~ ^[0-9]+$ ]] && printf '%s' "$n" || printf '0'
+}
+
+issue_state() {
+  local issue="$1" states_file="$2" row
+  row="$(grep -E "^${issue}	" "$states_file" 2>/dev/null | head -1)"
+  [[ -n "$row" ]] && printf '%s' "${row#*	}" || printf 'UNKNOWN'
+}
+
+analyze() {
+  local ledger_dir="" runs_file="" issue_states="" inventory_file=""
+  local window_days="$DEFAULT_WINDOW_DAYS" min_runs="$DEFAULT_MIN_RUNS"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --ledger-dir)   ledger_dir="${2:-}"; shift 2 ;;
+      --runs-file)    runs_file="${2:-}"; shift 2 ;;
+      --issue-states) issue_states="${2:-}"; shift 2 ;;
+      --inventory)    inventory_file="${2:-}"; shift 2 ;;
+      --window-days)  window_days="${2:-}"; shift 2 ;;
+      --min-runs)     min_runs="${2:-}"; shift 2 ;;
+      *) die "analyze: unknown argument $1" ;;
+    esac
+  done
+  [[ -n "$ledger_dir" ]]   || die "analyze: --ledger-dir is required"
+  [[ -n "$issue_states" ]] || die "analyze: --issue-states is required"
+
+  local findings=() informational=() excluded_note=""
+  local agg total_records=0 test_count=0
+  agg="$(aggregate "$ledger_dir")"
+
+  local line test_id issue records outcomes schemas first_try file
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    test_id="$(printf '%s' "$line"  | jq -r '.testID')"
+    issue="$(printf '%s' "$line"    | jq -r '.issue // "null"')"
+    records="$(printf '%s' "$line"  | jq -r '.records')"
+    outcomes="$(printf '%s' "$line" | jq -r '.outcomes | to_entries | map("\(.key)=\(.value)") | join(", ")')"
+    schemas="$(printf '%s' "$line"  | jq -r '.schemas | join(",")')"
+    first_try="$(printf '%s' "$line" | jq -r '.outcomes | keys == ["passedFirstTry"]')"
+    file="$(printf '%s' "$line"     | jq -r '.file // "?"')"
+    test_count=$((test_count + 1))
+    total_records=$((total_records + records))
+
+    # F4 — schema drift. Deliberately NOT subject to the exclusion list: this is a
+    # property of the artifact format, not of any test's quarantine status, and
+    # the fixture's records are as good a witness to a bumped schema as any.
+    if [[ "$schemas" != "$EXPECTED_SCHEMA" ]]; then
+      findings+=("**F4 — ledger schema drift.** \`$test_id\` has records with schema \`$schemas\`, expected \`$EXPECTED_SCHEMA\`. The retry-metrics schema is a consumed API (Tests/CLAUDE.md); this audit's parsing may be reading the wrong shape. Re-check the consumer before trusting anything else in this report.")
+    fi
+
+    # F3 — the CI gate leaked. Reported, never filtered.
+    case "$test_id" in
+      *"$GATE_LEAK_SUFFIX")
+        findings+=("**F3 — THE CI GATE LEAKED.** \`$test_id\` produced $records record(s) ($outcomes). This fixture is gated off by \`TBD_FLAKY_SELFTEST_FAILURE\` and nothing in CI sets it, so it must contribute ZERO records. Something is setting that variable in CI. This is reported rather than excluded on purpose — an exclusion list grown to cover a broken gate turns the gate into silence.")
+        continue
+        ;;
+    esac
+
+    if [[ "$test_id" == "$EXCLUDED_TEST_ID" ]]; then
+      excluded_note="\`$test_id\` — permanent fixture for the quarantine mechanism itself (#499, kept open by design). $records record(s): $outcomes. Excluded from F1/F2 by contract; this is the only excluded entry."
+      continue
+    fi
+
+    # F1 — quarantine outliving its issue.
+    local state
+    state="$(issue_state "$issue" "$issue_states")"
+    if [[ "$state" == "CLOSED" ]]; then
+      findings+=("**F1 — quarantine references a CLOSED issue.** \`$test_id\` is \`.flaky(issue: $issue)\` but #$issue is CLOSED. Either the flake is fixed and the trait should be removed, or the issue was closed prematurely. ($records record(s) in window: $outcomes; $file)")
+    elif [[ "$state" == "UNKNOWN" ]]; then
+      informational+=("Could not resolve the state of #$issue for \`$test_id\` — the \`gh issue view\` lookup failed. Not treated as OPEN: a failed lookup is not evidence that quarantine is still justified.")
+    fi
+
+    # F2 — quietly fixed. Needs enough observations to mean anything.
+    if [[ "$first_try" == "true" && "$records" -ge "$min_runs" ]]; then
+      findings+=("**F2 — passed first-try every run in the window.** \`$test_id\` (#$issue): $records/$records \`passedFirstTry\` over the last $window_days days. Candidate for removing \`.flaky(issue: $issue)\` — quarantine is a deadline, not a resting place. ($file)")
+    fi
+  done <<< "$agg"
+
+  # F5 — a run that produced no ledger at all. test.yml uploads with
+  # `if-no-files-found: warn`, so a broken wiring is otherwise invisible.
+  #
+  # Scoped to runs NEWER than the oldest run in the window that DID produce a
+  # ledger. A run older than that predates the feature (or predates a fix) and
+  # reporting it says "the wiring is broken" about a commit where it did not yet
+  # exist. Using the observed first-ledger run rather than a hardcoded date keeps
+  # this self-maintaining: nothing to update when the window rolls forward.
+  # The all-missing case is NOT swallowed by that scoping — it is its own finding.
+  local runs_total=0 runs_with=0 runs_without=0 runs_unreadable=0 runs_skipped=0
+  if [[ -n "$runs_file" && -f "$runs_file" ]]; then
+    runs_total=$(count_matching '.' "$runs_file")
+    runs_with=$(count_matching '\tyes$' "$runs_file")
+    runs_unreadable=$(count_matching '\tunreadable$' "$runs_file")
+    runs_skipped=$(count_matching '\tskipped:' "$runs_file")
+    runs_without=$(count_matching '\tno$' "$runs_file")
+
+    local first_ledger_at="" late_missing=""
+    if [[ "$runs_with" -gt 0 ]]; then
+      first_ledger_at="$(grep '\tyes$' "$runs_file" | cut -f2 | sort | head -1)"
+      late_missing="$(awk -F'\t' -v since="$first_ledger_at" \
+        '$3 == "no" && $2 > since { print $1 }' "$runs_file" | tr '\n' ' ')"
+    fi
+
+    local eligible=$((runs_with + runs_without + runs_unreadable))
+    if [[ "$runs_with" -eq 0 && "$eligible" -gt 0 ]]; then
+      findings+=("**F5 — NO run in the window produced a \`retry-metrics\` artifact at all** ($eligible eligible run(s)). Either the ledger wiring is entirely broken or the artifacts have expired. Nothing in this report about quarantine health can be trusted until that is resolved — an empty ledger reads exactly like a healthy one.")
+    elif [[ -n "$late_missing" ]]; then
+      findings+=("**F5 — run(s) after the ledger was already working produced NO \`retry-metrics\` artifact.** \`if-no-files-found: warn\` does not fail the job, so this is invisible unless something looks for it. Run IDs: $late_missing(first ledger in window: $first_ledger_at)")
+    fi
+    if [[ "$runs_unreadable" -gt 0 ]]; then
+      informational+=("$runs_unreadable run(s) had a \`retry-metrics\` artifact this audit could not download or unzip. Not counted as F5 — a download failure is not the test job's fault.")
+    fi
+  fi
+
+  # F6 — informational only. `alwaysFails()` is legitimately absent from the
+  # ledger (it is gated off), so a FINDING here would directly contradict F3.
+  if [[ -n "$inventory_file" && -f "$inventory_file" ]]; then
+    local inv_file inv_func inv_issue
+    while IFS=$'\t' read -r inv_file inv_func inv_issue; do
+      [[ -n "$inv_func" ]] || continue
+      if ! printf '%s' "$agg" | jq -e --arg f "/$inv_func()" 'select(.testID | endswith($f))' >/dev/null 2>&1; then
+        informational+=("\`$inv_func()\` in \`$inv_file\` is \`.flaky(issue: $inv_issue)\` but has NO records in the window — it never ran, or it is gated off. (\`alwaysFails()\` is expected here.)")
+      fi
+    done < "$inventory_file"
+  fi
+
+  # --- report ---
+  local today="${AUDIT_TODAY:-$(date -u +%Y-%m-%d)}"
+  echo "## Quarantine audit — $today"
+  echo
+  echo "Window: last $window_days days of \`main\` runs of \`test.yml\`. Source: the \`retry-metrics\` JSONL ledger (no log parsing)."
+  echo
+  echo "- Runs examined: **$runs_total** — $runs_with with a ledger artifact, $runs_without without, $runs_unreadable unreadable, $runs_skipped ineligible (cancelled/skipped: never reach the upload step)"
+  echo "- Quarantined tests seen: **$test_count**, total records: **$total_records**"
+  echo
+
+  if [[ ${#findings[@]} -eq 0 ]]; then
+    echo "### No findings"
+    echo
+    # Say what was actually checked, not "everything is fine". $runs_without is
+    # deliberately reported here even in the clean case: those runs predate the
+    # first ledger in the window, and a reader deserves the number rather than a
+    # blanket reassurance the data does not support.
+    echo "No quarantine references a closed issue, none passed first-try across the whole window (threshold: $min_runs runs), and the self-test gate has not leaked."
+    echo
+    echo "Ledger coverage: $runs_with of $((runs_with + runs_without + runs_unreadable)) eligible run(s) carried a \`retry-metrics\` artifact. The $runs_without without one all predate the oldest ledger in this window, so they are treated as pre-feature rather than as a wiring break — see F5."
+  else
+    echo "### Findings (${#findings[@]})"
+    echo
+    local f
+    for f in "${findings[@]}"; do echo "- $f"; echo; done
+  fi
+  echo
+
+  if [[ -n "$excluded_note" ]]; then
+    echo "### Excluded by contract (1)"
+    echo
+    echo "- $excluded_note"
+    echo
+  fi
+
+  if [[ ${#informational[@]} -gt 0 ]]; then
+    echo "### Informational (${#informational[@]}) — not findings"
+    echo
+    local i
+    for i in "${informational[@]}"; do echo "- $i"; echo; done
+  fi
+
+  [[ ${#findings[@]} -eq 0 ]]
+}
+
+# --- run: the CI entry point --------------------------------------------------
+
+run() {
+  local work_dir="" days="$DEFAULT_WINDOW_DAYS"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --work-dir) work_dir="${2:-}"; shift 2 ;;
+      --days)     days="${2:-}"; shift 2 ;;
+      *) die "run: unknown argument $1" ;;
+    esac
+  done
+  [[ -n "$work_dir" ]] || work_dir="$(mktemp -d "${TMPDIR:-/tmp}/quarantine-audit.XXXXXX")"
+  mkdir -p "$work_dir"
+  # Inventory reads the source tree, so anchor it to the repo rather than to
+  # whatever cwd the caller happens to have.
+  local repo_root; repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+  fetch --out-dir "$work_dir" --days "$days" || return 2
+  states --ledger-dir "$work_dir/ledger" --out "$work_dir/issue-states.tsv" || return 2
+  inventory --out "$work_dir/inventory.tsv" --root "$repo_root" || return 2
+  analyze --ledger-dir "$work_dir/ledger" \
+          --runs-file "$work_dir/runs.tsv" \
+          --issue-states "$work_dir/issue-states.tsv" \
+          --inventory "$work_dir/inventory.tsv" \
+          --window-days "$days"
+}
+
+main() {
+  local cmd="${1:-}"
+  [[ $# -gt 0 ]] && shift
+  case "$cmd" in
+    run)       run "$@" ;;
+    fetch)     fetch "$@" ;;
+    states)    states "$@" ;;
+    inventory) inventory "$@" ;;
+    analyze)   analyze "$@" ;;
+    *) die "usage: $0 {run|fetch|states|inventory|analyze} [...]" ;;
+  esac
+}
+
+# Source-guard: the test file sources this for its functions without running main.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/nightly-quarantine-audit.test.sh
+++ b/scripts/nightly-quarantine-audit.test.sh
@@ -376,6 +376,30 @@ test_inventory_finds_the_real_selftests() {
 
 # ---------------------------------------------------------------------------
 
+test_workflow_grants_actions_read_because_this_script_reads_the_actions_api() {
+  # Declaring a `permissions:` block sets every scope NOT listed to `none`, so
+  # omitting `actions: read` does not fall back to a default — it revokes it.
+  # `fetch()` reads the Actions API three ways; without the scope every one of
+  # them 403s and the audit dies without ever auditing anything.
+  #
+  # DERIVED rather than hardcoded: the requirement is asserted only if this
+  # script actually still calls the Actions API, so the check tracks the code
+  # instead of restating a fact about it. It also fires the other way — add an
+  # Actions-API call to a workflow that lacks the scope and this goes red.
+  #
+  # This is here because my own end-to-end verification could not have caught it:
+  # I ran `fetch` under my personal `gh` auth, which has scopes the constrained
+  # workflow token does not.
+  local wf="$HERE/../.github/workflows/nightly.yml"
+  local uses_actions_api=0
+  grep -qE "gh run list|actions/runs/|actions/artifacts/|run list --repo" "$SCRIPT" && uses_actions_api=1
+  assert_eq "the audit still reads the Actions API (premise of this check)" "1" "$uses_actions_api"
+  if [[ "$uses_actions_api" -eq 1 ]]; then
+    assert_eq "so nightly.yml must grant actions: read" "1" \
+      "$(grep -cE '^[[:space:]]*actions:[[:space:]]*read' "$wf")"
+  fi
+}
+
 for t in $(declare -F | awk '{print $3}' | grep '^test_' | sort); do
   echo "== $t"
   "$t"

--- a/scripts/nightly-quarantine-audit.test.sh
+++ b/scripts/nightly-quarantine-audit.test.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+# Tests for scripts/nightly-quarantine-audit.sh
+# Run: bash scripts/nightly-quarantine-audit.test.sh
+#
+# WHY THIS FILE EXISTS, in one sentence: a quarantine audit that silently never
+# fires is indistinguishable from a clean codebase. Three of the test-hardening
+# program's broken instruments were in the verification layer rather than the
+# measurement layer — a poller that matched its own posts, a tally that grepped
+# for a glyph the toolchain never prints, a spinner-survival check that cleared
+# its PID array before checking. So every finding below is proven to FIRE on a
+# known-positive input, and then MUTATION-CHECKED: the guard is broken on a copy
+# of the script and the same input must stop reporting. A check that cannot fail
+# is not a check.
+#
+# No network. `analyze` is a pure function of its input files, which is the whole
+# reason fetch/states/inventory are separate subcommands.
+# shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F` below
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/nightly-quarantine-audit.sh"
+
+FAIL=0
+assert_eq()       { if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: output lacks [$3]"; FAIL=1; fi; }
+assert_lacks()    { if [[ "$2" != *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: output unexpectedly contains [$3]"; FAIL=1; fi; }
+mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/audit-test.XXXXXX"; }
+
+# Build a work dir: $1 = ledger JSONL on stdin, plus default runs/states files.
+mk_work() {
+  local d; d="$(mktmpd)"
+  mkdir -p "$d/ledger"
+  cat > "$d/ledger/run1.jsonl"
+  printf '1\t2026-07-20T00:00:00Z\tyes\n' > "$d/runs.tsv"
+  : > "$d/issue-states.tsv"
+  printf '%s' "$d"
+}
+
+# Run `analyze` against a work dir. Sets ANALYZE_OUT and ANALYZE_RC as globals
+# rather than echoing the report: `out="$(analyze_in ...)"` would run the whole
+# function in a command-substitution SUBSHELL, so the exit code it recorded would
+# be discarded and every rc assertion would read a stale value. That is the same
+# family of defect as a check that cannot fail.
+ANALYZE_OUT=""
+ANALYZE_RC=0
+analyze_in() {
+  local d="$1"; shift
+  ANALYZE_OUT="$(AUDIT_TODAY=2026-07-27 bash "$SCRIPT" analyze \
+          --ledger-dir "$d/ledger" --runs-file "$d/runs.tsv" \
+          --issue-states "$d/issue-states.tsv" "$@" 2>&1)"
+  ANALYZE_RC=$?
+}
+
+# Run a MUTATED copy of the script — `sed -E "$1"` applied to the source.
+analyze_mutated() {
+  local sed_expr="$1" d="$2"; shift 2
+  local mutant; mutant="$(mktmpd)/mutant.sh"
+  sed -E "$sed_expr" "$SCRIPT" > "$mutant"
+  AUDIT_TODAY=2026-07-27 bash "$mutant" analyze \
+    --ledger-dir "$d/ledger" --runs-file "$d/runs.tsv" \
+    --issue-states "$d/issue-states.tsv" "$@" >/dev/null 2>&1
+  echo $?
+}
+
+# ---------------------------------------------------------------------------
+# TRUE NEGATIVE — the real artifact, byte for byte
+# ---------------------------------------------------------------------------
+
+# This is the actual content of the `retry-metrics` artifact from CI run
+# 30145614672 (slice E's end-to-end verification, PR #500). Kept verbatim rather
+# than fetched, so this test is offline and stable: it is the shape a HEALTHY
+# repo produces today, and the audit must report nothing on it.
+readonly REAL_ARTIFACT='{"attempts":2,"file":"Tests/TBDDaemonTests/FlakyQuarantineSelfTests.swift","issue":499,"line":29,"outcome":"passedOnRetry","schema":1,"testID":"TBDDaemonTests.FlakyQuarantineSelfTests/retriesUntilPass()"}'
+
+test_real_artifact_is_clean() {
+  local d; d="$(printf '%s\n' "$REAL_ARTIFACT" | mk_work)"
+  printf '499\tOPEN\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "real artifact from run 30145614672 -> exit 0" "0" "$ANALYZE_RC"
+  assert_contains "real artifact -> no findings" "$out" "### No findings"
+  assert_contains "real artifact -> fixture listed as excluded" "$out" "Excluded by contract (1)"
+  assert_contains "real artifact -> record counted" "$out" "total records: **1**"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# F1 — quarantine referencing a CLOSED issue
+# ---------------------------------------------------------------------------
+
+test_f1_fires_on_closed_issue() {
+  local d; d="$(mk_work <<'JSON'
+{"attempts":1,"file":"Tests/TBDDaemonTests/AcmeTests.swift","issue":458,"line":10,"outcome":"passedFirstTry","schema":1,"testID":"TBDDaemonTests.AcmeTests/racesOnAttach()"}
+JSON
+)"
+  # #458 is a genuinely closed issue in this repo.
+  printf '458\tCLOSED\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "closed-issue quarantine -> exit 1" "1" "$ANALYZE_RC"
+  assert_contains "F1 named" "$out" "F1 — quarantine references a CLOSED issue"
+  assert_contains "F1 names the test" "$out" "AcmeTests/racesOnAttach()"
+  assert_contains "F1 names the issue" "$out" "#458 is CLOSED"
+  # MUTATION: break the F1 guard; the same input must stop reporting.
+  # shellcheck disable=SC2016 # the sed expression must reach sed unexpanded
+  assert_eq "F1 mutation: guard removed -> no longer fires" "0" \
+    "$(analyze_mutated 's/if \[\[ "\$state" == "CLOSED" \]\]/if [[ "$state" == "NEVER_MATCHES" ]]/' "$d")"
+  rm -rf "$d"
+}
+
+test_f1_unknown_state_is_informational_not_a_finding() {
+  local d; d="$(mk_work <<'JSON'
+{"attempts":1,"file":"Tests/TBDDaemonTests/AcmeTests.swift","issue":777,"line":10,"outcome":"passedFirstTry","schema":1,"testID":"TBDDaemonTests.AcmeTests/racesOnAttach()"}
+JSON
+)"
+  : > "$d/issue-states.tsv"   # lookup failed for #777
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "unresolvable issue state -> exit 0 (not a finding)" "0" "$ANALYZE_RC"
+  assert_contains "unresolvable issue state -> informational" "$out" "Could not resolve the state of #777"
+  assert_lacks "unresolvable issue state is not reported as CLOSED" "$out" "F1 —"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# F2 — passed first-try all week
+# ---------------------------------------------------------------------------
+
+_six_first_try_records() {
+  local i
+  for i in 1 2 3 4 5 6; do
+    printf '{"attempts":1,"file":"Tests/TBDDaemonTests/AcmeTests.swift","issue":494,"line":%d,"outcome":"passedFirstTry","schema":1,"testID":"TBDDaemonTests.AcmeTests/quietlyFixed()"}\n' "$i"
+  done
+}
+
+test_f2_fires_when_all_first_try_over_threshold() {
+  local d; d="$(_six_first_try_records | mk_work)"
+  printf '494\tOPEN\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "6/6 passedFirstTry -> exit 1" "1" "$ANALYZE_RC"
+  assert_contains "F2 named" "$out" "F2 — passed first-try every run"
+  assert_contains "F2 shows the ratio" "$out" "6/6"
+  assert_eq "F2 mutation: threshold made unreachable -> no longer fires" "0" \
+    "$(analyze_mutated 's/readonly DEFAULT_MIN_RUNS=5/readonly DEFAULT_MIN_RUNS=9999/' "$d")"
+  rm -rf "$d"
+}
+
+test_f2_does_not_fire_below_threshold() {
+  local d; d="$(mk_work <<'JSON'
+{"attempts":1,"file":"Tests/TBDDaemonTests/AcmeTests.swift","issue":494,"line":1,"outcome":"passedFirstTry","schema":1,"testID":"TBDDaemonTests.AcmeTests/quietlyFixed()"}
+{"attempts":1,"file":"Tests/TBDDaemonTests/AcmeTests.swift","issue":494,"line":1,"outcome":"passedFirstTry","schema":1,"testID":"TBDDaemonTests.AcmeTests/quietlyFixed()"}
+JSON
+)"
+  printf '494\tOPEN\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "2 clean runs is not evidence of a fix -> exit 0" "0" "$ANALYZE_RC"
+  assert_lacks "no F2 below threshold" "$out" "F2 —"
+  rm -rf "$d"
+}
+
+test_f2_does_not_fire_when_a_retry_happened() {
+  local d; d="$({ _six_first_try_records; printf '{"attempts":2,"file":"Tests/TBDDaemonTests/AcmeTests.swift","issue":494,"line":1,"outcome":"passedOnRetry","schema":1,"testID":"TBDDaemonTests.AcmeTests/quietlyFixed()"}\n'; } | mk_work)"
+  printf '494\tOPEN\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "one retry in the window -> still quarantined, exit 0" "0" "$ANALYZE_RC"
+  assert_lacks "no F2 when a retry occurred" "$out" "F2 —"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# F3 — the CI gate leaked. REPORTED, never filtered.
+# ---------------------------------------------------------------------------
+
+test_f3_fires_on_alwaysfails_records() {
+  local d; d="$(mk_work <<'JSON'
+{"attempts":3,"file":"Tests/TBDDaemonTests/FlakyQuarantineSelfTests.swift","issue":499,"line":54,"outcome":"failed","schema":1,"testID":"TBDDaemonTests.FlakyQuarantineSelfTests/alwaysFails()"}
+JSON
+)"
+  printf '499\tOPEN\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "alwaysFails record -> exit 1" "1" "$ANALYZE_RC"
+  assert_contains "F3 named" "$out" "F3 — THE CI GATE LEAKED"
+  assert_contains "F3 explains why it is not excluded" "$out" "turns the gate into silence"
+  # THE MUTATION THAT MATTERS: slice E's reviewer proposed exactly this — adding
+  # alwaysFails() to the exclusion list. Here it does NOT silence F3, and that is
+  # a deliberate ordering property, not luck: the gate-leak check runs BEFORE the
+  # exclusion check, so no future edit to the exclusion list can hide a leaked
+  # gate. (I wrote this assertion the other way round first, expecting the
+  # exclusion to win; the run said otherwise and the implementation was the
+  # stronger of the two. Kept as a regression guard on the ordering.)
+  assert_eq "F3 ordering: even excluding alwaysFails cannot silence the gate leak" "1" \
+    "$(analyze_mutated 's|readonly EXCLUDED_TEST_ID=.*|readonly EXCLUDED_TEST_ID="TBDDaemonTests.FlakyQuarantineSelfTests/alwaysFails()"|' "$d")"
+  # And the real kill, so this test is provably coupled to the F3 code path:
+  # break the suffix it matches on and the same input must stop reporting.
+  assert_eq "F3 mutation: suffix match broken -> no longer fires" "0" \
+    "$(analyze_mutated 's|readonly GATE_LEAK_SUFFIX=.*|readonly GATE_LEAK_SUFFIX="/neverMatches()"|' "$d")"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# F4 — ledger schema drift
+# ---------------------------------------------------------------------------
+
+test_f4_fires_on_schema_bump() {
+  local d; d="$(mk_work <<'JSON'
+{"attempts":1,"file":"Tests/TBDDaemonTests/AcmeTests.swift","issue":494,"line":1,"outcome":"passedFirstTry","schema":2,"testID":"TBDDaemonTests.AcmeTests/racesOnAttach()"}
+JSON
+)"
+  printf '494\tOPEN\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "schema 2 -> exit 1" "1" "$ANALYZE_RC"
+  assert_contains "F4 named" "$out" "F4 — ledger schema drift"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# F5 — a run that produced no ledger artifact at all
+# ---------------------------------------------------------------------------
+
+test_f5_fires_on_missing_artifact_after_the_ledger_worked() {
+  local d; d="$(printf '%s\n' "$REAL_ARTIFACT" | mk_work)"
+  printf '499\tOPEN\n' > "$d/issue-states.tsv"
+  {
+    printf '1\t2026-07-20T00:00:00Z\tyes\n'
+    printf '2\t2026-07-21T00:00:00Z\tno\n'
+    printf '3\t2026-07-22T00:00:00Z\tno\n'
+  } > "$d/runs.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "artifact stopped appearing after it had worked -> exit 1" "1" "$ANALYZE_RC"
+  assert_contains "F5 named" "$out" "F5 — run(s) after the ledger was already working"
+  assert_contains "F5 lists the run IDs" "$out" "2 3"
+  # shellcheck disable=SC2016 # the sed expression must reach sed unexpanded
+  assert_eq "F5 mutation: late-missing detection broken -> no longer fires" "0" \
+    "$(analyze_mutated 's/\$3 == "no" && \$2 > since/$3 == "never" \&\& $2 > since/' "$d")"
+  rm -rf "$d"
+}
+
+test_f5_ignores_runs_that_predate_the_first_ledger() {
+  # These runs are older than the ledger feature itself. Reporting them says
+  # "the wiring is broken" about commits where the wiring did not yet exist.
+  local d; d="$(printf '%s\n' "$REAL_ARTIFACT" | mk_work)"
+  printf '499\tOPEN\n' > "$d/issue-states.tsv"
+  {
+    printf '1\t2026-07-20T00:00:00Z\tno\n'
+    printf '2\t2026-07-21T00:00:00Z\tno\n'
+    printf '3\t2026-07-22T00:00:00Z\tyes\n'
+  } > "$d/runs.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "pre-feature runs are not a wiring break -> exit 0" "0" "$ANALYZE_RC"
+  assert_lacks "no F5 for runs older than the first ledger" "$out" "F5 —"
+  rm -rf "$d"
+}
+
+test_f5_does_not_count_cancelled_runs() {
+  # MEASURED, not theorised: the first live run of this audit reported 30 missing
+  # artifacts, and the three that post-dated the feature were all
+  # `cancel-in-progress` cancellations — runs that never reach the upload step.
+  # Counting those reports a concurrency cancellation as a broken ledger.
+  local d; d="$(printf '%s\n' "$REAL_ARTIFACT" | mk_work)"
+  printf '499\tOPEN\n' > "$d/issue-states.tsv"
+  {
+    printf '1\t2026-07-20T00:00:00Z\tyes\n'
+    printf '2\t2026-07-21T00:00:00Z\tskipped:cancelled\n'
+    printf '3\t2026-07-22T00:00:00Z\tskipped:cancelled\n'
+  } > "$d/runs.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "cancelled runs are not a wiring break -> exit 0" "0" "$ANALYZE_RC"
+  assert_lacks "no F5 for cancelled runs" "$out" "F5 —"
+  assert_contains "cancelled runs are still visible in the counts" "$out" "2 ineligible"
+  rm -rf "$d"
+}
+
+test_f5_reports_a_total_absence_of_ledgers_as_its_own_finding() {
+  # The scoping above must not swallow the case that matters most: if NOTHING in
+  # the window produced a ledger, an empty ledger reads exactly like a healthy one.
+  local d; d="$(printf '' | mk_work)"
+  {
+    printf '1\t2026-07-20T00:00:00Z\tno\n'
+    printf '2\t2026-07-21T00:00:00Z\tno\n'
+  } > "$d/runs.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "no ledger anywhere in the window -> exit 1" "1" "$ANALYZE_RC"
+  assert_contains "total absence named" "$out" "NO run in the window produced a"
+  assert_contains "and says why it matters" "$out" "reads exactly like a healthy one"
+  rm -rf "$d"
+}
+
+test_f5_unreadable_artifact_is_informational_not_a_finding() {
+  local d; d="$(printf '%s\n' "$REAL_ARTIFACT" | mk_work)"
+  printf '499\tOPEN\n' > "$d/issue-states.tsv"
+  printf '9\t2026-07-22T00:00:00Z\tunreadable\n' >> "$d/runs.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "unreadable artifact is a download failure, not a wiring break" "0" "$ANALYZE_RC"
+  assert_contains "unreadable artifact -> informational" "$out" "could not download or unzip"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# F6 — informational only (a finding here would contradict F3)
+# ---------------------------------------------------------------------------
+
+test_f6_absent_quarantine_is_informational_only() {
+  local d; d="$(printf '%s\n' "$REAL_ARTIFACT" | mk_work)"
+  printf '499\tOPEN\n' > "$d/issue-states.tsv"
+  printf 'Tests/TBDDaemonTests/FlakyQuarantineSelfTests.swift\talwaysFails\t499\n' > "$d/inv.tsv"
+  analyze_in "$d" --inventory "$d/inv.tsv"; local out="$ANALYZE_OUT"
+  assert_eq "a quarantine with no records does not fail the audit" "0" "$ANALYZE_RC"
+  assert_contains "F6 reported as informational" "$out" "has NO records in the window"
+  assert_contains "F6 names alwaysFails as expected there" "$out" "is expected here"
+  rm -rf "$d"
+}
+
+test_f6_matches_a_present_quarantine_and_stays_quiet() {
+  local d; d="$(printf '%s\n' "$REAL_ARTIFACT" | mk_work)"
+  printf '499\tOPEN\n' > "$d/issue-states.tsv"
+  printf 'Tests/TBDDaemonTests/FlakyQuarantineSelfTests.swift\tretriesUntilPass\t499\n' > "$d/inv.tsv"
+  analyze_in "$d" --inventory "$d/inv.tsv"; local out="$ANALYZE_OUT"
+  assert_eq "a quarantine WITH records -> exit 0" "0" "$ANALYZE_RC"
+  assert_lacks "no spurious F6 for a test that did run" "$out" "has NO records in the window"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# The exclusion list: exactly one entry
+# ---------------------------------------------------------------------------
+
+test_excluded_fixture_never_produces_f1_or_f2() {
+  # Six first-try passes AND a closed issue — both F1 and F2 would fire on any
+  # other test. The fixture is exempt from both, and only the fixture is.
+  local d; d="$(for i in 1 2 3 4 5 6; do
+      printf '{"attempts":1,"file":"Tests/TBDDaemonTests/FlakyQuarantineSelfTests.swift","issue":499,"line":29,"outcome":"passedFirstTry","schema":1,"testID":"TBDDaemonTests.FlakyQuarantineSelfTests/retriesUntilPass()"}\n'
+    done | mk_work)"
+  printf '499\tCLOSED\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "the one excluded fixture is exempt from F1 and F2" "0" "$ANALYZE_RC"
+  assert_contains "and is still reported as excluded" "$out" "Excluded by contract (1)"
+  # MUTATION: shrink the exclusion to nothing — the fixture must then trip both.
+  assert_eq "exclusion mutation: emptied -> the fixture now trips findings" "1" \
+    "$(analyze_mutated 's|readonly EXCLUDED_TEST_ID=.*|readonly EXCLUDED_TEST_ID="none"|' "$d")"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# Degenerate inputs must not read as "healthy"
+# ---------------------------------------------------------------------------
+
+test_empty_ledger_reports_zero_rather_than_pretending() {
+  local d; d="$(printf '' | mk_work)"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_eq "empty ledger -> exit 0" "0" "$ANALYZE_RC"
+  assert_contains "empty ledger states the count plainly" "$out" "Quarantined tests seen: **0**"
+  rm -rf "$d"
+}
+
+test_malformed_record_does_not_crash_the_audit() {
+  local d; d="$(mk_work <<'JSON'
+not json at all
+{"attempts":1,"file":"f.swift","issue":494,"line":1,"outcome":"passedFirstTry","schema":1,"testID":"TBDDaemonTests.AcmeTests/x()"}
+JSON
+)"
+  printf '494\tOPEN\n' > "$d/issue-states.tsv"
+  analyze_in "$d"; local out="$ANALYZE_OUT"
+  assert_contains "a malformed line does not take the report down" "$out" "Quarantine audit"
+  rm -rf "$d"
+}
+
+# ---------------------------------------------------------------------------
+# inventory: parses the real source tree
+# ---------------------------------------------------------------------------
+
+test_inventory_finds_the_real_selftests() {
+  local out; out="$(mktmpd)/inv.tsv"
+  bash "$SCRIPT" inventory --out "$out" --root "$HERE/.." >/dev/null 2>&1
+  local content; content="$(cat "$out")"
+  assert_contains "inventory finds retriesUntilPass" "$content" "retriesUntilPass"
+  assert_contains "inventory finds alwaysFails" "$content" "alwaysFails"
+  assert_contains "inventory records the issue number" "$content" "499"
+  assert_lacks "inventory skips the trait's own definition file" "$content" "FlakyTestSupport.swift"
+}
+
+# ---------------------------------------------------------------------------
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_' | sort); do
+  echo "== $t"
+  "$t"
+done
+if [[ $FAIL -eq 0 ]]; then echo "ALL PASS"; else echo "FAILURES"; fi
+exit $FAIL

--- a/scripts/nightly-report.sh
+++ b/scripts/nightly-report.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/nightly-report.sh — post a nightly finding as an issue comment.
+#
+# §9: "Failures land as issue comments — never as PR noise." That invariant is
+# enforced structurally by nightly.yml's trigger set (schedule + workflow_dispatch
+# only, so there is no PR for it to comment on), not by this script's manners.
+#
+# What this script adds is the other half: a comment that says WHERE it came
+# from. A finding with no run link is a finding somebody has to go hunting for.
+#
+# Usage:
+#   scripts/nightly-report.sh --issue 519 --title "Quarantine audit" --body-file F
+#   scripts/nightly-report.sh ... --post          # actually comment (CI only)
+#   scripts/nightly-report.sh --issue 519 --fixture --post
+#
+# DRY-RUN IS THE DEFAULT. Without --post it prints the exact comment to stdout
+# and touches nothing, so the composition can be inspected and tested offline.
+#
+# --fixture posts the wire-verification comment: a labelled, deliberate comment
+# proving `gh issue comment` actually works. A clean nightly posts NOTHING, so
+# without this the reporting path would be unverified precisely when everything
+# is healthy — which is this program's signature failure mode. The fixture
+# comment is KEPT, not deleted: a deleted verification leaves no evidence the
+# wire was ever proven.
+#
+# Test seams (env):
+#   REPORT_GH_CMD   command standing in for `gh`   (default: gh)
+#   REPORT_REPO     owner/repo                     (default: cheapsteak/tbd)
+#   REPORT_RUN_URL  link back to the workflow run  (default: derived from GITHUB_*)
+#   REPORT_TODAY    ISO date in the footer         (default: today, UTC)
+
+set -uo pipefail
+
+GH_CMD="${REPORT_GH_CMD:-gh}"
+REPO="${REPORT_REPO:-cheapsteak/tbd}"
+
+die() { echo "nightly-report: $*" >&2; exit 2; }
+
+run_url() {
+  if [[ -n "${REPORT_RUN_URL:-}" ]]; then
+    printf '%s' "$REPORT_RUN_URL"
+  elif [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+    printf '%s/%s/actions/runs/%s' "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID"
+  else
+    printf 'local run (no GITHUB_RUN_ID)'
+  fi
+}
+
+compose() {
+  local title="$1" body_file="$2"
+  echo "### 🌙 $title"
+  echo
+  if [[ -n "$body_file" ]]; then
+    [[ -f "$body_file" ]] || die "body file not found: $body_file"
+    cat "$body_file"
+  fi
+  echo
+  echo "---"
+  echo "<sub>Nightly test-hardening workflow · ${REPORT_TODAY:-$(date -u +%Y-%m-%d)} · [run]($(run_url)) · \`scripts/nightly-report.sh\`</sub>"
+}
+
+compose_fixture() {
+  cat <<'FIXTURE'
+### 🔌 WIRE VERIFICATION FIXTURE — not a real report
+
+This comment exists to prove that the nightly workflow can actually post here.
+
+A healthy nightly posts **nothing** — so without a deliberate fixture, the
+reporting path would be exercised for the first time on the night something
+breaks, which is exactly when you least want to discover it does not work. That
+is this program's signature failure: a mechanism that only appears to work
+because it is never exercised.
+
+It is kept rather than deleted on purpose. A deleted verification leaves no
+evidence the wire was ever proven; six months from now "was the comment path
+ever tested?" is answerable by scrolling, or it is answerable by nobody.
+
+Nothing here is a finding. Real reports carry a `🌙` heading and a findings count.
+FIXTURE
+  echo
+  echo "---"
+  echo "<sub>Posted by \`scripts/nightly-report.sh --fixture\` · ${REPORT_TODAY:-$(date -u +%Y-%m-%d)} · [run]($(run_url))</sub>"
+}
+
+main() {
+  local issue="" title="" body_file="" post=0 fixture=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --issue)     issue="${2:-}"; shift 2 ;;
+      --title)     title="${2:-}"; shift 2 ;;
+      --body-file) body_file="${2:-}"; shift 2 ;;
+      --post)      post=1; shift ;;
+      --fixture)   fixture=1; shift ;;
+      *) die "unknown argument $1" ;;
+    esac
+  done
+  [[ -n "$issue" ]] || die "--issue is required"
+  [[ "$fixture" -eq 1 || -n "$title" ]] || die "--title is required"
+
+  local comment
+  if [[ "$fixture" -eq 1 ]]; then
+    comment="$(compose_fixture)"
+  else
+    comment="$(compose "$title" "$body_file")" || exit 2
+  fi
+
+  if [[ "$post" -eq 0 ]]; then
+    echo "── DRY RUN — would comment on #$issue in $REPO (pass --post to send):"
+    echo
+    printf '%s\n' "$comment"
+    return 0
+  fi
+
+  printf '%s\n' "$comment" | "$GH_CMD" issue comment "$issue" --repo "$REPO" --body-file - \
+    || die "failed to comment on #$issue"
+  echo "nightly-report: commented on $REPO#$issue"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/nightly-report.test.sh
+++ b/scripts/nightly-report.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Tests for scripts/nightly-report.sh — run: bash scripts/nightly-report.test.sh
+#
+# The thing worth proving about a reporting wire is that it does NOT fire when it
+# should not: a dry run must reach `gh` zero times. The `--post` path is proven
+# against a stub here and for real, once, against issue #519 (the wire-verification
+# fixture) — see nightly.yml.
+# shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F` below
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/nightly-report.sh"
+
+FAIL=0
+assert_eq()       { if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: output lacks [$3]"; FAIL=1; fi; }
+assert_lacks()    { if [[ "$2" != *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: unexpectedly contains [$3]"; FAIL=1; fi; }
+mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/report-test.XXXXXX"; }
+
+# A stand-in for `gh` that records that it was called, and with what.
+mk_gh_stub() {
+  local dir="$1"
+  cat > "$dir/gh" <<STUB
+#!/usr/bin/env bash
+echo "\$@" >> "$dir/gh-calls"
+cat >> "$dir/gh-stdin"
+STUB
+  chmod +x "$dir/gh"
+  : > "$dir/gh-calls"    # pre-create so "never called" reads as 0, not as an error
+  : > "$dir/gh-stdin"
+}
+
+test_dry_run_never_touches_gh() {
+  local d; d="$(mktmpd)"; mk_gh_stub "$d"
+  echo "some findings" > "$d/body.md"
+  local out
+  out="$(REPORT_GH_CMD="$d/gh" REPORT_TODAY=2026-07-27 REPORT_RUN_URL="https://example/run/1" \
+        bash "$SCRIPT" --issue 519 --title "Quarantine audit" --body-file "$d/body.md" 2>&1)"
+  assert_eq "dry run calls gh zero times" "0" "$(wc -l < "$d/gh-calls" 2>/dev/null | tr -d ' ' || echo 0)"
+  assert_contains "dry run announces itself" "$out" "DRY RUN"
+  assert_contains "dry run shows the body" "$out" "some findings"
+  rm -rf "$d"
+}
+
+test_post_sends_the_composed_comment() {
+  local d; d="$(mktmpd)"; mk_gh_stub "$d"
+  echo "F1 — quarantine references a CLOSED issue" > "$d/body.md"
+  REPORT_GH_CMD="$d/gh" REPORT_TODAY=2026-07-27 REPORT_RUN_URL="https://example/run/1" \
+    bash "$SCRIPT" --issue 519 --title "Quarantine audit" --body-file "$d/body.md" --post >/dev/null 2>&1
+  local call body
+  call="$(cat "$d/gh-calls")"
+  body="$(cat "$d/gh-stdin")"
+  assert_contains "gh is called as issue comment on the right issue" "$call" "issue comment 519"
+  assert_contains "and against the right repo" "$call" "--repo cheapsteak/tbd"
+  assert_contains "the body carries the title" "$body" "Quarantine audit"
+  assert_contains "the body carries the findings" "$body" "F1 —"
+  assert_contains "the body links back to the run" "$body" "https://example/run/1"
+  rm -rf "$d"
+}
+
+test_fixture_is_unmistakably_labelled() {
+  local d; d="$(mktmpd)"; mk_gh_stub "$d"
+  REPORT_GH_CMD="$d/gh" REPORT_TODAY=2026-07-27 REPORT_RUN_URL="https://example/run/1" \
+    bash "$SCRIPT" --issue 519 --fixture --post >/dev/null 2>&1
+  local body heading; body="$(cat "$d/gh-stdin")"
+  heading="$(printf '%s' "$body" | grep -m1 '^###')"
+  assert_contains "fixture says what it is, in the heading" "$heading" "WIRE VERIFICATION FIXTURE — not a real report"
+  assert_contains "fixture says why it is kept" "$body" "kept rather than deleted on purpose"
+  # WHITELIST THE HEADING, don't blacklist the glyph across the whole body: the
+  # fixture's own text explains that real reports carry 🌙, so `assert_lacks 🌙`
+  # on the full body fails from the wrong side — the prohibition contains the
+  # thing prohibited. Assert on the unit that actually distinguishes them.
+  assert_lacks "the fixture's heading is not a real-report heading" "$heading" "🌙"
+  assert_contains "and a real report's heading is" \
+    "$(REPORT_GH_CMD=true REPORT_TODAY=2026-07-27 bash "$SCRIPT" --issue 519 --title T | grep -m1 '^###')" "🌙"
+  rm -rf "$d"
+}
+
+test_missing_body_file_is_an_error_not_an_empty_comment() {
+  local d; d="$(mktmpd)"; mk_gh_stub "$d"
+  local rc
+  REPORT_GH_CMD="$d/gh" bash "$SCRIPT" --issue 519 --title "T" --body-file "$d/nope.md" --post >/dev/null 2>&1
+  rc=$?
+  assert_eq "a missing body file fails loudly" "2" "$rc"
+  assert_eq "and posts nothing" "0" "$(wc -l < "$d/gh-calls" 2>/dev/null | tr -d ' ' || echo 0)"
+  rm -rf "$d"
+}
+
+test_a_failed_gh_call_is_not_reported_as_success() {
+  local d; d="$(mktmpd)"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$d/gh"; chmod +x "$d/gh"
+  echo "body" > "$d/body.md"
+  local rc
+  REPORT_GH_CMD="$d/gh" bash "$SCRIPT" --issue 519 --title "T" --body-file "$d/body.md" --post >/dev/null 2>&1
+  rc=$?
+  assert_eq "gh failing makes the reporter fail" "2" "$rc"
+  rm -rf "$d"
+}
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_' | sort); do
+  echo "== $t"
+  "$t"
+done
+if [[ $FAIL -eq 0 ]]; then echo "ALL PASS"; else echo "FAILURES"; fi
+exit $FAIL

--- a/scripts/nightly-report.test.sh
+++ b/scripts/nightly-report.test.sh
@@ -85,6 +85,26 @@ test_missing_body_file_is_an_error_not_an_empty_comment() {
   rm -rf "$d"
 }
 
+test_every_workflow_step_that_tees_a_report_body_captures_stderr() {
+  # A comment is only worth posting if it carries the reason. Every nightly step
+  # that tees its output into a file which later becomes an issue-comment body
+  # must redirect stderr into that file first — the scripts report harness
+  # failures via stderr + a non-zero exit, which is exactly the case that gets
+  # commented about, and a clean run posts nothing at all.
+  #
+  # This exists because one of the three steps was missing `2>&1` on the first
+  # version of this PR: the audit's die() path produced ZERO bytes of stdout, so
+  # #519 would have received a comment with no reason in it. Two correct siblings
+  # in the same file did not stop the third from being wrong, so the check is
+  # mechanical rather than a habit.
+  local wf="$HERE/../.github/workflows/nightly.yml"
+  local total bad
+  total="$(grep -c 'tee "\$' "$wf")"
+  bad="$(grep 'tee "\$' "$wf" | grep -cv '2>&1 | tee')"
+  assert_eq "nightly.yml still has the three tee'd report steps" "3" "$total"
+  assert_eq "every tee'd step redirects stderr into the body it will post" "0" "$bad"
+}
+
 test_a_failed_gh_call_is_not_reported_as_success() {
   local d; d="$(mktmpd)"
   printf '#!/usr/bin/env bash\nexit 1\n' > "$d/gh"; chmod +x "$d/gh"

--- a/scripts/nightly-tmux-cc-probe.py
+++ b/scripts/nightly-tmux-cc-probe.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Drive a `tmux -CC` control-mode client over a real pty and dump the transcript.
+
+Used by scripts/nightly-tmux-probes.sh for probes P6/P7/P8. It exists as a
+separate file for one reason: **control mode requires a tty.** Feeding
+`tmux -CC attach` from a pipe or a fifo dies immediately with
+
+    tcgetattr failed: Operation not supported on socket
+
+and macOS `script -q /dev/null` does not rescue it (it fails the same way on its
+own stdin). A pty has to be allocated explicitly, which shell cannot do.
+
+Writes the raw transcript to stdout with `@@MARK <label>` lines separating
+phases and a final `@@EXIT <status>` line. It asserts nothing — every claim is
+checked by the shell harness, so the probe definitions all live in one file.
+
+Usage: nightly-tmux-cc-probe.py <socket-name> <session-name>
+"""
+
+import os
+import pty
+import select
+import subprocess
+import sys
+import termios
+import time
+
+# Each phase gets a fixed drain window. These are transcript-collection budgets,
+# not synchronisation primitives: the shell harness asserts on what the
+# transcript contains, so a slow runner yields a late line, never a wrong verdict.
+ATTACH_DRAIN = 2.0
+COMMAND_DRAIN = 1.5
+DETACH_DRAIN = 2.5
+EXIT_WAIT = 3.0
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        sys.stderr.write("usage: nightly-tmux-cc-probe.py <socket> <session>\n")
+        return 2
+    socket_name, session = sys.argv[1], sys.argv[2]
+
+    master, slave = pty.openpty()
+    # Turn off echo and canonical mode on the slave: with echo on, everything we
+    # write comes back in the transcript and a "%begin block count" probe would
+    # be counting its own input.
+    attrs = termios.tcgetattr(slave)
+    attrs[3] &= ~(termios.ECHO | termios.ICANON)
+    termios.tcsetattr(slave, termios.TCSANOW, attrs)
+
+    proc = subprocess.Popen(
+        ["tmux", "-L", socket_name, "-CC", "attach", "-t", session],
+        stdin=slave, stdout=slave, stderr=slave, start_new_session=True,
+    )
+    os.close(slave)
+
+    chunks: list[str] = []
+
+    def drain(seconds: float) -> None:
+        end = time.time() + seconds
+        while True:
+            remaining = end - time.time()
+            if remaining <= 0:
+                return
+            readable, _, _ = select.select([master], [], [], remaining)
+            if not readable:
+                return
+            try:
+                data = os.read(master, 65536)
+            except OSError:
+                return
+            if not data:
+                return
+            chunks.append(data.decode("utf-8", "replace"))
+
+    def mark(label: str) -> None:
+        chunks.append("\n@@MARK %s\n" % label)
+
+    def send(text: str) -> None:
+        os.write(master, text.encode())
+
+    try:
+        drain(ATTACH_DRAIN)
+        mark("attached")
+
+        send("display-message -p CCPROBE_OK\n")
+        drain(COMMAND_DRAIN)
+        mark("after-good-command")
+
+        send("this-is-not-a-command\n")
+        drain(COMMAND_DRAIN)
+        mark("after-bad-command")
+
+        # Whitespace-only line: claimed to produce no command blocks at all.
+        send("   \n")
+        drain(COMMAND_DRAIN)
+        mark("after-whitespace-line")
+
+        # Blank line: claimed to detach the client.
+        send("\n")
+        drain(DETACH_DRAIN)
+        mark("after-blank-line")
+
+        try:
+            status = str(proc.wait(timeout=EXIT_WAIT))
+        except subprocess.TimeoutExpired:
+            status = "alive"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+        os.close(master)
+
+    chunks.append("\n@@EXIT %s\n" % status)
+    sys.stdout.write("".join(chunks))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/nightly-tmux-probes.sh
+++ b/scripts/nightly-tmux-probes.sh
@@ -243,7 +243,7 @@ probe_control_mode_framing() {
   ws_phase="$(phase_of "$transcript" after-bad-command after-whitespace-line)"
 
   probe "P8" "a command yields %begin/%end with a matching id triple; an INVALID command yields %begin/%error" \
-        "TmuxControlConnection's block parser — %error, not %end, terminates a failed command"
+        "TmuxControlParser.swift:34-55 — the %begin…%end/%error framing; %error, not %end, terminates a failed command"
   local good_begin good_end
   good_begin="$(printf '%s' "$good_phase" | sed -n 's/^%begin \(.*\)$/\1/p' | tr -d '\r' | head -1)"
   good_end="$(printf '%s' "$good_phase"   | sed -n 's/^%end \(.*\)$/\1/p'   | tr -d '\r' | head -1)"

--- a/scripts/nightly-tmux-probes.sh
+++ b/scripts/nightly-tmux-probes.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# scripts/nightly-tmux-probes.sh — executable checks of tmux behaviours this repo
+# currently trusts from memory. Step 1 of the nightly workflow
+# (docs/specs/2026-07-24-test-hardening-design.md §9).
+#
+# TBD's tmux layer rests on a set of claims that live in code comments and in
+# people's heads: that pane IDs get reused, that `paste-buffer -p` is the sole
+# thing wrapping a bracketed paste, that a blank line detaches a control-mode
+# client. Each is load-bearing, none is asserted anywhere, and tmux is free to
+# change any of them in a point release. These probes turn them into checks that
+# run every night against the real binary, so the day one changes we find out
+# from a nightly report instead of from a user.
+#
+# Each probe names the claim AND the code that depends on it, so a failure is a
+# starting point rather than a puzzle.
+#
+# Usage:
+#   scripts/nightly-tmux-probes.sh              # run all probes
+#   scripts/nightly-tmux-probes.sh --list       # list probe IDs and claims
+#
+# Exit: 0 = every claim held, 1 = at least one claim FAILED, 2 = harness error.
+#
+# Test seam (env):
+#   PROBE_INJECT_FAILURE=<probe id>   corrupt that probe's observed value, to
+#                                     prove the harness reports a failure as a
+#                                     failure. Used by nightly-tmux-probes.test.sh.
+#   PROBE_SOCKET=<name>               override the private socket name, so the
+#                                     test can assert on that EXACT socket rather
+#                                     than counting a shared prefix.
+#
+# SAFETY: every probe runs against a private tmux server (`-L tbdnightly-probe-$$`)
+# and the cleanup trap kills THAT SOCKET ONLY. It never touches the developer's
+# tmux server, never uses `pkill -f` (which matches across worktrees), and never
+# signals a process group.
+#
+# The prefix is `tbdnightly-probe-`, NOT `tbd-probe-`: this box already carries
+# 43 sockets named `tbd-probe-<HEX>` left by unrelated tooling, and TBD's own
+# servers are `tbd-<8 hex>` (TmuxManager.serverName). A cleanup — or a leak
+# CHECK — written against `tbd-probe-*` reaches into a namespace that is not
+# ours. That is the cross-worktree hazard arriving through the checking layer
+# instead of through a kill, and this file hit it before the rename.
+
+set -uo pipefail
+
+readonly SOCKET="${PROBE_SOCKET:-tbdnightly-probe-$$}"
+WORK_DIR=""
+CURRENT_PROBE=""
+PASSED=0
+FAILED=0
+FAILURES=()
+
+# --- harness ------------------------------------------------------------------
+
+cleanup() {
+  local rc=$?
+  tmux -L "$SOCKET" kill-server >/dev/null 2>&1
+  # `kill-server` stops the server but LEAVES THE SOCKET FILE — measured, after
+  # nine of them accumulated here in one session. Ephemeral on a CI runner,
+  # but this also runs on a developer box where that directory already holds
+  # ~19,700 dead sockets. Remove our own by exact path; never glob a prefix.
+  rm -f "${TMUX_TMPDIR:-/tmp}/tmux-$(id -u)/$SOCKET" 2>/dev/null
+  [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]] && rm -rf "$WORK_DIR"
+  exit "$rc"
+}
+# INT/TERM as well as EXIT: an externally killed probe run must still take its
+# private tmux server with it rather than leaking one per night.
+trap cleanup EXIT INT TERM
+
+tmuxp() { tmux -L "$SOCKET" "$@"; }
+
+probe() {
+  CURRENT_PROBE="$1"
+  echo
+  echo "── $1 — $2"
+  echo "   depends on: $3"
+}
+
+# Compare an observed value against the claim. PROBE_INJECT_FAILURE corrupts the
+# observed value for one probe so the harness's own reporting can be tested; a
+# reporting path that has only ever seen passes is not known to report failures.
+expect_eq() {
+  local what="$1" want="$2" got="$3"
+  if [[ "${PROBE_INJECT_FAILURE:-}" == "$CURRENT_PROBE" ]]; then
+    got="__INJECTED_FAILURE__"
+  fi
+  if [[ "$want" == "$got" ]]; then
+    echo "   PASS  $what"
+    PASSED=$((PASSED + 1))
+  else
+    echo "   FAIL  $what"
+    echo "         claimed:  [$want]"
+    echo "         observed: [$got]"
+    FAILED=$((FAILED + 1))
+    FAILURES+=("$CURRENT_PROBE — $what (claimed [$want], observed [$got])")
+  fi
+}
+
+# Bounded wait for a file to reach an exact size. Returns 1 on deadline; the
+# caller then compares content and reports what it actually saw.
+wait_for_size() {
+  local file="$1" want="$2" deadline_s="${3:-5}"
+  local deadline=$((SECONDS + deadline_s))
+  while [[ $SECONDS -lt $deadline ]]; do
+    [[ -f "$file" ]] && [[ "$(wc -c < "$file" | tr -d ' ')" -ge "$want" ]] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+file_hex() { xxd -p "$1" 2>/dev/null | tr -d '\n'; }
+
+# --- probes -------------------------------------------------------------------
+
+probe_pane_ids_are_not_reused_within_a_server() {
+  probe "P1" "pane IDs are never reused while a server lives" \
+        "issue #384 (stale terminal→pane coordinates routing keystrokes to the wrong session)"
+
+  tmuxp new-session -d -s probe -x 80 -y 24 'sleep 300' >/dev/null 2>&1
+  tmuxp new-window -d 'sleep 300' >/dev/null 2>&1
+  tmuxp new-window -d 'sleep 300' >/dev/null 2>&1
+  local before; before="$(tmuxp list-panes -a -F '#{pane_id}' | sort | tr '\n' ' ')"
+
+  # Kill the middle pane, then create a new one. If IDs were recycled, the new
+  # pane would take the dead pane's ID — which is what "pane reuse" would mean.
+  local victim; victim="$(tmuxp list-panes -a -F '#{pane_id}' | sed -n 2p)"
+  tmuxp kill-pane -t "$victim" >/dev/null 2>&1
+  tmuxp new-window -d 'sleep 300' >/dev/null 2>&1
+  local after; after="$(tmuxp list-panes -a -F '#{pane_id}' | sort | tr '\n' ' ')"
+
+  expect_eq "the killed pane's ID ($victim) is not handed out again" \
+            "absent" \
+            "$(if [[ " $after " == *" $victim "* ]]; then echo "REUSED"; else echo "absent"; fi)"
+  expect_eq "three panes remain after kill+create" "3" \
+            "$(tmuxp list-panes -a -F '#{pane_id}' | grep -c .)"
+  echo "         (before: $before/ after: $after)"
+  tmuxp kill-server >/dev/null 2>&1
+}
+
+probe_pane_ids_restart_at_zero_after_server_death() {
+  probe "P2" "pane IDs restart at %0 when the server dies — so a PERSISTED pane ID can collide across a server restart" \
+        "issue #384; this is the actual mechanism behind 'pane reuse', and it is narrower than the folklore"
+
+  tmuxp new-session -d -s probe -x 80 -y 24 'sleep 300' >/dev/null 2>&1
+  tmuxp new-window -d 'sleep 300' >/dev/null 2>&1
+  local first_generation; first_generation="$(tmuxp list-panes -a -F '#{pane_id}' | sort | tr '\n' ' ')"
+  tmuxp kill-server >/dev/null 2>&1
+  sleep 0.3
+
+  tmuxp new-session -d -s probe -x 80 -y 24 'sleep 300' >/dev/null 2>&1
+  local reborn; reborn="$(tmuxp list-panes -a -F '#{pane_id}')"
+  expect_eq "a fresh server's first pane is %0 again (collides with the old server's %0)" "%0" "$reborn"
+  echo "         (first server had: ${first_generation}— a stored '%0' now points at a different pane)"
+  tmuxp kill-server >/dev/null 2>&1
+}
+
+probe_paste_buffer_p_is_conditional_on_bracketed_paste_mode() {
+  probe "P3" "\`paste-buffer -p\` wraps in ESC[200~/ESC[201~ ONLY IF the pane's application enabled bracketed-paste mode (DECSET 2004)" \
+        "PasteExecutor.swift; TerminalPanelView.swift:727 and TBDTerminalView.swift:78 call the daemon-side -p the SOLE bracketed-paste wrapping — true, but silently contingent on the TUI having requested it"
+
+  local payload="ABCDEFGHIJ"
+  printf '%s' "$payload" > "$WORK_DIR/payload.txt"
+  local payload_hex; payload_hex="$(printf '%s' "$payload" | xxd -p | tr -d '\n')"
+  local wrapped_hex="1b5b3230307e${payload_hex}1b5b3230317e"
+
+  # Arm A — the pane requests bracketed paste. Expect the markers.
+  tmuxp new-session -d -s probe -x 80 -y 24 \
+    "stty raw -echo; printf '\033[?2004h'; head -c 22 > $WORK_DIR/on.bin" >/dev/null 2>&1
+  sleep 0.5
+  tmuxp load-buffer -b probeon "$WORK_DIR/payload.txt" >/dev/null 2>&1
+  tmuxp paste-buffer -d -p -b probeon -t "$(tmuxp list-panes -F '#{pane_id}')" >/dev/null 2>&1
+  wait_for_size "$WORK_DIR/on.bin" 22 8
+  expect_eq "with DECSET 2004 set: payload arrives wrapped" "$wrapped_hex" "$(file_hex "$WORK_DIR/on.bin")"
+  tmuxp kill-server >/dev/null 2>&1; sleep 0.3
+
+  # Arm B — the pane never requested it. Expect NO markers, same -p flag.
+  tmuxp new-session -d -s probe -x 80 -y 24 \
+    "stty raw -echo; head -c 10 > $WORK_DIR/off.bin" >/dev/null 2>&1
+  sleep 0.5
+  tmuxp load-buffer -b probeoff "$WORK_DIR/payload.txt" >/dev/null 2>&1
+  tmuxp paste-buffer -d -p -b probeoff -t "$(tmuxp list-panes -F '#{pane_id}')" >/dev/null 2>&1
+  wait_for_size "$WORK_DIR/off.bin" 10 8
+  expect_eq "without DECSET 2004: SAME -p flag delivers the payload verbatim" \
+            "$payload" "$(cat "$WORK_DIR/off.bin" 2>/dev/null)"
+  tmuxp kill-server >/dev/null 2>&1
+}
+
+probe_paste_buffer_without_p_is_verbatim() {
+  probe "P4" "\`paste-buffer\` without -p delivers bytes verbatim" \
+        "TmuxManager.swift:560 and PasteExecutorIntegrationTests — the >4 KB bulk-paste path relies on no wrapping being added"
+
+  local payload="ABCDEFGHIJ"
+  printf '%s' "$payload" > "$WORK_DIR/payload4.txt"
+  tmuxp new-session -d -s probe -x 80 -y 24 \
+    "stty raw -echo; printf '\033[?2004h'; head -c 10 > $WORK_DIR/nop.bin" >/dev/null 2>&1
+  sleep 0.5
+  tmuxp load-buffer -b probenop "$WORK_DIR/payload4.txt" >/dev/null 2>&1
+  # DECSET 2004 is deliberately ON here: without -p there must be no wrapping
+  # EVEN THOUGH the application asked for bracketed paste.
+  tmuxp paste-buffer -d -b probenop -t "$(tmuxp list-panes -F '#{pane_id}')" >/dev/null 2>&1
+  wait_for_size "$WORK_DIR/nop.bin" 10 8
+  expect_eq "no -p: verbatim even with DECSET 2004 set" "$payload" "$(cat "$WORK_DIR/nop.bin" 2>/dev/null)"
+  tmuxp kill-server >/dev/null 2>&1
+}
+
+probe_paste_buffer_d_deletes_the_buffer() {
+  probe "P5" "\`paste-buffer -d\` deletes the named buffer; without -d it survives" \
+        "PasteExecutor.swift:58-72 — the delete-buffer fallback only makes sense if -d normally did the delete"
+
+  printf 'x' > "$WORK_DIR/payload5.txt"
+  tmuxp new-session -d -s probe -x 80 -y 24 'sleep 300' >/dev/null 2>&1
+  local pane; pane="$(tmuxp list-panes -F '#{pane_id}')"
+
+  tmuxp load-buffer -b probekeep "$WORK_DIR/payload5.txt" >/dev/null 2>&1
+  tmuxp paste-buffer -b probekeep -t "$pane" >/dev/null 2>&1
+  expect_eq "without -d the buffer survives the paste" "present" \
+            "$(if tmuxp list-buffers 2>/dev/null | grep -q '^probekeep:'; then echo present; else echo GONE; fi)"
+
+  tmuxp load-buffer -b probedel "$WORK_DIR/payload5.txt" >/dev/null 2>&1
+  tmuxp paste-buffer -d -b probedel -t "$pane" >/dev/null 2>&1
+  expect_eq "with -d the buffer is gone" "absent" \
+            "$(if tmuxp list-buffers 2>/dev/null | grep -q '^probedel:'; then echo STILL_PRESENT; else echo absent; fi)"
+  tmuxp kill-server >/dev/null 2>&1
+}
+
+# P6/P7/P8 share one control-mode transcript: attaching three times would triple
+# the runtime and test nothing extra.
+probe_control_mode_framing() {
+  local script_dir; script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  local transcript="$WORK_DIR/cc.txt"
+
+  tmuxp new-session -d -s cc -x 80 -y 24 'sleep 300' >/dev/null 2>&1
+  if ! python3 "$script_dir/nightly-tmux-cc-probe.py" "$SOCKET" cc > "$transcript" 2>"$WORK_DIR/cc.err"; then
+    echo "   HARNESS ERROR: control-mode driver failed: $(cat "$WORK_DIR/cc.err")" >&2
+    FAILED=$((FAILED + 1))
+    FAILURES+=("P6/P7/P8 — control-mode driver failed to run: $(cat "$WORK_DIR/cc.err")")
+    tmuxp kill-server >/dev/null 2>&1
+    return
+  fi
+
+  local good_phase bad_phase ws_phase
+  good_phase="$(phase_of "$transcript" attached after-good-command)"
+  bad_phase="$(phase_of "$transcript" after-good-command after-bad-command)"
+  ws_phase="$(phase_of "$transcript" after-bad-command after-whitespace-line)"
+
+  probe "P8" "a command yields %begin/%end with a matching id triple; an INVALID command yields %begin/%error" \
+        "TmuxControlConnection's block parser — %error, not %end, terminates a failed command"
+  local good_begin good_end
+  good_begin="$(printf '%s' "$good_phase" | sed -n 's/^%begin \(.*\)$/\1/p' | tr -d '\r' | head -1)"
+  good_end="$(printf '%s' "$good_phase"   | sed -n 's/^%end \(.*\)$/\1/p'   | tr -d '\r' | head -1)"
+  expect_eq "a good command's %begin and %end carry the same id triple" "$good_begin" "$good_end"
+  expect_eq "a good command's output appears inside the block" "yes" \
+            "$(if printf '%s' "$good_phase" | grep -q 'CCPROBE_OK'; then echo yes; else echo no; fi)"
+  local bad_begin bad_error
+  bad_begin="$(printf '%s' "$bad_phase" | sed -n 's/^%begin \(.*\)$/\1/p' | tr -d '\r' | head -1)"
+  bad_error="$(printf '%s' "$bad_phase" | sed -n 's/^%error \(.*\)$/\1/p' | tr -d '\r' | head -1)"
+  expect_eq "an invalid command terminates with %error carrying the same id triple" "$bad_begin" "$bad_error"
+  expect_eq "an invalid command emits no %end" "0" \
+            "$(printf '%s' "$bad_phase" | grep -c '^%end')"
+
+  probe "P7" "a whitespace-only line produces ZERO command blocks and does not detach" \
+        "control-mode input routing — a stray whitespace write must not be read as a command"
+  expect_eq "whitespace-only line produces no %begin block" "0" \
+            "$(printf '%s' "$ws_phase" | grep -c '^%begin')"
+  expect_eq "whitespace-only line produces no %exit" "0" \
+            "$(printf '%s' "$ws_phase" | grep -c '^%exit')"
+
+  probe "P6" "a BLANK line detaches the control-mode client (%exit)" \
+        "control-mode input routing — an empty write is a detach, so it must never be sent as a no-op keepalive"
+  local blank_phase; blank_phase="$(phase_of "$transcript" after-whitespace-line after-blank-line)"
+  expect_eq "blank line yields %exit" "1" \
+            "$(printf '%s' "$blank_phase" | grep -c '^%exit')"
+  expect_eq "and the client process actually exits" "0" \
+            "$(sed -n 's/^@@EXIT \(.*\)$/\1/p' "$transcript" | head -1)"
+
+  tmuxp kill-server >/dev/null 2>&1
+}
+
+# Extract the transcript between two @@MARK labels.
+phase_of() {
+  local file="$1" from="$2" to="$3"
+  awk -v from="@@MARK $from" -v to="@@MARK $to" '
+    $0 == to   { inside = 0 }
+    inside     { print }
+    $0 == from { inside = 1 }
+  ' "$file"
+}
+
+# --- main ---------------------------------------------------------------------
+
+PROBES=(
+  probe_pane_ids_are_not_reused_within_a_server
+  probe_pane_ids_restart_at_zero_after_server_death
+  probe_paste_buffer_p_is_conditional_on_bracketed_paste_mode
+  probe_paste_buffer_without_p_is_verbatim
+  probe_paste_buffer_d_deletes_the_buffer
+  probe_control_mode_framing
+)
+
+main() {
+  if [[ "${1:-}" == "--list" ]]; then
+    printf '%s\n' "${PROBES[@]}"
+    return 0
+  fi
+
+  command -v tmux >/dev/null 2>&1 || { echo "nightly-tmux-probes: tmux not found" >&2; exit 2; }
+  # A missing python3 must be a HARNESS ERROR, never a silent skip: three probes
+  # would vanish and the run would still report success.
+  command -v python3 >/dev/null 2>&1 || { echo "nightly-tmux-probes: python3 not found (needed for the control-mode pty driver)" >&2; exit 2; }
+
+  WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tmux-probes.XXXXXX")" || exit 2
+  echo "tmux $(tmux -V | awk '{print $2}') on $(uname -s) — private socket $SOCKET"
+
+  local p
+  for p in "${PROBES[@]}"; do "$p"; done
+
+  echo
+  echo "═══ $((PASSED + FAILED)) claims checked: $PASSED held, $FAILED FAILED"
+  if [[ $FAILED -gt 0 ]]; then
+    echo
+    echo "Failed claims:"
+    local f
+    for f in "${FAILURES[@]}"; do echo "  - $f"; done
+    return 1
+  fi
+  return 0
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/nightly-tmux-probes.test.sh
+++ b/scripts/nightly-tmux-probes.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Tests for scripts/nightly-tmux-probes.sh — run: bash scripts/nightly-tmux-probes.test.sh
+#
+# This file tests the HARNESS, not tmux. The probes themselves assert claims
+# about tmux; what is proven here is that the harness would actually TELL US if
+# a claim stopped holding, and that it cleans up after itself even when killed.
+#
+# Both properties were learned the expensive way by this program: a checker that
+# has only ever seen passes is not known to report failures, and a stress harness
+# that leaks processes onto a shared box is not safe to run nightly.
+# shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F` below
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/nightly-tmux-probes.sh"
+
+
+FAIL=0
+assert_eq()       { if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: output lacks [$3]"; FAIL=1; fi; }
+
+# Is a SPECIFIC probe server still serving? Asserting on one known socket name
+# rather than counting a shared prefix: the first version of this check counted
+# `tbd-probe-*` and dutifully reported 40 sockets belonging to unrelated tooling
+# as leaks of mine. A check that measures someone else's namespace tells you
+# nothing about your own cleanup — and it fails in the direction that looks like
+# diligence.
+probe_server_live() {
+  if tmux -L "$1" ls >/dev/null 2>&1; then echo live; else echo gone; fi
+}
+
+test_injected_failure_is_reported_as_a_failure() {
+  # THE POINT OF THIS FILE. Corrupt one probe's observed value and require that
+  # the harness (a) exits non-zero, (b) prints FAIL with both values, and
+  # (c) names the probe in its summary. A green run proves nothing on its own.
+  local out rc
+  out="$(PROBE_INJECT_FAILURE=P5 bash "$SCRIPT" 2>&1)"; rc=$?
+  assert_eq "an injected false claim makes the run exit non-zero" "1" "$rc"
+  assert_contains "the failing claim is marked FAIL" "$out" "   FAIL  "
+  assert_contains "the observed value is shown, not just the expectation" "$out" "__INJECTED_FAILURE__"
+  assert_contains "the summary counts it" "$out" "FAILED"
+  assert_contains "the failed-claims list names the probe" "$out" "P5 —"
+  # And the run must not report a clean sweep alongside the failure.
+  assert_eq "a failed run does not claim 0 failures" "0" \
+    "$(printf '%s' "$out" | grep -c '0 FAILED')"
+}
+
+test_clean_run_passes_every_claim_and_exits_zero() {
+  local out rc
+  out="$(bash "$SCRIPT" 2>&1)"; rc=$?
+  assert_eq "an uninjected run exits 0" "0" "$rc"
+  assert_contains "and reports zero failures" "$out" "0 FAILED"
+  # Guard against the empty-suite failure mode: a harness that ran no probes at
+  # all would also report "0 FAILED". `swift test --filter` exiting green on zero
+  # matches has cost this program five separate times; same shape, same guard.
+  local checked
+  checked="$(printf '%s' "$out" | sed -n 's/^═══ \([0-9]*\) claims checked.*/\1/p')"
+  assert_eq "the run actually checked the expected number of claims" "16" "$checked"
+}
+
+test_every_listed_probe_function_exists() {
+  # A typo in the PROBES array would silently drop a probe, and the count guard
+  # above would only catch it if someone remembered to update the number.
+  local missing=0 p
+  for p in $(bash "$SCRIPT" --list); do
+    grep -q "^${p}()" "$SCRIPT" || { echo "     missing: $p"; missing=$((missing + 1)); }
+  done
+  assert_eq "every probe named in PROBES is defined" "0" "$missing"
+}
+
+test_cleanup_leaves_no_tmux_server_behind() {
+  local sock="tbdnightly-probetest-done-$$"
+  PROBE_SOCKET="$sock" bash "$SCRIPT" >/dev/null 2>&1
+  assert_eq "a completed run leaves no live probe server" "gone" "$(probe_server_live "$sock")"
+}
+
+test_cleanup_survives_an_external_kill() {
+  # C4's harness survived four external kills with zero leaked spinners, and that
+  # property is what made it safe to run on a shared box at all. Same requirement
+  # here: a nightly that leaks a tmux server per interrupted run is not nightly-safe.
+  local sock="tbdnightly-probetest-kill-$$" pid
+  PROBE_SOCKET="$sock" bash "$SCRIPT" >/dev/null 2>&1 &
+  pid=$!                                  # captured at spawn — never `jobs -p`
+  sleep 3                                 # let it get a server up mid-probe
+  # Assert the server was actually UP before the kill. Without this the test
+  # would pass just as happily if the run had died instantly and never started
+  # anything — a cleanup check that can only succeed proves nothing.
+  assert_eq "the run really had a server up before we killed it" "live" "$(probe_server_live "$sock")"
+  kill -TERM "$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+  # Stopping a parent orphans its children, so re-check rather than assuming.
+  sleep 1
+  assert_eq "a TERM'd run leaves no live probe server" "gone" "$(probe_server_live "$sock")"
+  tmux -L "$sock" kill-server >/dev/null 2>&1   # backstop, by exact socket name
+}
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_' | sort); do
+  echo "== $t"
+  "$t"
+done
+if [[ $FAIL -eq 0 ]]; then echo "ALL PASS"; else echo "FAILURES"; fi
+exit $FAIL


### PR DESCRIPTION
Stage 3 of the test-hardening program (`docs/specs/2026-07-24-test-hardening-design.md` §9). One scheduled workflow, three steps. Every check in it is proven to fire on a known-positive input before it shipped — a quarantine audit that silently never fires is indistinguishable from a clean codebase, and three of this program's broken instruments were in the verification layer rather than the measurement layer.

## Summary

- **Live tmux probes (16 claims).** Pane-ID reuse, `paste-buffer` semantics and control-mode framing stop being folklore in code comments and become checks that run against the real binary every night. Each probe names the claim *and* the code that depends on it.
- **Flake-ledger stress loop.** The historically flaky suites re-run under induced CPU load, attached to the issues that name them. Every iteration is judged on **(summary present) AND (count ≥ measured floor) AND (rc == 0)** — never rc alone.
- **Quarantine audit.** Consumes slice E's `retry-metrics` JSONL ledger. **No log parsing anywhere.**

Failures land as issue comments. The trigger set (`schedule` + `workflow_dispatch` only) makes "never PR noise" **structural** — there is no PR for this workflow to comment on and it can never become a required check.

## Which issues the ledger loop attaches to

| Target | Filter | Floor | Issue |
|---|---|---|---|
| `ControlModeInputHealthTests` | `--parallel -j 2 --filter` | 5 (measured 10) | **#494** |
| `GitManagerTimeoutTests` | `--no-parallel --filter` | 3 (measured 6) | **#503** |
| `AppearanceDebounceTests` | `--parallel -j 2 --filter` | 4 (measured 7) | **#496** |
| whole fast pass (#503's real repro shape) | `--skip '^TBDDaemonLiveTests\.'` | 3000 (measured 4308) | **#503** |

Probe failures, audit findings and harness errors go to the tracking issue **#519**.

Floors are **measured**, not grepped from `@Test` counts, and sit below the measured value per `test.yml`'s precedent — they fire when a pass collapses to near-nothing, not when someone adds a test. `swift test --filter` exits **green on zero matches** and matches the *type* name, not the `@Suite` string.

### What a failure comment looks like

> ### 🌙 Nightly stress loop reproduced this flake
>
> **`ControlModeInputHealth` failed 2 of 10 iteration(s) under induced load.**
>
> - Machine: 12 cores, 12 induced spinners, load1m now: 41.2
>   (`load1m` is the 1-minute average and LAGS the induced load — early iterations under-report it. The spinner count is the reliable half.)
> - Filter: `swift test --parallel -j 2 --filter ControlModeInputHealthTests`, executed-test floor 5
> - Iteration deadline: 600s (an outer timeout — `.clockDriven` was measured NOT bounding a hang)
>
> Signatures:
>
> iteration 4 (load1m 41.2 at start, 12 spinners): rc=1 with 10 tests executed
> ✘ Test "health events carry the attach generation registered with the route (R6-M7)" recorded an issue
> iteration 7: wedged — no completion within 600s (killed by the harness deadline)
>
> > This is one night's sample from CI's regime (a few idle cores), not the regime this flake was characterised in (loadavg ~150 on 12 shared cores). Treat it as evidence the flake is still live, not as a rate.

The script never emits the word "fixed". A zero-failure night is one sample from a much gentler regime than the one these flakes were characterised in.

## The exclusion list is exactly one entry

`TBDDaemonTests.FlakyQuarantineSelfTests/retriesUntilPass()` — the permanent fixture (#499).

`alwaysFails()` is **deliberately not excluded.** It is gated off by `TBD_FLAKY_SELFTEST_FAILURE`, nothing in CI sets that, so it must contribute zero records; if any appear the gate leaked and **F3 reports it**. Slice E was asked in review to add this entry and refused, because an exclusion list grown to cover a broken gate turns the gate into silence. Honoured — and the gate-leak check is ordered *before* the exclusion check, so no future edit to the list can hide it. Both properties are asserted.

## A probe that contradicts what our comments say

**`paste-buffer -p` wraps in `ESC[200~`/`ESC[201~` only if the pane's application has enabled bracketed-paste mode (DECSET 2004).** Measured, both arms, same payload: with 2004 → 22 bytes wrapped; without → 10 bytes verbatim, *same `-p` flag*.

`TerminalPanelView.swift:727` and `TBDTerminalView.swift:78` call the daemon-side `-p` the SOLE bracketed-paste wrapping. That is true, but silently contingent on the TUI having requested it. **Not filed as a bug and no `Sources/` change here** — that is slice F's tree and there is no evidence of a live defect, only an unstated precondition. P3 ships as a two-arm probe so the precondition is asserted nightly instead of assumed.

Also settled, narrower than the folklore: pane IDs are **never reused while a server lives** (kill `%1`, next pane is `%3`), but a fresh server on the same socket starts again at `%0` — so a persisted pane ID collides only **across a server restart**. That is the actual mechanism behind #384.

## Deviations, stated so they aren't read as drift

- **The audit runs in its own `ubuntu-latest` job**, not as a fourth step on the macOS job as §9 describes. It needs only `gh` + `jq`; as a step it would be suppressed whenever the macOS half wedges or a runner is unavailable — i.e. it would stop reporting exactly when things are worst. Approved on that reasoning.
- **Cache is restore-only**, so nightly benefits from the PR cache but never churns or evicts it.
- **TTYHOG truncation is deliberately not probed.** It is load-sensitive, so a probe of it would be an instrument that flakes — building a flaky check into the flake-detection system.
- A marked, empty slot is reserved in the macOS job for slice I's fuzz step.

## Recommendation for whoever owns `test.yml` next

**`actionlint` mechanically catches the defect that nearly shipped this feature dead-on-arrival.** Slice E's first commit had a job-level `env: ... ${{ runner.temp }}`, which resolves to the **empty string** without erroring. I fed actionlint that exact shape and it rejects it (`context "runner" is not allowed here`), at both workflow and job level. It is not currently run anywhere. The natural home is the `lint` job in `test.yml`, which is not my file. Note for whoever adds it: `test.yml:72` currently carries one SC2086 (unquoted `$GITHUB_ENV`) so the first run won't be clean — a real, harmless finding, not a reason to skip the tool.

## Test plan

- [x] `actionlint .github/workflows/nightly.yml` — clean. Also **verified it catches** the `runner.temp` trap rather than assuming it does.
- [x] `shellcheck` clean on all five scripts; `python3 -m py_compile` clean on the pty driver.
- [x] **110 assertions across four suites**, all green: audit 56, stress 26, report 15, probes 13.
- [x] **Audit proven against the real artifact** from CI run `30145614672` (slice E's verification) as a true negative, plus known-positives for F1 (closed issue), F2 (passed first-try all week), F3 (leaked gate), F4 (schema drift), F5 (missing ledger) — each **mutation-checked**: break the guard, confirm the input stops reporting.
- [x] **Audit run end-to-end against live GitHub data**: 46 real `main` runs, 16 real ledger artifacts downloaded and aggregated → clean, exit 0.
- [x] **Probes actually run**: 16/16 claims held in ~9s. Harness self-test proves an injected false claim is reported as a failure, and that cleanup leaks no tmux server even when the run is externally `TERM`'d.
- [x] **Stress loop actually run** under 6 induced spinners (load1m reached 24): 4 targets, all clean, **0 spinners needed SIGKILL**, 0 leaked. Failure path exercised separately by forcing a floor violation — report file named by issue, routed to the right issue, comment composed.
- [ ] **Post-merge:** dispatch the workflow for real, verify the run, and post the result. This is a condition, not a caveat — `workflow_dispatch` only becomes available once the workflow is on the default branch, so no CI execution is possible from this PR. Do not read this merging as "it ran in CI".

## Defects found in my own instruments, and fixed

Recorded because each produced a *confident wrong answer* rather than an error:

1. **F5 reported 30 broken ledger uploads on its first live run. All 30 were false.** Three were `cancelled` runs, which never reach the upload step; 27 predated slice E's merge two days ago. Rescoped to `success|failure` runs only, and to missing artifacts *newer than the oldest ledger observed in the window* — a boundary that is observed rather than configured, so nothing needs updating as the window rolls forward. The case that scoping could have swallowed (no ledger anywhere in the window) is kept as its own finding, because an empty ledger reads exactly like a healthy one.
2. **My leak check measured a namespace that wasn't mine.** It counted `tbd-probe-*` tmux sockets and reported 40 leaks — files from July 7 belonging to unrelated tooling, while TBD's own servers are `tbd-<8hex>`. My probes sat *inside* that namespace. Renamed to `tbdnightly-probe-`, and the check now asserts one exact socket via a `PROBE_SOCKET` seam. A cleanup written the same way would have swept 43 sockets belonging to something else.
3. **My kill-survival check could not have failed** — it killed the run and asserted no server remained, but never asserted one was ever up. Now asserts `live` before and `gone` after.
4. **I asserted the fixture comment "must not contain 🌙" while the fixture's own text explains that real reports carry 🌙.** The prohibition contained the thing prohibited. Whitelisted the heading line and added the positive arm.
5. A mutation surprised me: removing the truncated-log guard did **not** let a wedged run pass, because the floor guard catches it next. Rather than flip the expectation to green, both true properties are now asserted — defense in depth, *and* that removing both guards does score a wedge as PASS.

Related: **#520** (the `background-jobs` guardrail's rejection message recommends `trap 'kill 0' EXIT`, the advice `Tests/CLAUDE.md` retracted as hazard #2).

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=02C09118-36BC-4363-875D-ACC7BC8FDD19)