### PR TITLE
fix: three stale facts the nightwatch judge was acting on

### DIFF
--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -26,6 +26,11 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// immediately (matching RPCRouter+ScratchHandlers) instead of waiting for a poll.
     private let subscriptions: StateSubscriptionManager?
     private let skillDir: String
+    /// Date seam for the nudge-overlap guard — a compared timestamp, so per
+    /// `Tests/CLAUDE.md` this is the `now:` shape, not an injected `Clock`.
+    /// Without it the 10-minute window is unreachable in a test, which is why the
+    /// guard went so long with no observable beyond "doesn't throw".
+    private let now: @Sendable () -> Date
 
     // MARK: - State
 
@@ -65,6 +70,20 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// M2: nudge-overlap guard. Phase B upgrade: claim-file (queue/claims) single-driver enforcement.
     private var lastNudgeTime: Date?
 
+    /// Mode carried by the last nudge that actually reached the session.
+    ///
+    /// The judge is told to read `JUDGE-INSTRUCTIONS.md` once rather than every
+    /// tick, so *someone* has to notice when the body it memorized stops matching
+    /// the body on disk. The desk is deliberately reused across daywatch ↔
+    /// nightwatch without respawning (see `ensureDeskSession`), and the two bodies
+    /// differ on exactly the thing that matters — whether an unattended
+    /// `gh pr merge` is authorized. `nil` means nothing has been nudged yet, which
+    /// is treated the same as changed: a judge with no reads is a judge that must read.
+    ///
+    /// Internal rather than private so tests can assert the transition; it is state
+    /// the manager needs regardless.
+    private(set) var lastNudgedMode: NightwatchMode?
+
     // MARK: - Init
 
     public init(
@@ -72,13 +91,15 @@ public actor DeskSessionManager: DeskSessionManaging {
         lifecycle: WorktreeLifecycle,
         tmux: TmuxManager,
         skillDir: String,
-        subscriptions: StateSubscriptionManager? = nil
+        subscriptions: StateSubscriptionManager? = nil,
+        now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.db = db
         self.lifecycle = lifecycle
         self.tmux = tmux
         self.subscriptions = subscriptions
         self.skillDir = skillDir
+        self.now = now
         self.deskWorktreeID = nil
     }
 
@@ -101,8 +122,11 @@ public actor DeskSessionManager: DeskSessionManaging {
             if terminals.first(where: { $0.label == TerminalLabel.claudeCode }) != nil {
                 // Fast path: cached desk is alive and valid.
                 // Mode switches (daywatch ↔ nightwatch) intentionally REUSE the existing desk and terminal.
-                // The desk is NOT respawned on mode switch because the per-tick judgePrompt (via nudgeDeskSession)
-                // carries the current mode/act flag each cycle. Initial frame is one-time; steady-state mode is driven per-tick.
+                // The desk is NOT respawned on mode switch because every tick re-derives the mode and
+                // rewrites JUDGE-INSTRUCTIONS.md to match. Since the judge is told to read that file once
+                // rather than per tick, reuse-without-respawn is exactly the case where a memorized copy
+                // can go stale — `nudgeDeskSession` compares against `lastNudgedMode` and flags the flip.
+                // Initial frame is one-time; steady-state mode is driven per-tick.
                 return existing
             }
         }
@@ -257,7 +281,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         defer { gateRelease() }
         // M2: Skip nudge if previous nudge was < 10 min ago (prevent overlapping judge runs)
         if let last = lastNudgeTime {
-            let elapsed = Date().timeIntervalSince(last)
+            let elapsed = now().timeIntervalSince(last)
             if elapsed < 10 * 60 {
                 logger.debug("Skipping nudge: last nudge was \(Int(elapsed))s ago (< 10 min)")
                 return
@@ -290,7 +314,16 @@ public actor DeskSessionManager: DeskSessionManaging {
             // nothing is a silent one.
             let prompt: String
             if let instructionsPath = writeJudgeInstructions(deskPath: worktree.path, mode: mode) {
-                prompt = NightwatchDeskPrompts.judgeNudge(mode: mode, instructionsPath: instructionsPath)
+                // A mode flip rewrites the file under a judge that was told to read
+                // it once. Nothing on the judge's side can see that happen, so the
+                // daemon — the only party that knows both the old and new mode —
+                // has to say so. First nudge (nil) counts as changed: a judge that
+                // has read nothing must read.
+                prompt = NightwatchDeskPrompts.judgeNudge(
+                    mode: mode,
+                    instructionsPath: instructionsPath,
+                    instructionsChanged: lastNudgedMode != mode
+                )
             } else {
                 logger.warning("Could not write judge instructions to \(worktree.path, privacy: .public); falling back to the inline prompt")
                 prompt = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir)
@@ -310,8 +343,12 @@ public actor DeskSessionManager: DeskSessionManaging {
                 key: "Enter"
             )
 
-            // Record nudge time for overlap guard
-            lastNudgeTime = Date()
+            // Record nudge time for overlap guard. `lastNudgedMode` is set only
+            // here, after the paste actually went out — a nudge that failed to
+            // reach the session must not count as "the judge has seen this mode",
+            // or the next tick would tell it nothing changed when everything did.
+            lastNudgeTime = now()
+            lastNudgedMode = mode
 
             logger.debug("Nudged Watch Desk session: act=\(act, privacy: .public)")
         } catch {

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -265,7 +265,6 @@ public actor DeskSessionManager: DeskSessionManaging {
         }
 
         let mode: NightwatchMode = act ? .nightwatch : .daywatch
-        let prompt = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir)
 
         do {
             let terminals = try await db.terminals.list(worktreeID: worktreeID)
@@ -277,6 +276,24 @@ public actor DeskSessionManager: DeskSessionManaging {
             guard let worktree = try await db.worktrees.get(id: worktreeID) else {
                 logger.warning("Watch Desk worktree not found: \(worktreeID, privacy: .public)")
                 return
+            }
+
+            // The ~5 KB instructions go to a file; only the one-line pointer goes
+            // into the session. Rewritten every tick rather than once at spawn
+            // because it is mode-specific and a local write costs nothing — that
+            // also makes the file self-healing across daemon restarts, mode
+            // switches, and a desk whose directory was cleaned out under it.
+            //
+            // Fallback, deliberately: if the write fails there is no file to point
+            // at, so we paste the full prompt exactly as before. A judge holding
+            // stale instructions is a bad night; a judge holding a pointer to
+            // nothing is a silent one.
+            let prompt: String
+            if let instructionsPath = writeJudgeInstructions(deskPath: worktree.path, mode: mode) {
+                prompt = NightwatchDeskPrompts.judgeNudge(mode: mode, instructionsPath: instructionsPath)
+            } else {
+                logger.warning("Could not write judge instructions to \(worktree.path, privacy: .public); falling back to the inline prompt")
+                prompt = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir)
             }
 
             // Paste the prompt text (matches handleTerminalSend pattern for reliability)
@@ -346,6 +363,25 @@ public actor DeskSessionManager: DeskSessionManaging {
 
     // MARK: - Private Helpers
 
+    /// Write the mode-specific judge instructions into the desk worktree.
+    ///
+    /// Returns the absolute path on success, `nil` on any failure — callers treat
+    /// `nil` as "fall back to the inline prompt" rather than proceeding with a
+    /// pointer to a file that may not exist. Deliberately non-throwing: a desk
+    /// that cannot write a file must still get nudged.
+    private func writeJudgeInstructions(deskPath: String, mode: NightwatchMode) -> String? {
+        let url = URL(fileURLWithPath: deskPath)
+            .appendingPathComponent(NightwatchDeskPrompts.judgeInstructionsFileName)
+        let body = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir)
+        do {
+            try body.write(to: url, atomically: true, encoding: .utf8)
+            return url.path
+        } catch {
+            logger.warning("Failed to write judge instructions: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
     /// Spawn a Claude terminal in the desk worktree using lifecycle.spawnPrimaryTerminals.
     /// This reuses the production spawn path which handles trust seeding, overlay injection, etc.
     /// Note: Model selection (daywatch=Sonnet, nightwatch=Opus) requires per-profile configuration.
@@ -354,6 +390,14 @@ public actor DeskSessionManager: DeskSessionManaging {
     private func spawnDeskTerminal(worktree: Worktree, mode: NightwatchMode) async throws {
         // Get initial prompt for mode (includes absolute skillDir paths and field learnings)
         let initialPrompt = NightwatchDeskPrompts.initialPrompt(mode: mode, skillDir: skillDir)
+
+        // Lay the instructions down before the session exists, so a judge that
+        // reads them on its own initiative — before its first tick ever fires —
+        // finds them there. Best-effort: the nudge path rewrites this every tick
+        // and falls back to the inline prompt if it can't.
+        writeJudgeInstructions(deskPath: worktree.path, mode: mode).map { path in
+            logger.debug("Wrote judge instructions to \(path, privacy: .public)")
+        }
 
         // Use production spawn path which handles trust, overlay, and all lifecycle concerns
         _ = try await lifecycle.spawnPrimaryTerminals(

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -428,6 +428,25 @@ public actor DeskSessionManager: DeskSessionManaging {
         // Get initial prompt for mode (includes absolute skillDir paths and field learnings)
         let initialPrompt = NightwatchDeskPrompts.initialPrompt(mode: mode, skillDir: skillDir)
 
+        // A new session has read nothing, so nothing it could have memorized is
+        // still valid. `lastNudgedMode` is keyed on the MODE, not on which session
+        // is running, so without this reset a crash-respawn with the mode
+        // unchanged computes `lastNudgedMode != mode` == false and tells a
+        // brand-new judge "you already read the instructions — don't re-read".
+        // It hasn't. It doesn't. (Caught in review of PR #551.)
+        //
+        // `lastNudgeTime` goes with it for the same reason: a rate-limit window
+        // opened by a session that no longer exists should not silence the first
+        // tick of its replacement. Both are per-session facts that were living on
+        // the actor, and this is the one chokepoint both spawn paths — fresh
+        // create and crash recovery — pass through.
+        //
+        // Reset unconditionally, before the spawn can throw: over-signalling
+        // costs one extra file Read, under-signalling costs a judge running an
+        // unattended shift on instructions it never opened.
+        lastNudgedMode = nil
+        lastNudgeTime = nil
+
         // Lay the instructions down before the session exists, so a judge that
         // reads them on its own initiative — before its first tick ever fires —
         // finds them there. Best-effort: the nudge path rewrites this every tick

--- a/Sources/TBDShared/NightwatchDeskPrompts.swift
+++ b/Sources/TBDShared/NightwatchDeskPrompts.swift
@@ -34,8 +34,8 @@ public enum NightwatchDeskPrompts {
         • Single-driver rule: Before actioning any atlantis apply/merge, claim the item in queue/claims
         • Escalations in batches ≤4: Each question with exact PR#/command/recommendation
         • Capacity check: Before nudging others, verify profile usage <80% weekly cap
-        • Context ceiling: At ~200k tokens, run the handoff relay (below) — do NOT defer it and keep working
-        • The gate stops short of merging: get PRs *ready*, the human merges (never run `gh pr merge`)
+        • Context ceiling: At ~600k tokens, run the handoff relay (below) — do NOT defer it and keep working
+        • Merging: only loop-perfect PRs authored by `zionts` qualify, and only nightwatch acts (see below)
         • NEVER trigger `/closeout` — a finished-looking worktree is an archive question for the human
 
         **Standing rules (set by Chang — these override anything else in this prompt):**
@@ -45,9 +45,13 @@ public enum NightwatchDeskPrompts {
         that looks finished is an *archive question for the human*, not a harvest to fire.
         Report it and move on.
 
-        **Hand off at the context ceiling — never push through it.** There is no babysitter
-        daemon and no respawner; nothing will restart you. When this session passes ~200k
-        tokens it starts truncating its own shift, so use the relay:
+        \(mergeRule(mode: mode))
+
+        **Hand off at the context ceiling — never push through it.** Nothing respawns this desk
+        by itself: a machine-local babysitter daemon may be watching worker panes, but it does
+        not restart the judge, and the only thing that spawns your successor is you running
+        `handoff.py --act`. It does work — run it, don't "flag for respawn". When this session
+        passes ~600k tokens it starts truncating its own shift, so use the relay:
 
             python3 \(skillDir)/scripts/handoff.py --check
                 # exit 0 = under the ceiling · exit 10 = OVER
@@ -93,7 +97,7 @@ public enum NightwatchDeskPrompts {
         if mode == .daywatch {
             actionHint = "(daywatch: triage only; act on small_safe/preclear; batch rest for human review)"
         } else {
-            actionHint = "(nightwatch: act on what the gate allows — the gate stops short of merging; the human merges)"
+            actionHint = "(nightwatch: act on what the gate allows — including merging loop-perfect `zionts` PRs, and only his)"
         }
 
         let queueDir = skillDir + "/queue"
@@ -108,18 +112,18 @@ public enum NightwatchDeskPrompts {
         2. Apply the policy per the skill docs
         3. For each decision:
            - Daywatch: act ONLY if clearanceKind in [preclear, small_safe]; otherwise batch for human review
-           - Nightwatch: act on what the gate allows — but NEVER merge (see the gate below)
+           - Nightwatch: act on what the gate allows — merging included, within the limits below
         4. Write results to \(queueDir)/acted.jsonl (one JSON line per action taken)
 
         **The gate (never automate past this):**
         - A PR may only be enqueued when claude-review = APPROVED on the CURRENT SHA and
           checks are clean. Human approval never substitutes for the bot verdict.
-        - NEVER run `gh pr merge`. It is not a safe wedge — it always escalates to the
-          human. Your job is to get PRs *ready*; the human merges.
         - Re-read live PR state in the same breath as any send that asserts it
           (`gh pr view N --json state,headRefOid,mergeStateStatus`); never dispatch a fact
           older than the current tool call.
         5. Write a summary to \(queueDir)/judge-summary.txt
+
+        \(mergeRule(mode: mode))
 
         **Field learnings — apply these rules:**
 
@@ -144,9 +148,12 @@ public enum NightwatchDeskPrompts {
 
         **Context ceiling — hand off, never push through:**
         - Symptom: running slow, many retries, unclear reasoning, truncated history
-        - Do NOT just mark the session for later recycling and keep working. That is a
-          no-op: there is no babysitter daemon and no respawner. Nothing will restart you.
-        - Check: `python3 \(skillDir)/scripts/handoff.py --check` (exit 0 = under, 10 = OVER)
+        - Do NOT just mark the session for later recycling and keep working. Nothing respawns
+          this desk on its own — a machine-local babysitter daemon may be watching worker
+          panes, but it does not restart the judge. The relay below is what continues the
+          shift, and it does work: run it rather than deferring to something that won't.
+        - Check: `python3 \(skillDir)/scripts/handoff.py --check` (exit 0 = under, 10 = OVER;
+          the ceiling is 600k tokens — the script is the authority, don't eyeball it)
         - When OVER: write your handoff notes to a file, then
           `python3 \(skillDir)/scripts/handoff.py --act --notes-file <your-notes.md>`
           which writes the handoff doc and spawns a fresh successor in this worktree
@@ -168,6 +175,46 @@ public enum NightwatchDeskPrompts {
 
     // MARK: - Private Helpers
 
+    /// The merge authorization, written once and shared by both prompts.
+    ///
+    /// Set by Adam 2026-07-29, replacing the older "nightwatch gets PRs *ready*;
+    /// the human merges" rule. Two halves that must travel together: *what*
+    /// qualifies a PR (loop-perfect, and `zionts`-authored only), and *who* may
+    /// act on it (nightwatch — daywatch reports and stops).
+    ///
+    /// Daywatch is told the qualifying rule even though it may not act on it,
+    /// deliberately: it decides what to *report*, and a policy it has never read
+    /// is one it cannot apply. Both prompts carry the identical text so a session
+    /// that only ever sees one of them still gets the whole rule.
+    private static func mergeRule(mode: NightwatchMode) -> String {
+        let authorization = mode == .nightwatch
+            ? "On a nightwatch shift you MAY run `gh pr merge <N>` on such a PR, unattended."
+            : """
+            Merging is a NIGHTWATCH action. On a daywatch shift, *report* a loop-perfect PR
+            and stop — do not enqueue it, no matter how clean it looks.
+            """
+
+        return """
+        **Merging (set by Adam 2026-07-29 — supersedes any "the human merges" text elsewhere,
+        including older copies of the skill docs):**
+
+        A PR is **loop-perfect** when all three hold at once, re-read in the same tool call as
+        the merge: `mergeable_state` is clean AND claude-review = APPROVED on the CURRENT head
+        SHA AND every required status context is green. A verdict on a superseded SHA is not a
+        verdict. Only PRs **authored by `zionts`** qualify — never a teammate's, never a bot's.
+        **Never `--admin`**, and never merge *toward* green: anything short of loop-perfect goes
+        back to its owner or to the human. `gh pr merge` also stays off the auto-approve wedge
+        allowlist — a merge is a judged act, never a rubber-stamped permission prompt.
+
+        \(authorization)
+
+        `main` is behind a **merge queue**, so `gh pr merge <N>` *enqueues*; GitHub merges it
+        once the queue's own checks pass. The line `! The merge strategy for main is set by the
+        merge queue` is a **warning, not a failure** — the enqueue succeeded. Don't retry it,
+        don't add `--squash`/`--merge` to "fix" it, and don't report it as a blocked merge.
+        """
+    }
+
     private static func jobDescription(mode: NightwatchMode) -> String {
         switch mode {
         case .daywatch:
@@ -176,17 +223,21 @@ public enum NightwatchDeskPrompts {
             - Act immediately only on small_safe/preclear clearances (safe, well-tested, low risk)
             - Batch everything else (experimental, novel, uncertain) into a human-review summary
             - Use AskUserQuestion for uncertain calls
-            - NEVER run `gh pr merge` — no clearance kind authorizes a merge; the human merges
+            - Merging is nightwatch's, not daywatch's: no daytime clearance kind authorizes
+              `gh pr merge`. Report a loop-perfect PR; don't enqueue it on a triage shift.
             - Never trigger `/closeout` — a finished-looking worktree is an archive
               question for the human
             """
 
         case .nightwatch:
             return """
-            Get PRs *ready* — the human merges:
+            Drive PRs to loop-perfect, and merge Adam's once they are:
             - A PR may only be enqueued when claude-review = APPROVED on the current SHA
               AND checks are clean. Human approval never substitutes for the bot verdict.
-            - NEVER run `gh pr merge`. It always escalates to the human, by design.
+            - You MAY run `gh pr merge <N>` on a loop-perfect PR authored by `zionts`, and
+              only his. Never `--admin`, never anyone else's PR. `main` uses a merge queue,
+              so this enqueues rather than merges, and the "merge strategy is set by the
+              merge queue" line is a warning, not a failure.
             - Escalate blockers (conflicts, status checks) with context
             - Never trigger `/closeout` — a finished-looking worktree is an archive
               question for the human

--- a/Sources/TBDShared/NightwatchDeskPrompts.swift
+++ b/Sources/TBDShared/NightwatchDeskPrompts.swift
@@ -25,6 +25,14 @@ public enum NightwatchDeskPrompts {
         - Skill docs: \(skillDocPath) (full job description)
         - Approved PRs memory: \(queueDir)/approved-prs.jsonl (PRs human already approved today — auto-answer on re-prompt)
         - Claim registry: \(queueDir)/claims (lock file before atlantis apply/merge; unlock when done)
+        - Judge instructions: `\(judgeInstructionsFileName)` in THIS worktree (your cwd)
+
+        **How the per-tick nudge works:** every ~15 min you get a one-line tick message carrying
+        the mode and act flag, pointing at `\(judgeInstructionsFileName)` by absolute path. Read
+        that file ONCE, on your first tick. Later ticks change only the mode/act line, so
+        re-reading it every tick just spends your own context on your own heartbeat — which is
+        what makes a desk hit its handoff ceiling early. If a tick arrives and you have not read
+        the file yet (fresh session, or you took over from a predecessor), read it then.
 
         **Your job (\(modeLabel)):**
         \(jobDescription(mode: mode))
@@ -90,7 +98,48 @@ public enum NightwatchDeskPrompts {
     When you're ready, start typing your summary.
     """
 
-    /// Prompt sent when the daemon nudges the desk session with a batch of queued judgments.
+    /// Filename of the per-desk judge instructions, written into the desk worktree
+    /// by `DeskSessionManager` and pointed at by `judgeNudge`.
+    public static let judgeInstructionsFileName = "JUDGE-INSTRUCTIONS.md"
+
+    /// The one line the daemon actually pastes into the desk on every tick.
+    ///
+    /// `judgePrompt` is ~5 KB and identical from tick to tick except for the
+    /// mode/act flag. Pasting all of it every ~15 minutes spent the judge's own
+    /// context on its own heartbeat — the session reached its handoff ceiling
+    /// faster the more reliably it was nudged, which is the wrong direction for a
+    /// mechanism whose entire job is to keep the desk alive. The body now lives in
+    /// a file; this carries only what changes.
+    ///
+    /// Two details are load-bearing rather than cosmetic:
+    ///
+    /// - **The mode and act flag are inline**, not in the file, so a judge that
+    ///   already read the instructions needs nothing from disk to act on this tick.
+    /// - **It tells the judge not to re-read.** Without that, the paste cost simply
+    ///   becomes a `Read` cost and nothing is saved. The saving is real only if the
+    ///   file is read once per session, not once per tick.
+    ///
+    /// Short pastes are also more likely to *arrive*: a large paste can land as
+    /// `[Pasted text #N]` and sit in the composer unsubmitted, which for an
+    /// unattended desk is indistinguishable from never having been nudged.
+    ///
+    /// - Parameters:
+    ///   - mode: current shift; also determines the act flag the judge applies
+    ///   - instructionsPath: absolute path to the written `JUDGE-INSTRUCTIONS.md`
+    public static func judgeNudge(mode: NightwatchMode, instructionsPath: String) -> String {
+        let icon = mode == .daywatch ? "◐" : "🌙"
+        let act = mode == .nightwatch
+        return """
+        \(icon) Judge tick — mode: \(mode.rawValue), act=\(act). Run the cycle per \(instructionsPath). \
+        Already read that file this session? Don't re-read it — this line carries the only thing that changes between ticks.
+        """
+    }
+
+    /// The full judge instructions — the *body*, written once per desk to
+    /// `judgeInstructionsFileName` rather than pasted per tick (see `judgeNudge`).
+    ///
+    /// Still regenerated on every nudge because it is mode-specific and a local
+    /// file write is free; what was expensive was putting it in the session.
     /// - Parameter skillDir: Absolute path to the nightwatch skill directory for file references
     public static func judgePrompt(mode: NightwatchMode, skillDir: String) -> String {
         let actionHint: String

--- a/Sources/TBDShared/NightwatchDeskPrompts.swift
+++ b/Sources/TBDShared/NightwatchDeskPrompts.swift
@@ -29,10 +29,15 @@ public enum NightwatchDeskPrompts {
 
         **How the per-tick nudge works:** every ~15 min you get a one-line tick message carrying
         the mode and act flag, pointing at `\(judgeInstructionsFileName)` by absolute path. Read
-        that file ONCE, on your first tick. Later ticks change only the mode/act line, so
-        re-reading it every tick just spends your own context on your own heartbeat — which is
-        what makes a desk hit its handoff ceiling early. If a tick arrives and you have not read
-        the file yet (fresh session, or you took over from a predecessor), read it then.
+        that file ONCE, on your first tick; re-reading it every tick just spends your own context
+        on your own heartbeat, which is what makes a desk hit its handoff ceiling early.
+
+        **The exception, and it matters:** that file is MODE-SPECIFIC — the merge rule is not the
+        same under daywatch and nightwatch, and this desk is reused across a mode switch without
+        being respawned. So the tick line tells you which case you are in. When it says the
+        instructions CHANGED, re-read the file before acting; a memorized copy from the previous
+        shift may grant or withhold a merge that the current shift does not. Never infer this
+        yourself from the mode — act on what the tick line says.
 
         **Your job (\(modeLabel)):**
         \(jobDescription(mode: mode))
@@ -111,13 +116,21 @@ public enum NightwatchDeskPrompts {
     /// mechanism whose entire job is to keep the desk alive. The body now lives in
     /// a file; this carries only what changes.
     ///
-    /// Two details are load-bearing rather than cosmetic:
+    /// Three details are load-bearing rather than cosmetic:
     ///
     /// - **The mode and act flag are inline**, not in the file, so a judge that
     ///   already read the instructions needs nothing from disk to act on this tick.
-    /// - **It tells the judge not to re-read.** Without that, the paste cost simply
-    ///   becomes a `Read` cost and nothing is saved. The saving is real only if the
-    ///   file is read once per session, not once per tick.
+    /// - **A steady-state tick tells the judge not to re-read.** Without that, the
+    ///   paste cost simply becomes a `Read` cost and nothing is saved. The saving is
+    ///   real only if the file is read once per session, not once per tick.
+    /// - **`instructionsChanged` overrides that and demands a re-read.** The first
+    ///   version of this said "later ticks change only the mode/act line", which is
+    ///   false: the desk session is deliberately reused across daywatch ↔ nightwatch
+    ///   switches without respawning, and `mergeRule(mode:)` differs between them —
+    ///   nightwatch grants an unattended `gh pr merge` that daywatch withholds. A
+    ///   judge told never to re-read would carry a memorized authorization from the
+    ///   previous shift across the flip. Caught in review of PR #551, which is itself
+    ///   about stale facts baked into these prompts.
     ///
     /// Short pastes are also more likely to *arrive*: a large paste can land as
     /// `[Pasted text #N]` and sit in the composer unsubmitted, which for an
@@ -126,12 +139,23 @@ public enum NightwatchDeskPrompts {
     /// - Parameters:
     ///   - mode: current shift; also determines the act flag the judge applies
     ///   - instructionsPath: absolute path to the written `JUDGE-INSTRUCTIONS.md`
-    public static func judgeNudge(mode: NightwatchMode, instructionsPath: String) -> String {
+    ///   - instructionsChanged: true when this tick's body differs from the last one
+    ///     the judge was nudged with — a mode flip, or the first tick of a session,
+    ///     where "what I already read" is either wrong or absent. The caller decides;
+    ///     the safe default at any call site that cannot tell is `true`.
+    public static func judgeNudge(
+        mode: NightwatchMode,
+        instructionsPath: String,
+        instructionsChanged: Bool
+    ) -> String {
         let icon = mode == .daywatch ? "◐" : "🌙"
         let act = mode == .nightwatch
+        let readInstruction = instructionsChanged
+            ? "The instructions CHANGED since your last tick (or this is your first) — RE-READ \(instructionsPath) before you act. The merge rule differs by mode; do not act on a memorized copy."
+            : "Already read \(instructionsPath) this session? Don't re-read it — nothing in it changed since your last tick."
         return """
         \(icon) Judge tick — mode: \(mode.rawValue), act=\(act). Run the cycle per \(instructionsPath). \
-        Already read that file this session? Don't re-read it — this line carries the only thing that changes between ticks.
+        \(readInstruction)
         """
     }
 

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -95,7 +95,28 @@ terminals verified DONE — every hand-composed "resume" wake would have been st
 
 ## The gate (never automate past this)
 
-A PR may only be enqueued when **claude-review = APPROVED on the current SHA + checks clean**. Human approval never substitutes. `gh pr merge` is NOT a safe-wedge — it always escalates. nightwatch's job is to get PRs *ready*; the human merges.
+A PR may only be enqueued when **claude-review = APPROVED on the current SHA + checks clean**. Human approval never substitutes for the bot verdict.
+
+**Merging (revised 2026-07-29 — this replaces the older "the human merges" rule).** The
+**nightwatch** judge MAY enqueue a **loop-perfect PR authored by `zionts`**, and only those.
+Daywatch does not merge: it runs while a human is around, so it *reports* a loop-perfect PR and
+stops. Loop-perfect means all three hold at once, re-read in the same tool call as the merge:
+
+- `mergeable_state` is `clean`
+- `claude-review` = APPROVED **on the current head SHA** (a verdict on an older SHA is not a verdict)
+- every required status context is green — currently **10** on `longeye-ai/monorepo`; the 11th,
+  `Merge Queue Result`, is reported from *inside* the queue and cannot be green beforehand
+
+**Never `--admin`.** Never anyone else's PR — not a teammate's, not a bot's. A judge never merges
+*toward* green: anything short of loop-perfect goes back to its owner, or to the human. Auto-approving
+a `gh pr merge` permission wedge is still forbidden (see `config/safe_wedges.txt`) — a merge is a
+deliberate act after the three checks above, never a rubber-stamped prompt.
+
+`main` sits behind a **merge queue**, so `gh pr merge <N>` *enqueues*; it does not merge. GitHub runs
+the queue's own checks and merges when they pass. The line
+`! The merge strategy for main is set by the merge queue` is a **warning, not a failure** — the
+enqueue succeeded. Do not retry it, do not bolt on `--squash`/`--merge` to "fix" it, and do not
+report it as a blocked merge.
 
 **Send-time verification — the wake.py rule applies to EVERY PR-state message, not just wakes.**
 Before dispatching any message that asserts PR state (a gate denial, a "checks failing" nudge, a
@@ -117,7 +138,10 @@ is an *archive question for the human*, not a harvest to fire. Report it and mov
 they are wrong; this rule wins.)
 
 **Hand off at the context ceiling — never push through it.** A judge session that runs past
-~200k tokens starts truncating its own shift. Do not "flag for respawn" and keep working, and
+~600k tokens starts truncating its own shift. (The ceiling was 200k until 2026-07-29; on a
+1000k Opus window that forced a relay roughly every two hours, so the desk spent its shift
+handing off instead of judging. `handoff.py --check` is the authority — don't eyeball it.)
+Do not "flag for respawn" and keep working, and
 do NOT use `tbd terminal close --all` — **that command does not exist** (there is no
 `tbd terminal close` subcommand at all; the only real close is killing the tmux window).
 The working relay is `scripts/handoff.py`:
@@ -154,23 +178,35 @@ tab; the old tab disappears when the successor closes it.
 
 ## Config (`config/`)
 - `priorities.txt` — must-keep-moving worktrees (flagged ★, reported first)
-- `safe_wedges.txt` — permission-wedge prefixes a future daemon may auto-approve (never `gh pr merge`)
+- `safe_wedges.txt` — permission-wedge prefixes a daemon may auto-approve (never `gh pr merge`: the
+  nightwatch judge merges deliberately, after the three gate checks — never by rubber-stamping a prompt)
 - `dont_touch.txt` — panes/names nightwatch must never nudge (human-driven, e.g. Adam's own session)
 
-## There is no babysitter daemon (retired 2026-07-25)
+## The babysitter daemon is machine-local — this skill does not ship one
 
-This section used to describe a "durable spine already on launchd": `scripts/daemon.py`
-auto-approving safe wedges, `scripts/watchdog.sh` restarting it, both "currently live as
-`~/.fleet/babysitter_daemon.py`". **None of it ever existed** — no scripts in this skill, no
-`~/.fleet/`, no launchd jobs, no plists, no log. Every tick dutifully reported
-`daemon: log-missing` as though a live service had crashed, and judge sessions burned five
-days escalating a *restart* for software with no install to restore.
+**This skill installs no daemon.** There is no `scripts/daemon.py` and no `scripts/watchdog.sh`
+in `NightwatchSkillContent.scripts`, so on a fresh install nothing auto-approves wedges and
+`tick.py`'s `daemon_health()` is a stub. `config/safe_wedges.txt` is the allowlist a daemon
+*would* consult, kept for that reason; without one, wedges route through judge ticks.
 
-The fleet ran fine without it. `tick.py`'s `daemon_health()` is now a stub, `config/safe_wedges.txt`
-is the allowlist a future daemon *would* use (kept for that reason), and wedges route through
-judge ticks. If you ever build one: it types into ~96 live panes, so it MUST use the composer
-ghost-guard in `_composer()` — before that guard existed the dispatch path would have fired dim
-suggestions and raw mouse escape sequences as if a human had typed them.
+**But "there is no babysitter daemon anywhere" is false, and a judge must not reason from it.**
+An operator can install one out-of-band, and on this fleet's box one is live: LaunchAgents
+`com.fleet-babysitter` (KeepAlive, running `~/.fleet/babysitter_daemon.py`) and
+`com.fleet-babysitter-watchdog` (StartInterval 300, kickstarting it when its log goes stale
+past 30 min of *awake* time). Both plists date to 2026-06-23. It auto-approves a narrow
+read-only wedge allowlist across live panes and appends everything else to an escalation file.
+A 2026-07-25 edit to this section asserted none of it had ever existed; that was wrong, and it
+propagated into the desk prompts as "nothing will restart you" — see the handoff rule above for
+what actually keeps a shift alive.
+
+Two things that daemon does **not** do, so don't wait on them: it does not restart the *desk
+session* (only `handoff.py --act` does that, and only because you ran it), and it never merges —
+`gh pr merge` is deliberately excluded from its allowlist, because a merge is a judged act, not a
+rubber-stamped prompt.
+
+If you build one: it types into ~96 live panes, so it MUST use the composer ghost-guard in
+`_composer()` — before that guard existed the dispatch path would have fired dim suggestions and
+raw mouse escape sequences as if a human had typed them.
 
 ## TBD integration
 - **Read:** `~/tbd/state.db` (worktrees/terminals/`tmuxServer` per pane — pane IDs collide across servers, always read the server, never hardcode)
@@ -237,7 +273,7 @@ QUEUE = f"{SKILL}/queue"
 STANDING_RULE = ("If the task is complete, SAY SO AND STOP — do not run /closeout. "
                  "A finished-looking worktree is an archive question for the human, "
                  "not a harvest to fire. Resume only if genuinely unfinished. "
-                 "Do NOT merge — the human merges.")
+                 "Do NOT merge your own PR — the nightwatch judge or the human does that.")
 
 
 def sh(args, t=20, cwd=None):
@@ -721,17 +757,23 @@ def _composer(lines, raw_lines=None):
     return ""
 
 def daemon_health():
-    """Health of the babysitter daemon — which does not exist on this machine.
+    """Deliberately unwired: this skill ships no babysitter daemon.
 
-    Retired 2026-07-25 (Chang's call). There is no daemon.py, no watchdog, no
-    launchd job and no log: the "durable spine" SKILL.md described was never
-    built. For five days every tick reported `daemon: log-missing` as if a live
-    service had fallen over, and judge sessions kept escalating a restart for
-    software that had no install to restore. The fleet ran fine without it.
-    Kept as a stub returning absent=True so anything still reading
+    Retired as a live check 2026-07-25 (Chang's call), because it probed a
+    `scripts/daemon.py` this skill has never installed and reported
+    `daemon: log-missing` every tick as if a live service had fallen over —
+    judge sessions then escalated a *restart* for software with no install to
+    restore. The fleet ran fine without it.
+
+    The stub is NOT an assertion that no daemon exists anywhere. An operator may
+    run one out-of-band, and this fleet does (SKILL.md, "The babysitter daemon is
+    machine-local"). It stays unwired because a machine-local install is not this
+    skill's to health-check, and a shipped probe would go back to crying wolf on
+    every box that has none. Returns absent=True so anything reading
     tick-report.json["daemon"] gets a shape instead of a KeyError.
     """
-    return {"ok": True, "absent": True, "age_s": None, "reason": "no-daemon (retired 2026-07-25)"}
+    return {"ok": True, "absent": True, "age_s": None,
+            "reason": "not-checked (this skill ships no daemon; a machine-local one may exist)"}
 
 def fleet():
     rows = sh(["sqlite3","-separator","\t",DB,
@@ -1008,7 +1050,11 @@ import time
 
 QUEUE = pathlib.Path(__file__).resolve().parent.parent / "queue"
 LATEST = QUEUE / "HANDOFF-LATEST.md"
-DEFAULT_THRESHOLD = 200_000
+# 600k of a 1000k Opus window. Raised from 200k on 2026-07-29: at 200k a desk
+# session hit the ceiling roughly every two hours and spent the shift relaying
+# instead of judging, while the model it runs on had 800k of headroom left.
+# 600k still leaves ~400k of slack for the handoff write + the successor's boot.
+DEFAULT_THRESHOLD = 600_000
 SUCCESSOR_MODEL = "opus"
 
 
@@ -1236,15 +1282,20 @@ def selftest():
 
     # context_tokens: the reported figure is input + BOTH cache buckets, and the
     # largest record in the tail wins (the tail holds smaller earlier turns).
+    # Derived from DEFAULT_THRESHOLD, never a literal: the 2026-07-29 raise to
+    # 600k silently turned a hardcoded 250_000 "over" fixture into an "under"
+    # one, so the selftest would have kept passing while asserting the opposite
+    # of its own label.
+    over_total = DEFAULT_THRESHOLD + 50_000
     with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
-        for total in (10_000, 250_000, 40_000):
+        for total in (10_000, over_total, 40_000):
             fh.write(json.dumps({"message": {"usage": {
                 "input_tokens": total - 30, "cache_creation_input_tokens": 20,
                 "cache_read_input_tokens": 10}}}) + "\n")
         fh.write("not json at all\n")          # tolerated, not fatal
         fh.write(json.dumps({"message": {}}) + "\n")   # no usage block
         path = fh.name
-    check("largest usage record wins", context_tokens(path), 250_000)
+    check("largest usage record wins", context_tokens(path), over_total)
     check("over ceiling exits 10", with_row({"transcriptPath": path}), 10)
 
     with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as fh:
@@ -1404,7 +1455,11 @@ def main():
             adv = a.get("advance_skill")
             ready = (verdict == "APPROVED" and mstate == "clean")
             if ready:
-                for_adam.append(f"READY — #{pr}: claude-APPROVED + clean. Human merge.")
+                # Reported, never merged here: this script has no head-SHA or
+                # required-context check, and the gate wants all three re-read in
+                # the same tool call as the enqueue. The judge does that itself.
+                for_adam.append(f"READY — #{pr}: claude-APPROVED + clean. Judge may enqueue "
+                                f"(`gh pr merge {pr}`) after re-reading head SHA + required contexts.")
             elif owner and adv and a.get("state") != "WORKING":
                 txt = f"nightwatch: PR #{pr} not yet claude-APPROVED ({verdict}). Run `/{adv}` to drive it to APPROVED on the current SHA. Do NOT merge."
                 if not sat and dispatch(owner["tid"], txt, act): acted += 1; tag = "DISPATCHED"

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import TestSupport
 @testable import TBDDaemonLib
 @testable import TBDShared
 
@@ -364,6 +365,115 @@ extension TBDHomeSerialized {
             await manager.nudgeDeskSession(worktreeID: desk.id, act: false)
             #expect(!FileManager.default.fileExists(atPath: instructions.path),
                     "the overlap guard let a second nudge through inside its window")
+        }
+
+        /// The finding that rejected PR #551's first head: the desk is reused
+        /// across a daywatch ↔ nightwatch flip without respawning, while the judge
+        /// is told to read `JUDGE-INSTRUCTIONS.md` once. Nothing on the judge's
+        /// side can observe the file being rewritten underneath it, so the daemon
+        /// has to track which mode it last nudged with and say when that changes.
+        ///
+        /// Every previous test here nudged exactly once, which is why the gap
+        /// survived: a single-tick test cannot see a transition by construction.
+        /// The injected clock is what makes a second tick reachable past the
+        /// 10-minute overlap guard.
+        @Test("a mode flip between ticks is tracked, and only the flip is a change")
+        func testModeFlipBetweenTicksIsTracked() async throws {
+            let tmpHome = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("tbd-desk-flip-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: tmpHome, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tmpHome) }
+
+            setenv("TBD_HOME", tmpHome.path, 1)
+            defer { unsetenv("TBD_HOME") }
+
+            let db = try TBDDatabase(inMemory: true)
+            let lifecycle = WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            )
+            let skillDir = tmpHome.appendingPathComponent("skills/nightwatch").path
+
+            // Walk the clock forward past the overlap guard between ticks.
+            let clock = TestDateSource(Date(timeIntervalSince1970: 1_000_000))
+            let manager = DeskSessionManager(
+                db: db,
+                lifecycle: lifecycle,
+                tmux: TmuxManager(dryRun: true),
+                skillDir: skillDir,
+                now: clock.provider
+            )
+
+            let desk = try await manager.ensureDeskSession(mode: .daywatch)
+            let instructions = URL(fileURLWithPath: desk.path)
+                .appendingPathComponent(NightwatchDeskPrompts.judgeInstructionsFileName)
+
+            // Nothing nudged yet: a judge that has read nothing must read.
+            #expect(await manager.lastNudgedMode == nil)
+
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+            #expect(await manager.lastNudgedMode == .daywatch)
+            var body = try String(contentsOf: instructions, encoding: .utf8)
+            #expect(!body.contains("you MAY run `gh pr merge"),
+                    "daywatch tick wrote an authorization daywatch does not grant")
+
+            // Same mode, a tick later: steady state, nothing changed.
+            clock.advance(by: 11 * 60)
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+            #expect(await manager.lastNudgedMode == .daywatch)
+
+            // The flip. The body on disk must now grant the merge, and the manager
+            // must know the judge's memorized copy predates it.
+            clock.advance(by: 11 * 60)
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            #expect(await manager.lastNudgedMode == .nightwatch,
+                    "manager did not record the flip; the next tick would claim nothing changed")
+            body = try String(contentsOf: instructions, encoding: .utf8)
+            #expect(body.contains("you MAY run `gh pr merge"),
+                    "nightwatch tick left the daywatch body on disk")
+        }
+
+        /// A nudge that never reached the session must not count as "the judge has
+        /// seen this mode" — otherwise the next tick reports no change across a
+        /// flip the judge never learned about. Exercised via the overlap guard,
+        /// which is the reachable way to make a nudge return without pasting.
+        @Test("a skipped nudge does not advance the recorded mode")
+        func testSkippedNudgeDoesNotRecordMode() async throws {
+            let tmpHome = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("tbd-desk-skipmode-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: tmpHome, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tmpHome) }
+
+            setenv("TBD_HOME", tmpHome.path, 1)
+            defer { unsetenv("TBD_HOME") }
+
+            let db = try TBDDatabase(inMemory: true)
+            let lifecycle = WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            )
+            let skillDir = tmpHome.appendingPathComponent("skills/nightwatch").path
+            let clock = TestDateSource(Date(timeIntervalSince1970: 2_000_000))
+            let manager = DeskSessionManager(
+                db: db,
+                lifecycle: lifecycle,
+                tmux: TmuxManager(dryRun: true),
+                skillDir: skillDir,
+                now: clock.provider
+            )
+
+            let desk = try await manager.ensureDeskSession(mode: .daywatch)
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+            #expect(await manager.lastNudgedMode == .daywatch)
+
+            // Inside the window: guarded, so the flip never reaches the session.
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            #expect(await manager.lastNudgedMode == .daywatch,
+                    "a nudge the guard dropped still recorded its mode; the judge would never be told it changed")
         }
 
         @Test("concurrent ensureDeskSession calls are serialized — single desk")

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -476,6 +476,66 @@ extension TBDHomeSerialized {
                     "a nudge the guard dropped still recorded its mode; the judge would never be told it changed")
         }
 
+        /// A respawned judge has read nothing, so it must be told to read.
+        ///
+        /// `lastNudgedMode` is keyed on the mode, not on which session is running
+        /// — so a crash-respawn that does NOT change mode leaves it matching, and
+        /// the next nudge tells a session that has opened no files "don't
+        /// re-read". The mode-flip guard was necessary but not sufficient: it
+        /// answered "did the instructions change under the reader" and missed
+        /// "did the reader change under the instructions".
+        ///
+        /// The pre-existing respawn test never nudged afterward, which is why
+        /// this was invisible to it.
+        @Test("respawning the desk terminal makes the next nudge demand a re-read")
+        func testRespawnClearsTheReadMemory() async throws {
+            let tmpHome = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("tbd-desk-respawn-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: tmpHome, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tmpHome) }
+
+            setenv("TBD_HOME", tmpHome.path, 1)
+            defer { unsetenv("TBD_HOME") }
+
+            let db = try TBDDatabase(inMemory: true)
+            let lifecycle = WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            )
+            let skillDir = tmpHome.appendingPathComponent("skills/nightwatch").path
+            let clock = TestDateSource(Date(timeIntervalSince1970: 3_000_000))
+            let manager = DeskSessionManager(
+                db: db,
+                lifecycle: lifecycle,
+                tmux: TmuxManager(dryRun: true),
+                skillDir: skillDir,
+                now: clock.provider
+            )
+
+            let desk = try await manager.ensureDeskSession(mode: .nightwatch)
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            #expect(await manager.lastNudgedMode == .nightwatch)
+
+            // The judge's terminal dies; ensure respawns a fresh session into the
+            // same worktree, with the mode unchanged — the exact case where a
+            // mode-only guard reports "nothing changed".
+            try await db.terminals.deleteForWorktree(worktreeID: desk.id)
+            let recovered = try await manager.ensureDeskSession(mode: .nightwatch)
+            #expect(recovered.id == desk.id, "expected the same desk to be recovered, not a new one")
+
+            #expect(await manager.lastNudgedMode == nil,
+                    "respawned judge would be told 'don't re-read' despite having read nothing")
+
+            // And the dead session's rate-limit window must not silence the new
+            // session's first tick: this nudge lands immediately, without the
+            // clock having moved past the 10-minute guard.
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            #expect(await manager.lastNudgedMode == .nightwatch,
+                    "first nudge to the respawned session was suppressed by the dead session's window")
+        }
+
         @Test("concurrent ensureDeskSession calls are serialized — single desk")
         func testConcurrentEnsureSerialized() async throws {
             let tmpHome = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -272,6 +272,100 @@ extension TBDHomeSerialized {
             // If this reaches here without exception, the overlap guard worked
         }
 
+        /// The ~5 KB judge instructions must land on disk, not in the session.
+        ///
+        /// Asserted on the file's *content*, not just its existence: the failure
+        /// this guards against is a pointer to a file that is empty, stale, or
+        /// written for the other mode — all of which leave the desk pointed at
+        /// something, which is exactly as bad as pointing at nothing while looking
+        /// healthier.
+        @Test("nudgeDeskSession writes mode-correct judge instructions into the desk")
+        func testNudgeWritesInstructionsFile() async throws {
+            let tmpHome = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("tbd-desk-instr-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: tmpHome, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tmpHome) }
+
+            setenv("TBD_HOME", tmpHome.path, 1)
+            defer { unsetenv("TBD_HOME") }
+
+            let db = try TBDDatabase(inMemory: true)
+            let lifecycle = WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            )
+            let skillDir = tmpHome.appendingPathComponent("skills/nightwatch").path
+            let manager = DeskSessionManager(
+                db: db,
+                lifecycle: lifecycle,
+                tmux: TmuxManager(dryRun: true),
+                skillDir: skillDir
+            )
+
+            let desk = try await manager.ensureDeskSession(mode: .nightwatch)
+            let instructions = URL(fileURLWithPath: desk.path)
+                .appendingPathComponent(NightwatchDeskPrompts.judgeInstructionsFileName)
+
+            // Written at spawn, before any tick fires.
+            #expect(FileManager.default.fileExists(atPath: instructions.path),
+                    "desk spawn did not lay down \(NightwatchDeskPrompts.judgeInstructionsFileName)")
+
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            let written = try String(contentsOf: instructions, encoding: .utf8)
+            #expect(written == NightwatchDeskPrompts.judgePrompt(mode: .nightwatch, skillDir: skillDir),
+                    "instructions file does not match the nightwatch judge prompt the pointer promises")
+            #expect(written.contains("you MAY run `gh pr merge"),
+                    "act=true wrote the daywatch body; the judge would be told it may not merge")
+        }
+
+        /// The overlap guard previously had no observable — the old test could only
+        /// assert "doesn't throw", which passes just as well if the guard is gone.
+        /// The instructions write gives it one: a skipped nudge should touch
+        /// nothing, so a deleted file stays deleted.
+        @Test("a nudge skipped by the overlap guard does no work at all")
+        func testSkippedNudgeWritesNothing() async throws {
+            let tmpHome = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("tbd-desk-skip-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: tmpHome, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tmpHome) }
+
+            setenv("TBD_HOME", tmpHome.path, 1)
+            defer { unsetenv("TBD_HOME") }
+
+            let db = try TBDDatabase(inMemory: true)
+            let lifecycle = WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            )
+            let skillDir = tmpHome.appendingPathComponent("skills/nightwatch").path
+            let manager = DeskSessionManager(
+                db: db,
+                lifecycle: lifecycle,
+                tmux: TmuxManager(dryRun: true),
+                skillDir: skillDir
+            )
+
+            let desk = try await manager.ensureDeskSession(mode: .daywatch)
+            let instructions = URL(fileURLWithPath: desk.path)
+                .appendingPathComponent(NightwatchDeskPrompts.judgeInstructionsFileName)
+
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+            #expect(FileManager.default.fileExists(atPath: instructions.path))
+
+            try FileManager.default.removeItem(at: instructions)
+
+            // Second nudge inside the 10-minute window: guarded, so it must not
+            // reach the write.
+            await manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+            #expect(!FileManager.default.fileExists(atPath: instructions.path),
+                    "the overlap guard let a second nudge through inside its window")
+        }
+
         @Test("concurrent ensureDeskSession calls are serialized — single desk")
         func testConcurrentEnsureSerialized() async throws {
             let tmpHome = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -352,23 +352,51 @@ struct NightwatchDeskPromptsTests {
     @Test("The per-tick nudge carries the variables and points at the rest", arguments: liveModes)
     func judgeNudgeIsAPointer(mode: NightwatchMode) {
         let path = "/desk/\(NightwatchDeskPrompts.judgeInstructionsFileName)"
-        let nudge = NightwatchDeskPrompts.judgeNudge(mode: mode, instructionsPath: path)
+        for changed in [true, false] {
+            let nudge = NightwatchDeskPrompts.judgeNudge(
+                mode: mode, instructionsPath: path, instructionsChanged: changed)
 
-        #expect(nudge.contains(path), "nudge does not name the instructions file it points at")
-        #expect(nudge.contains("mode: \(mode.rawValue)"), "nudge does not carry the mode")
-        #expect(nudge.contains("act=\(mode == .nightwatch)"), "nudge does not carry the act flag")
+            #expect(nudge.contains(path), "nudge does not name the instructions file it points at")
+            #expect(nudge.contains("mode: \(mode.rawValue)"), "nudge does not carry the mode")
+            #expect(nudge.contains("act=\(mode == .nightwatch)"), "nudge does not carry the act flag")
 
-        // The whole reason for the split. `judgePrompt` is ~5 KB; if the nudge
-        // ever drifts back toward inlining it, this is what notices. The bound is
-        // deliberately loose — it catches a wall, not a reworded sentence.
-        #expect(nudge.utf8.count < 400,
-                "nudge is \(nudge.utf8.count) bytes; it is meant to be one line, not the instructions")
+            // The whole reason for the split. `judgePrompt` is ~5 KB; if the nudge
+            // ever drifts back toward inlining it, this is what notices. The bound is
+            // deliberately loose — it catches a wall, not a reworded sentence.
+            #expect(nudge.utf8.count < 500,
+                    "nudge is \(nudge.utf8.count) bytes; it is meant to be one line, not the instructions")
+        }
+    }
 
-        // Moving the body to a file only saves context if the file is read once
-        // per session rather than once per tick. Without this instruction the
-        // paste cost simply becomes a Read cost.
-        #expect(nudge.contains("Don't re-read"),
-                "nudge does not tell the judge to skip re-reading; the saving evaporates into per-tick Reads")
+    /// Both branches of the re-read instruction, which is a mode-switch gate and
+    /// therefore owes a test per branch (`CLAUDE.md`, Workflow).
+    ///
+    /// The steady-state branch is the optimization: without "don't re-read", the
+    /// paste cost merely becomes a `Read` cost and the change saves nothing.
+    /// The changed branch is the correction: the desk is reused across daywatch ↔
+    /// nightwatch without respawning, and the two instruction bodies differ on
+    /// whether an unattended `gh pr merge` is authorized — so a judge that obeyed
+    /// "never re-read" would carry the previous shift's merge rule across the flip.
+    /// Both are load-bearing and they contradict each other, which is exactly why
+    /// the caller has to choose rather than the prompt hardcoding one.
+    @Test("The nudge demands a re-read when the instructions changed, and only then",
+          arguments: liveModes)
+    func judgeNudgeSignalsInstructionChange(mode: NightwatchMode) {
+        let path = "/desk/\(NightwatchDeskPrompts.judgeInstructionsFileName)"
+
+        let changed = NightwatchDeskPrompts.judgeNudge(
+            mode: mode, instructionsPath: path, instructionsChanged: true)
+        #expect(changed.contains("RE-READ"),
+                "\(mode) changed-nudge does not tell the judge to re-read; a stale merge rule survives the flip")
+        #expect(!changed.contains("Don't re-read"),
+                "\(mode) changed-nudge both demands and forbids a re-read")
+
+        let steady = NightwatchDeskPrompts.judgeNudge(
+            mode: mode, instructionsPath: path, instructionsChanged: false)
+        #expect(steady.contains("Don't re-read"),
+                "\(mode) steady-nudge lost the skip-the-read instruction; the context saving evaporates")
+        #expect(!steady.contains("RE-READ"),
+                "\(mode) steady-nudge asks for a re-read every tick, which is the cost this removes")
     }
 
     /// The pointer and the file have to be described the same way in both places,

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -338,6 +338,50 @@ struct NightwatchDeskPromptsTests {
         }
     }
 
+    /// The per-tick nudge is a pointer, not a prompt.
+    ///
+    /// It is deliberately NOT in `prompts(mode:skillDir:)` above, so the policy
+    /// invariants — forbid `/closeout`, state the merge limits, name the relay —
+    /// are not asserted on it. That is the point of the split: those rules live in
+    /// the file it points at, and re-stating them every tick is the ~5 KB cost
+    /// this change exists to remove.
+    ///
+    /// What must hold instead is that the pointer is *self-sufficient for one
+    /// tick*: it carries the mode and act flag (the only per-tick variables) and
+    /// an unambiguous absolute path to everything else.
+    @Test("The per-tick nudge carries the variables and points at the rest", arguments: liveModes)
+    func judgeNudgeIsAPointer(mode: NightwatchMode) {
+        let path = "/desk/\(NightwatchDeskPrompts.judgeInstructionsFileName)"
+        let nudge = NightwatchDeskPrompts.judgeNudge(mode: mode, instructionsPath: path)
+
+        #expect(nudge.contains(path), "nudge does not name the instructions file it points at")
+        #expect(nudge.contains("mode: \(mode.rawValue)"), "nudge does not carry the mode")
+        #expect(nudge.contains("act=\(mode == .nightwatch)"), "nudge does not carry the act flag")
+
+        // The whole reason for the split. `judgePrompt` is ~5 KB; if the nudge
+        // ever drifts back toward inlining it, this is what notices. The bound is
+        // deliberately loose — it catches a wall, not a reworded sentence.
+        #expect(nudge.utf8.count < 400,
+                "nudge is \(nudge.utf8.count) bytes; it is meant to be one line, not the instructions")
+
+        // Moving the body to a file only saves context if the file is read once
+        // per session rather than once per tick. Without this instruction the
+        // paste cost simply becomes a Read cost.
+        #expect(nudge.contains("Don't re-read"),
+                "nudge does not tell the judge to skip re-reading; the saving evaporates into per-tick Reads")
+    }
+
+    /// The pointer and the file have to be described the same way in both places,
+    /// or the judge is told to read one file and handed another.
+    @Test("The initial prompt explains the pointer the judge will receive", arguments: liveModes)
+    func initialPromptExplainsTheNudgeProtocol(mode: NightwatchMode) {
+        let initial = NightwatchDeskPrompts.initialPrompt(mode: mode, skillDir: "/skill")
+        #expect(initial.contains(NightwatchDeskPrompts.judgeInstructionsFileName),
+                "initial prompt never names the file the per-tick nudge will point at")
+        #expect(initial.contains("ONCE"),
+                "initial prompt does not tell the judge to read the instructions once rather than per tick")
+    }
+
     /// Merging is the one action the two shifts differ on (Adam, 2026-07-29:
     /// nightwatch only). Daywatch runs while a human is around, so a loop-perfect
     /// PR is something it *reports*; the unattended shift is the one that acts.

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -9,10 +9,15 @@ import TBDShared
 /// agent behavior fleet-wide. Nothing asserted on their content until
 /// 2026-07-25, and by then the judge prompt had spent five days telling sessions
 /// to run `tbd terminal close --all` — a command that has never existed — as its
-/// context-ceiling remedy, and to merge PRs that the nightwatch gate reserves
-/// for the human.
+/// context-ceiling remedy.
 ///
 /// Each expectation below therefore pins a *policy invariant*, not phrasing.
+/// Which means: when the policy itself changes, these change with it. They did on
+/// 2026-07-29, when Adam authorized the nightwatch judge to merge his own
+/// loop-perfect PRs. The invariant did not disappear — it narrowed, from "never
+/// merge" to "merge only `zionts`-authored, only loop-perfect, never `--admin`,
+/// and only on the nightwatch shift". A test that had merely banned the substring
+/// `gh pr merge` would have had nothing left to say about that.
 @Suite("Nightwatch desk prompt policy invariants")
 struct NightwatchDeskPromptsTests {
     /// Modes that actually reach a desk session. `.off` is a programmer-error
@@ -47,23 +52,45 @@ struct NightwatchDeskPromptsTests {
     @Test("The only context-ceiling remedy offered is the handoff relay", arguments: liveModes)
     func ceilingRemedyIsTheRelay(mode: NightwatchMode) {
         for (label, text) in prompts(mode: mode, skillDir: "/skill") {
-            let mentionsCeiling = text.contains("200k") || text.lowercased().contains("context ceiling")
+            let mentionsCeiling = text.contains("600k") || text.lowercased().contains("context ceiling")
             #expect(mentionsCeiling, "\(mode) \(label) never states the context ceiling")
 
             #expect(
                 text.contains("handoff.py"),
                 "\(mode) \(label) raises the context ceiling without naming the handoff relay"
             )
-            // No prompt may point at a recycler that does not exist. Asserted on
-            // concrete artifacts rather than on phrasing: a blacklist of wordings
-            // like "will restart you" is defeated from BOTH sides — a reworded
-            // reintroduction slips through, and the sentence that *forbids* the
-            // promise trips it, because a prohibition quotes what it prohibits.
-            // These names have no innocent reading in a prompt; none of them exist.
+            // No prompt may point the session at machine-local infrastructure as
+            // its remedy. Asserted on concrete artifacts rather than on phrasing:
+            // a blacklist of wordings like "will restart you" is defeated from
+            // BOTH sides — a reworded reintroduction slips through, and the
+            // sentence that *forbids* the promise trips it, because a prohibition
+            // quotes what it prohibits.
+            //
+            // These names were listed in 2026-07-25 as things that "were never
+            // built". That was wrong — `~/.fleet/babysitter_daemon.py` and its
+            // watchdog are real, launchd-loaded, and predate the claim by a month
+            // (see SKILL.md, "The babysitter daemon is machine-local"). The list
+            // survives on a *different* rationale, which is the durable one: this
+            // skill ships to any machine, and none of these paths is installed by
+            // it, so naming one in a shipped prompt points most readers at
+            // nothing. The relay is the remedy; a daemon is never the answer to a
+            // context ceiling either way.
             for phantom in ["daemon.py", "watchdog.sh", "~/.fleet", "babysitter_daemon"] {
                 #expect(
                     !text.contains(phantom),
-                    "\(mode) \(label) points at \(phantom), which was never built"
+                    "\(mode) \(label) points at \(phantom), which this skill does not install"
+                )
+            }
+            // The 2026-07-25 error that this file's own comment propagated: the
+            // prompts told the judge "nothing will restart you", which reads as
+            // "your handoff is pointless" — the exact inference that makes a
+            // session push through its ceiling. No prompt may deny that a
+            // successor is reachable.
+            for despair in ["Nothing will restart you", "nothing will restart you",
+                            "no respawner", "there is no babysitter daemon"] {
+                #expect(
+                    !text.contains(despair),
+                    "\(mode) \(label) tells the judge nothing can succeed it (\"\(despair)\"), which makes the handoff relay look pointless"
                 )
             }
         }
@@ -102,16 +129,50 @@ struct NightwatchDeskPromptsTests {
         #expect(text.contains("NEVER closes itself"))
     }
 
-    @Test("No prompt authorizes a merge — the human merges", arguments: liveModes)
-    func noMergeAuthorization(mode: NightwatchMode) {
+    /// Merging is authorized as of 2026-07-29, but narrowly. The dangerous
+    /// failure is no longer "the prompt permits a merge" — it is a prompt that
+    /// permits one while dropping any of the three limits, because a judge acting
+    /// on a partial rule merges someone else's PR, or merges toward green, and
+    /// both are irreversible on a repo behind a merge queue.
+    ///
+    /// So each limit is pinned separately: an author scope, a completeness bar,
+    /// and the `--admin` prohibition. Dropping any single clause reds this test.
+    @Test("Every prompt states all three limits on the merge authorization", arguments: liveModes)
+    func mergeAuthorizationIsBounded(mode: NightwatchMode) {
         for (label, text) in prompts(mode: mode, skillDir: "/skill") {
             #expect(
-                text.contains("NEVER run `gh pr merge`") || text.contains("never run `gh pr merge`"),
-                "\(mode) \(label) does not forbid `gh pr merge`; the SKILL.md gate reserves merging for the human"
+                text.contains("`zionts`"),
+                "\(mode) \(label) authorizes merging without naming whose PRs qualify"
+            )
+            #expect(
+                text.contains("loop-perfect"),
+                "\(mode) \(label) authorizes merging without the completeness bar"
+            )
+            #expect(
+                text.contains("Never `--admin`") || text.contains("never `--admin`"),
+                "\(mode) \(label) does not forbid `--admin`, which bypasses the gate entirely"
             )
             #expect(
                 !text.contains("Merge PRs cleared"),
-                "\(mode) \(label) authorizes merging cleared PRs, contradicting the gate"
+                "\(mode) \(label) authorizes merging cleared PRs in general, ignoring the author scope"
+            )
+        }
+    }
+
+    /// `gh pr merge` on a merge-queue repo *enqueues*, and prints
+    /// `! The merge strategy for main is set by the merge queue` while succeeding.
+    /// A judge that reads that `!` as a failure retries the merge, or reports a
+    /// merged PR as blocked — so the prompt has to say which it is.
+    @Test("Every prompt disambiguates the merge-queue warning", arguments: liveModes)
+    func mergeQueueWarningExplained(mode: NightwatchMode) {
+        for (label, text) in prompts(mode: mode, skillDir: "/skill") {
+            #expect(
+                text.contains("merge queue"),
+                "\(mode) \(label) tells the judge to merge without mentioning the merge queue"
+            )
+            #expect(
+                text.contains("warning, not a failure"),
+                "\(mode) \(label) does not tell the judge the merge-queue notice is not an error"
             )
         }
     }
