### PR TITLE
DX: Stop the ~42% red rate on main -- the fast pass outgrew its own deadlines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,7 +193,16 @@ jobs:
       # tests are conditionally skipped at runtime. The floors are set against
       # the executed counts (the summary line these steps grep), which is the
       # only number the check can see; don't "correct" them to the listed
-      # totals. Observed in CI on this PR: 2194 / 2342 / 57.
+      # totals.
+      #
+      # And the executed count is NOT stable run to run: two CI runs on this PR,
+      # on commits differing only in doc comments (zero tests added,
+      # `--list-tests` unchanged), executed 2194 and 2204 for step 1. The cause
+      # is not established — it is not conditional skips (the only
+      # `.enabled(if:)` here is gated on an env var CI does not set) and not
+      # parameterization (all `arguments:` are static literals). Left unexplained
+      # rather than guessed at. The practical consequence is the point: pin a
+      # floor near the exact count and it WILL fire spuriously. Keep the margin.
       # The floors sit well below each step's total
       # so ordinary test additions/removals never trip them. Their job is NOT
       # to catch an unlisted new target (the complement shape already does

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,10 @@ jobs:
 
   test:
     runs-on: macos-26
-    # Both test steps below append their `.flaky(issue:)` retry records here
-    # (docs/specs/2026-07-24-test-hardening-design.md §7), so one run produces
-    # one artifact covering the fast and quiet passes together. Unset locally,
-    # where the trait writes nothing.
+    # All three test steps below append their `.flaky(issue:)` retry records
+    # here (docs/specs/2026-07-24-test-hardening-design.md §7), so one run
+    # produces one artifact covering both fast passes and the quiet pass
+    # together. Unset locally, where the trait writes nothing.
     #
     # A LITERAL path, not `${{ runner.temp }}`: the `runner` context is not
     # available in a job-level `env:` block, and GitHub resolves an unavailable
@@ -125,16 +125,77 @@ jobs:
       # frontend RSS each, measured), so the cap is likely over-conservative
       # now — kept as safety margin; candidate for re-validation.
       #
-      # Two sequential steps, one job (docs/specs/2026-07-24-test-hardening-design.md
+      # Three sequential steps, one job (docs/specs/2026-07-24-test-hardening-design.md
       # §4): the tier-3 live suites live in their own target so they can run
       # serially on an otherwise idle machine instead of contending with the
       # parallel pass. A second *job* would draw from the 5-concurrent-macOS-job
-      # cap and re-pay the build, so both passes share this one.
+      # cap and re-pay the build, so all passes share this one.
       #
-      # Floors: the fast pass runs ~3859 tests and the quiet pass ~54 today.
-      # The floors sit well below those so ordinary test additions/removals never
-      # trip them — they only fire when a pass collapses to near-nothing.
-      - name: Test (fast parallel pass — tiers 1 and 2)
+      # ---------------------------------------------------------------------
+      # Why the fast pass is TWO steps instead of one
+      #
+      # Swift Testing parallelizes every non-serialized test in ONE process with
+      # no concurrency cap. All targets compile into that process, so per-test
+      # scheduling latency scales with the *total* population, not with the
+      # suite you are looking at. Evidence from 9 mined CI runs: p50 per-test
+      # reported duration is ~1/3 of total wall time in every run, red AND
+      # green — a trivial test "takes" 16–29 s because it is mostly suspended
+      # waiting for a turn. Population grew 3013 -> 4536 in three weeks. What
+      # flips a run red is whether one of the fixed wall-clock scheduling
+      # handshakes (ControlModeInputHealth, ControlModeInputRouter, the archived
+      # search debounce) loses a coin flip inside a ~2 s band; the failures are
+      # all handshake timeouts, never logic assertions.
+      #
+      # Halving the in-flight population halves the tail those deadlines must
+      # absorb. Measured locally under induced load, arms INTERLEAVED (not run
+      # in blocks — an earlier attempt at this comparison was invalidated by
+      # load drift on a shared box) and population held constant, means over 5
+      # iterations: p90 26.4 s -> 14.6 s, p50 8.8 s -> 7.6 s.
+      #
+      # The cost is +26 s of wall time (56 s -> 82 s mean), because the second
+      # invocation re-pays SPM's no-op build check and process startup. That is
+      # the honest figure: a single iteration showed +6 s and it did not hold up
+      # across the run. Set against a step that already spends 139-404 s on the
+      # compile, it is a good trade for halving the tail.
+      #
+      # This is NOT the "sharding across runners" that §1 considered and
+      # rejected and §2 lists as a non-goal. That rejection was about extra
+      # *jobs*: the 5-concurrent-macOS-job cap, and each shard re-paying the
+      # ~2 min build. These are two sequential `swift test` invocations in ONE
+      # job sharing ONE build — the same shape this file already uses for the
+      # fast/quiet split. It pays neither the job cap nor a second build.
+      #
+      # Why step 2 is a COMPLEMENT (`--skip`) and not an enumeration
+      #
+      # The three passes must partition the package exhaustively, and that has
+      # to hold *by construction* rather than by anyone remembering to update a
+      # list. The spec makes exactly this point about the target boundary in §3
+      # ("Enforcement mechanism = target boundary"): it is "compiler-enforced,
+      # cannot silently zero-match like a `--filter` regex". A fast pass
+      # expressed as two `--filter` enumerations gives that
+      # property up — `swift test --filter` exits GREEN on zero matches, so a
+      # newly added `TBDFooTests` would simply appear in no list, run in NO
+      # pass, and nothing would go red.
+      #
+      # The floors cannot cover that hole, and it is worth being precise about
+      # why: adding a target does not *reduce* any listed step's count, so both
+      # floors still clear and both steps stay green while the new target's
+      # tests execute nowhere. Expressing step 2 as "everything except
+      # TBDDaemonTests and TBDDaemonLiveTests" closes it — a new target lands
+      # in step 2 automatically and runs. Step 1 takes TBDDaemonTests, step 2
+      # takes the complement of steps 1+3, the quiet pass takes
+      # TBDDaemonLiveTests: no gap, no overlap, nothing to maintain.
+      #
+      # Floors: today TBDDaemonTests is 2194, TBDAppTests 1725, TBDSharedTests
+      # 502, TBDCLITests 127, TBDDaemonLiveTests 57 (verified with
+      # `swift test --list-tests`). The floors sit well below each step's total
+      # so ordinary test additions/removals never trip them. Their job is NOT
+      # to catch an unlisted new target (the complement shape already does
+      # that) — it is to catch a *collapse or rename* of a target that is
+      # named in one of these regexes, where `--filter`/`--skip` would
+      # otherwise zero-match or over-skip its way to a green run of nothing.
+      # ---------------------------------------------------------------------
+      - name: Test (fast parallel pass 1/2 — TBDDaemonTests)
         # A tier-1 test can still hang indefinitely: an over-long TestClock
         # advance chain wedged for >10 min and `.clockDriven` did NOT bound it
         # (the hung work sits where the time limit cannot cancel it). Without
@@ -150,15 +211,45 @@ jobs:
         timeout-minutes: 30
         run: |
           set -o pipefail
-          swift test --parallel -j 2 --skip '^TBDDaemonLiveTests\.' 2>&1 | tee /tmp/fast-pass.log
-          count=$(grep -oE 'Test run with [0-9]+ tests?' /tmp/fast-pass.log | grep -oE '[0-9]+' | head -1)
+          swift test --parallel -j 2 --filter '^TBDDaemonTests\.' 2>&1 | tee /tmp/fast-pass-daemon.log
+          count=$(grep -oE 'Test run with [0-9]+ tests?' /tmp/fast-pass-daemon.log | grep -oE '[0-9]+' | head -1)
           # `swift test --filter/--skip` exits GREEN on zero matches, so a bad
           # regex or a renamed target would silently run nothing and pass.
-          if [ -z "$count" ] || [ "$count" -lt 3000 ]; then
-            echo "::error::Fast pass ran ${count:-no} tests (floor 3000) — the --skip regex likely over-matched."
+          if [ -z "$count" ] || [ "$count" -lt 1800 ]; then
+            echo "::error::Fast pass 1/2 ran ${count:-no} tests (floor 1800) — the --filter regex matched nothing or the target was renamed."
             exit 1
           fi
