### PR TITLE
Fix: New worktrees stall on Claude's folder-trust dialog until a human clicks through

### DIFF
--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -304,6 +304,19 @@ extension AppState {
         }
     }
 
+    /// Persist the worktree auto-trust switch, then re-fetch capabilities so
+    /// the Settings toggle reflects the daemon's persisted state. Applies to
+    /// the next Claude spawn or wake; never un-trusts an already-seeded path.
+    func setAutoTrustWorktrees(_ enabled: Bool) async {
+        do {
+            try await autoTrustWorktreesSetter(enabled)
+            await refreshDaemonCapabilities()
+        } catch {
+            logger.error("Failed to set worktree auto-trust: \(error, privacy: .public)")
+            showAlert("Failed to set worktree auto-trust: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     /// Set or clear a per-repo model profile override.
     func setRepoProfileOverride(repoID: UUID, profileID: UUID?) async {
         do {

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1041,6 +1041,10 @@ final class AppState: ObservableObject {
     /// same reason as `controlModeSetter`.
     lazy var autoCloseSetupSetter: @MainActor (Bool) async throws -> Void =
         { [daemonClient] enabled in try await daemonClient.setAutoCloseSetup(enabled: enabled) }
+    /// How `setAutoTrustWorktrees` persists the flag — injectable for the
+    /// same reason as `controlModeSetter`.
+    lazy var autoTrustWorktreesSetter: @MainActor (Bool) async throws -> Void =
+        { [daemonClient] enabled in try await daemonClient.setAutoTrustWorktrees(enabled: enabled) }
     /// Asks the user to confirm closing a note tab whose note has content —
     /// closing a note tab hard-deletes the note row (`closeTab` →
     /// `deleteNote`). Injectable so tests can exercise both branches without

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -900,6 +900,15 @@ actor DaemonClient {
         )
     }
 
+    /// Persist the worktree auto-trust switch (default ON). Applies to the
+    /// next Claude spawn or wake.
+    func setAutoTrustWorktrees(enabled: Bool) async throws {
+        try await callVoidAsync(
+            method: RPCMethod.configSetAutoTrustWorktrees,
+            params: ConfigSetAutoTrustWorktreesParams(enabled: enabled)
+        )
+    }
+
     /// Set or clear a repo's free-form env overrides.
     func setRepoEnvOverrides(repoID: UUID, overrides: [String: String]) async throws {
         try await callVoidAsync(

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -299,20 +299,22 @@ struct GeneralSettingsTab: View {
         .help("When a repo's setup hook exits cleanly, close its tab automatically. A failed hook keeps the tab open with a shell for debugging. Off by default (soaking). Applies to newly created worktrees.")
     }
 
-    /// Pre-accept Claude's folder-trust dialog for TBD-created worktrees.
-    /// Reads the persisted flag from `daemon.capabilities` and writes via
+    /// Pre-accept Claude's folder-trust dialog for the worktrees of registered
+    /// repos. Reads the persisted flag from `daemon.capabilities` and writes via
     /// `config.setAutoTrustWorktrees`. ON by default — the trust question has
-    /// a known answer for a worktree TBD made from a repo you registered, and
+    /// a known answer for a worktree TBD made from a repo you registered (and
+    /// for that repo's own checkout, which you registered deliberately), and
     /// the dialog blocks before any hook fires, so a stalled session is
-    /// invisible to TBD.
+    /// invisible to TBD. Worktrees checked out from a PR head are excluded:
+    /// their contents may be fork-authored, which is what the prompt gates.
     @ViewBuilder
     private var autoTrustWorktreesToggle: some View {
         let capabilities = appState.daemonCapabilities
-        Toggle("Trust worktrees TBD creates", isOn: Binding(
+        Toggle("Trust repos you add and the worktrees TBD makes in them", isOn: Binding(
             get: { capabilities?.autoTrustWorktrees ?? true },
             set: { newValue in Task { await appState.setAutoTrustWorktrees(newValue) } }
         ))
-        .help("Answer Claude's \u{201C}do you trust the files in this folder?\u{201D} prompt ahead of time for worktrees TBD created. TBD made the worktree from a repo you registered, so the answer is already known \u{2014} and the prompt blocks before any Claude hook fires, so a session waiting on it looks idle to TBD instead of stuck. On by default. Turning it off only stops future worktrees from being pre-trusted; nothing already trusted is undone, and TBD's own scratch spaces are always trusted.")
+        .help("Answer Claude's \u{201C}do you trust the files in this folder?\u{201D} prompt ahead of time for worktrees TBD created and for the checkout of each repo you added. You registered the repo and TBD made the worktree, so the answer is already known \u{2014} and the prompt blocks before any Claude hook fires, so a session waiting on it looks idle to TBD instead of stuck. Worktrees checked out from a pull request head are never pre-trusted, on or off: their files may come from someone else's fork, which is exactly what the prompt is for. On by default. Turning it off stops any further pre-trusting, including for worktrees that already exist; nothing already trusted is undone, and TBD's own scratch spaces are always trusted.")
     }
 
     /// Remote agent sessions master switch. Reads the persisted flag from

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -156,6 +156,7 @@ struct GeneralSettingsTab: View {
             Section("Claude") {
                 Toggle("Launch claude with --dangerously-skip-permissions", isOn: $skipPermissions)
                     .help("Skip the interactive permission prompt when launching claude in new worktrees")
+                autoTrustWorktreesToggle
                 Toggle("Auto-resume Claude sessions when the usage limit resets",
                        isOn: Binding(
                     get: { appState.autoResumeOnLimitReset },
@@ -296,6 +297,22 @@ struct GeneralSettingsTab: View {
             set: { newValue in Task { await appState.setAutoCloseSetupEnabled(newValue) } }
         ))
         .help("When a repo's setup hook exits cleanly, close its tab automatically. A failed hook keeps the tab open with a shell for debugging. Off by default (soaking). Applies to newly created worktrees.")
+    }
+
+    /// Pre-accept Claude's folder-trust dialog for TBD-created worktrees.
+    /// Reads the persisted flag from `daemon.capabilities` and writes via
+    /// `config.setAutoTrustWorktrees`. ON by default — the trust question has
+    /// a known answer for a worktree TBD made from a repo you registered, and
+    /// the dialog blocks before any hook fires, so a stalled session is
+    /// invisible to TBD.
+    @ViewBuilder
+    private var autoTrustWorktreesToggle: some View {
+        let capabilities = appState.daemonCapabilities
+        Toggle("Trust worktrees TBD creates", isOn: Binding(
+            get: { capabilities?.autoTrustWorktrees ?? true },
+            set: { newValue in Task { await appState.setAutoTrustWorktrees(newValue) } }
+        ))
+        .help("Answer Claude's \u{201C}do you trust the files in this folder?\u{201D} prompt ahead of time for worktrees TBD created. TBD made the worktree from a repo you registered, so the answer is already known \u{2014} and the prompt blocks before any Claude hook fires, so a session waiting on it looks idle to TBD instead of stuck. On by default. Turning it off only stops future worktrees from being pre-trusted; nothing already trusted is undone, and TBD's own scratch spaces are always trusted.")
     }
 
     /// Remote agent sessions master switch. Reads the persisted flag from

--- a/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
@@ -5,15 +5,40 @@ import TBDShared
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust")
 
 /// Pre-accepts Claude Code's "Do you trust the files in this folder?" dialog for
-/// TBD-owned scratch spaces.
+/// directories TBD itself created.
 ///
-/// Claude Code persists the folder-trust decision per-directory in
+/// **Why pre-seeding is legitimate, not a bypass.** The dialog asks one
+/// question: "is this a project you created, or one you trust?" For a worktree
+/// TBD created — from a repo the operator explicitly registered with TBD — the
+/// answer is yes *by construction*. TBD holds every fact the dialog is asking
+/// about: it knows the directory is brand new, that it made it, and which
+/// registered repo it came from. Seeding does not skip the question; it writes
+/// the already-known answer through Claude's own config persistence, so the
+/// prompt never renders.
+///
+/// **Why prevention is the only fix.** The trust dialog blocks *before*
+/// SessionStart, so no Claude Code hook ever fires while it is up. A session
+/// stalled on trust is machine-invisible to TBD — nothing can detect it, and
+/// nothing can dismiss it. Fleet worktrees would simply sit there at first
+/// spawn. There is no detect-and-recover path; there is only never rendering
+/// the dialog.
+///
+/// Claude Code persists the decision per-directory in
 /// `<CLAUDE_CONFIG_DIR>/.claude.json` under
-/// `projects["<absolute-cwd-path>"].hasTrustDialogAccepted = true`. Scratch dirs
-/// are brand new, TBD-created, empty directories each time, so that key is always
-/// absent and Claude prompts on every launch. Since TBD owns the directory, the
-/// trust gate has no security value there — this seeder pre-writes the accepted
-/// flag so the prompt never appears.
+/// `projects["<absolute-cwd-path>"].hasTrustDialogAccepted = true`. A fresh
+/// worktree or scratch dir has never been seen at that path, so the key is
+/// absent and Claude prompts.
+///
+/// **Two-tier gate** (`ensureTrusted`):
+/// - **Scratch spaces seed unconditionally.** TBD created the directory, owns
+///   it, and it is empty — there is nothing there a trust prompt could protect,
+///   and the dir is new on every spawn so the prompt would otherwise be
+///   guaranteed. Not user-configurable.
+/// - **Non-scratch TBD-created worktrees seed only when `autoTrustWorktrees`
+///   is on** (`config.auto_trust_worktrees`, default ON). These live in real
+///   repos with real contents, so an operator who wants Claude to ask anyway
+///   can turn the setting off. Turning it off never un-trusts an already
+///   seeded path; it only stops future seeding.
 ///
 /// This is a separate gate from `--dangerously-skip-permissions`, which does NOT
 /// suppress the trust dialog. There is no CLI flag or env var for it; pre-seeding
@@ -27,23 +52,32 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust
 /// appears. This is no worse than the pre-seeder behavior and is unresolvable from
 /// the daemon side, so we accept it.
 enum ClaudeTrustSeeder {
-    /// Pre-accept Claude Code's folder-trust dialog for a scratch worktree by
-    /// writing `projects["<path>"].hasTrustDialogAccepted = true` into the
-    /// effective config dir's `.claude.json`. No-op for non-scratch worktrees.
+    /// Pre-accept Claude Code's folder-trust dialog for a TBD-created worktree
+    /// by writing `projects["<path>"].hasTrustDialogAccepted = true` into the
+    /// effective config dir's `.claude.json`.
+    ///
+    /// - Parameter autoTrustNonScratch: the resolved
+    ///   `config.autoTrustWorktrees` value (default ON). Governs non-scratch
+    ///   worktrees only — scratch spaces seed regardless. Callers pass
+    ///   `config?.autoTrustWorktrees ?? true` so a config read failure keeps
+    ///   the shipped default rather than silently reinstating the stall.
     ///
     /// Best-effort: never throws (logs on failure). Idempotent. Preserves all
     /// existing top-level keys and all existing keys inside the target project
     /// entry via read-merge-write. Leaves a malformed `.claude.json` untouched.
-    static func ensureTrustedForScratch(
+    static func ensureTrusted(
         worktree: Worktree,
+        autoTrustNonScratch: Bool,
         profileConfigDir: String?,
         homeDirectory: String = NSHomeDirectory(),
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) {
-        // THE gate: only scratch spaces get pre-seeded. Non-scratch worktrees
-        // live in real repos where the user may legitimately want the trust
-        // prompt, so we never touch their config.
-        guard worktree.isScratch else { return }
+        // Two-tier gate (see the type doc comment for the full argument):
+        // scratch spaces are TBD-owned empty dirs and always seed; non-scratch
+        // worktrees are still TBD-created from a registered repo — so the trust
+        // answer is equally known — but the operator can opt out of seeding
+        // them via `config.auto_trust_worktrees`.
+        guard worktree.isScratch || autoTrustNonScratch else { return }
 
         // Resolve the effective config dir the same way Claude Code does:
         // an explicit profile config dir wins, then CLAUDE_CONFIG_DIR, then the
@@ -116,7 +150,7 @@ enum ClaudeTrustSeeder {
             let data = try JSONSerialization.data(
                 withJSONObject: topLevel, options: [.prettyPrinted, .sortedKeys])
             try data.write(to: claudeJSONPath, options: [.atomic])
-            logger.debug("seeded folder-trust for scratch worktree at \(claudeJSONPath.path, privacy: .public)")
+            logger.debug("seeded folder-trust for TBD-created worktree at \(claudeJSONPath.path, privacy: .public)")
         } catch {
             logger.warning("failed to seed folder-trust at \(claudeJSONPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }

--- a/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
@@ -5,7 +5,7 @@ import TBDShared
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust")
 
 /// Pre-accepts Claude Code's "Do you trust the files in this folder?" dialog for
-/// directories TBD itself created.
+/// directories whose trust answer TBD already holds.
 ///
 /// **Why pre-seeding is legitimate, not a bypass.** The dialog asks one
 /// question: "is this a project you created, or one you trust?" For a worktree
@@ -15,6 +15,18 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust
 /// registered repo it came from. Seeding does not skip the question; it writes
 /// the already-known answer through Claude's own config persistence, so the
 /// prompt never renders.
+///
+/// The same argument covers a repo's **`.main` worktree**, which TBD did not
+/// create: pointing `tbd repo add` at a checkout is itself a deliberate
+/// operator trust gesture, so that directory is "one you trust" even though it
+/// is not "one TBD made".
+///
+/// It does **not** cover contents TBD merely *hosted*. A worktree flagged
+/// `foreignHead` was checked out from `refs/pull/<n>/head`, whose commits can
+/// come from a third-party fork: TBD created the directory, but a stranger
+/// authored the `.claude/settings.json`, hooks, MCP config and `CLAUDE.md`
+/// inside it. That is precisely what the dialog exists to gate, so these
+/// worktrees are never seeded and Claude asks as usual.
 ///
 /// **Why prevention is the only fix.** The trust dialog blocks *before*
 /// SessionStart, so no Claude Code hook ever fires while it is up. A session
@@ -33,12 +45,14 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust
 /// - **Scratch spaces seed unconditionally.** TBD created the directory, owns
 ///   it, and it is empty — there is nothing there a trust prompt could protect,
 ///   and the dir is new on every spawn so the prompt would otherwise be
-///   guaranteed. Not user-configurable.
-/// - **Non-scratch TBD-created worktrees seed only when `autoTrustWorktrees`
-///   is on** (`config.auto_trust_worktrees`, default ON). These live in real
-///   repos with real contents, so an operator who wants Claude to ask anyway
-///   can turn the setting off. Turning it off never un-trusts an already
-///   seeded path; it only stops future seeding.
+///   guaranteed. Not user-configurable, and not subject to the `foreignHead`
+///   exclusion: a scratch space has no git contents at all.
+/// - **Non-scratch worktrees seed only when `autoTrustWorktrees` is on**
+///   (`config.auto_trust_worktrees`, default ON) **and the worktree is not
+///   `foreignHead`.** These live in real repos with real contents, so an
+///   operator who wants Claude to ask anyway can turn the setting off. Turning
+///   it off never un-trusts an already seeded path; it only stops future
+///   seeding, including for worktrees that were never seeded before.
 ///
 /// This is a separate gate from `--dangerously-skip-permissions`, which does NOT
 /// suppress the trust dialog. There is no CLI flag or env var for it; pre-seeding
@@ -52,15 +66,19 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust
 /// appears. This is no worse than the pre-seeder behavior and is unresolvable from
 /// the daemon side, so we accept it.
 enum ClaudeTrustSeeder {
-    /// Pre-accept Claude Code's folder-trust dialog for a TBD-created worktree
-    /// by writing `projects["<path>"].hasTrustDialogAccepted = true` into the
-    /// effective config dir's `.claude.json`.
+    /// Pre-accept Claude Code's folder-trust dialog for a worktree whose trust
+    /// answer TBD holds, by writing `projects["<path>"].hasTrustDialogAccepted
+    /// = true` into the effective config dir's `.claude.json`.
     ///
     /// - Parameter autoTrustNonScratch: the resolved
     ///   `config.autoTrustWorktrees` value (default ON). Governs non-scratch
-    ///   worktrees only — scratch spaces seed regardless. Callers pass
-    ///   `config?.autoTrustWorktrees ?? true` so a config read failure keeps
-    ///   the shipped default rather than silently reinstating the stall.
+    ///   worktrees only — scratch spaces seed regardless. The four call sites
+    ///   that read config with `try?` pass `config?.autoTrustWorktrees ?? true`,
+    ///   so a config-read failure keeps the shipped default rather than
+    ///   silently reinstating the stall; the two create-path sites pass a
+    ///   non-optional `config.autoTrustWorktrees` from a throwing read that
+    ///   already aborts worktree creation on failure, so there is nothing to
+    ///   fall back from.
     ///
     /// Best-effort: never throws (logs on failure). Idempotent. Preserves all
     /// existing top-level keys and all existing keys inside the target project
@@ -73,11 +91,22 @@ enum ClaudeTrustSeeder {
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) {
         // Two-tier gate (see the type doc comment for the full argument):
-        // scratch spaces are TBD-owned empty dirs and always seed; non-scratch
-        // worktrees are still TBD-created from a registered repo — so the trust
-        // answer is equally known — but the operator can opt out of seeding
-        // them via `config.auto_trust_worktrees`.
-        guard worktree.isScratch || autoTrustNonScratch else { return }
+        // scratch spaces are TBD-owned empty dirs and always seed; a non-scratch
+        // worktree's contents come from a repo the operator registered — so the
+        // trust answer is equally known — but the operator can opt out of
+        // seeding them via `config.auto_trust_worktrees`.
+        //
+        // The `foreignHead` exclusion is the boundary of the whole argument:
+        // TBD vouches for the directory it created, NOT for contents fetched
+        // from an unvetted ref. A fork contributor's `refs/pull/<n>/head` brings
+        // its own `.claude/settings.json`, hooks, MCP config and `CLAUDE.md`
+        // into a directory TBD made — which is exactly the case the trust
+        // dialog exists to gate, so let it render. Note this is deliberately
+        // NOT keyed on `prNumber`: a decorated same-repo PR row stamps a number
+        // while checking out an ordinary local branch, and must still seed.
+        // It applies to the non-scratch tier only — a scratch space has no git
+        // contents to be foreign, and its unconditional tier stays absolute.
+        guard worktree.isScratch || (autoTrustNonScratch && !worktree.foreignHead) else { return }
 
         // Resolve the effective config dir the same way Claude Code does:
         // an explicit profile config dir wins, then CLAUDE_CONFIG_DIR, then the
@@ -128,9 +157,9 @@ enum ClaudeTrustSeeder {
         // write to this SHARED file: our atomic rename from a slightly-stale read
         // would drop whatever that process wrote (history, numStartups, project
         // state) between our read and our write. Returning here collapses writes
-        // to at most once per new scratch path instead of once per spawn, keeping
-        // us within the same infrequent-writer envelope Claude's own multi-instance
-        // writes already tolerate.
+        // to at most once per newly-seen path — scratch or worktree — instead of
+        // once per spawn, keeping us within the same infrequent-writer envelope
+        // Claude's own multi-instance writes already tolerate.
         let existingProjects = (topLevel["projects"] as? [String: Any]) ?? [:]
         let allAlreadyTrusted = projectKeys.allSatisfy { key in
             (existingProjects[key] as? [String: Any])?["hasTrustDialogAccepted"] as? Bool == true
@@ -150,7 +179,7 @@ enum ClaudeTrustSeeder {
             let data = try JSONSerialization.data(
                 withJSONObject: topLevel, options: [.prettyPrinted, .sortedKeys])
             try data.write(to: claudeJSONPath, options: [.atomic])
-            logger.debug("seeded folder-trust for TBD-created worktree at \(claudeJSONPath.path, privacy: .public)")
+            logger.debug("seeded folder-trust for \(worktree.path, privacy: .public) in \(claudeJSONPath.path, privacy: .public)")
         } catch {
             logger.warning("failed to seed folder-trust at \(claudeJSONPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }

--- a/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
@@ -22,11 +22,12 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust
 /// is not "one TBD made".
 ///
 /// It does **not** cover contents TBD merely *hosted*. A worktree flagged
-/// `foreignHead` was checked out from `refs/pull/<n>/head`, whose commits can
-/// come from a third-party fork: TBD created the directory, but a stranger
-/// authored the `.claude/settings.json`, hooks, MCP config and `CLAUDE.md`
-/// inside it. That is precisely what the dialog exists to gate, so these
-/// worktrees are never seeded and Claude asks as usual.
+/// `foreignHead` was checked out from a pull-request head TBD fetched
+/// (`refs/pull/<n>/head`) rather than from a branch already present in the
+/// operator's repo. TBD created the directory, but the `.claude/settings.json`,
+/// hooks, MCP config and `CLAUDE.md` inside it came in with that fetched ref —
+/// which may be a third-party fork's. That is precisely what the dialog exists
+/// to gate, so these worktrees are never seeded and Claude asks as usual.
 ///
 /// **Why prevention is the only fix.** The trust dialog blocks *before*
 /// SessionStart, so no Claude Code hook ever fires while it is up. A session
@@ -58,6 +59,17 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claude-trust
 /// suppress the trust dialog. There is no CLI flag or env var for it; pre-seeding
 /// the JSON key is the only mechanism.
 ///
+/// **Concurrency.** `.claude.json` is a single shared file that many worktrees
+/// target at once (the six seed call sites fire on create, extra-session
+/// restore, terminal create, revive, profile swap and hibernation wake, across
+/// unrelated repos and therefore unrelated `RepoSerializer` lanes). The
+/// read-merge-write is not atomic on its own, so it runs inside
+/// `ClaudeTrustSeeder.writer`, an actor whose critical section covers read →
+/// parse → merge → atomic rename. That makes TBD's own seeds safe against each
+/// other: two worktrees can never both read the same base and have the loser's
+/// key dropped by the winner's rename. See `writer` for what it does *not*
+/// cover.
+///
 /// Known limitation (degrades gracefully to the status quo): when a user sets
 /// `CLAUDE_CONFIG_DIR` only in their interactive shell rc (e.g. `.zshrc`) and uses
 /// no TBD model profile, the daemon can't observe that value — it isn't in the
@@ -83,13 +95,17 @@ enum ClaudeTrustSeeder {
     /// Best-effort: never throws (logs on failure). Idempotent. Preserves all
     /// existing top-level keys and all existing keys inside the target project
     /// entry via read-merge-write. Leaves a malformed `.claude.json` untouched.
+    ///
+    /// `async` only because the read-merge-write hops onto `writer` to
+    /// serialize; the gate and path resolution below are pure and stay on the
+    /// caller.
     static func ensureTrusted(
         worktree: Worktree,
         autoTrustNonScratch: Bool,
         profileConfigDir: String?,
         homeDirectory: String = NSHomeDirectory(),
         environment: [String: String] = ProcessInfo.processInfo.environment
-    ) {
+    ) async {
         // Two-tier gate (see the type doc comment for the full argument):
         // scratch spaces are TBD-owned empty dirs and always seed; a non-scratch
         // worktree's contents come from a repo the operator registered — so the
@@ -98,10 +114,16 @@ enum ClaudeTrustSeeder {
         //
         // The `foreignHead` exclusion is the boundary of the whole argument:
         // TBD vouches for the directory it created, NOT for contents fetched
-        // from an unvetted ref. A fork contributor's `refs/pull/<n>/head` brings
-        // its own `.claude/settings.json`, hooks, MCP config and `CLAUDE.md`
-        // into a directory TBD made — which is exactly the case the trust
-        // dialog exists to gate, so let it render. Note this is deliberately
+        // from a ref that was not already in the operator's repo. The flag means
+        // exactly that — the contents came from a pull-request head TBD fetched
+        // (`refs/pull/<n>/head`) rather than from a local branch. That covers a
+        // fork contributor's PR, and also a colleague's same-repo PR whose head
+        // branch has not been fetched locally (see `PickerItem` in
+        // BranchPickerMerge.swift: every PR-only row sets `checkoutPRHead`).
+        // Either way the ref brings its own `.claude/settings.json`, hooks, MCP
+        // config and `CLAUDE.md` into a directory TBD made, which is what the
+        // trust dialog exists to gate — so let it render. Erring toward asking
+        // on a same-repo PR head is the safe direction. Note this is deliberately
         // NOT keyed on `prNumber`: a decorated same-repo PR row stamps a number
         // while checking out an ordinary local branch, and must still seed.
         // It applies to the non-scratch tier only — a scratch space has no git
@@ -135,53 +157,97 @@ enum ClaudeTrustSeeder {
             projectKeys.append(resolvedPath)
         }
 
-        let fm = FileManager.default
+        await writer.seed(
+            projectKeys: projectKeys,
+            configDirURL: configDirURL,
+            claudeJSONPath: claudeJSONPath,
+            worktreePath: worktree.path)
+    }
 
-        // Read-merge-write, preserving every existing key. If the file exists but
-        // is malformed JSON, do NOT clobber it — log and return (best-effort).
-        var topLevel: [String: Any] = [:]
-        if fm.fileExists(atPath: claudeJSONPath.path) {
-            guard let existing = try? Data(contentsOf: claudeJSONPath) else {
-                logger.warning("could not read \(claudeJSONPath.path, privacy: .public); skipping trust seed")
-                return
+    /// The process-wide lane every seed's read-merge-write runs on.
+    ///
+    /// One lane rather than one per config dir: the early return below collapses
+    /// writes to at most once per newly-seen path, so contention is negligible
+    /// and a lane table would be state to keep for no measurable gain.
+    private static let writer = TrustSeedWriter()
+
+    /// Serializes the read → parse → merge → write critical section.
+    ///
+    /// **What this covers:** TBD's own concurrent seeds. The six call sites fire
+    /// from unrelated `RepoSerializer` lanes (and wake / revive / terminal-create
+    /// are not serialized against creates at all), so without this two seeds could
+    /// read the same base and the loser's key would vanish under the winner's
+    /// atomic rename — leaving that worktree stalled on the trust dialog, exactly
+    /// the machine-invisible failure the seeder exists to prevent.
+    ///
+    /// **What this does NOT cover:** an ambient Claude Code process writing the
+    /// same `.claude.json`. That is a different OS process; in-process
+    /// serialization cannot order against it, and no file lock is taken. The
+    /// mitigation there is frequency, not exclusion — see the early return in
+    /// `seed(projectKeys:configDirURL:claudeJSONPath:worktreePath:)`.
+    actor TrustSeedWriter {
+        fileprivate init() {}
+
+        /// Read-merge-write, preserving every existing key. Runs to completion
+        /// without suspending, so the actor's serial execution makes the whole
+        /// read-through-rename window atomic against other seeds.
+        ///
+        /// Best-effort: never throws (logs on failure). If the file exists but is
+        /// malformed JSON, do NOT clobber it — log and return.
+        func seed(
+            projectKeys: [String],
+            configDirURL: URL,
+            claudeJSONPath: URL,
+            worktreePath: String
+        ) {
+            let fm = FileManager.default
+
+            var topLevel: [String: Any] = [:]
+            if fm.fileExists(atPath: claudeJSONPath.path) {
+                guard let existing = try? Data(contentsOf: claudeJSONPath) else {
+                    logger.warning("could not read \(claudeJSONPath.path, privacy: .public); skipping trust seed")
+                    return
+                }
+                guard let parsed = try? JSONSerialization.jsonObject(with: existing) as? [String: Any] else {
+                    logger.warning("malformed .claude.json at \(claudeJSONPath.path, privacy: .public); leaving untouched")
+                    return
+                }
+                topLevel = parsed
             }
-            guard let parsed = try? JSONSerialization.jsonObject(with: existing) as? [String: Any] else {
-                logger.warning("malformed .claude.json at \(claudeJSONPath.path, privacy: .public); leaving untouched")
-                return
+
+            // Skip the write entirely when every target key is already trusted,
+            // so a repeat spawn / wake / revive of an already-seeded path does no
+            // I/O at all. Beyond saving work, this is the only mitigation left for
+            // the CROSS-PROCESS case the actor cannot reach: an ambient Claude
+            // Code process writes this same shared file, and our atomic rename
+            // from a slightly-stale read would drop whatever it wrote (history,
+            // numStartups, project state) between our read and our write.
+            // Collapsing writes to at most once per newly-seen path — scratch or
+            // worktree — instead of once per spawn shrinks that window; it does
+            // not close it.
+            let existingProjects = (topLevel["projects"] as? [String: Any]) ?? [:]
+            let allAlreadyTrusted = projectKeys.allSatisfy { key in
+                (existingProjects[key] as? [String: Any])?["hasTrustDialogAccepted"] as? Bool == true
             }
-            topLevel = parsed
-        }
+            if allAlreadyTrusted { return }
 
-        // Skip the write entirely when every target key is already trusted. The
-        // early return avoids clobbering a concurrently-running ambient Claude's
-        // write to this SHARED file: our atomic rename from a slightly-stale read
-        // would drop whatever that process wrote (history, numStartups, project
-        // state) between our read and our write. Returning here collapses writes
-        // to at most once per newly-seen path — scratch or worktree — instead of
-        // once per spawn, keeping us within the same infrequent-writer envelope
-        // Claude's own multi-instance writes already tolerate.
-        let existingProjects = (topLevel["projects"] as? [String: Any]) ?? [:]
-        let allAlreadyTrusted = projectKeys.allSatisfy { key in
-            (existingProjects[key] as? [String: Any])?["hasTrustDialogAccepted"] as? Bool == true
-        }
-        if allAlreadyTrusted { return }
+            var projects = existingProjects
+            for key in projectKeys {
+                var entry = (projects[key] as? [String: Any]) ?? [:]
+                entry["hasTrustDialogAccepted"] = true
+                projects[key] = entry
+            }
+            topLevel["projects"] = projects
 
-        var projects = existingProjects
-        for key in projectKeys {
-            var entry = (projects[key] as? [String: Any]) ?? [:]
-            entry["hasTrustDialogAccepted"] = true
-            projects[key] = entry
-        }
-        topLevel["projects"] = projects
-
-        do {
-            try fm.createDirectory(at: configDirURL, withIntermediateDirectories: true)
-            let data = try JSONSerialization.data(
-                withJSONObject: topLevel, options: [.prettyPrinted, .sortedKeys])
-            try data.write(to: claudeJSONPath, options: [.atomic])
-            logger.debug("seeded folder-trust for \(worktree.path, privacy: .public) in \(claudeJSONPath.path, privacy: .public)")
-        } catch {
-            logger.warning("failed to seed folder-trust at \(claudeJSONPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            do {
+                try fm.createDirectory(at: configDirURL, withIntermediateDirectories: true)
+                let data = try JSONSerialization.data(
+                    withJSONObject: topLevel, options: [.prettyPrinted, .sortedKeys])
+                try data.write(to: claudeJSONPath, options: [.atomic])
+                logger.debug("seeded folder-trust for \(worktreePath, privacy: .public) in \(claudeJSONPath.path, privacy: .public)")
+            } catch {
+                logger.warning("failed to seed folder-trust at \(claudeJSONPath.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            }
         }
     }
 }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -30,8 +30,10 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var auto_resume_on_api_error: Bool?
     var hibernate_input_veto_enabled: Bool?
     var auto_close_setup_enabled: Bool?
-    /// Pre-accept Claude's folder-trust dialog for TBD-created worktrees.
-    /// Default ON (see the `v66_config_auto_trust_worktrees` migration).
+    /// Pre-accept Claude's folder-trust dialog for the worktrees of registered
+    /// repos (TBD-created ones and the repo's own checkout), excluding
+    /// fork-PR-head checkouts. Default ON (see the
+    /// `v66_config_auto_trust_worktrees` migration).
     var auto_trust_worktrees: Bool?
     var gc_enabled: Bool?
     var gc_grace_seconds: Int?

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -30,6 +30,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var auto_resume_on_api_error: Bool?
     var hibernate_input_veto_enabled: Bool?
     var auto_close_setup_enabled: Bool?
+    /// Pre-accept Claude's folder-trust dialog for TBD-created worktrees.
+    /// Default ON (see the `v66_config_auto_trust_worktrees` migration).
+    var auto_trust_worktrees: Bool?
     var gc_enabled: Bool?
     var gc_grace_seconds: Int?
     var gc_snapshot_retention_days: Int?
@@ -58,6 +61,7 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             autoResumeOnApiError: auto_resume_on_api_error ?? false,
             hibernateInputVetoEnabled: hibernate_input_veto_enabled ?? false,
             autoCloseSetupEnabled: auto_close_setup_enabled ?? false,
+            autoTrustWorktrees: auto_trust_worktrees ?? true,
             gcEnabled: gc_enabled ?? true,
             gcGraceSeconds: gc_grace_seconds ?? Config.defaultGCGraceSeconds,
             gcSnapshotRetentionDays: gc_snapshot_retention_days ?? Config.defaultGCSnapshotRetentionDays,
@@ -278,6 +282,20 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET auto_close_setup_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the auto-trust opt-out for TBD-created worktrees (default ON).
+    /// Read fresh at every spawn/wake, so no daemon restart is required — the
+    /// next Claude spawn picks it up. Turning it OFF does not un-trust anything
+    /// already seeded; it only stops TBD from seeding new non-scratch paths.
+    /// Scratch spaces are seeded unconditionally and are not governed by this.
+    public func setAutoTrustWorktrees(enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET auto_trust_worktrees = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1146,6 +1146,28 @@ public final class TBDDatabase: Sendable {
                 type: .boolean, defaults: true)
         }
 
+        // Marks a worktree whose CONTENTS came from a ref TBD cannot vouch for
+        // — a `refs/pull/<n>/head` checkout, whose commits may be authored by a
+        // third-party fork contributor. TBD created the directory; it did not
+        // create what is inside it, so v66's auto-trust seeding must skip these
+        // rows and let Claude ask (see `ClaudeTrustSeeder`).
+        //
+        // Persisted rather than passed as a create-time parameter because
+        // seeding happens at six call sites — create, extra-session restore,
+        // terminal create, revive, profile swap, hibernation wake — and all but
+        // the first see only the stored row.
+        //
+        // `ADD COLUMN ... DEFAULT false` backfills existing rows to false, which
+        // is the intended reading: rows created before this column existed are
+        // treated as ordinary TBD-created contents (the status quo ante). The
+        // default-flip trap in CLAUDE.md does not apply — this is not a
+        // user-facing toggle and there is no plan to flip its default.
+        migrator.registerMigration("v67_worktree_foreign_head") { db in
+            try db.addColumnIfMissing(
+                table: "worktree", column: "foreign_head",
+                type: .boolean, defaults: false)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1123,6 +1123,29 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(table: "remote_session", column: "pinnedAt", type: .datetime)
         }
 
+        // Pre-accept Claude Code's folder-trust dialog for worktrees TBD itself
+        // created. Default ON — deliberately, and NOT a soak flag:
+        //
+        // The dialog asks "is this a project you created or one you trust?" For
+        // a worktree TBD created from a repo the operator explicitly registered,
+        // the answer is yes *by construction* — TBD holds every fact the dialog
+        // is asking about. Pre-seeding just writes that already-known answer
+        // through Claude's own config persistence, so the dialog never renders.
+        //
+        // Prevention is the only available fix: the dialog blocks BEFORE
+        // SessionStart, so no hook fires while it is up and a stalled-on-trust
+        // session is machine-invisible to TBD. A default-OFF flag would leave
+        // the stall in place for everyone who never finds the toggle.
+        //
+        // `ADD COLUMN ... DEFAULT true` backfills existing rows to true, which
+        // IS the intent here (see the CLAUDE.md default-flip note): every
+        // existing install should stop stalling on first spawn.
+        migrator.registerMigration("v66_config_auto_trust_worktrees") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "auto_trust_worktrees",
+                type: .boolean, defaults: true)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -599,14 +599,14 @@ public struct WorktreeStore: Sendable {
     }
 
     /// Record that this worktree's contents were checked out from an unvetted
-    /// ref (a PR head, whose commits may come from a third-party fork). Write-
-    /// once at create time; nothing clears it, because the contents never stop
-    /// being foreign-authored.
-    public func setForeignHead(id: UUID, value: Bool) async throws {
+    /// ref (a PR head, whose commits may come from a third-party fork).
+    /// One-way: only ever sets the flag to `true`. Nothing clears it, because
+    /// the contents never stop being foreign-authored.
+    public func markForeignHead(id: UUID) async throws {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE worktree SET foreign_head = ? WHERE id = ?",
-                arguments: [value, id.uuidString]
+                arguments: [true, id.uuidString]
             )
         }
     }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -31,6 +31,9 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var prStatus: String?  // JSON-encoded PRStatus, nil when never observed
     var promotedToRepoID: String?  // set only on promoted scratch rows
     var pr_number: Int?  // number of the PR this worktree was created from, nil otherwise
+    // Contents checked out from an unvetted ref (fork PR head); nil on rows
+    // written before v67, which read as false.
+    var foreign_head: Bool?
     var panel_surface_imported_at: Date?  // stamped once the legacy layout is imported; nil = never imported
     var pinnedAt: Date?  // sidebar dock pin; nil = unpinned
     var pinSortOrder: Int?  // sidebar dock ordering; nil = falls back to pinnedAt
@@ -61,6 +64,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.prStatus = wt.prStatus.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
         self.promotedToRepoID = wt.promotedToRepoID?.uuidString
         self.pr_number = wt.prNumber
+        self.foreign_head = wt.foreignHead
         self.panel_surface_imported_at = nil  // new worktrees start unimported; stamped via stampPanelSurfaceImported
         self.pinnedAt = wt.pinnedAt
         self.pinSortOrder = wt.pinSortOrder
@@ -121,6 +125,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             promotedToRepoID: promotedToRepoID.flatMap { UUID(uuidString: $0) },
             prStatus: pr,
             prNumber: pr_number,
+            foreignHead: foreign_head ?? false,
             pinnedAt: pinnedAt,
             pinSortOrder: pinSortOrder
         )
@@ -590,6 +595,19 @@ public struct WorktreeStore: Sendable {
             }
             record.branch = branch
             try record.update(db)
+        }
+    }
+
+    /// Record that this worktree's contents were checked out from an unvetted
+    /// ref (a PR head, whose commits may come from a third-party fork). Write-
+    /// once at create time; nothing clears it, because the contents never stop
+    /// being foreign-authored.
+    public func setForeignHead(id: UUID, value: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE worktree SET foreign_head = ? WHERE id = ?",
+                arguments: [value, id.uuidString]
+            )
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -536,11 +536,15 @@ public actor HibernationCoordinator {
             repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
         )
         let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
-        // Pre-accept Claude's folder-trust dialog for scratch spaces so a wake
-        // onto a fresh isolated profile dir (never seeded before) doesn't re-prompt.
-        // Self-gates on isScratch; a cheap no-op once already trusted.
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: worktree, profileConfigDir: profileConfigDir)
+        // Pre-accept Claude's folder-trust dialog so a wake onto a fresh
+        // isolated profile dir (never seeded before) doesn't re-prompt — the
+        // dialog blocks before SessionStart, so the stalled wake would be
+        // machine-invisible. Cheap no-op once already trusted. `config` is a
+        // `try?` read; fall back to the shipped default.
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: worktree,
+            autoTrustNonScratch: config?.autoTrustWorktrees ?? true,
+            profileConfigDir: profileConfigDir)
         // Pre-resume freshness: if the worktree was moved/promoted while this
         // session was parked, its transcript still lives under the OLD munged
         // project dir; the cwd-scoped `claude --resume` below only checks the

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -541,7 +541,7 @@ public actor HibernationCoordinator {
         // dialog blocks before SessionStart, so the stalled wake would be
         // machine-invisible. Cheap no-op once already trusted. `config` is a
         // `try?` read; fall back to the shipped default.
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: worktree,
             autoTrustNonScratch: config?.autoTrustWorktrees ?? true,
             profileConfigDir: profileConfigDir)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -623,11 +623,16 @@ extension WorktreeLifecycle {
                     scratchInstructions: config.scratchInstructions,
                     scratchRenamePrompt: config.scratchRenamePrompt)
             let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
-            // Pre-accept Claude Code's folder-trust dialog for scratch spaces so
-            // fresh, TBD-owned scratch dirs don't prompt on every launch.
-            // Self-gates on isScratch; best-effort, never throws.
-            ClaudeTrustSeeder.ensureTrustedForScratch(
-                worktree: worktree, profileConfigDir: profileConfigDir)
+            // Pre-accept Claude Code's folder-trust dialog. TBD just created
+            // this worktree from a repo the operator registered, so the trust
+            // answer is known by construction — and the dialog blocks before
+            // SessionStart, so a stall here would be machine-invisible.
+            // Scratch always seeds; non-scratch honors the config flag.
+            // Best-effort, never throws.
+            ClaudeTrustSeeder.ensureTrusted(
+                worktree: worktree,
+                autoTrustNonScratch: config.autoTrustWorktrees,
+                profileConfigDir: profileConfigDir)
             if isResume {
                 // Pre-resume freshness: `claude --resume` only looks in the
                 // project dir derived from the current cwd. If the archived
@@ -818,10 +823,12 @@ extension WorktreeLifecycle {
                 let plannedID = UUID()
                 createdTerminalIDs.append(plannedID)
                 let restoreProfileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
-                // Pre-accept the folder-trust dialog for scratch spaces so restoring
-                // an extra archived session onto a fresh profile dir doesn't re-prompt.
-                ClaudeTrustSeeder.ensureTrustedForScratch(
-                    worktree: worktree, profileConfigDir: restoreProfileConfigDir)
+                // Pre-accept the folder-trust dialog so restoring an extra
+                // archived session onto a fresh profile dir doesn't re-prompt.
+                ClaudeTrustSeeder.ensureTrusted(
+                    worktree: worktree,
+                    autoTrustNonScratch: config.autoTrustWorktrees,
+                    profileConfigDir: restoreProfileConfigDir)
                 // Same pre-resume freshness sync as the primary terminal above.
                 await TranscriptProjectDirSync.ensureSessionResumableDetached(
                     sessionID: sessionID,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -648,7 +648,7 @@ extension WorktreeLifecycle {
             // Scratch always seeds; non-scratch honors the config flag and is
             // skipped entirely when the row is `foreignHead` (PR-head checkout,
             // possibly fork-authored contents). Best-effort, never throws.
-            ClaudeTrustSeeder.ensureTrusted(
+            await ClaudeTrustSeeder.ensureTrusted(
                 worktree: worktree,
                 autoTrustNonScratch: config.autoTrustWorktrees,
                 profileConfigDir: profileConfigDir)
@@ -844,7 +844,7 @@ extension WorktreeLifecycle {
                 let restoreProfileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
                 // Pre-accept the folder-trust dialog so restoring an extra
                 // archived session onto a fresh profile dir doesn't re-prompt.
-                ClaudeTrustSeeder.ensureTrusted(
+                await ClaudeTrustSeeder.ensureTrusted(
                     worktree: worktree,
                     autoTrustNonScratch: config.autoTrustWorktrees,
                     profileConfigDir: restoreProfileConfigDir)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -270,7 +270,7 @@ extension WorktreeLifecycle {
                         // TBD made this directory but not its contents: stamp
                         // the row so folder-trust is never pre-answered for it.
                         checkedOutForeignHead = true
-                        try await db.worktrees.setForeignHead(id: worktreeID, value: true)
+                        try await db.worktrees.markForeignHead(id: worktreeID)
                     } else if ref.hasPrefix("origin/") {
                         try await git.worktreeAddTrackingRemote(
                             repoPath: repo.path,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -229,6 +229,12 @@ extension WorktreeLifecycle {
             // 2. git worktree add (fetch was run beforehand in the RPC handler)
             let worktreeAddStart = clock.now
             let resultPath: String
+            // Set by the PR-head branch below: this worktree's contents came
+            // from `refs/pull/<n>/head`, which a third-party fork may have
+            // authored. Persisted on the row so the five *later* trust-seeding
+            // call sites (wake, revive, terminal create, profile swap,
+            // extra-session restore) can see it too.
+            var checkedOutForeignHead = false
             if let ref = existingBranchRef {
                 // Existing-branch flow: check out the chosen ref. Local branches
                 // get `git worktree add <path> <branch>`; remote refs get
@@ -261,6 +267,10 @@ extension WorktreeLifecycle {
                         if localBranch != worktree.branch {
                             try await db.worktrees.updateBranch(id: worktreeID, branch: localBranch)
                         }
+                        // TBD made this directory but not its contents: stamp
+                        // the row so folder-trust is never pre-answered for it.
+                        checkedOutForeignHead = true
+                        try await db.worktrees.setForeignHead(id: worktreeID, value: true)
                     } else if ref.hasPrefix("origin/") {
                         try await git.worktreeAddTrackingRemote(
                             repoPath: repo.path,
@@ -302,6 +312,14 @@ extension WorktreeLifecycle {
             let worktreeAddElapsedMs = worktreeAddStart.duration(to: clock.now) / .milliseconds(1)
             timingLogger.debug("worktree-add \(worktreeID.uuidString, privacy: .public) \(Int(worktreeAddElapsedMs))ms")
 
+            // The spawn paths below take this value rather than re-reading the
+            // row, so carry the `foreignHead` stamp onto the in-memory copy —
+            // otherwise the very first Claude spawn would still seed trust for
+            // a tree it just fetched from a fork.
+            var stamped = worktree
+            stamped.foreignHead = stamped.foreignHead || checkedOutForeignHead
+            let spawnWorktree = stamped
+
             // 3. Setup tmux terminals.
             let terminalSpawnStart = clock.now
             // 3a. Blocking preSession hook: spawn its terminal FIRST and gate
@@ -309,7 +327,7 @@ extension WorktreeLifecycle {
             // a background task so the caller's RepoSerializer lane is freed
             // immediately — never block it for the duration of the hook.
             if let preSession = try await spawnPreSessionTerminal(
-                worktree: worktree, repo: repo,
+                worktree: spawnWorktree, repo: repo,
                 worktreePath: resultPath,
                 cols: cols, rows: rows
             ) {
@@ -333,7 +351,7 @@ extension WorktreeLifecycle {
                 let phase3 = Task.detached { [self] in
                     await runPreSessionPhase3(
                         preSession: preSession,
-                        worktree: worktree, repo: repo,
+                        worktree: spawnWorktree, repo: repo,
                         worktreePath: resultPath,
                         skipClaude: skipClaude,
                         initialPrompt: initialPrompt,
@@ -356,7 +374,7 @@ extension WorktreeLifecycle {
             // 3b. No preSession hook: spawn primary terminals inline
             // (behavior identical to before the preSession hook existed).
             _ = try await spawnPrimaryTerminals(
-                worktree: worktree, repo: repo,
+                worktree: spawnWorktree, repo: repo,
                 worktreePath: resultPath,
                 skipClaude: skipClaude,
                 initialPrompt: initialPrompt,
@@ -627,8 +645,9 @@ extension WorktreeLifecycle {
             // this worktree from a repo the operator registered, so the trust
             // answer is known by construction — and the dialog blocks before
             // SessionStart, so a stall here would be machine-invisible.
-            // Scratch always seeds; non-scratch honors the config flag.
-            // Best-effort, never throws.
+            // Scratch always seeds; non-scratch honors the config flag and is
+            // skipped entirely when the row is `foreignHead` (PR-head checkout,
+            // possibly fork-authored contents). Best-effort, never throws.
             ClaudeTrustSeeder.ensureTrusted(
                 worktree: worktree,
                 autoTrustNonScratch: config.autoTrustWorktrees,

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -120,6 +120,18 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the worktree auto-trust switch (default ON). Every Claude spawn
+    /// and wake re-reads it, so this applies to the next one immediately.
+    /// Turning it off never un-trusts a path that was already seeded — it only
+    /// stops TBD from seeding new non-scratch worktrees.
+    func handleConfigSetAutoTrustWorktrees(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetAutoTrustWorktreesParams.self, from: paramsData)
+        try await db.config.setAutoTrustWorktrees(enabled: params.enabled)
+        // Broadcast so the app reloads daemon capabilities.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the orphan-GC master switch. Turning it off does not cancel or
     /// undo any in-progress sweep — `OrphanGC.sweep` re-reads the flag itself
     /// on its next pass — this just flips the persisted gate.

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -291,7 +291,7 @@ extension RPCRouter {
         // falling back to `true` keeps the shipped default rather than silently
         // reinstating the stall.
         if isClaudeType {
-            ClaudeTrustSeeder.ensureTrusted(
+            await ClaudeTrustSeeder.ensureTrusted(
                 worktree: worktree,
                 autoTrustNonScratch: createConfig?.autoTrustWorktrees ?? true,
                 profileConfigDir: profileConfigDir)
@@ -590,7 +590,7 @@ extension RPCRouter {
             // `foreignHead` refusal, which is why the flag lives on the row
             // rather than in the create-time parameter list. `reviveConfig` is a
             // `try?` read; fall back to the shipped default.
-            ClaudeTrustSeeder.ensureTrusted(
+            await ClaudeTrustSeeder.ensureTrusted(
                 worktree: worktree,
                 autoTrustNonScratch: reviveConfig?.autoTrustWorktrees ?? true,
                 profileConfigDir: profileConfigDir)
@@ -1344,7 +1344,7 @@ extension RPCRouter {
         // resolve the same `resolveConfigDir(for: resolved)`; seed it once here.
         // Claude-only handler. `swapConfig` is a `try?` read; fall back to the
         // shipped default.
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: worktree,
             autoTrustNonScratch: swapConfig?.autoTrustWorktrees ?? true,
             profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolved))

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -282,13 +282,14 @@ extension RPCRouter {
             ? ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
             : nil
 
-        // Pre-accept Claude Code's folder-trust dialog: this worktree is
-        // TBD-created from a registered repo, so the trust answer is known by
-        // construction, and the dialog blocks before SessionStart (a stall
-        // would be machine-invisible). Only the claude path can trigger it;
-        // best-effort (never throws), so seeding on fresh and resume is safe.
-        // `createConfig` is a `try?` read — falling back to `true` keeps the
-        // shipped default rather than silently reinstating the stall.
+        // Pre-accept Claude Code's folder-trust dialog: this worktree belongs to
+        // a registered repo, so the trust answer is known by construction, and
+        // the dialog blocks before SessionStart (a stall would be
+        // machine-invisible). The seeder still declines for `foreignHead` rows.
+        // Only the claude path can trigger it; best-effort (never throws), so
+        // seeding on fresh and resume is safe. `createConfig` is a `try?` read —
+        // falling back to `true` keeps the shipped default rather than silently
+        // reinstating the stall.
         if isClaudeType {
             ClaudeTrustSeeder.ensureTrusted(
                 worktree: worktree,
@@ -584,8 +585,10 @@ extension RPCRouter {
                 resolvedProfile = nil
             }
             let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
-            // Reviving a closed terminal respawns claude in the same TBD-created
-            // worktree, so the same trust argument applies. `reviveConfig` is a
+            // Reviving a closed terminal respawns claude in the same worktree,
+            // so the same trust argument applies — including the seeder's
+            // `foreignHead` refusal, which is why the flag lives on the row
+            // rather than in the create-time parameter list. `reviveConfig` is a
             // `try?` read; fall back to the shipped default.
             ClaudeTrustSeeder.ensureTrusted(
                 worktree: worktree,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -282,13 +282,18 @@ extension RPCRouter {
             ? ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
             : nil
 
-        // Pre-accept Claude Code's folder-trust dialog for scratch spaces so
-        // fresh, TBD-owned scratch dirs don't prompt on every launch. Only the
-        // claude path can trigger the dialog; self-gates on isScratch and is
-        // best-effort (never throws), so seeding on both fresh and resume is safe.
+        // Pre-accept Claude Code's folder-trust dialog: this worktree is
+        // TBD-created from a registered repo, so the trust answer is known by
+        // construction, and the dialog blocks before SessionStart (a stall
+        // would be machine-invisible). Only the claude path can trigger it;
+        // best-effort (never throws), so seeding on fresh and resume is safe.
+        // `createConfig` is a `try?` read — falling back to `true` keeps the
+        // shipped default rather than silently reinstating the stall.
         if isClaudeType {
-            ClaudeTrustSeeder.ensureTrustedForScratch(
-                worktree: worktree, profileConfigDir: profileConfigDir)
+            ClaudeTrustSeeder.ensureTrusted(
+                worktree: worktree,
+                autoTrustNonScratch: createConfig?.autoTrustWorktrees ?? true,
+                profileConfigDir: profileConfigDir)
         }
 
         // Pre-resume freshness: `claude --resume` only looks in the project
@@ -579,8 +584,13 @@ extension RPCRouter {
                 resolvedProfile = nil
             }
             let profileConfigDir = ClaudeProfileConfigDirManager.resolveConfigDir(for: resolvedProfile)
-            ClaudeTrustSeeder.ensureTrustedForScratch(
-                worktree: worktree, profileConfigDir: profileConfigDir)
+            // Reviving a closed terminal respawns claude in the same TBD-created
+            // worktree, so the same trust argument applies. `reviveConfig` is a
+            // `try?` read; fall back to the shipped default.
+            ClaudeTrustSeeder.ensureTrusted(
+                worktree: worktree,
+                autoTrustNonScratch: reviveConfig?.autoTrustWorktrees ?? true,
+                profileConfigDir: profileConfigDir)
             await TranscriptProjectDirSync.ensureSessionResumableDetached(
                 sessionID: sessionID,
                 worktreePath: worktree.path,
@@ -1325,13 +1335,15 @@ extension RPCRouter {
             repo: repo?.envOverrides,
             profile: resolved?.envOverrides
         )
-        // Pre-accept the folder-trust dialog for scratch spaces before either
-        // swap spawn (resume or fresh) — a swap onto a new profile's isolated
-        // config dir would otherwise re-prompt. Both build calls below resolve
-        // the same `resolveConfigDir(for: resolved)`; seed it once here. This is
-        // a claude-only handler; the method self-gates on isScratch.
-        ClaudeTrustSeeder.ensureTrustedForScratch(
+        // Pre-accept the folder-trust dialog before either swap spawn (resume
+        // or fresh) — a swap onto a new profile's isolated config dir has never
+        // seen this path and would otherwise re-prompt. Both build calls below
+        // resolve the same `resolveConfigDir(for: resolved)`; seed it once here.
+        // Claude-only handler. `swapConfig` is a `try?` read; fall back to the
+        // shipped default.
+        ClaudeTrustSeeder.ensureTrusted(
             worktree: worktree,
+            autoTrustNonScratch: swapConfig?.autoTrustWorktrees ?? true,
             profileConfigDir: ClaudeProfileConfigDirManager.resolveConfigDir(for: resolved))
 
         let spawn: ClaudeSpawnCommandBuilder.Result

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -390,6 +390,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetHibernateInputVeto(request.paramsData)
             case RPCMethod.configSetAutoCloseSetup:
                 return try await handleConfigSetAutoCloseSetup(request.paramsData)
+            case RPCMethod.configSetAutoTrustWorktrees:
+                return try await handleConfigSetAutoTrustWorktrees(request.paramsData)
             case RPCMethod.configSetGCEnabled:
                 return try await handleConfigSetGCEnabled(request.paramsData)
             case RPCMethod.remoteProviders:
@@ -457,6 +459,7 @@ public final class RPCRouter: Sendable {
             controlModeSupported: version.map { $0 >= TmuxVersion.controlModeMinimum } ?? false,
             hibernateInputVetoEnabled: config.hibernateInputVetoEnabled,
             autoCloseSetupEnabled: config.autoCloseSetupEnabled,
+            autoTrustWorktrees: config.autoTrustWorktrees,
             panelSurfaceEnabled: config.panelSurfaceEnabled,
             remoteBackendsEnabled: config.remoteBackendsEnabled,
             remoteBackendsLive: remoteManager != nil))

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -808,6 +808,22 @@ public struct Config: Codable, Sendable, Equatable {
     /// shell for debugging. Default OFF: this kills a pane and deletes rows
     /// without a user gesture, so it is opt-in until it soaks.
     public var autoCloseSetupEnabled: Bool
+    /// Pre-accept Claude Code's folder-trust dialog for worktrees TBD created.
+    /// Default ON.
+    ///
+    /// The dialog asks "is this a project you created or one you trust?" — and
+    /// for a worktree TBD created from a repo the operator registered, TBD
+    /// already holds every fact the question is about, so the answer is yes by
+    /// construction. Seeding writes that answer through Claude's own config
+    /// persistence and the dialog never renders. That matters because the
+    /// dialog blocks BEFORE SessionStart: no hook fires while it is up, so a
+    /// stalled-on-trust session is invisible to TBD and prevention is the only
+    /// available fix.
+    ///
+    /// Turning this OFF only stops future seeding of non-scratch worktrees; it
+    /// never un-trusts a path. Scratch spaces are seeded unconditionally and
+    /// are not governed by this flag.
+    public var autoTrustWorktrees: Bool
     /// Master switch for the daemon-owned orphan GC sweep. Default ON.
     public var gcEnabled: Bool
     /// Minimum age (seconds) an orphaned worktree/scratchpad must reach
@@ -854,6 +870,7 @@ public struct Config: Codable, Sendable, Equatable {
                 autoResumeOnApiError: Bool = false,
                 hibernateInputVetoEnabled: Bool = false,
                 autoCloseSetupEnabled: Bool = false,
+                autoTrustWorktrees: Bool = true,
                 gcEnabled: Bool = true,
                 gcGraceSeconds: Int = Config.defaultGCGraceSeconds,
                 gcSnapshotRetentionDays: Int = Config.defaultGCSnapshotRetentionDays,
@@ -877,6 +894,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.autoResumeOnApiError = autoResumeOnApiError
         self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
         self.autoCloseSetupEnabled = autoCloseSetupEnabled
+        self.autoTrustWorktrees = autoTrustWorktrees
         self.gcEnabled = gcEnabled
         self.gcGraceSeconds = gcGraceSeconds
         self.gcSnapshotRetentionDays = gcSnapshotRetentionDays
@@ -918,6 +936,10 @@ public struct Config: Codable, Sendable, Equatable {
             Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
         autoCloseSetupEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .autoCloseSetupEnabled) ?? false
+        // Absent (older daemon / older persisted JSON) defaults to ON, matching
+        // the column default — the trust answer is known by construction.
+        autoTrustWorktrees = try c.decodeIfPresent(
+            Bool.self, forKey: .autoTrustWorktrees) ?? true
         gcEnabled = try c.decodeIfPresent(Bool.self, forKey: .gcEnabled) ?? true
         gcGraceSeconds = try c.decodeIfPresent(Int.self, forKey: .gcGraceSeconds)
             ?? Config.defaultGCGraceSeconds

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -158,6 +158,19 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// local branch) get tracked.
     public var prNumber: Int?
 
+    /// True when this worktree's *contents* were checked out from a ref TBD
+    /// cannot vouch for — today, a `refs/pull/<n>/head` fetch of a PR whose
+    /// commits may come from a third-party fork. TBD created the directory, but
+    /// a stranger authored what is in it (`.claude/settings.json`, hooks, MCP
+    /// config, `CLAUDE.md`), so the folder-trust question does *not* have a
+    /// known answer and `ClaudeTrustSeeder` must not pre-answer it.
+    ///
+    /// Set only by the PR-head checkout branch of `completeCreateWorktree`.
+    /// `false` for everything else — including a *decorated* same-repo PR row,
+    /// which stamps `prNumber` for status tracking but checks out an ordinary
+    /// local branch, so it stays seedable.
+    public var foreignHead: Bool = false
+
     /// When this worktree was pinned to the sidebar dock; `nil` = unpinned.
     /// Purely a UI affordance — the daemon stores it but never acts on it.
     /// Ordering in the dock is ascending by this timestamp, so new pins append.
@@ -198,6 +211,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 promotedToRepoID: UUID? = nil,
                 prStatus: PRStatus? = nil,
                 prNumber: Int? = nil,
+                foreignHead: Bool = false,
                 pinnedAt: Date? = nil,
                 pinSortOrder: Int? = nil) {
         self.id = id
@@ -221,6 +235,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.promotedToRepoID = promotedToRepoID
         self.prStatus = prStatus
         self.prNumber = prNumber
+        self.foreignHead = foreignHead
         self.pinnedAt = pinnedAt
         self.pinSortOrder = pinSortOrder
     }
@@ -231,7 +246,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         case archivedClaudeSessions, sortOrder, archivedHeadSHA
         case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge
         case autoHibernateOnMerge
-        case promotedToRepoID, prStatus, prNumber, pinnedAt, pinSortOrder
+        case promotedToRepoID, prStatus, prNumber, foreignHead, pinnedAt, pinSortOrder
     }
 
     public init(from decoder: Decoder) throws {
@@ -257,6 +272,9 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         promotedToRepoID = try c.decodeIfPresent(UUID.self, forKey: .promotedToRepoID)
         prStatus = try c.decodeIfPresent(PRStatus.self, forKey: .prStatus)
         prNumber = try c.decodeIfPresent(Int.self, forKey: .prNumber)
+        // Absent in JSON written before v67 — those rows predate fork-PR
+        // checkout tracking, so treat them as ordinary TBD-created contents.
+        foreignHead = try c.decodeIfPresent(Bool.self, forKey: .foreignHead) ?? false
         pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
         pinSortOrder = try c.decodeIfPresent(Int.self, forKey: .pinSortOrder)
     }
@@ -808,21 +826,30 @@ public struct Config: Codable, Sendable, Equatable {
     /// shell for debugging. Default OFF: this kills a pane and deletes rows
     /// without a user gesture, so it is opt-in until it soaks.
     public var autoCloseSetupEnabled: Bool
-    /// Pre-accept Claude Code's folder-trust dialog for worktrees TBD created.
+    /// Pre-accept Claude Code's folder-trust dialog for the worktrees TBD
+    /// created in a registered repo, and for that repo's own checkout.
     /// Default ON.
     ///
     /// The dialog asks "is this a project you created or one you trust?" — and
     /// for a worktree TBD created from a repo the operator registered, TBD
     /// already holds every fact the question is about, so the answer is yes by
-    /// construction. Seeding writes that answer through Claude's own config
-    /// persistence and the dialog never renders. That matters because the
-    /// dialog blocks BEFORE SessionStart: no hook fires while it is up, so a
-    /// stalled-on-trust session is invisible to TBD and prevention is the only
-    /// available fix.
+    /// construction. The repo's `.main` checkout is covered by the second half
+    /// of the question: TBD did not create it, but registering it with
+    /// `tbd repo add` was itself a deliberate trust gesture. Seeding writes that
+    /// answer through Claude's own config persistence and the dialog never
+    /// renders. That matters because the dialog blocks BEFORE SessionStart: no
+    /// hook fires while it is up, so a stalled-on-trust session is invisible to
+    /// TBD and prevention is the only available fix.
     ///
-    /// Turning this OFF only stops future seeding of non-scratch worktrees; it
-    /// never un-trusts a path. Scratch spaces are seeded unconditionally and
-    /// are not governed by this flag.
+    /// Worktrees flagged `Worktree.foreignHead` — contents fetched from a PR
+    /// head that a third-party fork may have authored — are never seeded, on or
+    /// off: TBD vouches for the directory it created, not for what was fetched
+    /// into it.
+    ///
+    /// Turning this OFF only stops future seeding of non-scratch worktrees —
+    /// including worktrees that already exist but were never seeded — and never
+    /// un-trusts a path. Scratch spaces are seeded unconditionally and are not
+    /// governed by this flag.
     public var autoTrustWorktrees: Bool
     /// Master switch for the daemon-owned orphan GC sweep. Default ON.
     public var gcEnabled: Bool

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1798,8 +1798,10 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// Whether the setup-hook tab auto-closes after a clean run (soak flag,
     /// default OFF). Re-evaluated by the daemon on every call.
     public let autoCloseSetupEnabled: Bool
-    /// Whether TBD pre-accepts Claude's folder-trust dialog for the worktrees
-    /// it created (default ON). Re-evaluated by the daemon on every call.
+    /// Whether TBD pre-accepts Claude's folder-trust dialog for the worktrees of
+    /// registered repos — the ones TBD created plus the repo's own checkout, but
+    /// never a fork-PR-head checkout (default ON). Re-evaluated by the daemon on
+    /// every call.
     public let autoTrustWorktrees: Bool
     /// Whether the daemon owns panel-surface state (`daemon_panel_surface_enabled`,
     /// spec C Phase 2 §8/§10). Default OFF while the feature soaks — the app

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -215,6 +215,7 @@ public enum RPCMethod {
     public static let configSetControlMode = "config.setControlMode"
     public static let configSetHibernateInputVeto = "config.setHibernateInputVeto"
     public static let configSetAutoCloseSetup = "config.setAutoCloseSetup"
+    public static let configSetAutoTrustWorktrees = "config.setAutoTrustWorktrees"
     public static let gcList = "gc.list"
     public static let gcRestore = "gc.restore"
     public static let gcSweepNow = "gc.sweepNow"
@@ -1644,6 +1645,15 @@ public struct ConfigSetAutoCloseSetupParams: Codable, Sendable {
     public init(enabled: Bool) { self.enabled = enabled }
 }
 
+/// Params for `config.setAutoTrustWorktrees` — pre-accept Claude's folder-trust
+/// dialog for TBD-created worktrees (default ON). Read fresh at every Claude
+/// spawn/wake, so the change applies to the next one; no daemon restart needed.
+/// Turning it off never un-trusts an already-seeded path.
+public struct ConfigSetAutoTrustWorktreesParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
 /// Params for `config.setGCEnabled` — the orphan-GC master switch.
 public struct ConfigSetGCEnabledParams: Codable, Sendable {
     public var enabled: Bool
@@ -1788,6 +1798,9 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// Whether the setup-hook tab auto-closes after a clean run (soak flag,
     /// default OFF). Re-evaluated by the daemon on every call.
     public let autoCloseSetupEnabled: Bool
+    /// Whether TBD pre-accepts Claude's folder-trust dialog for the worktrees
+    /// it created (default ON). Re-evaluated by the daemon on every call.
+    public let autoTrustWorktrees: Bool
     /// Whether the daemon owns panel-surface state (`daemon_panel_surface_enabled`,
     /// spec C Phase 2 §8/§10). Default OFF while the feature soaks — the app
     /// uses this to decide whether `panel.get`/`panel.apply` are live or the
@@ -1818,6 +1831,7 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
                 controlModeSupported: Bool = false,
                 hibernateInputVetoEnabled: Bool = false,
                 autoCloseSetupEnabled: Bool = false,
+                autoTrustWorktrees: Bool = true,
                 panelSurfaceEnabled: Bool = false,
                 remoteBackendsEnabled: Bool = false,
                 remoteBackendsLive: Bool = false) {
@@ -1826,6 +1840,7 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         self.controlModeSupported = controlModeSupported
         self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
         self.autoCloseSetupEnabled = autoCloseSetupEnabled
+        self.autoTrustWorktrees = autoTrustWorktrees
         self.panelSurfaceEnabled = panelSurfaceEnabled
         self.remoteBackendsEnabled = remoteBackendsEnabled
         self.remoteBackendsLive = remoteBackendsLive
@@ -1842,6 +1857,9 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         hibernateInputVetoEnabled = try c.decodeIfPresent(Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
         // New field for setup-tab auto-close; absent from older daemons defaults to false (soaking).
         autoCloseSetupEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoCloseSetupEnabled) ?? false
+        // New field for worktree auto-trust; absent from older daemons defaults
+        // to true, matching the column default (it is not a soak flag).
+        autoTrustWorktrees = try c.decodeIfPresent(Bool.self, forKey: .autoTrustWorktrees) ?? true
         // New field for the panel-surface flag; absent from older daemons defaults to false (soaking).
         panelSurfaceEnabled = try c.decodeIfPresent(Bool.self, forKey: .panelSurfaceEnabled) ?? false
         // New fields for the remote-backends flag; absent from older daemons defaults to false (soaking).

--- a/Tests/TBDAppTests/ModelProfileAppStateTests.swift
+++ b/Tests/TBDAppTests/ModelProfileAppStateTests.swift
@@ -150,6 +150,37 @@ import TBDShared
             "a transient refresh failure after a successful set must not snap the toggle off")
 }
 
+// Same pair for worktree auto-trust. Note the OFF direction is the interesting
+// one here: this flag ships ON, so the toggle's job is persisting an opt-out.
+@MainActor
+@Test func appState_setAutoTrustWorktreesRefreshesCapabilitiesOnSuccess() async {
+    let state = AppState()
+    state.autoTrustWorktreesSetter = { _ in }  // set RPC succeeds
+    state.daemonCapabilitiesFetcher = {
+        DaemonCapabilitiesResult(controlModeEnabled: false, autoTrustWorktrees: false)
+    }
+    #expect(state.daemonCapabilities == nil)
+
+    await state.setAutoTrustWorktrees(false)
+
+    #expect(state.daemonCapabilities?.autoTrustWorktrees == false,
+            "a successful toggle must re-fetch the daemon's persisted state")
+}
+
+@MainActor
+@Test func appState_setAutoTrustWorktreesKeepsLastKnownCapabilitiesOnRefreshFailure() async {
+    let state = AppState()
+    state.autoTrustWorktreesSetter = { _ in }  // set RPC succeeds...
+    state.daemonCapabilitiesFetcher = { nil }  // ...but the re-fetch transiently fails
+    state.daemonCapabilities = DaemonCapabilitiesResult(
+        controlModeEnabled: false, autoTrustWorktrees: false)
+
+    await state.setAutoTrustWorktrees(false)
+
+    #expect(state.daemonCapabilities?.autoTrustWorktrees == false,
+            "a transient refresh failure after a successful set must not snap the toggle back on")
+}
+
 @MainActor
 @Test func appState_dismissedProxyWarningsStartsEmptyAndAcceptsInsertions() {
     // The banner dismissal logic in TerminalPanelView writes to this set so a

--- a/Tests/TBDDaemonTests/AutoTrustWorktreesRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoTrustWorktreesRPCTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Worktree auto-trust RPC tests. Covers the `config.setAutoTrustWorktrees`
+/// RPC, the `daemon.capabilities` field carrying the flag, and the Codable
+/// back-compat defaults.
+///
+/// Unlike its soak-flag siblings this flag ships default **ON**: the trust
+/// dialog asks a question TBD already knows the answer to for a worktree it
+/// created from a registered repo, and it blocks before SessionStart, so a
+/// stalled-on-trust session is machine-invisible and cannot be recovered from.
+@Suite("Worktree auto-trust RPC")
+struct AutoTrustWorktreesRPCTests {
+
+    private func makeRouterAndDB() throws -> (RPCRouter, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date()
+        )
+        return (router, db)
+    }
+
+    private func setAutoTrust(_ router: RPCRouter, enabled: Bool) async throws {
+        let request = try RPCRequest(
+            method: RPCMethod.configSetAutoTrustWorktrees,
+            params: ConfigSetAutoTrustWorktreesParams(enabled: enabled))
+        let response = await router.handle(request)
+        #expect(response.success)
+    }
+
+    // MARK: - config.setAutoTrustWorktrees
+
+    @Test("config.setAutoTrustWorktrees persists the opt-out")
+    func setDisabledPersists() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setAutoTrust(router, enabled: false)
+        #expect(try await db.config.get().autoTrustWorktrees == false)
+    }
+
+    @Test("config.setAutoTrustWorktrees persists the flag back to true")
+    func setEnabledPersists() async throws {
+        let (router, db) = try makeRouterAndDB()
+        try await setAutoTrust(router, enabled: false)
+        try await setAutoTrust(router, enabled: true)
+        #expect(try await db.config.get().autoTrustWorktrees == true)
+    }
+
+    // MARK: - daemon.capabilities
+
+    @Test("capabilities reports auto-trust ON by default")
+    func capabilitiesDefaultsOn() async throws {
+        let (router, _) = try makeRouterAndDB()
+        let response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        let result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.autoTrustWorktrees == true)
+    }
+
+    @Test("capabilities re-evaluates auto-trust without a daemon restart")
+    func capabilitiesReEvaluatesFlag() async throws {
+        let (router, _) = try makeRouterAndDB()
+
+        try await setAutoTrust(router, enabled: false)
+        var response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        var result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.autoTrustWorktrees == false)
+
+        try await setAutoTrust(router, enabled: true)
+        response = await router.handle(RPCRequest(method: RPCMethod.daemonCapabilities))
+        result = try response.decodeResult(DaemonCapabilitiesResult.self)
+        #expect(result.autoTrustWorktrees == true)
+    }
+
+    // MARK: - Codable back-compat
+
+    /// Capabilities JSON from a daemon without the new key must decode to the
+    /// shipped default — ON, matching the column default.
+    @Test("capabilities JSON without autoTrustWorktrees decodes as true")
+    func capabilitiesDecodeBackCompat() throws {
+        let json = Data(#"{"controlModeEnabled":true,"controlModeSupported":false}"#.utf8)
+        let result = try JSONDecoder().decode(DaemonCapabilitiesResult.self, from: json)
+        #expect(result.autoTrustWorktrees == true)
+    }
+
+    /// Config JSON persisted before v66 must decode to the shipped default.
+    @Test("Config JSON without autoTrustWorktrees decodes as true")
+    func configDecodeBackCompat() throws {
+        let result = try JSONDecoder().decode(Config.self, from: Data("{}".utf8))
+        #expect(result.autoTrustWorktrees == true)
+    }
+}

--- a/Tests/TBDDaemonTests/AutoTrustWorktreesRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoTrustWorktreesRPCTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -96,5 +97,59 @@ struct AutoTrustWorktreesRPCTests {
     func configDecodeBackCompat() throws {
         let result = try JSONDecoder().decode(Config.self, from: Data("{}".utf8))
         #expect(result.autoTrustWorktrees == true)
+    }
+
+    // MARK: - worktree.foreign_head (v67)
+
+    @Test("worktree foreignHead defaults false and round-trips through the store")
+    func foreignHeadRoundTrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/repoFH", displayName: "repoFH", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", displayName: "w", branch: "b",
+            path: "/tmp/repoFH/w", tmuxServer: "s", status: .active)
+        #expect(wt.foreignHead == false, "ordinary creates are TBD-authored contents")
+        #expect(try await db.worktrees.get(id: wt.id)?.foreignHead == false)
+
+        try await db.worktrees.setForeignHead(id: wt.id, value: true)
+        #expect(try await db.worktrees.get(id: wt.id)?.foreignHead == true)
+
+        try await db.worktrees.setForeignHead(id: wt.id, value: false)
+        #expect(try await db.worktrees.get(id: wt.id)?.foreignHead == false)
+    }
+
+    /// A row written before v67 has no value for the column. The migration
+    /// backfills `false`, but the record type must also survive a NULL rather
+    /// than failing to decode and dropping the worktree.
+    @Test("worktree row with a NULL foreign_head reads as false")
+    func nullForeignHeadReadsFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let repo = try await db.repos.create(
+            path: "/tmp/repoFHNull", displayName: "repoFHNull", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", displayName: "w", branch: "b",
+            path: "/tmp/repoFHNull/w", tmuxServer: "s", status: .active)
+
+        try await db.writerForTests.write { database in
+            try database.execute(
+                sql: "UPDATE worktree SET foreign_head = NULL WHERE id = ?",
+                arguments: [wt.id.uuidString])
+        }
+
+        let reread = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(reread.foreignHead == false)
+    }
+
+    /// Worktree JSON from a daemon without the new key must decode to false —
+    /// pre-v67 rows predate fork-PR checkout tracking.
+    @Test("Worktree JSON without foreignHead decodes as false")
+    func worktreeDecodeBackCompat() throws {
+        let json = Data(#"""
+        {"id":"11111111-1111-1111-1111-111111111111","name":"w","displayName":"w",
+         "branch":"b","path":"/tmp/w","status":"active","createdAt":0,"tmuxServer":"s"}
+        """#.utf8)
+        let wt = try JSONDecoder().decode(Worktree.self, from: json)
+        #expect(wt.foreignHead == false)
     }
 }

--- a/Tests/TBDDaemonTests/AutoTrustWorktreesRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoTrustWorktreesRPCTests.swift
@@ -112,11 +112,8 @@ struct AutoTrustWorktreesRPCTests {
         #expect(wt.foreignHead == false, "ordinary creates are TBD-authored contents")
         #expect(try await db.worktrees.get(id: wt.id)?.foreignHead == false)
 
-        try await db.worktrees.setForeignHead(id: wt.id, value: true)
+        try await db.worktrees.markForeignHead(id: wt.id)
         #expect(try await db.worktrees.get(id: wt.id)?.foreignHead == true)
-
-        try await db.worktrees.setForeignHead(id: wt.id, value: false)
-        #expect(try await db.worktrees.get(id: wt.id)?.foreignHead == false)
     }
 
     /// A row written before v67 has no value for the column. The migration

--- a/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
@@ -13,14 +13,18 @@ struct ClaudeTrustSeederTests {
             .appendingPathComponent("tbd-trust-seed-test-\(UUID().uuidString)", isDirectory: true)
     }
 
-    private func makeWorktree(isScratch: Bool, path: String) -> Worktree {
+    private func makeWorktree(
+        isScratch: Bool, path: String, prNumber: Int? = nil, foreignHead: Bool = false
+    ) -> Worktree {
         Worktree(
             repoID: isScratch ? nil : UUID(),
             name: "wt",
             displayName: "wt",
             branch: "main",
             path: path,
-            tmuxServer: "srv"
+            tmuxServer: "srv",
+            prNumber: prNumber,
+            foreignHead: foreignHead
         )
     }
 
@@ -113,6 +117,71 @@ struct ClaudeTrustSeederTests {
             worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
 
         #expect(try String(contentsOf: file, encoding: .utf8) == sentinel)
+    }
+
+    // MARK: - Foreign-head tier: contents TBD cannot vouch for
+
+    @Test("toggle ON: foreign-head worktree is NOT seeded")
+    func foreignHeadIsNotSeededWithToggleOn() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-fork-pr-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: false, path: wtPath, prNumber: 42, foreignHead: true)
+
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
+
+        #expect(isTrusted(wtPath, in: configDir) == false,
+                "a fork contributor authored these contents — the dialog must render")
+        let file = configDir.appendingPathComponent(".claude.json")
+        #expect(FileManager.default.fileExists(atPath: file.path) == false)
+    }
+
+    @Test("toggle OFF: foreign-head worktree is NOT seeded either")
+    func foreignHeadIsNotSeededWithToggleOff() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-fork-pr-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: false, path: wtPath, prNumber: 42, foreignHead: true)
+
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
+
+        #expect(isTrusted(wtPath, in: configDir) == false)
+    }
+
+    /// Over-exclusion guard: a *decorated* same-repo PR row carries `prNumber`
+    /// for status tracking but checks out an ordinary local branch, so
+    /// `foreignHead` stays false and it must still seed. Gating on `prNumber`
+    /// instead of `foreignHead` would fail the originally reported bug.
+    @Test("toggle ON: same-repo PR worktree (prNumber set, not foreign) IS seeded")
+    func decoratedPRWorktreeIsStillSeeded() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-same-repo-pr-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: false, path: wtPath, prNumber: 9, foreignHead: false)
+
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
+
+        #expect(isTrusted(wtPath, in: configDir),
+                "a PR-review worktree on a same-repo branch is the exact case the seeder exists for")
+    }
+
+    /// The scratch tier is absolute: a scratch space has no git contents that
+    /// could be foreign, so even a (nonsensical) `foreignHead` stamp must not
+    /// reintroduce the guaranteed first-spawn stall.
+    @Test("scratch + foreignHead is still seeded (scratch tier is unconditional)")
+    func scratchIgnoresForeignHead() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: true, path: wtPath, foreignHead: true)
+
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
+
+        #expect(isTrusted(wtPath, in: configDir))
     }
 
     // MARK: - Preserve top-level keys

--- a/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
@@ -32,7 +32,14 @@ struct ClaudeTrustSeederTests {
         return json
     }
 
-    // MARK: - Gate ON
+    /// True when `.claude.json` in `configDir` marks `path` as trusted.
+    private func isTrusted(_ path: String, in configDir: URL) -> Bool {
+        let projects = readClaudeJSON(configDir)?["projects"] as? [String: Any]
+        let entry = projects?[path] as? [String: Any]
+        return entry?["hasTrustDialogAccepted"] as? Bool == true
+    }
+
+    // MARK: - Scratch tier: seeds regardless of the toggle
 
     @Test("scratch worktree seeds hasTrustDialogAccepted=true")
     func gateOnSeedsTrust() {
@@ -41,29 +48,71 @@ struct ClaudeTrustSeederTests {
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: wt, profileConfigDir: configDir.path)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
-        let json = readClaudeJSON(configDir)
-        let projects = json?["projects"] as? [String: Any]
-        let entry = projects?[wtPath] as? [String: Any]
-        #expect(entry?["hasTrustDialogAccepted"] as? Bool == true)
+        #expect(isTrusted(wtPath, in: configDir))
     }
 
-    // MARK: - Gate OFF (required both-branches test)
+    @Test("toggle OFF: scratch worktree is still seeded (unconditional tier)")
+    func toggleOffStillSeedsScratch() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: true, path: wtPath)
 
-    @Test("non-scratch worktree writes nothing")
-    func gateOffWritesNothing() {
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
+
+        #expect(isTrusted(wtPath, in: configDir),
+                "scratch spaces are TBD-owned empty dirs — the toggle must not gate them")
+    }
+
+    // MARK: - Non-scratch tier: both branches of the toggle
+
+    @Test("toggle ON: non-scratch TBD-created worktree is seeded")
+    func toggleOnSeedsNonScratch() {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-real-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: false, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: wt, profileConfigDir: configDir.path)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
+
+        #expect(isTrusted(wtPath, in: configDir),
+                "the spawn-stall fix: TBD created this worktree, so pre-seed the known answer")
+    }
+
+    @Test("toggle OFF: non-scratch worktree writes nothing")
+    func toggleOffWritesNothingForNonScratch() {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        let wtPath = "/private/tmp/tbd-real-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: false, path: wtPath)
+
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
 
         let file = configDir.appendingPathComponent(".claude.json")
         #expect(FileManager.default.fileExists(atPath: file.path) == false)
+    }
+
+    @Test("toggle OFF leaves an existing .claude.json untouched for non-scratch")
+    func toggleOffLeavesExistingConfigUntouched() throws {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let file = configDir.appendingPathComponent(".claude.json")
+        let sentinel = "{\"hasCompletedOnboarding\":true,\"projects\":{}}"
+        try sentinel.write(to: file, atomically: true, encoding: .utf8)
+
+        let wtPath = "/private/tmp/tbd-real-\(UUID().uuidString)"
+        let wt = makeWorktree(isScratch: false, path: wtPath)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
+
+        #expect(try String(contentsOf: file, encoding: .utf8) == sentinel)
     }
 
     // MARK: - Preserve top-level keys
@@ -86,8 +135,8 @@ struct ClaudeTrustSeederTests {
 
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: wt, profileConfigDir: configDir.path)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         let json = readClaudeJSON(configDir)
         #expect(json?["hasCompletedOnboarding"] as? Bool == true)
@@ -117,8 +166,8 @@ struct ClaudeTrustSeederTests {
         try JSONSerialization.data(withJSONObject: existing).write(to: file)
 
         let wt = makeWorktree(isScratch: true, path: wtPath)
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: wt, profileConfigDir: configDir.path)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         let json = readClaudeJSON(configDir)
         let projects = json?["projects"] as? [String: Any]
@@ -136,12 +185,12 @@ struct ClaudeTrustSeederTests {
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: wt, profileConfigDir: configDir.path)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
         let firstData = try Data(contentsOf: configDir.appendingPathComponent(".claude.json"))
 
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: wt, profileConfigDir: configDir.path)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
         let secondData = try Data(contentsOf: configDir.appendingPathComponent(".claude.json"))
 
         #expect(firstData == secondData)
@@ -165,8 +214,8 @@ struct ClaudeTrustSeederTests {
 
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: wt, profileConfigDir: configDir.path)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         let after = try String(contentsOf: file, encoding: .utf8)
         #expect(after == garbage)
@@ -185,8 +234,9 @@ struct ClaudeTrustSeederTests {
         let homeDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: homeDir) }
 
-        ClaudeTrustSeeder.ensureTrustedForScratch(
+        ClaudeTrustSeeder.ensureTrusted(
             worktree: wt,
+            autoTrustNonScratch: true,
             profileConfigDir: nil,
             homeDirectory: homeDir.path,
             environment: ["CLAUDE_CONFIG_DIR": configDir.path])
@@ -205,8 +255,9 @@ struct ClaudeTrustSeederTests {
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrustedForScratch(
+        ClaudeTrustSeeder.ensureTrusted(
             worktree: wt,
+            autoTrustNonScratch: true,
             profileConfigDir: nil,
             homeDirectory: homeDir.path,
             environment: [:])
@@ -233,8 +284,8 @@ struct ClaudeTrustSeederTests {
         try sentinel.write(to: file, atomically: true, encoding: .utf8)
 
         let wt = makeWorktree(isScratch: true, path: wtPath)
-        ClaudeTrustSeeder.ensureTrustedForScratch(
-            worktree: wt, profileConfigDir: configDir.path)
+        ClaudeTrustSeeder.ensureTrusted(
+            worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         let after = try String(contentsOf: file, encoding: .utf8)
         #expect(after == sentinel)

--- a/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
@@ -46,26 +46,26 @@ struct ClaudeTrustSeederTests {
     // MARK: - Scratch tier: seeds regardless of the toggle
 
     @Test("scratch worktree seeds hasTrustDialogAccepted=true")
-    func gateOnSeedsTrust() {
+    func gateOnSeedsTrust() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         #expect(isTrusted(wtPath, in: configDir))
     }
 
     @Test("toggle OFF: scratch worktree is still seeded (unconditional tier)")
-    func toggleOffStillSeedsScratch() {
+    func toggleOffStillSeedsScratch() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
 
         #expect(isTrusted(wtPath, in: configDir),
@@ -75,13 +75,13 @@ struct ClaudeTrustSeederTests {
     // MARK: - Non-scratch tier: both branches of the toggle
 
     @Test("toggle ON: non-scratch TBD-created worktree is seeded")
-    func toggleOnSeedsNonScratch() {
+    func toggleOnSeedsNonScratch() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-real-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: false, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         #expect(isTrusted(wtPath, in: configDir),
@@ -89,13 +89,13 @@ struct ClaudeTrustSeederTests {
     }
 
     @Test("toggle OFF: non-scratch worktree writes nothing")
-    func toggleOffWritesNothingForNonScratch() {
+    func toggleOffWritesNothingForNonScratch() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-real-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: false, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
 
         let file = configDir.appendingPathComponent(".claude.json")
@@ -103,7 +103,7 @@ struct ClaudeTrustSeederTests {
     }
 
     @Test("toggle OFF leaves an existing .claude.json untouched for non-scratch")
-    func toggleOffLeavesExistingConfigUntouched() throws {
+    func toggleOffLeavesExistingConfigUntouched() async throws {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
@@ -113,7 +113,7 @@ struct ClaudeTrustSeederTests {
 
         let wtPath = "/private/tmp/tbd-real-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: false, path: wtPath)
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
 
         #expect(try String(contentsOf: file, encoding: .utf8) == sentinel)
@@ -122,13 +122,13 @@ struct ClaudeTrustSeederTests {
     // MARK: - Foreign-head tier: contents TBD cannot vouch for
 
     @Test("toggle ON: foreign-head worktree is NOT seeded")
-    func foreignHeadIsNotSeededWithToggleOn() {
+    func foreignHeadIsNotSeededWithToggleOn() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-fork-pr-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: false, path: wtPath, prNumber: 42, foreignHead: true)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         #expect(isTrusted(wtPath, in: configDir) == false,
@@ -138,13 +138,13 @@ struct ClaudeTrustSeederTests {
     }
 
     @Test("toggle OFF: foreign-head worktree is NOT seeded either")
-    func foreignHeadIsNotSeededWithToggleOff() {
+    func foreignHeadIsNotSeededWithToggleOff() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-fork-pr-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: false, path: wtPath, prNumber: 42, foreignHead: true)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
 
         #expect(isTrusted(wtPath, in: configDir) == false)
@@ -155,13 +155,13 @@ struct ClaudeTrustSeederTests {
     /// `foreignHead` stays false and it must still seed. Gating on `prNumber`
     /// instead of `foreignHead` would fail the originally reported bug.
     @Test("toggle ON: same-repo PR worktree (prNumber set, not foreign) IS seeded")
-    func decoratedPRWorktreeIsStillSeeded() {
+    func decoratedPRWorktreeIsStillSeeded() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-same-repo-pr-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: false, path: wtPath, prNumber: 9, foreignHead: false)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         #expect(isTrusted(wtPath, in: configDir),
@@ -172,13 +172,13 @@ struct ClaudeTrustSeederTests {
     /// could be foreign, so even a (nonsensical) `foreignHead` stamp must not
     /// reintroduce the guaranteed first-spawn stall.
     @Test("scratch + foreignHead is still seeded (scratch tier is unconditional)")
-    func scratchIgnoresForeignHead() {
+    func scratchIgnoresForeignHead() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath, foreignHead: true)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: false, profileConfigDir: configDir.path)
 
         #expect(isTrusted(wtPath, in: configDir))
@@ -187,7 +187,7 @@ struct ClaudeTrustSeederTests {
     // MARK: - Preserve top-level keys
 
     @Test("preserves unrelated top-level keys and other project entries")
-    func preservesTopLevelKeys() throws {
+    func preservesTopLevelKeys() async throws {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
@@ -204,7 +204,7 @@ struct ClaudeTrustSeederTests {
 
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         let json = readClaudeJSON(configDir)
@@ -220,7 +220,7 @@ struct ClaudeTrustSeederTests {
     // MARK: - Preserve intra-project keys
 
     @Test("preserves existing keys inside the target project entry")
-    func preservesIntraProjectKeys() throws {
+    func preservesIntraProjectKeys() async throws {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
@@ -235,7 +235,7 @@ struct ClaudeTrustSeederTests {
         try JSONSerialization.data(withJSONObject: existing).write(to: file)
 
         let wt = makeWorktree(isScratch: true, path: wtPath)
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         let json = readClaudeJSON(configDir)
@@ -248,17 +248,17 @@ struct ClaudeTrustSeederTests {
     // MARK: - Idempotent
 
     @Test("running twice produces identical valid JSON")
-    func idempotent() throws {
+    func idempotent() async throws {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
         let firstData = try Data(contentsOf: configDir.appendingPathComponent(".claude.json"))
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
         let secondData = try Data(contentsOf: configDir.appendingPathComponent(".claude.json"))
 
@@ -272,7 +272,7 @@ struct ClaudeTrustSeederTests {
     // MARK: - Malformed JSON
 
     @Test("malformed .claude.json is left untouched and no throw")
-    func malformedJSONLeftUntouched() throws {
+    func malformedJSONLeftUntouched() async throws {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
@@ -283,7 +283,7 @@ struct ClaudeTrustSeederTests {
 
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         let after = try String(contentsOf: file, encoding: .utf8)
@@ -293,7 +293,7 @@ struct ClaudeTrustSeederTests {
     // MARK: - Config-dir fallback branches
 
     @Test("nil profileConfigDir falls back to environment CLAUDE_CONFIG_DIR")
-    func fallsBackToEnvConfigDir() {
+    func fallsBackToEnvConfigDir() async {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
@@ -303,7 +303,7 @@ struct ClaudeTrustSeederTests {
         let homeDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: homeDir) }
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt,
             autoTrustNonScratch: true,
             profileConfigDir: nil,
@@ -317,14 +317,14 @@ struct ClaudeTrustSeederTests {
     }
 
     @Test("nil profileConfigDir + no CLAUDE_CONFIG_DIR falls back to homeDirectory")
-    func fallsBackToHomeDirectory() {
+    func fallsBackToHomeDirectory() async {
         // Use a temp dir as homeDirectory so the real ~/.claude.json is never touched.
         let homeDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: homeDir) }
         let wtPath = "/private/tmp/tbd-scratch-\(UUID().uuidString)"
         let wt = makeWorktree(isScratch: true, path: wtPath)
 
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt,
             autoTrustNonScratch: true,
             profileConfigDir: nil,
@@ -338,7 +338,7 @@ struct ClaudeTrustSeederTests {
     // MARK: - Skip-if-already-trusted (no clobbering a concurrent writer)
 
     @Test("already-trusted key: file is not rewritten (byte-identical)")
-    func alreadyTrustedSkipsWrite() throws {
+    func alreadyTrustedSkipsWrite() async throws {
         let configDir = tempConfigDir()
         defer { try? FileManager.default.removeItem(at: configDir) }
         try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
@@ -353,10 +353,69 @@ struct ClaudeTrustSeederTests {
         try sentinel.write(to: file, atomically: true, encoding: .utf8)
 
         let wt = makeWorktree(isScratch: true, path: wtPath)
-        ClaudeTrustSeeder.ensureTrusted(
+        await ClaudeTrustSeeder.ensureTrusted(
             worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDir.path)
 
         let after = try String(contentsOf: file, encoding: .utf8)
         #expect(after == sentinel)
+    }
+
+    // MARK: - Concurrent seeds (TBD racing itself)
+
+    /// Tier 2 (real concurrency, real filesystem).
+    ///
+    /// `.claude.json` is ONE shared file that every worktree targets whenever no
+    /// per-profile config dir resolves, and the six seed call sites fire from
+    /// unrelated `RepoSerializer` lanes — wake / revive / terminal-create are not
+    /// serialized against creates at all. Without `ClaudeTrustSeeder.writer`, two
+    /// seeds read the same base and the loser's key vanishes under the winner's
+    /// atomic rename, leaving that worktree stalled on the trust dialog: exactly
+    /// the machine-invisible failure the seeder exists to prevent, and most likely
+    /// right after ship when every existing worktree is simultaneously unseeded.
+    ///
+    /// This asserts the serialization, not just the happy path — it goes red if
+    /// the critical section stops being serialized.
+    @Test("concurrent seeds into one .claude.json: every key survives")
+    func concurrentSeedsAllSurvive() async throws {
+        let configDir = tempConfigDir()
+        defer { try? FileManager.default.removeItem(at: configDir) }
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let file = configDir.appendingPathComponent(".claude.json")
+
+        // Pre-existing payload with some bulk, so the read → parse → merge →
+        // serialize → rename window is wide enough for an unserialized version to
+        // lose the race. A real `~/.claude.json` carries conversation history and
+        // is far larger than this.
+        let filler = String(repeating: "x", count: 2048)
+        let existing: [String: Any] = [
+            "hasCompletedOnboarding": true,
+            "history": (0..<150).map { ["display": "\(filler)-\($0)"] },
+            "projects": [String: Any](),
+        ]
+        try JSONSerialization.data(withJSONObject: existing).write(to: file)
+
+        let worktrees = (0..<40).map { i in
+            makeWorktree(isScratch: false, path: "/private/tmp/tbd-concurrent-\(i)-\(UUID().uuidString)")
+        }
+        let configDirPath = configDir.path
+
+        await withTaskGroup(of: Void.self) { group in
+            for wt in worktrees {
+                group.addTask {
+                    await ClaudeTrustSeeder.ensureTrusted(
+                        worktree: wt, autoTrustNonScratch: true, profileConfigDir: configDirPath)
+                }
+            }
+        }
+
+        let missing = worktrees.map(\.path).filter { !isTrusted($0, in: configDir) }
+        #expect(
+            missing.isEmpty,
+            // Each lost key is a worktree that will stall on the trust dialog.
+            "\(missing.count) of \(worktrees.count) seeds were lost to a concurrent rename")
+        // The unrelated top-level state a merge must never drop is still there.
+        let json = readClaudeJSON(configDir)
+        #expect(json?["hasCompletedOnboarding"] as? Bool == true)
+        #expect((json?["history"] as? [Any])?.count == 150)
     }
 }

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -198,4 +198,21 @@ struct ConfigStoreTests {
         let cfg = try await db.config.get()
         #expect(cfg.hibernateInputVetoEnabled == false)
     }
+
+    /// `auto_trust_worktrees` (v66) ships default ON, unlike its soak-flag
+    /// siblings: the trust answer is known by construction for a TBD-created
+    /// worktree, and the dialog stalls the spawn invisibly when it renders.
+    @Test func autoTrustWorktreesDefaultsToTrue() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.autoTrustWorktrees == true, "auto_trust_worktrees must default ON")
+    }
+
+    @Test func setAutoTrustWorktreesRoundtrips() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoTrustWorktrees(enabled: false)
+        #expect(try await db.config.get().autoTrustWorktrees == false)
+        try await db.config.setAutoTrustWorktrees(enabled: true)
+        #expect(try await db.config.get().autoTrustWorktrees == true)
+    }
 }

--- a/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
+++ b/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
@@ -100,6 +100,10 @@ import Testing
 
         let stored = try #require(try await db.worktrees.get(id: wt.id))
         #expect(stored.prNumber == 7)
+        // The contents came from refs/pull/7/head, which a fork may have
+        // authored — the row must say so, or every later spawn/wake/revive
+        // would pre-accept Claude's folder-trust dialog for it.
+        #expect(stored.foreignHead == true)
     }
 
     @Test func createFromPRDoesNotClobberExistingLocalBranch() async throws {
@@ -168,5 +172,10 @@ import Testing
 
         let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
         #expect(listed.contains { $0.branch == "feature-x" && $0.path.hasSuffix("/feature-x") })
+
+        // ...and because the contents are an ordinary same-repo branch, the row
+        // is NOT foreign-head, so folder-trust seeding still applies to it.
+        let stored = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(stored.foreignHead == false)
     }
 }


### PR DESCRIPTION
## What's broken

Spawn a Claude session in a fresh TBD worktree and it can sit there forever on Claude Code's *"Do you trust the files in this folder?"* prompt, doing nothing until a human notices and clicks through. Observed today in a fresh `gh-review` worktree.

The nasty part is that **TBD cannot see this happen**. The trust dialog renders *before* `SessionStart`, so no hook ever fires while it's up. There is no event, no activity state, no transcript — a stalled-on-trust session is machine-invisible. Nothing downstream can detect it and nothing can recover it. Prevention is the only fix available.

## Why it happens

`ClaudeTrustSeeder` already knows how to pre-accept the dialog — it writes `projects["<path>"].hasTrustDialogAccepted = true` into the effective config dir's `.claude.json`, which is Claude's own persistence for that decision. But it opened with:

```swift
guard worktree.isScratch else { return }
```

so only scratch spaces were ever pre-seeded. Every real worktree got the prompt.

## How it got broken

Not a regression — a deliberate gate whose reasoning has expired. It shipped with the seeder itself in `75033306` (*"feat(scratch): auto-accept Claude folder-trust prompt for scratch spaces"*, #381), whose comment read: *"Non-scratch worktrees live in real repos where the user may legitimately want the trust prompt, so we never touch their config."*

That was a defensible narrow scope for a first cut. It stopped being defensible as the fleet grew: the prompt is not a meaningful decision point for a directory TBD created itself, and its failure mode is a silent stall rather than a visible question.

## What this PR does

Extends seeding to TBD-created worktrees, with the scope narrowed to what TBD can actually vouch for.

**The argument.** The dialog asks "is this a project you created or one you trust?" For a worktree TBD created from a repo the operator registered, the answer is yes *by construction* — TBD holds every fact the dialog asks about. Pre-seeding writes that answer through Claude's own config persistence, the same machine interface the scratch path has used since #381, so the dialog never renders.

**But TBD vouches for the directory it created, not for arbitrary contents.** Reviewing this surfaced a real hole: picking a PR-only row in the branch picker fetches `refs/pull/<n>/head` — potentially a third-party contributor's tree — into a TBD-created worktree. Auto-trusting that would load a stranger's `.claude/settings.json`, hooks, MCP config and `CLAUDE.md` with the dialog suppressed, which is exactly the case the dialog exists to gate. So worktrees checked out from a PR head are stamped and permanently excluded.

Gate:

```swift
worktree.isScratch || (autoTrustNonScratch && !worktree.foreignHead)
```

Scratch stays **unconditional** — unchanged by the toggle and unchanged by `foreignHead` — so no existing behavior regresses.

**Seeding is now serialized.** The read-merge-write on `.claude.json` was unsynchronized, justified by an "infrequent writer" envelope that held when only scratch creation wrote to it. This PR invalidates that: 6 call sites x every non-scratch worktree. Two racing seeds both read the same base and both rename, so the loser's key is dropped — reinstating the exact invisible stall this PR fixes, most likely right after ship when every worktree in a fleet is simultaneously "never seeded." A `TrustSeedWriter` actor now makes the whole critical section atomic. A mutation check confirms this matters: without it, **37 of 40 concurrent seeds were lost**.

## Flag, default, and the honest tension

**Flag:** `config.auto_trust_worktrees` (migration `v66_config_auto_trust_worktrees`), surfaced as a General Settings toggle. **Default: ON.**

The house rule says large or autonomous new behavior ships default-OFF, and it explicitly exempts bug fixes. This is a bug fix — a spawn stall — so it opens ON, but the tension is real and worth stating rather than glossing:

- **For ON:** default-OFF ships a fix nobody receives. The failure it prevents is invisible to every automated surface TBD has, so "soak it and watch" has nothing to watch. And `ADD COLUMN ... DEFAULT` backfills existing rows, so a default-OFF column would need a forcing `UPDATE` migration to graduate later — the choice made now is close to permanent in practice.
- **Against ON:** the seeder mutates a *third-party tool's* persisted config with no per-worktree user gesture, which brushes the rule's "mutates persisted state" trigger.
- **The cautionary precedent, cited honestly:** `auto_hibernate_enabled` shipped default-ON in `v39` and had to be force-disabled in `v50`. Its lesson cuts both ways — the same backfill mechanic that made that walk-back painful also means picking the wrong default here is expensive to undo, and the v50 force-off additionally destroyed deliberate opt-ins.

Turning the toggle off stops any further pre-trusting, including for worktrees that were never seeded. **If review prefers default-OFF, flipping `defaults:` in the v66 migration is the whole change** — that outcome is acceptable.

**Known boundary, stated rather than implied:** `foreignHead` only catches TBD's own `refs/pull/<n>/head` fetch. A branch the operator manually fetched from a fork into their own repo and then picked as a plain branch row is still seeded — TBD has no way to distinguish it. `foreignHead` also fails *closed* for same-repo PRs whose head isn't fetched locally (they get excluded too); that's the safe direction and is left as-is.

## Brainstorm gate

This trips the blast-radius triggers (config column, feature flag, two migrations) and there is no `docs/specs/` entry. Calling that out explicitly, as the convention asks: the design questions the brainstorm would have asked — column name, default, gating scope, call-site routing, test shape — were answered out-of-band by a human in the originating brief, not by an agent. The change is a bug fix for an unrecoverable stall, and the column exists solely as an escape hatch for that fix rather than as new autonomous behavior.

## Changes

- **`v66_config_auto_trust_worktrees`** — `config.auto_trust_worktrees`, boolean, `defaults: true`. Full chain per the migrations rule, one commit: migration + GRDB `ConfigRecord` + Codable `Config` + RPC (`config.setAutoTrustWorktrees`) + Settings toggle.
- **`v67_worktree_foreign_head`** — `worktree.foreign_head`, boolean, `defaults: false`, stamped one-way at the fork-PR checkout. Persisted rather than passed as a create-time parameter, because seeding also happens at wake, history revive and profile swap.
- `ensureTrustedForScratch` → `ensureTrusted(worktree:autoTrustNonScratch:...)`, now `async`; all 6 call sites routed consistently (create x2, terminal create, history revive, profile swap, hibernation wake). The four optional-config sites fall back to `true` — a failed config read must not silently reinstate the stall.
- `TrustSeedWriter` actor serializing the read-merge-write.

Both migrations are additive; no existing migration was modified.

## Test plan

Both branches covered, per the house rule for flag-gated behavior. **4580 tests in 508 suites pass** (`swift test --parallel -j 2`); the single known issue is the by-design `FlakyQuarantineSelfTests/retriesUntilPass` fixture. `swiftlint --strict`: 0 violations across 614 files.

- [x] Toggle **ON** ⇒ non-scratch worktree **is** seeded
- [x] Toggle **OFF** ⇒ non-scratch **not** seeded, and an existing `.claude.json` is left byte-identical
- [x] Toggle **OFF** ⇒ scratch **still** seeded (invariant is absolute)
- [x] Scratch + `foreignHead: true` ⇒ **still** seeded (invariant beats both gates)
- [x] Foreign-head worktree + toggle ON ⇒ **not** seeded
- [x] Decorated same-repo PR row (`prNumber` set, `checkoutPRHead` false) + toggle ON ⇒ **is** seeded — guards against over-exclusion; this is the originally reported `gh-review` case
- [x] Real-git create paths assert `foreignHead == true` for the pull-ref checkout, `false` for the decorated same-repo row
- [x] 40 concurrent seeds into one pre-padded `.claude.json` ⇒ every key survives and unrelated top-level state is intact. Mutation-checked: reverting the actor fails it, losing 37 of 40 seeds
- [x] Both columns round-trip; NULL/absent reads hit the intended default; Codable back-compat decodes absent keys correctly
- [x] RPC persists both directions; capabilities re-evaluate without a daemon restart

Manual check worth doing before merge: with the toggle ON, create a worktree in a registered repo and confirm the first Claude spawn skips the dialog; then create one from a fork PR row and confirm the dialog **does** appear.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=85743019-01BC-406A-A611-BF607EBE640C)