@@ -148,15 +209,31 @@ struct NightwatchDeskPromptsTests {
     /// It must not contradict the prompt.
     @Suite("Shipped nightwatch skill content")
     struct SkillContentTests {
-        @Test("SKILL.md does not claim a babysitter daemon exists")
-        func noBabysitterDaemonClaim() {
+        /// Two errors, in opposite directions, both of which SKILL.md has made.
+        ///
+        /// Before 2026-07-25 it advertised a "durable spine already on launchd"
+        /// that this skill has never installed, and ticks escalated restarts for
+        /// software with no install to restore. The 2026-07-25 correction then
+        /// overshot into "none of it ever existed" — also false, since the
+        /// operator's `com.fleet-babysitter` LaunchAgents predate that claim by a
+        /// month — and that overshoot propagated into the desk prompts as
+        /// "nothing will restart you".
+        ///
+        /// The true statement sits between them and is the one pinned here: *this
+        /// skill ships no daemon*, which is a fact about the package rather than
+        /// about any machine, and is therefore still true wherever it installs.
+        @Test("SKILL.md claims neither a shipped daemon nor a universally absent one")
+        func babysitterDaemonClaimIsScoped() {
             let md = NightwatchSkillContent.skillMd
             for claim in ["durable spine (already on launchd",
                           "These keep the critical safety net running",
                           "`scripts/daemon.py` (babysitter) — auto-approves"] {
-                #expect(!md.contains(claim), "SKILL.md still asserts a babysitter daemon: \(claim)")
+                #expect(!md.contains(claim), "SKILL.md still asserts a shipped babysitter daemon: \(claim)")
             }
-            #expect(md.contains("There is no babysitter daemon"))
+            #expect(!md.contains("None of it ever existed"),
+                    "SKILL.md again claims no babysitter daemon exists anywhere; the operator's runs under launchd")
+            #expect(md.contains("this skill does not ship one"),
+                    "SKILL.md lost the scoped claim — that the absence is the package's, not the machine's")
         }
 
         @Test("SKILL.md carries the standing rules the prompts echo")
@@ -192,6 +269,37 @@ struct NightwatchDeskPromptsTests {
             }
             #expect(py.contains("refusing to close myself"),
                     "handoff.py lost the self-close guard the relay depends on")
