### PR TITLE
feat: pin remote sessions to the sidebar dock

### DIFF
--- a/Sources/TBDApp/AppState+Remote.swift
+++ b/Sources/TBDApp/AppState+Remote.swift
@@ -203,6 +203,34 @@ extension AppState {
         }
     }
 
+    // MARK: - Pinned dock
+
+    /// Pin or unpin a remote session for the sidebar's pinned dock, then
+    /// re-fetch the mirror so the dock reflects daemon state.
+    ///
+    /// No optimistic local update, deliberately — same reasoning as
+    /// `setPinned(worktreeID:pinned:)`: the daemon stamps `pinnedAt`, so pin
+    /// ORDER is server-assigned and a guessed local timestamp could order the
+    /// dock differently from the next refresh. A failed pin therefore visibly
+    /// does not take, which is honest.
+    func setRemoteSessionPinned(provider: String, sessionID: String, pinned: Bool) async {
+        do {
+            try await remoteSessionPinSetter(provider, sessionID, pinned)
+            await refreshRemote()
+        } catch {
+            remoteLogger.error(
+                "Failed to set remote session pin for \(provider, privacy: .public)/\(sessionID, privacy: .public): \(error, privacy: .public)")
+            showAlert("Couldn't update pin: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    /// Whether this session currently carries a dock pin. Reads the mirror
+    /// (not a local copy of the row) so a menu built from a stale row still
+    /// offers the correct Pin/Unpin verb.
+    func remoteSessionIsPinned(provider: String, sessionID: String) -> Bool {
+        remoteSessions.first { $0.provider == provider && $0.payload.id == sessionID }?.pinnedAt != nil
+    }
+
     // MARK: - Settings toggle (Task 11)
 
     /// Persist the remote-backends master switch, then re-fetch capabilities

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1022,6 +1022,15 @@ final class AppState: ObservableObject {
     /// tests can exercise the success branch without a real daemon.
     lazy var remoteBackendsSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setRemoteBackends(enabled: enabled) }
+    /// How `setRemoteSessionPinned` pins/unpins a remote session for the
+    /// sidebar dock — injectable for the same reason as `remoteRenamePusher`,
+    /// so the pin action's success and failure branches are testable without
+    /// a real daemon.
+    lazy var remoteSessionPinSetter: @MainActor (String, String, Bool) async throws -> Void =
+        { [daemonClient] provider, sessionID, pinned in
+            try await daemonClient.setRemoteSessionPin(
+                provider: provider, sessionID: sessionID, pinned: pinned)
+        }
 
     /// Best-effort re-fetch of `daemonCapabilities` (R7-minor). Used by the
     /// `.modelProfilesChanged` delta handler so a control-mode toggle from

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -981,6 +981,17 @@ actor DaemonClient {
         )
     }
 
+    /// Pin or unpin a remote session for the sidebar's pinned dock. The
+    /// `pinnedAt` timestamp is stamped daemon-side, so pin ORDER is
+    /// server-assigned — the client only says whether it wants the pin on or
+    /// off (mirrors `setWorktreePin`).
+    func setRemoteSessionPin(provider: String, sessionID: String, pinned: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.remoteSetPin,
+            params: RemoteSetPinParams(provider: provider, sessionID: sessionID, pinned: pinned)
+        )
+    }
+
     /// Set the remote-agent-backends master switch.
     func setRemoteBackends(enabled: Bool) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Remote/RemoteSessionActionMenu.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionActionMenu.swift
@@ -23,6 +23,8 @@ enum RemoteSessionActionMenu {
         case copySessionID
         case stop
         case dismiss
+        case pin
+        case unpin
     }
 
     /// Whether an action reads as destructive. Mapped by the view to SwiftUI's
@@ -58,6 +60,11 @@ enum RemoteSessionActionMenu {
     static let copySessionIDLabel = "Copy Session ID"
     static let stopLabel = "Stop"
     static let dismissLabel = "Dismiss"
+    /// Pin wording is taken from `RowActionMenu`, not re-typed, so a remote
+    /// row and a worktree row can never drift into two different names for
+    /// the same dock.
+    static let pinLabel = RowActionMenu.pinLabel
+    static let unpinLabel = RowActionMenu.unpinLabel
 
     /// The `describe.capabilities` string this composition checks for each
     /// optional verb — kept as named constants (not re-typed at each call
@@ -72,19 +79,31 @@ enum RemoteSessionActionMenu {
     ///
     /// `gone` rows (absent from the provider's last two `list` snapshots —
     /// see the contract's "Identity & drift" section) collapse to exactly
-    /// Copy Session ID + Dismiss: every other action assumes a session verb
-    /// the provider can still run against a row it no longer reports, and
-    /// renaming/stopping a row that's already a caller-side tombstone isn't
-    /// meaningful.
+    /// Copy Session ID + the pin toggle + Dismiss: every other action assumes
+    /// a session verb the provider can still run against a row it no longer
+    /// reports, and renaming/stopping a row that's already a caller-side
+    /// tombstone isn't meaningful.
     ///
     /// For a live row: Rename…, then Attach/View Log/Send Text… gated on
     /// their respective capabilities, then Copy Session ID (always
-    /// available — the id is known locally, no provider call needed), then a
-    /// divider, then Stop as the last, destructive item.
-    static func items(capabilities: [String], gone: Bool) -> [Item] {
+    /// available — the id is known locally, no provider call needed), then
+    /// the pin toggle, then a divider, then Stop as the last, destructive
+    /// item.
+    ///
+    /// The pin toggle is offered in BOTH branches, right beside Copy Session
+    /// ID, because it shares Copy's defining property: it is a purely local
+    /// action needing no provider verb and no declared capability. A pinned
+    /// session that goes `gone` must stay unpinnable without the user having
+    /// to dismiss it, which is why the collapsed branch carries it too.
+    static func items(capabilities: [String], gone: Bool, isPinned: Bool) -> [Item] {
+        let pinAction = isPinned
+            ? Action(kind: .unpin, title: unpinLabel)
+            : Action(kind: .pin, title: pinLabel)
+
         if gone {
             return [
                 .action(Action(kind: .copySessionID, title: copySessionIDLabel)),
+                .action(pinAction),
                 .action(Action(kind: .dismiss, title: dismissLabel)),
             ]
         }
@@ -100,6 +119,7 @@ enum RemoteSessionActionMenu {
             actions.append(Action(kind: .sendText, title: sendTextLabel))
         }
         actions.append(Action(kind: .copySessionID, title: copySessionIDLabel))
+        actions.append(pinAction)
 
         var items = actions.map(Item.action)
         items.append(.divider)

--- a/Sources/TBDApp/Sidebar/PinnedDockContent.swift
+++ b/Sources/TBDApp/Sidebar/PinnedDockContent.swift
@@ -17,6 +17,22 @@ struct PinnedDockRow: Identifiable, Equatable {
     var id: UUID { worktree.id }
 }
 
+/// One rendered line in the pinned dock's remote group: a pinned remote
+/// session. Deliberately a SEPARATE row type from `PinnedDockRow` rather than
+/// an enum case inside it, because the two render into two different
+/// `ForEach`es — only the worktree one carries `.onMove` (see
+/// `PinnedDockView`). A remote session also has none of the nesting context a
+/// worktree row needs: the mirror is flat, so there is no depth and no
+/// section repo to inherit.
+struct PinnedDockRemoteRow: Identifiable, Equatable {
+    let session: RemoteSessionInfo
+
+    /// The deterministic per-`(provider, sessionID)` UUID from
+    /// `RemoteSessionIdentity` — the same tag the row carries in the remote
+    /// section, so selecting in either place lights up both copies.
+    var id: UUID { session.id }
+}
+
 /// Pure content model for the sidebar's pinned dock. Takes values and one
 /// lookup closure, returns values — no SwiftUI, no `AppState`, fully testable.
 ///
@@ -115,6 +131,51 @@ enum PinnedDockContent {
                               depth: depth + 1, children: children,
                               emitted: &emitted, into: &result)
         }
+    }
+
+    /// The pinned remote sessions, rendered as a group BELOW the pinned
+    /// worktrees in the same dock.
+    ///
+    /// Grouped rather than interleaved with worktree pins by `pinnedAt`, for
+    /// two reasons. Structurally, `.onMove` addresses one `ForEach`'s own
+    /// elements, and only worktrees carry a persisted `pinSortOrder` to drag
+    /// against — interleaving would put unmovable rows inside the movable
+    /// `ForEach` and make every drag index ambiguous. Behaviourally, the
+    /// grouping is predictable: dock order stays "worktrees you arranged,
+    /// then remote sessions in the order you pinned them".
+    ///
+    /// Filters, and the lifecycle choice behind each:
+    /// - `pinnedAt != nil` — the pin itself.
+    /// - `!dismissed` — dismissing means "get rid of it", so a dismissed
+    ///   session leaves the dock. The daemon also clears `pinnedAt` on
+    ///   dismiss (`RemoteSessionStore.dismiss`); this check is what makes the
+    ///   rendering correct regardless, including for a row dismissed by an
+    ///   older daemon that never cleared the column.
+    ///
+    /// Deliberately NOT filtered: `gone` and `exited`. A `gone` row is one the
+    /// provider stopped reporting, which self-heals the moment it reappears in
+    /// a snapshot (`RemoteSessionStore.applySnapshot` clears the flag), and an
+    /// exited session is still the thing the user pinned — both keep their
+    /// slot and render with `RemoteSessionRowView`'s existing dimmed /
+    /// secondary styling, the same way an archived WORKTREE keeps its pin
+    /// (see `rows`' `archivedAt` note — the difference is that a remote
+    /// session has no archived state to hide behind).
+    ///
+    /// Sorted oldest-pin-first so a new pin appends, matching `rows`'
+    /// `pinnedAt` fallback. Ties break on `(provider, sessionID)` so the order
+    /// is total — two sessions pinned inside the same millisecond must not
+    /// swap places between renders.
+    static func remoteRows(allRemoteSessions: [RemoteSessionInfo]) -> [PinnedDockRemoteRow] {
+        allRemoteSessions
+            .filter { $0.pinnedAt != nil && !$0.dismissed }
+            .sorted { lhs, rhs in
+                let l = lhs.pinnedAt ?? .distantPast
+                let r = rhs.pinnedAt ?? .distantPast
+                if l != r { return l < r }
+                if lhs.provider != rhs.provider { return lhs.provider < rhs.provider }
+                return lhs.payload.id < rhs.payload.id
+            }
+            .map(PinnedDockRemoteRow.init)
     }
 
     /// The contiguous run of rows belonging to one pinned root: the root itself

--- a/Sources/TBDApp/Sidebar/PinnedDockView.swift
+++ b/Sources/TBDApp/Sidebar/PinnedDockView.swift
@@ -13,6 +13,10 @@ import TBDShared
 /// gesture is attached.
 struct PinnedDockView: View {
     let rows: [PinnedDockRow]
+    /// Pinned remote sessions, rendered as a group below the worktree pins —
+    /// see `PinnedDockContent.remoteRows` for why they're grouped rather than
+    /// interleaved.
+    let remoteRows: [PinnedDockRemoteRow]
     let availableHeight: CGFloat
     @EnvironmentObject var appState: AppState
 
@@ -40,8 +44,22 @@ struct PinnedDockView: View {
         .tag(row.worktree.id)
     }
 
+    /// A pinned remote session's dock line. Renders the SAME
+    /// `RemoteSessionRowView` the remote/repo sections use, so status icon,
+    /// captions, exited/gone styling, rename, click-to-select and the context
+    /// menu (including Unpin) all come along unchanged — a dock copy of a row
+    /// must not be a second, drifting presentation of the same session.
+    @ViewBuilder
+    private func remoteDockRow(_ row: PinnedDockRemoteRow) -> some View {
+        RemoteSessionRowView(session: row.session)
+            .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 0))
+            .listRowSeparator(.hidden)
+            .listRowBackground(Color.clear)
+            .tag(row.id)
+    }
+
     var body: some View {
-        if !rows.isEmpty {
+        if !rows.isEmpty || !remoteRows.isEmpty {
             ScrollViewReader { proxy in
                 List(selection: $appState.selectedWorktreeIDs) {
                     // Nested deliberately: `.onMove` hands back indices into its
@@ -67,6 +85,13 @@ struct PinnedDockView: View {
                     .onMove { source, destination in
                         appState.reorderPins(fromOffsets: source, toOffset: destination)
                     }
+                    // A SEPARATE ForEach, deliberately outside the one above:
+                    // `.onMove`'s offsets index its own ForEach's elements, and
+                    // remote pins carry no `pinSortOrder` to drag against, so
+                    // folding them in would make every drag index ambiguous.
+                    ForEach(remoteRows) { row in
+                        remoteDockRow(row)
+                    }
                 }
                 .onChange(of: appState.selectedWorktreeIDs) { _, ids in
                     // Expanding a subtree can push the dock past its cap; keep
@@ -75,10 +100,22 @@ struct PinnedDockView: View {
                         withAnimation { proxy.scrollTo(target) }
                     }
                 }
+                // A remote selection needs its own observer: the tag is
+                // stripped back out of `selectedWorktreeIDs` on the way in
+                // (see `AppState.selectedWorktreeIDs`'s `didSet`), so the
+                // handler above never sees a remote id.
+                .onChange(of: appState.selectedRemoteSession) { _, selection in
+                    guard let selection,
+                          let row = remoteRows.first(where: {
+                              $0.session.provider == selection.provider
+                                  && $0.session.payload.id == selection.sessionID
+                          }) else { return }
+                    withAnimation { proxy.scrollTo(row.id) }
+                }
             }
             .listStyle(.plain)
             .scrollContentBackground(.hidden)
-            .frame(height: PinnedDockMetrics.height(rowCount: rows.count,
+            .frame(height: PinnedDockMetrics.height(rowCount: rows.count + remoteRows.count,
                                                    availableHeight: availableHeight))
         }
     }

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -447,10 +447,15 @@ struct RemoteSessionRowView: View {
         .contextMenu {
             let capabilities = appState.remoteProviders
                 .first { $0.config.name == session.provider }?.describe?.capabilities ?? []
-            ForEach(
-                Array(RemoteSessionActionMenu.items(capabilities: capabilities, gone: session.gone).enumerated()),
-                id: \.offset
-            ) { _, item in
+            let items = RemoteSessionActionMenu.items(
+                capabilities: capabilities, gone: session.gone,
+                // Read from the mirror rather than this row's captured
+                // `session`, so a dock copy and a section copy of the same
+                // session always offer the same verb.
+                isPinned: appState.remoteSessionIsPinned(
+                    provider: session.provider, sessionID: session.payload.id)
+            )
+            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                 switch item {
                 case let .action(action):
                     actionButton(action)
@@ -508,6 +513,12 @@ struct RemoteSessionRowView: View {
                     remoteRowLogger.error(
                         "remoteDismiss failed for \(session.provider, privacy: .public)/\(session.payload.id, privacy: .public): \(error, privacy: .public)")
                 }
+            }
+        case .pin, .unpin:
+            let pinned = kind == .pin
+            Task {
+                await appState.setRemoteSessionPinned(
+                    provider: session.provider, sessionID: session.payload.id, pinned: pinned)
             }
         }
     }

--- a/Sources/TBDApp/Sidebar/SidebarView.swift
+++ b/Sources/TBDApp/Sidebar/SidebarView.swift
@@ -76,6 +76,9 @@ struct SidebarView: View {
                 selectedIDs: appState.selectedWorktreeIDs,
                 children: appState.children(of:)
             )
+            let dockRemoteRows = PinnedDockContent.remoteRows(
+                allRemoteSessions: appState.remoteSessions
+            )
             let desk = PinnedDockContent.deskRow(
                 allWorktrees: appState.allWorktrees,
                 mode: appState.nightwatchMode,
@@ -88,7 +91,8 @@ struct SidebarView: View {
                 // Dock, desk slot, mode toggle and Add Repository share this
                 // VStack's `.background(.bar)` as a single visual group.
                 Divider()
-                PinnedDockView(rows: dockRows, availableHeight: sidebarHeight)
+                PinnedDockView(rows: dockRows, remoteRows: dockRemoteRows,
+                               availableHeight: sidebarHeight)
                 PinnedDockDeskSlot(desk: desk)
                 if nightwatchExperimental {
                     NightwatchModeToggle()

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1109,6 +1109,20 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "worktree", column: "pinSortOrder", type: .integer)
         }
 
+        // Pin a remote session to the same sidebar dock worktrees pin to.
+        // Nullable with NO default and NO backfill, for the same reasons
+        // v63 gives for `worktree.pinnedAt`: existing rows must land on NULL
+        // (= unpinned), and there is no Swift-side default to flip later, so
+        // the `ADD COLUMN ... DEFAULT` backfill trap does not apply. The pin
+        // rides on the mirror row rather than a side table because the row's
+        // primary key `(provider, sessionID)` is already the durable identity
+        // for a remote session (see `RemoteSessionIdentity`) and mirror rows
+        // are never deleted — only marked gone/dismissed — so a pin survives
+        // provider drift and daemon restarts.
+        migrator.registerMigration("v65_remote_session_pinned_at") { db in
+            try db.addColumnIfMissing(table: "remote_session", column: "pinnedAt", type: .datetime)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/RemoteSessionStore.swift
+++ b/Sources/TBDDaemon/Database/RemoteSessionStore.swift
@@ -26,6 +26,10 @@ public struct RemoteSessionRow: Codable, FetchableRecord, PersistableRecord, Sen
     /// (matching `RepoRecord.id`'s convention) rather than a GRDB-native UUID
     /// type.
     public var resolvedRepoID: String?
+    /// Sidebar-dock pin timestamp, or nil when unpinned — see
+    /// `RemoteSessionInfo.pinnedAt`. Purely presentational: nothing in the
+    /// daemon reads this value beyond echoing it to clients.
+    public var pinnedAt: Date?
 
     public var decodedPayload: RemoteSessionPayload? {
         payload.data(using: .utf8).flatMap { try? JSONDecoder().decode(RemoteSessionPayload.self, from: $0) }
@@ -137,7 +141,11 @@ public struct RemoteSessionStore: Sendable {
                 agentState: session.agentState.rawValue,
                 firstSeen: now, lastSeen: now,
                 missingCount: 0, gone: false, dismissed: false,
-                resolvedRepoID: resolvedRepoID?.uuidString
+                resolvedRepoID: resolvedRepoID?.uuidString,
+                // A brand-new session is never pinned. An EXISTING row's pin
+                // is preserved because the branch above mutates and updates
+                // the row it read, never reconstructing it.
+                pinnedAt: nil
             ).insert(db)
             return (true, nil)
         }
@@ -253,12 +261,48 @@ public struct RemoteSessionStore: Sendable {
     /// Returns whether a row actually changed (an unknown session, or one
     /// already dismissed, changes nothing) — mirrors `markGone`'s contract so
     /// callers can skip a pointless UI broadcast.
+    ///
+    /// Dismissing also DROPS any sidebar-dock pin: dismiss means "get this
+    /// out of my sight", and a dismissed row is filtered out of every session
+    /// list, so leaving `pinnedAt` set would strand an invisible pin that
+    /// silently resurrects the row in the dock if the session were ever
+    /// un-dismissed. Deliberately part of the same UPDATE (not a second
+    /// statement) so the two can't diverge.
     @discardableResult
     public func dismiss(provider: String, sessionID: String) async throws -> Bool {
         try await writer.write { db in
             try db.execute(
-                sql: "UPDATE remote_session SET dismissed = 1 WHERE provider = ? AND sessionID = ? AND dismissed = 0",
+                sql: """
+                    UPDATE remote_session SET dismissed = 1, pinnedAt = NULL
+                    WHERE provider = ? AND sessionID = ? AND dismissed = 0
+                    """,
                 arguments: [provider, sessionID])
+            return db.changesCount > 0
+        }
+    }
+
+    /// Pin or unpin one mirror row for the sidebar dock. `pinnedAt` is
+    /// stamped by the caller (the RPC handler, daemon-side) so pin order is
+    /// server-assigned and consistent across clients — the same contract
+    /// `WorktreeStore.setPinned` follows.
+    ///
+    /// Returns whether a row actually changed, mirroring `dismiss`/`markGone`
+    /// so the handler can skip a pointless UI broadcast. An unknown session
+    /// changes nothing; re-pinning an already-pinned row DOES change it (the
+    /// timestamp moves), which is why this compares against the requested
+    /// null-ness rather than blanket-writing.
+    @discardableResult
+    public func setPinned(provider: String, sessionID: String, pinnedAt: Date?) async throws -> Bool {
+        try await writer.write { db in
+            if let pinnedAt {
+                try db.execute(
+                    sql: "UPDATE remote_session SET pinnedAt = ? WHERE provider = ? AND sessionID = ?",
+                    arguments: [pinnedAt, provider, sessionID])
+            } else {
+                try db.execute(
+                    sql: "UPDATE remote_session SET pinnedAt = NULL WHERE provider = ? AND sessionID = ? AND pinnedAt IS NOT NULL",
+                    arguments: [provider, sessionID])
+            }
             return db.changesCount > 0
         }
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -66,7 +66,8 @@ extension RPCRouter {
             guard let payload = row.decodedPayload else { return nil }
             return RemoteSessionInfo(provider: row.provider, payload: payload,
                                      gone: row.gone, dismissed: row.dismissed,
-                                     lastSeen: row.lastSeen, resolvedRepoID: row.resolvedRepoIDUUID)
+                                     lastSeen: row.lastSeen, resolvedRepoID: row.resolvedRepoIDUUID,
+                                     pinnedAt: row.pinnedAt)
         }
         return try RPCResponse(result: RemoteSessionsResult(sessions: sessions))
     }
@@ -234,6 +235,30 @@ extension RPCRouter {
         }
         let params = try decoder.decode(RemoteDismissParams.self, from: paramsData)
         let changed = try await db.remoteSessions.dismiss(provider: params.provider, sessionID: params.sessionID)
+        if changed {
+            subscriptions.broadcast(delta: .remoteSessionsChanged)
+        }
+        return .ok()
+    }
+
+    /// Pin or unpin a remote session for the sidebar dock. Local-only — it
+    /// touches the mirror row and never invokes a provider verb, so unlike
+    /// every handler above it needs no `RemoteProviderManager` (a session
+    /// whose provider has gone unhealthy, or whose row is already `gone`, can
+    /// still be unpinned). It still passes through `remoteGate()` because the
+    /// whole feature hides behind `config.remoteBackendsEnabled`.
+    ///
+    /// The timestamp is stamped HERE rather than by the client, so pin order
+    /// is server-assigned and consistent across clients — the same contract
+    /// `handleWorktreeSetPin` follows.
+    func handleRemoteSetPin(_ paramsData: Data) async throws -> RPCResponse {
+        guard try await remoteGate() != nil else {
+            return Self.remoteBackendsDisabledResponse
+        }
+        let params = try decoder.decode(RemoteSetPinParams.self, from: paramsData)
+        let changed = try await db.remoteSessions.setPinned(
+            provider: params.provider, sessionID: params.sessionID,
+            pinnedAt: params.pinned ? Date() : nil)
         if changed {
             subscriptions.broadcast(delta: .remoteSessionsChanged)
         }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -408,6 +408,8 @@ public final class RPCRouter: Sendable {
                 return try await handleRemoteRename(request.paramsData)
             case RPCMethod.remoteDismiss:
                 return try await handleRemoteDismiss(request.paramsData)
+            case RPCMethod.remoteSetPin:
+                return try await handleRemoteSetPin(request.paramsData)
             case RPCMethod.configSetRemoteBackends:
                 return try await handleConfigSetRemoteBackends(request.paramsData)
             case RPCMethod.gcList:

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -227,6 +227,7 @@ public enum RPCMethod {
     public static let remoteLog = "remote.log"
     public static let remoteRename = "remote.rename"
     public static let remoteDismiss = "remote.dismiss"
+    public static let remoteSetPin = "remote.setPin"
     public static let configSetRemoteBackends = "config.setRemoteBackends"
     public static let panelGet = "panel.get"
     public static let panelApply = "panel.apply"
@@ -1003,7 +1004,7 @@ public struct RemoteProvidersResult: Codable, Sendable {
 /// One row of the `remote.sessions` mirror — the provider-scoped payload
 /// plus the drift bookkeeping (`gone`/`dismissed`) the app needs to render
 /// (or hide) a stale session.
-public struct RemoteSessionInfo: Codable, Sendable, Identifiable {
+public struct RemoteSessionInfo: Codable, Sendable, Identifiable, Equatable {
     /// Stable synthetic identity for this mirror row — see
     /// `RemoteSessionIdentity`. ALWAYS recomputed from `provider`/
     /// `payload.id` rather than trusted off the wire (see `init(from:)`):
@@ -1026,17 +1027,26 @@ public struct RemoteSessionInfo: Codable, Sendable, Identifiable {
     /// keeps retrying resolution only while this stays nil. Once non-nil, it
     /// never changes, even if the provider's reported meta later does.
     public let resolvedRepoID: UUID?
+    /// When the user pinned this session to the sidebar's pinned dock, or nil
+    /// when it isn't pinned. Stamped daemon-side (`remote.setPin`) so pin
+    /// ORDER is server-assigned, exactly like `Worktree.pinnedAt`. Survives
+    /// app and daemon restarts because it lives on the mirror row, whose
+    /// primary key `(provider, sessionID)` is durable by contract.
+    /// `decodeIfPresent` so a payload from an older daemon still decodes.
+    public let pinnedAt: Date?
 
     public init(provider: String, payload: RemoteSessionPayload,
-                gone: Bool, dismissed: Bool, lastSeen: Date, resolvedRepoID: UUID? = nil) {
+                gone: Bool, dismissed: Bool, lastSeen: Date, resolvedRepoID: UUID? = nil,
+                pinnedAt: Date? = nil) {
         self.id = RemoteSessionIdentity.uuid(provider: provider, sessionID: payload.id)
         self.provider = provider; self.payload = payload
         self.gone = gone; self.dismissed = dismissed; self.lastSeen = lastSeen
         self.resolvedRepoID = resolvedRepoID
+        self.pinnedAt = pinnedAt
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, provider, payload, gone, dismissed, lastSeen, resolvedRepoID
+        case id, provider, payload, gone, dismissed, lastSeen, resolvedRepoID, pinnedAt
     }
 
     public init(from decoder: Decoder) throws {
@@ -1047,6 +1057,7 @@ public struct RemoteSessionInfo: Codable, Sendable, Identifiable {
         dismissed = try c.decode(Bool.self, forKey: .dismissed)
         lastSeen = try c.decode(Date.self, forKey: .lastSeen)
         resolvedRepoID = try c.decodeIfPresent(UUID.self, forKey: .resolvedRepoID)
+        pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
         // See the `id` doc comment — deliberately recomputed, never decoded.
         id = RemoteSessionIdentity.uuid(provider: provider, sessionID: payload.id)
     }
@@ -1104,6 +1115,20 @@ public struct RemoteDismissParams: Codable, Sendable {
     public let sessionID: String
     public init(provider: String, sessionID: String) {
         self.provider = provider; self.sessionID = sessionID
+    }
+}
+
+/// Pin or unpin a remote session for the sidebar dock. Purely local — no
+/// provider verb is involved, so this works for any provider regardless of
+/// declared capabilities, and for a `gone` row too. Mirrors
+/// `WorktreeSetPinParams`: the client only says whether it wants the pin on
+/// or off, and the daemon stamps `pinnedAt` so pin order is server-assigned.
+public struct RemoteSetPinParams: Codable, Sendable {
+    public let provider: String
+    public let sessionID: String
+    public let pinned: Bool
+    public init(provider: String, sessionID: String, pinned: Bool) {
+        self.provider = provider; self.sessionID = sessionID; self.pinned = pinned
     }
 }
 

--- a/Tests/TBDAppTests/PinnedDockContentTests.swift
+++ b/Tests/TBDAppTests/PinnedDockContentTests.swift
@@ -39,6 +39,18 @@ struct PinnedDockContentTests {
     /// and Swift 6 rejects it outright.
     private static let noChildren: @Sendable (UUID) -> [Worktree] = { _ in [] }
 
+    private static func remote(_ sessionID: String,
+                               provider: String = "prov",
+                               pinnedAt: Date? = nil,
+                               dismissed: Bool = false,
+                               gone: Bool = false,
+                               state: RemoteProcessState = .running) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider,
+            payload: RemoteSessionPayload(id: sessionID, state: state, agentState: .working),
+            gone: gone, dismissed: dismissed, lastSeen: at(0), pinnedAt: pinnedAt)
+    }
+
     // MARK: deskRow
 
     @Test("desk resolves only when the flag is on and mode is not off",
@@ -230,6 +242,105 @@ struct PinnedDockContentTests {
         let rows = PinnedDockContent.rows(allWorktrees: [newer, older],
                                           selectedIDs: [], children: Self.noChildren)
         #expect(rows.map(\.worktree.name) == ["older", "newer"])
+    }
+
+    // MARK: remoteRows
+
+    @Test("an unpinned remote session never reaches the dock")
+    func remoteUnpinnedExcluded() {
+        let rows = PinnedDockContent.remoteRows(
+            allRemoteSessions: [Self.remote("a"), Self.remote("b", pinnedAt: Self.at(0))])
+        #expect(rows.map(\.session.payload.id) == ["b"])
+    }
+
+    @Test("pinned remote sessions sort oldest-pin-first so a new pin appends")
+    func remotePinOrdering() {
+        let rows = PinnedDockContent.remoteRows(allRemoteSessions: [
+            Self.remote("a", pinnedAt: Self.at(30)),
+            Self.remote("b", pinnedAt: Self.at(10)),
+            Self.remote("c", pinnedAt: Self.at(20)),
+        ])
+        #expect(rows.map(\.session.payload.id) == ["b", "c", "a"])
+    }
+
+    /// Two pins landing on the same timestamp must not swap places between
+    /// renders — the sort has to be total, not merely stable-by-luck.
+    @Test("identical pin timestamps break the tie on (provider, sessionID)")
+    func remotePinTiesAreTotallyOrdered() {
+        let same = Self.at(5)
+        let sessions = [
+            Self.remote("z", provider: "alpha", pinnedAt: same),
+            Self.remote("a", provider: "beta", pinnedAt: same),
+            Self.remote("b", provider: "alpha", pinnedAt: same),
+        ]
+        let forward = PinnedDockContent.remoteRows(allRemoteSessions: sessions)
+        let reversed = PinnedDockContent.remoteRows(allRemoteSessions: sessions.reversed())
+        #expect(forward.map(\.id) == reversed.map(\.id))
+        #expect(forward.map(\.session.payload.id) == ["b", "z", "a"])
+    }
+
+    /// Dismiss means "get rid of it", so the row leaves the dock even if the
+    /// stored pin somehow survived (an older daemon that didn't clear the
+    /// column on dismiss).
+    @Test("a dismissed remote session leaves the dock even while pinned")
+    func remoteDismissedExcluded() {
+        let rows = PinnedDockContent.remoteRows(allRemoteSessions: [
+            Self.remote("a", pinnedAt: Self.at(0), dismissed: true),
+            Self.remote("b", pinnedAt: Self.at(10)),
+        ])
+        #expect(rows.map(\.session.payload.id) == ["b"])
+    }
+
+    /// The counterpart choice: a session the provider stopped reporting keeps
+    /// its slot (it self-heals when the provider lists it again) and renders
+    /// with `RemoteSessionRowView`'s existing dimmed styling.
+    @Test("a gone remote session keeps its pin and its dock slot")
+    func remoteGoneStaysPinned() {
+        let rows = PinnedDockContent.remoteRows(
+            allRemoteSessions: [Self.remote("a", pinnedAt: Self.at(0), gone: true)])
+        #expect(rows.map(\.session.payload.id) == ["a"])
+        #expect(rows[0].session.gone)
+    }
+
+    @Test("an exited remote session keeps its pin and its dock slot")
+    func remoteExitedStaysPinned() {
+        let rows = PinnedDockContent.remoteRows(
+            allRemoteSessions: [Self.remote("a", pinnedAt: Self.at(0), state: .exited)])
+        #expect(rows.map(\.session.payload.id) == ["a"])
+        #expect(rows[0].session.payload.state == .exited)
+    }
+
+    /// Two providers can mint the same session id; the dock rows must still
+    /// be distinct, because `List`/`ForEach` identity is the row `id`.
+    @Test("same session id on two providers yields two distinct dock rows")
+    func remoteRowsAreKeyedByProviderAndSession() {
+        let rows = PinnedDockContent.remoteRows(allRemoteSessions: [
+            Self.remote("dup", provider: "alpha", pinnedAt: Self.at(0)),
+            Self.remote("dup", provider: "beta", pinnedAt: Self.at(10)),
+        ])
+        #expect(rows.count == 2)
+        #expect(rows[0].id != rows[1].id)
+        #expect(rows[0].id == RemoteSessionIdentity.uuid(provider: "alpha", sessionID: "dup"))
+    }
+
+    @Test("no pinned remote sessions means no remote dock rows")
+    func remoteRowsEmpty() {
+        #expect(PinnedDockContent.remoteRows(allRemoteSessions: []).isEmpty)
+        #expect(PinnedDockContent.remoteRows(allRemoteSessions: [Self.remote("a")]).isEmpty)
+    }
+
+    /// Pinning a remote session must not disturb the worktree half of the
+    /// dock — the two groups are computed independently.
+    @Test("remote pins do not appear in, or reorder, the worktree rows")
+    func remoteAndWorktreePinsAreIndependent() {
+        let wtRows = PinnedDockContent.rows(
+            allWorktrees: [Self.wt("a", pinnedAt: Self.at(0)), Self.wt("b", pinnedAt: Self.at(10))],
+            selectedIDs: [], children: Self.noChildren)
+        #expect(wtRows.map(\.worktree.name) == ["a", "b"])
+        let remoteRows = PinnedDockContent.remoteRows(
+            allRemoteSessions: [Self.remote("r", pinnedAt: Self.at(5))])
+        #expect(remoteRows.map(\.session.payload.id) == ["r"])
+        #expect(wtRows.count == 2)   // the remote pin added no worktree row
     }
 
     // MARK: subtree

--- a/Tests/TBDAppTests/RemoteAppStateTests.swift
+++ b/Tests/TBDAppTests/RemoteAppStateTests.swift
@@ -15,6 +15,18 @@ import TBDShared
 /// coverage goes through the injectable `remoteProvidersFetcher` /
 /// `remoteSessionsFetcher` seams (same pattern as `daemonCapabilitiesFetcher`
 /// in `ModelProfileAppStateTests.swift`) rather than a live daemon.
+/// Records calls made through an injected `AppState` seam. A reference type
+/// because the seams are escaping closures — a captured local `var` can't be
+/// mutated from one.
+@MainActor
+private final class Recorder {
+    private var calls: [String] = []
+    func record(_ call: String) { calls.append(call) }
+    func snapshot() -> [String] { calls }
+}
+
+private enum TestPinError: Error { case boom }
+
 @MainActor
 @Suite("Remote backends — app state")
 struct RemoteAppStateTests {
@@ -451,6 +463,86 @@ struct RemoteAppStateTests {
 
             #expect(state.daemonCapabilities?.remoteBackendsEnabled == true,
                     "a transient refresh failure after a successful set must not snap the toggle off")
+        }
+    }
+
+    // MARK: - Sidebar-dock pin
+
+    private func session(_ id: String, provider: String = "acme",
+                         pinnedAt: Date? = nil) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider, payload: RemoteSessionPayload(id: id, state: .running),
+            gone: false, dismissed: false, lastSeen: Date(), pinnedAt: pinnedAt)
+    }
+
+    @Test func setRemoteSessionPinned_callsTheSetterAndRefreshes() async {
+        await withStateAsync { state in
+            let calls = Recorder()
+            state.remoteSessionPinSetter = { provider, sessionID, pinned in
+                calls.record("\(provider)/\(sessionID)/\(pinned)")
+            }
+            state.remoteProvidersFetcher = { RemoteProvidersResult(providers: []) }
+            state.remoteSessionsFetcher = {
+                RemoteSessionsResult(sessions: [self.session("s1", pinnedAt: Date())])
+            }
+
+            await state.setRemoteSessionPinned(provider: "acme", sessionID: "s1", pinned: true)
+
+            #expect(calls.snapshot() == ["acme/s1/true"])
+            // The refresh is what makes the dock reflect the new pin — the
+            // action deliberately does no optimistic local write.
+            #expect(state.remoteSessions.first?.pinnedAt != nil)
+        }
+    }
+
+    @Test func setRemoteSessionPinned_unpinPassesFalseThrough() async {
+        await withStateAsync { state in
+            let calls = Recorder()
+            state.remoteSessionPinSetter = { provider, sessionID, pinned in
+                calls.record("\(provider)/\(sessionID)/\(pinned)")
+            }
+            state.remoteProvidersFetcher = { RemoteProvidersResult(providers: []) }
+            state.remoteSessionsFetcher = { RemoteSessionsResult(sessions: [self.session("s1")]) }
+
+            await state.setRemoteSessionPinned(provider: "acme", sessionID: "s1", pinned: false)
+
+            #expect(calls.snapshot() == ["acme/s1/false"])
+            #expect(state.remoteSessions.first?.pinnedAt == nil)
+        }
+    }
+
+    /// A failed pin must not leave the UI claiming a pin that never landed —
+    /// there is no optimistic write to roll back, so the mirror is untouched.
+    @Test func setRemoteSessionPinned_failureLeavesTheMirrorUntouched() async {
+        await withStateAsync { state in
+            state.remoteSessions = [self.session("s1")]
+            state.remoteSessionPinSetter = { _, _, _ in throw TestPinError.boom }
+            var refreshed = false
+            state.remoteSessionsFetcher = {
+                refreshed = true
+                return RemoteSessionsResult(sessions: [])
+            }
+
+            await state.setRemoteSessionPinned(provider: "acme", sessionID: "s1", pinned: true)
+
+            #expect(refreshed == false, "a failed pin must not trigger the refresh")
+            #expect(state.remoteSessions.first?.pinnedAt == nil)
+        }
+    }
+
+    @Test func remoteSessionIsPinned_readsTheMirror() {
+        withState { state in
+            state.remoteSessions = [
+                self.session("pinned", pinnedAt: Date()),
+                self.session("plain"),
+                self.session("pinned", provider: "other"),
+            ]
+            #expect(state.remoteSessionIsPinned(provider: "acme", sessionID: "pinned"))
+            #expect(!state.remoteSessionIsPinned(provider: "acme", sessionID: "plain"))
+            // Same session id, different provider — pins are per-pair.
+            #expect(!state.remoteSessionIsPinned(provider: "other", sessionID: "pinned"))
+            // An unknown session is not pinned (and must not trap).
+            #expect(!state.remoteSessionIsPinned(provider: "acme", sessionID: "nope"))
         }
     }
 

--- a/Tests/TBDAppTests/RemoteSessionActionMenuTests.swift
+++ b/Tests/TBDAppTests/RemoteSessionActionMenuTests.swift
@@ -4,7 +4,7 @@ import Testing
 import TBDShared
 
 /// Task 10: pure composition of a remote-session row's context menu
-/// (`RemoteSessionActionMenu.items(capabilities:gone:)`). One test per
+/// (`RemoteSessionActionMenu.items(capabilities:gone:isPinned:)`). One test per
 /// capability gate branch, per repo policy for behavior-gating conditionals.
 @Suite("Remote session action menu — pure composition")
 struct RemoteSessionActionMenuTests {
@@ -21,17 +21,17 @@ struct RemoteSessionActionMenuTests {
     // MARK: - gone rows collapse, regardless of capabilities
 
     @Test func goneRowCollapsesToCopySessionIDAndDismiss() {
-        let items = RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: true)
-        #expect(kinds(items) == [.copySessionID, .dismiss])
+        let items = RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: true, isPinned: false)
+        #expect(kinds(items) == [.copySessionID, .pin, .dismiss])
     }
 
     @Test func goneRowCollapsesEvenWithNoCapabilities() {
-        let items = RemoteSessionActionMenu.items(capabilities: [], gone: true)
-        #expect(kinds(items) == [.copySessionID, .dismiss])
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: true, isPinned: false)
+        #expect(kinds(items) == [.copySessionID, .pin, .dismiss])
     }
 
     @Test func goneRowNeverIncludesRenameOrStop() {
-        let items = RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: true)
+        let items = RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: true, isPinned: false)
         let allKinds = Set(kinds(items).compactMap { $0 })
         #expect(!allKinds.contains(.rename))
         #expect(!allKinds.contains(.stop))
@@ -43,8 +43,8 @@ struct RemoteSessionActionMenuTests {
     // MARK: - live rows: base shape with no optional capabilities
 
     @Test func liveRowWithNoCapabilitiesShowsRenameCopyDividerStop() {
-        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false)
-        #expect(kinds(items) == [.rename, .copySessionID, nil, .stop])
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false, isPinned: false)
+        #expect(kinds(items) == [.rename, .copySessionID, .pin, nil, .stop])
         #expect(items.last == .action(RemoteSessionActionMenu.Action(
             kind: .stop, title: RemoteSessionActionMenu.stopLabel, role: .destructive)))
     }
@@ -52,40 +52,40 @@ struct RemoteSessionActionMenuTests {
     // MARK: - live rows: one capability gate at a time
 
     @Test func attachCapabilityAddsAttachItem() {
-        let items = RemoteSessionActionMenu.items(capabilities: ["attach"], gone: false)
-        #expect(kinds(items) == [.rename, .attach, .copySessionID, nil, .stop])
+        let items = RemoteSessionActionMenu.items(capabilities: ["attach"], gone: false, isPinned: false)
+        #expect(kinds(items) == [.rename, .attach, .copySessionID, .pin, nil, .stop])
     }
 
     @Test func attachCapabilityAbsentOmitsAttachItem() {
-        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false)
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false, isPinned: false)
         #expect(!kinds(items).contains(.attach))
     }
 
     @Test func logCapabilityAddsViewLogItem() {
-        let items = RemoteSessionActionMenu.items(capabilities: ["log"], gone: false)
-        #expect(kinds(items) == [.rename, .viewLog, .copySessionID, nil, .stop])
+        let items = RemoteSessionActionMenu.items(capabilities: ["log"], gone: false, isPinned: false)
+        #expect(kinds(items) == [.rename, .viewLog, .copySessionID, .pin, nil, .stop])
     }
 
     @Test func logCapabilityAbsentOmitsViewLogItem() {
-        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false)
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false, isPinned: false)
         #expect(!kinds(items).contains(.viewLog))
     }
 
     @Test func sendCapabilityAddsSendTextItem() {
-        let items = RemoteSessionActionMenu.items(capabilities: ["send"], gone: false)
-        #expect(kinds(items) == [.rename, .sendText, .copySessionID, nil, .stop])
+        let items = RemoteSessionActionMenu.items(capabilities: ["send"], gone: false, isPinned: false)
+        #expect(kinds(items) == [.rename, .sendText, .copySessionID, .pin, nil, .stop])
     }
 
     @Test func sendCapabilityAbsentOmitsSendTextItem() {
-        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false)
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false, isPinned: false)
         #expect(!kinds(items).contains(.sendText))
     }
 
     // MARK: - full capability set: exact order
 
     @Test func allCapabilitiesProduceTheFullOrderedMenu() {
-        let items = RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: false)
-        #expect(kinds(items) == [.rename, .attach, .viewLog, .sendText, .copySessionID, nil, .stop])
+        let items = RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: false, isPinned: false)
+        #expect(kinds(items) == [.rename, .attach, .viewLog, .sendText, .copySessionID, .pin, nil, .stop])
     }
 
     /// Items are omitted, never disabled — `RemoteSessionActionMenu` carries