-          echo "Fast pass executed $count tests."
+          echo "Fast pass 1/2 (TBDDaemonTests) executed $count tests."
+
+      - name: Test (fast parallel pass 2/2 — everything except TBDDaemonTests and the live target)
+        # Expressed as a COMPLEMENT, not a list of targets — see the "Why step 2
+        # is a COMPLEMENT" block above. A new test target lands here on its own.
+        #
+        # 30, matching step 1. The earlier 15 was justified by "the previous
+        # step already paid the test-target compile, so this one is warm" — but
+        # compile time is no longer the binding constraint. With `.clockDriven`
+        # raised to 4 minutes the per-test worst case went 60 s -> 240 s, and a
+        # wedged `.clockDriven, .serialized` suite pays that *per test, in
+        # series*: FileWatcherTests (11 tests, in this pass) passes 15 minutes
+        # after only four of them. The step would then die on the GitHub
+        # timeout, which names no suite — precisely the uninformative outcome
+        # this `timeout-minutes` exists to prevent. 30 gives the per-test limits
+        # room to fire first and attribute the hang to a named test. (A suite
+        # wedged in *every* test still overruns 30; the aim is to make the
+        # ordinary case report itself, not to bound the pathological one.)
+        timeout-minutes: 30
+        run: |
+          set -o pipefail
+          swift test --parallel -j 2 --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.' 2>&1 | tee /tmp/fast-pass-app.log
+          count=$(grep -oE 'Test run with [0-9]+ tests?' /tmp/fast-pass-app.log | grep -oE '[0-9]+' | head -1)
+          # `swift test --filter/--skip` exits GREEN on zero matches, so an
+          # over-broad skip or a renamed target would silently run nothing and
+          # pass.
+          if [ -z "$count" ] || [ "$count" -lt 1900 ]; then
+            echo "::error::Fast pass 2/2 ran ${count:-no} tests (floor 1900) — the --skip regex over-matched or a target was renamed."
+            exit 1
+          fi
+          echo "Fast pass 2/2 (everything except TBDDaemonTests) executed $count tests."
 
       - name: Test (quiet pass — tier-3 live suites, serial, idle machine)
         # `--no-parallel` is REQUIRED and is not the same as omitting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,9 +186,15 @@ jobs:
       # takes the complement of steps 1+3, the quiet pass takes
       # TBDDaemonLiveTests: no gap, no overlap, nothing to maintain.
       #
-      # Floors: today TBDDaemonTests is 2194, TBDAppTests 1725, TBDSharedTests
-      # 502, TBDCLITests 127, TBDDaemonLiveTests 57 (verified with
-      # `swift test --list-tests`). The floors sit well below each step's total
+      # Floors: `swift test --list-tests` today reports TBDDaemonTests 2194,
+      # TBDAppTests 1725, TBDSharedTests 502, TBDCLITests 127,
+      # TBDDaemonLiveTests 57 (4605 total). What actually EXECUTES is slightly
+      # lower for step 2 — 2342, not 1725+502+127=2354 — because a handful of
+      # tests are conditionally skipped at runtime. The floors are set against
+      # the executed counts (the summary line these steps grep), which is the
+      # only number the check can see; don't "correct" them to the listed
+      # totals. Observed in CI on this PR: 2194 / 2342 / 57.
+      # The floors sit well below each step's total
       # so ordinary test additions/removals never trip them. Their job is NOT
       # to catch an unlisted new target (the complement shape already does
       # that) — it is to catch a *collapse or rename* of a target that is

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -85,6 +85,123 @@ in the parallel pass is merely the status quo, but moving a fast
 deterministic suite into the serial pass taxes every PR forever. When in
 doubt, leave it in the parallel pass.
 