+        }
+
+        /// The ceiling is the one number in this skill that both prompts quote in
+        /// prose, so a change to `DEFAULT_THRESHOLD` that misses the prose leaves
+        /// the judge acting on a figure the script disagrees with.
+        ///
+        /// The literal fixture is also pinned. `handoff.py --selftest` asserted
+        /// "over ceiling exits 10" against a hardcoded 250_000, which the raise to
+        /// 600k turned into an *under*-ceiling case — the selftest would have kept
+        /// passing while testing the opposite of its label, so the fixture is now
+        /// derived from `DEFAULT_THRESHOLD` and that derivation is what's checked.
+        @Test("The context ceiling is 600k in the script and in every prompt")
+        func ceilingIsConsistent() {
+            #expect(NightwatchSkillContent.handoffPy.contains("DEFAULT_THRESHOLD = 600_000"),
+                    "handoff.py's ceiling moved off 600k")
+            #expect(NightwatchSkillContent.handoffPy.contains("over_total = DEFAULT_THRESHOLD + 50_000"),
+                    "the selftest's over-ceiling fixture is a literal again; it will rot on the next raise")
+            #expect(NightwatchSkillContent.skillMd.contains("~600k tokens"),
+                    "SKILL.md quotes a ceiling other than the script's")
+
+            for mode in NightwatchDeskPromptsTests.liveModes {
+                for (label, text) in [
+                    ("initialPrompt", NightwatchDeskPrompts.initialPrompt(mode: mode, skillDir: "/skill")),
+                    ("judgePrompt", NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: "/skill"))
+                ] {
+                    #expect(!text.contains("200k"),
+                            "\(mode) \(label) still quotes the retired 200k ceiling as current")
+                    #expect(text.contains("600k"),
+                            "\(mode) \(label) does not state the 600k ceiling")
+                }
+            }
         }
 
         /// The never-/closeout standing rule has to hold for the whole shipped
