### PR TITLE
fix(ci): a complete cache restore can still hand you a broken workspace

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,6 +93,11 @@ jobs:
           restore-keys: |
             spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-
 
+      # Same exposure as the PR job: this restores the same cache entry, so it
+      # can inherit the same damaged-checkout state. See the script's header.
+      - name: Repair the restored SwiftPM workspace if it is damaged
+        run: bash scripts/repair-spm-workspace.sh
+
       # ── Step 1: live tmux probes ────────────────────────────────────────────
       # continue-on-error so a probe failure still lets the stress loop run and
       # still gets reported; the job is failed deliberately at the end.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,16 @@ jobs:
           restore-keys: |
             spm-build-${{ runner.os }}-${{ env.SWIFT_VERSION }}-deps-${{ hashFiles('Package.resolved') }}-
 
+      # A restored `.build/` can come back with a dependency checkout present but
+      # its manifest missing, which fails the job at manifest planning before a
+      # single test compiles (run 30557645064, PR #554 — a docs-only diff). The
+      # stored cache entry was intact; the rerun restored the same key and
+      # passed. Probe the workspace here and re-resolve if it is damaged, so that
+      # class of red self-heals instead of costing a rerun. Rationale, and why
+      # only checkouts/ and repositories/ are discarded, in the script's header.
+      - name: Repair the restored SwiftPM workspace if it is damaged
+        run: bash scripts/repair-spm-workspace.sh
+
       # Workaround for swiftlang/swift-package-manager#7715: a cache-restored
       # `.build/` can hold a stale object archive for a first-party library
       # target next to a fresh `.swiftmodule`. Downstream files (incl. test

--- a/scripts/repair-spm-workspace.sh
+++ b/scripts/repair-spm-workspace.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Repair a cache-restored SwiftPM workspace before anything tries to build it.
+#
+# A restored `.build/` can come back with a dependency checkout present but its
+# manifest missing. Observed on run 30557645064 (PR #554): `.build/checkouts/
+# swift-cmark/Package.swift` was absent after an error-free restore, SPM failed
+# at manifest planning ("the package manifest ... cannot be accessed"), and the
+# job went red before a single test compiled — on a docs-only diff.
+#
+# The stored cache entry was NOT the problem: the rerun restored the same key at
+# the same byte count and passed. So the damage is workspace-local, one runner's
+# copy, and a bare rerun clears it. That is precisely the red worth spending a
+# few seconds to prevent — a rerun costs ~6 minutes of CI and a human deciding
+# whether the failure was real.
+#
+# `swift package resolve` is the probe rather than a hand-rolled "does every
+# checkout have a Package.swift" check: it is SPM's own validation, so it also
+# catches damage a file-existence test would miss. On failure, discard only what
+# SPM can rebuild — `checkouts/` and `repositories/` — and resolve again.
+# Compiled artifacts under `.build/*/debug/` are untouched, so the cache stays
+# warm for everything except the dependencies themselves. (Re-cloned checkouts
+# get fresh mtimes, so the repair path does pay a dependency rebuild. That only
+# happens on a run that was otherwise going to fail outright.)
+#
+# Wired into .github/workflows/{test,nightly}.yml immediately after the cache
+# restore. Safe to run anywhere: on a cold workspace with no `.build/` it is a
+# no-op, and on a healthy one it is a single resolve.
+
+# Seam so the tests can drive both branches without a network or a toolchain.
+: "${SPM_RESOLVE_CMD:=swift package resolve}"
+
+resolve() { $SPM_RESOLVE_CMD; }
+
+main() {
+  if [[ ! -d .build ]]; then
+    echo "no .build/ — cold workspace, nothing to repair"
+    return 0
+  fi
+
+  if resolve; then
+    echo "restored SwiftPM workspace resolves cleanly"
+    return 0
+  fi
+
+  # Deliberately a warning, not an error: the run is expected to recover, and an
+  # ::error:: annotation on a green run reads as a failure to whoever skims it.
+  echo "::warning::swift package resolve failed on the restored workspace — discarding .build/checkouts and .build/repositories, then re-resolving. See scripts/repair-spm-workspace.sh."
+  rm -rf .build/checkouts .build/repositories
+
+  if resolve; then
+    echo "workspace repaired by re-resolving dependencies"
+    return 0
+  fi
+
+  # A second failure is not the cache-damage signature — it is a genuinely
+  # broken Package.resolved, an unreachable dependency, or a toolchain problem.
+  # Fail loudly here rather than let it surface later as a confusing test error.
+  echo "::error::swift package resolve still fails after discarding dependency checkouts — this is not restored-cache damage. Check Package.resolved and dependency availability."
+  return 1
+}
+
+# --- entrypoint (strict mode only when executed, not when sourced) -----------
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -uo pipefail
+  main "$@"
+fi