@@ -95,17 +95,64 @@ struct RemoteSessionActionMenuTests {
     /// an extra guard against a future accidental "always append, gate
     /// visibility in the view" regression.
     @Test func itemCountMatchesExactlyTheDeclaredCapabilities() {
-        #expect(RemoteSessionActionMenu.items(capabilities: [], gone: false).count == 4) // rename, copy, divider, stop
-        #expect(RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: false).count == 7)
+        #expect(RemoteSessionActionMenu.items(capabilities: [], gone: false, isPinned: false).count == 5) // rename, copy, pin, divider, stop
+        #expect(RemoteSessionActionMenu.items(capabilities: ["attach", "log", "send"], gone: false, isPinned: false).count == 8)
     }
 
     // MARK: - unrecognized capability strings are ignored, not erroring
 
     @Test func unrecognizedCapabilityStringsAreIgnored() {
-        let items = RemoteSessionActionMenu.items(capabilities: ["events", "rename", "future-verb"], gone: false)
+        let items = RemoteSessionActionMenu.items(capabilities: ["events", "rename", "future-verb"], gone: false, isPinned: false)
         // `rename` (the capability) doesn't map to any menu item here — the
         // rename PUSH is handled entirely by `AppState.supportsRenamePush`,
         // not this menu; "Rename…" is always present regardless.
-        #expect(kinds(items) == [.rename, .copySessionID, nil, .stop])
+        #expect(kinds(items) == [.rename, .copySessionID, .pin, nil, .stop])
+    }
+
+    // MARK: - pin toggle: both branches, both row states
+
+    @Test func unpinnedLiveRowOffersPin() {
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false, isPinned: false)
+        #expect(kinds(items) == [.rename, .copySessionID, .pin, nil, .stop])
+        #expect(items.contains(.action(RemoteSessionActionMenu.Action(
+            kind: .pin, title: RemoteSessionActionMenu.pinLabel))))
+    }
+
+    @Test func pinnedLiveRowOffersUnpinInstead() {
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: false, isPinned: true)
+        #expect(kinds(items) == [.rename, .copySessionID, .unpin, nil, .stop])
+        #expect(items.contains(.action(RemoteSessionActionMenu.Action(
+            kind: .unpin, title: RemoteSessionActionMenu.unpinLabel))))
+    }
+
+    /// The whole point of carrying the toggle into the collapsed branch: a
+    /// pinned session that stops being reported must still be unpinnable
+    /// without dismissing it.
+    @Test func pinnedGoneRowStillOffersUnpin() {
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: true, isPinned: true)
+        #expect(kinds(items) == [.copySessionID, .unpin, .dismiss])
+    }
+
+    @Test func unpinnedGoneRowOffersPin() {
+        let items = RemoteSessionActionMenu.items(capabilities: [], gone: true, isPinned: false)
+        #expect(kinds(items) == [.copySessionID, .pin, .dismiss])
+    }
+
+    /// Pin is local-only — it needs no provider capability, so it appears
+    /// with an empty capability list and with a full one alike.
+    @Test func pinToggleIsNeverCapabilityGated() {
+        for capabilities in [[], ["attach", "log", "send"]] {
+            for gone in [true, false] {
+                let items = RemoteSessionActionMenu.items(
+                    capabilities: capabilities, gone: gone, isPinned: false)
+                #expect(kinds(items).contains(.pin))
+            }
+        }
+    }
+
+    /// A remote row and a worktree row must name the same dock the same way.
+    @Test func pinWordingMatchesTheWorktreeRowMenu() {
+        #expect(RemoteSessionActionMenu.pinLabel == RowActionMenu.pinLabel)
+        #expect(RemoteSessionActionMenu.unpinLabel == RowActionMenu.unpinLabel)
     }
 }

