### PR TITLE
Keep remote-session attach terminals alive across section navigation

### DIFF
--- a/Sources/TBDApp/AppState+RemoteAttach.swift
+++ b/Sources/TBDApp/AppState+RemoteAttach.swift
@@ -87,4 +87,20 @@ extension AppState {
     var attachedRemoteSelections: [RemoteSessionSelection] {
         attachedRemoteSelections(now: Date())
     }
+
+    /// Which selection the persistently-mounted remote-session detail host
+    /// (`DetailSectionHostPager`'s `.remote` tab, via `RemoteSessionHostSlot`)
+    /// should currently render its chrome for: the active selection when
+    /// one exists, otherwise the most-recently-viewed remote session — so
+    /// the host still has SOME concrete session to describe while the user
+    /// is elsewhere (`RemoteSessionDetailView.selection` is non-optional,
+    /// and the host stays mounted, just hidden, across that excursion
+    /// specifically so `RemoteAttachPager`'s live connections survive it).
+    /// `nil` only when no remote session has ever been selected this app
+    /// session. Which stale session an invisible host's chrome technically
+    /// describes never matters for correctness — visibility is separately
+    /// gated on `selectedRemoteSession` itself, not this value.
+    var remoteSessionHostSelection: RemoteSessionSelection? {
+        selectedRemoteSession ?? recentlyAttachedRemoteSessions.first
+    }
 }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -30,42 +30,6 @@ struct ContentView: View {
         }
     }
 
-    /// The `NavigationSplitView`'s `detail:` content — extracted from an
-    /// inline `if/else` chain that had grown to include a nested `HStack`
-    /// with several `.background`/`.overlay`/`.onPreferenceChange` closures
-    /// (now `WorktreeDetailAreaView`), which was contributing to
-    /// `ContentView.body`'s type-check time (and SourceKit occasionally
-    /// giving up on live diagnostics for this file). Pure restructuring —
-    /// same branches, same order, same conditions.
-    @ViewBuilder
-    private var detailContent: some View {
-        if !appState.isConnected {
-            disconnectedView
-        } else if appState.selectedScratchSection {
-            ScratchDetailView()
-        } else if let remoteSelection = appState.selectedRemoteSession {
-            // Deliberately NOT `.id(remoteSelection)`-keyed: `RemoteSessionDetailView`
-            // now hosts `RemoteAttachPager`, which keeps recently-viewed
-            // sessions' attach terminals alive across selection changes
-            // (bounded keep-alive) — `.id()`-ing this would tear the pager
-            // (and every live connection it holds) down on every switch.
-            // The view resets its own per-session-only `@State` itself via
-            // `.onChange(of: selection)`. Routed independently of
-            // `appState.repos.isEmpty`/`selectedWorktreeIDs`: a remote
-            // session has no local repo requirement.
-            RemoteSessionDetailView(selection: remoteSelection)
-        } else if appState.repos.isEmpty {
-            emptyStateView
-        } else if let repoID = appState.selectedRepoID {
-            RepoDetailView(repoID: repoID)
-        } else if appState.selectedWorktreeIDs.isEmpty {
-            Text("Select a worktree or click + to create one")
-                .foregroundStyle(.secondary)
-        } else {
-            WorktreeDetailAreaView(showFilePanel: $showFilePanel, filePanelWidth: $filePanelWidth)
-        }
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             // Persistent, non-blocking cross-build warning: the shared daemon
@@ -92,7 +56,7 @@ struct ContentView: View {
                 SidebarView()
                     .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 400)
             } detail: {
-                detailContent
+                DetailSectionHostPager(showFilePanel: $showFilePanel, filePanelWidth: $filePanelWidth)
             }
             .toolbar(removing: .sidebarToggle)
             .toolbar {
@@ -334,6 +298,174 @@ struct ContentView: View {
         }
     }
 
