### PR TITLE
Fix: Fork PR reviews lose git log and blame to a shallow clone that fetch-depth 0 doesn't prevent

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -107,6 +107,12 @@ jobs:
           # base branch for `git diff origin/main...HEAD` (a shallow clone made
           # that impossible — PR #434 diagnostics), and git log/blame for
           # premise-audit checks. The repo packs to ~10 MB; the cost is seconds.
+          #
+          # NOT sufficient on its own for a FORK PR: the head SHA is not reachable
+          # from any base-repo branch, so checkout fetches it as a targeted fetch
+          # and the clone stays shallow regardless of this value. The "Ensure a
+          # merge-base" step below repairs that — don't delete it thinking
+          # fetch-depth covers it.
           fetch-depth: 0
           # actions/checkout v7.0.0 (backported to the floating v4 tag in v4.4.0,
           # 2026-07-20) refuses to check out a fork PR head under
@@ -128,6 +134,42 @@ jobs:
         # killed or timed out before writing its own, sail through the gate.
         run: rm -f "$GITHUB_WORKSPACE/claude-verdict.txt"
 
+      - name: Ensure a merge-base with the base branch
+        if: steps.trust.outputs.trusted == 'true'
+        # `fetch-depth: 0` does NOT give a fork PR full history. The head SHA
+        # isn't reachable from any base-repo branch, so checkout fetches just
+        # that commit and the clone stays shallow — `origin/<base>` ends up with
+        # a single commit and no common ancestor with HEAD.
+        #
+        # Measured on PR #545, the first fork PR through this gate:
+        #   git rev-parse --is-shallow-repository -> true
+        #   git diff origin/main...HEAD -> fatal: no merge base
+        # The reviewer silently fell back to `gh pr diff`, which still yields a
+        # diff but loses `git log`/`git blame` — exactly what the premise-audit
+        # instructions in the prompt below depend on. Same-repo PRs were never
+        # affected, which is why this survived until the gate admitted forks.
+        #
+        # `--unshallow` errors on an already-complete repo, hence the guard.
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -uo pipefail
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            echo "Shallow clone (expected on a fork PR) — unshallowing."
+            git fetch --no-tags --unshallow origin
+          else
+            echo "Clone already complete — nothing to unshallow."
+          fi
+
+          # Self-reporting check: if this ever regresses, the run says so rather
+          # than the reviewer quietly degrading to gh-pr-diff-only again.
+          if merge_base="$(git merge-base "origin/$BASE_REF" HEAD 2>&1)"; then
+            echo "Merge base with origin/$BASE_REF: $merge_base"
+          else
+            # git merge-base exits 1 with no output on unrelated histories.
+            echo "::warning::No merge base with origin/$BASE_REF (${merge_base:-unrelated histories}). The reviewer will fall back to \`gh pr diff\` and lose git log/blame for premise-audit checks."
+          fi
+
       - name: Restore review hooks from the base branch
         if: steps.trust.outputs.trusted == 'true'
         # The Stop hook + its settings.json must come from the BASE branch, not the PR
@@ -136,9 +178,8 @@ jobs:
         # (ENOENT) — this blocked pre-existing fork PRs; (2) a PR must not be able to
         # neuter the gate that reviews it. github.event.pull_request.base.ref is the
         # base branch under pull_request_target; FETCH_HEAD is its tip after the fetch.
-        # No --depth=1 on this fetch: a shallow fetch into the now-complete clone
-        # (checkout uses fetch-depth: 0) would write shallow grafts and break the
-        # merge-base the reviewer relies on for `git diff origin/main...HEAD`.
+        # No --depth=1 on this fetch: it would re-introduce shallow grafts and undo
+        # the unshallow the previous step just performed.
         run: |
           git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
           rm -rf "$GITHUB_WORKSPACE/.github/workflows/claude-review-hooks"

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -56,6 +56,33 @@ step is already gated on `trusted == true`, the opt-in restores exactly the
 pre-v4.4.0 behavior and adds no new exposure: untrusted fork code still never
 reaches the checkout.
 
