### PR TITLE
DX: Triage the last 50 sleep suppressions -- only 3 should migrate, and 9 defects fell out

### DIFF
--- a/Sources/TBDApp/AppState+Toast.swift
+++ b/Sources/TBDApp/AppState+Toast.swift
@@ -31,7 +31,7 @@ extension AppState {
         let toastID = activeToast?.id
         let delay = toastTickDuration * 4
         toastDismissTask = Task { @MainActor [weak self] in
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+            // swiftlint:disable:next no_raw_task_sleep - already seamed: the duration is `AppState.toastTickDuration` (a settable `Duration` on AppState.swift, doc'd as the injectable clock seam), exercised by Tests/TBDAppTests/DeepLinkToastTests.swift which sets it to .milliseconds(5) and joins via `await toastDismissTask?.value`; see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: delay)
             guard !Task.isCancelled,
                   let self, self.activeToast?.id == toastID else { return }

--- a/Sources/TBDApp/Sidebar/HoverMenuModel.swift
+++ b/Sources/TBDApp/Sidebar/HoverMenuModel.swift
@@ -85,7 +85,7 @@ final class HoverMenuModel: ObservableObject {
             openTaskGeneration += 1
             let generation = openTaskGeneration
             openTask = Task { [weak self] in
-                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+                // swiftlint:disable:next no_raw_task_sleep - already seamed: `openDelay` is an `init(openDelay:closeGrace:)` parameter and `_drainForTesting()` joins the in-flight task, exercised by Tests/TBDAppTests/HoverMenuModelTests.swift at .zero; see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: self?.openDelay ?? .zero)
                 guard let self else { return }
                 if self.openTaskGeneration == generation { self.openTask = nil }
@@ -98,7 +98,7 @@ final class HoverMenuModel: ObservableObject {
             closeTaskGeneration += 1
             let generation = closeTaskGeneration
             closeTask = Task { [weak self] in
-                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+                // swiftlint:disable:next no_raw_task_sleep - already seamed: `closeGrace` is an `init(openDelay:closeGrace:)` parameter and `_drainForTesting()` joins the in-flight task, exercised by Tests/TBDAppTests/HoverMenuModelTests.swift at .zero; see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: self?.closeGrace ?? .zero)
                 guard let self else { return }
                 if self.closeTaskGeneration == generation { self.closeTask = nil }

--- a/Sources/TBDApp/Terminal/FDSidecarClient.swift
+++ b/Sources/TBDApp/Terminal/FDSidecarClient.swift
@@ -285,7 +285,7 @@ final class FDPromise: @unchecked Sendable {
     /// by the receive loop's no-waiter path.
     func value(timeout: Duration) async throws -> Int32 {
         let timeoutTask = Task { [weak self] in
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+            // swiftlint:disable:next no_raw_task_sleep - already seamed: the duration is the caller-supplied `timeout:` parameter of `value(timeout:)`, exercised by Tests/TBDAppTests/FDSidecarClientTests.swift which drives the timeout path at .milliseconds(100); see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: timeout)
             self?.onCancelOrTimeout?()
             self?.settle(fd: nil, error: FDSidecarError.timedOut)

--- a/Sources/TBDApp/Terminal/PasteInterception.swift
+++ b/Sources/TBDApp/Terminal/PasteInterception.swift
@@ -8,6 +8,17 @@ import TBDShared
 /// `load-buffer` + `paste-buffer -d -p`). tmux is the SOLE bracketed-paste
 /// authority.
 ///
+/// That authority is CONTINGENT, and the precondition is worth naming here
+/// because nothing in this file expresses it: `paste-buffer -p` wraps in
+/// ESC[200~/ESC[201~ only *because* the application in the pane has enabled
+/// bracketed-paste mode (DECSET 2004). Against a pane whose app has not, the
+/// same `-p` delivers the bytes verbatim — measured on tmux 3.6a, 22 wrapped
+/// bytes vs 10 bare for the same payload. So if an agent TUI ever stops
+/// setting 2004, nothing on this path wraps and "SOLE authority" becomes
+/// "no authority". Asserted nightly by probe P3 in
+/// `scripts/nightly-tmux-probes.sh` (two arms: 2004 on -> wrapped, off ->
+/// verbatim), so the comment and the check move together.
+///
 /// Why no keystroke-path rider survives: stock tmux (our 3.2 floor) exposes no
 /// bracketed-paste format variable, so §3's attach replay cannot restore
 /// SwiftTerm's DECSET-2004 tracking after a tab-switch re-attach — SwiftTerm's

--- a/Sources/TBDApp/Terminal/TBDTerminalView.swift
+++ b/Sources/TBDApp/Terminal/TBDTerminalView.swift
@@ -78,6 +78,15 @@ class TBDTerminalView: TerminalView {
     /// daemon-side `paste-buffer -p` owns bracketed-paste wrapping) or refused
     /// as oversize. Fall through to SwiftTerm's normal three-call bracketed
     /// paste ONLY when no control-mode attach is live.
+    ///
+    /// That ownership is CONTINGENT, not unconditional: `-p` wraps in
+    /// ESC[200~/ESC[201~ only because the pane's application has enabled
+    /// bracketed-paste mode (DECSET 2004). Against a pane that has NOT, the
+    /// same `-p` delivers the bytes verbatim with no markers — measured on
+    /// tmux 3.6a (22 wrapped bytes vs 10 bare). If an agent TUI ever stops
+    /// setting 2004, handing the paste to the daemon wraps nothing. Asserted
+    /// nightly by probe P3 in `scripts/nightly-tmux-probes.sh` (PR #523), a
+    /// two-arm probe: 2004 on → wrapped, 2004 off → verbatim.
     override func paste(_ sender: Any) {
         if let handler = onControlModePaste,
            let text = NSPasteboard.general.string(forType: .string),

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -727,6 +727,15 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                 // so the daemon-side `paste-buffer -p` is the SOLE wrapping
                 // authority — SwiftTerm's own 2004 tracking can be stale after
                 // a tab-switch re-attach, so no size rides the keystroke path.
+                // That sole-authority claim is CONTINGENT, not unconditional:
+                // `-p` wraps in ESC[200~/ESC[201~ only because the pane's
+                // application has enabled bracketed-paste mode (DECSET 2004).
+                // Against a pane that has NOT, the same `-p` delivers the bytes
+                // verbatim with no markers — measured on tmux 3.6a (22 wrapped
+                // bytes vs 10 bare). If an agent TUI ever stops setting 2004,
+                // nothing here wraps. Asserted nightly by probe P3 in
+                // scripts/nightly-tmux-probes.sh (PR #523), a two-arm probe:
+                // 2004 on → wrapped, 2004 off → verbatim.
                 // Returns true → the paste is consumed here (frame sent, or
                 // oversize refused); false → not attached, SwiftTerm's normal
                 // local paste runs.

--- a/Sources/TBDDaemon/Claude/LoginSessionCoordinator.swift
+++ b/Sources/TBDDaemon/Claude/LoginSessionCoordinator.swift
@@ -144,7 +144,7 @@ public actor LoginSessionCoordinator {
                 activePumps.remove(terminalID)
                 pendingAutoLogin.remove(terminalID)
             }
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+            // swiftlint:disable:next no_raw_task_sleep - already seamed: the duration comes from the injected `Delays` struct, exercised by Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift (`fastDelays()`) and Tests/TBDDaemonTests/ModelProfileSpawnTests.swift; see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: delays.pumpInitialDelay)
             var elapsed: Duration = .zero
             var sends = 0
@@ -158,11 +158,11 @@ public actor LoginSessionCoordinator {
                     sends += 1
                     logger.info("auto-login: typing /login into terminal \(terminalID, privacy: .public) (attempt \(sends, privacy: .public))")
                     await typeLogin()
-                    // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+                    // swiftlint:disable:next no_raw_task_sleep - already seamed: the duration comes from the injected `Delays` struct, exercised by Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift (`fastDelays()`) and Tests/TBDDaemonTests/ModelProfileSpawnTests.swift; see docs/specs/2026-07-24-test-hardening-design.md
                     try? await Task.sleep(for: delays.pumpPostSendDelay)
                     elapsed += delays.pumpPostSendDelay
                 case .promptReady, .notReady:
-                    // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+                    // swiftlint:disable:next no_raw_task_sleep - already seamed: the duration comes from the injected `Delays` struct, exercised by Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift (`fastDelays()`) and Tests/TBDDaemonTests/ModelProfileSpawnTests.swift; see docs/specs/2026-07-24-test-hardening-design.md
                     try? await Task.sleep(for: delays.pumpPollInterval)
                     elapsed += delays.pumpPollInterval
                 }
@@ -196,7 +196,7 @@ public actor LoginSessionCoordinator {
                     onLogin()
                     return
                 }
-                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+                // swiftlint:disable:next no_raw_task_sleep - already seamed: the duration is `watchLoginIdentity`'s own `interval:` parameter (NOT the `Delays` struct — this loop predates it), exercised by Tests/TBDDaemonTests/LoginSessionCoordinatorTests.swift which passes .milliseconds(10); see docs/specs/2026-07-24-test-hardening-design.md
                 try? await Task.sleep(for: interval)
                 elapsed += interval
             }

--- a/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
+++ b/Sources/TBDDaemon/Claude/OAuthProfileUsagePoller.swift
@@ -114,7 +114,7 @@ public actor OAuthProfileUsagePoller {
         self.configDirPath = configDirPath
         self.fetcher = fetcher
         self.broadcast = broadcast
-        // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+        // swiftlint:disable:next no_raw_task_sleep - already seamed: this closure IS the default of the type's own `sleeper:` seam (which sits alongside the `now:` and `jitter:` seams), injected as `sleeper: { _ in }` at 6 sites in Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift — but only the `sweep()` inter-profile stagger below is actually REACHED by those tests: no test calls `start()`, so `runLoop()`'s cadence use of this same closure is unexercised; see docs/specs/2026-07-24-test-hardening-design.md
         self.sleeper = sleeper ?? { try await Task.sleep(for: .seconds($0)) }
         self.now = now ?? { Date() }
         // Default jitter: uniform in [0, span). Injectable for deterministic

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -805,19 +805,36 @@ public final class Daemon: Sendable {
         daemonLogger.info("Started successfully (PID \(ProcessInfo.processInfo.processIdentifier, privacy: .public))")
     }
 
-    /// Sleep in `GitPollCadence.pollTick` ticks until the gated interval has
-    /// elapsed. `interval` is re-evaluated every tick, so a foreground
+    /// Sleep in `tick`-sized steps (default `GitPollCadence.pollTick`) until the
+    /// gated interval has elapsed. `interval` is re-evaluated every tick, so a foreground
     /// transition or app disconnect changes the effective cadence within one
     /// tick instead of one full background interval (e.g. after a daemon
     /// restart under a foregrounded app, the first fetch still lands at ~60s
     /// rather than the 5min sampled before the app reconnected). Returns
     /// promptly on task cancellation.
-    static func sleepThroughGatedInterval(_ interval: @Sendable () async -> Duration) async {
+    ///
+    /// - Parameters:
+    ///   - tick: how long to wait between re-evaluations of `interval`.
+    ///     Injectable so a test can cross a threshold in two or three clock
+    ///     advances instead of a production-sized chain.
+    ///   - clock: delay seam (`Tests/CLAUDE.md`, "Clock and date seams"). This
+    ///     loop is pure `Duration` accumulation, so the existential's inability
+    ///     to express `Instant` math never bites.
+    static func sleepThroughGatedInterval(
+        _ interval: @Sendable () async -> Duration,
+        tick: Duration = GitPollCadence.pollTick,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) async {
         var waited = Duration.zero
         while !Task.isCancelled {
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
-            try? await Task.sleep(for: GitPollCadence.pollTick)
-            waited += GitPollCadence.pollTick
+            // `try?` swallows the cancellation error rather than checking for it;
+            // the loop head is what observes cancellation. A cancelled sleep
+            // therefore costs one extra `interval()` evaluation, which is
+            // side-effect-free today. That stops holding if `interval` ever gains
+            // side effects or if the `while` condition stops re-checking
+            // `Task.isCancelled`.
+            try? await clock.sleep(for: tick)
+            waited += tick
             let due = await interval()
             if waited >= due { return }
         }

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -697,7 +697,7 @@ public final class Daemon: Sendable {
                 tmux: tmux,
                 inspector: ProductionPaneProcessInspector(),
                 readTranscript: { path in FileManager.default.contents(atPath: path) },
-                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+                // swiftlint:disable:next no_raw_task_sleep - already seamed: this closure IS the production value of `LimitResumeActuator`'s non-defaulted `waiter:` parameter (the seam itself), exercised by Tests/TBDDaemonTests/LimitResumeActuatorTests.swift which injects `waiter: { _ in }` at 5 construction sites; see docs/specs/2026-07-24-test-hardening-design.md
                 waiter: { duration in _ = try? await Task.sleep(for: duration) }
             )
             let resumeScheduler = LimitResumeScheduler(

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -126,8 +126,22 @@ public actor HibernationCoordinator {
     /// re-check the pane's current command, and how long we wait between checks.
     /// 15 × 200ms ≈ 3s — ported from the old Suspend feature. If claude is still
     /// the pane's program after the whole window, we fall back to SIGTERM.
-    static let exitPollAttempts = 15
-    static let exitPollInterval: Duration = .milliseconds(200)
+    ///
+    /// Injectable (defaulted init parameters) rather than `static let`, so a
+    /// test can cross the exhaustion threshold in a handful of `TestClock`
+    /// advances instead of paying ~3s of real wall time to prove one branch.
+    /// Deliberately not `private`: the production defaults are pinned by a test.
+    /// `nonisolated` because both are immutable and `Sendable`, so reading them
+    /// needs no actor hop — without it a test's synchronous `#expect` against
+    /// them fails to compile. Safe only while they stay `let`; a `var` here
+    /// would have to drop `nonisolated` and every reader would need `await`.
+    nonisolated let exitPollAttempts: Int
+    nonisolated let exitPollInterval: Duration
+
+    /// Delay seam for the verify-exit poll (`Duration` is behavior). Tests
+    /// inject a `TestClock` so the poll's pacing is virtual and the
+    /// "escalate after exactly N attempts" boundary is exact.
+    private let clock: any Clock<Duration>
 
     private var defaultShell: String {
         ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
@@ -139,7 +153,10 @@ public actor HibernationCoordinator {
         modelProfileResolver: ModelProfileResolver? = nil,
         subscriptions: StateSubscriptionManager? = nil,
         configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager(),
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        exitPollAttempts: Int = 15,
+        exitPollInterval: Duration = .milliseconds(200),
+        clock: any Clock<Duration> = ContinuousClock()
     ) {
         self.db = db
         self.tmux = tmux
@@ -149,6 +166,9 @@ public actor HibernationCoordinator {
         self.configDirManager = configDirManager
         self.inputActivity = InputActivityTracker()
         self.now = now
+        self.exitPollAttempts = exitPollAttempts
+        self.exitPollInterval = exitPollInterval
+        self.clock = clock
     }
 
     /// Projects root for a wake spawn's resolved profile config dir path,
@@ -894,9 +914,16 @@ public actor HibernationCoordinator {
             logger.debug("hibernate: /exit send failed for \(terminalID, privacy: .public): \(error.localizedDescription, privacy: .public)")
             return false
         }
-        for _ in 0..<Self.exitPollAttempts {
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
-            try? await Task.sleep(for: Self.exitPollInterval)
+        // Invariant, preserved verbatim from the pre-clock version: `try?` is
+        // NOT a cancellation check. On a cancelled task every `sleep` throws
+        // immediately, so this loop burns all `exitPollAttempts` iterations at
+        // zero delay, returns false, and the caller escalates straight to
+        // SIGTERM. That is a real defect, filed separately; it is deliberately
+        // NOT fixed here — an untested cancellation guard on a kill path is
+        // exactly the accretion this migration refuses. Anything added to this
+        // loop must keep that behaviour or change it with its own test.
+        for _ in 0..<exitPollAttempts {
+            try? await clock.sleep(for: exitPollInterval)
             if let cmd = try? await tmux.paneCurrentCommand(server: server, paneID: paneID),
                !ClaudeStateDetector.isClaudeProcess(cmd) {
                 return true

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -252,7 +252,7 @@ extension WorktreeLifecycle {
                 }
                 return .paneKilled
             }
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+            // swiftlint:disable:next no_raw_task_sleep - already seamed: `preSessionPollInterval` / `preSessionTimeout` are injected `WorktreeLifecycle.init` parameters, exercised by Tests/TBDDaemonTests/PreSessionHookTests.swift (via PreSessionTestSupport's `makeLifecycle`, which injects 0.05); migrating to `any Clock<Duration>` would also have to restructure the `Date()`-based deadline above, since the existential pins `Duration` but not `Instant`; see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(nanoseconds: pollNanos)
         }
         // Deadline race: the marker may have landed during the final poll

--- a/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
+++ b/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
@@ -64,7 +64,7 @@ public struct ProcessDaywatchExecutor: DaywatchExecuting {
             // Set up a 5-minute deadline. The timeout Task's check-and-set is also protected
             // by the lock, so only one of {termination, timeout} will successfully resume.
             Task {
-                // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+                // swiftlint:disable:next no_raw_task_sleep - see issue #529: not migrated because this deadline Task is armed AFTER `process.run()`, the same ordering `BoundedProcessRunner` documents as a measured flake (a real fork/exec sits in front of a TestClock sleeper's registration, so a fast child can finish before the sleeper is registered), and fixing the ordering needs a kill-on-arrival branch that is untested-by-construction — see issue #529 for the analysis plus two further defects at this site, and docs/specs/2026-07-24-test-hardening-design.md
                 try await Task.sleep(for: .seconds(5 * 60))
                 state.lock.withLock { s in
                     if !s.finished {

--- a/Sources/TBDDaemon/Process/AgentReaper.swift
+++ b/Sources/TBDDaemon/Process/AgentReaper.swift
@@ -75,7 +75,7 @@ public struct AgentReaper: Sendable {
         signaller.terminate(pid)
         for _ in 0..<graceAttempts {
             if !signaller.isAlive(pid) { return }
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+            // swiftlint:disable:next no_raw_task_sleep - already seamed: `graceAttempts` / `pollInterval` are injected `init` parameters (and `WorktreeLifecycle` re-exposes both as `reaperGraceAttempts` / `reaperPollInterval`), exercised by Tests/TBDDaemonTests/Process/AgentReaperTests.swift at .milliseconds(1); see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: pollInterval)
         }
         if signaller.isAlive(pid) {
@@ -90,7 +90,7 @@ public struct AgentReaper: Sendable {
     func escalateAfterHangup(_ pid: Int32) async {
         for _ in 0..<graceAttempts {
             if !signaller.isAlive(pid) { return }
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
+            // swiftlint:disable:next no_raw_task_sleep - already seamed: `graceAttempts` / `pollInterval` are injected `init` parameters (and `WorktreeLifecycle` re-exposes both as `reaperGraceAttempts` / `reaperPollInterval`), exercised by Tests/TBDDaemonTests/Process/AgentReaperTests.swift at .milliseconds(1); see docs/specs/2026-07-24-test-hardening-design.md
             try? await Task.sleep(for: pollInterval)
         }
         guard signaller.isAlive(pid) else { return }

--- a/Sources/TBDDaemon/Server/FDVendingServer.swift
+++ b/Sources/TBDDaemon/Server/FDVendingServer.swift
@@ -73,6 +73,25 @@ actor FDVendingServer {
     private var socketPath: String?
     private var listenerFD: Int32 = -1
 
+    /// How many times `send(fd:header:)` checks for an adopted client before
+    /// giving up, and how long it waits between checks. `retryAttempts` checks
+    /// are separated by `retryAttempts - 1` waits, so the default 10/50 ms pair
+    /// is a 450 ms window — the pre-seam behaviour, unchanged.
+    private let retryAttempts: Int
+    private let retryInterval: Duration
+    /// Delay seam (`docs/specs/2026-07-24-test-hardening-design.md` §5).
+    /// Existential, not generic: this is an `actor` carrying `Sendable`
+    /// conformances, and a generic parameter would infect its type.
+    private let clock: any Clock<Duration>
+
+    init(retryAttempts: Int = 10,
+         retryInterval: Duration = .milliseconds(50),
+         clock: any Clock<Duration> = ContinuousClock()) {
+        self.retryAttempts = retryAttempts
+        self.retryInterval = retryInterval
+        self.clock = clock
+    }
+
     /// Sink for app → daemon input frames. Set once by the daemon wiring BEFORE
     /// `listen`/`adoptConnection` (M2.2 delivers keystrokes here). Captured per
     /// connection at adopt time. When nil, input frames are logged and dropped.
@@ -214,16 +233,31 @@ actor FDVendingServer {
     /// Send `fd` plus `header` to the currently connected app client, wrapped in
     /// a `.fdVend` frame. Retries briefly while no client is adopted — the app
     /// connects eagerly at startup, so this only papers over a connect-vs-accept
-    /// race measured in milliseconds.
+    /// race measured in milliseconds. `retryAttempts` connection checks spaced
+    /// by `retryInterval` (see those properties for the window arithmetic).
+    ///
+    /// `clientFD` is re-read on EVERY iteration, never captured before the
+    /// loop, so a client adopted mid-window is picked up and — just as
+    /// importantly — a connection torn down mid-window is NOT vended into after
+    /// its fd number was closed and possibly recycled. The frame is encoded once
+    /// up front because it depends only on `header`, not on the connection.
     func send(fd: Int32, header: Data) async throws {
         let frame = SidecarFrameCodec.encode(type: .fdVend, payload: header)
-        for attempt in 0..<10 {
+        for attempt in 0..<retryAttempts {
             if clientFD >= 0 {
                 try FDChannel.sendFD(fd, over: clientFD, frame: frame)
                 return
             }
-            // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md
-            if attempt < 9 { try? await Task.sleep(for: .milliseconds(50)) }
+            // No cancellation check, deliberately: `try?` swallows the
+            // `CancellationError`, the remaining attempts then burn instantly
+            // and the loop throws `.notConnected` — the same outcome, which the
+            // sole caller already handles by undoing the attach. That
+            // equivalence holds only because the post-wait step is a pure
+            // re-check that either sends or gives up; it stops being safe if
+            // this loop ever grows a side effect that must not run after
+            // cancellation, at which point it needs a real
+            // `Task.checkCancellation()`.
+            if attempt < retryAttempts - 1 { try? await clock.sleep(for: retryInterval) }
         }
         throw FDVendingServerError.notConnected
     }

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -164,11 +164,42 @@ Four rules. Each traces to a real flake — provenance kept so the rule sticks.
    In `Tests/` it stays a review rule: the lint rule deliberately does not
    cover test code, where tier-2/3 bounded polling is legitimate. See
    "Clock and date seams" below for the seam the rule pushes you toward.
-4. **Timeout errors must report observed state, not just expected.**
-   (`fileBytesMismatch(expected: 6150, actual: 6150)` re-read the file
-   *after* the deadline and therefore lied about what it saw;
+4. **Timeout errors must report observed state, not just expected — and the
+   report has to survive into the CI summary.** Two halves; the second is the
+   one you satisfy accidentally-wrong.
+
+   *Observed, not expected.* `fileBytesMismatch(expected: 6150, actual: 6150)`
+   re-read the file *after* the deadline and therefore lied about what it saw;
    `fileBytesUnmatched(expected:observed:correctPrefix:)` is the corrected
-   shape.)
+   shape.
+
+   *Reaching the summary.* Only `Issue.record(_: some Error)` puts your text on
+   the **primary** failure line. Both `#expect(cond, "message")` and
+   `Issue.record(String)` demote the message to a trailing `↳` line that **CI
+   summaries drop** — measured with a render probe, not assumed. So the
+   thrown-`Error` shape this rule already cites is **load-bearing, not
+   incidental**: the error is what carries the diagnostic to the place you will
+   read it. The failure that established this arrived in CI as bare
+   `condition(value → 0)` and `condition(value → 2)`, distinguishable only by
+   column number, from two `#expect` calls whose message strings were perfect.
+   Verified rendering of the corrected shape:
+
+   ```
+   Caught error: FileWatcher: exactly one FD closed (baseline 0) — observed 1
+   after polling up to 25.0 seconds
+   ```
+
+   Scope: this applies to **timeout and bounded-wait diagnostics**, where the
+   expression (`condition(value → 0)`) is uninformative by construction and the
+   message *is* the whole finding. It is not a ban on `#expect(cond, "…")` for
+   ordinary assertions whose expression already describes itself. There is no
+   lint rule for it, deliberately — nothing can mechanically tell a timeout
+   diagnostic from an ordinary assertion, and a rule that fired on both would
+   be one people disable.
+
+   Consequence for tooling: anything that reads a **CI summary** to extract
+   diagnostics will not find them in the `#expect` form. (Readers of the full
+   tee'd log are unaffected — the `↳` line is present there.)
 
 Full rationale: `docs/specs/2026-07-24-test-hardening-design.md` §6.
 

--- a/Tests/TBDAppTests/TerminalAutoResizeFlagTests.swift
+++ b/Tests/TBDAppTests/TerminalAutoResizeFlagTests.swift
@@ -21,9 +21,17 @@ struct TerminalAutoResizeFlagTests {
     private let key = AppState.terminalAutoResizeKey
 
     /// Build an isolated UserDefaults domain seeded with the flag value,
-    /// hand the body an `AppState` wired to that domain, then tear the
-    /// domain down so nothing persists across tests.
-    private func withFlag(_ enabled: Bool, _ body: (AppState) throws -> Void) rethrows {
+    /// hand the body an `AppState` wired to that domain plus the domain
+    /// itself, then tear the domain down so nothing persists across tests.
+    ///
+    /// The body gets the `UserDefaults` because `AppState.terminalAutoResizeEnabled`
+    /// is a *live* `userDefaults.bool(forKey:)` read, not a cached-at-init
+    /// value — so writing the key mid-test flips the flag for subsequent
+    /// reads. `mainAreaTerminalSizeOn` relies on that; see the comment there.
+    private func withFlag(
+        _ enabled: Bool,
+        _ body: (AppState, UserDefaults) throws -> Void
+    ) rethrows {
         let suiteName = "TBDAppTests.TerminalAutoResize.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer {
@@ -31,14 +39,17 @@ struct TerminalAutoResizeFlagTests {
         }
         defaults.set(enabled, forKey: key)
         let state = AppState(userDefaults: defaults)
-        try body(state)
+        try body(state, defaults)
     }
 
     @Test("returns (nil, nil) when flag is off so daemon falls back to its 220×50 default")
     func mainAreaTerminalSizeOff() {
-        withFlag(false) { state in
+        withFlag(false) { state, _ in
             // The defaults seed mainAreaSize at 1120x776, which would
             // otherwise produce a real cell count — verify the flag wins.
+            // Safe to assign with the flag off: the `didSet` reaches
+            // `scheduleMainAreaSizeBroadcast()`, which returns at its own
+            // `guard terminalAutoResizeEnabled` before arming anything.
             state.mainAreaSize = CGSize(width: 1200, height: 800)
             let size = state.mainAreaTerminalSize()
             // nil (not 0) is required so callers' Int? params trigger the
@@ -51,8 +62,31 @@ struct TerminalAutoResizeFlagTests {
 
     @Test("returns real cell counts when flag is on")
     func mainAreaTerminalSizeOn() throws {
-        try withFlag(true) { state in
+        try withFlag(true) { state, defaults in
+            // Seed the viewport with the flag OFF, then flip it back on.
+            //
+            // Assigning `mainAreaSize` while the flag is on runs its `didSet`
+            // → `scheduleMainAreaSizeBroadcast()`, which arms a 300ms debounce
+            // in a stored Task. That task outlives this test and then fires a
+            // REAL `setMainAreaSize` RPC at `~/tbd/sock` — the developer's
+            // running daemon — violating the repo's "tests must not touch
+            // ~/tbd" rule, and reporting any failure from a Task with no
+            // enclosing test scope. `AppState.daemonClient` is a
+            // non-injectable `let` with no protocol, so nothing can intercept
+            // that RPC; the seam is filed as issue #532. Until it lands, the
+            // flag guard is the only interception point we have — and
+            // cancelling the debounce isn't an option either, because
+            // `mainAreaSizeBroadcastTask` is `private` (not `@testable`-reachable).
+            //
+            // This costs no coverage: the subject here is
+            // `mainAreaTerminalSize()` with the flag ON, which is exercised
+            // exactly as before. The debounce was only ever an unasserted
+            // side effect of the setup. `terminalAutoResizeEnabled` reads
+            // UserDefaults on every access, so the flip below is immediate.
+            defaults.set(false, forKey: key)
             state.mainAreaSize = CGSize(width: 1200, height: 800)
+            defaults.set(true, forKey: key)
+
             let size = state.mainAreaTerminalSize()
             // Exact cell metrics depend on the platform monospaced font, so
             // we just assert plausible bounds — the floor is 80x24 and a

--- a/Tests/TBDDaemonTests/FDVendingServerTests.swift
+++ b/Tests/TBDDaemonTests/FDVendingServerTests.swift
@@ -1,3 +1,4 @@
+import Clocks
 import Darwin
 import Foundation
 import TestSupport
@@ -5,8 +6,20 @@ import Testing
 @testable import TBDDaemonLib
 import TBDShared
 
-@Suite("FDVendingServer")
+/// `.clockDriven` bounds the classic virtual-time hang (a `TestClock` sleep
+/// nobody advances); `.serialized` keeps the four retry-window tests from
+/// starving each other on the arming handshake, which is the house pattern for
+/// clock-driven suites here. The remaining tests are bounded-wait, so
+/// serializing costs the suite almost nothing.
+@Suite("FDVendingServer", .clockDriven, .serialized)
 struct FDVendingServerTests {
+
+    /// The retry pacing these tests inject. Deliberately the same *shape* as
+    /// production (a fixed interval between connection checks) with a smaller
+    /// attempt budget, so advance chains stay in the single digits per
+    /// `Tests/CLAUDE.md` — "exhaustion" below means exhausting the injected
+    /// budget, and each test's name says what it actually crosses.
+    private static let interval: Duration = .milliseconds(50)
 
     private func makeSocketPair() throws -> (Int32, Int32) {
         var pair: [Int32] = [-1, -1]
@@ -56,12 +69,109 @@ struct FDVendingServerTests {
         #expect(Int(n) == msg.count)
     }
 
-    @Test("send without an adopted connection throws")
+    @Test("send without an adopted connection throws once its retry window is exhausted")
     func sendBeforeAdoptFails() async {
-        let server = FDVendingServer()
-        await #expect(throws: FDVendingServerError.notConnected) {
+        // Tier 1: virtual time. 3 attempts → 2 waits; crossing both exhausts
+        // the window, which is the same claim the 10/50 ms production pair
+        // makes over 450 ms of real time.
+        let clock = TestClock()
+        let server = FDVendingServer(retryAttempts: 3, retryInterval: Self.interval, clock: clock)
+
+        let send = Task { try await server.send(fd: 0, header: Data()) }
+        await clock.advanceWhenSuspended(by: Self.interval)
+        await clock.advanceWhenSuspended(by: Self.interval)
+
+        await #expect(throws: FDVendingServerError.notConnected) { try await send.value }
+    }
+
+    @Test("the retry loop vends to a client that only connects mid-window")
+    func sendSucceedsWhenClientAdoptsMidWindow() async throws {
+        // The behaviour the docstring claims — papering over a connect-vs-accept
+        // race — and the half nothing asserted before this test: that the retry
+        // can SUCCEED, not merely that it eventually gives up.
+        let (serverSideFD, clientSideFD) = try makeSocketPair()
+        defer { Darwin.close(clientSideFD) }
+
+        let clock = TestClock()
+        let server = FDVendingServer(retryAttempts: 5, retryInterval: Self.interval, clock: clock)
+
+        let (readFD, writeFD) = try makePipe()
+        defer { Darwin.close(writeFD) }
+        let header = try JSONEncoder().encode(
+            FDVendHeader(worktreeID: UUID(), paneID: "%late", attachID: UUID()))
+
+        let send = Task { try await server.send(fd: readFD, header: header) }
+
+        // Two intervals with nobody connected: still retrying, not yet failed.
+        await clock.advanceWhenSuspended(by: Self.interval)
+        await clock.advanceWhenSuspended(by: Self.interval)
+
+        // The app finally connects, mid-window. `send` is parked inside the
+        // actor's sleep, so this adoption is free to run and the next
+        // iteration re-reads `clientFD`.
+        await server.adoptConnection(fd: serverSideFD)
+        await clock.advanceWhenSuspended(by: Self.interval)
+
+        try await send.value   // must NOT throw
+        Darwin.close(readFD)
+
+        let (rxFD, rxHeader) = try SidecarTestSupport.receiveVend(from: clientSideFD)
+        defer { Darwin.close(rxFD) }
+        #expect(rxHeader.paneID == "%late", "the late-adopted client must receive the vend")
+
+        await server.disconnect()
+    }
+
+    @Test("send gives up on its last retry interval, not before")
+    func sendGivesUpOnlyOnItsLastInterval() async {
+        // Pins the attempt count itself: with N attempts there are N-1 waits,
+        // so at N-2 crossings it must still be retrying and the N-1st crossing
+        // is what makes it throw. Nothing pinned this boundary before.
+        let clock = TestClock()
+        let attempts = 4
+        let server = FDVendingServer(retryAttempts: attempts, retryInterval: Self.interval, clock: clock)
+
+        let finished = SidecarInputCollector()   // reused as a thread-safe flag holder
+        let send = Task {
+            defer { finished.record(SidecarInputHeader(worktreeID: UUID(), paneID: ""), Data()) }
             try await server.send(fd: 0, header: Data())
         }
+
+        await clock.advanceWhenSuspended(by: Self.interval)
+        await clock.advanceWhenSuspended(by: Self.interval)
+
+        // Re-armed for wait 3 of 3: it is parked, so it demonstrably has not
+        // run its `defer` yet. `waitForSuspension` is the happens-before that
+        // makes the count check below non-vacuous.
+        await clock.waitForSuspension()
+        #expect(finished.count == 0,
+                "must still be retrying after \(attempts - 2) of its \(attempts - 1) waits")
+
+        await clock.advance(by: Self.interval)
+        await #expect(throws: FDVendingServerError.notConnected) { try await send.value }
+    }
+
+    @Test("the default retry interval is 50 ms")
+    func defaultRetryIntervalIsFiftyMilliseconds() async {
+        // The injected-pacing tests above deliberately say nothing about the
+        // production numbers. This one pins the default interval exactly, in
+        // two advances: 2 attempts → exactly 1 wait, so 49 ms must not fire it
+        // and the 50th millisecond must.
+        let clock = TestClock()
+        let server = FDVendingServer(retryAttempts: 2, clock: clock)   // default interval
+
+        let finished = SidecarInputCollector()
+        let send = Task {
+            defer { finished.record(SidecarInputHeader(worktreeID: UUID(), paneID: ""), Data()) }
+            try await server.send(fd: 0, header: Data())
+        }
+
+        await clock.advanceWhenSuspended(by: .milliseconds(49))
+        await clock.waitForSuspension()   // still parked → the wait is > 49 ms
+        #expect(finished.count == 0, "a 50 ms interval must not elapse at 49 ms")
+
+        await clock.advance(by: .milliseconds(1))
+        await #expect(throws: FDVendingServerError.notConnected) { try await send.value }
     }
 
     @Test("bytes written to the daemon-side pipe reach the client-side reader")
@@ -246,7 +356,8 @@ struct FDVendingServerTests {
         // Deterministic teardown: the exit hook now fires AFTER the actor clears
         // clientFD, so once it fires the stale fd is already gone.
         let exited = SidecarInputCollector()
-        let server = FDVendingServer()
+        let clock = TestClock()
+        let server = FDVendingServer(retryAttempts: 3, retryInterval: Self.interval, clock: clock)
         await server.setOnReceiveLoopExit {
             exited.record(SidecarInputHeader(worktreeID: UUID(), paneID: ""), Data())
         }
@@ -257,13 +368,16 @@ struct FDVendingServerTests {
 
         // A real payload fd to vend. The point: send() must REFUSE because the
         // stale clientFD was cleared — NOT sendmsg() a vend frame into a closed
-        // or recycled fd number.
+        // or recycled fd number. The retry window is virtual here (3 attempts →
+        // 2 waits), so exhausting it costs no wall time, but the assertion is
+        // unchanged: it must still throw rather than write.
         let (readFD, writeFD) = try makePipe()
         defer { Darwin.close(readFD); Darwin.close(writeFD) }
         let header = try JSONEncoder().encode(FDVendHeader(worktreeID: UUID(), paneID: "%stale", attachID: UUID()))
-        await #expect(throws: FDVendingServerError.notConnected) {
-            try await server.send(fd: readFD, header: header)
-        }
+        let send = Task { try await server.send(fd: readFD, header: header) }
+        await clock.advanceWhenSuspended(by: Self.interval)
+        await clock.advanceWhenSuspended(by: Self.interval)
+        await #expect(throws: FDVendingServerError.notConnected) { try await send.value }
 
         await server.stop()
     }

--- a/Tests/TBDDaemonTests/GatedIntervalSleepTests.swift
+++ b/Tests/TBDDaemonTests/GatedIntervalSleepTests.swift
@@ -1,0 +1,181 @@
+import Clocks
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+
+// Tier 1 (docs/specs/2026-07-24-test-hardening-design.md §3): in-process,
+// deterministic, driven entirely by virtual time. The only real sleeping is the
+// scheduling handshake inside `advanceWhenSuspended`/`waitForSuspension`, which
+// `Tests/CLAUDE.md` ("Clock and date seams") explicitly rules not a tier
+// violation.
+//
+// DEFECT UNDER TEST: the gated interval stops being re-evaluated, so a
+// foreground/background transition no longer shortens an in-flight wait.
+// `Daemon.sleepThroughGatedInterval`'s doc comment — and `AppForegroundState`'s,
+// which cites it — claim that per-tick re-evaluation is what *replaces*
+// sleep-cancellation plumbing. Before this suite, nothing proved it: an
+// implementation that sampled `interval()` once and slept it out whole would
+// have passed the entire test suite while silently pinning the daemon to the
+// 5-minute background cadence for five minutes after the app came forward.
+//
+// Two failure shapes are covered, because they are distinguishable:
+//   - the closure stops being *called* → the call-count assertions catch it;
+//   - the closure is called but its new value ignored (a cached `due`) → the
+//     "no sleeper remains on the clock" assertions catch it.
+
+/// Records how many times the gated-interval closure was evaluated, and lets a
+/// test change the value it returns mid-wait. An actor because the closure is
+/// `@Sendable` and `async`; no lock ceremony needed.
+private actor GatedIntervalProbe {
+    private(set) var callCount = 0
+    private(set) var didReturn = false
+    private var interval: Duration
+
+    init(interval: Duration) {
+        self.interval = interval
+    }
+
+    /// The gated-interval closure body.
+    func next() -> Duration {
+        callCount += 1
+        return interval
+    }
+
+    func set(interval: Duration) {
+        self.interval = interval
+    }
+
+    func markReturned() {
+        didReturn = true
+    }
+}
+
+@Suite(.clockDriven)
+struct GatedIntervalSleepTests {
+    /// Injected pacing, not production values: `Tests/CLAUDE.md` requires
+    /// advance chains to stay in single digits, so the thresholds below are
+    /// crossed in two or three advances instead of thirty.
+    private static let tick: Duration = .seconds(10)
+
+    @Test("returns after exactly the number of polls the interval implies")
+    func returnsAfterExpectedPollCount() async {
+        let clock = TestClock<Duration>()
+        let probe = GatedIntervalProbe(interval: .seconds(30))  // 3 ticks
+
+        let waiter = Task {
+            await Daemon.sleepThroughGatedInterval(
+                { await probe.next() }, tick: Self.tick, clock: clock)
+            await probe.markReturned()
+        }
+
+        // Tick 1 and 2 re-evaluate and keep waiting; each advance sits next to
+        // the re-park it produces rather than being batched at the top.
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.waitForSuspension()
+        #expect(await probe.callCount == 1)
+
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.waitForSuspension()
+        #expect(await probe.callCount == 2)
+
+        // Tick 3 crosses the threshold.
+        await clock.advanceWhenSuspended(by: Self.tick)
+
+        // `checkSuspension()` throws while a sleeper IS registered, so "no
+        // error" is the assertion that the wait ended rather than re-parking.
+        // Its opening `megaYield()` is what gives the resumed task its turn.
+        await #expect(throws: Never.self) { try await clock.checkSuspension() }
+
+        // Deterministic join. `cancel()` is a no-op on a task that already
+        // returned; on a defective loop still parked on the clock it resumes
+        // the sleeper so the loop head exits, which keeps this suite reporting
+        // the assertions above instead of wedging on `await waiter.value`.
+        waiter.cancel()
+        await waiter.value
+        let observedCalls = await probe.callCount
+        #expect(observedCalls == 3, "expected 3 interval evaluations, observed \(observedCalls)")
+        #expect(await probe.didReturn)
+    }
+
+    @Test("one tick short of the threshold has not returned; the next tick returns")
+    func boundaryIsExact() async {
+        let clock = TestClock<Duration>()
+        let probe = GatedIntervalProbe(interval: .seconds(30))  // 3 ticks
+
+        let waiter = Task {
+            await Daemon.sleepThroughGatedInterval(
+                { await probe.next() }, tick: Self.tick, clock: clock)
+            await probe.markReturned()
+        }
+
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.advanceWhenSuspended(by: Self.tick)
+
+        // 20s waited against a 30s gate. The re-park is the happens-before for
+        // the flag read: reaching a suspension means the loop chose to keep
+        // waiting rather than return.
+        await clock.waitForSuspension()
+        let returnedEarly = await probe.didReturn
+        let callsAtBoundary = await probe.callCount
+        #expect(
+            !returnedEarly,
+            """
+            returned after \(callsAtBoundary) tick(s) — 20s waited against a 30s \
+            gate should still be waiting
+            """
+        )
+
+        // The final tick, and only it, ends the wait.
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await #expect(throws: Never.self) { try await clock.checkSuspension() }
+
+        waiter.cancel()
+        await waiter.value
+        #expect(await probe.didReturn)
+        let observedCalls = await probe.callCount
+        #expect(observedCalls == 3, "expected 3 interval evaluations, observed \(observedCalls)")
+    }
+
+    @Test("an interval shortened mid-wait shortens the wait")
+    func shortenedIntervalShortensInFlightWait() async {
+        let clock = TestClock<Duration>()
+        // Background cadence, in miniature: 30 ticks away.
+        let probe = GatedIntervalProbe(interval: .seconds(300))
+
+        let waiter = Task {
+            await Daemon.sleepThroughGatedInterval(
+                { await probe.next() }, tick: Self.tick, clock: clock)
+            await probe.markReturned()
+        }
+
+        await clock.advanceWhenSuspended(by: Self.tick)
+        await clock.waitForSuspension()
+        let callsBeforeFlip = await probe.callCount
+        #expect(callsBeforeFlip == 1, "expected 1 interval evaluation, observed \(callsBeforeFlip)")
+        #expect(await probe.didReturn == false)
+
+        // The app comes to the foreground mid-wait: the gate drops to 20s,
+        // which the 20s already waited after the next tick satisfies.
+        await probe.set(interval: .seconds(20))
+        await clock.advanceWhenSuspended(by: Self.tick)
+
+        // THE HEADLINE ASSERTION. A loop that sampled the interval once — or
+        // cached the first `due` — is still parked here, waiting out the
+        // original 300s, and `checkSuspension()` throws because its sleeper is
+        // registered.
+        await #expect(throws: Never.self) { try await clock.checkSuspension() }
+
+        waiter.cancel()
+        await waiter.value
+        #expect(await probe.didReturn)
+        let observedCalls = await probe.callCount
+        #expect(
+            observedCalls == 2,
+            """
+            expected the shortened gate to end the wait after 2 evaluations, \
+            observed \(observedCalls)
+            """
+        )
+    }
+}

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1,5 +1,7 @@
+import Clocks
 import Testing
 import Foundation
+import TestSupport
 @testable import TBDDaemonLib
 @testable import TBDShared
 
@@ -17,7 +19,15 @@ private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
     )
 }
 
-@Suite("HibernationCoordinator")
+/// `.clockDriven` is applied at SUITE level even though only the three
+/// park-poll tests below drive a `TestClock`. The trait is a one-minute time
+/// limit — a hang-catcher, not a perf budget — so it costs the other tests
+/// nothing and it catches the one failure mode virtual time introduces here (a
+/// `TestClock` sleep nobody advances hangs forever instead of going red).
+/// `.serialized` is deliberately NOT applied: three clock-driven tests out of
+/// ~35 don't justify serializing the whole suite, and it stays available as
+/// the documented escape hatch if the arming handshake ever flakes under load.
+@Suite("HibernationCoordinator", .clockDriven)
 struct HibernationCoordinatorTests {
 
     /// In-memory DB + repo + worktree + an idle Claude terminal.
@@ -113,23 +123,44 @@ struct HibernationCoordinatorTests {
 
     // MARK: - Park path: polite /exit success vs SIGTERM fallback
     //
-    // The unified park sequence tries an in-band `/exit` first and polls up to
-    // ~3s for the claude process to leave; only if it's STILL claude after the
-    // poll does it escalate to the graceful-interrupt SIGTERM fallback. These
-    // two branches are tested SEPARATELY.
+    // The unified park sequence tries an in-band `/exit` first and polls
+    // `exitPollAttempts` × `exitPollInterval` (production: 15 × 200ms ≈ 3s) for
+    // the claude process to leave; only if it's STILL claude after the whole
+    // window does it escalate to the graceful-interrupt SIGTERM fallback.
+    //
+    // DEFECT these three tests exist to catch: *the poll gives up too early or
+    // never escalates* — so a hung claude is SIGTERMed while it is still
+    // exiting, or a wedged one is never escalated at all.
+    //
+    // The poll's pacing is injected (`exitPollAttempts` / `exitPollInterval`)
+    // and its delay runs on an injected `clock`, so the exhaustion branch is
+    // crossed in virtual time. Before that seam existed, the fallback test paid
+    // ~3s of REAL wall time on every run to prove one branch, and nothing
+    // pinned the attempt count at all.
 
     /// `/exit` succeeds: the pane's current command reads as a non-claude shell
     /// during the poll, so the polite exit is observed and NO SIGTERM-fallback
     /// interrupt (Escape / C-c) is sent. The row is still marked hibernated.
+    ///
+    /// Runs the PRODUCTION pacing (15 × 200ms) deliberately: exactly ONE
+    /// interval is ever advanced, so the test also pins "the poll returns on
+    /// the first successful observation". A poll that kept checking would park
+    /// on an un-advanced sleep and be surfaced by `.clockDriven`.
     @Test func parkViaExitSucceedsWithoutSigtermFallback() async throws {
         let (db, _, terminalID) = try await setup(activityState: .idle)
         let recorded = RecordedTmuxCommands()
         // dryRun default paneCurrentCommand is "zsh" (not claude) → poll sees the
         // process leave immediately after `/exit`.
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let clock = TestClock<Duration>()
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), clock: clock)
 
-        let result = await coord.manualHibernate(terminalID: terminalID)
+        let park = Task { await coord.manualHibernate(terminalID: terminalID) }
+        // Unblocks the single verify-exit poll attempt.
+        await clock.advanceWhenSuspended(by: coord.exitPollInterval)
+        let result = await park.value
+
         #expect(result == .ok)
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt != nil)
 
@@ -143,9 +174,17 @@ struct HibernationCoordinatorTests {
     }
 
     /// `/exit` does NOT terminate claude within the poll window: the pane keeps
-    /// reporting a claude process, so the park escalates to the graceful
-    /// interrupt (Escape → C-c C-c → SIGTERM). The row is still marked
-    /// hibernated afterward (respawn-window -k guarantees termination).
+    /// reporting a claude process for EVERY attempt, so the park exhausts the
+    /// whole window and escalates to the graceful interrupt (Escape → C-c C-c →
+    /// SIGTERM). The row is still marked hibernated afterward (respawn-window
+    /// -k guarantees termination).
+    ///
+    /// The window is 3 attempts here rather than the production 15 — pacing is
+    /// injected precisely so the exhaustion threshold is still fully crossed
+    /// (every attempt is advanced, and the escalation happens only after the
+    /// last one) inside a 3-advance budget instead of 15 real 200ms sleeps.
+    /// `defaultPollPacingIsFifteenTimesTwoHundredMillis` keeps the production
+    /// ~3s window itself pinned.
     @Test func parkFallsBackToSigtermWhenExitDoesNotKill() async throws {
         let (db, _, terminalID) = try await setup(activityState: .idle)
         let recorded = RecordedTmuxCommands()
@@ -155,9 +194,19 @@ struct HibernationCoordinatorTests {
             dryRunRecorder: { recorded.append($0) },
             dryRunPaneCurrentCommand: { _, _ in "1.2.3" }  // claude reports its version as pane_current_command
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let clock = TestClock<Duration>()
+        let pollInterval: Duration = .milliseconds(200)
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            exitPollAttempts: 3, exitPollInterval: pollInterval, clock: clock)
 
-        let result = await coord.manualHibernate(terminalID: terminalID)
+        let park = Task { await coord.manualHibernate(terminalID: terminalID) }
+        // Exhaust the whole poll window: one advance per attempt.
+        for _ in 0..<3 {
+            await clock.advanceWhenSuspended(by: pollInterval)
+        }
+        let result = await park.value
+
         #expect(result == .ok)
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt != nil)
 
@@ -168,6 +217,67 @@ struct HibernationCoordinatorTests {
         // Then the SIGTERM-fallback graceful interrupt (C-c) must have fired.
         #expect(joined.contains { $0.contains("send-keys") && $0.contains("C-c") },
                 "expected a C-c interrupt in the SIGTERM-fallback branch; got: \(joined)")
+    }
+
+    /// The escalation BOUNDARY: with `exitPollAttempts == 3` the park must
+    /// still be polling after 2 attempts (no interrupt sent yet) and must
+    /// escalate on the 3rd. Both halves matter and neither was pinned before
+    /// the pacing seam existed — the defect has two directions, giving up early
+    /// (SIGTERM while claude is still exiting) and never escalating (a wedged
+    /// claude polled forever).
+    ///
+    /// The "hasn't escalated yet" half is proved by `waitForSuspension()`: the
+    /// coordinator is parked on attempt 3's sleep, which means it completed
+    /// attempts 1–2, observed claude both times, and did NOT leave the loop.
+    @Test func escalatesOnlyAfterExactlyTheConfiguredAttemptCount() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorded.append($0) },
+            dryRunPaneCurrentCommand: { _, _ in "1.2.3" }  // still claude, every attempt
+        )
+        let clock = TestClock<Duration>()
+        let pollInterval: Duration = .milliseconds(200)
+        let attempts = 3
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            exitPollAttempts: attempts, exitPollInterval: pollInterval, clock: clock)
+        func interruptSent() -> Bool {
+            recorded.snapshot()
+                .map { $0.joined(separator: " ") }
+                .contains { $0.contains("send-keys") && $0.contains("C-c") }
+        }
+
+        let park = Task { await coord.manualHibernate(terminalID: terminalID) }
+
+        // N-1 attempts: still inside the poll window.
+        for _ in 0..<(attempts - 1) {
+            await clock.advanceWhenSuspended(by: pollInterval)
+        }
+        await clock.waitForSuspension()  // armed for attempt N ⇒ N-1 are done
+        #expect(!interruptSent(),
+                "must not escalate before the poll window is exhausted; got: \(recorded.snapshot())")
+
+        // The Nth (final) attempt: the window is exhausted, so escalate.
+        await clock.advanceWhenSuspended(by: pollInterval)
+        let result = await park.value
+        #expect(result == .ok)
+        #expect(interruptSent(),
+                "must escalate once all \(attempts) attempts observed claude; got: \(recorded.snapshot())")
+    }
+
+    /// Pins the SHIPPED poll window, which the two injected-pacing tests above
+    /// deliberately no longer run: 15 × 200ms ≈ 3s. Making the pacing
+    /// injectable must not quietly change what production waits before it
+    /// SIGTERMs a claude that is still shutting down.
+    @Test func defaultPollPacingIsFifteenTimesTwoHundredMillis() async throws {
+        let (db, _, _) = try await setup()
+        let coord = coordinator(db)
+        #expect(coord.exitPollAttempts == 15)
+        #expect(coord.exitPollInterval == .milliseconds(200))
+        #expect(coord.exitPollInterval * coord.exitPollAttempts == .seconds(3),
+                "the shipped verify-exit window must stay ~3s")
     }
 
     /// The ANSI pane snapshot captured before the kill is persisted into

--- a/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
+++ b/Tests/TBDDaemonTests/OAuthProfileUsagePollerTests.swift
@@ -491,9 +491,25 @@ private final class MutableClock: @unchecked Sendable {
 
 @Suite struct OAuthProfileUsagePollerBackoffTests {
 
-    /// Build a poller whose scheduled loop runs exactly one sweep (the cadence
-    /// sleeper throws to stop the loop), with a deterministic clock and zero
-    /// jitter.
+    /// Build a poller for testing the *backoff arithmetic* of sweeps that the
+    /// test drives by hand — `sweepNow()` (the picker-open refresh) and
+    /// `sweepForTest()` (which stands in for the scheduled sweep `runLoop()`
+    /// would issue). The injected `now` makes every backoff window a pure
+    /// function of `clock.advance(_:)`, and zero jitter makes the exponential
+    /// windows exact rather than ranged.
+    ///
+    /// Nothing here starts or stops a loop. An earlier version of this comment
+    /// claimed the cadence sleeper "throws to stop the loop"; that mechanism
+    /// does not exist. The sleeper below is non-throwing, `runLoop()` swallows
+    /// its sleeper's errors with `try?` and would keep looping anyway, and —
+    /// decisively — no test in this file calls `poller.start()`, so `runLoop()`
+    /// is never entered. The sleeper is consulted only by `sweep()`'s
+    /// inter-profile stagger, which is why a no-op makes sweeps instant.
+    ///
+    /// Coverage gap this leaves, stated so the next reader need not re-derive
+    /// it: because nothing calls `start()`, `runLoop()`'s cadence pacing and
+    /// its startup `skipFresherThan: cadence` handoff (set once, then cleared
+    /// to nil for every subsequent tick) are untested.
     private func scheduledPoller(
         profile: ModelProfile,
         fetcher: ScriptedProfileUsageFetcher,


### PR DESCRIPTION
## Summary

- Triaged **all 50** remaining `no_raw_task_sleep` suppressions in `Sources/`. **3 migrate to a clock seam, 47 stay suppressed with a stated reason, 0 delete.** The 47 are the headline.
- The three that moved were each untestable or wall-clock-bound: one documented contract with **zero tests**, and two whose pacing cost **~4.2 s of real sleep** in the fast parallel pass. All mutation-verified 15/15 KILLED.
- The triage turned up **9 defects** (filed #525–#532), one of them a HIGH-severity production bug where daemon shutdown can SIGKILL a healthy agent mid transcript-flush. Two test-side ones are fixed here, including a test that fired a live RPC at the developer's running daemon.

**Slice F** of the test-hardening program (design: `docs/specs/2026-07-24-test-hardening-design.md`, slicing: `-slicing.md`). Wave 3, alongside slice G (#523, merged).

## The framing was wrong, and correcting it is the first deliverable

The slicing plan calls F a *"mechanical burn-down"* of the remaining `no_raw_task_sleep` suppressions. It isn't one.

Wave 2 established that **a seam with no test behind it is speculative** — C1 declined to seam `AppState.init` on those grounds, a grant to C4 was withdrawn citing them, and C2's `:67` was ruled to F the same way. Threading `clock:` through 50 sites would have been 50 speculative seams: exactly the accretion this program spent a night refusing.

So the work was a three-way triage per site — **migrate with a test / leave suppressed with justification / delete** — with the criteria written down before they were applied.

## Result: 3 migrate, 47 stay, 0 delete

| Outcome | Count |
|---|---|
| **MIGRATE** (seam + test + a named defect) | **3** |
| LEAVE — already a working, test-injected seam | 13 |
| LEAVE — unobservable (view-private `@State`, a log level, or a keystroke gap nothing can observe) | 14 |
| LEAVE — observable in principle, **not constructible** | 19 |
| LEAVE — `:67`, see below | 1 |
| **DELETE** | **0** |

**47 of 50 stay suppressed. That is the headline, not the 3.** Suppression count 51 → 48; the one `- sanctioned:` site (`PollerClock`) is untouched.

Two structural walls produce nearly all of the "not constructible" bucket, and both are facts rather than judgments:

- **`AppState.daemonClient` is `let daemonClient = DaemonClient()`** — no protocol, no injection point. Every app debounce whose trailing edge is an RPC dies there. Filed as **#532**, with the count attached: it is why 19 sites are observable-but-untestable.
- **`Daemon.start()`** needs `~/tbd`, a migrated DB, a socket, an HTTP server and tmux, and is called by **zero** tests. Four sweep loops live in inline `Task {}` closures inside it.

Also worth stating: **zero of the 13 enclosing SwiftUI view types is constructed or driven by any test in `Tests/`.** Every apparent hit was a comment mention or a test of a collaborator.

## The three migrations

Each meets all four criteria (observable, constructible, a **named defect written before choosing the mutation**, and a pure *swap* rather than an added path).

1. **`Daemon.sleepThroughGatedInterval`** — a documented behavioural contract with **zero tests**. Already a standalone static func with an injected `interval` closure; the raw sleep was the only thing between it and a test. *This is the only one of the three that adds coverage.*
2. **`HibernationCoordinator.politeExitThenPoll`** — pacing was `static let`, so no test could change it and proving the escalation branch cost **~3 seconds of real wall time** in the fast parallel pass. The only site in the 50 whose pacing was neither a literal nor already injectable.
3. **`FDVendingServer.send`** — two tests paid 450 ms each. The file already carried `onReceiveLoopExit`, documented as a test seam so tests "can await deterministic post-cleanup state **instead of sleeping**"; the retry loop was the one place that wasn't done.

**What I am not claiming.** M2 and M3 add **no coverage** — both branches were already asserted. Their payoff is determinism plus ~4.2 s of real sleep removed from the fast pass. A speed win is not a flake kill, and I'm not dressing it as one.

## Zero deletes, and I went looking

The one real candidate — `NotepadPopoverView`'s 200 ms focus settle, which duplicates a declarative `.defaultFocus` one line above — is a **live-UI** question that reading cannot close, and this repo's record is that SwiftUI focus bugs pass green headless while being broken live. Deleting a focus mechanism on a reasoned guess wasn't available. Filed, not deleted.

## `:67` — decision upheld, and one of its stated grounds was false

The earlier ruling rested partly on *"an executor whose own doc comment marks it interim pending the Phase A rewrite."* **That is not what the doc says.** `ProcessDaywatchExecutor`'s type doc reads, in full: `/// Real executor: runs tick.py and judge.py via Process.` The interim language is on a different method, about judge *spawning*.

Reported in good faith by C2, ruled on, inherited by me — and none of the three of us re-read the line. That ground is **withdrawn**. The decision stands on the two that hold, and reading made one *stronger*: the deadline `Task` is armed **after** `process.run()`, the exact ordering `BoundedProcessRunner` documents as a measured flake (1 failure in 10 runs at loadavg ~150).

## Verification

- `swift build --build-tests` **rc=0**, and **each of the 7 commits compiles alone** (6 detached builds plus the tip, all rc=0).
- `swiftlint --strict` **0 violations / 603 files**, run by hand — there are no git hooks on this box.
- Fast pass **4316 tests / 474 suites passed**; quiet pass **57 / 19 passed**.
- **Mutations: 15/15 KILLED, 0 RED-OTHER**, baseline-green gated, 3 runs each, executed-count asserted per run, missing summary treated as failure.
- **Lint ratchet proven in both directions** — (A) reintroduce a raw `Task.sleep` into a migrated file → `no_raw_task_sleep` fires; (B) leave a **stale** suppression on a migrated line → `superfluous_disable_command` fires; (C) restore → clean. Direction B is the one that matters for a burn-down: it proves the three deleted suppressions *had* to be deleted.

### Two instrument defects in my own work, both caught before they became conclusions

- **My mutation matcher accused my own tests.** First scoring said 3/15. Swift Testing prints the *display name* when `@Test` has one, so the function names I matched on never appear. The logs were fixed evidence and only the parse was wrong, so I fixed the instrument and re-parsed the same bytes — nothing re-run, nothing re-rolled — after proving the correction on positive controls for **both** name forms and a negative control on green baselines.
- **My first build was red and a `tail` of the log said it was fine.** Re-running with an explicit exit code gave rc=1 and 6 actor-isolation errors. A tail is not an exit code.

Two of five mutations were also wrong when written (one mutated a plausible break rather than the named defect; one used a `sed` insert that could have silently no-op'd) and were corrected before running. The harness aborts if a mutation changes nothing, since an unapplied mutation looks identical to a test that caught nothing.

## Growth curve (#496 / slice J): trigger did not fire, and the unit was wrong

I pre-committed to re-opening the slice-J question if triage returned more than ~8 migrations in fast-pass targets. It returned 3.

**Correcting a unit both C4 and I had wrong:** `.clockDriven` was being tracked as a raw grep-line count, which counts doc-comment mentions — `FileWatcherTests` has 3 lines but **one** `@Suite`. Counted as suite attributes, which is what actually runs concurrently and therefore what the megaYield flood scales with:

- fast parallel pass: **6 → 9 suites** (+3, exactly the three migrations)
- quiet serial pass: 11 markers, structurally inert (`--no-parallel` means a concurrent population of one)

The honest trade, both directions: F **adds** 3 clock-driven suites to the fast pass while **removing** ~4.2 s of real sleep from it. Those cut opposite ways and cannot be netted on this box given the ambient load swing others measured. Both reported; neither claimed as a win.

## Findings — 9 filed, and they outweigh the migrations

`#525` (**HIGH**) cancelled `AgentReaper` skips the entire grace window and SIGKILLs immediately, reachable at daemon shutdown — contradicting the reaper spec's own §3 · `#526` `escalateAfterHangup` signals a pid cached across a ~3 s gap without the ownership re-verification both its siblings perform · `#527` cancelled pre-session wait becomes a tight spin over real tmux subprocesses for up to 600 s · `#528` cancelled hibernate escalates straight to SIGTERM · `#529` `:67`'s deadline task is never cancelled, and `terminate()` lacks the `isRunning` guard four siblings use · `#530` a superseded proxy probe fires an RPC at an abandoned `baseURL` · `#531` two uncancellable 5 s recapture tasks, leaked into ~15 tests · `#532` the `daemonClient` injection gap.

`#525`/`#527`/`#528` are one family and share one unanswered design question — *what should a cancelled teardown do?* Today all three escalate immediately, **by accident rather than by decision**. None is fixed here: an untested guard in a kill path is the accretion this program refuses, and each fix needs a test more than it needs a one-liner.

**Fixed here instead:** `#P7` a test that fired a live `setMainAreaSize` RPC at the developer's **running daemon** ~300 ms after it returned (a "tests must not touch `~/tbd`" violation), and a docstring claiming a mechanism that existed neither in the test nor in production.

## Also in this PR

- **47 suppressions keep their comment; 14 gain a reason.** Two claims were corrected while being written rather than written as briefed — `LoginSessionCoordinator`'s fourth site is not `Delays`-driven, and `OAuthProfileUsagePoller`'s seam is *injected* at 6 sites but only *reached* on one path.
- **Slice G's DECSET-2004 measurement, applied to three comments** that asserted `paste-buffer -p` is "the SOLE bracketed-paste authority" without stating the precondition. True and silently contingent; G's nightly probe now asserts both arms, so the comment and the check move together. (G found two of the three sites; the third carried the same claim and is amended here too.)
- **`Tests/CLAUDE.md` rule 4**, which C4 measured to be satisfiable by a form that loses the diagnostic in CI. Scoped to timeout diagnostics, with the absence of a lint rule stated rather than left looking like an oversight.

Behavior-preserving by construction (defaulted clock parameters, unchanged call sites), so **no feature flag applies**.

**Amended DoD claim, verbatim:** the wall-clock-**assertion** flake class is eliminated for the sites migrated; residual scheduler-starvation is inherited from the dependency, named and quantified (#496, slice J).


## Test plan

- [x] `swift build --build-tests` — rc=0, and each of the 7 commits compiles alone (6 detached builds + the tip)
- [x] `swiftlint --strict` — 0 violations / 603 files, run by hand (no git hooks on this box)
- [x] CI fast pass — `swift test --parallel -j 2 --skip '^TBDDaemonLiveTests\.'` → 4316 tests / 474 suites passed
- [x] CI quiet pass — `swift test --filter '^TBDDaemonLiveTests\.' --no-parallel` → 57 tests / 19 suites passed
- [x] Mutation testing — 5 defects, 3 runs each, baseline-green gated, executed-count asserted per run: **15/15 KILLED, 0 RED-OTHER**
- [x] Lint ratchet proven in **both** directions — reintroduced raw sleep fires `no_raw_task_sleep`; a stale suppression fires `superfluous_disable_command`; restored → clean
- [x] Suppression count 51 → 48, with the single `- sanctioned:` site untouched
- [ ] **CI is the arbiter for the load-sensitive half** — local runs are on a 12-core box; the three new clock-driven suites meet a different contention profile on a 3–4 core runner at `-j 2`

Closes nothing; files #525–#532 as follow-ups.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=D44D29A4-1804-4B20-8071-9657CF7A29C3)
