### PR TITLE
Fix: ActiveTabResolution's 30s waits measured main-actor contention, not the fetch they polled for

### DIFF
--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -128,12 +128,20 @@ extension AppState {
     ///   still spends the budget and stops.
     func scheduleTabStateHydration(worktreeID: UUID) {
         guard !tabStateHydratedWorktreeIDs.contains(worktreeID),
-              !tabStateFetchesInFlight.contains(worktreeID),
+              tabStateFetchTasks[worktreeID] == nil,
               tabStateFetchAttempts[worktreeID, default: 0] < Self.maxTabStateHydrationAttempts
         else { return }
         tabStateFetchAttempts[worktreeID, default: 0] += 1
-        tabStateFetchesInFlight.insert(worktreeID)
-        Task { await loadTabStates(worktreeID: worktreeID) }
+        // The handle is stored, not discarded: it IS the in-flight marker, and
+        // it lets a caller (today, only tests) await this scheduled work
+        // instead of watching for a side effect. The closure is MainActor-bound
+        // like its creator, so it cannot start before this assignment lands,
+        // and it clears its own entry as its last act — once `value` resumes,
+        // the worktree is eligible to schedule again.
+        tabStateFetchTasks[worktreeID] = Task {
+            await self.loadTabStates(worktreeID: worktreeID)
+            self.tabStateFetchTasks.removeValue(forKey: worktreeID)
+        }
     }
 
     /// Pull stored label overrides and tab order from the daemon for a worktree.
@@ -201,7 +209,11 @@ extension AppState {
             logger.error("loadTabStates failed for \(worktreeID, privacy: .public): \(error, privacy: .public)")
             handleConnectionError(error)
         }
-        tabStateFetchesInFlight.remove(worktreeID)
+        // NOTE: the in-flight entry is cleared by the scheduler's own `Task`,
+        // not here — this method is also called directly (initial load, tests),
+        // and clearing from here would drop a marker belonging to a fetch that
+        // is still running.
+        //
         // Gated one-shot legacy panel import (spec C §11.2) — fires at most
         // once per launch regardless of whether this particular listTabs
         // call succeeded, since it imports from AppState's already-loaded

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -549,9 +549,14 @@ final class AppState: ObservableObject {
     /// is legitimately and permanently empty re-fires the RPC on every
     /// `reconcileTabs` — which is every terminal-list change — forever.
     var tabStateFetchAttempts: [UUID: Int] = [:]
-    /// Worktrees with a hydration fetch in flight, so overlapping reconciles
-    /// can't stack `Task`s for the same worktree.
-    var tabStateFetchesInFlight: Set<UUID> = []
+    /// The in-flight hydration `Task` per worktree, so overlapping reconciles
+    /// can't stack `Task`s for the same worktree. Holding the handle rather than
+    /// a bare `Set<UUID>` marker means the completion of that work is directly
+    /// awaitable — tests observe it with `await task.value` instead of polling
+    /// wall time for the flag to clear, and only the scheduler's own `Task`
+    /// clears the entry, so a direct `loadTabStates(worktreeID:)` call can no
+    /// longer clear an in-flight marker it does not own.
+    var tabStateFetchTasks: [UUID: Task<Void, Never>] = [:]
     /// Hydration attempt budget. The gap this covers is one poll wide — the
     /// daemon persists tab order milliseconds after inserting the terminal
     /// rows — so a single retry is always enough; the extra one is slack.

--- a/Tests/TBDAppTests/ActiveTabResolutionTests.swift
+++ b/Tests/TBDAppTests/ActiveTabResolutionTests.swift
@@ -6,8 +6,10 @@ import TBDShared
 
 // Tier 1, except the "Hydration gap" section, which is tier 2: those tests
 // observe an unstructured `Task` (`reconcileTabs` schedules `loadTabStates` in
-// one) through bounded polling, which is real concurrency, not virtual time.
-// Everything else is a pure in-process AppState state machine.
+// one), which is real concurrency, not virtual time. They await that `Task`'s
+// completion directly (`settleHydration`) — no wall-clock deadline is involved
+// anywhere in this file. Everything else is a pure in-process AppState state
+// machine.
 //
 // The one RPC these paths make (`listTabs`) is driven through the
 // `tabStatesFetcher` injectable-closure seam other AppState tests already use
@@ -477,9 +479,9 @@ struct ActiveTabResolutionTests {
         }
     }
 
-    /// Tier 2 — bounded polling over the unstructured `Task` `reconcileTabs`
-    /// schedules. Uses the whole attempt budget: one empty response, then a
-    /// hydrating one on the last attempt the cap allows.
+    /// Tier 2 — awaits the unstructured `Task` `reconcileTabs` schedules. Uses
+    /// the whole attempt budget: one empty response, then a hydrating one on
+    /// the last attempt the cap allows.
     @Test("reconcileTabs re-fetches tab state until hydrated, then stops")
     func reconcileTabsRetriesTabStateFetchUntilHydrated() async {
         await withState { state in
@@ -494,13 +496,11 @@ struct ActiveTabResolutionTests {
                     : TabListResponse(tabs: [], order: [], activeTabID: nil)
             }
             let claudeTerminal = terminal(claude, worktreeID: worktreeID, label: "Claude")
-            // Waiting for the fetch to land (not merely to start) keeps the
+            // Awaiting the fetch to land (not merely to start) keeps the
             // in-flight dedup from swallowing the next reconcile's attempt.
             @MainActor func reconcileAndSettle() async {
                 state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
-                await waitFor("the scheduled fetch to finish") {
-                    !state.tabStateFetchesInFlight.contains(worktreeID)
-                }
+                await settleHydration(state, worktreeID: worktreeID)
             }
 
             await reconcileAndSettle()
@@ -516,10 +516,11 @@ struct ActiveTabResolutionTests {
             #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID))
             let settled = fetchCount
 
-            // ...and every reconcile after that is silent: no poll storm.
+            // ...and every reconcile after that is silent: no poll storm. Each
+            // round drains whatever it armed, so a re-fetch would land inside
+            // the loop and show up in the count below rather than racing it.
             await reconcileAndSettle()
             await reconcileAndSettle()
-            for _ in 0..<20 { await Task.yield() }
             #expect(fetchCount == settled, "a hydrated worktree must not re-fetch tab state")
         }
     }
@@ -551,8 +552,8 @@ struct ActiveTabResolutionTests {
         }
     }
 
-    /// Tier 2 — the retry is scheduled in an unstructured `Task`, observed by
-    /// bounded polling. End-to-end version of the gap: the app has the tabs but
+    /// Tier 2 — the retry is scheduled in an unstructured `Task`, awaited
+    /// through its handle. End-to-end version of the gap: the app has the tabs but
     /// the daemon has not written yet, and the retry is what lands the
     /// selection on the agent.
     @Test("the hydration gap closes: a retry lands the selection on the agent tab")
@@ -578,16 +579,17 @@ struct ActiveTabResolutionTests {
             ]
 
             state.reconcileTabs(worktreeID: worktreeID, terminals: terminals)
-            await waitFor("the mid-create fetch") { fetchCount >= 1 }
+            await settleHydration(state, worktreeID: worktreeID)
+            #expect(fetchCount == 1, "the mid-create reconcile must have fetched once")
             #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID) == false,
                     "an empty response must not latch the worktree as hydrated")
 
             // The daemon has written now; the next reconcile must try again.
             hydrated = true
             state.reconcileTabs(worktreeID: worktreeID, terminals: terminals)
