### PR TITLE
fix(nightwatch): the desk nudge always aimed at the oldest, deadest terminal

### DIFF
--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -194,6 +194,47 @@ public actor DeskSessionManager: DeskSessionManaging {
         return wt
     }
 
+    /// Resolve the Watch Desk's *live* Claude terminal, newest first.
+    ///
+    /// `TerminalStore.list` orders by `createdAt` ascending, so the previous
+    /// `terminals.first(where: { $0.label == .claudeCode })` deterministically returned
+    /// the OLDEST Claude row — not a race, a guarantee. Desk terminal rows outlive their
+    /// panes: a session that dies, or is killed out-of-band (the nightwatch judge handoff
+    /// `kill-window`s its predecessor directly, so the daemon never removes the row),
+    /// leaves its row behind forever. The oldest row is therefore the one *most* likely
+    /// to be dead, and every handoff inserted another corpse ahead of the live desk.
+    ///
+    /// Observed in production: one desk carried three `Claude Code` rows, the nudge aimed
+    /// at the first, and the judge prompt was discarded every fifteen minutes for hours
+    /// while ticks kept correctly reporting queued judgment.
+    ///
+    /// Two guards make that impossible. Prefer the NEWEST row, and confirm its tmux window
+    /// still exists before sending. The liveness check is not redundant belt-and-braces:
+    /// tmux recycles pane IDs per server — both dead rows in the incident above had been
+    /// assigned `%1` — so a stale row can start resolving to a *live pane owned by an
+    /// unrelated session*, which would then receive a pasted judge prompt plus Enter. That
+    /// is issue #384, and picking the newest row alone would not prevent it.
+    ///
+    /// - Returns: The newest Claude terminal whose tmux window is still alive, or nil.
+    private func liveClaudeTerminal(worktreeID: UUID, server: String) async throws -> Terminal? {
+        let candidates = try await db.terminals.list(worktreeID: worktreeID)
+            .filter { $0.label == TerminalLabel.claudeCode }
+            // Secondary key on id: Swift's sort is not stable, and two rows can share a
+            // createdAt, so without it the winner between same-instant rows is arbitrary.
+            .sorted { ($0.createdAt, $0.id.uuidString) > ($1.createdAt, $1.id.uuidString) }
+
+        for terminal in candidates {
+            if await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) {
+                return terminal
+            }
+            logger.notice("""
+                Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
+                window \(terminal.tmuxWindowID, privacy: .public) no longer exists
+                """)
+        }
+        return nil
+    }
+
     /// Post a shift wrap-up prompt to the desk session and fire a completion notification.
     /// Called when daywatch/nightwatch mode is turned OFF to gracefully end the shift.
     /// Sends the wrap-up prompt via tmux (non-destructive), fires a notification, and leaves
