### PR TITLE
fix: group remote sessions whose repo was renamed on the host

### DIFF
--- a/Sources/TBDShared/RemoteRepoMatching.swift
+++ b/Sources/TBDShared/RemoteRepoMatching.swift
@@ -81,13 +81,71 @@ public enum RemoteRepoMatching {
     /// Resolves `metaRepo` (a provider's `meta["repo"]` value) against
     /// `repos` by comparing normalized keys. Returns the first matching
     /// repo's id in `repos` order, or nil when `metaRepo` is nil/blank,
-    /// unparseable, or no repo's `remoteURL` normalizes to the same key.
+    /// unparseable, or no repo matches.
+    ///
+    /// Two passes, in this order — an exact `remoteURL` match must never lose
+    /// to the rename fallback, which is why this cannot be a single loop:
+    ///
+    /// 1. Exact: the provider's `org/name` equals the repo's `remoteURL`
+    ///    `org/name`. This is the normal case and the only one before renames
+    ///    were considered.
+    /// 2. Renamed-repo fallback: the **org** still agrees, and the provider's
+    ///    `name` equals the repo's local directory name. See
+    ///    `renamedRepoFallbackID` for why that is a real signal rather than a
+    ///    guess.
     public static func resolveRepoID(metaRepo: String?, repos: [Repo]) -> UUID? {
-        guard let metaRepo, let targetKey = normalizedKey(metaRepo) else { return nil }
+        guard let metaRepo, let target = segments(metaRepo) else { return nil }
+        let targetKey = "\(target.org.lowercased())/\(target.name.lowercased())"
+
         for repo in repos {
             guard let remoteURL = repo.remoteURL, let key = normalizedKey(remoteURL) else { continue }
             if key == targetKey { return repo.id }
         }
-        return nil
+        return renamedRepoFallbackID(target: target, repos: repos)
+    }
+
+    /// Second pass of `resolveRepoID`: tolerate a repo that has been **renamed
+    /// on the host** since the provider learned its name.
+    ///
+    /// A provider reports whatever name it clones by, and a host like GitHub
+    /// keeps serving the old name via a redirect indefinitely — so a provider
+    /// can go on reporting `acme/old-name` long after the repo became
+    /// `acme/new-name`, and pass 1 will never match it. Resolving the redirect
+    /// would mean a network call from a pure matching function, so instead we
+    /// use a signal already on disk: **a rename on the host does not rename
+    /// anyone's local clone directory**, so the directory usually still
+    /// carries the old name — the same name the provider is reporting.
+    ///
+    /// Deliberately kept narrow, because this is the one heuristic in an
+    /// otherwise deterministic matcher:
+    ///
+    /// - The org must still match the repo's `remoteURL`, so this can only
+    ///   ever pair repos already known to live under the same owner. It cannot
+    ///   introduce a cross-org match.
+    /// - Only the directory's own name is compared, never a path prefix.
+    /// - It runs only after pass 1 found nothing, so it can never override a
+    ///   real `remoteURL` match.
+    ///
+    /// Like pass 1, this returns the **first** match in `repos` order rather
+    /// than treating several as ambiguous. The same repo registered at two
+    /// paths is ordinary (a primary clone plus a worktree root), and it is
+    /// exactly the shape this fallback sees — both clones keep the old
+    /// directory name, so both match. Pass 1 already resolves that case by
+    /// taking the first; refusing to choose here would only mean the sessions
+    /// stay ungrouped for the users most likely to hit a rename.
+    private static func renamedRepoFallbackID(
+        target: (org: String, name: String), repos: [Repo]
+    ) -> UUID? {
+        let wantOrg = target.org.lowercased()
+        let wantName = target.name.lowercased()
+
+        return repos.first { repo in
+            guard let remoteURL = repo.remoteURL,
+                  let local = segments(remoteURL),
+                  local.org.lowercased() == wantOrg else { return false }
+            // Compare against the clone's directory name, not its remote name.
+            let directory = (repo.path as NSString).lastPathComponent.lowercased()
+            return directory == wantName
+        }?.id
     }
 }

--- a/Tests/TBDSharedTests/RemoteRepoMatchingTests.swift
+++ b/Tests/TBDSharedTests/RemoteRepoMatchingTests.swift
@@ -156,4 +156,55 @@ struct RemoteRepoMatchingTests {
         let repos = [repo(remoteURL: "https://github.com/other-org/api")]
         #expect(RemoteRepoMatching.resolveRepoID(metaRepo: "acme/api", repos: repos) == nil)
     }
