### PR TITLE
docs: known issue — terminal send silently no-ops on dead panes

### DIFF
--- a/docs/tmux-integration.md
+++ b/docs/tmux-integration.md
@@ -145,3 +145,24 @@ This is the key feature that makes embedding work — multiple viewers can look 
 - [Windows Terminal control mode request](https://github.com/microsoft/terminal/issues/5612) — more discussion of challenges
 - [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm) — the terminal emulator library we use
 - [tmux man page](https://man.openbsd.org/tmux.1) — authoritative reference
+
+## Known issues
+
+### `terminal send` silently no-ops on dead panes
+
+`tbd terminal send --terminal <id> --text "..." --submit` reports **"Text sent"**
+even when the target tmux pane is dead (`pane_dead=1`). The text goes nowhere and
+the caller gets no failure signal. During a 2026-07-01 multi-session rescue this
+masked five dead Claude sessions — every nudge "succeeded" while none delivered.
+
+Related trap: a pane can be alive (`pane_dead=0`) after its Claude process exits,
+leaving a bare `zsh` prompt — `send` then types into a shell, not a session.
+Ground truth today requires raw tmux:
+
+```sh
+tmux -L <server> list-panes -a -F '#{pane_id} dead=#{pane_dead} cmd=#{pane_current_command}'
+```
+
+Suggested fix: check `#{pane_dead}` before sending and exit non-zero with a
+respawn hint when dead; surface `pane_current_command` in `terminal list`/`output`
+so callers can tell "Claude running" from "shell prompt" without raw tmux.


### PR DESCRIPTION
Recovers a commit that has been **stranded in the `zionts/tbd` fork since 2026-07-28** and never reached this repo. Found while syncing that fork (it was 69 commits behind with exactly this one commit of its own, so catching it up would have discarded this).

The doc is unchanged from the original — cherry-picked as authored, not rewritten.

## Why it's worth landing now rather than dropping

It describes the failure class that caused a live outage today, 27 days after it was written:

> During a 2026-07-01 multi-session rescue this masked five dead Claude sessions — every nudge "succeeded" while none delivered.

That is precisely what happened to the Nightwatch Watch Desk on 2026-07-29: the daemon's per-tick desk nudge pasted into a pane that no longer existed, every fifteen minutes for hours, with the only symptom a log line. Fixed on the daemon side in #549, which resolves the newest *live* terminal and verifies `windowExists` before sending.

**The CLI-side problem this doc actually describes is still open.** `tbd terminal send` still reports "Text sent." on a dead pane, and still can't distinguish "Claude running" from "bare shell prompt" without raw tmux. #549 fixed one consumer; the reporting gap named here is unfixed, and the suggested fix (check `#{pane_dead}`, surface `pane_current_command` in `terminal list`/`output`) is still the right shape. Landing the doc means the next person hits a written warning instead of rediscovering it during a rescue.

Related: #384 (stale terminal→pane coordinates can route keystrokes to the wrong session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)