+    private func markSelectedWorktreesAsRead(_ selection: Set<UUID>) {
+        for worktreeID in selection {
+            appState.unreadByWorktree[worktreeID] = nil
+            Task {
+                await appState.markNotificationsRead(worktreeID: worktreeID)
+            }
+        }
+        appState.macNotificationManager.dismissDelivered(worktreeIDs: selection)
+    }
+
+}
+
+// MARK: - DetailSectionHostPager
+
+/// NSViewControllerRepresentable hosting `ContentView`'s entire `detail:`
+/// content as exactly two `NSTabViewController` tab items: `.remote` (the
+/// sticky `RemoteSessionDetailView` host — mounted once a remote session
+/// has ever been selected and NEVER removed afterward) and `.other`
+/// (whichever worktree/repo/scratch/empty/disconnected content currently
+/// applies — cheap to recreate on every switch, exactly as before; local
+/// worktree reattach is already instant via the daemon's own tmux sessions,
+/// so that half never needed keep-alive).
+///
+/// This exists because navigating OUT of remote-session mode (selecting a
+/// worktree/repo/scratch section) used to unmount `RemoteSessionDetailView`
+/// entirely, tearing down every live `RemoteAttachPager` connection it
+/// hosted — turning "switch back to the remote session" into a slow, full
+/// SSM/ssh reconnect instead of an instant resume. Hoisting the `.remote`
+/// slot here, one level above where sections get fully swapped, is what
+/// lets it survive that excursion.
+///
+/// Why `NSTabViewController` rather than a plain SwiftUI `ZStack` +
+/// `.opacity`/`.allowsHitTesting`: this codebase already hit exactly this
+/// class of bug once — see `WorktreePager`'s doc comment and
+/// `docs/superpowers/specs/research-2026-05-06-zstack-event-leak.md`.
+/// `.opacity(0)` leaves the underlying AppKit view fully attached to the
+/// window (`window != nil`, `isHidden == false`), so `TBDTerminalView`'s
+/// shared click-passthrough `NSEvent` monitor — which decides whether to
+/// fire based on `window != nil` plus a raw geometric bounds check, not
+/// SwiftUI's hit-testing/opacity — would keep matching a merely-invisible
+/// remote terminal that happens to share the exact same screen rect as
+/// whatever IS visible on top of it, forwarding clicks meant for the
+/// worktree page into the hidden remote session's pty. `NSTabViewController`
+/// tab-switching genuinely detaches the non-selected tab's content view
+/// (`window == nil`), which is the actual invariant `TBDTerminalView`'s
+/// monitor teardown already depends on for local worktree terminals (see
+/// the `tv.window != nil` guards in `TerminalPanelView`).
+///
+/// Each tab's content is a small internally-reactive wrapper — it reads
+/// `@EnvironmentObject`/`@Binding` state itself rather than being handed a
+/// fresh value on every `updateNSViewController` — so its
+/// `NSHostingController` is created exactly once and its `rootView` is
+/// never reassigned: the same "stable identity, reactive interior" shape
+/// `WorktreePager`/`RemoteAttachPager` already use for their own tab items.
+struct DetailSectionHostPager: NSViewControllerRepresentable {
+    @Binding var showFilePanel: Bool
+    @Binding var filePanelWidth: Double
+
+    @EnvironmentObject var appState: AppState
+    @EnvironmentObject var appearance: AppearanceSettings
+    @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
+
+    private static let remoteTabID = "remote"
+    private static let otherTabID = "other"
+
+    func makeNSViewController(context: Context) -> NSTabViewController {
+        let vc = NSTabViewController()
+        vc.tabStyle = .unspecified
+        vc.transitionOptions = []
+        return vc
+    }
+
+    func updateNSViewController(_ vc: NSTabViewController, context: Context) {
+        let currentIDs = Set(vc.tabViewItems.compactMap { $0.identifier as? String })
+
+        if !currentIDs.contains(Self.remoteTabID) {
+            let host = NSHostingController(
+                rootView: RemoteSessionHostSlot()
+                    .environmentObject(appState)
+                    .environmentObject(appearance)
+            )
+            let item = NSTabViewItem(viewController: host)
+            item.identifier = Self.remoteTabID
+            vc.addTabViewItem(item)
+        }
+
+        if !currentIDs.contains(Self.otherTabID) {
+            let host = NSHostingController(
+                rootView: OtherSectionContent(showFilePanel: $showFilePanel, filePanelWidth: $filePanelWidth)
+                    .environmentObject(appState)
+                    .environmentObject(overlayCoordinator)
+            )
+            let item = NSTabViewItem(viewController: host)
+            item.identifier = Self.otherTabID
+            vc.addTabViewItem(item)
+        }
+
+        let showingRemote = Self.showsRemoteTab(
+            isConnected: appState.isConnected, selectedRemoteSession: appState.selectedRemoteSession
+        )
+        let targetID = showingRemote ? Self.remoteTabID : Self.otherTabID
+        if let idx = vc.tabViewItems.firstIndex(where: { $0.identifier as? String == targetID }),
+           vc.selectedTabViewItemIndex != idx {
+            vc.selectedTabViewItemIndex = idx
+        }
+    }
+
+    /// Which tab should be in front. Disconnected always wins, matching the
+    /// former if/else's top-priority `!appState.isConnected` check —
+    /// `OtherSectionContent` renders the disconnected message itself, so
+    /// this just makes sure that's the tab actually in front while
+    /// disconnected, regardless of whatever remote session was selected
+    /// before the daemon dropped. Pure and `nonisolated` so it's directly
+    /// unit-testable without an `NSTabViewController`.
+    nonisolated static func showsRemoteTab(isConnected: Bool, selectedRemoteSession: RemoteSessionSelection?) -> Bool {
+        isConnected && selectedRemoteSession != nil
+    }
+}
+
+/// The `.remote` tab's content. Internally reactive — reads
+/// `AppState.remoteSessionHostSelection` itself on every body evaluation —
+/// so `DetailSectionHostPager` never needs to reassign this tab's
+/// `NSHostingController.rootView`; only the `selection` value `body`
+/// resolves to changes across renders, which is exactly the "same view
+/// identity, new property value" update `RemoteSessionDetailView` is
+/// already built to handle (see its own doc comment on why it's not
+/// `.id()`-keyed).
+private struct RemoteSessionHostSlot: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        if let selection = appState.remoteSessionHostSelection {
+            RemoteSessionDetailView(selection: selection)
+        } else {
+            EmptyView()
+        }
+    }
+}
+
+/// The `.other` tab's content: the non-remote top-level sections
+/// (disconnected/scratch/repo/empty/worktree). Pure relocation of
+/// `ContentView`'s former `detailContent` computed property, minus the
+/// remote-session branch (now `RemoteSessionHostSlot`'s job) — same
+/// conditions, same order, same views.
+private struct OtherSectionContent: View {
+    @Binding var showFilePanel: Bool
+    @Binding var filePanelWidth: Double
+
+    @EnvironmentObject var appState: AppState
+    @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
+
+    var body: some View {
+        if !appState.isConnected {
+            disconnectedView
+        } else if appState.selectedScratchSection {
+            ScratchDetailView()
+        } else if appState.repos.isEmpty {
+            emptyStateView
+        } else if let repoID = appState.selectedRepoID {
+            RepoDetailView(repoID: repoID)
+        } else if appState.selectedWorktreeIDs.isEmpty {
+            Text("Select a worktree or click + to create one")
+                .foregroundStyle(.secondary)
+        } else {
+            WorktreeDetailAreaView(showFilePanel: $showFilePanel, filePanelWidth: $filePanelWidth)
+        }
+    }
+
     // MARK: - Empty State
 
     private var emptyStateView: some View {
@@ -403,35 +535,23 @@ struct ContentView: View {
             }
         }
     }