-            await waitFor("the hydrating retry") {
-                state.tabStateHydratedWorktreeIDs.contains(worktreeID)
-            }
+            await settleHydration(state, worktreeID: worktreeID)
+            #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID),
+                    "the retry must latch once the daemon's answer carries content")
 
             #expect(state.tabs[worktreeID]?.map(\.id) == [claude, setup, note])
             #expect(state.resolvedActiveTab(worktreeID: worktreeID)?.id == claude,
@@ -615,9 +617,7 @@ struct ActiveTabResolutionTests {
             // so this measures the attempt cap and not the in-flight dedup.
             for _ in 0..<AppState.maxTabStateHydrationAttempts {
                 state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
-                await waitFor("the scheduled fetch to finish") {
-                    !state.tabStateFetchesInFlight.contains(worktreeID)
-                }
+                await settleHydration(state, worktreeID: worktreeID)
             }
             #expect(fetchCount == AppState.maxTabStateHydrationAttempts)
             #expect(state.tabStateHydratedWorktreeIDs.contains(worktreeID) == false)
@@ -627,11 +627,8 @@ struct ActiveTabResolutionTests {
             let settled = fetchCount
             for _ in 0..<5 {
                 state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
-                await waitFor("no further fetch") {
-                    !state.tabStateFetchesInFlight.contains(worktreeID)
-                }
+                await settleHydration(state, worktreeID: worktreeID)
             }
-            for _ in 0..<20 { await Task.yield() }
             #expect(fetchCount == settled,
                     "an empty-forever worktree must stop polling, not re-fire on every reconcile")
         }