@@ -230,14 +338,27 @@ struct NightwatchDeskPromptsTests {
         }
     }
 
-    @Test("Daywatch stays triage-only and nightwatch does not widen to merging")
+    /// Merging is the one action the two shifts differ on (Adam, 2026-07-29:
+    /// nightwatch only). Daywatch runs while a human is around, so a loop-perfect
+    /// PR is something it *reports*; the unattended shift is the one that acts.
+    ///
+    /// Both prompts still carry the full qualifying rule — see `mergeRule`'s doc
+    /// comment for why — so "daywatch does not merge" cannot be pinned by the
+    /// absence of merge vocabulary. It is pinned on the authorization sentence,
+    /// which is the only part that differs.
+    @Test("Only nightwatch is authorized to act on the merge rule")
     func modeSpecificScope() {
         let day = NightwatchDeskPrompts.judgePrompt(mode: .daywatch, skillDir: "/skill")
         let night = NightwatchDeskPrompts.judgePrompt(mode: .nightwatch, skillDir: "/skill")
 
         #expect(day.contains("triage only"))
-        // Nightwatch is the wider role, but "wider" must stop before merging.
-        #expect(night.contains("the human merges"))
+        #expect(day.contains("Merging is a NIGHTWATCH action"),
+                "daywatch judge prompt does not withhold the merge authorization")
+        #expect(!day.contains("you MAY run `gh pr merge"),
+                "daywatch judge prompt authorizes an unattended merge")
+
+        #expect(night.contains("you MAY run `gh pr merge"),
+                "nightwatch judge prompt withholds the authorization Adam granted 2026-07-29")
         #expect(!night.contains("act on everything the gate allows"))
         #expect(!night.contains("act on everything the gate approves"))
     }