--- a/scripts/repair-spm-workspace.test.sh
+++ b/scripts/repair-spm-workspace.test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Tests for scripts/repair-spm-workspace.sh — run: bash scripts/repair-spm-workspace.test.sh
+# shellcheck disable=SC2329 # test_* are dispatched dynamically via `declare -F`/"$t" below
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/repair-spm-workspace.sh"
+
+FAIL=0
+assert_eq()       { if [[ "$2" == "$3" ]]; then echo "ok   - $1"; else echo "FAIL - $1: expected [$2] got [$3]"; FAIL=1; fi; }
+assert_contains() { if [[ "$2" == *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: [$2] lacks [$3]"; FAIL=1; fi; }
+assert_lacks()    { if [[ "$2" != *"$3"* ]]; then echo "ok   - $1"; else echo "FAIL - $1: [$2] unexpectedly contains [$3]"; FAIL=1; fi; }
+mktmpd()          { mktemp -d "${TMPDIR:-/tmp}/repair-spm-test.XXXXXX"; }
+
+# A workspace shaped like a cache restore: dependency checkouts plus warm
+# compiled artifacts. `damaged` drops the manifest the real failure was missing.
+_mk_workspace() {
+  local root="$1" damaged="${2:-healthy}"
+  mkdir -p "$root/.build/checkouts/swift-cmark" "$root/.build/repositories" "$root/.build/arm64-apple-macosx/debug"
+  : > "$root/.build/arm64-apple-macosx/debug/TBDShared.o"
+  [[ "$damaged" == "damaged" ]] || : > "$root/.build/checkouts/swift-cmark/Package.swift"
+}
+
+# Fake resolves. The "heals" variant fails while the damaged checkout is present
+# and succeeds once it has been discarded — the real repair's whole premise. It
+# is written to a file rather than an inline `bash -c "…"` string because the
+# script invokes the seam unquoted, so embedded quoting would not survive word
+# splitting.
+RESOLVE_OK='true'
+RESOLVE_ALWAYS_FAILS='false'
+RESOLVE_HEALS='bash ./fake-resolve.sh'
+
+_mk_healing_resolve() {
+  cat > "$1/fake-resolve.sh" <<'EOF'
+if [ -d .build/checkouts/swift-cmark ] && [ ! -e .build/checkouts/swift-cmark/Package.swift ]; then
+  echo "error: the package manifest at .build/checkouts/swift-cmark/Package.swift cannot be accessed"
+  exit 1
+fi
+exit 0
+EOF
+}
+
+_run() { # _run <root> <resolve-cmd>
+  local root="$1" cmd="$2"
+  ( cd "$root" && SPM_RESOLVE_CMD="$cmd" bash "$SCRIPT" 2>&1 )
+}
+
+test_cold_workspace_is_a_noop() {
+  local root; root="$(mktmpd)"
+  local out; out="$(_run "$root" "$RESOLVE_ALWAYS_FAILS")"
+  assert_eq "cold workspace exits 0" "0" "$?"
+  assert_contains "cold workspace reported" "$out" "cold workspace, nothing to repair"
+  rm -rf "$root"
+}
+
+test_healthy_workspace_resolves_and_keeps_checkouts() {
+  local root; root="$(mktmpd)"; _mk_workspace "$root"
+  local out; out="$(_run "$root" "$RESOLVE_OK")"
+  assert_eq "healthy workspace exits 0" "0" "$?"
+  assert_contains "healthy path reported" "$out" "resolves cleanly"
+  assert_lacks "healthy path does not warn" "$out" "::warning::"
+  assert_eq "checkouts kept" "true" "$([[ -e "$root/.build/checkouts/swift-cmark/Package.swift" ]] && echo true || echo false)"
+  rm -rf "$root"
+}
+
+test_damaged_workspace_discards_checkouts_and_recovers() {
+  local root; root="$(mktmpd)"; _mk_workspace "$root" damaged; _mk_healing_resolve "$root"
+  local out; out="$(_run "$root" "$RESOLVE_HEALS")"
+  assert_eq "damaged workspace recovers to exit 0" "0" "$?"
+  assert_contains "repair warned" "$out" "::warning::"
+  assert_contains "repair reported" "$out" "workspace repaired by re-resolving"
+  assert_eq "checkouts discarded" "false" "$([[ -d "$root/.build/checkouts" ]] && echo true || echo false)"
+  assert_eq "repositories discarded" "false" "$([[ -d "$root/.build/repositories" ]] && echo true || echo false)"
+  rm -rf "$root"
+}
+
+test_repair_keeps_compiled_artifacts_warm() {
+  local root; root="$(mktmpd)"; _mk_workspace "$root" damaged; _mk_healing_resolve "$root"
+  _run "$root" "$RESOLVE_HEALS" >/dev/null
+  assert_eq "compiled artifacts survive the repair" "true" \
+    "$([[ -e "$root/.build/arm64-apple-macosx/debug/TBDShared.o" ]] && echo true || echo false)"
+  rm -rf "$root"
+}
+
+test_persistent_failure_is_not_swallowed() {
+  local root; root="$(mktmpd)"; _mk_workspace "$root" damaged
+  local out rc
+  out="$(_run "$root" "$RESOLVE_ALWAYS_FAILS")"; rc=$?
+  assert_eq "second failure exits non-zero" "1" "$rc"
+  assert_contains "second failure errors loudly" "$out" "::error::"
+  assert_contains "second failure names the real suspect" "$out" "not restored-cache damage"
+  rm -rf "$root"
+}
+
+for t in $(declare -F | awk '{print $3}' | grep '^test_'); do "$t"; done
+exit $FAIL


### PR DESCRIPTION
## The failure

Run [30557645064](https://github.com/cheapsteak/tbd/actions/runs/30557645064) failed the `test` job on #554 — a **docs-only** diff:

```
error: 'swift-cmark': the package manifest at
  .build/checkouts/swift-cmark/Package.swift
  cannot be accessed (doesn't exist in file system)
```

It died in build *planning*. No test compiled, let alone ran.

## What the evidence actually says

My first read was "corrupt cache entry." The logs say something narrower, and the distinction decides the fix:

- Attempt 1 got an **exact primary-key hit** and logged `Received 1527561868 of 1527561868 (100.0%)`, then `Cache restored successfully`. No tar warning, no truncation.
- The rerun restored **the same key, at the same byte count**, and passed.

So the stored entry is fine. One runner's extracted copy was missing a file that the same tarball delivered intact minutes later. Whether that is gtar, the filesystem, or SPM's own checkout management, I can't tell from the logs — and it doesn't change what to do about it. What matters is the shape: **a complete restore can still leave an incomplete workspace**, and the only recovery today is a human noticing and clicking rerun.

Rare, for calibration: zero occurrences across the last 12 failed `test` runs (back to 2026-07-26). This is cheap insurance against a rare-but-total failure, not a fire.

## The fix

`scripts/repair-spm-workspace.sh`, run immediately after the cache restore in both `test.yml` and `nightly.yml` (the nightly restores the same entry, so it has the same exposure):

1. No `.build/` → no-op (cold workspace).
2. `swift package resolve` → clean, done.
3. Resolve fails → `::warning::`, discard `.build/checkouts` and `.build/repositories`, resolve again.
4. Still fails → `::error::` and exit 1. That is not this signature — it's a broken `Package.resolved`, an unreachable dependency, or a toolchain problem, and it should stay loud.

`swift package resolve` is the probe rather than a hand-rolled "does every checkout have a `Package.swift`" scan: it's SPM's own validation, so it catches damage a file-existence check would miss. Only the two directories SPM can rebuild get discarded — compiled artifacts under `.build/*/debug/` stay warm, so the repair path costs a dependency rebuild, not a cold build, and only on a run that was going to fail outright.

## Considered and rejected

**Stop caching `.build/checkouts` + `.build/repositories`** (via `!` exclusions), so the fragile mutable directories are never restored from tar at all. This removes the failure mode at its source rather than repairing it, and I wanted to like it. But re-cloned checkouts get fresh mtimes, and the object files under `.build/*/debug/` are keyed to those sources — llbuild would rebuild every dependency on every run, which is exactly what the `git-restore-mtime` step above the cache exists to prevent. Wrong trade.

**Retry the whole test step.** Hides real failures behind a retry; the whole point of the existing `--filter` test-count floors is that this repo prefers a loud wrong answer to a quiet one.

## Cost

Measured locally on a healthy warm workspace: **6.2s**, once per run. Against a ~6-minute rerun plus a human deciding whether the red was real.

## Verification

- `scripts/repair-spm-workspace.test.sh` — 15 assertions across all four branches (cold, healthy, damaged-then-recovered, persistently-failing), plus one that the repair leaves compiled artifacts in place. Passing.
- **Mutation-checked**: replacing the `rm -rf` with a no-op turns 4 of those assertions red, so the tests are actually observing the repair, not just the exit code.
- Live smoke test against this checkout: healthy path resolves cleanly, exit 0.
- `actionlint` on both workflows: clean apart from one pre-existing SC2086 on an unrelated line. `shellcheck` on both new scripts: clean.
- No Swift changed, so `swift build` / `swift test` aren't meaningful gates here.

On the CLAUDE.md rule that a new gating conditional gets a test per branch: satisfied by the four-branch shell test above. It can't be a Swift test — the thing under test is a CI step.
