### PR TITLE
fix: enable native mouse reporting in remote attach view so wheel scroll reaches the remote session

### DIFF
--- a/Sources/TBDApp/Remote/RemoteAttachTerminalView.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachTerminalView.swift
@@ -79,13 +79,16 @@ private struct RemoteAttachTerminalRepresentable: NSViewRepresentable {
             font: appearance.font,
             appearance: appearance
         )
-        // Unlike `TerminalPanelView`, this view installs no NSEvent
-        // scroll/click monitors, so SwiftTerm's native mouse reporting is
-        // the ONLY path that can deliver wheel/click events to the remote
-        // app at all. The remote side (tmux `mouse on` + the app's own
-        // mouse-tracking request) decides whether an event actually gets
-        // consumed there; SwiftTerm still falls back to local scrollback
-        // scrolling whenever the remote app hasn't requested mouse mode.
+        // Unlike `TerminalPanelView`, this view installs no scroll monitor of
+        // its own, so SwiftTerm's native mouse reporting is the ONLY path
+        // that can deliver wheel events to the remote app at all. The remote
+        // side (tmux `mouse on` + the app's own mouse-tracking request)
+        // decides whether an event actually gets consumed there; SwiftTerm
+        // still falls back to local scrollback scrolling whenever the remote
+        // app hasn't requested mouse mode. Clicks are handled natively too —
+        // `TBDTerminalView`'s shared click-passthrough monitor stands down
+        // whenever `allowMouseReporting` is true (see
+        // `handleClickPassthrough`), so this doesn't double-forward.
         tv.allowMouseReporting = true
         tv.terminalDelegate = context.coordinator
         context.coordinator.terminalView = tv

--- a/Sources/TBDApp/Remote/RemoteAttachTerminalView.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachTerminalView.swift
@@ -79,7 +79,14 @@ private struct RemoteAttachTerminalRepresentable: NSViewRepresentable {
             font: appearance.font,
             appearance: appearance
         )
-        tv.allowMouseReporting = false
+        // Unlike `TerminalPanelView`, this view installs no NSEvent
+        // scroll/click monitors, so SwiftTerm's native mouse reporting is
+        // the ONLY path that can deliver wheel/click events to the remote
+        // app at all. The remote side (tmux `mouse on` + the app's own
+        // mouse-tracking request) decides whether an event actually gets
+        // consumed there; SwiftTerm still falls back to local scrollback
+        // scrolling whenever the remote app hasn't requested mouse mode.
+        tv.allowMouseReporting = true
         tv.terminalDelegate = context.coordinator
         context.coordinator.terminalView = tv
         context.coordinator.onDetached = onDetached

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -344,15 +344,30 @@ class TBDTerminalView: TerminalView {
             .isDisjoint(with: [.command, .shift, .control, .option])
     }
 
+    /// This monitor is one of two possible forwarders of a click to the pty —
+    /// the other is SwiftTerm's own native mouseDown/mouseUp, gated by
+    /// `allowMouseReporting`. Exactly one must be active at a time, or a
+    /// single left click reaches the remote session twice. Callers with
+    /// `allowMouseReporting == true` (e.g. `RemoteAttachTerminalView`) rely on
+    /// SwiftTerm as the sole forwarder, so this monitor must stand down.
+    nonisolated static func clickPassthroughActive(allowMouseReporting: Bool) -> Bool {
+        !allowMouseReporting
+    }
+
     private func handleClickPassthrough(at point: CGPoint, modifiers: NSEvent.ModifierFlags) {
         guard !Self.clickPassthroughBlocked(by: modifiers) else { return }
+        guard Self.clickPassthroughActive(allowMouseReporting: allowMouseReporting) else { return }
         // If this was a click (not a drag) and tmux has mouse mode enabled,
         // forward the click to tmux so it can handle pane switching.
         //
-        // This won't produce duplicate events: allowMouseReporting is set to
-        // false in TerminalPanelView, so SwiftTerm's mouseDown/mouseUp only
-        // handle local text selection — they never forward to the pty.
-        // We are the sole path that sends mouse events to tmux.
+        // This won't produce duplicate events either way: the guard above
+        // means exactly one of us is live. When `allowMouseReporting` is
+        // false (e.g. `TerminalPanelView`), SwiftTerm's mouseDown/mouseUp
+        // only handle local text selection — they never forward to the pty —
+        // so we are the sole path that sends mouse events to tmux. When
+        // `allowMouseReporting` is true (e.g. `RemoteAttachTerminalView`),
+        // SwiftTerm's native reporting is the sole forwarder and we stand
+        // down via the guard above.
         let term = getTerminal()
         guard !didDrag && term.mouseMode != .off else { return }
 

--- a/Tests/TBDAppTests/ClickPassthroughTests.swift
+++ b/Tests/TBDAppTests/ClickPassthroughTests.swift
@@ -23,4 +23,14 @@ struct ClickPassthroughTests {
     func capsLockAllowed() {
         #expect(TBDTerminalView.clickPassthroughBlocked(by: .capsLock) == false)
     }
+
+    @Test("manual passthrough stands down when native mouse reporting is on")
+    func standsDownWhenNativeReportingOn() {
+        #expect(TBDTerminalView.clickPassthroughActive(allowMouseReporting: true) == false)
+    }
+
+    @Test("manual passthrough stays active when native mouse reporting is off")
+    func activeWhenNativeReportingOff() {
+        #expect(TBDTerminalView.clickPassthroughActive(allowMouseReporting: false) == true)
+    }
 }


### PR DESCRIPTION
Scrolling inside a remote-session attach degraded to arrow keys — Claude Code on the box showed "Scroll wheel is sending arrow keys · use PgUp/PgDn to scroll" — even with the remote tmux in mouse mode and the remote app requesting mouse tracking.

`RemoteAttachTerminalView` copied `allowMouseReporting = false` from `TerminalPanelView`, where it's correct because that view installs its own NSEvent scroll/click monitors that forward mouse events to tmux. The remote attach view deliberately has no such monitors (its doc comment says so), so disabling native reporting left no path at all for wheel events — SwiftTerm fell back to alternate-screen arrow keys.

Fix: enable SwiftTerm's native mouse reporting in this view only. The remote side decides whether events are consumed (tmux `mouse on` + app mouse tracking), and SwiftTerm still falls back to local scrollback scrolling when the app hasn't requested mouse. No change to `TerminalPanelView` or `TBDTerminalView`.

Verified end to end against a live agent-box session: with this build, wheel scroll moves the remote Claude Code transcript (box-side prerequisites shipped separately in longeye-ai/monorepo#17177).