### PR TITLE
Fix: Dismiss a queued auto-resume, and stop it lingering on a session that already recovered

### DIFF
--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -219,9 +219,14 @@ struct SingleWorktreeView: View {
                 //   continue at ..." text would be misleading because nothing
                 //   is running to receive it.
                 switch HibernatedBannerModel.banner(for: activeTabTerminal) {
-                case .scheduledResume(let resumeAt)?:
+                case .scheduledResume(let resumeAt, let terminalID)?:
                     Divider()
-                    ScheduledResumeBanner(resumeAt: resumeAt)
+                    ScheduledResumeBanner(resumeAt: resumeAt) {
+                        // Same path as the tab context menu's "Cancel
+                        // Scheduled Resume" (TabBar), which stays as the
+                        // secondary affordance.
+                        Task { await appState.cancelScheduledResume(terminalID: terminalID) }
+                    }
                 case .hibernatedOverlay?, nil:
                     EmptyView()
                 }
@@ -337,8 +342,23 @@ enum HibernatedBannerModel {
         /// `parkedNoticeMessage` wiring in PanePlaceholder), carrying this
         /// reason-phrased message.
         case hibernatedOverlay(message: String)
-        /// Terminal has a scheduled auto-resume → the "⏳ resumes ..." footer.
-        case scheduledResume(Date)
+        /// Terminal has a scheduled auto-resume → the "⏳ resumes ..." footer,
+        /// which carries an inline Cancel button acting on `cancelTerminalID`
+        /// (the same `AppState.cancelScheduledResume` the tab context menu
+        /// calls).
+        case scheduledResume(at: Date, cancelTerminalID: UUID)
+
+        /// The terminal an inline Cancel button acts on, or nil for banner
+        /// states that expose no cancel affordance. Only the scheduled-resume
+        /// footer has something to cancel: a parked terminal gets no footer at
+        /// all, and its `pendingResumeAt` (if a stale mirror still carries one)
+        /// is already cancelled daemon-side by parking.
+        var cancelTerminalID: UUID? {
+            switch self {
+            case .scheduledResume(_, let terminalID): return terminalID
+            case .hibernatedOverlay: return nil
+            }
+        }
     }
 
     /// nil = neither footer nor overlay strip. Precedence: a parked terminal
@@ -353,7 +373,7 @@ enum HibernatedBannerModel {
             return .hibernatedOverlay(message: message(for: terminal.hibernateReason))
         }
         if let resumeAt = terminal.pendingResumeAt {
-            return .scheduledResume(resumeAt)
+            return .scheduledResume(at: resumeAt, cancelTerminalID: terminal.id)
         }
         return nil
     }