@@ -659,9 +656,7 @@ struct ActiveTabResolutionTests {
             let claudeTerminal = terminal(claude, worktreeID: worktreeID, label: "Claude")
             @MainActor func reconcileAndSettle() async {
                 state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
-                await waitFor("the scheduled fetch to finish") {
-                    !state.tabStateFetchesInFlight.contains(worktreeID)
-                }
+                await settleHydration(state, worktreeID: worktreeID)
             }
 
             for _ in 0..<AppState.maxTabStateHydrationAttempts { await reconcileAndSettle() }
@@ -671,7 +666,6 @@ struct ActiveTabResolutionTests {
 
             let settled = fetchCount
             for _ in 0..<5 { await reconcileAndSettle() }
-            for _ in 0..<20 { await Task.yield() }
             #expect(fetchCount == settled,
                     "a worktree whose listTabs always fails must stop re-firing the RPC")
         }
@@ -695,9 +689,7 @@ struct ActiveTabResolutionTests {
             let claudeTerminal = terminal(claude, worktreeID: worktreeID, label: "Claude")
             @MainActor func reconcileAndSettle() async {
                 state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
-                await waitFor("the scheduled fetch to finish") {
-                    !state.tabStateFetchesInFlight.contains(worktreeID)
-                }
+                await settleHydration(state, worktreeID: worktreeID)
             }
 
             // Deliberately more rounds than the cap: none of them may be spent.
@@ -731,42 +723,35 @@ struct ActiveTabResolutionTests {
             state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
             state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
             state.reconcileTabs(worktreeID: worktreeID, terminals: [claudeTerminal])
-            await waitFor("the single scheduled fetch") { fetchCount >= 1 }
-            for _ in 0..<20 { await Task.yield() }
+            // `settleHydration` drains until nothing is armed, so a broken
+            // dedup shows up as a count of 3 here rather than as a race.
+            await settleHydration(state, worktreeID: worktreeID)
 
             #expect(fetchCount == 1, "overlapping reconciles must share one in-flight fetch")
         }
     }
 
-    /// Bounded poll for a MainActor condition driven by an unstructured Task
-    /// (`reconcileTabs` schedules `loadTabStates` in one). Reports the timeout
-    /// as a thrown error so the diagnostic survives into a CI summary, at the
-    /// CALLER's source location — without threading `#_sourceLocation` every
-    /// call site reports as this one line.
+    /// Await the hydration work `reconcileTabs` schedules, until none is armed.
     ///