-
-    private func markSelectedWorktreesAsRead(_ selection: Set<UUID>) {
-        for worktreeID in selection {
-            appState.unreadByWorktree[worktreeID] = nil
-            Task {
-                await appState.markNotificationsRead(worktreeID: worktreeID)
-            }
-        }
-        appState.macNotificationManager.dismissDelivered(worktreeIDs: selection)
-    }
-
 }
 
 // MARK: - WorktreeDetailAreaView
 
-/// The terminal-grid branch of `ContentView.detailContent` — rendered when a
-/// worktree (not a remote session, scratch section, or repo-only selection)
-/// is what's showing. Extracted verbatim out of `ContentView.body`'s
-/// `detail:` closure (pure restructuring, see `detailContent`'s doc
-/// comment): `TerminalContainerView` + the optional file panel, the overlay
-/// coordinator's transcript overlay, and the window-wide click-outside
-/// catcher.
+/// The terminal-grid branch of `OtherSectionContent` (`DetailSectionHostPager`'s
+/// `.other` tab) — rendered when a worktree (not a remote session, scratch
+/// section, or repo-only selection) is what's showing: `TerminalContainerView`
+/// + the optional file panel, the overlay coordinator's transcript overlay,
+/// and the window-wide click-outside catcher.
 ///
 /// `showFilePanel`/`filePanelWidth` stay `@Binding` (not independent
 /// `@AppStorage` re-declarations of the same keys) — `ContentView`'s
 /// toolbar toggle button needs the SAME state, and threading one `Binding`