+
+    // MARK: - resolveRepoID — renamed-repo fallback
+    //
+    // A provider keeps reporting the name it clones by, and the host serves
+    // that old name via a redirect long after a rename. The local clone's
+    // DIRECTORY is not renamed by that, so it still carries the old name.
+
+    private func repo(id: UUID = UUID(), remoteURL: String?, path: String) -> Repo {
+        Repo(id: id, path: path, remoteURL: remoteURL, displayName: "r", defaultBranch: "main")
+    }
+
+    @Test func resolveRepoID_matchesRenamedRepoViaDirectoryName() {
+        // Host renamed acme/old-name -> acme/api; the clone directory did not follow.
+        let target = repo(remoteURL: "https://github.com/acme/api", path: "/repos/old-name")
+        let resolved = RemoteRepoMatching.resolveRepoID(metaRepo: "acme/old-name", repos: [target])
+        #expect(resolved == target.id)
+    }
+
+    @Test func resolveRepoID_exactRemoteMatchBeatsRenameFallback() {
+        // Ordered so the fallback candidate comes FIRST: a single-pass loop
+        // would return it and lose the real match.
+        let decoy = repo(remoteURL: "https://github.com/acme/api", path: "/repos/old-name")
+        let exact = repo(remoteURL: "https://github.com/acme/old-name", path: "/repos/whatever")
+        let resolved = RemoteRepoMatching.resolveRepoID(metaRepo: "acme/old-name",
+                                                        repos: [decoy, exact])
+        #expect(resolved == exact.id)
+    }
+
+    @Test func resolveRepoID_renameFallbackRequiresSameOrg() {
+        // Directory name agrees but the owner does not — must NOT match, or the
+        // fallback would invent cross-org matches pass 1 forbids.
+        let repos = [repo(remoteURL: "https://github.com/other-org/api", path: "/repos/old-name")]
+        #expect(RemoteRepoMatching.resolveRepoID(metaRepo: "acme/old-name", repos: repos) == nil)
+    }
+
+    @Test func resolveRepoID_renameFallbackIgnoresPathPrefix() {
+        // Only the directory's own name counts; a parent segment must not match.
+        let repos = [repo(remoteURL: "https://github.com/acme/api", path: "/old-name/checkout")]
+        #expect(RemoteRepoMatching.resolveRepoID(metaRepo: "acme/old-name", repos: repos) == nil)
+    }
+
+    @Test func resolveRepoID_renameFallbackTakesFirstWhenRepoRegisteredTwice() {
+        // The real shape: one repo cloned twice (primary + worktree root), both
+        // directories keeping the old name. Pass 1 resolves duplicates by taking
+        // the first, so this must too rather than refusing to choose.
+        let first = repo(remoteURL: "https://github.com/acme/api", path: "/primary/old-name")
+        let second = repo(remoteURL: "git@github.com:acme/api.git", path: "/worktrees/old-name")
+        let resolved = RemoteRepoMatching.resolveRepoID(metaRepo: "acme/old-name",
+                                                        repos: [first, second])
+        #expect(resolved == first.id)
+    }
 }

--- a/Tests/TBDSharedTests/RemoteRepoMatchingTests.swift
+++ b/Tests/TBDSharedTests/RemoteRepoMatchingTests.swift
@@ -197,6 +197,14 @@ struct RemoteRepoMatchingTests {
         #expect(RemoteRepoMatching.resolveRepoID(metaRepo: "acme/old-name", repos: repos) == nil)
     }
 
+    @Test func resolveRepoID_renameFallbackIsCaseInsensitive() {
+        // Both sides are lowercased before comparing; nothing else pins that,
+        // and directory casing is whatever the person who cloned it typed.
+        let target = repo(remoteURL: "https://github.com/Acme/api", path: "/repos/Old-Name")
+        let resolved = RemoteRepoMatching.resolveRepoID(metaRepo: "acme/old-name", repos: [target])
+        #expect(resolved == target.id)
+    }
+
     @Test func resolveRepoID_renameFallbackTakesFirstWhenRepoRegisteredTwice() {
         // The real shape: one repo cloned twice (primary + worktree root), both
         // directories keeping the old name. Pass 1 resolves duplicates by taking


### PR DESCRIPTION
## The bug

Every remote session in my sidebar rendered ungrouped, permanently.

`resolveRepoID` matches a provider's `meta.repo` against each local repo's `remoteURL` as an exact `org/name` key. But a provider reports whatever name it *clones by*, and GitHub keeps serving a renamed repo's old name via a redirect indefinitely. So the provider goes on saying `acme/old-name` long after the repo became `acme/api`, the keys never agree, and the sessions have no repo forever.

Nothing about this is specific to one provider — any provider that cloned before a rename reports the stale name, and the redirect means it keeps working, so there is no error to notice.

## The fix

Resolving the redirect would put a network call inside a pure matching function. Instead this uses a signal already on disk: **a rename on the host does not rename anyone's local clone directory**, so the directory usually still carries exactly the name the provider is reporting.

Deliberately narrow, since it is the one heuristic in a type whose doc comment opens with "deterministic (not heuristic)":

- **Second pass only** — an exact `remoteURL` match can never lose to it. That is why it is two loops rather than one, and there is a test that fails on a single-pass implementation (`exactRemoteMatchBeatsRenameFallback` orders the fallback candidate first on purpose).
- **Org must still agree**, so it can only pair repos already known to live under the same owner. It cannot invent a cross-org match.
- **Only the directory's own name** is compared, never a path prefix.

## The one judgement call

It takes the **first** match rather than treating duplicates as ambiguous.

I wrote it the strict way first and it left my own case unfixed: one repo registered twice — a primary clone plus a worktree root — is ordinary, and it is exactly the shape this pass sees, because *both* clones keep the old directory name and both therefore match. Refusing to choose would leave sessions ungrouped precisely for the people who hit a rename. Pass 1 already resolves duplicate remotes by taking the first, so this matches the behaviour its docstring already promises rather than inventing stricter semantics one pass down.

## Verification

Five tests, covering both branches of the new conditional and each narrowing constraint.

**Local `swift test` cannot run here** — neither the default 6.2.1 toolchain nor the installed 6.3.2 one has swift-testing (`no such module 'Testing'`), so CI is the first real execution of these. Flagging that rather than implying I ran them. `swift build --product TBDDaemon` is clean.

What I could verify is stronger than the unit tests for this particular bug: I ran the real code path against real data. Four live remote sessions that all report the stale name went from `(ungrouped)` to resolving onto the correct local repo after restarting the daemon with this build.

```
before:  final-check  repoGroup=(ungrouped)      ... x4
after:   final-check  repoGroup=69E45D41-...     ... x4
```