-    /// The deadline is deliberately generous: these tests finish in ~80 ms
-    /// alone but were measured taking ~9.4 s of wall time inside the full
-    /// 1600-test parallel pass, where every `Task.sleep` re-queues behind the
-    /// rest of the run. It is a hang catcher, not a perf budget.
-    private func waitFor(
-        _ what: String,
-        timeout: Duration = .seconds(30),
-        sourceLocation: SourceLocation = #_sourceLocation,
-        _ condition: () -> Bool
-    ) async {
-        let deadline = ContinuousClock().now + timeout
-        while ContinuousClock().now < deadline {
-            if condition() { return }
-            try? await Task.sleep(for: .milliseconds(5))
-        }
-        Issue.record(WaitTimeout(what: what, timeout: timeout), sourceLocation: sourceLocation)
-    }
-
-    private struct WaitTimeout: Error, CustomStringConvertible {
-        let what: String
-        let timeout: Duration
-        var description: String {
-            "timed out waiting for \(what) after polling up to \(timeout)"
+    /// `scheduleTabStateHydration` stores its unstructured `Task`, so the test
+    /// can await THAT rather than watch wall time for its side effects. This is
+    /// a completion signal, not a deadline: no budget to blow, so an
+    /// arbitrarily loaded machine makes the test slower and never red.
+    ///
+    /// The previous shape — polling `tabStateFetchesInFlight` every 5 ms
+    /// against a 30 s `ContinuousClock` deadline — measured the whole process's
+    /// contention for the (single, shared) main actor rather than this
+    /// worktree's fetch, and blew its budget on the full parallel pass while
+    /// sibling no-op tests in this same suite were themselves taking 25-45 s to
+    /// get a turn. It also added ~6000 main-actor wakeups per waiting test to
+    /// the congestion it was losing to.
+    ///
+    /// The loop drains rather than awaiting once, so a regression that armed
+    /// several overlapping fetches is still fully settled before the assertion.
+    /// Nothing arms a fetch except `reconcileTabs`, so it terminates.
+    private func settleHydration(_ state: AppState, worktreeID: UUID) async {
+        while let fetch = state.tabStateFetchTasks[worktreeID] {
+            await fetch.value
         }
     }
 }


### PR DESCRIPTION
## What's broken

Six of the 27 tests in `Active tab resolution` (`Tests/TBDAppTests/ActiveTabResolutionTests.swift`) fail on the fast parallel pass, on branches that cannot have touched them. Every failure is the same line:

```
Caught error: timed out waiting for the scheduled fetch to finish after polling up to 30.0 seconds
```

Failing runs, all on **PR #522, a docs-only branch**:

| run | result |
|---|---|
| [30275284765](https://github.com/cheapsteak/tbd/actions/runs/30275284765) | `✘ Suite "Active tab resolution" failed after 49.371 seconds with 6 issues` |
| [30279755880](https://github.com/cheapsteak/tbd/actions/runs/30279755880) | `✘ Suite "Active tab resolution" failed after 47.759 seconds with 6 issues` |

#538's own merge run, [30272477719](https://github.com/cheapsteak/tbd/actions/runs/30272477719), went red the same day on `ControlModeInputHealth` — a different suite with the same wait shape, and the same failure family this repo already knows (`timed out waiting for 2 health events`, tests "failed after 45.280 seconds").

**PR #522 is currently blocked on this**, having changed nothing but Markdown.

## Why it happens

The six failing tests are exactly the six that call the file's private `waitFor` helper — a 5 ms poll loop against a 30 s `ContinuousClock` deadline, watching for `AppState.tabStateFetchesInFlight` to lose a worktree id. What it is waiting on is the unstructured `Task` that `scheduleTabStateHydration` (`Sources/TBDApp/AppState+Tabs.swift:136` as merged) arms to run `loadTabStates`.

Both sides of that wait are `@MainActor`: `AppState` is main-actor isolated, `Task {}` inherits that isolation, and the suite is `@MainActor` too. So the poll is not waiting for the fetch — it is waiting for **main-actor turns**, and the main actor is a single serial executor shared by every `@MainActor` suite in the process. All test targets compile into one binary and Swift Testing parallelizes suites in-process, so on the full pass that one executor is arbitrated between ~480 suites at once.

The CI log proves the starvation directly, from this suite's own siblings. These are pure synchronous in-memory assertions with no I/O and no awaits:

```
✔ Test "plain command-w closes the active tab" passed after 25.305 seconds.
✔ Test "closing the trailing active tab clamps onto the new last tab" passed after 44.578 seconds.
✔ Test "closing the active tab moves the selection to the tab that takes its slot" passed after 44.578 seconds.
✘ Test "reconcileTabs re-fetches tab state until hydrated, then stops" ... timed out ... 30.0 seconds
```

A no-op test taking 44 s of wall time is the finding. The work under test is fine; getting scheduled is what costs 40 s. So a 30 s budget on the wait measures **whole-process contention**, not this worktree's fetch — the suite finishes in 80 ms alone and blows the budget in company, and raising the budget only moves the cliff. The poll also made the congestion it was losing to worse: 30 s at 5 ms is ~6000 extra main-actor wakeups per waiting test.

## How it got broken

The suite is one day old — it arrived with #538 (`2e359c82`, "new worktrees open on the agent tab") — and has flaked since its first full pass. Nothing about #538's production fix is wrong; only the way its tier-2 tests observe an unstructured `Task`.

## What the fix does

Replaces the wall-clock poll with a structured completion signal — there is now **no deadline anywhere in the file**, so there is no budget left to blow.

- `AppState.tabStateFetchesInFlight: Set<UUID>` becomes `tabStateFetchTasks: [UUID: Task<Void, Never>]`. The stored handle *is* the in-flight marker, so the dedup guard is unchanged in meaning, and the scheduled work is now directly awaitable.
- The scheduler's `Task` clears its own entry as its last act, so "the handle resumed" and "the worktree may schedule again" are the same instant.
- Tests call `settleHydration(state, worktreeID:)`, which `await`s that handle (draining in a loop, so a regression that armed several overlapping fetches is still fully settled before the assertion). A loaded machine now makes these tests slower and never red.
- The `for _ in 0..<20 { await Task.yield() }` spins that guarded "and no further fetch happens" are gone: each round drains what it armed, so a stray re-fetch lands *inside* the loop and shows up in the count instead of racing it. The assertions got stronger, not weaker.

One incidental correctness fix falls out: `loadTabStates` no longer clears the in-flight marker. It is also called directly (initial load, tier-1 tests), where it was clearing a marker belonging to a scheduled fetch it did not own.

No behavior change in the app: same guards, same attempt cap, same refund rule, same RPC.

## Test plan

- `swift build` — clean. `swiftlint --strict` — 0 violations, 612 files.
- `swift test --filter ActiveTabResolutionTests` — **27 tests in 1 suite passed** after 0.080 s.
- Full `swift test --parallel -j 2`, twice:
  - run 1 — `Test run with 4524 tests in 501 suites passed after 35.783 seconds with 1 known issue`
  - run 2 — `Test run with 4524 tests in 501 suites passed after 32.104 seconds with 1 known issue`

  (The known issue in both is `FlakyQuarantineSelfTests/retriesUntilPass`, the quarantine mechanism's own fixture, which fails once and passes on retry by design.)
- Mutation-checked, because the waits were rewritten and a rewritten wait can quietly stop proving anything:
  - deleting the in-flight dedup guard → `overlapping reconciles never stack tab-state fetches for one worktree` fails (`fetchCount` 3, not 1).
  - latching hydration unconditionally instead of only on a response carrying content (the bug #538 fixed) → `reconcileTabs re-fetches tab state until hydrated, then stops` and `the hydration gap closes: a retry lands the selection on the agent tab` fail, 4 issues between them.
  - Both guards restored and re-verified green.