-/// through avoids two literal copies of the UserDefaults key strings ever
-/// drifting apart. `contentAreaHeight` moves in as this view's own `@State`
-/// instead: nothing outside this branch ever read it in `ContentView`.
+/// through (via `DetailSectionHostPager` → `OtherSectionContent`) avoids two
+/// literal copies of the UserDefaults key strings ever drifting apart.
+/// `contentAreaHeight` moves in as this view's own `@State` instead: nothing
+/// outside this branch ever read it in `ContentView`.
 private struct WorktreeDetailAreaView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator

--- a/Sources/TBDApp/Remote/RemoteAttachPager.swift
+++ b/Sources/TBDApp/Remote/RemoteAttachPager.swift
@@ -21,12 +21,11 @@ import TBDShared
 /// DIFFERENT remote-session selections (that view is deliberately no longer
 /// `.id()`-keyed per selection — see its doc comment) so switching between
 /// recently-viewed sessions doesn't tear down and respawn their terminals.
-/// Background attaches do NOT currently survive leaving remote-session mode
-/// entirely (selecting a worktree/repo/scratch section tears down
-/// `RemoteSessionDetailView`, and this pager with it) — a deliberate,
-/// documented scope boundary: the requirement this satisfies is "switching
-/// back between remote sessions is instant," not "a background SSM
-/// connection survives an excursion to an unrelated worktree."
+/// Background attaches ALSO survive leaving remote-session mode entirely
+/// (selecting a worktree/repo/scratch section): `RemoteSessionDetailView`
+/// itself is now hosted inside `DetailSectionHostPager`'s `.remote` tab,
+/// which stays mounted (hidden, not torn down) across that excursion for
+/// exactly this reason — see that type's doc comment.
 struct RemoteAttachPager: NSViewControllerRepresentable {
     let selections: [RemoteSessionSelection]
     let activeSelection: RemoteSessionSelection?

--- a/Sources/TBDApp/Remote/RemoteSessionDetailView.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionDetailView.swift
@@ -14,19 +14,23 @@ enum RemoteSessionDetailTab: String, CaseIterable, Equatable, Hashable {
 }
 
 /// Detail pane shown when a remote-session sidebar row is selected
-/// (`AppState.selectedRemoteSession`) — routed from `ContentView` the same
-/// way `ScratchDetailView`/`RepoDetailView` are. No file viewer or diff
-/// panel: those are local-worktree-only and simply aren't rendered here
-/// (spec non-goal for v1 remote sessions).
+/// (`AppState.selectedRemoteSession`), hosted (via `RemoteSessionHostSlot`)
+/// inside `DetailSectionHostPager`'s `.remote` tab — mounted continuously
+/// for the lifetime of the app session once any remote session has ever
+/// been selected, hidden (not torn down) whenever a different top-level
+/// section is showing, so it survives navigating away and back. No file
+/// viewer or diff panel: those are local-worktree-only and simply aren't
+/// rendered here (spec non-goal for v1 remote sessions).
 ///
-/// UNLIKE its earlier revision, the caller (`ContentView`) deliberately does
-/// NOT key this view with `.id(selection)` any more: this view now hosts
-/// `RemoteAttachPager`, which keeps recently-viewed sessions' attach
-/// terminals alive across selection changes (bounded keep-alive — see
-/// `RemoteAttachLifecycle`), and `.id()`-ing the parent would tear that
-/// pager down (and every live connection it holds) on every single session
-/// switch, defeating the whole point. Instead this view resets its own
-/// per-session-only `@State` explicitly via `.onChange(of: selection)`.
+/// UNLIKE its earlier revision, the caller deliberately does NOT key this
+/// view with `.id(selection)`: this view now hosts `RemoteAttachPager`,
+/// which keeps recently-viewed sessions' attach terminals alive across
+/// selection changes AND across excursions to a non-remote section
+/// (bounded keep-alive — see `RemoteAttachLifecycle`), and `.id()`-ing the
+/// parent would tear that pager down (and every live connection it holds)
+/// on every single session switch, defeating the whole point. Instead this
+/// view resets its own per-session-only `@State` explicitly via
+/// `.onChange(of: selection)`.
 struct RemoteSessionDetailView: View {
     let selection: RemoteSessionSelection
     @EnvironmentObject var appState: AppState

--- a/Tests/TBDAppTests/DetailSectionHostPagerTests.swift
+++ b/Tests/TBDAppTests/DetailSectionHostPagerTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import TBDApp
+
+/// `DetailSectionHostPager.showsRemoteTab` is the pure decision behind which
+/// of the two always-mounted tabs (`.remote`/`.other`) is in front — see
+/// that type's doc comment for why the `.remote` tab stays mounted (rather
+/// than torn down) when not showing. Covers both inputs' branches.
+@Suite("DetailSectionHostPager tab selection")
+struct DetailSectionHostPagerTests {
+    private let selection = RemoteSessionSelection(provider: "acme", sessionID: "s1")
+
+    @Test("connected with a selected remote session shows the remote tab")
+    func connectedWithSelectionShowsRemote() {
+        #expect(DetailSectionHostPager.showsRemoteTab(isConnected: true, selectedRemoteSession: selection))
+    }
+
+    @Test("connected with no selected remote session shows the other tab")
+    func connectedWithoutSelectionShowsOther() {
+        #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: true, selectedRemoteSession: nil))
+    }
+
+    @Test("disconnected with a selected remote session still shows the other tab")
+    func disconnectedWithSelectionShowsOther() {
+        #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: false, selectedRemoteSession: selection))
+    }
+
+    @Test("disconnected with no selected remote session shows the other tab")
+    func disconnectedWithoutSelectionShowsOther() {
+        #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: false, selectedRemoteSession: nil))
+    }
+}

--- a/Tests/TBDAppTests/RemoteAttachStateTests.swift
+++ b/Tests/TBDAppTests/RemoteAttachStateTests.swift
@@ -364,6 +364,50 @@ struct RemoteAttachStateTests {
         }
     }
 
+    // MARK: - Sticky host selection (survives navigating away)
+
+    /// `remoteSessionHostSelection` is what `DetailSectionHostPager`'s
+    /// `.remote` tab renders for while it's mounted-but-hidden (see that
+    /// type's doc comment) — the whole point of the fix this task is about:
+    /// a session that was selected, then left (e.g. the user clicked over
+    /// to a worktree), must still resolve to something so the hidden host
+    /// keeps describing the right session rather than going blank.
+    @Test func hostSelectionIsNilBeforeAnySessionIsEverSelected() {
+        withState { state in
+            #expect(state.remoteSessionHostSelection == nil)
+        }
+    }
+
+    @Test func hostSelectionIsTheActiveSelectionWhileOneIsSelected() {
+        withState { state in
+            seedProvider(state, name: "acme")
+            seedSession(state, provider: "acme", id: "s1")
+            state.selectRemoteSession(provider: "acme", sessionID: "s1")
+
+            #expect(state.remoteSessionHostSelection == sel("acme", "s1"))
+        }
+    }
+
+    /// The core "survives navigating away" case: once nothing is selected
+    /// (mirrors a worktree/repo/scratch section becoming active, which sets
+    /// `selectedRemoteSession = nil`), the host selection falls back to the
+    /// most-recently-viewed remote session rather than going nil.
+    @Test func hostSelectionFallsBackToMostRecentlyViewedOnceNothingIsSelected() {
+        withState { state in
+            seedProvider(state, name: "acme")
+            seedSession(state, provider: "acme", id: "s1")
+            seedSession(state, provider: "acme", id: "s2")
+            state.selectRemoteSession(provider: "acme", sessionID: "s1")
+            state.selectRemoteSession(provider: "acme", sessionID: "s2")
+
+            // Simulate navigating to a worktree section (AppState+Worktrees.swift
+            // clears `selectedRemoteSession` on that transition).
+            state.selectedRemoteSession = nil
+
+            #expect(state.remoteSessionHostSelection == sel("acme", "s2"))
+        }
+    }
+
     // MARK: - Pruning on mirror refresh
 
     @Test func pruningDropsDetachAndRecencyStateForSessionsNoLongerReported() {


### PR DESCRIPTION
## Problem

Attaching to a remote session, navigating to a worktree/repo/scratch
section, then navigating back gave an empty terminal that had to
cold-reattach over SSM/ssh (slow) -- even though the keep-alive cap
(`AppState.remoteAttachKeepAliveLimit = 3`) says up to 3 background
remote sessions should stay warm.

Root cause: `RemoteAttachPager` (the NSTabViewController-backed host for
live remote-attach PTYs) was mounted only inside `RemoteSessionDetailView`,
and `ContentView`'s `detail:` content fully swapped between top-level
sections via an `if/else` -- so selecting a worktree/repo/scratch section
unmounted `RemoteSessionDetailView` entirely, tearing down every
attached connection via `dismantleNSView` -> `Coordinator.cleanup()` ->
`LocalProcess.terminate()`, regardless of whether that session was
still within the keep-alive cap.

## Mechanism

Added `DetailSectionHostPager`, an `NSTabViewController`-backed
container (the same shape as `WorktreePager`) that now hosts
`ContentView`'s entire `detail:` content as exactly two tabs:

- `.remote` -- `RemoteSessionDetailView`, wrapped in a small
  internally-reactive `RemoteSessionHostSlot` that reads
  `AppState.remoteSessionHostSelection` (new: current selection, or the
  most-recently-viewed one once nothing is currently selected). Created
  once, the first time any remote session is ever selected, and never
  removed afterward.
- `.other` -- the existing disconnected/scratch/repo/empty/worktree
  content (`OtherSectionContent`, a pure relocation of the old
  `detailContent`), still recreated freely on every switch exactly as
  before -- local worktree reattach is already instant via the daemon's
  tmux sessions, so that half never needed keep-alive.

Switching sections now just moves `NSTabViewController.selectedTabViewItemIndex`
between these two tabs instead of unmounting either one.

This uses `NSTabViewController` rather than a plain SwiftUI `ZStack` +
`.opacity`/`.allowsHitTesting`, on purpose: this codebase already hit
the opacity-based event-leak bug once for worktree keep-alive (see
`docs/superpowers/specs/research-2026-05-06-zstack-event-leak.md`).
`.opacity(0)` leaves the AppKit view fully attached to the window
(`window != nil`), so `TBDTerminalView`'s shared click-passthrough
`NSEvent` monitor -- which gates on `window != nil` plus a raw bounds
check, not SwiftUI's hit-testing -- would keep firing for a
merely-invisible remote terminal sharing the same screen rect as
whatever's actually showing, forwarding clicks into the wrong pty.
`NSTabViewController`'s own tab-switching genuinely detaches the
non-selected tab's view (`window == nil`), the same invariant
`TerminalPanelView`'s existing monitors already depend on.

## Eviction / detach semantics preserved

- **Cap eviction / explicit detach / mirror-vanish** still terminate the
  process: `RemoteAttachPager` (nested inside the `.remote` tab,
  unchanged) still reads `AppState.attachedRemoteSelections` on every
  update regardless of which outer tab is in front, and still removes +
  terminates any tab item that falls out of that set.
- **Recency ordering** is untouched: `touchAttachedRemoteSession` is
  still only called from `activateRemoteSession` (an actual remote
  session selection), never from selecting a worktree/repo/scratch
  section -- confirmed by grep and by the new `RemoteAttachStateTests`.
- **App quit** behavior is unchanged -- nothing about process teardown
  timing was touched.

No feature flag: this only changes *when* a live connection gets torn
down (later, not on every navigate-away), doesn't add a new background
connection type, and the existing cap/eviction/detach paths already
bound the resource. Chang explicitly expects this behavior.

## Test plan

- [x] `swift build` (clean `env -i` environment) succeeds
- [x] `swift test` -- new tests pass:
  - `DetailSectionHostPagerTests` (4 tests): `showsRemoteTab` pure
    decision, all 4 input combinations
  - `RemoteAttachStateTests` (+3 tests): `remoteSessionHostSelection`
    nil-before-ever-selected, active-selection-wins,
    falls-back-to-most-recently-viewed-once-nothing-selected
  - Pre-existing failures (62, unchanged count from before this
    branch) are environment-only noise under the sandboxed `env -i`
    build: tests needing a real `tmux` binary on `PATH` (not present
    under the required clean env) and a few needing a configured git
    identity -- none touch `ContentView`, `RemoteAttachPager`,
    `RemoteSessionDetailView`, or remote-attach state.
- [ ] Manual verification in the real app: attach a remote session,
      navigate to a worktree, navigate back -- terminal should still be
      live with no respawn.