### PR DESCRIPTION
Three facts baked into `Sources/TBDShared/NightwatchSkillContent.swift` and `NightwatchDeskPrompts.swift` had gone stale. That file is the source of truth the daemon installs to `~/Library/Application Support/TBD/plugin/skills/nightwatch` on every start, overwriting local edits — so this is the only place they can be fixed.

## 1. Context ceiling: 200k → 600k

The desk runs on Opus with a 1000k window. At 200k it hit the ceiling roughly every two hours and spent the shift relaying instead of judging, with 800k of headroom unused. Raised to 600k in `handoff.py`'s `DEFAULT_THRESHOLD`, in `SKILL.md`, and in both desk prompts.

**A trap worth calling out:** `handoff.py --selftest` asserted `"over ceiling exits 10"` against a hardcoded `250_000` fixture. Raising the ceiling to 600k turns that into an *under*-ceiling case — the selftest would have kept passing while asserting the opposite of its own label, and `PluginDirWriterTests.handoffPySelftest` would have gone red for a reason nobody would have connected to the ceiling. The fixture now derives from `DEFAULT_THRESHOLD`, and a test pins that derivation so the next raise can't re-plant it.

## 2. Merge authorization (Adam, 2026-07-29)

The prompts said `NEVER run gh pr merge` and *"the human merges"*. Replaced with the actual rule:

The **nightwatch** judge MAY merge a PR **authored by `zionts`**, and only his, once it is **loop-perfect** — all three re-read in the same tool call as the merge:

- `mergeable_state` is `clean`
- `claude-review` = APPROVED **on the current head SHA**
- every required status context green

Never `--admin`. Never anyone else's PR. Never merging *toward* green.

**Merge-queue nuance, now stated in the prompts.** `main` is behind a merge queue, so `gh pr merge <N>` *enqueues*; GitHub merges when the queue's checks pass. The line `! The merge strategy for main is set by the merge queue` is a **warning, not a failure**. A judge reading that `!` as an error retries a merge that already succeeded, or reports a merged PR as blocked.

**On the "10 required contexts":** confirmed against `longeye-ai/monorepo`'s rulesets — there are 11 required contexts, and the 11th is `Merge Queue Result`, which is reported from *inside* the queue and cannot be green beforehand. So 10 is exactly right pre-enqueue, and `SKILL.md` now says why rather than just quoting the number.

`gh pr merge` deliberately **stays off** `config/safe_wedges.txt`. That rule is about a daemon blind-approving a permission prompt; a judge merging after three explicit checks is a different act. Both prompts now say so, so the two rules don't read as contradictory.

**Daywatch does not merge** — it runs while a human is around, so it reports a loop-perfect PR and stops. This was the one thing your brief didn't specify and I asked about rather than guessing; both prompts still carry the full qualifying rule, because a shift that never reads the policy can't apply it when the shift flips.