@@ -382,8 +402,15 @@ enum HibernatedBannerModel {
 /// "continue" at `resumeAt`). Replaces the wide per-tab label text that used
 /// to inflate tab width; background tabs still signal via a bare "⏳" glyph
 /// in the tab label.
+///
+/// Carries an inline "Cancel" — same trailing-plain-button idiom as the
+/// proxy-unreachable banner's "Dismiss" in TerminalPanelView — so dropping a
+/// queued auto-resume doesn't require finding the tab context menu. The menu
+/// item stays as the secondary affordance; both call
+/// `AppState.cancelScheduledResume`.
 private struct ScheduledResumeBanner: View {
     let resumeAt: Date
+    let onCancel: () -> Void
 
     var body: some View {
         HStack(spacing: 6) {
@@ -392,6 +419,11 @@ private struct ScheduledResumeBanner: View {
                 .foregroundStyle(.orange)
                 .lineLimit(1)
             Spacer()
+            Button("Cancel", action: onCancel)
+                .buttonStyle(.plain)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.orange)
+                .help("Cancel the scheduled auto-resume")
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -403,11 +403,13 @@ enum HibernatedBannerModel {
 /// to inflate tab width; background tabs still signal via a bare "⏳" glyph
 /// in the tab label.
 ///
-/// Carries an inline "Cancel" — same trailing-plain-button idiom as the
-/// proxy-unreachable banner's "Dismiss" in TerminalPanelView — so dropping a
-/// queued auto-resume doesn't require finding the tab context menu. The menu
-/// item stays as the secondary affordance; both call
-/// `AppState.cancelScheduledResume`.
+/// Carries an inline "Cancel" so dropping a queued auto-resume doesn't require
+/// finding the tab context menu. The menu item stays as the secondary
+/// affordance; both call `AppState.cancelScheduledResume`.
+///
+/// The button sits immediately after the message (Spacer *after* it) rather
+/// than at the trailing window edge: on a wide window a far-right control is
+/// visually divorced from the sentence it acts on.
 private struct ScheduledResumeBanner: View {
     let resumeAt: Date
     let onCancel: () -> Void
@@ -418,17 +420,47 @@ private struct ScheduledResumeBanner: View {
                 .font(.system(size: 11))
                 .foregroundStyle(.orange)
                 .lineLimit(1)
+            ScheduledResumeCancelButton(action: onCancel)
             Spacer()
-            Button("Cancel", action: onCancel)
-                .buttonStyle(.plain)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(.orange)
-                .help("Cancel the scheduled auto-resume")
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.orange.opacity(0.15))
+    }
+}
+
+/// Hand-rolled chrome rather than `.buttonStyle(.bordered)`: a `.small`
+/// bordered button is ~20pt tall and would inflate this 21pt bar by a third.
+/// Follows `ModelRailButton` (WorktreeProfilePickerView) — plain button, tight
+/// rounded-rect fill that brightens on hover — with a stroke added so the
+/// affordance reads as a control against the banner's own orange wash, and the
+/// palette kept to `.orange` so no new accent color enters the bar.
+private struct ScheduledResumeCancelButton: View {
+    let action: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            Text("Cancel")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.orange)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.orange.opacity(isHovered ? 0.32 : 0.18))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .strokeBorder(Color.orange.opacity(isHovered ? 0.85 : 0.55), lineWidth: 1)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .help("Cancel the scheduled auto-resume")
     }
 }
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -433,9 +433,10 @@ private struct ScheduledResumeBanner: View {
 /// Hand-rolled chrome rather than `.buttonStyle(.bordered)`: a `.small`
 /// bordered button is ~20pt tall and would inflate this 21pt bar by a third.
 /// Follows `ModelRailButton` (WorktreeProfilePickerView) — plain button, tight
-/// rounded-rect fill that brightens on hover — with a stroke added so the
-/// affordance reads as a control against the banner's own orange wash, and the
-/// palette kept to `.orange` so no new accent color enters the bar.
+/// rounded-rect — but stays outline-only (no fill) so it reads as a light
+/// control against the banner's own orange wash; hover strengthens the
+/// stroke instead of introducing a background. Palette kept to `.orange` so
+/// no new accent color enters the bar.
 private struct ScheduledResumeCancelButton: View {
     let action: () -> Void
 
@@ -447,11 +448,7 @@ private struct ScheduledResumeCancelButton: View {
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(.orange)
                 .padding(.horizontal, 7)
-                .padding(.vertical, 2)
-                .background(
-                    RoundedRectangle(cornerRadius: 4)
-                        .fill(Color.orange.opacity(isHovered ? 0.32 : 0.18))
-                )
+                .padding(.vertical, 1)
                 .overlay(
                     RoundedRectangle(cornerRadius: 4)
                         .strokeBorder(Color.orange.opacity(isHovered ? 0.85 : 0.55), lineWidth: 1)

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -68,6 +68,9 @@ public struct LimitResumeActuator: LimitResumeActuating {
     private let tmux: any ResumeSendingTmux
     private let inspector: any PaneProcessInspecting
     private let readTranscript: @Sendable (String) -> Data?
+    /// Transcript mtime, kept separate from `readTranscript` so the
+    /// early-cancel pre-filter is testable without touching the filesystem.
+    private let transcriptModifiedAt: @Sendable (String) -> Date?
     /// Injectable sleep so unit tests run instantly.
     private let waiter: @Sendable (Duration) async -> Void
 
@@ -76,13 +79,56 @@ public struct LimitResumeActuator: LimitResumeActuating {
         tmux: any ResumeSendingTmux,
         inspector: any PaneProcessInspecting,
         readTranscript: @escaping @Sendable (String) -> Data?,
+        transcriptModifiedAt: @escaping @Sendable (String) -> Date?,
         waiter: @escaping @Sendable (Duration) async -> Void
     ) {
         self.db = db
         self.tmux = tmux
         self.inspector = inspector
         self.readTranscript = readTranscript
+        self.transcriptModifiedAt = transcriptModifiedAt
         self.waiter = waiter
+    }
+
+    /// Early-cancel probe (see `LimitResumeActuating.userAlreadyContinued`).
+    /// Read-only: no tmux calls, no writes, and — thanks to the mtime
+    /// pre-filter in `transcriptContinuation` — usually no file read either.
+    /// A terminal that has vanished answers `false`; cancelling for THAT
+    /// reason is fire time's job (`.terminalGone`), not this probe's.
+    public func userAlreadyContinued(_ resume: ScheduledResume) async -> Bool {
+        guard let terminal = ((try? await db.terminals.get(id: resume.terminalID)) ?? nil) else {
+            return false
+        }
+        return transcriptContinuation(
+            path: terminal.transcriptPath, since: resume.createdAt, mtimeGated: true
+        ).alreadyContinued
+    }
+
+    /// The single copy of the "already continued" predicate: does the
+    /// transcript hold a record newer than the limit-detection instant?
+    /// Returns the bytes it read alongside the verdict (nil when the read
+    /// was skipped or failed).
+    ///
+    /// `mtimeGated` selects the caller's cost profile:
+    /// - `false` — fire-time eligibility (step 2). ALWAYS reads, because
+    ///   those bytes double as the pre-send growth baseline for
+    ///   `verifyResumed`; skipping would leave `preSize == 0` and make any
+    ///   later read look like growth.
+    /// - `true` — the scheduler's early pass, which runs every
+    ///   `earlyCheckInterval` per pending row. Skips the whole-file read
+    ///   entirely when the file's mtime is at or before `cutoff`: nothing
+    ///   can have been appended since, and a long session's JSONL runs to
+    ///   tens of MB. An absent/unreadable mtime is NOT read as
+    ///   "unmodified" — it falls through to the read.
+    private func transcriptContinuation(
+        path: String?, since cutoff: Date, mtimeGated: Bool
+    ) -> (alreadyContinued: Bool, data: Data?) {
+        guard let path, !path.isEmpty else { return (false, nil) }
+        if mtimeGated, let mtime = transcriptModifiedAt(path), mtime <= cutoff {
+            return (false, nil)
+        }
+        guard let data = readTranscript(path) else { return (false, nil) }
+        return (RateLimitDetection.hasRecord(newerThan: cutoff, in: data), data)
     }
 
     public func actuate(_ resume: ScheduledResume) async -> ResumeActuationOutcome {
@@ -207,18 +253,18 @@ public struct LimitResumeActuator: LimitResumeActuating {
         }
 
         // 2. User already continued? Any transcript record newer than the
-        //    detection instant means yes — send nothing. Keep this read
-        //    around as the pre-send baseline for growth verification — a
-        //    fresh read later would race ahead of the baseline on a
-        //    fast-growing transcript and make growth undetectable.
-        var preSendTranscriptData: Data?
-        if let path = terminal.transcriptPath, !path.isEmpty {
-            preSendTranscriptData = readTranscript(path)
-            if let data = preSendTranscriptData,
-               RateLimitDetection.hasRecord(newerThan: resume.createdAt, in: data) {
-                return .notEligible(.userAlreadyContinued)
-            }
+        //    detection instant means yes — send nothing. Same predicate the
+        //    scheduler's early pass runs (`transcriptContinuation`), but
+        //    ungated: keep this read around as the pre-send baseline for
+        //    growth verification — a fresh read later would race ahead of
+        //    the baseline on a fast-growing transcript and make growth
+        //    undetectable.
+        let continuation = transcriptContinuation(
+            path: terminal.transcriptPath, since: resume.createdAt, mtimeGated: false)
+        if continuation.alreadyContinued {
+            return .notEligible(.userAlreadyContinued)
         }
+        let preSendTranscriptData = continuation.data
 
         // 3. Claude must be the pane's FOREGROUND process (+ flag). Never
         //    type into a bare shell.

--- a/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
@@ -283,12 +283,16 @@ public actor LimitResumeScheduler {
         for row in rows {
             guard await actuator.userAlreadyContinued(row) else { continue }
             inFlightOrFired.insert(row.id)
+            // Log only on a write that actually landed — a row whose retries
+            // all failed was NOT cancelled in the store. The failure itself is
+            // already logged at `.error` inside `setStatusWithRetry`, so
+            // there's no else branch here (same shape as `fire`).
             if await setStatusWithRetry(
                 id: row.id, status: .cancelled, terminalID: row.terminalID,
                 context: "early transcript growth") {
                 inFlightOrFired.remove(row.id)
+                logger.info("runLoop: cancelled pending resume early — transcript grew for terminal \(row.terminalID.uuidString, privacy: .public)")
             }
-            logger.info("runLoop: cancelled pending resume early — transcript grew for terminal \(row.terminalID.uuidString, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeScheduler.swift
@@ -28,6 +28,23 @@ public enum ResumeActuationOutcome: Equatable, Sendable {
 /// Seam between the scheduler (timing) and the actuator (tmux side effects).
 public protocol LimitResumeActuating: Sendable {
     func actuate(_ resume: ScheduledResume) async -> ResumeActuationOutcome
+
+    /// Read-only probe for the scheduler's early-cancel pass: has this
+    /// session's transcript gained a record newer than the resume's
+    /// detection instant?
+    ///
+    /// True means the session is alive again — either the user typed, or
+    /// (the case with no other signal) Claude Code retried and recovered
+    /// its OWN turn, which fires no `UserPromptSubmit` activity event. The
+    /// scheduler cancels the row immediately instead of leaving a live,
+    /// working session wearing an "auto-resume scheduled" badge until fire
+    /// time.
+    ///
+    /// Called for every not-yet-due pending row on the loop's
+    /// `earlyCheckInterval` cadence, so implementations must stay cheap:
+    /// `LimitResumeActuator` gates its whole-file transcript read behind an
+    /// mtime pre-filter.
+    func userAlreadyContinued(_ resume: ScheduledResume) async -> Bool
 }
 
 /// Terminal outcome surfaced to the user (notification copy lives in the
@@ -53,6 +70,13 @@ public actor LimitResumeScheduler {
     public static let jitterMax: TimeInterval = 30
     public static let copyModeRetryDelay: TimeInterval = 120
     public static let maxCopyModeAttempts = 15
+
+    /// Cap on any single sleep while a row is pending, so the loop runs an
+    /// early-cancel pass (`cancelResumesAlreadyContinued`) at least this
+    /// often instead of only waking at fire time. NOT a new timer or task —
+    /// it only shortens the existing `clock.sleep(until:)`, which `wake()`
+    /// already cancels and `PollerClock` already chunks internally.
+    static let earlyCheckInterval: TimeInterval = 15
 
     /// Post-actuation store-write retry (double-fire protection).
     private static let writeRetryAttempts = 3
@@ -215,7 +239,9 @@ public actor LimitResumeScheduler {
             }
 
             let clock = self.clock
-            let deadline = next.fireAt
+            // Cap the wait at `earlyCheckInterval` so a row whose session
+            // came back to life is cancelled early rather than at fire time.
+            let deadline = min(next.fireAt, clock.now().addingTimeInterval(Self.earlyCheckInterval))
             let sleepTask = Task<Void, Error> {
                 try await clock.sleep(until: deadline)
             }
@@ -225,16 +251,44 @@ public actor LimitResumeScheduler {
             if Task.isCancelled { return }
 
             let now = clock.now()
-            let due: [ScheduledResume]
+            let refreshed: [ScheduledResume]
             do {
-                due = try await store.pending().filter { $0.fireAt <= now && !inFlightOrFired.contains($0.id) }
+                refreshed = try await store.pending()
             } catch {
                 logger.error("runLoop: pending() read failed while collecting due rows: \(String(describing: error), privacy: .public)")
-                due = []
+                refreshed = []
             }
+            var due: [ScheduledResume] = []
+            var upcoming: [ScheduledResume] = []
+            for row in refreshed where !inFlightOrFired.contains(row.id) {
+                if row.fireAt <= now { due.append(row) } else { upcoming.append(row) }
+            }
+            // Rows that aren't due yet get the cheap transcript-growth probe;
+            // due rows skip it because `actuate`'s own eligibility pass runs
+            // the same predicate on fresher bytes moments from now.
+            await cancelResumesAlreadyContinued(upcoming)
             for row in due {
                 await fire(row)
             }
+        }
+    }
+
+    /// Early cancel: drop pending rows whose session's transcript has grown
+    /// past the detection instant. Reuses `fire`'s cancel path
+    /// (`setStatusWithRetry` → `.cancelled`, which nils
+    /// `terminal.pendingResumeAt` in the same write) and its
+    /// `inFlightOrFired` bookkeeping, so an early cancel can never race a
+    /// fire of the same row.
+    private func cancelResumesAlreadyContinued(_ rows: [ScheduledResume]) async {
+        for row in rows {
+            guard await actuator.userAlreadyContinued(row) else { continue }
+            inFlightOrFired.insert(row.id)
+            if await setStatusWithRetry(
+                id: row.id, status: .cancelled, terminalID: row.terminalID,
+                context: "early transcript growth") {
+                inFlightOrFired.remove(row.id)
+            }
+            logger.info("runLoop: cancelled pending resume early — transcript grew for terminal \(row.terminalID.uuidString, privacy: .public)")
         }
     }
 

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -697,6 +697,9 @@ public final class Daemon: Sendable {
                 tmux: tmux,
                 inspector: ProductionPaneProcessInspector(),
                 readTranscript: { path in FileManager.default.contents(atPath: path) },
+                transcriptModifiedAt: { path in
+                    (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
+                },
                 // swiftlint:disable:next no_raw_task_sleep - already seamed: this closure IS the production value of `LimitResumeActuator`'s non-defaulted `waiter:` parameter (the seam itself), exercised by Tests/TBDDaemonTests/LimitResumeActuatorTests.swift which injects `waiter: { _ in }` at 5 construction sites; see docs/specs/2026-07-24-test-hardening-design.md
                 waiter: { duration in _ = try? await Task.sleep(for: duration) }
             )

--- a/Tests/TBDAppTests/HibernatedBannerModelTests.swift
+++ b/Tests/TBDAppTests/HibernatedBannerModelTests.swift
@@ -108,8 +108,9 @@ struct HibernatedBannerModelTests {
     /// carrying the exact `resumeAt`.
     @Test func liveTerminalWithPendingResumeShowsScheduledBanner() {
         let resumeAt = Date(timeIntervalSince1970: 1_800_000_000)
-        let banner = HibernatedBannerModel.banner(for: terminal(pendingResumeAt: resumeAt))
-        #expect(banner == .scheduledResume(resumeAt))
+        let row = terminal(pendingResumeAt: resumeAt)
+        let banner = HibernatedBannerModel.banner(for: row)
+        #expect(banner == .scheduledResume(at: resumeAt, cancelTerminalID: row.id))
     }
 
     /// Precedence: parked AND `pendingResumeAt` set (parking now cancels the
@@ -125,6 +126,38 @@ struct HibernatedBannerModelTests {
         #expect(banner == .hibernatedOverlay(
             message: "Hibernated after the PR merged — click anywhere in the pane to resume"
         ))
+    }
+
+    // MARK: - Inline Cancel affordance
+    //
+    // The footer's "Cancel" button is driven off `Banner.cancelTerminalID`:
+    // non-nil only for the scheduled-resume footer, so the parked variants
+    // can't sprout a cancel control.
+
+    /// Scheduled resume → the footer exposes a cancel target, and it is THIS
+    /// terminal (what `AppState.cancelScheduledResume` gets handed).
+    @Test func scheduledResumeExposesCancelTarget() {
+        let row = terminal(pendingResumeAt: Date(timeIntervalSince1970: 1_800_000_000))
+        #expect(HibernatedBannerModel.banner(for: row)?.cancelTerminalID == row.id)
+    }
+
+    /// Parked → no cancel affordance (there is no footer to hang it on, and
+    /// parking already cancelled the resume daemon-side).
+    @Test func parkedBannerExposesNoCancelTarget() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: .manual)
+        )
+        #expect(banner?.cancelTerminalID == nil)
+    }
+
+    /// Parked AND a stale `pendingResumeAt` → still no cancel affordance,
+    /// same precedence as `parkedBeatsScheduledResume`.
+    @Test func parkedWithStalePendingResumeExposesNoCancelTarget() {
+        let banner = HibernatedBannerModel.banner(
+            for: terminal(hibernatedAt: Date(), hibernateReason: .auto,
+                          pendingResumeAt: Date(timeIntervalSince1970: 1_800_000_000))
+        )
+        #expect(banner?.cancelTerminalID == nil)
     }
 
     // MARK: - Full-pane wake overlay gate

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -89,11 +89,13 @@ struct FakeInspector: PaneProcessInspecting {
 
     private func makeActuator(
         inspector: FakeInspector = FakeInspector(claudePID: 4242),
-        transcript: Data? = Data("{}\n".utf8)
+        transcript: Data? = Data("{}\n".utf8),
+        transcriptMtime: Date? = nil
     ) -> LimitResumeActuator {
         LimitResumeActuator(
             db: db, tmux: tmux, inspector: inspector,
             readTranscript: { _ in transcript },
+            transcriptModifiedAt: { _ in transcriptMtime },
             waiter: { _ in })   // no real sleeping in unit tests
     }
 
@@ -182,7 +184,8 @@ struct FakeInspector: PaneProcessInspecting {
         }
         let actuator = LimitResumeActuator(
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
-            readTranscript: growing, waiter: { _ in })
+            readTranscript: growing,
+            transcriptModifiedAt: { _ in nil }, waiter: { _ in })
         let outcome = await actuator.actuate(row)
         #expect(outcome == .sent)
     }
@@ -222,7 +225,8 @@ struct FakeInspector: PaneProcessInspecting {
         }
         let actuator = LimitResumeActuator(
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
-            readTranscript: flipping, waiter: { _ in })
+            readTranscript: flipping,
+            transcriptModifiedAt: { _ in nil }, waiter: { _ in })
         let outcome = await actuator.actuate(row)
         #expect(outcome == .userAlreadyContinued)
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
@@ -248,6 +252,7 @@ struct FakeInspector: PaneProcessInspecting {
         let actuator = LimitResumeActuator(
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
             readTranscript: { _ in Data("{}\n".utf8) },
+            transcriptModifiedAt: { _ in nil },
             waiter: flippingWaiter)
         let outcome = await actuator.actuate(row)
         #expect(outcome == .cancelledExternally)
@@ -331,6 +336,7 @@ struct FakeInspector: PaneProcessInspecting {
         let actuator = LimitResumeActuator(
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
             readTranscript: { _ in Data("{}\n".utf8) },
+            transcriptModifiedAt: { _ in nil },
             waiter: cancellingWaiter)
         let outcome = await actuator.actuate(row)
         #expect(outcome == .cancelledExternally)
@@ -339,6 +345,100 @@ struct FakeInspector: PaneProcessInspecting {
         // The row stays cancelled — not resurrected by a stray write.
         let stored = try await db.scheduledResumes.get(id: row.id)
         #expect(stored?.status == .cancelled)
+    }
+
+    // MARK: - Early-cancel probe (`userAlreadyContinued`)
+
+    @Test func earlyProbeTrueWhenTranscriptHasRecordNewerThanDetection() async throws {
+        // Same predicate as fire-time step 2: createdAt is 1h ago, the
+        // record is timestamped 2099.
+        let line = #"{"type":"user","timestamp":"2099-01-01T00:00:00.000Z"}"#
+        let actuator = makeActuator(
+            transcript: Data((line + "\n").utf8),
+            transcriptMtime: row.createdAt.addingTimeInterval(1))
+        let continued = await actuator.userAlreadyContinued(row)
+        #expect(continued)
+        #expect(tmux.sends.isEmpty)   // read-only probe: never touches tmux
+    }
+
+    @Test func earlyProbeFalseWhenTranscriptHasNoNewerRecord() async throws {
+        let actuator = makeActuator(
+            transcript: Data("{}\n".utf8),
+            transcriptMtime: row.createdAt.addingTimeInterval(1))
+        let continued = await actuator.userAlreadyContinued(row)
+        #expect(continued == false)
+    }
+
+    @Test func earlyProbeFalseWhenTerminalIsGone() async throws {
+        let orphan = ScheduledResume(
+            terminalID: UUID(), worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: row.resetsAt, fireAt: row.fireAt,
+            limitType: "session", rawMessage: "m")
+        let continued = await makeActuator().userAlreadyContinued(orphan)
+        #expect(continued == false)   // cancelling for THAT is fire time's job
+    }
+
+    // MARK: - mtime pre-filter
+
+    /// The probe runs every `earlyCheckInterval` per pending row and a long
+    /// session's JSONL is tens of MB, so an mtime at or before the detection
+    /// instant must skip the whole-file read entirely. The injected content
+    /// WOULD trip the predicate, so `false` can only come from a skipped read.
+    @Test func earlyProbeSkipsReadWhenTranscriptUnmodifiedSinceDetection() async throws {
+        let reads = OSAllocatedUnfairLock(initialState: 0)
+        let newerRecord = Data(
+            (#"{"type":"user","timestamp":"2099-01-01T00:00:00.000Z"}"# + "\n").utf8)
+        let staleMtime = row.createdAt.addingTimeInterval(-1)
+        let actuator = LimitResumeActuator(
+            db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
+            readTranscript: { _ in
+                reads.withLock { $0 += 1 }
+                return newerRecord
+            },
+            transcriptModifiedAt: { _ in staleMtime }, waiter: { _ in })
+        let continued = await actuator.userAlreadyContinued(row)
+        #expect(continued == false)
+        #expect(reads.withLock { $0 } == 0)
+    }
+
+    @Test func earlyProbeReadsWhenTranscriptModifiedAfterDetection() async throws {
+        let reads = OSAllocatedUnfairLock(initialState: 0)
+        let newerRecord = Data(
+            (#"{"type":"user","timestamp":"2099-01-01T00:00:00.000Z"}"# + "\n").utf8)
+        let freshMtime = row.createdAt.addingTimeInterval(1)
+        let actuator = LimitResumeActuator(
+            db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
+            readTranscript: { _ in
+                reads.withLock { $0 += 1 }
+                return newerRecord
+            },
+            transcriptModifiedAt: { _ in freshMtime }, waiter: { _ in })
+        let continued = await actuator.userAlreadyContinued(row)
+        #expect(continued)
+        #expect(reads.withLock { $0 } == 1)
+    }
+
+    /// An unreadable mtime is NOT "unmodified" — fall through to the read
+    /// rather than silently answering false forever.
+    @Test func earlyProbeReadsWhenMtimeUnavailable() async throws {
+        let line = #"{"type":"user","timestamp":"2099-01-01T00:00:00.000Z"}"#
+        let actuator = makeActuator(
+            transcript: Data((line + "\n").utf8), transcriptMtime: nil)
+        let continued = await actuator.userAlreadyContinued(row)
+        #expect(continued)
+    }
+
+    /// Fire-time eligibility must NEVER be mtime-gated: its transcript read
+    /// doubles as `verifyResumed`'s pre-send growth baseline, and skipping it
+    /// would leave `preSize == 0` so any later read looks like growth.
+    @Test func fireTimeEligibilityIsNotMtimeGated() async throws {
+        let line = #"{"type":"user","timestamp":"2099-01-01T00:00:00.000Z"}"#
+        let outcome = await makeActuator(
+            transcript: Data((line + "\n").utf8),
+            transcriptMtime: row.createdAt.addingTimeInterval(-1)   // would skip the early read
+        ).actuate(row)
+        #expect(outcome == .userAlreadyContinued)
+        #expect(tmux.sends.isEmpty)
     }
 
     // MARK: - Thrown send retries instead of instant .failed

--- a/Tests/TBDDaemonTests/LimitResumeSchedulerTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeSchedulerTests.swift
@@ -8,7 +8,17 @@ final class FakeActuator: LimitResumeActuating, @unchecked Sendable {
     private let queue = DispatchQueue(label: "FakeActuator")
     private var outcomes: [ResumeActuationOutcome]
     private var _calls: [ScheduledResume] = []
+    private var _alreadyContinued = false
+    private var _earlyProbes: [ScheduledResume] = []
     var calls: [ScheduledResume] { queue.sync { _calls } }
+    /// Rows the scheduler ran the early-cancel probe against.
+    var earlyProbes: [ScheduledResume] { queue.sync { _earlyProbes } }
+    /// What `userAlreadyContinued` answers — flip mid-test to simulate the
+    /// session's transcript growing while the row is still pending.
+    var alreadyContinued: Bool {
+        get { queue.sync { _alreadyContinued } }
+        set { queue.sync { _alreadyContinued = newValue } }
+    }
 
     init(_ outcomes: [ResumeActuationOutcome] = [.sent]) {
         self.outcomes = outcomes
@@ -18,6 +28,13 @@ final class FakeActuator: LimitResumeActuating, @unchecked Sendable {
         queue.sync {
             _calls.append(resume)
             return outcomes.count > 1 ? outcomes.removeFirst() : outcomes[0]
+        }
+    }
+
+    func userAlreadyContinued(_ resume: ScheduledResume) async -> Bool {
+        queue.sync {
+            _earlyProbes.append(resume)
+            return _alreadyContinued
         }
     }
 }
@@ -246,6 +263,7 @@ final class OutcomeCollector: @unchecked Sendable {
                 _ = try? await store.cancelPending(terminalID: resume.terminalID)
                 return .paneInCopyMode
             }
+            func userAlreadyContinued(_ resume: ScheduledResume) async -> Bool { false }
         }
         let actuator = CancellingActuator(store: db.scheduledResumes)
         let collector = OutcomeCollector()
@@ -261,6 +279,89 @@ final class OutcomeCollector: @unchecked Sendable {
         await pump()
         #expect(try await db.scheduledResumes.pending().isEmpty)
         #expect(collector.events.isEmpty)
+        await scheduler.stop()
+    }
+
+    // MARK: - Early cancel on transcript growth
+
+    /// Claude Code retried and recovered its OWN turn: no UserPromptSubmit
+    /// event fires, so the only signal is transcript growth. The loop's
+    /// capped sleep must catch it well before fireAt instead of leaving the
+    /// session badged "auto-resume scheduled" for the whole wait.
+    @Test func transcriptGrowthCancelsPendingRowLongBeforeFireAt() async throws {
+        let actuator = FakeActuator([.sent])
+        let collector = OutcomeCollector()
+        let scheduler = makeScheduler(actuator: actuator) { collector.record($0, $1) }
+        await scheduler.start()
+        let scheduled = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(600),
+            limitType: "session", rawMessage: "m")
+        #expect(scheduled != nil)
+        await pump()
+        #expect(actuator.calls.isEmpty)   // parked, nowhere near fireAt
+
+        actuator.alreadyContinued = true
+        await clock.advance(by: LimitResumeScheduler.earlyCheckInterval + 1)
+        await pump()
+
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .cancelled)
+        // The UI mirror is nilled by the same write (setStatus).
+        #expect(try await db.terminals.get(id: terminalID)?.pendingResumeAt == nil)
+        #expect(actuator.calls.isEmpty)   // never actuated
+        #expect(collector.events.isEmpty)
+
+        // Still cancelled past the original fireAt — no late fire.
+        await clock.advance(by: 700)
+        await pump()
+        #expect(actuator.calls.isEmpty)
+        await scheduler.stop()
+    }
+
+    /// Other branch: the probe says the transcript did NOT grow, so the row
+    /// survives every early pass and fires normally at fireAt.
+    @Test func noTranscriptGrowthLeavesRowPendingAndStillFiresAtFireAt() async throws {
+        let actuator = FakeActuator([.sent])
+        let scheduler = makeScheduler(actuator: actuator)
+        await scheduler.start()
+        let scheduled = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(600),
+            limitType: "session", rawMessage: "m")
+        #expect(scheduled != nil)
+        await pump()
+
+        await clock.advance(by: LimitResumeScheduler.earlyCheckInterval + 1)
+        await pump()
+        #expect(!actuator.earlyProbes.isEmpty)   // the pass really ran
+        #expect(try await db.scheduledResumes.pending(terminalID: terminalID) != nil)
+        #expect(actuator.calls.isEmpty)
+
+        await clock.advance(by: 700)             // past resetsAt + slack
+        await pump()
+        #expect(actuator.calls.count == 1)
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .sent)
+        await scheduler.stop()
+    }
+
+    /// A due row is never early-probed — `actuate`'s own eligibility pass
+    /// runs the same predicate on fresher bytes moments later.
+    @Test func dueRowSkipsEarlyProbeAndFires() async throws {
+        let actuator = FakeActuator([.sent])
+        actuator.alreadyContinued = true   // would cancel if it were probed
+        let scheduler = makeScheduler(actuator: actuator)
+        await scheduler.start()
+        let scheduled = await scheduler.schedule(
+            terminalID: terminalID, worktreeID: worktreeID, claudeSessionID: nil,
+            resetsAt: clock.now().addingTimeInterval(-120),
+            limitType: "session", rawMessage: "m")
+        await pump()
+        #expect(actuator.earlyProbes.isEmpty)
+        #expect(actuator.calls.count == 1)
+        let row = try await db.scheduledResumes.get(id: scheduled!.id)
+        #expect(row?.status == .sent)
         await scheduler.stop()
     }
 

--- a/docs/specs/2026-07-03-session-limit-auto-resume-design.md
+++ b/docs/specs/2026-07-03-session-limit-auto-resume-design.md
@@ -151,6 +151,13 @@ terminal (user continued manually), terminal close/suspend, global toggle
 switched off (cancels all pending), or explicit user action ("Cancel
 scheduled resume" in the terminal context menu / notification).
 
+The scheduler also cancels early, before `fireAt`: on its own loop cadence it
+runs step 2's **user-already-continued** predicate against every not-yet-due
+row, so a session whose transcript grew (user typed, or Claude Code recovered
+its own turn — which fires no `UserPromptSubmit`) drops its badge right away
+instead of wearing "auto-resume scheduled" until fire time. Same verdict as
+the fire-time check, reached sooner.
+
 ## UI
 
 - New `NotificationType` case `limit_reached`: toggle on → "Session limit hit

--- a/docs/specs/2026-07-08-transient-api-error-auto-continue-design.md
+++ b/docs/specs/2026-07-08-transient-api-error-auto-continue-design.md
@@ -140,6 +140,10 @@ Same choke points as the parent, plus toggle scoping:
   regardless of type (unchanged).
 - **`autoResumeOnApiError` switched off cancels pending `api_error` rows
   only**; `autoResumeOnLimitReset` off cancels only limit rows.
+- The scheduler's pre-`fireAt` early-cancel pass applies to `api_error` rows
+  too (unchanged): the same user-already-continued predicate the fire-time
+  eligibility check runs, just reached sooner — a transcript that grew before
+  the backoff elapses cancels the row on the spot.
 
 ## UI
 


### PR DESCRIPTION
A queued auto-resume could sit armed on a session that was running perfectly fine, with no obvious way to get rid of it.

## What was actually happening

Reported against `🔓 auto-trust tbd worktrees`. The row was real, and it was benign:

| field | value |
|---|---|
| limitType | `api_error` (transient auto-continue) |
| rawMessage | `API Error: Connection closed mid-response. The response above may be incomplete.` |
| fireAt | +60s (first rung of the backoff ladder) |
| final status | `cancelled` — never fired |

Claude Code dropped a connection mid-turn, the `StopFailure` hook fired, TBD armed a 60-second auto-continue, and the session then recovered **on its own**. The badge was correct at arm time and stale for the rest of the window.

The gap: the only early cancel signal is an `activityState == working` event from the `UserPromptSubmit` hook. When Claude Code retries its *own* turn internally, no such event fires — so nothing tells TBD the session is alive again until fire time.

This is not rare. Across the local DB's full history:

| limitType | sent | cancelled | failed |
|---|---|---|---|
| `api_error` | 110 | 38 | 1 |
| `session` | 24 | 35 | — |

**59% of session-limit and 26% of api-error scheduled resumes end up cancelled.** The badge routinely advertises a resume that never needed to happen.

## Changes

**1. An inline Cancel on the scheduled-resume banner.**

A cancel already existed — but only as a tab context-menu item, with no affordance on the ⏳ badge or on the footer banner itself. Effectively undiscoverable.

The banner now carries an outline Cancel button next to its text, wired to the same `AppState.cancelScheduledResume` the context menu calls. No new RPC, no duplicated logic. `HibernatedBannerModel.Banner.scheduledResume` gained a `cancelTerminalID`; the parked case returns `nil`, so a cancel can never render on a parked pane (parking already cancels the resume daemon-side, and nothing is running there to receive a "continue").

**2. Cancel early when the transcript grows.**

The actuator already ran a "user already continued" transcript check — but only at fire time. This runs the same predicate on a 15s cadence, so a self-recovered session clears its badge promptly instead of wearing it for the full window.

Deliberately not a new subsystem. The scheduler's existing long sleep is capped at `min(fireAt, now + 15s)`; `PollerClock`'s chunking and `wake()` cancellation are untouched; no new type, task, timer, or clock seam. Cancellation goes through the same `setStatusWithRetry` path with the same `inFlightOrFired` bookkeeping `fire()` uses — no third cancel path. **The pass iterates pending rows (typically 0–2), not terminals**, so it does not scale with fleet size.

An injected `transcriptModifiedAt` seam skips the whole-file JSONL read when the transcript is untouched since detection — a long session's transcript is tens of MB and would otherwise be re-read every 15s.

## Two judgment calls worth reviewing

**No feature flag.** CLAUDE.md says behavior that acts without a user gesture and mutates persisted state ships behind a default-off flag with a spec. This is exempt, and the argument is stronger than "it's small": `RateLimitDetection.hasRecord` inspects only the newest timestamped record, and the transcript is append-only with monotonic timestamps — so once the predicate is true it stays true. The early pass and the fire-time check **provably return the same verdict** for a given row. This changes *when* an existing, already-unflagged mutation happens, not *whether*. The failure mode is one-way: it can only prevent an auto-send, never cause one.

**The mtime gate is applied only on the early path, never at fire time.** This asymmetry is required, not merely defensible. `checkEligibility`'s transcript read doubles as `verifyResumed`'s `preSize` baseline. A session sitting at a limit prompt for hours has an unmodified transcript *by definition* — so gating the fire path would skip the read, leave `preSize == 0`, and make the first poll against a non-empty history file register as growth, falsely reporting `.sent`. Pinned by `fireTimeEligibilityIsNotMtimeGated`.

## Known trade-off, accepted

Capping the sleep raises the daemon's wakeup cadence from 60s to 15s for a row's pending lifetime — roughly 5,760 wakes/day instead of 1,440 — and each wake now runs the loop body (a `store.pending()` query, plus a `db.terminals.get` and a `stat` per upcoming row) rather than just re-checking wall time. These are microsecond SQLite reads on an open pool, and the mtime pre-filter keeps the expensive whole-file read out of the hot path.

It matters most for multi-day weekly-limit waits, which the original spec explicitly contemplates. If it proves too chatty, the fix is to scale the cap by how far out `fireAt` is rather than using a flat 15s. Not doing that now — it adds complexity for a cost I can't yet measure.

## Testing

- `LimitResume` suites: **51 tests, 4 suites**. Both branches covered — transcript grew → cancelled early, never fires; no growth → survives and still fires at `fireAt`. The survive test asserts `!actuator.earlyProbes.isEmpty` so it cannot pass by the pass never running. The mtime tests assert read *counts*, not just booleans.
- `HibernatedBannerModelTests`: **17 tests** (was 14) — scheduled exposes a cancel target, parked does not, parked-with-stale-`pendingResumeAt` does not.
- Full suite: **4572 tests, 507 suites** green.
- `swiftlint --strict`: 0 violations, 614 files.

**Verification honesty:** the banner and its Cancel were verified live — restarted from this worktree, injected a synthetic pending resume with `tbd hooks fake-rate-limit`, confirmed the banner renders and the button reads correctly through three rounds of styling feedback. **The daemon-side early cancel was not exercised live** — `restart.sh` refuses to restart the shared daemon from a WIP worktree (PR #468's guard), so the running daemon is a different build. It rests on unit tests until this merges.

Both specs under `docs/specs/` were updated to list the new cancellation trigger.

## Not addressed here

The investigation surfaced a separate, nastier false-positive path: `StopFailureCommand` runs its rate-limit regex over `last_assistant_message`, so an agent that merely *writes about* hitting a usage limit can schedule a real resume. Out of scope for this PR; worth filing.

[🔁 Fix Spurious Auto Resume](https://cheapsteak.github.io/tbd/open/?worktree=AD76F6C9-F586-4146-845C-A1EF78EBCCEB)