@@ -204,14 +245,16 @@ public actor DeskSessionManager: DeskSessionManaging {
         defer { gateRelease() }
 
         do {
-            let terminals = try await db.terminals.list(worktreeID: worktreeID)
-            guard let claudeTerminal = terminals.first(where: { $0.label == TerminalLabel.claudeCode }) else {
-                logger.warning("No Claude terminal found in Watch Desk; skipping wrap-up prompt")
+            // Worktree first: resolving a live terminal needs the tmux server to query.
+            guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+                logger.warning("Watch Desk worktree not found: \(worktreeID, privacy: .public)")
                 return
             }
 
-            guard let worktree = try await db.worktrees.get(id: worktreeID) else {
-                logger.warning("Watch Desk worktree not found: \(worktreeID, privacy: .public)")
+            guard let claudeTerminal = try await liveClaudeTerminal(
+                worktreeID: worktreeID, server: worktree.tmuxServer
+            ) else {
+                logger.warning("No live Claude terminal in Watch Desk; skipping wrap-up prompt")
                 return
             }
 
@@ -268,14 +311,19 @@ public actor DeskSessionManager: DeskSessionManaging {
         let prompt = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir)
 
         do {
-            let terminals = try await db.terminals.list(worktreeID: worktreeID)
-            guard let claudeTerminal = terminals.first(where: { $0.label == TerminalLabel.claudeCode }) else {
-                logger.warning("No Claude terminal found in Watch Desk; skipping nudge")
+            // Worktree first: resolving a live terminal needs the tmux server to query.
+            guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+                logger.warning("Watch Desk worktree not found: \(worktreeID, privacy: .public)")
                 return
             }
 
-            guard let worktree = try await db.worktrees.get(id: worktreeID) else {
-                logger.warning("Watch Desk worktree not found: \(worktreeID, privacy: .public)")
+            guard let claudeTerminal = try await liveClaudeTerminal(
+                worktreeID: worktreeID, server: worktree.tmuxServer
+            ) else {
+                // Deliberately does NOT stamp lastNudgeTime: a nudge that never reached a
+                // pane must not start the 10-minute overlap cooldown, or one dead desk
+                // would suppress the retry that recovers it.
+                logger.warning("No live Claude terminal in Watch Desk; skipping nudge")
                 return
             }
 

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -3,6 +3,47 @@ import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
 
+/// Records the argv TmuxManager *would* have run in dry-run mode, so a test can assert
+/// which pane a nudge actually targeted rather than merely that it didn't throw.
+private final class DeskTmuxRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [[String]] = []
+
+    func record(_ args: [String]) {
+        lock.lock(); defer { lock.unlock() }
+        _calls.append(args)
+    }
+
+    /// Target panes of every `paste-buffer` call, in order. `pasteBufferCommand` renders
+    /// `["-L", server, "paste-buffer", "-d", "-p", "-b", buffer, "-t", paneID]`.
+    var pastedPanes: [String] {
+        lock.lock(); defer { lock.unlock() }
+        return _calls.compactMap { args in
+            guard args.contains("paste-buffer"), let t = args.lastIndex(of: "-t"),
+                  args.index(after: t) < args.endIndex else { return nil }
+            return args[args.index(after: t)]
+        }
+    }
+}
+
+/// Mutable set of tmux windows that `windowExists` should report as gone. Mutable rather
+/// than a fixed closure because one test has to *revive* a desk mid-flight to prove a
+/// failed nudge didn't start the overlap cooldown.
+private final class DeadWindows: @unchecked Sendable {
+    private let lock = NSLock()
+    private var dead: Set<String> = []
+
+    func markDead(_ windowID: String) {
+        lock.lock(); defer { lock.unlock() }
+        dead.insert(windowID)
+    }
+
+    func isDead(_ windowID: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return dead.contains(windowID)
+    }
+}
+
 extension TBDHomeSerialized {
     @Suite("DeskSessionManager — TBD_HOME isolated")
     struct DeskSessionManagerTests {
@@ -455,6 +496,155 @@ extension TBDHomeSerialized {
             let terminals2 = try await db.terminals.list(worktreeID: desk1ID)
             let claudeTerminal2 = terminals2.first(where: { $0.label == TerminalLabel.claudeCode })
             #expect(claudeTerminal2 != nil, "Terminal should be respawned")
+        }
+
+        // MARK: - Live-terminal resolution (stale desk rows)
+
+        /// Temp TBD_HOME + in-memory DB + a DeskSessionManager whose own tmux records argv
+        /// and consults a mutable dead-window set. The lifecycle gets a separate dry-run
+        /// tmux so desk *creation* never lands in the recorder the assertions read.
+        /// Caller owns cleanup of `home` and TBD_HOME.
+        private func makeDeskFixture(tag: String) throws -> (
+            db: TBDDatabase, manager: DeskSessionManager,
+            recorder: DeskTmuxRecorder, dead: DeadWindows, home: URL
+        ) {
+            let home = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("tbd-desk-\(tag)-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+            setenv("TBD_HOME", home.path, 1)
+
+            let db = try TBDDatabase(inMemory: true)
+            let recorder = DeskTmuxRecorder()
+            let dead = DeadWindows()
+            let manager = DeskSessionManager(
+                db: db,
+                lifecycle: WorktreeLifecycle(
+                    db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+                ),
+                tmux: TmuxManager(
+                    dryRun: true,
+                    dryRunRecorder: { recorder.record($0) },
+                    dryRunWindowIsDead: { dead.isDead($0) }
+                ),
+                skillDir: home.appendingPathComponent("skills/nightwatch").path
+            )
+            return (db, manager, recorder, dead, home)
+        }
+
+        /// The regression: `TerminalStore.list` orders createdAt ASC, so resolving the desk
+        /// terminal with `first(where:)` always picked the OLDEST row. Judge handoffs kill
+        /// the predecessor's window out-of-band and leave its row behind, so the oldest row
+        /// is the likeliest corpse — in production three rows accumulated and every nudge
+        /// for hours was pasted at a pane that no longer existed.
+        @Test("nudgeDeskSession targets the newest Claude terminal, not the oldest")
+        func testNudgeTargetsNewestClaudeTerminal() async throws {
+            let f = try makeDeskFixture(tag: "nudge-newest")
+            defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let oldest = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // A later Claude row on the same desk — the live session after a handoff.
+            let newest = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
+                label: TerminalLabel.claudeCode)
+
+            // Asserted, not assumed: if the clock ever ties these two, the recency
+            // assertion below proves nothing, so fail where the cause is legible.
+            #expect(newest.createdAt > oldest.createdAt, "fixture must yield distinct createdAt")
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+
+            let targets = Array(f.recorder.pastedPanes.dropFirst(before))
+            #expect(targets == ["%9"], "nudge must reach the newest Claude terminal, got \(targets)")
+        }
+
+        /// Recency alone is not enough. tmux recycles pane IDs per server, so a stale row
+        /// can start resolving to a live pane owned by an unrelated session, which would
+        /// then be handed a judge prompt plus Enter (#384). The window-liveness check is
+        /// what makes that unreachable.
+        @Test("nudgeDeskSession skips a newer terminal whose tmux window is gone")
+        func testNudgeSkipsStaleTerminal() async throws {
+            let f = try makeDeskFixture(tag: "nudge-stale")
+            defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let live = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // Newer by createdAt, but its window is dead — exactly the orphan a handoff leaves.
+            _ = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@dead", tmuxPaneID: "%dead",
+                label: TerminalLabel.claudeCode)
+            f.dead.markDead("@dead")
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+
+            let targets = Array(f.recorder.pastedPanes.dropFirst(before))
+            #expect(targets == [live.tmuxPaneID], "must fall through to the live row, got \(targets)")
+            #expect(!targets.contains("%dead"), "a dead window must never be pasted into")
+        }
+
+        /// A nudge that reached nothing must not start the 10-minute overlap cooldown, or a
+        /// single dead desk would suppress the very retry that recovers it — which is how a
+        /// transient gap becomes a silent all-night outage.
+        @Test("a nudge with no live terminal sends nothing and does not start the cooldown")
+        func testFailedNudgeDoesNotStartCooldown() async throws {
+            let f = try makeDeskFixture(tag: "nudge-cooldown")
+            defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let original = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+            f.dead.markDead(original.tmuxWindowID)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            #expect(
+                Array(f.recorder.pastedPanes.dropFirst(before)).isEmpty,
+                "no live terminal means nothing should be pasted anywhere")
+
+            // Desk comes back; the next nudge must fire immediately.
+            _ = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@revived", tmuxPaneID: "%7",
+                label: TerminalLabel.claudeCode)
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            #expect(
+                Array(f.recorder.pastedPanes.dropFirst(before)) == ["%7"],
+                "the failed attempt must not have armed the overlap guard")
+        }
+
+        /// `postShiftWrapUp` resolved its target the same broken way, and failed the same
+        /// way in production ("Failed to post shift wrap-up: TmuxError error 0").
+        @Test("postShiftWrapUp targets the newest live terminal")
+        func testWrapUpTargetsNewestLiveTerminal() async throws {
+            let f = try makeDeskFixture(tag: "wrapup-live")
+            defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let original = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+            f.dead.markDead(original.tmuxWindowID)
+
+            _ = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@live", tmuxPaneID: "%5",
+                label: TerminalLabel.claudeCode)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.postShiftWrapUp(worktreeID: desk.id)
+
+            #expect(
+                Array(f.recorder.pastedPanes.dropFirst(before)) == ["%5"],
+                "wrap-up must reach the live terminal, not the dead original")
+
+            let notifications = try await f.db.notifications.unread(worktreeID: desk.id)
+            #expect(
+                notifications.contains(where: { $0.type == .taskComplete }),
+                "wrap-up should still fire its completion notification")
         }
     }
 }