--- a/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
@@ -80,7 +80,8 @@ struct RPCRouterRemoteTests: ~Copyable {
     @Test func remoteVerbsErrorWhenFlagOff() async throws {
         let r = router(invoker: FakeProviderInvoker(script: []))
         for method in ["remote.providers", "remote.sessions", "remote.create",
-                       "remote.stop", "remote.send", "remote.log", "remote.rename", "remote.dismiss"] {
+                       "remote.stop", "remote.send", "remote.log", "remote.rename", "remote.dismiss",
+                       "remote.setPin"] {
             let response = await call(r, method,
                 #"{"provider": "fake", "sessionID": "x", "text": "t", "title": "t", "paramsJSON": "{}"}"#)
             #expect(response.success == false, "expected \(method) to be gated")
@@ -97,7 +98,8 @@ struct RPCRouterRemoteTests: ~Copyable {
         try await db.config.setRemoteBackendsEnabled(true)
         let r = router(manager: nil)
         for method in ["remote.providers", "remote.sessions", "remote.create",
-                       "remote.stop", "remote.send", "remote.log", "remote.rename", "remote.dismiss"] {
+                       "remote.stop", "remote.send", "remote.log", "remote.rename", "remote.dismiss",
+                       "remote.setPin"] {
             let response = await call(r, method,
                 #"{"provider": "fake", "sessionID": "x", "text": "t", "title": "t", "paramsJSON": "{}"}"#)
             #expect(response.success == false, "expected \(method) to be gated")
@@ -406,6 +408,100 @@ struct RPCRouterRemoteTests: ~Copyable {
             return false
         }
         #expect(changeBroadcasts.isEmpty)
+    }
+
+    @Test func setPinStampsPinnedAtAndBroadcastsChange() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake", sessions: [RemoteSessionPayload(id: "a", state: .running)], now: Date())
+        let deltas = BroadcastDeltas()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let r = router(invoker: FakeProviderInvoker(script: []))
+        let before = Date()
+        let response = await call(r, "remote.setPin",
+            #"{"provider": "fake", "sessionID": "a", "pinned": true}"#)
+        #expect(response.success)
+        // Stamped daemon-side, not supplied by the client — the timestamp
+        // must land inside the window this call spanned.
+        let pinnedAt = try #require(try await db.remoteSessions.list().first?.pinnedAt)
+        #expect(pinnedAt >= before && pinnedAt <= Date())
+        let changeBroadcasts = deltas.snapshot().filter {
+            if case .remoteSessionsChanged = $0 { return true }
+            return false
+        }
+        #expect(changeBroadcasts.count == 1, "pinning must broadcast a change delta")
+    }
+
+    @Test func setPinUnpinsAndSurfacesPinnedAtOverTheWire() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake", sessions: [RemoteSessionPayload(id: "a", state: .running)], now: Date())
+        let r = router(invoker: FakeProviderInvoker(script: []))
+        #expect(await call(r, "remote.setPin", #"{"provider": "fake", "sessionID": "a", "pinned": true}"#).success)
+
+        var sessions = try (await call(r, "remote.sessions")).decodeResult(RemoteSessionsResult.self).sessions
+        #expect(sessions.first?.pinnedAt != nil, "remote.sessions must carry the pin to the app")
+
+        #expect(await call(r, "remote.setPin", #"{"provider": "fake", "sessionID": "a", "pinned": false}"#).success)
+        sessions = try (await call(r, "remote.sessions")).decodeResult(RemoteSessionsResult.self).sessions
+        #expect(sessions.first?.pinnedAt == nil)
+    }
+
+    /// Same `changed`-gated broadcast contract `remote.dismiss` follows.
+    @Test func setPinDoesNotBroadcastWhenNothingChanged() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let deltas = BroadcastDeltas()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let r = router(invoker: FakeProviderInvoker(script: []))
+        let response = await call(r, "remote.setPin",
+            #"{"provider": "fake", "sessionID": "nonexistent", "pinned": true}"#)
+        #expect(response.success)
+        let changeBroadcasts = deltas.snapshot().filter {
+            if case .remoteSessionsChanged = $0 { return true }
+            return false
+        }
+        #expect(changeBroadcasts.isEmpty)
+    }
+
+    /// Pinning is local-only, so unlike every other `remote.*` verb it needs
+    /// no `RemoteProviderManager` to reach the DB — but it stays behind the
+    /// same feature flag, in both of the gate's two failure modes.
+    @Test func setPinIsGatedByTheFlagInBothModes() async throws {
+        let params = #"{"provider": "fake", "sessionID": "x", "pinned": true}"#
+        let flagOff = await call(router(invoker: FakeProviderInvoker(script: [])), "remote.setPin", params)
+        #expect(flagOff.success == false)
+        #expect(flagOff.error == "remote backends disabled")
+
+        try await db.config.setRemoteBackendsEnabled(true)
+        let noManager = await call(router(manager: nil), "remote.setPin", params)
+        #expect(noManager.success == false)
+        #expect(noManager.error == "remote backends disabled")
+    }
+
+    /// A pinned session the provider stopped reporting must still be
+    /// unpinnable — no provider verb is involved, so `gone` is irrelevant.
+    @Test func setPinWorksOnAGoneRow() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake", sessions: [RemoteSessionPayload(id: "a", state: .running)], now: Date())
+        let r = router(invoker: FakeProviderInvoker(script: []))
+        #expect(await call(r, "remote.setPin", #"{"provider": "fake", "sessionID": "a", "pinned": true}"#).success)
+        _ = try await db.remoteSessions.markGone(provider: "fake", sessionID: "a")
+
+        #expect(await call(r, "remote.setPin", #"{"provider": "fake", "sessionID": "a", "pinned": false}"#).success)
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.first?.gone == true)
+        #expect(rows.first?.pinnedAt == nil)
     }
 
     @Test func configToggleRoundTrips() async throws {

--- a/Tests/TBDDaemonTests/RemoteSessionStoreTests.swift
+++ b/Tests/TBDDaemonTests/RemoteSessionStoreTests.swift
@@ -83,6 +83,93 @@ struct RemoteSessionStoreTests {
         #expect(second == false)
     }
 
+    // MARK: - Sidebar-dock pin
+
+    @Test func setPinnedStampsAndClearsPinnedAt() async throws {
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [payload("a")], now: Date())
+        var rows = try await db.remoteSessions.list()
+        #expect(rows[0].pinnedAt == nil, "a freshly mirrored session is never pinned")
+
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let pinned = try await db.remoteSessions.setPinned(provider: "p", sessionID: "a", pinnedAt: stamp)
+        #expect(pinned)
+        rows = try await db.remoteSessions.list()
+        #expect(rows[0].pinnedAt == stamp)
+
+        let unpinned = try await db.remoteSessions.setPinned(provider: "p", sessionID: "a", pinnedAt: nil)
+        #expect(unpinned)
+        rows = try await db.remoteSessions.list()
+        #expect(rows[0].pinnedAt == nil)
+    }
+
+    /// Both no-op branches of the `changed` contract: unpinning something
+    /// that was never pinned, and pinning a session that isn't mirrored.
+    @Test func setPinnedReportsNoChangeWhenThereIsNothingToChange() async throws {
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [payload("a")], now: Date())
+        let unpinUnpinned = try await db.remoteSessions.setPinned(
+            provider: "p", sessionID: "a", pinnedAt: nil)
+        #expect(unpinUnpinned == false)
+        let unknown = try await db.remoteSessions.setPinned(
+            provider: "p", sessionID: "nope", pinnedAt: Date())
+        #expect(unknown == false)
+    }
+
+    /// The whole point of storing the pin on the mirror row: a pin has to
+    /// outlive ordinary provider churn. A session that goes absent twice
+    /// (gone), then comes back, keeps its pin the entire way through.
+    @Test func pinSurvivesSnapshotChurnIncludingGoneAndReappearance() async throws {
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [payload("a")], now: Date())
+        _ = try await db.remoteSessions.setPinned(provider: "p", sessionID: "a", pinnedAt: Date())
+
+        // Ordinary re-poll with changed agent state.
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "p", sessions: [payload("a", agent: .waitingInput)], now: Date())
+        #expect(try await db.remoteSessions.list()[0].pinnedAt != nil)
+
+        // Two absences → gone. The pin must not be collateral damage.
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [], now: Date())
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [], now: Date())
+        var rows = try await db.remoteSessions.list()
+        #expect(rows[0].gone)
+        #expect(rows[0].pinnedAt != nil)
+
+        // Reappears → still pinned, still in the dock.
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [payload("a")], now: Date())
+        rows = try await db.remoteSessions.list()
+        #expect(rows[0].gone == false)
+        #expect(rows[0].pinnedAt != nil)
+    }
+
+    @Test func pinSurvivesAnEventDrivenUpsertOne() async throws {
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [payload("a")], now: Date())
+        _ = try await db.remoteSessions.setPinned(provider: "p", sessionID: "a", pinnedAt: Date())
+        _ = try await db.remoteSessions.upsertOne(
+            provider: "p", session: payload("a", agent: .waitingInput), now: Date())
+        #expect(try await db.remoteSessions.list()[0].pinnedAt != nil)
+    }
+
+    /// Dismiss means "get rid of it", so it drops the pin in the same
+    /// statement — a dismissed row must not keep an invisible pin that would
+    /// resurrect it in the dock.
+    @Test func dismissClearsThePin() async throws {
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [payload("a")], now: Date())
+        _ = try await db.remoteSessions.setPinned(provider: "p", sessionID: "a", pinnedAt: Date())
+        #expect(try await db.remoteSessions.dismiss(provider: "p", sessionID: "a"))
+        let rows = try await db.remoteSessions.list()
+        #expect(rows[0].dismissed)
+        #expect(rows[0].pinnedAt == nil)
+    }
+
+    @Test func pinsAreScopedToOneProviderSessionPair() async throws {
+        _ = try await db.remoteSessions.applySnapshot(provider: "p", sessions: [payload("a"), payload("b")], now: Date())
+        _ = try await db.remoteSessions.applySnapshot(provider: "q", sessions: [payload("a")], now: Date())
+        _ = try await db.remoteSessions.setPinned(provider: "p", sessionID: "a", pinnedAt: Date())
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.first { $0.provider == "p" && $0.sessionID == "a" }?.pinnedAt != nil)
+        #expect(rows.first { $0.provider == "p" && $0.sessionID == "b" }?.pinnedAt == nil)
+        #expect(rows.first { $0.provider == "q" && $0.sessionID == "a" }?.pinnedAt == nil)
+    }
+
     @Test func upsertOneAppliesEdgeDetectionWithoutTouchingOtherRows() async throws {
         _ = try await db.remoteSessions.applySnapshot(
             provider: "p", sessions: [payload("a"), payload("b")], now: Date())

--- a/Tests/TBDSharedTests/RemoteProviderTests.swift
+++ b/Tests/TBDSharedTests/RemoteProviderTests.swift
@@ -169,4 +169,38 @@ struct RemoteProviderTests {
         let decoded = try decoder.decode(RemoteSessionInfo.self, from: try encoder.encode(info))
         #expect(decoded.resolvedRepoID == repoID)
     }
+
+    // MARK: - RemoteSessionInfo — pinnedAt wire defaults
+
+    /// A payload from a daemon predating the dock pin must decode with the
+    /// session simply unpinned, not fail.
+    @Test func sessionInfoDecodesWhenPinnedAtIsAbsent() throws {
+        let json = """
+        {"provider": "acme", "payload": {"id": "s1", "state": "running"},
+         "gone": false, "dismissed": false, "lastSeen": \(Date().timeIntervalSinceReferenceDate)}
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .deferredToDate
+        let info = try decoder.decode(RemoteSessionInfo.self, from: json)
+        #expect(info.pinnedAt == nil)
+    }
+
+    @Test func sessionInfoRoundTripsPinnedAt() throws {
+        let pinnedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let info = RemoteSessionInfo(
+            provider: "acme", payload: RemoteSessionPayload(id: "s1", state: .running),
+            gone: false, dismissed: false, lastSeen: Date(), pinnedAt: pinnedAt)
+        let decoded = try JSONDecoder().decode(
+            RemoteSessionInfo.self, from: try JSONEncoder().encode(info))
+        #expect(decoded.pinnedAt == pinnedAt)
+    }
+
+    @Test func setPinParamsRoundTrip() throws {
+        let params = RemoteSetPinParams(provider: "acme", sessionID: "s1", pinned: true)
+        let decoded = try JSONDecoder().decode(
+            RemoteSetPinParams.self, from: try JSONEncoder().encode(params))
+        #expect(decoded.provider == "acme")
+        #expect(decoded.sessionID == "s1")
+        #expect(decoded.pinned)
+    }
 }


### PR DESCRIPTION
## What you get

Right-click a remote session → **Pin to dock**. It shows up in the sidebar's bottom pinned dock, alongside your pinned worktrees, and stays there across app and daemon restarts. Clicking it selects the session exactly as its row in the remote section does; the dock row is literally the same `RemoteSessionRowView`, so the globe icon, agent-state suffix, working dots, captions, rename and the rest come along unchanged. **Unpin from dock** is on both the section row's menu and the dock row's menu.

## Persistence design

A `pinnedAt` timestamp on the mirror row — the direct analogue of `Worktree.pinnedAt`.

- **Migration `v65_remote_session_pinned_at`** adds a nullable `pinnedAt` to `remote_session`, no default and no backfill (same reasoning `v63` gives for `worktree.pinnedAt`: existing rows must land on NULL, and there's no Swift-side default to flip later, so the `ADD COLUMN … DEFAULT` trap doesn't apply). `RemoteSessionRow` and `RemoteSessionInfo` both carry it; the wire field is `decodeIfPresent`, so a payload from a daemon predating this still decodes as unpinned.
- **`remote.setPin`** is a new RPC that stamps the timestamp **daemon-side**, so pin order is server-assigned and consistent across clients — the contract `worktree.setPin` already follows. It's the one `remote.*` verb that invokes no provider subprocess (it only touches the mirror), so it needs no `RemoteProviderManager` and no declared capability, but it still sits behind the `remoteBackendsEnabled` flag like everything else in the feature.
- **The pin survives the row's realistic lifecycle.** It's keyed by the mirror row's primary key `(provider, sessionID)`, which the provider contract already requires to be durable, and mirror rows are never deleted — only marked `gone`/`dismissed`. `RemoteSessionStore.upsert` mutates and updates the row it read rather than reconstructing it, so ordinary polling, an `events`-driven `upsertOne`, going `gone` after two absences, and reappearing afterwards all preserve the pin. There's a test walking that whole sequence.

No feature flag: this is additive UI plus one persisted nullable column, and the whole surface is already behind the default-off `remoteBackendsEnabled` switch. The migration does trip the "blast-radius work starts with a spec" trigger, but adding a nullable presentational column to an existing table alongside an existing, specced pinning mechanism (`docs/specs/2026-07-26-pinned-worktree-dock-design.md`) didn't warrant its own brainstorm.

## Lifecycle choices

| Event | Behaviour | Why |
|---|---|---|
| **Dismissed** | Unpinned | Dismiss means "get rid of it". `RemoteSessionStore.dismiss` clears `pinnedAt` in the *same* UPDATE so the two can't diverge, and `PinnedDockContent.remoteRows` also filters `dismissed` so rendering is correct regardless (e.g. a row dismissed by an older daemon). |
| **`gone`** (dropped from two provider snapshots) | Keeps its pin and its dock slot | `gone` self-heals — the flag clears the moment the provider lists the session again — so evicting the row would silently lose a pin over a transport flake. It renders with `RemoteSessionRowView`'s existing 0.5 opacity + "no longer reported" caption. Pin/Unpin is carried into the `gone` row's collapsed context menu precisely so a stranded pin is removable without dismissing. |
| **`exited`** | Keeps its pin | Still the thing the user pinned; renders with the existing secondary/"exited (code N)" styling. |

## Ordering / reorder

Remote pins render as a group **below** the worktree pins, in `pinnedAt` order (oldest first, so a new pin appends), ties broken on `(provider, sessionID)` so the order is total.

**Drag-reorder stays worktree-only** — deliberate punt, and the diff-balloon tradeoff the alternative implies. `.onMove`'s offsets index its own `ForEach`'s elements, and only worktrees carry a persisted `pinSortOrder` to drag against; folding remote rows into the movable `ForEach` would make every drag index ambiguous, and giving remote sessions their own sort-order column plus a `remote.reorderPins` RPC is a bigger change than the ask. Grouping also keeps dock order predictable: "the worktrees you arranged, then the remote sessions in the order you pinned them."

## Test coverage

19 files, ~800 lines. Every new gating conditional has a test per branch.

- **`PinnedDockContentTests`** (extended, as asked): unpinned excluded; oldest-pin-first ordering; identical-timestamp ties are totally ordered (same result from a reversed input); dismissed excluded even while pinned; `gone` kept; `exited` kept; same session id on two providers yields two distinct rows; empty cases; remote pins neither appear in nor reorder the worktree rows.
- **`RemoteSessionActionMenuTests`**: pinned vs unpinned on a live row, pinned vs unpinned on a `gone` row, the toggle is never capability-gated (cross-product of capability sets × `gone`), and a fence asserting the labels equal `RowActionMenu`'s.
- **`RemoteSessionStoreTests`**: stamp/clear round-trip; both no-change branches; the pin surviving snapshot churn → `gone` → reappearance; surviving `upsertOne`; dismiss clearing the pin; pins scoped to one `(provider, sessionID)` pair.
- **`RPCRouterRemoteTests`**: the timestamp lands inside the call's window (proving it's daemon-stamped); `remote.sessions` carries the pin to the app; broadcast fires once on change and not at all on a no-op; the flag gate in both of its modes; unpinning a `gone` row.
- **`RemoteAppStateTests`**: the setter is called with the right arguments for pin and unpin, the refresh follows, a failed pin does neither, and `remoteSessionIsPinned` reads the mirror per-pair.
- **`RemoteProviderTests`**: `pinnedAt` absent from the wire decodes as unpinned; round-trips when present; `RemoteSetPinParams` round-trips.

Clean-env `swift build` and `swift test` both run: 4415 tests, and the only failures are the pre-existing ones that need `tmux` on PATH or git-identity fixtures (control-mode/tmux supervisor suites, `GitManager`, `ScratchPromote*`) — untouched by this change. All 320 tests in the affected suites pass.

Not exercised live: the feature sits behind the default-off `remoteBackendsEnabled` switch and needs a registered provider, and this branch was built from the main checkout, where restarting the daemon would disturb the running app.