## 3. "There is no babysitter daemon and no respawner. Nothing will restart you."

False, and load-bearing in the worst way: it tells the judge its handoff is pointless, which is precisely the inference that makes a session push through its ceiling.

What's actually true, verified on this box:

- `com.fleet-babysitter` — LaunchAgent, KeepAlive, **currently running**, beating every ~2 min
- `com.fleet-babysitter-watchdog` — `StartInterval` 300, kickstarts the daemon when its log goes stale past 30 min of *awake* time
- Both plists are dated **2026-06-23** — a month *before* the 2026-07-25 edit that declared "none of it ever existed"

That daemon auto-approves a narrow read-only wedge allowlist across worker panes and escalates everything else. It does **not** restart the desk session, and it never merges. What continues a shift is `handoff.py --act`, and it works.

The correction is scoped rather than flipped: `SKILL.md` now says **this skill ships no daemon** — a fact about the package, true wherever it installs — instead of a claim about the world. `tick.py`'s `daemon_health()` stays a stub for the same reason, with a docstring that no longer asserts the stronger claim.

## Tests

Updated with the policy, not deleted. The merge invariant didn't disappear, it narrowed — from "never merge" to three separately-pinned limits, so dropping any one clause reds the suite:

- author scope (`` `zionts` ``), completeness bar (`loop-perfect`), and the `--admin` prohibition, each asserted independently
- new: every prompt must disambiguate the merge-queue warning
- new: the ceiling agrees between `DEFAULT_THRESHOLD`, `SKILL.md`, and both prompts, and no prompt still quotes 200k as current
- new: no prompt may tell the judge nothing can succeed it (`"nothing will restart you"`, `"no respawner"`, …)
- `babysitterDaemonClaimIsScoped` now pins the middle ground and fails on *either* overshoot — a shipped-daemon claim or a universally-absent one

