### PR TITLE
Fix: New worktrees open on the Notes tab instead of the agent

### DIFF
--- a/Sources/TBDApp/AppState+Notifications.swift
+++ b/Sources/TBDApp/AppState+Notifications.swift
@@ -75,14 +75,28 @@ extension AppState {
 
     // MARK: - Helpers
 
+    /// Whether an error means "the daemon is gone" rather than "this one call
+    /// failed". Only these two cases stop the poll timer; every other
+    /// `DaemonClientError` — a decode failure, an RPC-level rejection, a
+    /// timeout — leaves the app connected and the ~2s poll running, so the
+    /// caller keeps being re-driven.
+    ///
+    /// Shared so retry budgets and the connection flag cannot disagree about
+    /// what counts as a disconnect: a budget that forgave *every* error would
+    /// never bite on the persistent per-worktree failures this does not cover.
+    static func isDisconnectError(_ error: Error) -> Bool {
+        guard let dcError = error as? DaemonClientError else { return false }
+        switch dcError {
+        case .daemonNotRunning, .connectionFailed:
+            return true
+        default:
+            return false
+        }
+    }
+
     func handleConnectionError(_ error: Error) {
-        if let dcError = error as? DaemonClientError {
-            switch dcError {
-            case .daemonNotRunning, .connectionFailed:
-                isConnected = false
-            default:
-                break
-            }
+        if Self.isDisconnectError(error) {
+            isConnected = false
         }
     }
 

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -10,40 +10,198 @@ enum DropEdge: Sendable, Equatable {
     case leading, trailing
 }
 
+/// What the active selection should follow when `applyStoredOrder` re-points it.
+///
+/// A bare `UUID?` cannot express this: it conflates "the caller omitted an
+/// anchor, derive one" with "the caller captured no valid pre-mutation
+/// selection". Those need opposite handling — deriving after a mutation reads
+/// the already-mutated array, where a stale index has silently re-bound to
+/// whatever slid into its slot (the note tab is last, so usually Notes), and
+/// pinning that would hand the resolver an arbitrary tab it then honours as a
+/// deliberate choice.
+enum ActiveTabAnchor: Sendable, Equatable {
+    /// Derive the anchor from the current selection. Correct only for a pure
+    /// reorder — i.e. when no tab has been added or removed since that
+    /// selection was made.
+    case derive
+    /// Follow this tab id, captured BEFORE the caller mutated the array. `nil`
+    /// means there was no explicit selection to preserve, and the selection is
+    /// cleared so `resolvedActiveTabIndex`'s default applies.
+    case pinned(UUID?)
+}
+
 extension AppState {
+
+    // MARK: - Active tab resolution
+
+    /// The tab index a worktree should display: the stored selection when it is
+    /// still in range, otherwise the FIRST non-note tab, otherwise 0.
+    ///
+    /// Single source of truth for "which tab is showing". Every read of
+    /// `activeTabIndices` that used to spell its own `?? 0` / `min(idx, count - 1)`
+    /// fallback routes through here, because those spellings disagreed: a stale or
+    /// oversized index clamped to `count - 1`, and the daemon appends a worktree's
+    /// note tab LAST, so the clamp landed on Notes for every freshly-created
+    /// worktree. Falling forward to the first non-note tab instead lands on the
+    /// agent — matching the daemon's own "active = primary" default — while a
+    /// note-only worktree still shows its note at index 0.
+    ///
+    /// Never overrides a deliberate selection: an in-range stored index is
+    /// returned as-is, note tab or not. Returns 0 for an empty tab array;
+    /// callers must guard on `isEmpty` before indexing.
+    func resolvedActiveTabIndex(worktreeID: UUID) -> Int {
+        let arr = tabs[worktreeID] ?? []
+        guard !arr.isEmpty else { return 0 }
+        if let stored = activeTabIndices[worktreeID], arr.indices.contains(stored) {
+            return stored
+        }
+        return arr.firstIndex { tab in
+            if case .note = tab.content { return false }
+            return true
+        } ?? 0
+    }
+
+    /// The tab a worktree should display, or nil when it has no tabs.
+    func resolvedActiveTab(worktreeID: UUID) -> TBDShared.Tab? {
+        let arr = tabs[worktreeID] ?? []
+        guard !arr.isEmpty else { return nil }
+        return arr[resolvedActiveTabIndex(worktreeID: worktreeID)]
+    }
+
+    /// The tab.id of the worktree's EXPLICIT selection — nil when nothing is
+    /// selected or the stored index is out of range. Deliberately does not fall
+    /// back to `resolvedActiveTabIndex`: this is the identity a mutation must
+    /// preserve, and "no explicit selection" has to stay "no explicit
+    /// selection" so the resolver's default keeps applying dynamically.
+    func explicitActiveTabID(worktreeID: UUID) -> UUID? {
+        guard let arr = tabs[worktreeID],
+              let idx = activeTabIndices[worktreeID],
+              arr.indices.contains(idx) else { return nil }
+        return arr[idx].id
+    }
+
+    /// Re-point the stored active index at `tabID`'s CURRENT position after a
+    /// mutation of `tabs[worktreeID]`. A nil `tabID` — or one that no longer
+    /// exists — clears the entry rather than leaving a stale index behind, so
+    /// `resolvedActiveTabIndex`'s first-non-note default takes over instead of a
+    /// clamp that would land on the trailing note tab.
+    ///
+    /// Writes nothing when the entry already holds the right value — every
+    /// write to `activeTabIndices` publishes an `AppState.objectWillChange`.
+    func repointActiveTab(worktreeID: UUID, to tabID: UUID?) {
+        guard let tabID,
+              let newIdx = tabs[worktreeID]?.firstIndex(where: { $0.id == tabID }) else {
+            if activeTabIndices[worktreeID] != nil {
+                activeTabIndices.removeValue(forKey: worktreeID)
+            }
+            return
+        }
+        if activeTabIndices[worktreeID] != newIdx {
+            activeTabIndices[worktreeID] = newIdx
+        }
+    }
 
     // MARK: - Tab metadata loading
 
+    /// Fetch a worktree's persisted tab state, unless it is already hydrated, a
+    /// fetch is already in flight, or the attempt budget is spent.
+    ///
+    /// The retry this gates exists for one narrow window: the daemon inserts a
+    /// new worktree's terminal rows *before* it persists tab order / active
+    /// tab, so a poll landing in between answers `[]` + nil and the worktree is
+    /// stranded with no stored order and no hydrated selection. One retry
+    /// always suffices in practice — the daemon writes milliseconds later and
+    /// the terminal poll is ~2s.
+    ///
+    /// Three guards, because `reconcileTabs` (the only caller) runs on every
+    /// terminal-list change and `Terminal` compares unequal whenever an agent's
+    /// `activityState` flips, i.e. constantly:
+    ///
+    /// - **hydrated** — the success latch; nothing more to fetch.
+    /// - **in flight** — overlapping reconciles must not stack `Task`s for the
+    ///   same worktree.
+    /// - **attempt cap** — a worktree whose tab state is legitimately and
+    ///   permanently empty (bare `main` rows exist in the wild), or whose
+    ///   `listTabs` fails the same way every time, would otherwise re-fire the
+    ///   RPC forever, with no backoff. `loadTabStates` refunds the attempt only
+    ///   for a disconnect (see its `catch`), so a persistent per-worktree error
+    ///   still spends the budget and stops.
+    func scheduleTabStateHydration(worktreeID: UUID) {
+        guard !tabStateHydratedWorktreeIDs.contains(worktreeID),
+              !tabStateFetchesInFlight.contains(worktreeID),
+              tabStateFetchAttempts[worktreeID, default: 0] < Self.maxTabStateHydrationAttempts
+        else { return }
+        tabStateFetchAttempts[worktreeID, default: 0] += 1
+        tabStateFetchesInFlight.insert(worktreeID)
+        Task { await loadTabStates(worktreeID: worktreeID) }
+    }
+
     /// Pull stored label overrides and tab order from the daemon for a worktree.
     /// Called the first time a worktree's tabs appear in memory.
+    ///
+    /// Every state write below is guarded on an actual change: this runs on a
+    /// retry path, and an unconditional `@Published` write fires a full
+    /// `AppState.objectWillChange` for a response that changed nothing.
     func loadTabStates(worktreeID: UUID) async {
         do {
-            let response = try await daemonClient.listTabs(worktreeID: worktreeID)
-            worktreeTabOrders[worktreeID] = response.order
+            let response = try await tabStatesFetcher(worktreeID)
+            if worktreeTabOrders[worktreeID] != response.order {
+                worktreeTabOrders[worktreeID] = response.order
+            }
+            // Only a response that actually carried persisted state counts as
+            // hydrated. A poll landing between the daemon inserting the terminal
+            // rows and persisting tab order / active tab answers `[]` + nil; the
+            // re-fetch gate in `scheduleTabStateHydration` keeps retrying (up to
+            // its cap) until the daemon has written something, and stops once it
+            // has (see `tabStateHydratedWorktreeIDs`).
+            if !response.order.isEmpty || response.activeTabID != nil {
+                tabStateHydratedWorktreeIDs.insert(worktreeID)
+            }
             // Apply stored labels to any in-memory tabs that already exist.
             if var arr = tabs[worktreeID] {
                 let labelByID = Dictionary(uniqueKeysWithValues: response.tabs.map { ($0.id, $0.label) })
+                var changed = false
                 for i in arr.indices {
-                    if let label = labelByID[arr[i].id] {
-                        arr[i].label = label
-                    }
+                    guard let label = labelByID[arr[i].id], arr[i].label != label else { continue }
+                    arr[i].label = label
+                    changed = true
                 }
-                tabs[worktreeID] = arr
+                if changed {
+                    tabs[worktreeID] = arr
+                }
                 applyStoredOrder(worktreeID: worktreeID)
             }
             // Hydrate the persisted active tab. Must run AFTER applyStoredOrder
             // so the resolved index reflects the persisted order. If the stored
             // ID no longer exists (tab was deleted), gracefully fall through and
-            // leave activeTabIndices unchanged (defaults to 0 at the view layer).
+            // leave activeTabIndices unchanged (the view layer then shows the
+            // first non-note tab via `resolvedActiveTabIndex`).
             if let activeID = response.activeTabID,
                let arr = tabs[worktreeID],
-               let idx = arr.firstIndex(where: { $0.id == activeID }) {
+               let idx = arr.firstIndex(where: { $0.id == activeID }),
+               activeTabIndices[worktreeID] != idx {
                 activeTabIndices[worktreeID] = idx
             }
         } catch {
+            // Only a DISCONNECT is refunded. It says nothing about whether the
+            // daemon has written yet, the poll that would retry is stopped
+            // anyway (`handleConnectionError` clears `isConnected`), and
+            // burning the budget would strand the worktree for the session.
+            //
+            // Every other error consumes budget, and must: a decode failure or
+            // a per-worktree RPC rejection repeats deterministically while
+            // `isConnected` stays set, so the ~2s poll keeps driving
+            // `refreshWorktrees` -> `reconcileTabs` -> here. Refunding those
+            // would re-fire `listTabs` every poll, forever, with no backoff —
+            // the exact storm the cap exists to prevent.
+            if Self.isDisconnectError(error),
+               let spent = tabStateFetchAttempts[worktreeID], spent > 0 {
+                tabStateFetchAttempts[worktreeID] = spent - 1
+            }
             logger.error("loadTabStates failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
             handleConnectionError(error)
         }
+        tabStateFetchesInFlight.remove(worktreeID)
         // Gated one-shot legacy panel import (spec C §11.2) — fires at most
         // once per launch regardless of whether this particular listTabs
         // call succeeded, since it imports from AppState's already-loaded
@@ -87,31 +245,44 @@ extension AppState {
     /// Sort `tabs[worktreeID]` against `worktreeTabOrders[worktreeID]`. Unknown
     /// tab IDs (e.g. newly-created since last save) go to the end, preserving
     /// their current relative order.
-    func applyStoredOrder(worktreeID: UUID) {
-        guard let storedOrder = worktreeTabOrders[worktreeID], !storedOrder.isEmpty,
-              var arr = tabs[worktreeID] else { return }
-        let storedIndex = Dictionary(uniqueKeysWithValues: storedOrder.enumerated().map { ($1, $0) })
-        // Capture which tab.id is currently active so we can re-point activeTabIndices.
-        let activeID: UUID? = activeTabIndices[worktreeID].flatMap { idx in
-            arr.indices.contains(idx) ? arr[idx].id : nil
+    ///
+    /// `anchor` says which tab the selection must follow. Callers that have just
+    /// ADDED or REMOVED tabs pass `.pinned(id)` with the id they captured from
+    /// the array BEFORE mutating it — including `.pinned(nil)` when there was no
+    /// valid selection to capture. `.derive` reads the live array and is correct
+    /// only for a pure reorder; using it after a mutation would read the
+    /// already-mutated array, where the stored index has silently re-bound to
+    /// whatever slid into that slot (with the note tab last, usually Notes).
+    func applyStoredOrder(worktreeID: UUID, anchor: ActiveTabAnchor = .derive) {
+        let followID: UUID?
+        switch anchor {
+        case .derive: followID = explicitActiveTabID(worktreeID: worktreeID)
+        case .pinned(let id): followID = id
         }
-        // Stable sort: known first (by stored position), unknown after (in input order).
-        // Use enumerated original index as a tiebreaker so unknown tabs keep their input order.
-        let withIndex = arr.enumerated().map { (origIdx: $0.offset, tab: $0.element) }
-        let sorted = withIndex.sorted { a, b in
-            switch (storedIndex[a.tab.id], storedIndex[b.tab.id]) {
-            case let (ai?, bi?): return ai < bi
-            case (_?, nil):      return true
-            case (nil, _?):      return false
-            case (nil, nil):     return a.origIdx < b.origIdx
+        if let storedOrder = worktreeTabOrders[worktreeID], !storedOrder.isEmpty,
+           let arr = tabs[worktreeID] {
+            let storedIndex = Dictionary(uniqueKeysWithValues: storedOrder.enumerated().map { ($1, $0) })
+            // Stable sort: known first (by stored position), unknown after (in input order).
+            // Use enumerated original index as a tiebreaker so unknown tabs keep their input order.
+            let withIndex = arr.enumerated().map { (origIdx: $0.offset, tab: $0.element) }
+            let sorted = withIndex.sorted { a, b in
+                switch (storedIndex[a.tab.id], storedIndex[b.tab.id]) {
+                case let (ai?, bi?): return ai < bi
+                case (_?, nil):      return true
+                case (nil, _?):      return false
+                case (nil, nil):     return a.origIdx < b.origIdx
+                }
+            }
+            let reordered = sorted.map(\.tab)
+            if arr != reordered {
+                tabs[worktreeID] = reordered
             }
         }
-        arr = sorted.map(\.tab)
-        tabs[worktreeID] = arr
-        // Keep active index pointing at the same tab.id.
-        if let activeID, let newIdx = arr.firstIndex(where: { $0.id == activeID }) {
-            activeTabIndices[worktreeID] = newIdx
-        }
+        // Keep the active index pointing at the same tab.id — outside the sort
+        // branch, because a caller that just mutated the array still needs the
+        // re-point when nothing is persisted yet (the daemon writes tab order
+        // after it inserts the terminal rows).
+        repointActiveTab(worktreeID: worktreeID, to: followID)
     }
 
     // MARK: - Rename
@@ -162,6 +333,17 @@ extension AppState {
             return
         }
 
+        // Whether the tab being closed is the one on screen decides what the
+        // selection does. Both captures must happen BEFORE the array is
+        // mutated. Closing the ACTIVE tab moves the selection to whichever tab
+        // takes its slot; closing a BACKGROUND tab must leave the user exactly
+        // where they were. The call site used to clamp unconditionally, which
+        // slid the selection one tab to the right on every background close —
+        // onto the trailing note tab, which the resolver then honours as a
+        // deliberate choice.
+        let closingActiveTab = resolvedActiveTabIndex(worktreeID: worktreeID) == index
+        let selectionToPreserve = closingActiveTab ? nil : explicitActiveTabID(worktreeID: worktreeID)
+
         let layout = layouts[tab.id] ?? .pane(tab.content)
         let terminalIDsInTab = Set(layout.allTerminalIDs())
 
@@ -193,8 +375,15 @@ extension AppState {
             }
         }
 
-        let remaining = arr.count
-        activeTabIndices[worktreeID] = remaining > 0 ? min(index, remaining - 1) : 0
+        if closingActiveTab {
+            if arr.isEmpty {
+                activeTabIndices.removeValue(forKey: worktreeID)
+            } else {
+                activeTabIndices[worktreeID] = min(index, arr.count - 1)
+            }
+        } else {
+            repointActiveTab(worktreeID: worktreeID, to: selectionToPreserve)
+        }
 
         let snapshot = arr.map(\.id)
         Task {
@@ -241,9 +430,7 @@ extension AppState {
               var arr = tabs[worktreeID],
               let from = arr.firstIndex(where: { $0.id == draggedID }) else { return }
         // Capture which tab.id is currently active so we can re-point activeTabIndices.
-        let activeID: UUID? = activeTabIndices[worktreeID].flatMap { idx in
-            arr.indices.contains(idx) ? arr[idx].id : nil
-        }
+        let activeID = explicitActiveTabID(worktreeID: worktreeID)
         let item = arr.remove(at: from)
         // Look up target's index *after* removal (it may have shifted left by 1).
         guard let targetIdx = arr.firstIndex(where: { $0.id == targetID }) else {
@@ -255,9 +442,7 @@ extension AppState {
         arr.insert(item, at: insertAt)
         tabs[worktreeID] = arr
         worktreeTabOrders[worktreeID] = arr.map(\.id)
-        if let activeID, let newIdx = arr.firstIndex(where: { $0.id == activeID }) {
-            activeTabIndices[worktreeID] = newIdx
-        }
+        repointActiveTab(worktreeID: worktreeID, to: activeID)
         let snapshot = arr.map(\.id)
         Task {
             do {

--- a/Sources/TBDApp/AppState+TerminalFocus.swift
+++ b/Sources/TBDApp/AppState+TerminalFocus.swift
@@ -44,15 +44,11 @@ extension AppState {
 
     func terminalIDForAutofocus(worktreeID: UUID) -> UUID? {
         guard !historyActiveWorktrees.contains(worktreeID),
-              let worktreeTabs = tabs[worktreeID],
-              !worktreeTabs.isEmpty
+              let activeTab = resolvedActiveTab(worktreeID: worktreeID)
         else {
             return nil
         }
 
-        let rawIndex = activeTabIndices[worktreeID] ?? 0
-        let activeIndex = min(max(rawIndex, 0), worktreeTabs.count - 1)
-        let activeTab = worktreeTabs[activeIndex]
         let activeLayout = layouts[activeTab.id] ?? .pane(activeTab.content)
 
         return activeLayout.allTerminalIDs().first

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -58,13 +58,11 @@ extension AppState {
     }
 
     /// Terminal ID at the root of the active tab's content (nil for
-    /// note/file tabs or when no tabs exist). Mirrors the view layer's
-    /// `?? 0` default for an unset active index.
+    /// note/file tabs or when no tabs exist). Shares the view layer's
+    /// active-tab resolution via `resolvedActiveTab`.
     private func activeTabTerminalID(worktreeID: UUID) -> UUID? {
-        let arr = tabs[worktreeID] ?? []
-        guard !arr.isEmpty else { return nil }
-        let idx = min(activeTabIndices[worktreeID] ?? 0, arr.count - 1)
-        guard case .terminal(let id) = arr[idx].content else { return nil }
+        guard let tab = resolvedActiveTab(worktreeID: worktreeID),
+              case .terminal(let id) = tab.content else { return nil }
         return id
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -459,10 +459,7 @@ final class AppState: ObservableObject {
     var visibleTerminalIDs: Set<UUID> {
         var ids = Set<UUID>()
         for worktreeID in selectedWorktreeIDs {
-            let wtTabs = tabs[worktreeID] ?? []
-            guard !wtTabs.isEmpty else { continue }
-            let activeIndex = activeTabIndices[worktreeID] ?? 0
-            let tab = wtTabs[min(activeIndex, wtTabs.count - 1)]
+            guard let tab = resolvedActiveTab(worktreeID: worktreeID) else { continue }
             let layout = layouts[tab.id] ?? .pane(tab.content)
             for id in layout.allTerminalIDs() {
                 ids.insert(id)
@@ -536,8 +533,29 @@ final class AppState: ObservableObject {
         didSet { persistPaneHistories() }
     }
     @Published var tabs: [UUID: [TBDShared.Tab]] = [:]
+    /// EXPLICIT per-worktree tab selection. Absent (or out of range) means "no
+    /// deliberate selection" — read it through `resolvedActiveTabIndex` rather
+    /// than defaulting to 0 or clamping at the call site.
     @Published var activeTabIndices: [UUID: Int] = [:]
     @Published var worktreeTabOrders: [UUID: [UUID]] = [:]
+    /// Worktrees whose persisted tab order / active tab has been hydrated from
+    /// the daemon with actual content. Distinct from `worktreeTabOrders[id] != nil`,
+    /// which is also true for the empty response a poll gets while the daemon is
+    /// still mid-create — treating that as loaded stranded the worktree without
+    /// its persisted "active = agent" selection for the rest of the session.
+    var tabStateHydratedWorktreeIDs: Set<UUID> = []
+    /// `listTabs` fetches already spent trying to hydrate a worktree, capped at
+    /// `maxTabStateHydrationAttempts`. Without a cap, a worktree whose tab state
+    /// is legitimately and permanently empty re-fires the RPC on every
+    /// `reconcileTabs` — which is every terminal-list change — forever.
+    var tabStateFetchAttempts: [UUID: Int] = [:]
+    /// Worktrees with a hydration fetch in flight, so overlapping reconciles
+    /// can't stack `Task`s for the same worktree.
+    var tabStateFetchesInFlight: Set<UUID> = []
+    /// Hydration attempt budget. The gap this covers is one poll wide — the
+    /// daemon persists tab order milliseconds after inserting the terminal
+    /// rows — so a single retry is always enough; the extra one is slack.
+    static let maxTabStateHydrationAttempts = 3
     @Published var draggingTabID: UUID? = nil
     @Published var repoFilter: UUID? = nil
     @Published var pendingWorktreeIDs: Set<UUID> = []
@@ -984,6 +1002,12 @@ final class AppState: ObservableObject {
         alert.buttons[1].keyEquivalent = "\r"
         return alert.runModal() == .alertFirstButtonReturn
     }
+    /// How `loadTabStates` fetches a worktree's persisted tab order / labels /
+    /// active tab — injectable for the same reason as `daemonCapabilitiesFetcher`
+    /// (`DaemonClient` is concrete, no protocol), so hydration tests can drive
+    /// the sequence of responses without a daemon.
+    lazy var tabStatesFetcher: @MainActor (UUID) async throws -> TabListResponse =
+        { [daemonClient] worktreeID in try await daemonClient.listTabs(worktreeID: worktreeID) }
     /// How the one-shot legacy panel import fires its RPC — injectable for the
     /// same reason as `daemonCapabilitiesFetcher` (`DaemonClient` is concrete,
     /// no protocol), so trigger tests can record calls without a real daemon.
@@ -1817,20 +1841,16 @@ final class AppState: ObservableObject {
     /// looking at must never bold.
     func isActiveTabTerminal(_ terminalID: UUID, inFocusedWorktree worktreeID: UUID) -> Bool {
         guard selectedWorktreeIDs == [worktreeID] else { return false }
-        guard let arr = tabs[worktreeID], !arr.isEmpty else { return false }
-        let activeIndex = activeTabIndices[worktreeID] ?? 0
-        guard arr.indices.contains(activeIndex) else { return false }
-        return terminalIDs(in: arr[activeIndex]).contains(terminalID)
+        guard let tab = resolvedActiveTab(worktreeID: worktreeID) else { return false }
+        return terminalIDs(in: tab).contains(terminalID)
     }
 
     /// Remove the active tab's terminal(s) from `unreadTerminals` for the given
     /// worktree. Called when the user activates a tab or focuses a worktree so
     /// the surface they're now looking at clears its bold.
     func clearUnreadForActiveTab(worktreeID: UUID) {
-        guard let arr = tabs[worktreeID], !arr.isEmpty else { return }
-        let activeIndex = activeTabIndices[worktreeID] ?? 0
-        guard arr.indices.contains(activeIndex) else { return }
-        let tids = terminalIDs(in: arr[activeIndex])
+        guard let tab = resolvedActiveTab(worktreeID: worktreeID) else { return }
+        let tids = terminalIDs(in: tab)
         guard !tids.isEmpty else { return }
         unreadTerminals.subtract(tids)
     }
@@ -2289,7 +2309,11 @@ final class AppState: ObservableObject {
     /// terminals that aren't already represented (either as a tab root or
     /// embedded in another tab's split layout).
     func reconcileTabs(worktreeID: UUID, terminals: [Terminal]) {
-        let alreadyLoadedOrder = worktreeTabOrders[worktreeID] != nil
+        // Capture the active tab's IDENTITY before touching the array: every
+        // mutation below shifts indices, so a stored index re-binds to whatever
+        // slid into its slot. The auto-close of the `setup` tab makes that a
+        // routine event, not an edge case, and the note tab is always last.
+        let previousActiveTabID = explicitActiveTabID(worktreeID: worktreeID)
         var currentTabs = tabs[worktreeID] ?? []
         let terminalIDs = Set(terminals.map(\.id))
 
@@ -2343,15 +2367,21 @@ final class AppState: ObservableObject {
         }
 
         tabs[worktreeID] = currentTabs
-        applyStoredOrder(worktreeID: worktreeID)
-        if !alreadyLoadedOrder {
-            Task { await loadTabStates(worktreeID: worktreeID) }
-        }
+        applyStoredOrder(worktreeID: worktreeID, anchor: .pinned(previousActiveTabID))
+        // Re-fetch until the daemon has actually persisted tab order / active
+        // tab. `worktreeTabOrders[worktreeID] != nil` was the old gate and it
+        // latched on the empty response a poll gets while the daemon is still
+        // mid-create, permanently stranding the worktree with no stored order
+        // and no hydrated selection. The scheduler owns the dedup and the
+        // attempt cap that keep this from becoming a poll loop.
+        scheduleTabStateHydration(worktreeID: worktreeID)
     }
 
     /// Reconcile note tabs — remove tabs whose note no longer exists,
     /// add tabs for notes not already represented.
-    private func reconcileNoteTabs(worktreeID: UUID, notes: [Note]) {
+    func reconcileNoteTabs(worktreeID: UUID, notes: [Note]) {
+        // Same identity capture as reconcileTabs — see the comment there.
+        let previousActiveTabID = explicitActiveTabID(worktreeID: worktreeID)
         var currentTabs = tabs[worktreeID] ?? []
         let noteIDs = Set(notes.map(\.id))
 
@@ -2374,7 +2404,7 @@ final class AppState: ObservableObject {
         }
 
         tabs[worktreeID] = currentTabs
-        applyStoredOrder(worktreeID: worktreeID)
+        applyStoredOrder(worktreeID: worktreeID, anchor: .pinned(previousActiveTabID))
     }
 
     /// Poll all cached PR statuses from the daemon (background, every ~30s).

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -94,7 +94,7 @@ struct SingleWorktreeView: View {
     @State private var showAccountPicker = false
 
     private var activeTabIndex: Int {
-        get { appState.activeTabIndices[worktreeID] ?? 0 }
+        get { appState.resolvedActiveTabIndex(worktreeID: worktreeID) }
         nonmutating set {
             appState.setActiveTab(worktreeID: worktreeID, tabIndex: newValue)
             appState.historyActiveWorktrees.remove(worktreeID)
@@ -306,9 +306,7 @@ struct SingleWorktreeView: View {
     }
 
     private var activeTab: TBDShared.Tab? {
-        let tabs = worktreeTabs
-        guard !tabs.isEmpty else { return nil }
-        return tabs[min(activeTabIndex, tabs.count - 1)]
+        appState.resolvedActiveTab(worktreeID: worktreeID)
     }
 
     /// The active tab's terminal, if any — used to decide whether to show
@@ -502,10 +500,9 @@ private struct MultiWorktreeCell: View {
     /// The terminal shown in this cell — derived from the active tab's layout
     /// so it stays consistent with the dock's visibleTerminalIDs filter.
     private var primaryTerminal: Terminal? {
-        let tabs = appState.tabs[worktreeID] ?? []
-        guard !tabs.isEmpty else { return appState.terminals[worktreeID]?.first }
-        let activeIndex = appState.activeTabIndices[worktreeID] ?? 0
-        let tab = tabs[min(activeIndex, tabs.count - 1)]
+        guard let tab = appState.resolvedActiveTab(worktreeID: worktreeID) else {
+            return appState.terminals[worktreeID]?.first
+        }
         let layout = appState.layouts[tab.id] ?? .pane(tab.content)
         // Use the first terminal in the active tab's layout tree
         guard let firstID = layout.allTerminalIDs().first else {
@@ -515,10 +512,7 @@ private struct MultiWorktreeCell: View {
     }
 
     private var activeTab: TBDShared.Tab? {
-        let tabs = appState.tabs[worktreeID] ?? []
-        guard !tabs.isEmpty else { return nil }
-        let activeIndex = appState.activeTabIndices[worktreeID] ?? 0
-        return tabs[min(activeIndex, tabs.count - 1)]
+        appState.resolvedActiveTab(worktreeID: worktreeID)
     }
 
     var body: some View {

--- a/Tests/TBDAppTests/ActiveTabResolutionTests.swift
+++ b/Tests/TBDAppTests/ActiveTabResolutionTests.swift
@@ -1,0 +1,772 @@
+import Combine
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+// Tier 1, except the "Hydration gap" section, which is tier 2: those tests
+// observe an unstructured `Task` (`reconcileTabs` schedules `loadTabStates` in
+// one) through bounded polling, which is real concurrency, not virtual time.
+// Everything else is a pure in-process AppState state machine.
+//
+// The one RPC these paths make (`listTabs`) is driven through the
+// `tabStatesFetcher` injectable-closure seam other AppState tests already use
+// (`daemonCapabilitiesFetcher`, `panelImportTrigger`, ...), so nothing touches
+// the network or `~/tbd`.
+//
+// Regression coverage for "a new worktree opens on its Notes tab": the daemon
+// appends the note LAST in tab order, so every `?? 0` / `min(idx, count - 1)`
+// fallback in the app resolved a missing or stale selection to Notes.
+
+@MainActor
+@Suite("Active tab resolution")
+struct ActiveTabResolutionTests {
+
+    // MARK: - Fixtures
+
+    /// Runs `body` against a fresh `AppState` backed by a throwaway defaults
+    /// suite (never the developer's real `TBDApp.plist`), torn down afterwards.
+    private func withState(_ body: (AppState) -> Void) {
+        let suiteName = "ActiveTabResolutionTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(makeState(defaults))
+    }
+
+    private func withState(_ body: (AppState) async -> Void) async {
+        let suiteName = "ActiveTabResolutionTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        await body(makeState(defaults))
+    }
+
+    private func makeState(_ defaults: UserDefaults) -> AppState {
+        let state = AppState(userDefaults: defaults)
+        // Nothing here should reach a daemon unless the test opts in.
+        state.tabStatesFetcher = { _ in
+            Issue.record("unexpected listTabs fetch")
+            return TabListResponse(tabs: [], order: [], activeTabID: nil)
+        }
+        return state
+    }
+
+    private func terminal(_ id: UUID, worktreeID: UUID, label: String) -> Terminal {
+        Terminal(
+            id: id,
+            worktreeID: worktreeID,
+            tmuxWindowID: "@\(label)",
+            tmuxPaneID: "%\(label)",
+            label: label,
+            kind: .shell
+        )
+    }
+
+    private func terminalTab(_ id: UUID, label: String? = nil) -> TBDShared.Tab {
+        TBDShared.Tab(id: id, content: .terminal(terminalID: id), label: label)
+    }
+
+    private func noteTab(_ id: UUID) -> TBDShared.Tab {
+        TBDShared.Tab(id: id, content: .note(noteID: id), label: nil)
+    }
+
+    // MARK: - Resolver defaults
+
+    @Test("nothing selected resolves to the agent tab, never the trailing note")
+    func unselectedWorktreeResolvesToAgentNotNote() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [terminalTab(claude, label: "Claude"), noteTab(note)]
+
+            #expect(state.activeTabIndices[worktreeID] == nil)
+            #expect(state.resolvedActiveTabIndex(worktreeID: worktreeID) == 0)
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude)
+        }
+    }
+
+    @Test("a note-only worktree still shows its note at index 0")
+    func noteOnlyWorktreeResolvesToTheNote() {
+        withState { state in
+            let worktreeID = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [noteTab(note)]
+
+            #expect(state.resolvedActiveTabIndex(worktreeID: worktreeID) == 0)
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == note)
+        }
+    }
+
+    @Test("no tabs resolves to 0 and yields no tab")
+    func emptyWorktreeResolvesToZero() {
+        withState { state in
+            let worktreeID = UUID()
+
+            #expect(state.resolvedActiveTabIndex(worktreeID: worktreeID) == 0)
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID) == nil)
+        }
+    }
+
+    @Test("an in-range selection is returned verbatim, note tab or not")
+    func inRangeSelectionIsNeverOverridden() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [terminalTab(claude), noteTab(note)]
+            state.activeTabIndices[worktreeID] = 1
+
+            #expect(state.resolvedActiveTabIndex(worktreeID: worktreeID) == 1)
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == note)
+        }
+    }
+
+    // MARK: - Stale index
+
+    @Test("a stale out-of-range index falls forward to the first non-note tab")
+    func staleIndexResolvesToFirstNonNoteTab() {
+        withState { state in
+            let worktreeID = UUID()
+            let leadingNote = UUID()
+            let claude = UUID()
+            let trailingNote = UUID()
+            // A leading note proves the fallback is "first NON-NOTE", not "first".
+            state.tabs[worktreeID] = [noteTab(leadingNote), terminalTab(claude), noteTab(trailingNote)]
+            state.activeTabIndices[worktreeID] = 7  // stale — the array used to be longer
+
+            #expect(state.resolvedActiveTabIndex(worktreeID: worktreeID) == 1)
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude)
+        }
+    }
+
+    /// The nastier half of a stale index: a mutation that GROWS the array puts
+    /// it back in range, so anything that re-derives the selection after the
+    /// mutation pins an arbitrary tab — and the resolver then honours that pin
+    /// as deliberate, which is the exact bug class this change removes.
+    @Test("a stale index that lands back in range is not pinned by reconcileTabs")
+    func staleIndexIsNotPinnedByReconcileTabs() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let note = UUID()
+            let arrivals = (0..<6).map { _ in UUID() }
+            state.tabs[worktreeID] = [terminalTab(claude, label: "Claude"), noteTab(note)]
+            state.tabStateHydratedWorktreeIDs.insert(worktreeID)
+            // Out of range now (2 tabs), back in range once the array grows to 8.
+            state.activeTabIndices[worktreeID] = 5
+
+            state.reconcileTabs(
+                worktreeID: worktreeID,
+                terminals: ([claude] + arrivals).map {
+                    terminal($0, worktreeID: worktreeID, label: "t")
+                }
+            )
+
+            #expect(state.activeTabIndices[worktreeID] == nil,
+                    "a stale index must be cleared, never re-bound to whatever slid into it")
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude)
+        }
+    }
+
+    @Test("a stale index that lands back in range is not pinned by reconcileNoteTabs")
+    func staleIndexIsNotPinnedByReconcileNoteTabs() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let noteIDs = (0..<4).map { _ in UUID() }
+            state.tabs[worktreeID] = [terminalTab(claude, label: "Claude")]
+            // Out of range now (1 tab), back in range once the notes arrive.
+            state.activeTabIndices[worktreeID] = 3
+
+            state.reconcileNoteTabs(
+                worktreeID: worktreeID,
+                notes: noteIDs.map { Note(id: $0, worktreeID: worktreeID, title: "n") }
+            )
+
+            #expect(state.activeTabIndices[worktreeID] == nil,
+                    "a stale index must be cleared, never re-bound to an arriving note")
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude)
+        }
+    }
+
+    // MARK: - Close
+
+    /// `[claude, shell, note]` with `claude` deliberately selected — the shape
+    /// from the bug report. Closing the background `shell` used to slide the
+    /// selection one tab right, onto Notes.
+    private func withCloseFixture(
+        activeIndex: Int,
+        close closeIndex: Int,
+        _ assertions: (AppState, _ worktreeID: UUID, _ ids: (claude: UUID, shell: UUID, note: UUID)) -> Void
+    ) {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let shell = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [
+                terminalTab(claude, label: "Claude"),
+                terminalTab(shell, label: "shell"),
+                noteTab(note),
+            ]
+            state.activeTabIndices[worktreeID] = activeIndex
+
+            state.closeTab(worktreeID: worktreeID, index: closeIndex)
+
+            assertions(state, worktreeID, (claude, shell, note))
+        }
+    }
+
+    @Test("closing a background tab after the active one leaves the selection put")
+    func closingTrailingBackgroundTabKeepsSelection() {
+        withCloseFixture(activeIndex: 0, close: 1) { state, worktreeID, ids in
+            #expect(state.tabs[worktreeID]?.map(\.id) == [ids.claude, ids.note])
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == ids.claude,
+                    "closing a background tab must never move the user off the tab they were on")
+        }
+    }
+
+    /// Deliberately on the note, closing the leading tab: the clamp would have
+    /// answered `min(0, 1) == 0` and dropped the user on `shell`.
+    @Test("closing a background tab before the active one follows it by identity")
+    func closingLeadingBackgroundTabFollowsSelectionByIdentity() {
+        withCloseFixture(activeIndex: 2, close: 0) { state, worktreeID, ids in
+            #expect(state.tabs[worktreeID]?.map(\.id) == [ids.shell, ids.note])
+            #expect(state.activeTabIndices[worktreeID] == 1, "the index must shift with the tab")
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == ids.note)
+        }
+    }
+
+    @Test("closing the active tab moves the selection to the tab that takes its slot")
+    func closingActiveTabMovesToNeighbour() {
+        withCloseFixture(activeIndex: 1, close: 1) { state, worktreeID, ids in
+            #expect(state.tabs[worktreeID]?.map(\.id) == [ids.claude, ids.note])
+            #expect(state.activeTabIndices[worktreeID] == 1)
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == ids.note)
+        }
+    }
+
+    @Test("closing the trailing active tab clamps onto the new last tab")
+    func closingTrailingActiveTabClampsToLast() {
+        withCloseFixture(activeIndex: 2, close: 2) { state, worktreeID, ids in
+            #expect(state.tabs[worktreeID]?.map(\.id) == [ids.claude, ids.shell])
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == ids.shell)
+        }
+    }
+
+    /// Closing a worktree's ONLY tab: there is nothing left for the selection
+    /// to point at, so the entry must be removed rather than pinned to 0. A
+    /// leftover 0 is back in range the instant one tab reappears, and
+    /// `resolvedActiveTabIndex` honours an in-range index as deliberate — which
+    /// is how a re-created worktree ends up on whatever tab arrives first.
+    @Test("closing a worktree's only tab clears its selection entry")
+    func closingTheLastTabClearsTheSelectionEntry() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            state.tabs[worktreeID] = [terminalTab(claude, label: "Claude")]
+            state.activeTabIndices[worktreeID] = 0
+
+            state.closeTab(worktreeID: worktreeID, index: 0)
+
+            #expect(state.tabs[worktreeID]?.isEmpty == true)
+            #expect(state.activeTabIndices[worktreeID] == nil,
+                    "an emptied worktree must hold no selection, not a stale 0")
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID) == nil)
+        }
+    }
+
+    /// Cmd-W goes through `focusedTabCloseContext`, and nothing resyncs that
+    /// context when the user switches tabs *within* a worktree — so it can name
+    /// a tab that is no longer the active one. That close is a BACKGROUND
+    /// close: the user must stay on the tab they were actually looking at. The
+    /// old unconditional clamp answered `min(0, 1) == 0` here and dropped them
+    /// on `shell`.
+    @Test("closing via a stale focus context leaves the selection where the user was")
+    func closeFocusedTabWithStaleContextKeepsTheUsersTab() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let shell = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [
+                terminalTab(claude, label: "Claude"),
+                terminalTab(shell, label: "shell"),
+                noteTab(note),
+            ]
+            // The user moved to Notes; the focus context still names claude.
+            state.activeTabIndices[worktreeID] = 2
+            state.focusedTabCloseContext = .init(worktreeID: worktreeID, tabID: claude)
+
+            state.closeFocusedTab()
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [shell, note])
+            #expect(state.activeTabIndices[worktreeID] == 1, "the index must shift with the tab")
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == note,
+                    "a stale focus context must not slide the user off their tab")
+            #expect(state.focusedTabCloseContext == nil,
+                    "the consumed context must be cleared with the tab it named")
+        }
+    }
+
+    // MARK: - Auto-close of the `setup` tab
+
+    /// `[claude, setup, note] -> [claude, note]`, the shape produced on every
+    /// worktree create while `auto_close_setup_enabled` is on.
+    private func runSetupAutoClose(
+        startingOn startIndex: Int?,
+        _ assertions: (AppState, _ worktreeID: UUID, _ claude: UUID, _ note: UUID) -> Void
+    ) {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let setup = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [
+                terminalTab(claude, label: "Claude"),
+                terminalTab(setup, label: "setup"),
+                noteTab(note),
+            ]
+            state.worktreeTabOrders[worktreeID] = [claude, setup, note]
+            // Already hydrated, so reconcileTabs schedules no tab-state re-fetch.
+            state.tabStateHydratedWorktreeIDs.insert(worktreeID)
+            if let startIndex { state.activeTabIndices[worktreeID] = startIndex }
+
+            state.reconcileTabs(
+                worktreeID: worktreeID,
+                terminals: [terminal(claude, worktreeID: worktreeID, label: "Claude")]
+            )
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [claude, note])
+            assertions(state, worktreeID, claude, note)
+        }
+    }
+
+    @Test("removing the setup tab while on claude keeps the selection on claude")
+    func setupAutoCloseKeepsSelectionOnClaude() {
+        runSetupAutoClose(startingOn: 0) { state, worktreeID, claude, _ in
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude)
+        }
+    }
+
+    @Test("removing the setup tab while on setup falls back to claude, not the note")
+    func setupAutoCloseFromSetupFallsBackToClaude() {
+        runSetupAutoClose(startingOn: 1) { state, worktreeID, claude, _ in
+            #expect(state.activeTabIndices[worktreeID] == nil,
+                    "the removed tab's index must be cleared, not left stale")
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude)
+        }
+    }
+
+    @Test("removing the setup tab with nothing selected still resolves to claude")
+    func setupAutoCloseWithNoSelectionResolvesToClaude() {
+        runSetupAutoClose(startingOn: nil) { state, worktreeID, claude, _ in
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude)
+        }
+    }
+
+    // MARK: - Deliberate note selections survive reconciles
+
+    @Test("an explicit note selection survives a reconcile that adds and removes tabs")
+    func explicitNoteSelectionSurvivesReconcileTabs() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let setup = UUID()
+            let note = UUID()
+            let newShell = UUID()
+            state.tabs[worktreeID] = [terminalTab(claude), terminalTab(setup), noteTab(note)]
+            state.worktreeTabOrders[worktreeID] = [claude, setup, note]
+            state.tabStateHydratedWorktreeIDs.insert(worktreeID)
+            state.activeTabIndices[worktreeID] = 2  // the user deliberately opened Notes
+
+            // setup disappears and a brand new shell appears in the same poll.
+            state.reconcileTabs(worktreeID: worktreeID, terminals: [
+                terminal(claude, worktreeID: worktreeID, label: "Claude"),
+                terminal(newShell, worktreeID: worktreeID, label: "shell"),
+            ])
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [claude, note, newShell])
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == note,
+                    "a deliberate note selection must never be overridden")
+        }
+    }
+
+    @Test("appending a note tab never steals the selection")
+    func reconcileNoteTabsDoesNotStealSelection() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let setup = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [terminalTab(claude), terminalTab(setup)]
+            state.activeTabIndices[worktreeID] = 1  // on setup
+
+            state.reconcileNoteTabs(
+                worktreeID: worktreeID,
+                notes: [Note(id: note, worktreeID: worktreeID, title: "Notes")]
+            )
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [claude, setup, note])
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == setup)
+        }
+    }
+
+    @Test("an explicit note selection survives a note reconcile that drops another note")
+    func explicitNoteSelectionSurvivesNoteReconcile() {
+        withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let deletedNote = UUID()
+            let keptNote = UUID()
+            state.tabs[worktreeID] = [terminalTab(claude), noteTab(deletedNote), noteTab(keptNote)]
+            state.activeTabIndices[worktreeID] = 2  // on the kept note
+
+            state.reconcileNoteTabs(
+                worktreeID: worktreeID,
+                notes: [Note(id: keptNote, worktreeID: worktreeID, title: "Kept")]
+            )
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [claude, keptNote])
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == keptNote)
+        }
+    }
+
+    // MARK: - Hydration gap
+
+    @Test("an empty listTabs response is not hydration; a later one lands on claude")
+    func emptyTabStateResponseIsRetriedUntilTheDaemonHasWritten() async {
+        await withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let setup = UUID()
+            let note = UUID()
+            // In-memory append order from the terminal list — NOT the daemon's order.
+            state.tabs[worktreeID] = [
+                terminalTab(setup, label: "setup"),
+                terminalTab(claude, label: "Claude"),
+                noteTab(note),
+            ]
+
+            var responses = [
+                // Poll landed after the terminal rows existed but before the
+                // daemon persisted tab order / active tab.
+                TabListResponse(tabs: [], order: [], activeTabID: nil),
+                TabListResponse(tabs: [], order: [claude, setup, note], activeTabID: claude),
+            ]
+            var fetchCount = 0
+            state.tabStatesFetcher = { _ in
+                fetchCount += 1
+                guard !responses.isEmpty else {
+                    return TabListResponse(tabs: [], order: [], activeTabID: nil)
+                }
+                return responses.removeFirst()
+            }
+
+            await state.loadTabStates(worktreeID: worktreeID)
+            #expect(fetchCount == 1)
+            #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID) == false,
+                    "an empty response must not latch the worktree as loaded")
+
+            await state.loadTabStates(worktreeID: worktreeID)
+            #expect(fetchCount == 2)
+            #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID))
+            #expect(state.tabs[worktreeID]?.map(\.id) == [claude, setup, note])
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude,
+                    "the daemon's persisted active tab must win once it exists")
+        }
+    }
+
+    /// Tier 2 — bounded polling over the unstructured `Task` `reconcileTabs`
+    /// schedules. Uses the whole attempt budget: one empty response, then a
+    /// hydrating one on the last attempt the cap allows.
+    @Test("reconcileTabs re-fetches tab state until hydrated, then stops")
+    func reconcileTabsRetriesTabStateFetchUntilHydrated() async {
+        await withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            var fetchCount = 0
+            var hydrated = false
+            state.tabStatesFetcher = { _ in
+                fetchCount += 1
+                return hydrated
+                    ? TabListResponse(tabs: [], order: [claude], activeTabID: claude)
+                    : TabListResponse(tabs: [], order: [], activeTabID: nil)
+            }
+            let claudeTerminal = terminal(claude, worktreeID: worktreeID, label: "Claude")
+            // Waiting for the fetch to land (not merely to start) keeps the
+            // in-flight dedup from swallowing the next reconcile's attempt.
+            @MainActor func reconcileAndSettle() async {
+                state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
+                await waitFor("the scheduled fetch to finish") {
+                    !state.tabStateFetchesInFlight.contains(worktreeID)
+                }
+            }
+
+            await reconcileAndSettle()
+            #expect(fetchCount == 1)
+
+            // Still unhydrated: a later reconcile must try again.
+            await reconcileAndSettle()
+            #expect(fetchCount == 2, "an empty response must not latch the worktree as hydrated")
+
+            // The daemon has written now — one more reconcile hydrates...
+            hydrated = true
+            await reconcileAndSettle()
+            #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID))
+            let settled = fetchCount
+
+            // ...and every reconcile after that is silent: no poll storm.
+            await reconcileAndSettle()
+            await reconcileAndSettle()
+            for _ in 0..<20 { await Task.yield() }
+            #expect(fetchCount == settled, "a hydrated worktree must not re-fetch tab state")
+        }
+    }
+
+    /// A retry that changes nothing must also *publish* nothing: every write to
+    /// an `@Published` dictionary fires a full `AppState.objectWillChange`, and
+    /// this path is on a repeat timer by construction.
+    @Test("a repeat fetch that changes nothing publishes nothing")
+    func idempotentTabStateFetchDoesNotRepublish() async {
+        await withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [terminalTab(claude, label: "Claude"), noteTab(note)]
+            state.tabStatesFetcher = { _ in
+                TabListResponse(tabs: [], order: [claude, note], activeTabID: claude)
+            }
+
+            await state.loadTabStates(worktreeID: worktreeID)
+
+            var publishes = 0
+            let token = state.objectWillChange.sink { _ in publishes += 1 }
+            defer { token.cancel() }
+
+            await state.loadTabStates(worktreeID: worktreeID)
+
+            #expect(publishes == 0,
+                    "an identical response must not fan out an objectWillChange")
+        }
+    }
+
+    /// Tier 2 — the retry is scheduled in an unstructured `Task`, observed by
+    /// bounded polling. End-to-end version of the gap: the app has the tabs but
+    /// the daemon has not written yet, and the retry is what lands the
+    /// selection on the agent.
+    @Test("the hydration gap closes: a retry lands the selection on the agent tab")
+    func reconcileTabsRetryLandsSelectionOnTheAgentTab() async {
+        await withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            let setup = UUID()
+            let note = UUID()
+            state.tabs[worktreeID] = [noteTab(note)]
+            var hydrated = false
+            var fetchCount = 0
+            state.tabStatesFetcher = { _ in
+                fetchCount += 1
+                return hydrated
+                    ? TabListResponse(tabs: [], order: [claude, setup, note], activeTabID: claude)
+                    : TabListResponse(tabs: [], order: [], activeTabID: nil)
+            }
+            // In-memory append order from the terminal list — NOT the daemon's.
+            let terminals = [
+                terminal(setup, worktreeID: worktreeID, label: "setup"),
+                terminal(claude, worktreeID: worktreeID, label: "Claude"),
+            ]
+
+            state.reconcileTabs(worktreeID: worktreeID, terminals: terminals)
+            await waitFor("the mid-create fetch") { fetchCount >= 1 }
+            #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID) == false,
+                    "an empty response must not latch the worktree as hydrated")
+
+            // The daemon has written now; the next reconcile must try again.
+            hydrated = true
+            state.reconcileTabs(worktreeID: worktreeID, terminals: terminals)
+            await waitFor("the hydrating retry") {
+                state.tabStateHydratedWorktreeIDs.contains(worktreeID)
+            }
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [claude, setup, note])
+            #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude,
+                    "the daemon's persisted active tab must win once it exists")
+        }
+    }
+
+    /// Tier 2 — same shape. 4 of 101 live non-archived worktrees have neither a
+    /// stored tab order nor an active tab, and `main` rows stay that way for
+    /// good. Their `listTabs` answer is indistinguishable from the mid-create
+    /// one, so the retry has to give up on its own.
+    @Test("a permanently-empty worktree stops re-fetching once the attempt cap is spent")
+    func permanentlyEmptyWorktreeStopsRefetching() async {
+        await withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            var fetchCount = 0
+            state.tabStatesFetcher = { _ in
+                fetchCount += 1
+                return TabListResponse(tabs: [], order: [], activeTabID: nil)
+            }
+            let claudeTerminal = terminal(claude, worktreeID: worktreeID, label: "Claude")
+
+            // Each reconcile is allowed to finish its fetch before the next one,
+            // so this measures the attempt cap and not the in-flight dedup.
+            for _ in 0..<AppState.maxTabStateHydrationAttempts {
+                state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
+                await waitFor("the scheduled fetch to finish") {
+                    !state.tabStateFetchesInFlight.contains(worktreeID)
+                }
+            }
+            #expect(fetchCount == AppState.maxTabStateHydrationAttempts)
+            #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID) == false)
+
+            // `reconcileTabs` runs on every terminal-list change, and a working
+            // agent flips `activityState` constantly — the count must stop here.
+            let settled = fetchCount
+            for _ in 0..<5 {
+                state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
+                await waitFor("no further fetch") {
+                    !state.tabStateFetchesInFlight.contains(worktreeID)
+                }
+            }
+            for _ in 0..<20 { await Task.yield() }
+            #expect(fetchCount == settled,
+                    "an empty-forever worktree must stop polling, not re-fire on every reconcile")
+        }
+    }
+
+    /// Tier 2 — the failing half of the cap. `handleConnectionError` only
+    /// clears `isConnected` for `.daemonNotRunning` / `.connectionFailed`; a
+    /// decode failure, an RPC rejection or a timeout leaves the app connected
+    /// and the ~2s poll running, so `refreshWorktrees` -> `reconcileTabs` keeps
+    /// re-driving this path. A blanket attempt refund therefore meant a
+    /// throwing fetch never consumed budget and re-fired `listTabs` every poll,
+    /// per affected worktree, forever — a daemon RPC storm this repo has
+    /// already shipped once.
+    @Test("a persistently failing listTabs stops re-firing once the attempt cap is spent")
+    func persistentFetchErrorStopsRefetching() async {
+        await withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            state.isConnected = true
+            var fetchCount = 0
+            state.tabStatesFetcher = { _ in
+                fetchCount += 1
+                throw DaemonClientError.invalidResponse
+            }
+            let claudeTerminal = terminal(claude, worktreeID: worktreeID, label: "Claude")
+            @MainActor func reconcileAndSettle() async {
+                state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
+                await waitFor("the scheduled fetch to finish") {
+                    !state.tabStateFetchesInFlight.contains(worktreeID)
+                }
+            }
+
+            for _ in 0..<AppState.maxTabStateHydrationAttempts { await reconcileAndSettle() }
+            #expect(fetchCount == AppState.maxTabStateHydrationAttempts)
+            #expect(state.isConnected,
+                    "a non-disconnect error must leave the poll running, which is why the budget has to bite")
+
+            let settled = fetchCount
+            for _ in 0..<5 { await reconcileAndSettle() }
+            for _ in 0..<20 { await Task.yield() }
+            #expect(fetchCount == settled,
+                    "a worktree whose listTabs always fails must stop re-firing the RPC")
+        }
+    }
+
+    /// The other side of that asymmetry: a disconnect says nothing about
+    /// whether the daemon has written yet, and the poll that would retry is
+    /// stopped anyway — so it is refunded, and the worktree is not stranded
+    /// unhydrated for the rest of the session once the daemon comes back.
+    @Test("a disconnect refunds its attempt and keeps the worktree eligible")
+    func disconnectErrorRefundsTheHydrationAttempt() async {
+        await withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            state.isConnected = true
+            var fetchCount = 0
+            state.tabStatesFetcher = { _ in
+                fetchCount += 1
+                throw DaemonClientError.connectionFailed("socket went away")
+            }
+            let claudeTerminal = terminal(claude, worktreeID: worktreeID, label: "Claude")
+            @MainActor func reconcileAndSettle() async {
+                state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
+                await waitFor("the scheduled fetch to finish") {
+                    !state.tabStateFetchesInFlight.contains(worktreeID)
+                }
+            }
+
+            // Deliberately more rounds than the cap: none of them may be spent.
+            let rounds = AppState.maxTabStateHydrationAttempts + 3
+            for _ in 0..<rounds { await reconcileAndSettle() }
+
+            #expect(fetchCount == rounds,
+                    "a transient disconnect must not burn the hydration budget")
+            #expect(state.tabStateFetchAttempts[worktreeID] == 0)
+            #expect(state.isConnected == false)
+        }
+    }
+
+    /// Tier 2 — the old gate used a bare `Task {}` with no dedup, so reconciles
+    /// arriving back-to-back (a terminal-list change per activity flip) each
+    /// stacked their own in-flight `listTabs`.
+    @Test("overlapping reconciles never stack tab-state fetches for one worktree")
+    func overlappingReconcilesDedupeTheTabStateFetch() async {
+        await withState { state in
+            let worktreeID = UUID()
+            let claude = UUID()
+            var fetchCount = 0
+            state.tabStatesFetcher = { _ in
+                fetchCount += 1
+                return TabListResponse(tabs: [], order: [], activeTabID: nil)
+            }
+            let claudeTerminal = terminal(claude, worktreeID: worktreeID, label: "Claude")
+
+            // Three reconciles with no suspension between them: the scheduled
+            // Task has not run yet, so only the first may be allowed to arm.
+            state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
+            state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
+            state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
+            await waitFor("the single scheduled fetch") { fetchCount >= 1 }
+            for _ in 0..<20 { await Task.yield() }
+
+            #expect(fetchCount == 1, "overlapping reconciles must share one in-flight fetch")
+        }
+    }
+
+    /// Bounded poll for a MainActor condition driven by an unstructured Task
+    /// (`reconcileTabs` schedules `loadTabStates` in one). Reports the timeout
+    /// as a thrown error so the diagnostic survives into a CI summary, at the
+    /// CALLER's source location — without threading `#_sourceLocation` every
+    /// call site reports as this one line.
+    ///
+    /// The deadline is deliberately generous: these tests finish in ~80 ms
+    /// alone but were measured taking ~9.4 s of wall time inside the full
+    /// 1600-test parallel pass, where every `Task.sleep` re-queues behind the
+    /// rest of the run. It is a hang catcher, not a perf budget.
+    private func waitFor(
+        _ what: String,
+        timeout: Duration = .seconds(30),
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ condition: () -> Bool
+    ) async {
+        let deadline = ContinuousClock().now + timeout
+        while ContinuousClock().now < deadline {
+            if condition() { return }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        Issue.record(WaitTimeout(what: what, timeout: timeout), sourceLocation: sourceLocation)
+    }
+
+    private struct WaitTimeout: Error, CustomStringConvertible {
+        let what: String
+        let timeout: Duration
+        var description: String {
+            "timed out waiting for \(what) after polling up to \(timeout)"
+        }
+    }
+}

