### PR TITLE
Feat: Find an archived worktree without scrolling 500 rows

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -205,12 +205,12 @@ extension AppState {
         // so a concurrent invocation can't overwrite the .done state with
         // an "already active" error.
         guard revivingArchived[worktreeID] == nil else { return }
-        // Find the snapshot in archivedWorktrees so we can keep the row visible
-        // after the daemon reconciles the worktree out of the archived list.
-        guard let snapshot = archivedWorktrees.values
-            .flatMap({ $0 })
-            .first(where: { $0.id == worktreeID })
-        else {
+        // Find the snapshot so we can keep the row visible after the daemon
+        // reconciles the worktree out of the archived list. Must consult BOTH
+        // row sources (loaded pages ∪ search results) — see
+        // `AppState.mergeArchivedSnapshots`; against the loaded pages alone
+        // this silently no-ops for any row the user reached via search.
+        guard let snapshot = archivedSnapshot(id: worktreeID) else {
             logger.warning("reviveWithSession: no archived snapshot for \(worktreeID, privacy: .public)")
             return
         }

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -331,10 +331,11 @@ extension AppState {
         // Idempotency: see `reviveWithSession`. Concurrent invocations
         // would race the `.done` state to nil on the second call's error.
         guard revivingArchived[id] == nil else { return }
-        guard let snapshot = archivedWorktrees.values
-            .flatMap({ $0 })
-            .first(where: { $0.id == id })
-        else {
+        // `archivedSnapshot` covers BOTH row sources. Resolving against
+        // `archivedWorktrees` alone made this guard fail — silently, with no
+        // RPC and no alert — for any row the user reached via search, i.e. any
+        // row past the first loaded page.
+        guard let snapshot = archivedSnapshot(id: id) else {
             logger.warning("reviveWorktree: no archived snapshot for \(id, privacy: .public)")
             return
         }
@@ -652,25 +653,199 @@ extension AppState {
         selectedRemoteSession = nil
     }
 
-    private static let archivedPageSize = 50
+    static let archivedPageSize = 50
 
     /// Fetch archived worktrees for a repo, preserving any pages the user has
     /// already loaded (re-fetches up to `max(currentCount, pageSize)` items).
     func refreshArchivedWorktrees(repoID: UUID) async {
-        let currentCount = archivedWorktrees[repoID]?.count ?? 0
-        let fetchCount = max(currentCount, Self.archivedPageSize)
-        let knownExhausted = currentCount > 0 && currentCount % Self.archivedPageSize != 0
+        let plan = ArchivedRefreshPlan(
+            currentCount: archivedWorktrees[repoID]?.count ?? 0,
+            pageSize: Self.archivedPageSize
+        )
         do {
             let archived = try await daemonClient.listWorktrees(
                 repoID: repoID, status: .archived,
-                limit: fetchCount
+                limit: plan.fetchCount
             )
             archivedWorktrees[repoID] = archived
-            archivedWorktreesHasMore[repoID] = knownExhausted ? false : archived.count >= fetchCount
+            archivedWorktreesHasMore[repoID] = plan.hasMore(fetched: archived.count)
             ensureArchivedSelectionValid(repoID: repoID)
         } catch {
             logger.error("Failed to list archived worktrees: \(error)")
         }
+        // Re-run any active search so a revive/archive doesn't leave stale
+        // search rows on screen (the search set is fetched separately and is
+        // not touched by the refetch above).
+        await refreshArchivedSearch(repoID: repoID)
+    }
+
+    // MARK: - Archived row sources
+
+    /// Union of the two sources the archived UI renders from, de-duplicated by
+    /// id preferring `loaded` (which every `refreshArchivedWorktrees` re-fetches
+    /// and is therefore the fresher of the two).
+    ///
+    /// Search results are a genuinely SECOND row source: the whole point of the
+    /// daemon-side `nameQuery` filter is surfacing matches from pages
+    /// `archivedWorktrees` never loaded. Any lookup written against the loaded
+    /// pages alone silently fails for those rows — which is how Revive came to
+    /// no-op on exactly the row a user searched to find. Keep every archived-row
+    /// lookup routed through here rather than re-deriving the union.
+    nonisolated static func mergeArchivedSnapshots(
+        loaded: [Worktree],
+        searchResults: [Worktree]
+    ) -> [Worktree] {
+        var seen = Set(loaded.map(\.id))
+        var merged = loaded
+        for wt in searchResults where seen.insert(wt.id).inserted {
+            merged.append(wt)
+        }
+        return merged
+    }
+
+    /// Every archived snapshot the UI can currently render for `repoID`.
+    func archivedSnapshots(repoID: UUID) -> [Worktree] {
+        Self.mergeArchivedSnapshots(
+            loaded: archivedWorktrees[repoID] ?? [],
+            searchResults: archivedSearchResults[repoID]?.worktrees ?? []
+        )
+    }
+
+    /// Resolve one archived snapshot by id across every repo — for callers
+    /// (the revive paths) that hold a row id but not its repo.
+    func archivedSnapshot(id: UUID) -> Worktree? {
+        Self.mergeArchivedSnapshots(
+            loaded: archivedWorktrees.values.flatMap { $0 },
+            searchResults: archivedSearchResults.values.flatMap(\.worktrees)
+        ).first { $0.id == id }
+    }
+
+    // MARK: - Archived-worktree search
+
+    /// Re-fetch the active search after the archived set changed, preserving the
+    /// pages the user already pulled in — the same invariant
+    /// `refreshArchivedWorktrees` maintains for the unsearched list, via the
+    /// same `ArchivedRefreshPlan`.
+    ///
+    /// Calling plain `searchArchivedWorktrees` here instead would always refetch
+    /// page 0 and replace the stored results, silently collapsing Load
+    /// More–accumulated search pages back to the first 50 — triggered by the
+    /// feature's own primary action (revive), plus `selectRepo`, deep-link
+    /// archived navigation, and back/forward restore.
+    ///
+    /// Keys off the query the stored results ANSWER, not the in-flight one: if
+    /// a newer search is already in flight its own response is the right answer
+    /// and this refresh has nothing useful to add.
+    func refreshArchivedSearch(repoID: UUID) async {
+        guard let current = archivedSearchResults[repoID] else { return }
+        let query = current.query
+        let plan = ArchivedRefreshPlan(
+            currentCount: current.worktrees.count,
+            pageSize: Self.archivedPageSize
+        )
+        do {
+            let matches = try await daemonClient.listWorktrees(
+                repoID: repoID, status: .archived,
+                limit: plan.fetchCount,
+                nameQuery: query
+            )
+            // Drop the response if the user has since typed a different query
+            // (or cleared the search) — it answers a question nobody is asking.
+            guard archivedSearchQuery[repoID] == query else { return }
+            archivedSearchResults[repoID] = ArchivedSearchResults(
+                query: query,
+                worktrees: matches,
+                hasMore: plan.hasMore(fetched: matches.count)
+            )
+        } catch {
+            logger.error("Failed to refresh archived search: \(error)")
+        }
+    }
+
+    /// Fetch the first page of archived worktrees matching `query` for a repo.
+    ///
+    /// The filter runs in the daemon's SQL (`nameQuery`), not client-side, so
+    /// matches in pages the user hasn't loaded still show up — and pagination
+    /// continues to page over the *matching* set (`loadMoreArchivedSearchResults`).
+    /// A blank query clears the search instead of fetching.
+    func searchArchivedWorktrees(repoID: UUID, query: String) async {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            clearArchivedSearch(repoID: repoID)
+            return
+        }
+        // Stamp the in-flight query BEFORE awaiting so a later keystroke's
+        // search supersedes this one; the post-await checks drop the stale
+        // response rather than letting it overwrite newer results.
+        //
+        // The previous query's RESULTS are deliberately left in place: the view
+        // keys off `ArchivedSearchResults.query`, sees it no longer matches
+        // what's typed, and falls back to the client-side preview on its own.
+        archivedSearchQuery[repoID] = trimmed
+        archivedSearchFailed[repoID] = false
+        do {
+            let matches = try await daemonClient.listWorktrees(
+                repoID: repoID, status: .archived,
+                limit: Self.archivedPageSize,
+                nameQuery: trimmed
+            )
+            guard archivedSearchQuery[repoID] == trimmed else { return }
+            archivedSearchResults[repoID] = ArchivedSearchResults(
+                query: trimmed,
+                worktrees: matches,
+                hasMore: matches.count >= Self.archivedPageSize
+            )
+        } catch {
+            logger.error("Failed to search archived worktrees: \(error)")
+            // Only flag the failure if this is still the query the user is
+            // waiting on — a superseded search's failure is not their problem.
+            guard archivedSearchQuery[repoID] == trimmed else { return }
+            archivedSearchFailed[repoID] = true
+        }
+    }
+
+    /// Load the next page of archived search results, appending to the existing
+    /// ones. Mirrors `loadMoreArchivedWorktrees`, including its concurrent-call
+    /// guard and its "did the list shift under us" append check.
+    func loadMoreArchivedSearchResults(repoID: UUID) async {
+        guard isLoadingMoreArchivedSearch[repoID] != true else { return }
+        // Only a SETTLED result set can be paged: the stored rows must answer
+        // the query that is still in flight/current, or the next page would be
+        // offset into a different search's answer.
+        guard let current = archivedSearchResults[repoID],
+              archivedSearchQuery[repoID] == current.query else { return }
+        isLoadingMoreArchivedSearch[repoID] = true
+        defer { isLoadingMoreArchivedSearch[repoID] = false }
+
+        let currentCount = current.worktrees.count
+        do {
+            let more = try await daemonClient.listWorktrees(
+                repoID: repoID, status: .archived,
+                limit: Self.archivedPageSize, offset: currentCount,
+                nameQuery: current.query
+            )
+            // Drop the page if the stored results were replaced or extended
+            // while it was in flight (query changed, or a refresh re-ran the
+            // search) — it belongs to a result set that no longer exists.
+            guard let latest = archivedSearchResults[repoID],
+                  latest.query == current.query,
+                  latest.worktrees.count == currentCount else { return }
+            archivedSearchResults[repoID] = ArchivedSearchResults(
+                query: current.query,
+                worktrees: latest.worktrees + more,
+                hasMore: more.count >= Self.archivedPageSize
+            )
+        } catch {
+            logger.error("Failed to load more archived search results: \(error)")
+        }
+    }
+
+    /// Drop all search state for a repo — called when the query goes empty, so
+    /// the view falls back to the unsearched `archivedWorktrees` pages.
+    func clearArchivedSearch(repoID: UUID) {
+        archivedSearchQuery.removeValue(forKey: repoID)
+        archivedSearchResults.removeValue(forKey: repoID)
+        archivedSearchFailed.removeValue(forKey: repoID)
     }
 
     /// Fetch orphan-GC reap records for a repo (History → Reclaimed).
@@ -735,7 +910,14 @@ extension AppState {
         let lingering = revivingArchived.values
             .map(\.snapshot)
             .filter { $0.repoID == repoID }
-        let allIDs = Set(archived.map(\.id) + lingering.map(\.id))
+        // Validity spans BOTH row sources: a selection on a search-only row is
+        // legitimate, and judging it stale against the loaded pages alone would
+        // silently re-point the detail pane at the most recent loaded row on
+        // the next refresh. The fallback PICK below deliberately stays on the
+        // loaded set — a loaded row is always a row we still hold.
+        let allIDs = Set(
+            archivedSnapshots(repoID: repoID).map(\.id) + lingering.map(\.id)
+        )
 
         let current = selectedArchivedWorktreeIDs[repoID]
         let needsNew = current == nil || !allIDs.contains(current!)

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -303,6 +303,36 @@ final class AppState: ObservableObject {
     /// Guards against concurrent loadMoreArchivedWorktrees calls (double-tap, race with refresh).
     @Published var isLoadingMoreArchived: [UUID: Bool] = [:]
 
+    // MARK: Archived-worktree search
+    //
+    // The archived list is paginated (50/page), so a purely client-side filter
+    // would silently miss older, unloaded archives — and fetching every
+    // remaining page is unaffordable (`handleWorktreeList` enriches each
+    // archived row with a `~/.claude/projects` scan; full enrichment measured
+    // ~19 s). So search is a daemon-side SQL filter with its OWN paginated
+    // result set, held separately from the unsearched `archivedWorktrees`
+    // pages so clearing the query restores them without a refetch.
+
+    /// The query whose search RPC is currently IN FLIGHT for a repo, stamped
+    /// before the await so a superseded response can be dropped.
+    ///
+    /// This is deliberately NOT the query the stored rows answer — that lives
+    /// inside `ArchivedSearchResults`. Deciding what to *display* from this
+    /// value would render the previous query's rows as if they were the answer
+    /// for the new one during the whole in-flight window.
+    @Published var archivedSearchQuery: [UUID: String] = [:]
+    /// Daemon-side search results (page-accumulated) and the query they answer,
+    /// keyed by repo ID. Absent until some response has landed.
+    @Published var archivedSearchResults: [UUID: ArchivedSearchResults] = [:]
+    /// Repos whose most recent archived-search RPC failed. Set only for the
+    /// query that was in flight, cleared when the next search starts or the
+    /// search is cleared. The rail reads it so a failed search degrades to a
+    /// *labelled* client-side view rather than silently claiming the loaded
+    /// rows are the whole answer.
+    @Published var archivedSearchFailed: [UUID: Bool] = [:]
+    /// Guards against concurrent `loadMoreArchivedSearchResults` calls.
+    @Published var isLoadingMoreArchivedSearch: [UUID: Bool] = [:]
+
     /// Orphan-GC reap records (History → Reclaimed), keyed by repo ID and
     /// fetched on demand alongside `archivedWorktrees`.
     @Published var reapRecords: [UUID: [ReapRecord]] = [:]

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -1,6 +1,99 @@
 import SwiftUI
 import TBDShared
 
+/// Pure substring match behind the archived list's search field: folder `name`
+/// OR `displayName`, case-insensitive, no fuzzy matching. A blank query matches
+/// everything.
+///
+/// This is also the documented semantics of the daemon-side filter
+/// (`WorktreeStore.list(nameQuery:)`, SQL `LIKE '%q%'` over the same two
+/// columns) — the two are kept deliberately identical so the client-side
+/// preview shown during the debounce window is a subset of the daemon's answer
+/// rather than a different question. Extracted from the view so it is
+/// unit-testable without SwiftUI (same pattern as `PaneHistoryPaletteFilter`).
+enum ArchivedWorktreeSearchFilter {
+    static func matches(name: String, displayName: String, query: String) -> Bool {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return true }
+        return name.lowercased().contains(needle)
+            || displayName.lowercased().contains(needle)
+    }
+
+    static func matches(_ worktree: Worktree, query: String) -> Bool {
+        matches(name: worktree.name, displayName: worktree.displayName, query: query)
+    }
+}
+
+/// One repo's archived-search answer: the rows the daemon returned, the query
+/// they answer, and whether more pages of matches exist — held as ONE value so
+/// the rows and their query can never disagree.
+///
+/// They did disagree when these were separate `AppState` dicts: the in-flight
+/// query was stamped *before* the await while the rows were replaced *after*
+/// it, so for the whole in-flight window the view saw "stored query == typed
+/// query" and rendered the PREVIOUS query's rows as a settled answer. Since
+/// daemon results are deliberately not re-filtered client-side (they arrive
+/// pre-filtered), that showed rows which do not match what the user typed — a
+/// superset of the true answer, i.e. exactly the failure the client-side
+/// preview exists to prevent. Typing appeared not to narrow the list.
+struct ArchivedSearchResults {
+    /// The trimmed query these rows answer.
+    let query: String
+    let worktrees: [Worktree]
+    /// Whether more pages of matches exist beyond `worktrees`.
+    let hasMore: Bool
+}
+
+/// Page-preserving refetch arithmetic, shared by the unsearched archived
+/// refresh and the search refresh so the invariant lives in one place.
+///
+/// The invariant (PR #236): a refresh must not collapse pages the user already
+/// pulled in with "Load More", so it re-fetches `max(currentCount, pageSize)`
+/// rows rather than one page. `knownExhausted` is the other half — a partial
+/// last page proves the server has nothing more, and without it the larger
+/// refetch (which returns fewer rows than it asked for) would keep re-arming
+/// "Load More" forever.
+struct ArchivedRefreshPlan {
+    let fetchCount: Int
+    let knownExhausted: Bool
+
+    init(currentCount: Int, pageSize: Int) {
+        fetchCount = max(currentCount, pageSize)
+        knownExhausted = currentCount > 0 && currentCount % pageSize != 0
+    }
+
+    func hasMore(fetched: Int) -> Bool {
+        knownExhausted ? false : fetched >= fetchCount
+    }
+}
+
+/// Which row set the archived list should show, given the query in the field
+/// and the query the results in hand actually answer. Pure and total, so the
+/// stale-results branch is directly testable without a daemon seam.
+enum ArchivedSearchDisplay {
+    enum Decision: Equatable {
+        /// No query: show every loaded archived row.
+        case unfiltered
+        /// The results in hand answer exactly this query, so they ARE the row
+        /// set — they span archives beyond the locally loaded pages.
+        case daemonResults
+        /// No answer for *this* query yet: debounce window, in-flight RPC,
+        /// results left over from an earlier query, or a failed search. Filter
+        /// the loaded rows client-side instead.
+        case clientPreview
+    }
+
+    /// - Parameter resultsQuery: the query carried by the stored
+    ///   `ArchivedSearchResults`, or nil when none have landed. Never the
+    ///   in-flight query — see `AppState.archivedSearchQuery`.
+    static func decide(query: String, resultsQuery: String?) -> Decision {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .unfiltered }
+        guard resultsQuery == trimmed else { return .clientPreview }
+        return .daemonResults
+    }
+}
+
 struct ArchivedWorktreesView: View {
     let repoID: UUID
     @EnvironmentObject var appState: AppState
@@ -9,18 +102,59 @@ struct ArchivedWorktreesView: View {
     @State private var dragStartWidth: CGFloat? = nil
     @AppStorage("archived.hideEmpty") private var hideEmpty: Bool = true
 
-    /// All archived rows for this repo (∪ lingering revive snapshots), unfiltered.
-    /// Used for the unfiltered count and to back the filter visibility decision.
-    private var allRows: [ArchivedRow] {
-        let archived = (appState.archivedWorktrees[repoID] ?? [])
-        let lingering = appState.revivingArchived
-            .compactMap { (_, state) -> Worktree? in
-                guard state.snapshot.repoID == repoID else { return nil }
-                return state.snapshot
-            }
+    /// Raw text in the search field. This view is NOT `.id(repoID)`-keyed by
+    /// `RepoDetailView`, so its `@State` survives a repo switch — hence the
+    /// explicit reset in `.onChange(of: repoID)` below.
+    @State private var searchQuery: String = ""
+    /// Keystrokes must not each become an RPC. Trailing-edge, clock-injected;
+    /// see `SearchQueryDebouncer`.
+    @State private var searchDebouncer = SearchQueryDebouncer()
+
+    private var trimmedQuery: String {
+        searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isSearching: Bool { !trimmedQuery.isEmpty }
+
+    /// What to render for the query currently in the field. Compares against
+    /// the query the stored results ACTUALLY answer — never the in-flight one,
+    /// which is stamped before its response lands.
+    private var displayDecision: ArchivedSearchDisplay.Decision {
+        ArchivedSearchDisplay.decide(
+            query: searchQuery,
+            resultsQuery: appState.archivedSearchResults[repoID]?.query
+        )
+    }
+
+    /// Daemon-side results for *exactly* the query currently in the field, or
+    /// nil while that answer hasn't landed (debounce window, in-flight RPC,
+    /// leftovers from an earlier query, or a failed search).
+    private var settledSearchResults: ArchivedSearchResults? {
+        guard displayDecision == .daemonResults else { return nil }
+        return appState.archivedSearchResults[repoID]
+    }
+
+    /// True when the search RPC for the current query failed and the list is
+    /// therefore showing the client-side preview of loaded rows only.
+    private var searchFailed: Bool {
+        isSearching && appState.archivedSearchFailed[repoID] == true
+    }
+
+    /// Merge a worktree list with this repo's lingering revive snapshots (so a
+    /// just-revived row doesn't vanish mid-flight), sort `archivedAt` desc, and
+    /// wrap in rows. `lingeringQuery` non-nil additionally requires those
+    /// snapshots to match it — daemon results arrive already filtered, local
+    /// snapshots don't.
+    private func makeRows(_ worktrees: [Worktree], lingeringQuery: String?) -> [ArchivedRow] {
         var byID: [UUID: Worktree] = [:]
-        for wt in archived { byID[wt.id] = wt }
-        for wt in lingering where byID[wt.id] == nil { byID[wt.id] = wt }
+        for wt in worktrees { byID[wt.id] = wt }
+        for (_, state) in appState.revivingArchived {
+            let wt = state.snapshot
+            guard wt.repoID == repoID, byID[wt.id] == nil else { continue }
+            if let lingeringQuery,
+               !ArchivedWorktreeSearchFilter.matches(wt, query: lingeringQuery) { continue }
+            byID[wt.id] = wt
+        }
         return byID.values
             .sorted { ($0.archivedAt ?? .distantPast) > ($1.archivedAt ?? .distantPast) }
             .map { wt in
@@ -28,11 +162,46 @@ struct ArchivedWorktreesView: View {
             }
     }
 
-    /// Visible rows after applying the current filter. Lingering revives
-    /// always pass through so a just-revived row doesn't vanish mid-flight.
+    /// All *loaded* archived rows for this repo (∪ lingering revive snapshots),
+    /// ignoring both filters. Backs the "this repo has no archives at all"
+    /// empty state.
+    private var allRows: [ArchivedRow] {
+        makeRows(appState.archivedWorktrees[repoID] ?? [], lingeringQuery: nil)
+    }
+
+    /// Rows after the search filter (before `hideEmpty`).
+    ///
+    /// While the daemon's answer for the current query hasn't arrived, this
+    /// falls back to filtering the already-loaded rows client-side rather than
+    /// showing an empty list or stale unfiltered rows. That preview is a close
+    /// approximation, not a guaranteed subset. For the *archived* rows it is
+    /// one: they are the newest N of the archived set in the same
+    /// `archivedAt desc` order the daemon returns, so the daemon's answer only
+    /// ever extends them. But `allRows` also unions in every lingering
+    /// `revivingArchived` snapshot — including `.done` ones whose worktree is
+    /// no longer archived server-side — so the preview can briefly show a row
+    /// the daemon would not return. That is the same deliberate "don't yank a
+    /// just-revived row out from under the user" behaviour the unsearched list
+    /// already has, not a search-specific inconsistency.
+    private var searchedRows: [ArchivedRow] {
+        switch displayDecision {
+        case .unfiltered:
+            return allRows
+        case .daemonResults:
+            guard let results = settledSearchResults else { return allRows }
+            return makeRows(results.worktrees, lingeringQuery: results.query)
+        case .clientPreview:
+            return allRows.filter {
+                ArchivedWorktreeSearchFilter.matches($0.worktree, query: trimmedQuery)
+            }
+        }
+    }
+
+    /// Visible rows after applying every filter. Lingering revives always pass
+    /// the `hideEmpty` filter so a just-revived row doesn't vanish mid-flight.
     private var rows: [ArchivedRow] {
-        guard hideEmpty else { return allRows }
-        return allRows.filter { row in
+        guard hideEmpty else { return searchedRows }
+        return searchedRows.filter { row in
             row.reviveState != nil || row.effectiveSessionCount > 0
         }
     }
@@ -48,12 +217,21 @@ struct ArchivedWorktreesView: View {
         appState.selectedReapRecordIDs[repoID]
     }
 
+    /// Whether the *currently displayed* set has more pages. While a search is
+    /// active but unsettled we have no verified answer for the matching set, so
+    /// no "Load More" is offered.
     private var hasMore: Bool {
-        appState.archivedWorktreesHasMore[repoID] == true
+        if isSearching {
+            guard let settled = settledSearchResults else { return false }
+            return settled.hasMore
+        }
+        return appState.archivedWorktreesHasMore[repoID] == true
     }
 
     var body: some View {
-        if allRows.isEmpty {
+        // "No archives at all" and "the search found nothing" are distinct: the
+        // latter must keep the rail (and its search field) on screen.
+        if allRows.isEmpty && !isSearching {
             emptyState
         } else {
             HStack(spacing: 0) {
@@ -75,8 +253,10 @@ struct ArchivedWorktreesView: View {
                     .font(.title3)
                     .fontWeight(.medium)
                 Spacer()
-                if hideEmpty && rows.count < allRows.count {
-                    Text("\(rows.count) of \(allRows.count)\(hasMore ? "+" : "")")
+                // Counts describe the *searched* set when a query is active,
+                // the whole loaded set otherwise (identical when not searching).
+                if hideEmpty && rows.count < searchedRows.count {
+                    Text("\(rows.count) of \(searchedRows.count)\(hasMore ? "+" : "")")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 } else if hasMore {
@@ -102,23 +282,28 @@ struct ArchivedWorktreesView: View {
                 .help("Filter")
             }
             .padding(.horizontal, 16)
-            .padding(.vertical, 12)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            searchField
+
+            // A failed search silently degrades to the client-side preview,
+            // which is a partial answer over the loaded pages only — say so
+            // rather than letting it pass as the real result set.
+            if searchFailed {
+                Text("Search failed — showing loaded results only")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+            }
 
             Divider()
 
             ScrollViewReader { proxy in
                 if rows.isEmpty {
-                    VStack(spacing: 8) {
-                        Image(systemName: "line.3.horizontal.decrease.circle")
-                            .font(.system(size: 28))
-                            .foregroundStyle(.tertiary)
-                        Text("No matches")
-                            .font(.callout)
-                            .foregroundStyle(.secondary)
-                        Button("Show all") { hideEmpty = false }
-                            .buttonStyle(.link)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    noMatchesState
                 } else {
                     List {
                         ForEach(rows) { row in
@@ -141,9 +326,11 @@ struct ArchivedWorktreesView: View {
                             }
                         }
                         if hasMore {
-                            let isLoading = appState.isLoadingMoreArchived[repoID] == true
+                            let isLoading = isSearching
+                                ? appState.isLoadingMoreArchivedSearch[repoID] == true
+                                : appState.isLoadingMoreArchived[repoID] == true
                             Button {
-                                Task { await appState.loadMoreArchivedWorktrees(repoID: repoID) }
+                                Task { await loadMore() }
                             } label: {
                                 Text(isLoading ? "Loading…" : "Load More…")
                                     .font(.callout)
@@ -179,8 +366,105 @@ struct ArchivedWorktreesView: View {
                 ReclaimedSectionView(repoID: repoID)
             }
         }
-        .onAppear { reconcileSelection() }
-        .onChange(of: hideEmpty) { _, _ in reconcileSelection() }
+        .onAppear {
+            // A fresh mount (tab switch away and back) starts with an empty
+            // field, so drop any search state left behind — otherwise the list
+            // and the field disagree, and every refresh re-runs a search the
+            // user can no longer see.
+            if trimmedQuery.isEmpty { appState.clearArchivedSearch(repoID: repoID) }
+            reconcileSelection()
+        }
+        // Any change to the VISIBLE row set — `hideEmpty`, a landed search
+        // result, a revive — can strand a selection the list no longer shows.
+        // Keyed on the ids rather than on the raw query text so the reconcile
+        // happens when the list actually changes, not one keystroke early.
+        .onChange(of: rows.map(\.id)) { _, _ in reconcileSelection() }
+        .onChange(of: searchQuery) { _, newValue in searchQueryChanged(newValue) }
+        // This view is reused across repos (not `.id(repoID)`-keyed), so the
+        // field would otherwise carry one repo's query into the next.
+        .onChange(of: repoID) { oldValue, _ in
+            searchDebouncer.cancel()
+            appState.clearArchivedSearch(repoID: oldValue)
+            searchQuery = ""
+        }
+    }
+
+    // MARK: - Search
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            TextField("Search by name", text: $searchQuery)
+                .textFieldStyle(.plain)
+                .font(.callout)
+            if !searchQuery.isEmpty {
+                Button {
+                    clearSearch()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .help("Clear search")
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 10)
+    }
+
+    /// Debounced query handling. An emptied field takes effect immediately —
+    /// there is nothing to fetch, and waiting would leave a filtered list up
+    /// after the user cleared it.
+    private func searchQueryChanged(_ newValue: String) {
+        let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            searchDebouncer.cancel()
+            appState.clearArchivedSearch(repoID: repoID)
+            return
+        }
+        searchDebouncer.schedule(trimmed) { [appState, repoID] query in
+            Task { await appState.searchArchivedWorktrees(repoID: repoID, query: query) }
+        }
+    }
+
+    private func clearSearch() {
+        searchQuery = ""
+        searchDebouncer.cancel()
+        appState.clearArchivedSearch(repoID: repoID)
+    }
+
+    private func loadMore() async {
+        if isSearching {
+            await appState.loadMoreArchivedSearchResults(repoID: repoID)
+        } else {
+            await appState.loadMoreArchivedWorktrees(repoID: repoID)
+        }
+    }
+
+    /// Nothing visible, but the repo does have archives — offer whichever
+    /// filter(s) are responsible for the miss.
+    private var noMatchesState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: isSearching ? "magnifyingglass" : "line.3.horizontal.decrease.circle")
+                .font(.system(size: 28))
+                .foregroundStyle(.tertiary)
+            Text("No matches")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            if isSearching {
+                Button("Clear search") { clearSearch() }
+                    .buttonStyle(.link)
+            }
+            // `searchedRows` non-empty means rows survived the search and only
+            // `hideEmpty` is hiding them, so "Show all" is a real remedy.
+            if hideEmpty && !searchedRows.isEmpty {
+                Button("Show all") { hideEmpty = false }
+                    .buttonStyle(.link)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     /// Make sure `selectedArchivedWorktreeIDs[repoID]` points to a row that

--- a/Sources/TBDApp/ArchivedWorktreesView.swift
+++ b/Sources/TBDApp/ArchivedWorktreesView.swift
@@ -92,6 +92,39 @@ enum ArchivedSearchDisplay {
         guard resultsQuery == trimmed else { return .clientPreview }
         return .daemonResults
     }
+
+    /// What the list area renders.
+    enum ListState: Equatable {
+        case rows
+        /// No verdict yet: the daemon's answer for this query hasn't arrived
+        /// and the client-side preview over the loaded page came up empty.
+        case searching
+        /// A verdict: nothing matches (or `hideEmpty` is hiding what does).
+        case noMatches
+    }
+
+    /// **"I don't know yet" and "there is nothing" must not look identical.**
+    ///
+    /// The client-side preview filters only the *loaded* page, so for the
+    /// feature's whole purpose — finding an archive older than the first 50 —
+    /// the preview is legitimately empty while the real answer is still in
+    /// flight. Rendering that as "No matches" made the list read as a verdict
+    /// during the entire time the user was typing: every keystroke restarts the
+    /// 250 ms debounce, so the unsettled window lasts as long as the typing
+    /// does, not the ~150 ms the RPC actually takes.
+    ///
+    /// A search that already FAILED is excluded deliberately: there is no
+    /// answer coming, so a spinner would run forever. The inline
+    /// "Search failed — showing loaded results only" note explains that case.
+    static func listState(
+        decision: Decision,
+        searchFailed: Bool,
+        hasVisibleRows: Bool
+    ) -> ListState {
+        if hasVisibleRows { return .rows }
+        guard decision == .clientPreview, !searchFailed else { return .noMatches }
+        return .searching
+    }
 }
 
 struct ArchivedWorktreesView: View {
@@ -138,6 +171,22 @@ struct ArchivedWorktreesView: View {
     /// therefore showing the client-side preview of loaded rows only.
     private var searchFailed: Bool {
         isSearching && appState.archivedSearchFailed[repoID] == true
+    }
+
+    /// True while the daemon's answer for the query in the field is still
+    /// outstanding (debounce window or in-flight RPC) and hasn't failed. Drives
+    /// both spinners — the list's "Searching…" and the field's inline one.
+    private var isSearchPending: Bool {
+        displayDecision == .clientPreview && !searchFailed
+    }
+
+    /// What the list area should render.
+    private var listState: ArchivedSearchDisplay.ListState {
+        ArchivedSearchDisplay.listState(
+            decision: displayDecision,
+            searchFailed: searchFailed,
+            hasVisibleRows: !rows.isEmpty
+        )
     }
 
     /// Merge a worktree list with this repo's lingering revive snapshots (so a
@@ -302,9 +351,12 @@ struct ArchivedWorktreesView: View {
             Divider()
 
             ScrollViewReader { proxy in
-                if rows.isEmpty {
+                switch listState {
+                case .searching:
+                    searchingState
+                case .noMatches:
                     noMatchesState
-                } else {
+                case .rows:
                     List {
                         ForEach(rows) { row in
                             ArchivedWorktreeRow(
@@ -399,6 +451,14 @@ struct ArchivedWorktreesView: View {
             TextField("Search by name", text: $searchQuery)
                 .textFieldStyle(.plain)
                 .font(.callout)
+            // The other half of "unsettled must not look settled": when the
+            // preview DOES have rows, the list looks like a final answer while
+            // it is still narrowing, so results appear to change after the fact
+            // for no visible reason.
+            if isSearchPending {
+                ProgressView()
+                    .controlSize(.mini)
+            }
             if !searchQuery.isEmpty {
                 Button {
                     clearSearch()
@@ -441,6 +501,21 @@ struct ArchivedWorktreesView: View {
         } else {
             await appState.loadMoreArchivedWorktrees(repoID: repoID)
         }
+    }
+
+    /// Nothing visible YET — the daemon's answer for this query is still
+    /// coming. Deliberately offers no Clear/Show-all affordances: there is no
+    /// verdict to remedy, and buttons here would invite the user to act on a
+    /// result that doesn't exist.
+    private var searchingState: some View {
+        VStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Searching…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     /// Nothing visible, but the repo does have archives — offer whichever

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -532,7 +532,8 @@ actor DaemonClient {
         offset: Int? = nil,
         excludeArchived: Bool = false,
         scratchOnly: Bool = false,
-        includeSessionCounts: Bool? = nil
+        includeSessionCounts: Bool? = nil,
+        nameQuery: String? = nil
     ) async throws -> [Worktree] {
         return try await callAsync(
             method: RPCMethod.worktreeList,
@@ -543,7 +544,8 @@ actor DaemonClient {
                 offset: offset,
                 excludeArchived: excludeArchived,
                 scratchOnly: scratchOnly,
-                includeSessionCounts: includeSessionCounts
+                includeSessionCounts: includeSessionCounts,
+                nameQuery: nameQuery
             ),
             resultType: [Worktree].self
         )

--- a/Sources/TBDApp/SearchQueryDebouncer.swift
+++ b/Sources/TBDApp/SearchQueryDebouncer.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Trailing-edge debounce for a typed search query, so a burst of keystrokes
+/// costs one RPC instead of one per character.
+///
+/// Same shape and same contract as `AppearanceBroadcastDebouncer` (see that
+/// file for the long-form rationale): cancel-and-replace a `Task` over
+/// `clock.sleep(for:)`, with the clock injected as the last, defaulted,
+/// **existential** parameter. Combine's `.debounce` is not an option — it takes
+/// a `Scheduler`, which can never be an `any Clock<Duration>`, so the project's
+/// clock seam (`docs/specs/2026-07-24-test-hardening-design.md` §5) cannot be
+/// threaded through it and the timing would only be testable against a wall
+/// clock.
+///
+/// Unlike `AppearanceBroadcastDebouncer` this one takes values directly rather
+/// than subscribing to a publisher: its input is SwiftUI `@State` text driven
+/// by `.onChange`, not a `@Published` property.
+@MainActor
+final class SearchQueryDebouncer {
+    private let interval: Duration
+    private let clock: any Clock<Duration>
+    private var pending: Task<Void, Never>?
+
+    /// - Parameter interval: quiet window before the query is acted on. 250 ms
+    ///   is long enough to swallow ordinary typing, short enough that results
+    ///   feel like they follow the keystroke.
+    /// - Parameter clock: last parameter, existential, defaulted — the shared
+    ///   seam contract. Existential rather than generic so this type doesn't
+    ///   have to become generic at every storage site.
+    init(interval: Duration = .milliseconds(250),
+         clock: any Clock<Duration> = ContinuousClock()) {
+        self.interval = interval
+        self.clock = clock
+    }
+
+    /// Cancels a pending fire, if any. Idempotent.
+    func cancel() {
+        pending?.cancel()
+        pending = nil
+    }
+
+    /// Trailing edge: every new value restarts the window, so a burst collapses
+    /// to one call with the last value.
+    func schedule(_ value: String, onQuiet: @escaping @MainActor (String) -> Void) {
+        pending?.cancel()
+        pending = Task { @MainActor [clock, interval] in
+            // Cancellation while still asleep surfaces as a thrown error — the
+            // "a newer keystroke superseded me" path.
+            guard (try? await clock.sleep(for: interval)) != nil else { return }
+            // Both checks are load-bearing; the throw alone is not enough.
+            // Cancellation that arrives *after* the sleep has already resumed
+            // cannot retroactively make that `await` throw. The window is real:
+            // the timer resumption is enqueued on the MainActor, and if the
+            // MainActor is mid-turn in something that types another character
+            // (or clears the field), `schedule`/`cancel` runs first — then our
+            // resumption executes anyway and fires a superseded query.
+            guard !Task.isCancelled else { return }
+            onQuiet(value)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -362,14 +362,28 @@ public struct WorktreeStore: Sendable {
     /// note `repoID: nil` alone means "no repo filter" (every repo plus
     /// scratch), not "scratch only"; `scratchOnly` is the only way to get
     /// scratch-only rows.
-    /// This composes with `status`: all filters are applied when given together.
+    /// When `nameQuery` is non-nil and not whitespace-only, restricts to rows
+    /// whose folder `name` OR `displayName` *contains* the query
+    /// (case-insensitive substring, not a prefix match). A blank or
+    /// whitespace-only query means "no filter". LIKE metacharacters (`%`, `_`)
+    /// and the escape character in the query are escaped, so they match
+    /// literally rather than acting as wildcards.
+    ///
+    /// Case-insensitivity comes from SQLite's built-in `LIKE`, which folds
+    /// **ASCII only** — a non-ASCII query matches case-sensitively. Accepted:
+    /// worktree names are generated ASCII slugs.
+    ///
+    /// This composes with `status`: all filters are applied when given
+    /// together, and all of them are applied *before* `limit`/`offset` so
+    /// pagination pages over the matching set.
     public func list(
         repoID: UUID? = nil,
         status: WorktreeStatus? = nil,
         excludeArchived: Bool = false,
         scratchOnly: Bool = false,
         limit: Int? = nil,
-        offset: Int? = nil
+        offset: Int? = nil,
+        nameQuery: String? = nil
     ) async throws -> [Worktree] {
         try await writer.read { db in
             var request = WorktreeRecord.all()
@@ -385,6 +399,14 @@ public struct WorktreeStore: Sendable {
             if excludeArchived {
                 request = request.filter(Column("status") != WorktreeStatus.archived.rawValue)
             }
+            if let pattern = Self.likePattern(for: nameQuery) {
+                // GRDB's `.like()` operator has no escape-character overload,
+                // so the ESCAPE clause is spelled out as raw SQL. Arguments
+                // stay bound (no interpolation of user text into SQL).
+                request = request.filter(sql: """
+                    (name LIKE ? ESCAPE '\\' OR displayName LIKE ? ESCAPE '\\')
+                    """, arguments: [pattern, pattern])
+            }
             if status == .archived {
                 request = request.order(Column("archivedAt").desc)
             } else {
@@ -395,6 +417,25 @@ public struct WorktreeStore: Sendable {
             }
             return try request.fetchAll(db).compactMap { $0.toModel() }
         }
+    }
+
+    /// Build the `%…%` LIKE pattern for a user-typed name query, or nil when
+    /// the query is absent/blank (== no filter).
+    ///
+    /// The escaping is the load-bearing part: without it a typed `%` is a
+    /// wildcard that matches every row, and `_` matches any single character.
+    /// The escape character itself must be escaped first, otherwise a trailing
+    /// `\` would escape the closing `%` we append. `internal` so it is directly
+    /// unit-testable.
+    static func likePattern(for nameQuery: String?) -> String? {
+        guard let raw = nameQuery else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let escaped = trimmed
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+        return "%\(escaped)%"
     }
 
     /// Get a worktree by ID.

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -125,7 +125,8 @@ extension RPCRouter {
             excludeArchived: params.excludeArchived ?? false,
             scratchOnly: params.scratchOnly ?? false,
             limit: params.limit,
-            offset: params.offset
+            offset: params.offset,
+            nameQuery: params.nameQuery
         )
         // Enrich archived worktrees with a real session-file count so the
         // client can filter on actual disk state, not stale stored IDs.

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -942,6 +942,17 @@ public struct WorktreeListParams: Codable, Sendable {
     /// backward compatibility — old daemons ignore the unknown key and always
     /// enrich; old clients omit it and get the enriched default.
     public let includeSessionCounts: Bool?
+    /// Substring filter over the worktree's folder `name` **and** its
+    /// `displayName`: a row matches when the query appears anywhere in either
+    /// (not just as a prefix). Matching is case-insensitive for ASCII — the
+    /// daemon implements this with SQLite `LIKE`, whose built-in case folding
+    /// does not cover non-ASCII characters.
+    ///
+    /// nil or blank (whitespace-only) means "no filter". The filter is applied
+    /// *before* `limit`/`offset`, so pagination pages over the matching set.
+    /// Optional (nil == no filter) for backward compatibility — old daemons
+    /// ignore the unknown key and return everything; old clients omit it.
+    public let nameQuery: String?
     public init(
         repoID: UUID? = nil,
         status: WorktreeStatus? = nil,
@@ -949,7 +960,8 @@ public struct WorktreeListParams: Codable, Sendable {
         offset: Int? = nil,
         excludeArchived: Bool? = nil,
         scratchOnly: Bool? = nil,
-        includeSessionCounts: Bool? = nil
+        includeSessionCounts: Bool? = nil,
+        nameQuery: String? = nil
     ) {
         self.repoID = repoID
         self.status = status
@@ -958,6 +970,7 @@ public struct WorktreeListParams: Codable, Sendable {
         self.excludeArchived = excludeArchived
         self.scratchOnly = scratchOnly
         self.includeSessionCounts = includeSessionCounts
+        self.nameQuery = nameQuery
     }
 }
 

--- a/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
+++ b/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
@@ -1,0 +1,329 @@
+import Clocks
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+import TestSupport
+
+/// Tier 1. The pure client-side half of archived-worktree search: the substring
+/// match that backs the preview shown while the daemon's SQL answer is still in
+/// flight. Kept semantically identical to `WorktreeStore.list(nameQuery:)` so
+/// the preview is a subset of the daemon's answer, not a different question.
+@Suite("Archived worktree search filter")
+struct ArchivedWorktreeSearchFilterTests {
+    private func worktree(name: String, displayName: String) -> Worktree {
+        Worktree(
+            repoID: UUID(),
+            name: name,
+            displayName: displayName,
+            branch: "tbd/\(name)",
+            path: "/tmp/\(name)",
+            status: .archived,
+            tmuxServer: "srv"
+        )
+    }
+
+    @Test("an empty or whitespace-only query matches everything")
+    func emptyQueryMatchesEverything() {
+        let wt = worktree(name: "curious-wolverine", displayName: "Curious Wolverine")
+        #expect(ArchivedWorktreeSearchFilter.matches(wt, query: ""))
+        #expect(ArchivedWorktreeSearchFilter.matches(wt, query: "   "))
+    }
+
+    @Test("matches the folder name, case-insensitively")
+    func matchesFolderName() {
+        let wt = worktree(name: "curious-wolverine", displayName: "Renamed")
+        #expect(ArchivedWorktreeSearchFilter.matches(wt, query: "wolverine"))
+        #expect(ArchivedWorktreeSearchFilter.matches(wt, query: "WOLVERINE"))
+    }
+
+    @Test("matches the display name even when the folder name does not")
+    func matchesDisplayName() {
+        let wt = worktree(name: "aaa-bbb", displayName: "Search Rail")
+        #expect(ArchivedWorktreeSearchFilter.matches(wt, query: "rail"))
+        #expect(!ArchivedWorktreeSearchFilter.matches(wt, query: "zzz"))
+    }
+
+    @Test("substring, not prefix")
+    func matchesMidStringSubstring() {
+        let wt = worktree(name: "tbd-archived-search", displayName: "tbd-archived-search")
+        #expect(ArchivedWorktreeSearchFilter.matches(wt, query: "archiv"))
+    }
+
+    @Test("the query is trimmed before matching")
+    func queryIsTrimmed() {
+        let wt = worktree(name: "curious-wolverine", displayName: "Curious Wolverine")
+        #expect(ArchivedWorktreeSearchFilter.matches(wt, query: "  wolverine  "))
+    }
+
+    @Test("a non-matching query matches neither name")
+    func nonMatchingQuery() {
+        let wt = worktree(name: "curious-wolverine", displayName: "Curious Wolverine")
+        #expect(!ArchivedWorktreeSearchFilter.matches(wt, query: "otter"))
+    }
+}
+
+/// Tier 1. Which row set the archived list renders for a given query, given
+/// the query the results in hand actually answer.
+///
+/// The `.clientPreview` case for a *mismatched* results-query is a regression
+/// test: the results and their query used to live in separate `AppState` dicts,
+/// and the in-flight query was stamped before the RPC while the rows were
+/// replaced after it. For that whole window the view believed the previous
+/// query's rows were the settled answer for the new one — and since daemon
+/// results are not re-filtered client-side, it displayed rows that do not match
+/// what the user typed. Typing appeared not to narrow the list.
+@Suite("Archived search display decision")
+struct ArchivedSearchDisplayTests {
+    @Test("no query shows every loaded row, whatever results are held")
+    func emptyQueryIsUnfiltered() {
+        #expect(ArchivedSearchDisplay.decide(query: "", resultsQuery: nil) == .unfiltered)
+        #expect(ArchivedSearchDisplay.decide(query: "   ", resultsQuery: "abc") == .unfiltered)
+    }
+
+    @Test("results answering exactly this query are the row set")
+    func matchingResultsQueryUsesDaemonResults() {
+        #expect(ArchivedSearchDisplay.decide(query: "abc", resultsQuery: "abc") == .daemonResults)
+        // The stored query is already trimmed; the typed one may not be.
+        #expect(ArchivedSearchDisplay.decide(query: "  abc ", resultsQuery: "abc") == .daemonResults)
+    }
+
+    @Test("results answering a DIFFERENT query fall back to the client-side preview")
+    func staleResultsQueryFallsBackToPreview() {
+        // The exact stale-results defect: "abc" answered, "abcd" now typed.
+        #expect(ArchivedSearchDisplay.decide(query: "abcd", resultsQuery: "abc") == .clientPreview)
+        // And the reverse (user deleted a character).
+        #expect(ArchivedSearchDisplay.decide(query: "abc", resultsQuery: "abcd") == .clientPreview)
+    }
+
+    @Test("no results at all fall back to the client-side preview")
+    func noResultsFallsBackToPreview() {
+        #expect(ArchivedSearchDisplay.decide(query: "abc", resultsQuery: nil) == .clientPreview)
+    }
+}
+
+/// Tier 1. Regression coverage for the second archived row source.
+///
+/// Search results are rows the daemon matched in pages `archivedWorktrees`
+/// never loaded. Every lookup written against the loaded pages alone silently
+/// fails for them — which made Revive a no-op (no RPC, no alert, just a
+/// `logger.warning`) on exactly the row a user searched to find, and made
+/// `ensureArchivedSelectionValid` judge a search-only selection stale and
+/// re-point the detail pane on the next refresh.
+///
+/// `AppState` constructs safely here: `init` skips its auto-connect under the
+/// test harness (see `AppStateTestModeGuardTests`), and none of the methods
+/// exercised below issue an RPC.
+@MainActor
+@Suite("Archived snapshot resolution")
+struct ArchivedSnapshotResolutionTests {
+    private func makeState() -> (AppState, String) {
+        let suiteName = "TBDAppTests.ArchivedSnapshots.\(UUID().uuidString)"
+        return (AppState(userDefaults: UserDefaults(suiteName: suiteName)!), suiteName)
+    }
+
+    private func worktree(repoID: UUID?, name: String) -> Worktree {
+        Worktree(
+            repoID: repoID, name: name, displayName: name, branch: "tbd/\(name)",
+            path: "/tmp/\(name)", status: .archived, tmuxServer: "srv"
+        )
+    }
+
+    // MARK: the pure union
+
+    @Test("the union carries rows that exist only in the search results")
+    func unionIncludesSearchOnlyRows() {
+        let loaded = worktree(repoID: UUID(), name: "loaded")
+        let searchOnly = worktree(repoID: UUID(), name: "search-only")
+        let merged = AppState.mergeArchivedSnapshots(
+            loaded: [loaded], searchResults: [searchOnly]
+        )
+        #expect(merged.map(\.id) == [loaded.id, searchOnly.id])
+    }
+
+    @Test("a row in both sources appears once, taking the loaded copy")
+    func unionDedupesPreferringLoaded() {
+        let repoID = UUID()
+        var loaded = worktree(repoID: repoID, name: "shared")
+        loaded.displayName = "fresh"
+        var stale = loaded
+        stale.displayName = "stale"
+
+        let merged = AppState.mergeArchivedSnapshots(loaded: [loaded], searchResults: [stale])
+        #expect(merged.count == 1)
+        #expect(merged.first?.displayName == "fresh")
+    }
+
+    @Test("either source may be empty")
+    func unionHandlesEmptySources() {
+        let only = worktree(repoID: UUID(), name: "only")
+        #expect(AppState.mergeArchivedSnapshots(loaded: [], searchResults: [only]).map(\.id) == [only.id])
+        #expect(AppState.mergeArchivedSnapshots(loaded: [only], searchResults: []).map(\.id) == [only.id])
+        #expect(AppState.mergeArchivedSnapshots(loaded: [], searchResults: []).isEmpty)
+    }
+
+    // MARK: the lookup the revive paths use
+
+    /// The Finding-1 regression: this is the exact resolution both
+    /// `reviveWorktree` and `reviveWithSession` guard on. Against
+    /// `archivedWorktrees` alone it returned nil and the revive silently
+    /// no-opped.
+    @Test("archivedSnapshot resolves a row present only in the search results")
+    func archivedSnapshotResolvesSearchOnlyRow() {
+        let (state, suite) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        let repoID = UUID()
+        let loaded = worktree(repoID: repoID, name: "loaded")
+        let searchOnly = worktree(repoID: repoID, name: "search-only")
+
+        state.archivedWorktrees[repoID] = [loaded]
+        state.archivedSearchResults[repoID] = ArchivedSearchResults(
+            query: "search", worktrees: [searchOnly], hasMore: false
+        )
+
+        #expect(state.archivedSnapshot(id: searchOnly.id)?.id == searchOnly.id)
+        #expect(state.archivedSnapshot(id: loaded.id)?.id == loaded.id)
+        #expect(state.archivedSnapshot(id: UUID()) == nil)
+    }
+
+    /// A selection on a search-only row must survive selection maintenance.
+    /// This branch early-returns, so no `fetchSessions` RPC is issued.
+    @Test("ensureArchivedSelectionValid keeps a selection on a search-only row")
+    func selectionOnSearchOnlyRowSurvives() {
+        let (state, suite) = makeState()
+        defer { UserDefaults.standard.removePersistentDomain(forName: suite) }
+        let repoID = UUID()
+        let loaded = worktree(repoID: repoID, name: "loaded")
+        let searchOnly = worktree(repoID: repoID, name: "search-only")
+
+        state.archivedWorktrees[repoID] = [loaded]
+        state.archivedSearchResults[repoID] = ArchivedSearchResults(
+            query: "search", worktrees: [searchOnly], hasMore: false
+        )
+        state.selectArchivedWorktree(searchOnly.id, repoID: repoID)
+
+        state.ensureArchivedSelectionValid(repoID: repoID)
+        #expect(state.selectedArchivedWorktreeIDs[repoID] == searchOnly.id,
+                "a search-only selection is legitimate and must not be re-pointed")
+    }
+}
+
+/// Tier 1. Regression coverage for the page-preserving refresh arithmetic
+/// shared by `refreshArchivedWorktrees` and `refreshArchivedSearch`.
+///
+/// The Finding-2 defect was that the search re-run refetched page 0 and
+/// replaced the stored results, collapsing Load More–accumulated pages. Both
+/// refreshes now derive their fetch size and `hasMore` from this one type; what
+/// is covered here is that arithmetic, not the RPC wiring (`AppState.daemonClient`
+/// has no injection seam, so the wiring itself is not reachable in a unit test).
+@Suite("Archived refresh plan")
+struct ArchivedRefreshPlanTests {
+    private let pageSize = 50
+
+    @Test("a first-time refresh fetches exactly one page")
+    func firstRefreshFetchesOnePage() {
+        let plan = ArchivedRefreshPlan(currentCount: 0, pageSize: pageSize)
+        #expect(plan.fetchCount == 50)
+        #expect(plan.knownExhausted == false)
+        #expect(plan.hasMore(fetched: 50))
+        #expect(!plan.hasMore(fetched: 12))
+    }
+
+    /// The invariant the search re-run was missing: with 150 rows already
+    /// pulled in, a refresh must ask for all 150, not the first 50.
+    @Test("a refresh preserves already-loaded pages")
+    func refreshPreservesLoadedPages() {
+        let plan = ArchivedRefreshPlan(currentCount: 150, pageSize: pageSize)
+        #expect(plan.fetchCount == 150)
+        #expect(plan.knownExhausted == false)
+        #expect(plan.hasMore(fetched: 150))
+    }
+
+    /// A partial last page proves the server has nothing more, so the larger
+    /// refetch returning fewer rows than it asked for must not re-arm
+    /// "Load More".
+    @Test("a partial page is known-exhausted and never re-arms Load More")
+    func partialPageIsKnownExhausted() {
+        let plan = ArchivedRefreshPlan(currentCount: 73, pageSize: pageSize)
+        #expect(plan.fetchCount == 73)
+        #expect(plan.knownExhausted)
+        #expect(!plan.hasMore(fetched: 73))
+        #expect(!plan.hasMore(fetched: 100))
+    }
+}
+
+/// Tier 1. Debounce contract for the archived search field: a burst of
+/// keystrokes must cost one RPC, not one per character. Entirely virtual time —
+/// see `Tests/CLAUDE.md` "Clock and date seams".
+///
+/// `.serialized` for the same reason as `AppearanceDebounceTests`: every test
+/// here drives a `TestClock`, and each advance costs a `Task.megaYield()`; run
+/// in parallel these starve each other on the arming handshake.
+@MainActor
+@Suite("Archived search debounce", .clockDriven, .serialized)
+struct SearchQueryDebouncerTests {
+    private static let interval = Duration.milliseconds(250)
+
+    @MainActor
+    private final class Box {
+        var values: [String] = []
+    }
+
+    @Test("a burst within one window collapses to a single fire with the last value")
+    func burstCollapsesToLastValue() async {
+        let clock = TestClock()
+        let debouncer = SearchQueryDebouncer(interval: Self.interval, clock: clock)
+        let fired = Box()
+
+        debouncer.schedule("w") { [fired] in fired.values.append($0) }
+        debouncer.schedule("wo") { [fired] in fired.values.append($0) }
+        debouncer.schedule("wolv") { [fired] in fired.values.append($0) }
+
+        await clock.advanceWhenSuspended(by: Self.interval)
+        #expect(fired.values == ["wolv"])
+    }
+
+    @Test("nothing fires until the full interval has elapsed")
+    func firesOnTheBoundary() async {
+        let clock = TestClock()
+        let debouncer = SearchQueryDebouncer(interval: Self.interval, clock: clock)
+        let fired = Box()
+
+        debouncer.schedule("wolv") { [fired] in fired.values.append($0) }
+
+        await clock.advanceWhenSuspended(by: Self.interval - .milliseconds(1))
+        #expect(fired.values.isEmpty, "one millisecond short of the window must not fire")
+
+        await clock.advance(by: .milliseconds(1))
+        #expect(fired.values == ["wolv"])
+    }
+
+    @Test("cancel() drops a pending fire")
+    func cancelDropsPendingFire() async {
+        let clock = TestClock()
+        let debouncer = SearchQueryDebouncer(interval: Self.interval, clock: clock)
+        let fired = Box()
+
+        debouncer.schedule("wolv") { [fired] in fired.values.append($0) }
+        await clock.advanceWhenSuspended(by: .milliseconds(100))
+
+        debouncer.cancel()
+        await clock.advance(by: Self.interval)
+        #expect(fired.values.isEmpty, "a cancelled query must never reach the daemon")
+    }
+
+    @Test("queries separated by a full window fire twice, in order")
+    func separatedQueriesFireTwice() async {
+        let clock = TestClock()
+        let debouncer = SearchQueryDebouncer(interval: Self.interval, clock: clock)
+        let fired = Box()
+
+        debouncer.schedule("wolv") { [fired] in fired.values.append($0) }
+        await clock.advanceWhenSuspended(by: Self.interval)
+        #expect(fired.values == ["wolv"])
+
+        debouncer.schedule("otter") { [fired] in fired.values.append($0) }
+        await clock.advanceWhenSuspended(by: Self.interval)
+        #expect(fired.values == ["wolv", "otter"])
+    }
+}

--- a/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
+++ b/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
@@ -102,6 +102,70 @@ struct ArchivedSearchDisplayTests {
     }
 }
 
+/// Tier 1. The full truth table for what the list area renders.
+///
+/// The bug this pins: an empty *client-side preview* was rendered as a
+/// definitive "No matches". The preview filters only the loaded page, so it is
+/// legitimately empty whenever the user is searching for an archive older than
+/// the first 50 — the feature's entire purpose. And because each keystroke
+/// restarts the 250 ms debounce, that state persists for as long as the user is
+/// typing, not for the ~150 ms the RPC takes: they read "No matches" the whole
+/// time they type the word.
+@Suite("Archived search list state")
+struct ArchivedSearchListStateTests {
+    private func state(
+        _ decision: ArchivedSearchDisplay.Decision,
+        failed: Bool = false,
+        rows: Bool
+    ) -> ArchivedSearchDisplay.ListState {
+        ArchivedSearchDisplay.listState(
+            decision: decision, searchFailed: failed, hasVisibleRows: rows
+        )
+    }
+
+    /// The reported bug. Asserted twice — the positive contract, and explicitly
+    /// that it is NOT the verdict it used to render.
+    @Test("an unsettled query with an empty preview is Searching, not No matches")
+    func unsettledEmptyPreviewIsSearching() {
+        let result = state(.clientPreview, failed: false, rows: false)
+        #expect(result == .searching)
+        #expect(result != .noMatches, "an unsettled preview must never read as a verdict")
+    }
+
+    /// No answer is coming, so a spinner would run forever. The inline
+    /// "Search failed" note carries the explanation instead.
+    @Test("a FAILED search with an empty preview is No matches, never a spinner")
+    func failedSearchIsNoMatchesNotSpinner() {
+        #expect(state(.clientPreview, failed: true, rows: false) == .noMatches)
+    }
+
+    @Test("the daemon's own empty answer is a genuine No matches")
+    func daemonEmptyAnswerIsNoMatches() {
+        #expect(state(.daemonResults, rows: false) == .noMatches)
+        // `searchFailed` is irrelevant once a settled answer exists.
+        #expect(state(.daemonResults, failed: true, rows: false) == .noMatches)
+    }
+
+    /// Regression guard for the pre-existing behaviour: with no query at all,
+    /// an empty list means `hideEmpty` is hiding everything — that must keep
+    /// its "Show all" verdict rather than becoming an endless spinner.
+    @Test("no query with an empty list stays No matches, not Searching")
+    func unfilteredEmptyIsNoMatches() {
+        #expect(state(.unfiltered, rows: false) == .noMatches)
+        #expect(state(.unfiltered, failed: true, rows: false) == .noMatches)
+    }
+
+    @Test("any decision with visible rows renders the rows")
+    func visibleRowsAlwaysRender() {
+        for decision: ArchivedSearchDisplay.Decision in [.unfiltered, .daemonResults, .clientPreview] {
+            for failed in [true, false] {
+                #expect(state(decision, failed: failed, rows: true) == .rows,
+                        "decision \(decision), failed \(failed) must render rows")
+            }
+        }
+    }
+}
+
 /// Tier 1. Regression coverage for the second archived row source.
 ///
 /// Search results are rows the daemon matched in pages `archivedWorktrees`

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import GRDB
 @testable import TBDDaemonLib
 import TBDShared
 
@@ -466,5 +467,181 @@ import TBDShared
 
         let result = try await db.worktrees.list(scratchOnly: true)
         #expect(result.map(\.id) == [scratch.id])
+    }
+
+    // MARK: - nameQuery filter
+    //
+    // Tier 1 (in-memory DB). The archived list is paginated, so this filter has
+    // to run in SQL: a client-side filter would silently miss archives in pages
+    // the app never loaded.
+
+    /// Create + archive a worktree, so it lands in the `status: .archived` set
+    /// the search field queries.
+    private func makeArchived(
+        db: TBDDatabase, repoID: UUID, name: String, displayName: String? = nil
+    ) async throws -> Worktree {
+        let wt = try await db.worktrees.create(
+            repoID: repoID, name: name, displayName: displayName, branch: "b-\(name)",
+            path: "/tmp/\(name)-\(UUID())", tmuxServer: "srv"
+        )
+        try await db.worktrees.archive(id: wt.id)
+        return wt
+    }
+
+    /// Overwrite a row's `archivedAt` with a deterministic value
+    /// (`2026-01-01T00:00:00Z + seconds`). `archive()` has no date seam, and
+    /// several archives inside the same stored-millisecond tie on the
+    /// `archivedAt desc` order.
+    private func stampArchivedAt(db: TBDDatabase, id: UUID, seconds: Int) async throws {
+        let date = Date(timeIntervalSince1970: 1_767_225_600).addingTimeInterval(TimeInterval(seconds))
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: "UPDATE worktree SET archivedAt = ? WHERE id = ?",
+                arguments: [date, id.uuidString]
+            )
+        }
+    }
+
+    @Test func nameQueryMatchesFolderName() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let hit = try await makeArchived(db: db, repoID: repo.id, name: "curious-wolverine", displayName: "Zebra")
+        _ = try await makeArchived(db: db, repoID: repo.id, name: "sleepy-otter", displayName: "Yak")
+
+        let result = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "wolverine")
+        #expect(result.map(\.id) == [hit.id])
+    }
+
+    @Test func nameQueryMatchesDisplayName() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let hit = try await makeArchived(db: db, repoID: repo.id, name: "aaa", displayName: "Search Rail")
+        _ = try await makeArchived(db: db, repoID: repo.id, name: "bbb", displayName: "Other")
+
+        let result = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "rail")
+        #expect(result.map(\.id) == [hit.id])
+    }
+
+    @Test func nameQueryIsCaseInsensitive() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let hit = try await makeArchived(db: db, repoID: repo.id, name: "MixedCaseName")
+
+        let lower = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "mixedcase")
+        let upper = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "MIXEDCASE")
+        #expect(lower.map(\.id) == [hit.id])
+        #expect(upper.map(\.id) == [hit.id])
+    }
+
+    /// Substring, not prefix: a query matching only the middle of the name hits.
+    @Test func nameQueryMatchesSubstringNotOnlyPrefix() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let hit = try await makeArchived(db: db, repoID: repo.id, name: "tbd-archived-search")
+
+        let result = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "archiv")
+        #expect(result.map(\.id) == [hit.id])
+    }
+
+    @Test func blankOrWhitespaceNameQueryAppliesNoFilter() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let a = try await makeArchived(db: db, repoID: repo.id, name: "alpha")
+        let b = try await makeArchived(db: db, repoID: repo.id, name: "beta")
+        let all: Set<UUID> = [a.id, b.id]
+
+        for query in ["", "   ", "\n\t "] {
+            let result = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: query)
+            #expect(Set(result.map(\.id)) == all, "query \(query.debugDescription) must not filter")
+        }
+        let noQuery = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: nil)
+        #expect(Set(noQuery.map(\.id)) == all)
+    }
+
+    /// Regression: LIKE metacharacters in the user's query must be escaped.
+    /// Unescaped, `%` is a wildcard that matches every row and `_` matches any
+    /// single character — a search would silently stop filtering.
+    @Test func likeMetacharactersInQueryMatchLiterally() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let percent = try await makeArchived(db: db, repoID: repo.id, name: "fifty%off")
+        let underscore = try await makeArchived(db: db, repoID: repo.id, name: "snake_case")
+        _ = try await makeArchived(db: db, repoID: repo.id, name: "plain")
+
+        // `%` is literal: matches only the row that really contains it.
+        let percentHits = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "%")
+        #expect(percentHits.map(\.id) == [percent.id])
+
+        // `_` is literal: "snake_case" hits, "snakeXcase" would not.
+        let underscoreHits = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "e_c")
+        #expect(underscoreHits.map(\.id) == [underscore.id])
+
+        // A backslash (the escape char itself) is literal too and matches nothing here.
+        let backslashHits = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "\\")
+        #expect(backslashHits.isEmpty)
+    }
+
+    /// Composes with `status` and `repoID`: an active row with a matching name,
+    /// and an archived row in another repo, are both excluded.
+    @Test func nameQueryComposesWithStatusAndRepoFilters() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+        let otherRepo = try await createRepo(db: db)
+
+        let hit = try await makeArchived(db: db, repoID: repo.id, name: "match-me")
+        let active = try await db.worktrees.create(
+            repoID: repo.id, name: "match-me-too", branch: "b-active",
+            path: "/tmp/active-\(UUID())", tmuxServer: "srv"
+        )
+        let otherRepoHit = try await makeArchived(db: db, repoID: otherRepo.id, name: "match-me-elsewhere")
+
+        let result = try await db.worktrees.list(repoID: repo.id, status: .archived, nameQuery: "match-me")
+        let ids = Set(result.map(\.id))
+        #expect(ids == [hit.id])
+        #expect(!ids.contains(active.id))
+        #expect(!ids.contains(otherRepoHit.id))
+    }
+
+    /// Pagination applies AFTER the match filter, so offset pages over the
+    /// matching set — not over all archived rows. Without this, page 2 of a
+    /// search would skip matches that happened to sit behind non-matching rows.
+    @Test func nameQueryPaginationPagesOverMatchesOnly() async throws {
+        let db = try makeDB()
+        let repo = try await createRepo(db: db)
+
+        // Interleave matches and non-matches so an unfiltered offset would
+        // land on the wrong rows.
+        var matches: [UUID] = []
+        var ordinal = 0
+        for i in 1...4 {
+            let hit = try await makeArchived(db: db, repoID: repo.id, name: "keep-\(i)")
+            matches.append(hit.id)
+            let miss = try await makeArchived(db: db, repoID: repo.id, name: "drop-\(i)")
+            // `archive()` stamps `Date()`, and eight archives inside one
+            // millisecond tie on the `archivedAt desc` sort — which makes page
+            // boundaries arbitrary. Restamp with explicit, well-separated
+            // values so the ordering under test is the query's, not the clock's.
+            for id in [hit.id, miss.id] {
+                ordinal += 1
+                try await stampArchivedAt(db: db, id: id, seconds: ordinal)
+            }
+        }
+        // `archivedAt desc` — newest first.
+        let expected = matches.reversed().map { $0 }
+
+        let page1 = try await db.worktrees.list(
+            repoID: repo.id, status: .archived, limit: 2, offset: 0, nameQuery: "keep-"
+        )
+        #expect(page1.map(\.id) == Array(expected[0..<2]))
+
+        let page2 = try await db.worktrees.list(
+            repoID: repo.id, status: .archived, limit: 2, offset: 2, nameQuery: "keep-"
+        )
+        #expect(page2.map(\.id) == Array(expected[2..<4]))
+
+        let page3 = try await db.worktrees.list(
+            repoID: repo.id, status: .archived, limit: 2, offset: 4, nameQuery: "keep-"
+        )
+        #expect(page3.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary

Repos accumulate archived worktrees faster than anyone can scroll them — the repo I tested against has 500+. There was no way to find one except paging through 50 at a time. This adds a search field to the repo's archived list, matching the worktree **folder name** and **display name** (case-insensitive substring). Searching session names or transcript content is deliberately out of scope.

## The one real decision: how search interacts with pagination

The archived list is paginated (page size 50), so a naive client-side filter only searches what's already loaded and silently misses everything older — which is precisely the case the feature exists for. Three options were on the table; I went with **daemon-side filtering** (`WorktreeListParams.nameQuery` → `WorktreeStore.list`, applied in SQL *before* `LIMIT`/`OFFSET`):

- **Client-side over loaded rows** — rejected. It ships a filter that lies about its coverage.
- **Client-side, fetching all remaining pages when a search begins** — rejected. `handleWorktreeList` enriches every archived row with a `~/.claude/projects` session-file scan; the code comment there records that full enrichment made a deep-link lookup take ~19s. Paging in 500 rows to answer one keystroke is not viable.
- **Daemon-side `nameQuery`** — chosen. Search covers every archive, pagination continues to page over the *matching* set, and per-page enrichment stays bounded to 50 rows.

Verified against live data via the daemon socket: `weasel` returns a match at **position 285** of the archived list, plus two beyond position 500. A client-side filter over the loaded first page would have found one of those four and shown nothing else.

LIKE metacharacters are escaped, so a typed `%` matches a literal percent instead of every row (`%` → 0 rows; `_` → only rows containing a literal underscore).

## Two bugs caught before merge

**Revive silently no-op'd on search-only rows.** Both revive paths resolved their snapshot by scanning the *loaded* pages. That guard was total before this change — every rendered row was provably loaded. Search breaks that invariant by design, so Revive on a row found only via search logged a warning and returned: no RPC, no alert, button does nothing, for exactly the row you searched to find. Now a single shared helper unions both row sources, and selection-validity uses it too.

**"No matches" appeared while it was still searching.** During the 250ms debounce and the in-flight RPC the view previews by filtering loaded rows; when the query matched nothing in those 50, an empty preview rendered as a definitive verdict. Since every keystroke restarts the debounce, you saw "No matches" the entire time you typed. Now `.searching` / `.noMatches` / `.rows` is a pure, unit-tested decision — "I don't know yet" and "there is nothing" no longer look identical. A failed search still resolves to "No matches" plus an inline note, so it can't spin forever.

## Notes

- **`ScratchArchivedView` deliberately left alone** — unpaginated and low-volume by design (its own doc comment says so). Say the word if it should get the same treatment.
- **No feature flag** — small additive UI, per the CLAUDE.md carve-out. No migration, no config column.
- **Debounce uses the injected clock seam** (`clock: any Clock<Duration> = ContinuousClock()`), not `Task.sleep` or a Combine scheduler.
- `nameQuery` is optional/defaulted, so old clients and daemons interoperate unchanged.

## Test plan

- [x] `swift build` clean; `swiftlint --strict` clean (0 violations, 614 files)
- [x] `swift test` — 4559 passing (baseline 4524; +35 across 7 suites)
- [x] Daemon filter probed directly over 500+ live archived rows: case-insensitivity, folder-name and display-name matching, `%`/`_` escaping, no-match
- [x] Live UI tested by @cheapsteak after a full `restart.sh`
- [x] Mutation-checked the two regression tests that matter (revive-selection on a search-only row; "searching" vs "no matches") — both go red when the fix is reverted

Unrelated flake seen once and reported rather than buried: `PaneFanoutFlowControlTests` `isPipeWritable` expected `.broken`, observed `.writable`; passed in isolation and on re-run. Also pre-existing: `WorktreeStoreTests/archivedWorktreesPaginationWithArchivedAtDesc` fails under a narrow `--filter` on a clean tree (millisecond ties on `archivedAt`).

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=CAFD9D2B-2D88-4311-91D3-BC196180034D)