### PR DESCRIPTION
## What was wrong

`nudgeDeskSession` and `postShiftWrapUp` resolved their target with:

```swift
terminals.first(where: { $0.label == TerminalLabel.claudeCode })
```

`TerminalStore.list` orders by `createdAt` **ascending**, so that deterministically selected the **oldest** Claude row on the desk. Not a race — a guarantee.

Desk terminal rows outlive their panes. A session that dies, or is killed out-of-band — the nightwatch judge handoff `kill-window`s its predecessor directly, so the daemon never removes the row — leaves its row behind forever. **The oldest row is therefore the one most likely to be dead, and every handoff inserted another corpse ahead of the live desk.**

## How it surfaced

Found while investigating a report that switching daywatch → nightwatch "did nothing." The mode switch itself is a documented reuse no-op, so the per-tick `nudgeDeskSession` is the *only* channel that carries the mode/act flag to the desk — and it had been failing for hours:

```
17:50:55 E  Failed to nudge desk session: TBDDaemonLib.TmuxError error 0
18:05 · 18:18 · 18:33 · 18:48 · 19:03 · 19:33   same error, same 15-minute cadence
18:16, 18:18  Failed to post shift wrap-up: TmuxError error 0
```

One active `◐ Watch Desk` carried three rows all labelled `Claude Code`:

| terminal | pane | created | reality |
|---|---|---|---|
| `4B9E7841` | `%1` | 18:04Z | dead — first desk session |
| `E54C8467` | `%1` | 19:06Z | dead — predecessor, closed at handoff |
| `A09D6BFB` | `%3` | 02:21Z | **live — the actual desk** |

`tmux list-panes` showed only `%3`. Ticks were correctly returning exit 10 every cycle; the nudge then pasted at a pane that did not exist and the judge prompt was discarded. The desk read as idle and unresponsive to mode changes, and every judge cycle that day was driven by hand instead.

## The fix

One shared `liveClaudeTerminal(worktreeID:server:)` used by both call sites: prefer the **newest** Claude row, and confirm its tmux window still exists (`windowExists`) before sending.

**The liveness check is not redundant with picking the newest.** tmux recycles pane IDs per server — note both dead rows above had been assigned `%1` — so a stale row can *begin* resolving to a live pane owned by an unrelated session, which would then be handed a pasted judge prompt plus Enter. That is #384, and recency alone does not prevent it.

Two smaller deliberate details:

- **A failed nudge does not stamp `lastNudgeTime`.** Arming the ten-minute overlap cooldown on a failure would suppress the very retry that recovers the desk, turning a transient gap into a silent all-night outage. Because it was never armed, this fix takes effect on the next tick with no restart needed.
- **Secondary sort key on `id`.** Swift's sort is not stable and two rows can share a `createdAt`, so without it the winner between same-instant rows would be arbitrary.

Both call sites now fetch the worktree first, since resolving a live terminal needs the tmux server to query.

## Tests

Four new tests in `DeskSessionManagerTests` (under `TBDHomeSerialized`, per the repo's `setenv("TBD_HOME")` rule), asserting on the argv a dry-run `TmuxManager` *would* have run — so they check which pane was actually targeted, not merely that nothing threw:

- newest Claude row wins over an older live one
- a newer row whose window is gone is skipped in favour of the older live row
- no live terminal → nothing pasted anywhere, **and** the immediately following nudge still fires (proves the cooldown was not armed)
- `postShiftWrapUp` resolves the same way and still fires its completion notification

The recency test asserts `newest.createdAt > oldest.createdAt` as an explicit precondition, so a clock tie fails where the cause is legible instead of making the real assertion meaningless.

## Verification note — please let CI run the tests

`swift build --product TBDDaemon` is clean. **I could not execute the test suite or swiftlint locally**: this machine has Command Line Tools only, no full Xcode, so swift-testing's overlay modules (`_Testing_Foundation`) and swiftlint's `sourcekitdInProc` don't resolve — every test file fails to compile, including untouched ones. The four new tests are therefore **unverified by execution** and CI is the first real run.

## Not fixed here

The *producer* of the stale rows is `handoff.py` in the nightwatch skill, which kills the predecessor's window with raw `tmux kill-window` instead of going through the daemon, so the row is never removed. That script isn't version-controlled in this repo. Worth closing separately — though the daemon should not trust stale rows regardless of who orphans them, which is what this change makes true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)