--- a/Tests/TBDAppTests/TabReorderTests.swift
+++ b/Tests/TBDAppTests/TabReorderTests.swift
@@ -151,6 +151,12 @@ import TBDShared
     let ids = [UUID(), UUID(), UUID()]
     state.tabs[worktreeID] = ids.map { Tab(id: $0, content: .terminal(terminalID: $0), label: nil) }
     state.layouts[ids[1]] = .pane(.terminal(terminalID: ids[1]))
+    // Focus lives in tab 1, which is therefore also the active tab — the state
+    // the app is really in when Cmd-W closes it. Closing the ACTIVE tab is what
+    // moves the selection to the neighbour that takes its slot; closing a
+    // background tab must leave the selection alone (see
+    // `ActiveTabResolutionTests`), so the fixture has to say which this is.
+    state.activeTabIndices[worktreeID] = 1
     state.focusedTabCloseContext = .init(worktreeID: worktreeID, tabID: ids[1])
 
     state.closeFocusedTab()


### PR DESCRIPTION
## Summary

**What's broken.** You create a worktree, click into it, and the first thing you see is the empty **Notes** tab — not the agent that is already running one tab to the left.

**Why it happens.** The daemon is right, and always was: `createInitialNoteTab` appends the note **last** in `tabOrder`, and `spawnPrimaryTerminals` persists `activeTabID = primary`. I confirmed both against the live DB — every recent worktree has the note last and Claude as the active tab. The app was throwing that selection away three separate ways:

1. **Eight call sites each spelled their own fallback** — `?? 0` in some, `min(idx, tabs.count - 1)` in others. Because the note is always the *last* tab, any stale or oversized index clamped straight onto Notes.
2. **`reconcileTabs` / `reconcileNoteTabs` captured the active tab's identity *after* mutating `tabs[worktreeID]`**, so removing a tab re-bound the index to whatever slid into that slot.
3. **`reconcileTabs` treated an empty `listTabs` response as "already loaded."** A poll landing between the daemon inserting the terminal rows and persisting the tab order gets `[]` + `nil`, which latched the gate permanently — that worktree never got its persisted "active = agent" selection for the rest of the session.

**How it got broken.** All three are older than the symptom. The clamp came in with Cmd-W close (#217), the load-once gate with tab persistence (#135). Both were harmless while the last tab was just another terminal. #485 made every new worktree grow a trailing note tab **and** turned on `auto_close_setup_enabled`, so the `setup` tab now gets removed on essentially every create — turning mechanism 2 from an edge case into a routine event, and giving mechanisms 1 and 3 a note tab to land on. Nothing caught it because the app's tab-selection fallbacks had no tests at all; each call site looked locally reasonable.

**What this PR does.**

- Adds one resolver, `resolvedActiveTabIndex`: the stored selection when it is still in range, otherwise the first **non-note** tab, otherwise `0`. All eight reads route through it, so they can no longer disagree. A deliberately-selected note tab is still returned verbatim.
- Both reconciles capture the active tab's id **before** mutating and pass it as an explicit `ActiveTabAnchor`. A bare `UUID?` conflated "caller omitted an anchor" with "caller captured no valid selection" — opposite cases needing opposite handling.
- Hydration latches only on a response that carried content, bounded by an attempt cap with in-flight dedup. A disconnect refunds its attempt; any other error consumes budget, so a persistently-failing `listTabs` can't re-fire every 2s forever.
- Fixes `closeTab`, which clamped unconditionally even when the closed tab wasn't active: with `[Claude, shell, Notes]`, closing the background `shell` tab jumped you to Notes.

**Not fixed here, worth knowing:** `closeTab` still never persists the new selection to the daemon. This was raised on #217 and never applied. Out of scope, but `repointActiveTab` is now the natural chokepoint if we want it. (An earlier draft of this section claimed `setActiveTab` has a single production call site, the tab-bar click — that is wrong. There are five: `TerminalContainerView.swift:99`, `AppState+Worktrees.swift:485`, `AppState+ModelProfiles.swift:407`, and `AppState+History.swift:172,191`. Anyone scoping the follow-up should size it against all five.)

## Test plan

- [ ] 27 new tests in `ActiveTabResolutionTests`, each mutation-checked — the fix was reverted per finding and the covering test confirmed red, then restored.
- [ ] `swift build` clean; `swiftlint --strict` clean (0 violations, 605 files).
- [ ] `swift test --parallel -j 2 --filter TBDAppTests` — 1612 tests passing.
- [ ] Full suite's only reds are the live-tmux integration suites, **identical with this branch stashed** (tmux `new-session` can't run in that shell) — environmental, not a regression.
- [ ] **Not yet verified live.** The symptom was diagnosed from the code and the DB, not reproduced in a running app. Worth one manual pass: create a worktree, confirm it opens on the agent tab; then click Notes, navigate away and back, and confirm the deliberate choice sticks.

One `TabReorderTests` fixture gains an explicit `activeTabIndices` entry. It described a state the app cannot be in — focus in a tab that isn't the active one — and its assertions are unchanged.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A45257B4-AB1C-444C-9FF9-ACA0BDE575DD)