The phantom-path list (`daemon.py`, `~/.fleet`, …) survives on a corrected rationale, documented in the test: those paths are real, but this skill doesn't install them, so naming one in a prompt that ships everywhere points most readers at nothing.

## Verification

Everything below was actually run on this machine.

- `swift build --product TBDDaemon` — clean
- `swift test --filter Nightwatch` — **36 tests, 8 suites, all passed**
- `swift test --filter PluginDirWriter` — **13 tests passed**, including the `handoff.py` / `wake.py` / `tick.py` `--selftest` executions
- `swiftlint --strict` — clean
- All four embedded Python scripts extracted and `py_compile`d; `handoff.py --selftest` re-run directly against the new ceiling (`650,000 / ceiling 600,000 — OVER`)

**Correcting my own brief:** I was told `swift test` and `swiftlint` can't run here (Command Line Tools only, no full Xcode). That's true of the default toolchain, but not of this machine — `~/Library/Developer/Toolchains/swift-latest.xctoolchain` (Swift 6.3.2) has both, and with `TOOLCHAIN_DIR` set plus `Tests/TBDAppTests/ArchiveTombstoneTests.swift` (the one remaining `import XCTest` file) moved aside, the suite runs. Worth knowing, since it's the difference between shipping this on inspection and shipping it verified. It also caught two real defects I'd otherwise have handed to CI: a `//` comment I'd written inside the embedded Python, and a `String` concatenation where `#expect` wants a `Comment`.

`swift test` was **not** run across the full ~4500-test population — only the two filters above. The rest is CI's.

## Reported, not fixed: `/closeout` and `/anything-left`

I was asked to investigate rather than invent, and the premise turned out to be wrong in an interesting way.

**They exist.** Not as slash commands — as **user-invocable skills**, committed to `longeye-ai/monorepo` on `origin/main`:

```
.claude/skills/closeout/SKILL.md          + references/, scripts/
.claude/skills/anything-left/SKILL.md     + references/, scripts/
```

Both carry `user-invocable: true` and explicit `patterns:` entries (`/closeout`, `/anything-left`, plus natural-language triggers like *"am I done"*, *"is it safe to delete this worktree"*). Claude Code surfaces user-invocable skills as `/<name>`, so the invocation in the prompts is well-formed.

**They were never commands.** `git log --all --diff-filter=ADR -- '.claude/commands/*closeout*' '.claude/commands/*anything*'` returns nothing — there's no rename to find. The search that came up empty looked in `.claude/commands/`, which is a real directory in that repo (~60 commands), just never their home. So: not renamed, not unshipped — looked for in the wrong place.

**The one real caveat:** they're scoped to `longeye-ai/monorepo`. A judge sending `/closeout` to a session in a *different* repo's worktree — this one, for instance — hits nothing, and an unknown slash command is dropped without creating a user message, so it fails silently. That's a genuine footgun, but it's a different bug from "the command doesn't exist", and fixing it (repo-aware dispatch, or a skill-presence check before sending) is out of scope here. Filing rather than fixing.

None of this changes the standing rule: the prompts still forbid triggering `/closeout`, and this PR doesn't touch that.

## Notes

- No feature flag or migration: this is prose in a shipped skill, no `config` column, no load-bearing path replaced. No brainstorm spec per `CLAUDE.md`'s blast-radius rule — the policy change was decided by Adam, not originated by an agent.
- `wake.py`'s `STANDING_RULE` (sent to *worker* sessions) still forbids self-merging; only its stale justification changed, from "the human merges" to "the nightwatch judge or the human does".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