+## Population is the scheduler, and it is a moving target
+
+Swift Testing runs every non-serialized test in **one process with no
+concurrency cap**, and all targets compile into that process. So per-test
+scheduling latency scales with the *total* population, not with the suite you
+are looking at. Mined CI runs put p50 per-test reported duration at ~1/3 of
+total wall time on green runs as well as red — a trivial test "takes" 16–29 s
+because it is mostly suspended waiting for a turn. Population went 3013 → 4536
+in three weeks. Two consequences, both load-bearing.
+
+**The fast pass is two sequential steps in one job.** `test.yml` runs
+`--filter '^TBDDaemonTests\.'` then
+`--skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.'`, sharing one build.
+Halving the in-flight population halves the tail: measured under induced load
+with arms interleaved, means over 5 iterations, p90 26.4 s → 14.6 s and p50
+8.8 s → 7.6 s, for **+26 s** of wall time (56 s → 82 s — the second invocation
+re-pays SPM's no-op build check and process startup). Quote that figure, not the
++6 s a single iteration showed; it did not survive the other four. This is not
+the "sharding across runners" that
+`docs/specs/2026-07-24-test-hardening-design.md` §1 rejected and §2 lists as a
+non-goal — that was about extra *jobs* paying the 5-concurrent-macOS-job cap and
+a second ~2 min build. **Step 2 is a complement, not an enumeration, and that
+is deliberate.** Two `--filter` lists would have reintroduced the hazard the
+spec's §3 names when it calls the target boundary "compiler-enforced, cannot
+silently zero-match like a `--filter` regex": `swift test --filter` exits GREEN
+on zero matches, so a new `TBDFooTests` named in neither list would run in
+**neither** pass with nothing going red — and the floors could not catch that,
+because adding a target reduces no existing step's count. Written as a
+complement, step 2 absorbs any new target automatically, and the three passes
+partition the package by construction. The per-step floors have a narrower job:
+catching a target that *is* named in one of these regexes collapsing or being
+renamed, where the regex would zero-match or over-skip its way to a green run
+of nothing. Keep them updated.
+
+**Wall-clock handshake deadlines are hang-catchers sized against the population
+of the day.** `ciSafeDeadline` (`Tests/TBDDaemonTests/ControlModeTestSupport.swift`)
+and `waitForSuspension`'s `timeout` / `.clockDriven`'s limit
+(`Tests/TestSupport/ClockTestSupport.swift`) bound a hang; they assert nothing
+and cost passing runs nothing. They are the first things to re-derive when the
+population moves materially — that is what turned the `ControlModeInputHealth`,
+`ControlModeInputRouter` and "Archived search debounce" reds into a ~42% red
+rate on `main` with **zero** logic assertions failing.
+
+**Derive the three together, and know the invariant.** They are currently
+`ciSafeDeadline` 90 s, `waitForSuspension` 45 s, `.clockDriven`
+`.timeLimit(.minutes(4))` = 240 s. The suite limit and the two wait deadlines
+race each other for real: `AttachRPCOrchestrationTests` and
+`PaneRepairCoordinatorTests` are both `.clockDriven` **and** consume
+`ciSafeDeadline`, across 48 `waitFor` call sites. Every one of those sites is
+unguarded — `waitFor` is `@discardableResult` and non-throwing on timeout, so
+the test continues and chained waits are real (the `try` covers only the inner
+`Task.sleep`).
+
+The rule is **not** "all N chained waits must fit inside the suite limit". That
+was never satisfiable — the deepest chain is 6 waits in one
+`PaneRepairCoordinator` test, and 6 × 30 s already blew the old one-minute
+limit. The rule is:
+
+> The suite limit must afford the **first** full deadline plus the rest of an
+> ordinary test. The first timeout's `Issue.record` fires immediately and
+> carries the named diagnostic, so it always survives even if the limit later
+> truncates the test. Chains beyond the first belong to a test that is already
+> failing; truncating those is acceptable and deliberate.
+
+Checked against 240 s: one `waitFor` + one `waitForSuspension` = 135 s ✓; two
+`waitFor` = 180 s ✓; two `waitForSuspension` = 90 s ✓ (this is the "a test that
+waits twice must afford both waits" property the old pairing was reasoned
+from).
+
+**Past that pair the margin is thin — 240 s is not roomy, and the real numbers
+are worth knowing before someone reaches for a raise.**
+`GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
+`DaywatchRunnerTests.testSubsequentTicksAtInterval` each chain **5**
+`waitForSuspension` calls, i.e. 225 s of the 240 s ceiling. And counting
+`waitFor` at 90 s plus each clock wait at 45 s, **9 of the 13**
+`PaneRepairCoordinatorTests` have a worst case above 240 s — not just the
+6-deep chain (540 s) usually cited. Every one of those is still consistent with
+the invariant, because only an already-failing test walks a full chain of
+timeouts and the first diagnostic is already recorded by then.
+
+**The remedy if they start tripping is to shorten the chain, not to raise the
+limit again.** "Keep advance chains short — single digits" below is already the
+rule, and a 5-deep chain sits at its edge; inject pacing values and cross the
+threshold in 2–3 advances. Raising 240 s buys room only for tests that are
+already failing, and taxes every genuinely wedged test with a longer wait
+before it gets attributed.
+
+**All three are sized for the fast parallel pass, so tier 3 opts out.** The
+quiet pass (`--no-parallel`, idle machine) never sees the saturation that forced
+`.clockDriven` up, and a tier-3 suite whose time limit is its *regression
+detector* rather than a hang guard is actively harmed by the raise — it disarms
+a mutation-verified proof with nothing going red. Those pin their own
+`.timeLimit(.minutes(1))`: `SubprocessTimeoutStarvationTests` (a `sleep 90`
+child must outlive the limit), `GitManagerTimeoutTests` and
+`SubprocessTimeoutTests` (a regressed EOF-waiting drain must outlive it). Don't
+"tidy" them back to `.clockDriven`; the residual — that 45 s makes two chained
+`waitForSuspension`s exceed 60 s — is acceptable only because none of those
+suites chains two and a healthy handshake there returns in milliseconds.
+
+Three remedies are already refuted; don't re-litigate them.
+
+- **Per-suite `.serialized`.** "Archived search debounce" is already
+  `.clockDriven, .serialized` and still failed twice in CI. The contention is
+  process-global, so serializing one suite does not shrink the queue its waiter
+  sits behind. (The advice under "Clock and date seams" still holds for its own
+  case — a suite starving *itself*.)
+- **`TASK_MEGA_YIELD_COUNT=1`.** Measured across interleaved runs: p90
+  26.5/31.2 → 26.0/29.4, p99 26.6 → 27.0. Noise. Real but secondary
+  contributor; resolves the open question in issue #496.
+- **Blanket retry.** Banned in every tier — see "Quarantine" below.
+
+**The measurement method is the transferable part.** Arms must be
+**interleaved, not batched**, with population held constant. An earlier attempt
+at this same comparison ran each arm as a block and was invalidated by
+uncontrolled load drift from sibling agents on the shared box — the arms
+measured different machines, not different configurations.
+
 New tests should state their tier. Tier-1 tests put no real sleep in the
 *behaviour under test* — the code under test is driven entirely by virtual
 time. The scheduling handshake that observes it may still sleep; see "Clock and
@@ -243,6 +360,11 @@ other. If a clock-driven suite fails on the arming handshake, reach for
 suite rather than the target, and measured on the appearance suite it was both
 reliable *and* faster.
 
+That advice covers a suite starving **itself**. It does not cover
+process-global saturation, where a suite starves on the other 4000 tests — see
+"Population is the scheduler" above, where an already-`.serialized` suite still
+flaked and the remedy was population, not suite ordering.
+
 **Keep advance chains short — single digits.** If crossing a threshold would
 take many production-sized intervals, **inject the pacing values** (that is
 what the interval init parameters are for) and cross it in 2–3 advances rather
@@ -314,8 +436,12 @@ Two shapes, also not interchangeable:
 Don't roll your own test clock wrapper, advance helper, `.timeLimit` default,
 or date box. This file is the whole shared surface:
 
-- `@Suite(.clockDriven)` — a one-minute time limit (Swift Testing's floor
-  granularity). A hang-catcher, not a perf budget.
+- `@Suite(.clockDriven)` — a four-minute time limit (Swift Testing expresses
+  limits in whole minutes, so that is the dial). A hang-catcher, not a perf
+  budget; sized against the wall-clock waits a clock-driven test can sit on in
+  the **fast parallel pass** — see "Population is the scheduler" above for the
+  triple, its invariant, and the three tier-3 live suites that pin their own
+  `.timeLimit` instead because their limit is a regression detector.
 - `await clock.advanceWhenSuspended(by:)` — the one you want by default.
 - `await clock.waitForSuspension()` — the same wait without advancing.
 - `TestDateSource` — a lock-guarded box behind the `now: @Sendable () -> Date`
@@ -331,7 +457,7 @@ unblocks**, not in a setup block far away.
 
 **`.clockDriven` is not a reliable backstop on its own** — known limitation,
 measured: a desynced advance chain hung past 10 minutes with the trait applied
-and the one-minute limit never fired (the hung work most likely sits in a
+and the then one-minute limit never fired (the hung work most likely sits in a
 detached task the time limit cannot cancel). It usually works and is worth
 keeping. Do not make it your *only* hang guard: stress harnesses, corpus
 runners and fuzzers need an outer timeout of their own.
@@ -350,8 +476,9 @@ collected one event instead of two, the discarded `false` return let the test
 carry on, and the visible failure was `[42] == [42, 42]` — which reads as a
 generation-numbering bug and sends the reader to the wrong line entirely. A
 crash announces itself; this does not. **The tell was the duration**: 62 s for
-what should have been a fast assertion failure, i.e. two ~30 s bounded waits
-timing out back to back. When an assertion failure took far longer than an
+what should have been a fast assertion failure, i.e. two bounded waits timing
+out back to back against the 30 s `ciSafeDeadline` of the day (90 s now, so the
+same signature is ~180 s). When an assertion failure took far longer than an
 assertion failure should, suspect a swallowed waiter before you believe the
 message.
 

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -156,12 +156,17 @@ from).
 
 **Past that pair the margin is thin — 240 s is not roomy, and the real numbers
 are worth knowing before someone reaches for a raise.**
-`GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
-`DaywatchRunnerTests.testSubsequentTicksAtInterval` each chain **5**
-`waitForSuspension` calls, i.e. 225 s of the 240 s ceiling. And counting
-`waitFor` at 90 s plus each clock wait at 45 s, **9 of the 13**
-`PaneRepairCoordinatorTests` have a worst case above 240 s — not just the
-6-deep chain (540 s) usually cited. Every one of those is still consistent with
+**Count `advanceWhenSuspended` as a `waitForSuspension`** — it opens with one
+(`await waitForSuspension(...)`, then `advance`), so it pays the full 45 s
+guard. Grepping only for the literal `waitForSuspension(` undercounts every
+chain below, which is exactly the miscount a PR #547 reviewer made.
+
+On that basis: `GatedIntervalSleepTests.returnsAfterExpectedPollCount`
+(3 `advanceWhenSuspended` + 2 `waitForSuspension`) and
+`DaywatchRunnerTests.testSubsequentTicksAtInterval` (2 + 3) each pay **5**
+guards, i.e. 225 s of the 240 s ceiling. And counting `waitFor` at 90 s plus
+each clock wait at 45 s, **9 of the 13** `PaneRepairCoordinatorTests` have a
+worst case above 240 s — not just the 6-deep chain (540 s) usually cited. Every one of those is still consistent with
 the invariant, because only an already-failing test walks a full chain of
 timeouts and the first diagnostic is already recorded by then.
 

--- a/Tests/TBDAppTests/FileWatcherTests.swift
+++ b/Tests/TBDAppTests/FileWatcherTests.swift
@@ -44,39 +44,43 @@ import TestSupport
 /// | `poll` / `writeUntilArmed` default | 8 s | task scheduling, `AsyncStream` delivery, `clock.sleep` entry |
 /// | `fdCloseTimeout` | 25 s | `close(fd)` in a GCD **cancel handler on a utility-QoS global queue** |
 /// | `withWatchedFile` FD quiescence | 12 s | same cancel handler, but not an assertion |
-/// | `advanceWhenSuspended` | 15 s | fixed by `ClockTestSupport`, not ours to set |
+/// | `advanceWhenSuspended` | 45 s | fixed by `ClockTestSupport`, not ours to set |
 ///
 /// **The criterion these are sized against** is: the FIRST guard to fire must
-/// get its named diagnostic out inside `.clockDriven`'s 60 s per-test limit,
+/// get its named diagnostic out inside `.clockDriven`'s 240 s per-test limit,
 /// otherwise the limit kills the test and reports an unnamed "wedged" instead
 /// of observed state (rule 4). Healthy prefix ~0.6 s + the largest single
-/// deadline (25 s) = well under half the limit, for every test here.
+/// deadline (45 s, the fixed handshake guard) = well under a quarter of the
+/// limit, for every test here.
 ///
 /// It is deliberately *not* "the sum of every deadline in a test stays under
-/// 60 s", because for three tests that is unachievable at any non-thin value —
-/// `ClockTestSupport`'s fixed 15 s handshake guard is used 2–3× per test, and
-/// its own docstring only budgets for a test that waits **twice**:
+/// the limit". That framing was unachievable when the limit was 60 s and
+/// `ClockTestSupport`'s handshake guard was 15 s used 2–3× per test; it is a
+/// weak criterion rather than a wrong one, and it is not what these values are
+/// sized against. Worst-case cascades, at the current 45 s handshake guard:
 ///
 /// | Test | Worst-case cascade (all guards fire) |
 /// |---|---|
 /// | `liveStreamCountReturnsToBaselineAfterIteratorDrops` | 8 + 25 = 33 s |
 /// | `cancellingConsumingTaskTerminatesStream` | 2×8 + 25 = 41 s |
 /// | `nonExistentPathFinishesStreamImmediately` | 8 s |
-/// | `writesWithinOneWindowCollapseToOneNotification` | 3×8 + 15 + 8 + 12 = 59 s |
-/// | `nothingFiresUntilTheFullIntervalElapsed` | 8 + 15 + 8 + 12 = 43 s |
-/// | `lateWriteRestartsTheWindow` | 2×8 + **2×15** + 8 + 12 = 66 s |
-/// | `separatedWritesNotifyTwice` | 2×8 + **2×15** + 2×8 + 12 = 74 s |
-/// | `atomicSaveReopensAndKeepsStreamLive` | 2×8 + **3×15** + 3×8 + 25 + 12 = 122 s |
+/// | `writesWithinOneWindowCollapseToOneNotification` | 3×8 + 45 + 8 + 12 = 89 s |
+/// | `nothingFiresUntilTheFullIntervalElapsed` | 8 + 45 + 8 + 12 = 73 s |
+/// | `lateWriteRestartsTheWindow` | 2×8 + **2×45** + 8 + 12 = 126 s |
+/// | `separatedWritesNotifyTwice` | 2×8 + **2×45** + 2×8 + 12 = 134 s |
+/// | `atomicSaveReopensAndKeepsStreamLive` | 2×8 + **3×45** + 3×8 + 25 + 12 = 212 s |
 /// | `terminationWithAPendingDebounceStillClosesTheFD` | 8 + 8 + 25 + 12 = 53 s |
 /// | `defaultClockDeliversOneRealDebouncedNotification` | ~1.8 + 8 = 10 s |
 ///
-/// The three over-limit rows are dominated by the bolded fixed term (30 s,
-/// 30 s, 45 s) — `atomicSaveReopensAndKeepsStreamLive` cleared 60 s even at the
-/// thin 4 s deadlines this budget replaced (73 s then). Cutting the guards is
-/// therefore not what buys the property; only the first-diagnostic criterion
-/// above is actually satisfiable, and it is satisfied with room to spare. The
-/// remaining lever, if a full cascade ever needs to fit, is the suite's time
-/// limit, not the guards.
+/// Both inputs moved together (handshake guard 15 s → 45 s, suite limit 60 s →
+/// 240 s; see `ClockTestSupport`), and the limit outgrew the cascades: every
+/// row now fits, where three used to blow it. The docstring's own prediction —
+/// "the remaining lever, if a full cascade ever needs to fit, is the suite's
+/// time limit, not the guards" — is what happened, incidentally rather than by
+/// design. Do not start relying on it: the worst row (212 s) clears 240 s by
+/// only 28 s, so it would go back over on any further handshake-guard raise,
+/// and the first-diagnostic criterion above remains the property these values
+/// are actually sized against.
 @MainActor
 @Suite("FileWatcher", .clockDriven, .serialized)
 struct FileWatcherTests {

--- a/Tests/TBDDaemonLiveTests/GitManagerTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/GitManagerTimeoutTests.swift
@@ -24,10 +24,37 @@ import TestSupport
 /// - Timeout-path tests advance virtual time at the assertion that needs it.
 ///
 /// The production `SubprocessWatchdog` thread still arms the same deadline in
-/// parallel; a 600 s timeout is simply unreachable inside `.clockDriven`'s
+/// parallel; a 600 s timeout is simply unreachable inside the suite's
 /// one-minute limit, so the injected clock is the only armer that can fire here.
 /// `SubprocessTimeoutStarvationTests` covers the watchdog on a real clock.
-@Suite(.clockDriven)
+///
+/// WHY AN EXPLICIT `.timeLimit(.minutes(1))` AND NOT `.clockDriven`. Do not
+/// "tidy" this back to the shared trait — the two halves below are why.
+///
+/// 1. **60 s is this suite's detector, not a hang guard.**
+///    `timeoutThrowsPromptlyWhenGrandchildHoldsPipeOpen` and
+///    `returnsOutputWithoutWaitingForGrandchildEOF` prove promptness
+///    *structurally*: their grandchildren hold the pipe write ends open for 120 s
+///    and 30 s of REAL time, and the only thing that distinguishes "returned
+///    without waiting for EOF" from "regressed into an EOF-waiting drain" is that
+///    the latter blocks past the limit. At 240 s a regressed 120 s drain finishes
+///    inside the budget and the test goes green — mutation-verified proof,
+///    silently disarmed, with nothing going red to tell you.
+/// 2. **It does not need the raised budget.** `.clockDriven` was raised to
+///    4 minutes to absorb the arming latency of the fast parallel pass, whose
+///    ~4536-test population is what makes a `TestClock` handshake take tens of
+///    seconds. This is tier 3: CI runs `Tests/TBDDaemonLiveTests` as
+///    `--filter '^TBDDaemonLiveTests\.' --no-parallel` on an otherwise-idle
+///    machine, so real arming latency here is milliseconds.
+///
+/// One residual, stated rather than glossed: `waitForSuspension`'s default is
+/// now 45 s, so a test that waited **twice** would need 90 s and would trip this
+/// 60 s limit, where at the old 15 s default two waits cost only 30 s. No test
+/// here chains two — the suite's two `advanceWhenSuspended` sites are in
+/// different `@Test`s, one each — and in the quiet pass a healthy handshake
+/// returns in milliseconds, so only a genuine hang ever pays the timeout, which
+/// is exactly what this limit is here to catch.
+@Suite(.timeLimit(.minutes(1)))
 struct GitManagerTimeoutTests {
 
     /// Far enough out that the real watchdog cannot reach it inside the suite's
@@ -71,8 +98,8 @@ struct GitManagerTimeoutTests {
         // surface as a spurious GitTimeoutError. `GitManager.run` drains
         // incrementally via readabilityHandler + PipeDataAccumulator; lock down
         // that a 100KB emitter completes and returns its FULL output (no dropped
-        // trailing chunk). A deadlocked drain now hangs into `.clockDriven`
-        // rather than being masked as a timeout.
+        // trailing chunk). A deadlocked drain now hangs into the suite's time
+        // limit rather than being masked as a timeout.
         let bytes = 102_400
         let git = GitManager(subprocessTimeout: Self.unreachableTimeout, clock: TestClock())
         let out = try await git.runForTimeoutTesting(
@@ -114,7 +141,7 @@ struct GitManagerTimeoutTests {
         // call resolves after 600 VIRTUAL seconds while the grandchild holds the
         // pipe for 120 REAL ones, so returning at all proves nothing waited for
         // EOF. A regressed EOF-waiting drain would block ~120 real seconds and
-        // trip `.clockDriven`'s 60 s limit. This replaces a wall-clock upper
+        // trip the suite's 60 s limit. This replaces a wall-clock upper
         // bound that had been RAISED TWICE after measured breaches
         // (4s → 15s → 60s, the last at 19.4s on a 2-core runner) — tolerance
         // widening is the flake shape hygiene rule 2 exists to forbid.
@@ -142,7 +169,7 @@ struct GitManagerTimeoutTests {
         // drain that waits for pipe EOF stalls until the grandchild exits.
         // Previously that surfaced as a spurious GitTimeoutError (timeout 3s <<
         // grandchild 30s); with the deadline virtual and never advanced, a
-        // regression can only present as a hang caught by `.clockDriven`, and
+        // regression can only present as a hang caught by the suite's limit, and
         // the 3 s margin that a loaded runner could blow is gone. The
         // `sleep 30 &` grandchild may linger up to 30s — tolerable orphanage.
         let git = GitManager(subprocessTimeout: Self.unreachableTimeout, clock: TestClock())

--- a/Tests/TBDDaemonLiveTests/SubprocessTimeoutStarvationTests.swift
+++ b/Tests/TBDDaemonLiveTests/SubprocessTimeoutStarvationTests.swift
@@ -1,7 +1,6 @@
 import Clocks
 import Foundation
 import Testing
-import TestSupport
 @testable import TBDDaemonLib
 
 /// Regression coverage for the dispatch-pool-starvation flake behind three CI
@@ -39,8 +38,8 @@ import TestSupport
 /// A never-advanced `TestClock` disables that armer, leaving the deadline REAL
 /// and the satisfier set exactly as it was before the clock seam existed.
 ///
-/// HOW THIS SUITE DISCRIMINATES THE WATCHDOG — `sleep 90` + `.clockDriven`, and
-/// both halves are load-bearing. A THIRD mechanism can also report `.timedOut`:
+/// HOW THIS SUITE DISCRIMINATES THE WATCHDOG — `sleep 90` + a 60 s time limit,
+/// and both halves are load-bearing. A THIRD mechanism can also report `.timedOut`:
 /// the completion path's AUTHORITY check
 /// (`ContinuousClock.now - start >= timeout`). With the watchdog deleted, the
 /// child runs to natural completion and the authority check then reports
@@ -55,7 +54,7 @@ import TestSupport
 /// had neither.
 ///
 /// The fix is to make the authority path TOO SLOW to satisfy the test: a 90s
-/// child outlives `.clockDriven`'s 60s limit, so a broken watchdog surfaces as a
+/// child outlives the suite's 60s limit, so a broken watchdog surfaces as a
 /// time-limit failure, while a working one still SIGKILLs at ~100ms and the
 /// suite costs exactly what it did before. A hang-catcher, not a wall-clock
 /// tolerance — the distinction that keeps this out of hygiene rule 2.
@@ -64,7 +63,26 @@ import TestSupport
 /// time limit (the authority path would simply take 90s and pass), and the time
 /// limit alone changes nothing with a 3s child. Verified by mutation: deleting
 /// the watchdog armer turns both tests RED.
-@Suite("Subprocess timeout under dispatch-pool starvation", .serialized, .clockDriven)
+///
+/// WHY AN EXPLICIT `.timeLimit(.minutes(1))` AND NOT `.clockDriven`. Do not
+/// "tidy" this back to the shared trait — the two halves below are why.
+///
+/// 1. **60 s is this suite's detector, not a hang guard.** The mutation proof
+///    above works only because 60 s sits between the working watchdog's ~100 ms
+///    SIGKILL and the 90 s child that a broken watchdog leaves running. Inherit
+///    `.clockDriven`'s 240 s and the `sleep 90` child finishes comfortably
+///    inside the limit, the authority check reports `.timedOut` on its own, and
+///    both tests go green with the watchdog armer deleted. The proof silently
+///    disarms; nothing goes red to tell you.
+/// 2. **It does not need the raised budget.** `.clockDriven` was raised to
+///    4 minutes to absorb the arming latency of the fast parallel pass, whose
+///    ~4536-test population is what makes a `TestClock` handshake take tens of
+///    seconds. This is tier 3: CI runs `Tests/TBDDaemonLiveTests` as
+///    `--filter '^TBDDaemonLiveTests\.' --no-parallel` on an otherwise-idle
+///    machine, so real arming latency here is milliseconds and the saturation
+///    that motivated the raise never occurs. This suite never advances its
+///    `TestClock` at all, so it does not even pay the handshake.
+@Suite("Subprocess timeout under dispatch-pool starvation", .serialized, .timeLimit(.minutes(1)))
 struct SubprocessTimeoutStarvationTests {
 
     /// Number of blocking work items to flood the default-QoS pool with. The

--- a/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
+++ b/Tests/TBDDaemonLiveTests/SubprocessTimeoutTests.swift
@@ -15,7 +15,34 @@ import TestSupport
 /// both suites map the same `runBoundedProcess` machinery to different error
 /// types, and `SubprocessTimeoutStarvationTests` covers the production
 /// `SubprocessWatchdog` on a real clock.
-@Suite("Subprocess timeout / kill path", .clockDriven)
+///
+/// WHY AN EXPLICIT `.timeLimit(.minutes(1))` AND NOT `.clockDriven`. Do not
+/// "tidy" this back to the shared trait — the two halves below are why.
+///
+/// 1. **60 s is this suite's detector, not a hang guard.**
+///    `runExternalCommandTimesOutPromptlyWhenGrandchildHoldsPipeOpen` and
+///    `runExternalCommandReturnsWithoutWaitingForGrandchildEOF` prove promptness
+///    *structurally*: their grandchildren hold the pipe write ends open for 120 s
+///    and 30 s of REAL time, and the only thing that distinguishes "returned
+///    without waiting for EOF" from "regressed into an EOF-waiting drain" is that
+///    the latter blocks past the limit. At 240 s a regressed 120 s drain finishes
+///    inside the budget and the test goes green — mutation-verified proof,
+///    silently disarmed, with nothing going red to tell you.
+/// 2. **It does not need the raised budget.** `.clockDriven` was raised to
+///    4 minutes to absorb the arming latency of the fast parallel pass, whose
+///    ~4536-test population is what makes a `TestClock` handshake take tens of
+///    seconds. This is tier 3: CI runs `Tests/TBDDaemonLiveTests` as
+///    `--filter '^TBDDaemonLiveTests\.' --no-parallel` on an otherwise-idle
+///    machine, so real arming latency here is milliseconds.
+///
+/// One residual, stated rather than glossed: `waitForSuspension`'s default is
+/// now 45 s, so a test that waited **twice** would need 90 s and would trip this
+/// 60 s limit, where at the old 15 s default two waits cost only 30 s. No test
+/// here chains two — the suite's two `advanceWhenSuspended` sites are in
+/// different `@Test`s, one each — and in the quiet pass a healthy handshake
+/// returns in milliseconds, so only a genuine hang ever pays the timeout, which
+/// is exactly what this limit is here to catch.
+@Suite("Subprocess timeout / kill path", .timeLimit(.minutes(1)))
 struct SubprocessTimeoutTests {
 
     /// Far enough out that the real watchdog cannot reach it inside the suite's
@@ -60,7 +87,7 @@ struct SubprocessTimeoutTests {
         // original detectOrphanedClaudeProcesses call site, never). Lock down
         // that a 100KB emitter completes and returns its FULL output. With the
         // deadline virtual and never advanced, a regression presents as a hang
-        // caught by `.clockDriven` instead of being masked as a timeout.
+        // caught by the suite's limit instead of being masked as a timeout.
         let bytes = 102_400
         let out = try await TmuxManager.runExternalCommand(
             executable: "/bin/sh",
@@ -84,7 +111,7 @@ struct SubprocessTimeoutTests {
         // resolves after 600 VIRTUAL seconds while the grandchild holds the pipe
         // for 120 REAL ones, so returning at all proves nothing waited for EOF.
         // A regressed EOF-waiting drain would block ~120 real seconds and trip
-        // `.clockDriven`'s 60 s limit. This replaces a wall-clock upper bound
+        // the suite's 60 s limit. This replaces a wall-clock upper bound
         // RAISED TWICE after measured breaches (4s → 15s → 60s, the last at
         // 19.2s on a 2-core runner) — the tolerance-widening shape hygiene rule
         // 2 forbids.

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -14,7 +14,97 @@ import Testing
 /// for loaded parallel CI (PR #379: cooperative-pool starvation stretched
 /// sub-second async-drain deliveries past a 5 s poll). Passing runs still
 /// complete in milliseconds.
-let ciSafeDeadline: Duration = .seconds(30)
+///
+/// ## This is a hang-catcher, not a timing budget
+///
+/// "Raise a timeout" reads as a cover-up, so state the case plainly. No test
+/// that consumes this value asserts a timing property. They assert that a
+/// fake-tmux reply block eventually reaches the stream — the deadline exists
+/// only so a reply that never arrives fails with a named diagnostic instead of
+/// hanging the run. On success it costs nothing: the poll returns as soon as
+/// the condition holds.
+///
+/// The repo already has the precedent. PR #415 raised `bridge`'s `readyTimeout`
+/// from 5 s to an effectively-infinite 600 s for exactly this reason — "the
+/// ready-timeout is incidental machinery in every orchestration test here" —
+/// and the one test that genuinely exercises the timeout passes its own short
+/// value explicitly. That default is still live at
+/// `Tests/TBDDaemonTests/AttachRPCTests.swift:137`.
+///
+/// ## Sizing (30 s -> 90 s)
+///
+/// 30 s was sized against a ~3000-test population. The population is now 4536
+/// and Swift Testing runs all of it in one process with no concurrency cap, so
+/// per-test scheduling latency scales with the total, not with this suite. In
+/// CI the whole `ControlModeInputHealth` suite has been observed finishing
+/// green at 45.8 s / 47.4 s and red at 47.9 s — a ~2 s band on either side of
+/// a fixed 30 s wall-clock deadline, which is a coin flip, not a signal. The
+/// observed failures burned the *full* 30 s deadline, so the old value was the
+/// binding constraint rather than an incidental one.
+///
+/// 90 s is 3x that deadline, and it is spent against a tail that sharding the
+/// fast pass independently roughly halves (p90 26.4 s -> 14.6 s, means over 5
+/// iterations, measured interleaved under induced load with population held
+/// constant). Two compounding
+/// changes, so the effective headroom is well past 3x — and the deadline still
+/// elapses only on a genuine hang.
+///
+/// ## The interaction with `.clockDriven` — read before changing either value
+///
+/// Two suites that consume this value ARE `.clockDriven`, so its time limit and
+/// this deadline race each other: `AttachRPCOrchestrationTests`
+/// (`Tests/TBDDaemonTests/AttachRPCTests.swift`, 13 `waitFor` call sites) and
+/// `PaneRepairCoordinatorTests` (35 call sites).
+///
+/// All 48 of those call sites are **unguarded**. They read
+/// `try await waitFor(…)`, but `waitFor` is `@discardableResult` and does not
+/// throw on timeout — it records an `Issue` and returns `false`, and the `try`
+/// covers only the inner `Task.sleep`. Execution therefore continues past a
+/// timeout and chained waits are real. (Contrast `ControlModeInputHealthTests`,
+/// whose sites are `try #require(await waitFor…)` and so abort at the first
+/// timeout.)
+///
+/// The invariant is **not** "all N chained waits must fit inside the suite
+/// limit". That was never satisfiable and is not a property this change gives
+/// up: the deepest chain is 6 waits in one `PaneRepairCoordinator` test (the
+/// one whose name begins "swallowed successor overflow: gen-2's signal
+/// dedup…"), and 6 x 30 s = 180 s already blew the old `.minutes(1)` limit.
+///
+/// The operative invariant is: **the suite limit must afford the first full
+/// deadline plus the rest of an ordinary test.** The first timeout's
+/// `Issue.record` fires immediately and carries the named diagnostic, so it
+/// always survives even if the limit later truncates the test. Chains beyond
+/// the first belong to a test that is already failing; truncating those is
+/// acceptable and deliberate.
+///
+/// Checked against `.clockDriven`'s 4-minute (240 s) limit:
+/// - one `waitFor` (90 s) + one `waitForSuspension` (45 s) = 135 s ✓
+/// - two `waitFor` = 180 s ✓
+/// - two `waitForSuspension` = 90 s ✓ (preserves the "a test that waits twice
+///   must afford both waits" property the old pairing reasoned about)
+///
+/// The margin past that is thin, and the 6-deep chain is not the only case that
+/// overruns: counting `waitFor` at 90 s and each clock wait at 45 s, **9 of the
+/// 13** `PaneRepairCoordinatorTests` have a worst case above 240 s (the 6-deep
+/// one needs 540 s). All of them are consistent with the invariant above — only
+/// an already-failing test walks a full chain of timeouts, and the first
+/// timeout's diagnostic has already been recorded by then — but none of them
+/// has spare room. **If they start tripping, shorten the chains; do not raise
+/// 240 s again.** A longer limit only buys time for tests that are already
+/// failing, while making every genuine wedge that much slower to attribute.
+///
+/// ## Why not `@Suite(.serialized)`
+///
+/// It was considered and it is not the remedy here. `ArchivedWorktreeSearchTests`
+/// "Archived search debounce" is *already* `.clockDriven, .serialized` and
+/// still failed twice in CI, because the contention is process-global: every
+/// target compiles into one process and Swift Testing parallelizes across all
+/// of them, so serializing one suite does not reduce the number of runnable
+/// tasks its waiter is queued behind. `Tests/CLAUDE.md` advises reaching for
+/// `.serialized` before a longer timeout; that advice is about a suite starving
+/// *itself* (its own tests megaYielding against each other) and does not cover
+/// this case.
+let ciSafeDeadline: Duration = .seconds(90)
 
 /// Thread-safe, synchronous recorder of fake-client stream writes in call
 /// order.

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -20,7 +20,7 @@ private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
 }
 
 /// `.clockDriven` is applied at SUITE level even though only the three
-/// park-poll tests below drive a `TestClock`. The trait is a one-minute time
+/// park-poll tests below drive a `TestClock`. The trait is a four-minute time
 /// limit — a hang-catcher, not a perf budget — so it costs the other tests
 /// nothing and it catches the one failure mode virtual time introduces here (a
 /// `TestClock` sleep nobody advances hangs forever instead of going red).

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -25,12 +25,79 @@ public extension Trait where Self == TimeLimitTrait {
     /// test` run just stops. That is far worse than a red test, because CI
     /// burns its job timeout and the failure names no suite.
     ///
-    /// This bounds it. `.minutes(1)` is not a performance budget — it is
-    /// Swift Testing's floor granularity (time limits are expressed in whole
-    /// minutes), and it is a hang-catcher. A clock-driven tier-1 test should
-    /// finish in milliseconds; if it takes a minute, it is wedged, and you
-    /// want the failure attributed to the test rather than to the runner.
-    static var clockDriven: Self { .timeLimit(.minutes(1)) }
+    /// This bounds it. The value is not a performance budget — it is a
+    /// hang-catcher, and Swift Testing expresses time limits in whole minutes,
+    /// so the only dial available is an integer count of them. A clock-driven
+    /// tier-1 test should still finish in milliseconds; if it takes minutes, it
+    /// is wedged, and you want the failure attributed to the test rather than
+    /// to the runner.
+    ///
+    /// **Why 4 and no longer 1.** The floor argument (whole minutes) says the
+    /// limit cannot be *smaller* than a minute; it never argued that one minute
+    /// was right. What pins the value from below are the two wall-clock waits a
+    /// clock-driven test can sit on: this file's `waitForSuspension` (45 s,
+    /// re-derived below) and `ciSafeDeadline` (90 s,
+    /// `Tests/TBDDaemonTests/ControlModeTestSupport.swift`). Clock-driven
+    /// suites really do consume the latter — `AttachRPCOrchestrationTests` and
+    /// `PaneRepairCoordinatorTests` are both `.clockDriven, .serialized` and
+    /// between them hold 48 `waitFor` call sites — so the two values race and
+    /// must be derived together.
+    ///
+    /// The invariant is **not** "every chained wait in a test fits inside this
+    /// limit". `waitFor` is non-throwing on timeout, so chains are real, and the
+    /// deepest is 6 waits in one `PaneRepairCoordinator` test — unsatisfiable
+    /// then (6 x 30 s vs `.minutes(1)`) and unsatisfiable now. The invariant is:
+    /// **this limit must afford the first full deadline plus the rest of an
+    /// ordinary test.** The first timeout's `Issue.record` fires immediately
+    /// with its named diagnostic, so it survives even if this limit later
+    /// truncates the test; chains beyond the first belong to a test that is
+    /// already failing, and truncating those is deliberate.
+    ///
+    /// 4 minutes = 240 s satisfies that:
+    /// - one `waitFor` (90 s) + one `waitForSuspension` (45 s) = 135 s ✓
+    /// - two `waitFor` = 180 s ✓
+    /// - two `waitForSuspension` = 90 s ✓ — this keeps the original "a test that
+    ///   waits twice must afford both waits" property the one-minute pairing
+    ///   was reasoned from
+    ///
+    /// 240 s stays far above any legitimate clock-driven run, which finishes in
+    /// milliseconds.
+    ///
+    /// **The margin is thin, and it is worth naming how thin.** Do not read
+    /// "240 s" as comfortable headroom — several existing chains sit near or
+    /// past it, all consistent with the invariant (only an already-failing test
+    /// ever pays a full chain of timeouts), but with nothing to spare:
+    /// - `GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
+    ///   `DaywatchRunnerTests.testSubsequentTicksAtInterval` each chain **5**
+    ///   `waitForSuspension` calls: 225 s against a 240 s ceiling.
+    /// - In `PaneRepairCoordinatorTests`, **9 of 13** tests have a worst case
+    ///   above 240 s (counting `waitFor` at 90 s and each clock wait at 45 s),
+    ///   not just the one 6-deep chain (540 s) usually cited.
+    ///
+    /// **If these start tripping, shorten the chain — do not raise this limit
+    /// again.** `Tests/CLAUDE.md` already requires advance chains to stay in
+    /// single digits, and a 5-deep chain is at the edge of that rule; injecting
+    /// pacing values to cross a threshold in 2–3 advances is the remedy. Raising
+    /// 240 s buys room for chains that only an already-failing test walks, and
+    /// costs every genuinely wedged test that much longer to be attributed.
+    ///
+    /// **Scope: this is sized for the fast parallel pass.** Every input above —
+    /// the ~4536-test population, the arming latency it inflates, the two
+    /// wall-clock waits it makes expensive — is a property of the in-process
+    /// parallel run. Tier-3 suites in `Tests/TBDDaemonLiveTests` execute in the
+    /// quiet pass (`--filter '^TBDDaemonLiveTests\.' --no-parallel`, idle
+    /// machine), where arming latency is milliseconds and none of that applies.
+    ///
+    /// So a tier-3 suite whose time limit is its **regression detector** rather
+    /// than a hang guard must pin its own `.timeLimit` instead of inheriting
+    /// this one — a raise here would silently disarm the proof, with nothing
+    /// going red to say so. Precedent, all pinned to `.timeLimit(.minutes(1))`
+    /// with the reasoning in their suite docs:
+    /// `SubprocessTimeoutStarvationTests` (a `sleep 90` child must outlive the
+    /// limit), `GitManagerTimeoutTests` and `SubprocessTimeoutTests` (a
+    /// regressed EOF-waiting drain must outlive it). Don't widen those to
+    /// `.clockDriven` for consistency's sake.
+    static var clockDriven: Self { .timeLimit(.minutes(4)) }
 }
 
 // MARK: - TestClock
@@ -114,24 +181,58 @@ public extension TestClock {
     /// means a megaYield-free virtual clock replacing `TestClock`, which is a
     /// shared-contract change and deliberately not bundled here.
     ///
+    /// Lowering the megaYield count is **refuted** as a remedy at CI's regime,
+    /// and this closes the open question in issue #496. `TASK_MEGA_YIELD_COUNT=1`
+    /// was measured against an unset baseline across interleaved runs under
+    /// induced load, population held constant: p90 26.5 s / 31.2 s -> 26.0 s /
+    /// 29.4 s, p99 26.6 s -> 27.0 s. That is noise. The megaYield is a real but
+    /// **secondary** contributor; the dominant term is the number of runnable
+    /// tasks in the process (see the population note on `timeout` below), which
+    /// is why CI shards the fast pass in two rather than tuning this knob.
+    ///
     /// - Parameters:
     ///   - timeout: hang guard, and the value is a two-sided constraint. It must
-    ///     stay well under `.clockDriven`'s one-minute limit (Swift Testing's
-    ///     floor granularity) — a test that waits twice has to afford both waits
-    ///     and still get this helper's diagnostic, rather than tripping the
-    ///     suite limit first and reporting an uninformative "wedged". But it
-    ///     must also clear the worst-case real arming latency: at 5 s, the
-    ///     appearance suite failed 4 of 6 full-target runs on this handshake.
-    ///     15 s is ~10x the observed healthy-path arming cost inside a
-    ///     1332-test target while still leaving half the per-test budget for a
-    ///     twice-waiting test. Only a genuinely un-armed timer ever pays it.
+    ///     stay well under `.clockDriven`'s limit — a test that waits twice has
+    ///     to afford both waits and still get this helper's diagnostic, rather
+    ///     than tripping the suite limit first and reporting an uninformative
+    ///     "wedged". But it must also clear the worst-case real arming latency:
+    ///     at 5 s, the appearance suite failed 4 of 6 full-target runs on this
+    ///     handshake.
+    ///
+    ///     The pair is therefore derived together, and 15 s / `.minutes(1)` was
+    ///     derived against a 1332-test target inside a ~3000-test process. What
+    ///     invalidated it is population growth: 3013 -> 4536 tests in three
+    ///     weeks. Swift Testing runs every non-serialized test in one process
+    ///     with no concurrency cap, so real arming latency scales with the
+    ///     process-wide runnable-task count, not with the suite under test —
+    ///     mined CI runs show p50 per-test reported duration at ~1/3 of total
+    ///     wall time even on green runs, i.e. tests spend most of their
+    ///     "duration" suspended waiting for a turn.
+    ///
+    ///     Re-derived for the current population: 45 s here, so a twice-waiting
+    ///     test needs 90 s, inside `.clockDriven`'s 4-minute (240 s) limit with
+    ///     room for the rest of the test — and 45 s plus one 90 s
+    ///     `ciSafeDeadline` wait is 135 s, also inside it. See `.clockDriven`
+    ///     above for the full triple and the invariant that licenses it. Only a
+    ///     genuinely un-armed timer ever pays this timeout — a healthy handshake
+    ///     returns in milliseconds, so the raise costs passing runs nothing.
+    ///
+    ///     What 45 s does **not** buy is a deep chain: at five of these waits
+    ///     the test is at 225 s of a 240 s limit, and two live tests are exactly
+    ///     there (`GatedIntervalSleepTests.returnsAfterExpectedPollCount`,
+    ///     `DaywatchRunnerTests.testSubsequentTicksAtInterval`). That is
+    ///     consistent with the invariant — only a failing test walks the whole
+    ///     chain — but it is not headroom. The remedy if it bites is to shorten
+    ///     the chain (`Tests/CLAUDE.md`: keep advances in single digits; inject
+    ///     pacing), not to raise 240 s. Re-derive all three numbers again if the
+    ///     population moves materially.
     ///   - pollInterval: how long to step aside between probes. Each probe costs
     ///     a megaYield, so probing tightly floods the pool with background tasks
     ///     and starves the very task being waited for — lazier is better.
     /// Note both are `Swift.Duration`, not this clock's generic `Duration`: they
     /// are real wall-clock quantities for the scheduling handshake, deliberately
     /// unrelated to the virtual time the clock hands out.
-    func waitForSuspension(timeout: Swift.Duration = .seconds(15),
+    func waitForSuspension(timeout: Swift.Duration = .seconds(45),
                            pollInterval: Swift.Duration = .milliseconds(25),
                            sourceLocation: SourceLocation = #_sourceLocation) async {
         let deadline = ContinuousClock.now.advanced(by: timeout)

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -67,9 +67,15 @@ public extension Trait where Self == TimeLimitTrait {
     /// "240 s" as comfortable headroom — several existing chains sit near or
     /// past it, all consistent with the invariant (only an already-failing test
     /// ever pays a full chain of timeouts), but with nothing to spare:
-    /// - `GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
-    ///   `DaywatchRunnerTests.testSubsequentTicksAtInterval` each chain **5**
-    ///   `waitForSuspension` calls: 225 s against a 240 s ceiling.
+    /// Count `advanceWhenSuspended` as a `waitForSuspension` when you tally a
+    /// chain — it *calls* one before advancing, so it pays the full guard.
+    /// Grepping only for the literal `waitForSuspension(` undercounts every
+    /// figure below (a PR #547 reviewer did exactly that and read these as
+    /// 2 and 3 rather than 5).
+    /// - `GatedIntervalSleepTests.returnsAfterExpectedPollCount`
+    ///   (3 `advanceWhenSuspended` + 2 `waitForSuspension`) and
+    ///   `DaywatchRunnerTests.testSubsequentTicksAtInterval` (2 + 3) each pay
+    ///   **5** guards: 225 s against a 240 s ceiling.
     /// - In `PaneRepairCoordinatorTests`, **9 of 13** tests have a worst case
     ///   above 240 s (counting `waitFor` at 90 s and each clock wait at 45 s),
     ///   not just the one 6-deep chain (540 s) usually cited.
@@ -218,9 +224,12 @@ public extension TestClock {
     ///     returns in milliseconds, so the raise costs passing runs nothing.
     ///
     ///     What 45 s does **not** buy is a deep chain: at five of these waits
-    ///     the test is at 225 s of a 240 s limit, and two live tests are exactly
-    ///     there (`GatedIntervalSleepTests.returnsAfterExpectedPollCount`,
-    ///     `DaywatchRunnerTests.testSubsequentTicksAtInterval`). That is
+    ///     the test is at 225 s of a 240 s limit, and two tests in the fast
+    ///     pass are exactly there — `GatedIntervalSleepTests.returnsAfterExpectedPollCount`
+    ///     and `DaywatchRunnerTests.testSubsequentTicksAtInterval` (both count
+    ///     `advanceWhenSuspended` toward the five; see `.clockDriven` above).
+    ///     ("Fast pass", not "live": tier-3 `TBDDaemonLiveTests` pins its own
+    ///     limit and is unaffected.) That is
     ///     consistent with the invariant — only a failing test walks the whole
     ///     chain — but it is not headroom. The remedy if it bites is to shorten
     ///     the chain (`Tests/CLAUDE.md`: keep advances in single digits; inject

--- a/docs/specs/2026-07-24-test-hardening-design.md
+++ b/docs/specs/2026-07-24-test-hardening-design.md
@@ -42,19 +42,24 @@ Three tiers, defined by what a test may touch:
 
 This deviates from the original roadmap sketch ("tier 2 gets one retry") deliberately: blanket retry hides regressions, quarantine names them.
 
-**Enforcement mechanism = target boundary.** Tier 3 physically moves to a new `TBDDaemonLiveTests` test target (all current live suites are daemon-side; other modules can grow sibling `*LiveTests` targets if ever needed). Tiers 1 and 2 stay co-resident in the existing targets — their distinction is behavioral and enforced by convention + review, since they schedule fine together. The target boundary is the load-bearing one: compiler-enforced, cannot silently zero-match like a `--filter` regex, and gives CI an unambiguous handle.
+**Enforcement mechanism = target boundary.** Tier 3 physically moves to a new `TBDDaemonLiveTests` test target (all current live suites are daemon-side; other modules can grow sibling `*LiveTests` targets if ever needed). Tiers 1 and 2 stay co-resident in the existing targets — their distinction is behavioral and enforced by convention + review, since they schedule fine together. The target boundary is the load-bearing one: compiler-enforced, cannot silently zero-match like a `--filter` regex, and gives CI an unambiguous handle. CI does now select targets with `--filter`/`--skip` regexes (§4), so the zero-match hazard is live in the *invocation* even though the boundary itself is sound — which is why the fast pass's second step is expressed as a complement (`--skip`) rather than an enumeration: a target nobody listed still runs.
 
 ## 4. CI topology
 
-The existing `test` job keeps one build (no extra runner drawn from the 5-job macOS pool) and splits the test run into two sequential steps:
+The existing `test` job keeps one build (no extra runner drawn from the 5-job macOS pool) and splits the test run into three sequential steps:
 
-1. **Fast parallel pass:** `swift test --parallel -j 2 --skip TBDDaemonLiveTests`
-2. **Quiet pass:** the `TBDDaemonLiveTests` target run serially (no `--parallel`), with the machine otherwise idle.
+1. **Fast parallel pass 1/2:** `swift test --parallel -j 2 --filter '^TBDDaemonTests\.'`
+2. **Fast parallel pass 2/2:** `swift test --parallel -j 2 --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.'`
+3. **Quiet pass:** the `TBDDaemonLiveTests` target run serially (`--no-parallel`), with the machine otherwise idle.
+
+The fast pass was a single step originally; it was split in two to halve the in-flight test population, because Swift Testing runs every non-serialized test in one process with no concurrency cap and per-test scheduling latency scales with that total. Measured interleaved under induced load with population held constant: p90 26.4 s → 14.6 s, at a cost of +26 s of wall time (the second invocation re-pays SPM's no-op build check and process startup). This is not the cross-runner sharding §1 rejected — one job, one build, two sequential invocations.
+
+Step 2 is expressed as a **complement** (`--skip`) rather than an enumeration of the remaining targets, specifically to preserve §3's fail-safe property: `swift test --filter` exits green on zero matches, so a new test target listed in neither filter would run in no pass at all, and the count floors below cannot catch that (adding a target reduces no existing step's count). As a complement, the three steps partition the package exhaustively by construction and a new target lands in step 2 automatically.
 
 Guard rails:
 
-- The quiet pass parses the executed-test count from output and **fails if zero tests ran** (`swift test --filter` exits green on zero matches; a renamed target must not silently fall out of both passes).
-- The quiet step gets an explicit `timeout-minutes` so a wedged tmux test cannot eat the job's 6 h default.
+- Every step parses the executed-test count from output and **fails below a floor** (`swift test --filter`/`--skip` exits green on zero matches; a renamed or collapsed target must not silently fall out of its pass). The floors catch collapse and rename; the complement shape above is what catches an unlisted *new* target.
+- Every step gets an explicit `timeout-minutes` so a wedged tmux test — or a wedged clock-driven suite, whose per-test limit is now 4 minutes — cannot eat the job's 6 h default.
 
 PR CI never runs randomized anything. A new scheduled `nightly.yml` workflow (§9) carries fuzzing, live probes, the flake-ledger stress loop, and the quarantine audit.
 


### PR DESCRIPTION
## Summary

`main`'s Test workflow was red in **5 of the last 12 runs (~42%)**. The failing test name shuffled between `ControlModeInputHealth`, `ControlModeInputRouter` and `Archived search debounce` — but **every single failure was a wall-clock scheduling handshake timing out. Zero logic assertions failed.**

**Root cause is population, not any one test.** Swift Testing parallelizes every non-serialized test in one process with no concurrency cap, and all targets compile into that process, so per-test scheduling latency scales with the *total* population. Mined across 9 CI runs: **p50 per-test reported duration is ~1/3 of total wall time in every run** — a trivial test "takes" 16–29 s because it is mostly suspended waiting for a turn. The population grew **3013 → 4536 in three weeks**, pushing ambient latency into deadlines sized for the smaller process. `ControlModeInputHealth` finishes green at 45.8 s / 47.4 s and red at 47.9 s — a ~2 s coin-flip band, which is exactly why the name shuffles.

**The disconfirming evidence is the important part.** I expected red runs to show a fat duration tail and greens not to. They don't — saturation is the steady state of *every* run:

- Green run `30237707480`: 1097 tests >40 s, max 84.7 s — the **worst tail in the whole sample**, and it passed clean.
- Green `30279274612` (80.9 s wall, 806 >40 s) is statistically indistinguishable from red `30286937025` (81.3 s wall, 998 >40 s).

So "why was this run slow" will never converge. What flips a run red is **margin** on a fixed deadline.

**How it got this way.** Nothing here is a regression from one commit. Two things compounded: ordinary feature work grew the suite ~50%, and the test-hardening program added **13 `TestClock`-driven suites in 96 hours** (2026-07-24→27) where there had been zero. Issue #496 predicted this exact risk — *"the risk is that CI gets noisier, or that a slice ships a much larger clock-driven population"* — and guessed it wasn't CI-relevant yet. These logs say otherwise. It wasn't caught because the deadlines are hang-catchers that only elapse on failure, so they degrade silently until they don't.

## What this does

**1. Split the fast pass into two sequential invocations in the same job, sharing one build.** Halving the in-flight population halves the tail the deadlines must absorb: **p90 26.4 s → 14.6 s** (means over 5 interleaved iterations under induced load, population held constant), for **+26 s** of wall time.

This is **not** the "sharding across runners" that `docs/specs/2026-07-24-test-hardening-design.md` §1 rejected and §2 lists as a non-goal — that rejection was about extra *jobs* paying the 5-concurrent-macOS-job cap and re-paying the ~2 min build. This pays neither; it's the same shape the file already uses for the fast/quiet split.

Step 2 is a **complement** (`--skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.'`), not an enumeration. Two `--filter` lists would be fail-open: `swift test --filter` exits GREEN on zero matches, so a new target named in neither list would run in *neither* pass — and the floors can't catch that, because adding a target reduces no existing step's count. As a complement, the three passes partition the package by construction.

**2. Re-derive the handshake deadlines as a coherent triple.** `ciSafeDeadline` 30→90 s, `waitForSuspension` 15→45 s, `.clockDriven` 1→4 min. These are hang-catchers, not timing budgets — no test here asserts a timing property, and on success they cost nothing. Repo precedent: PR #415 raised an incidental `readyTimeout` 5 s → an un-hittable 600 s for exactly this reason, and that default is still live at `AttachRPCTests.swift:137`.

**3. Three tier-3 live suites pin `.timeLimit(.minutes(1))` rather than inherit the raise.** For them the 60 s bound *is* a mutation-verified detector (a `sleep 90` child; a ~120 s regressed drain) — inheriting 240 s would have silently disarmed the proof with nothing going red to say so. They run `--no-parallel` on an idle machine and never needed the raised budget. This was the most dangerous thing in the change and it was nearly shipped.

## Verified under induced load, not idle

- **Pre-fix tree WEDGED** at load ~260: no `Test run with N tests` summary, harness deadline at 912 s, single test at **727 s**.
- **The exact test that reds in CI** (`ArchivedWorktreeSearchTests.swift:346`) took **176.1 s unsharded** vs **43.0 s sharded**. Against the old 60 s limit the unsharded case dies with precisely the CI signature: `waitForSuspension` times out, `advance` moves virtual time with no sleeper registered, and `#expect(fired.values == ["wolv"])` fails with `[]`. Both fixes independently rescue it.

### Measured on CI itself (both runs, not the flattering one)

`pull_request` runs the workflow from the branch, so this PR exercises the sharded pipeline on itself.

| metric | pre-fix runs (9 mined) | run 1 | run 2 | run 3 |
|---|---|---|---|---|
| p50 per-test duration | 23.1 - 35.8 s | 3.7 s | 5.2 s | 3.9 s |
| p90 | 41.4 - 51.0 s | 22.3 s | 33.0 s | 20.1 s |
| tests > 40 s | 589 - 1693 | 2 | 110 | 2 |

Run 2 is materially worse than 1 and 3, and all three are reported rather than the flattering ones — runner variance here is large, and the pre-fix data showed exactly why a single sample misleads (its worst tail belonged to a run that passed). What holds across all three is what the diagnosis rests on: p50 sits below even the best pre-fix **green** run (16.4 s), and the >40 s tail is down by one to three orders of magnitude from the pre-fix range.

## Ruled out, with measurements rather than assertions

- **`TASK_MEGA_YIELD_COUNT=1`** — issue #496's open "option A". p90 26.4 → 26.2 s across interleaved runs. Noise. The megaYield background-QoS flood is real but **secondary** to raw population. This closes that question with the properly-interleaved measurement the earlier attempt lacked (it was invalidated by load drift on a shared box).
- **Per-suite `@Suite(.serialized)`** — `Archived search debounce` is *already* `.clockDriven, .serialized` and still failed twice, because the contention is process-global. `Tests/CLAUDE.md`'s "reach for `.serialized` before a longer timeout" advice is scoped to a suite starving *itself*; amended to say so.
- **Blanket retry / anonymous quarantine** — banned, and unnecessary: this has a root cause.

## Honest caveats

- One verification iteration went red on `FileWatcherTests.terminationWithAPendingDebounceStillClosesTheFD` — an **FD-count** assertion, not a handshake deadline, in a suite this PR touches only in comments. It did not recur, and did not appear in any of the 9 mined CI runs. Flagging as a separate load-sensitive flake to watch, not something this change causes or claims to fix.
- Two later iterations were discarded as **contaminated**: a parallel agent was relinking the test binary underneath the running experiment. They are not reported as failures.
- The deadline change alone might be sufficient; sharding is what buys headroom for the *next* 50% of growth. Easy to revert independently if the +26 s isn't worth it.

## Test plan

- [x] `swift build --build-tests -j 2` clean
- [x] `swiftlint --strict` — 0 violations, 614 files
- [x] Shard 1: **2194** tests green (35.3 s)
- [x] Shard 2: **2342** tests green (11.3 s) — 2194+2342 = 4536, the full population, no gap
- [x] Quiet pass: **57** tests green (28.4 s)
- [x] Verified the three regexes partition the five test targets with no gap and no overlap
- [ ] Watch `main`'s red rate after merge — that's the real acceptance test

Refs #494, #496.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=809725DF-7574-4EDD-990A-6E6DE6F86036)