+### A fork PR checkout is shallow even with `fetch-depth: 0`
+
+`fetch-depth: 0` does **not** give a fork PR full history. The head SHA is not
+reachable from any base-repo branch, so `actions/checkout` fetches that commit on
+its own and the clone stays shallow — `origin/<base>` ends up holding a single
+commit with no common ancestor with `HEAD`. Measured on PR #545, the first fork PR
+through this gate:
+
+```
+git rev-parse --is-shallow-repository   -> true
+git log --oneline origin/main | wc -l   -> 1
+git diff origin/main...HEAD             -> fatal: no merge base
+```
+
+The reviewer degrades quietly rather than failing: it falls back to `gh pr diff`,
+which still produces a diff but loses `git log` and `git blame` — precisely what
+the premise-audit instructions in the prompt rely on. Same-repo PRs were never
+affected, which is why this went unnoticed until the gate started admitting forks.
+
+The **Ensure a merge-base with the base branch** step repairs it, running
+`git fetch --unshallow origin` when (and only when) the clone is shallow —
+`--unshallow` errors on a complete repo. It then logs the resolved merge base, or
+emits a `::warning::` if there still isn't one, so a future regression reports
+itself instead of silently degrading the review again. Don't remove that step on
+the assumption `fetch-depth: 0` covers it; it doesn't, and the failure is invisible
+in the review output.
+
 ### What a trusted author's branch can execute
 
 The opt-in is only defensible because of the push-access gate above, so it is worth


### PR DESCRIPTION
Follow-up to #546, from a defect that PR's own review diagnostics exposed.

## What's wrong

`fetch-depth: 0` does **not** give a fork PR full history. The head SHA isn't reachable from any base-repo branch, so `actions/checkout` fetches that commit on its own and the clone stays shallow. Measured on #545, the first fork PR through the new gate:

```
git rev-parse --is-shallow-repository   -> true
git log --oneline origin/main | wc -l   -> 1
git diff origin/main...HEAD             -> fatal: no merge base
```

The reviewer **degrades quietly rather than failing**, which is what makes this worth fixing rather than tolerating: it falls back to `gh pr diff`, still produces a diff, and posts a normal-looking review — but `git log` and `git blame` are gone, and those are exactly what the premise-audit instructions in the prompt depend on. The review looks healthy while running with less evidence than it claims.

## How it got broken

It didn't regress; it was never right for forks. Same-repo PRs get a genuinely complete clone, so `fetch-depth: 0` worked for every PR this repo had until #546 started admitting forks. The comment I added on the checkout step in #546 asserted that `fetch-depth: 0` guarantees the merge base — true for same-repo, false for forks. That false premise is corrected in place here.

## The fix

A new **Ensure a merge-base with the base branch** step that unshallows when — and only when — the clone is shallow (`--unshallow` errors on a complete repo), then logs the resolved merge base or emits a `::warning::` if there still isn't one. That self-report is deliberate: the failure mode here is silent degradation, so the next regression should announce itself rather than quietly shrinking the reviewer's evidence again.

A degraded diff deliberately does **not** fail the gate — `gh pr diff` still yields a usable review, and blocking every fork PR on a history problem would be worse than the problem.

## Verification

I reconstructed the fork-PR clone shape locally rather than assuming what `--unshallow` would do: a base repo with real history, a fork branch published into it as `refs/pull/N/head` (as GitHub does), and depth-1 fetches. That reproduced `fatal: origin/main...HEAD: no merge base` exactly.

Running the step script verbatim against it:

```
Shallow clone (expected on a fork PR) — unshallowing.
Merge base with origin/main: 33f842e8

is-shallow: false
origin/main commits: 5
git diff origin/main...HEAD: OK -> fork.txt
git log depth from HEAD: 6 commits
git blame works: yes
```

All three branches exercised:

- **shallow (fork PR)** — unshallows, merge base restored, correct one-file diff
- **non-shallow (same-repo PR)** — skips cleanly, exit 0, no `--unshallow` error; re-running is idempotent
- **unrelated histories** — emits the `::warning::`, still exit 0

## Test plan

- [ ] This PR is same-repo, so its own run must take the "Clone already complete — nothing to unshallow" path and log a real merge base. Note it exercises `main`'s workflow, not this one — `pull_request_target` reads the workflow from the base branch, so the new step only runs after merge.
- [ ] After merge, the next fork PR should log `Shallow clone (expected on a fork PR) — unshallowing.` followed by a merge base, and its review diagnostics should no longer report falling back to `gh pr diff` for lack of a merge base.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=97A20FF8-15AB-4E89-A871-0E71822C6528)