### PR TITLE
fix: creating a worktree on a branch that already exists

### DIFF
--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -170,7 +170,24 @@ struct WorktreeCreate: AsyncParsableCommand {
                     return updated
                 }
             } else {
-                throw CLIError.invalidArgument("Worktree creation failed (see daemon logs)")
+                // The row vanished, so the daemon's background create failed and
+                // rolled it back. The reason exists — the daemon logs it with
+                // git's stderr embedded — but it goes to os_log, not down this
+                // RPC, because `worktreeCreate` returns the pending row and does
+                // the work in a detached lane.
+                //
+                // So the message has to name WHERE. The old "(see daemon logs)"
+                // named nothing, and the two obvious guesses are both wrong:
+                // ~/Library/Logs/TBD/exceptions.log is the app's crash log, and
+                // predicating on TBDApp searches the wrong process entirely.
+                throw CLIError.invalidArgument("""
+                    Worktree creation failed and was rolled back. The daemon logged why:
+
+                      log show --predicate 'subsystem == "com.tbd.daemon"' --last 5m --info
+
+                    (Common cause: the branch already exists and is checked out in \
+                    another worktree — git's error names that directory.)
+                    """)
             }
             let elapsed = Date().timeIntervalSince(start)
             if elapsed >= nextHeartbeat {

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -104,7 +104,7 @@ struct WorktreeCreate: AsyncParsableCommand {
                 repoID = id
             } else {
                 let resolver = PathResolver(client: client)
-                repoID = try resolver.resolveRepoID(path: repo)
+                repoID = try resolver.resolveRepoID(path: repo, context: .explicitRepoOption)
             }
         } else {
             let resolver = PathResolver(client: client)
@@ -229,7 +229,7 @@ struct WorktreeList: AsyncParsableCommand {
                 repoID = id
             } else {
                 let resolver = PathResolver(client: client)
-                repoID = try resolver.resolveRepoID(path: repo)
+                repoID = try resolver.resolveRepoID(path: repo, context: .explicitRepoOption)
             }
         }
 
@@ -307,7 +307,7 @@ struct WorktreeAdopt: AsyncParsableCommand {
                 repoID = id
             } else {
                 let resolver = PathResolver(client: client)
-                repoID = try resolver.resolveRepoID(path: repo)
+                repoID = try resolver.resolveRepoID(path: repo, context: .explicitRepoOption)
             }
         } else {
             // Auto-detect: run `git rev-parse --git-common-dir` from the worktree

--- a/Sources/TBDCLI/PathResolver.swift
+++ b/Sources/TBDCLI/PathResolver.swift
@@ -22,10 +22,23 @@ struct PathResolver {
     }
 
     /// Resolve a path to a repo ID, throwing if not found.
+    ///
+    /// The failure message names what was actually resolved. `--repo` takes a
+    /// UUID or a path; a bare repo *name* is neither, so it gets resolved as a
+    /// relative path and fails with a message about path detection — which
+    /// reads like a detection bug and sends people looking for one. Reported
+    /// from the field as "`--repo acme-app` is ambiguous between two registered
+    /// repos of that name"; it isn't ambiguous, because there is no name lookup
+    /// here to be ambiguous about.
     func resolveRepoID(path: String? = nil) throws -> UUID {
         let result = try resolve(path: path)
         guard let repoID = result.repoID else {
-            throw CLIError.invalidArgument("Could not determine repository from path. Use --repo to specify.")
+            let target = path.map { "'\($0)'" } ?? "the current directory"
+            throw CLIError.invalidArgument("""
+                No registered repository at \(target).
+                --repo takes a repository UUID or a path, not a repo name. \
+                Run `tbd repo list` for the registered repos and their IDs.
+                """)
         }
         return repoID
     }

--- a/Sources/TBDCLI/PathResolver.swift
+++ b/Sources/TBDCLI/PathResolver.swift
@@ -1,6 +1,11 @@
 import Foundation
 import TBDShared
 
+enum RepoResolutionContext {
+    case discoveredPath
+    case explicitRepoOption
+}
+
 /// Resolves the current working directory to a repo/worktree ID
 /// by querying the daemon via the resolve.path RPC.
 struct PathResolver {
@@ -22,23 +27,15 @@ struct PathResolver {
     }
 
     /// Resolve a path to a repo ID, throwing if not found.
-    ///
-    /// The failure message names what was actually resolved. `--repo` takes a
-    /// UUID or a path; a bare repo *name* is neither, so it gets resolved as a
-    /// relative path and fails with a message about path detection — which
-    /// reads like a detection bug and sends people looking for one. Reported
-    /// from the field as "`--repo acme-app` is ambiguous between two registered
-    /// repos of that name"; it isn't ambiguous, because there is no name lookup
-    /// here to be ambiguous about.
-    func resolveRepoID(path: String? = nil) throws -> UUID {
+    func resolveRepoID(
+        path: String? = nil,
+        context: RepoResolutionContext = .discoveredPath
+    ) throws -> UUID {
         let result = try resolve(path: path)
         guard let repoID = result.repoID else {
-            let target = path.map { "'\($0)'" } ?? "the current directory"
-            throw CLIError.invalidArgument("""
-                No registered repository at \(target).
-                --repo takes a repository UUID or a path, not a repo name. \
-                Run `tbd repo list` for the registered repos and their IDs.
-                """)
+            throw CLIError.invalidArgument(
+                repoResolutionFailureMessage(path: path, context: context)
+            )
         }
         return repoID
     }
@@ -64,5 +61,26 @@ struct PathResolver {
             fileURLWithPath: path,
             relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         ).standardized.path
+    }
+}
+
+func repoResolutionFailureMessage(
+    path: String?,
+    context: RepoResolutionContext
+) -> String {
+    let target = path.map { "'\($0)'" } ?? "the current directory"
+    switch context {
+    case .discoveredPath:
+        return """
+            No registered repository at \(target).
+            Register it with `tbd repo add <path>`, or run `tbd repo list` \
+            to see registered repositories.
+            """
+    case .explicitRepoOption:
+        return """
+            No registered repository at \(target).
+            --repo takes a repository UUID or a path, not a repo name. \
+            Run `tbd repo list` for the registered repos and their IDs.
+            """
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -479,6 +479,45 @@ extension WorktreeLifecycle {
 
         var lastError: Error? = nil
 
+        // A branch the caller NAMED that already exists locally gets checked
+        // out, not re-created. `git worktree add -b <branch>` is fatal when the
+        // ref exists ("a branch named 'x' already exists"), and every attempt
+        // below would hit it — both base branches, then both again after the
+        // folder-rename retry, which keeps a user-specified branch. Four
+        // failures, one cause.
+        //
+        // This is the ordinary case, not an edge case: spawning a session onto
+        // an existing PR means the branch is already there.
+        //
+        // Gated on `userSpecifiedBranch` deliberately. An auto-generated
+        // `tbd/<name>` that collides means the NAME collided — the right answer
+        // there is a fresh name (the retry below), not silently adopting
+        // whatever branch happens to hold that name.
+        //
+        // A failed existence probe falls through to the old path rather than
+        // failing creation: not knowing is not the same as knowing it's absent.
+        let branchExistsLocally = (try? await git.localBranchExists(repoPath: repoPath, name: branch)) ?? false
+        if userSpecifiedBranch && branchExistsLocally {
+            do {
+                try await git.worktreeAddExisting(
+                    repoPath: repoPath,
+                    worktreePath: worktreePath,
+                    branch: branch
+                )
+                return (name: name, branch: branch, path: worktreePath)
+            } catch {
+                try? FileManager.default.removeItem(atPath: worktreePath)
+                // No rename retry here: the branch is the caller's and is kept
+                // across retries, so a second attempt fails identically. Git's
+                // stderr is the useful part — for the common follow-on failure
+                // it reads "'x' is already used by worktree at <path>", which
+                // names the directory holding it.
+                throw WorktreeLifecycleError.createFailed(
+                    "could not check out existing branch '\(branch)'\(formatErrorForMessage(error))"
+                )
+            }
+        }
+
         for baseBranch in baseBranches {
             do {
                 try await git.worktreeAdd(

--- a/Tests/TBDCLITests/PathResolverTests.swift
+++ b/Tests/TBDCLITests/PathResolverTests.swift
@@ -1,0 +1,41 @@
+import Testing
+
+@testable import TBDCLI
+
+@Suite("PathResolver")
+struct PathResolverTests {
+    @Test func explicitRepoOptionExplainsAcceptedValues() {
+        let message = repoResolutionFailureMessage(
+            path: "acme-app",
+            context: .explicitRepoOption
+        )
+
+        #expect(message.contains("No registered repository at 'acme-app'."))
+        #expect(message.contains("--repo takes a repository UUID or a path, not a repo name."))
+        #expect(message.contains("tbd repo list"))
+        #expect(!message.contains("tbd repo add"))
+    }
+
+    @Test func discoveredCurrentDirectoryExplainsHowToRegisterIt() {
+        let message = repoResolutionFailureMessage(
+            path: nil,
+            context: .discoveredPath
+        )
+
+        #expect(message.contains("No registered repository at the current directory."))
+        #expect(message.contains("tbd repo add <path>"))
+        #expect(message.contains("tbd repo list"))
+        #expect(!message.contains("--repo"))
+    }
+
+    @Test func discoveredPathNamesTheTargetWithoutMentioningRepoOption() {
+        let message = repoResolutionFailureMessage(
+            path: "/tmp/acme-app",
+            context: .discoveredPath
+        )
+
+        #expect(message.contains("No registered repository at '/tmp/acme-app'."))
+        #expect(message.contains("tbd repo add <path>"))
+        #expect(!message.contains("--repo"))
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
@@ -251,3 +251,103 @@ import Testing
     #expect(second.branch == "feature/auth-refactor-other")
 }
 
+
+// MARK: - Named branch that already exists, WITHOUT `useExistingBranch`
+//
+// The `useExistingBranch` flag above is the deliberate, opt-in path. These
+// cover the accidental one: `tbd worktree create --branch <name>` where the
+// branch happens to already exist locally — which is every branch that already
+// has a PR, i.e. the normal case when spawning a session onto existing work.
+//
+// It used to fail with "Worktree creation failed (see daemon logs)". Cause was
+// `git worktree add -b <branch>`, fatal when the ref exists; all four attempts
+// (two base branches, then both again after the folder-rename retry, which
+// keeps a user-specified branch) hit the same wall.
+
+@Test func testNamedExistingBranchIsCheckedOutWithoutTheFlag() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    try await shell("git branch already-here", at: repoDir)
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    // Note: no `useExistingBranch`. This is the plain create path.
+    let wt = try await lifecycle.createWorktree(
+        repoID: repo.id, branch: "already-here", skipClaude: true
+    )
+
+    #expect(wt.status == .active)
+    #expect(wt.branch == "already-here", "should have adopted the existing branch, not renamed around it")
+    #expect(FileManager.default.fileExists(atPath: wt.path))
+
+    let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+    #expect(listed.contains { $0.branch == "already-here" })
+}
+
+/// The other side of the same gate: a named branch that does NOT exist still
+/// takes the create-it path. Without this, "always check out" would silently
+/// replace worktree creation with worktree adoption.
+@Test func testNamedAbsentBranchIsStillCreated() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    let wt = try await lifecycle.createWorktree(
+        repoID: repo.id, branch: "brand-new-branch", skipClaude: true
+    )
+
+    #expect(wt.status == .active)
+    #expect(wt.branch == "brand-new-branch")
+    let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+    #expect(listed.contains { $0.branch == "brand-new-branch" })
+}
+
+/// Branch exists but is already checked out somewhere else — git refuses, and
+/// the point of the fix is that its stderr survives into the thrown error,
+/// because that stderr names the directory holding the branch. A bare
+/// "creation failed" leaves the user hunting for a path the tool already knew.
+@Test func testBranchCheckedOutElsewhereReportsTheHoldingPath() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    try await shell("git branch contested", at: repoDir)
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    let first = try await lifecycle.createWorktree(
+        repoID: repo.id, branch: "contested", skipClaude: true
+    )
+    #expect(first.status == .active)
+
+    await #expect(throws: WorktreeLifecycleError.self) {
+        _ = try await lifecycle.createWorktree(
+            repoID: repo.id, folder: "second-take", branch: "contested", skipClaude: true
+        )
+    }
+
+    do {
+        _ = try await lifecycle.createWorktree(
+            repoID: repo.id, folder: "third-take", branch: "contested", skipClaude: true
+        )
+        Issue.record("expected a second checkout of 'contested' to fail")
+    } catch {
+        let text = String(describing: error)
+        #expect(text.contains("contested"), "error does not name the branch: \(text)")
+        #expect(text.contains("already used by worktree"),
+                "git's stderr was swallowed; it is what names the holding directory: \(text)")
+    }
+}


### PR DESCRIPTION
Two bugs found in live use while spawning several sessions at once. Sibling to #551 rather than folded into it — different subsystem, and #551 was one check from auto-merging.

## 1. `--branch <name>` failed whenever the branch already existed

**Repro:** any branch with a local ref.

```sh
tbd worktree create --folder foo --branch some-existing-branch --repo <uuid>
# Error: Worktree creation failed (see daemon logs)
```

**Cause:** the create path always ran `git worktree add -b <branch>`, which is fatal when the ref exists. Reproduced directly:

```
$ git worktree add wt1 -b existing-branch main
fatal: a branch named 'existing-branch' already exists

$ git worktree add wt2 existing-branch
HEAD is now at 1e6fc45 init          # works
```

All four attempts hit the same wall — two base branches, then both again after the folder-rename retry, which keeps a user-specified branch. Four failures, one cause.

**This is the ordinary case, not an edge case:** every branch that already has a PR hits it, which is exactly when you want to spawn a session onto existing work.

**Fix:** a *named* branch that already exists locally is checked out via `worktreeAddExisting` — the helper the opt-in `useExistingBranch` flow already used.

**The gate matters, and the bug report didn't mention it.** It's conditioned on `userSpecifiedBranch`. An auto-generated `tbd/<name>` that collides means the *name* collided, and the right answer there is a fresh name — not silently adopting whatever branch happens to hold it. "Always check out if it exists" would have quietly converted worktree creation into worktree adoption for generated names. A failed existence probe falls through to the old path: not knowing is not the same as knowing it's absent.

## 2. The error pointed at logs that don't exist

`"(see daemon logs)"` names no file, and both obvious guesses are wrong — `~/Library/Logs/TBD/exceptions.log` is the *app's* crash log, and predicating on `TBDApp` searches the wrong process entirely.

**The reason does exist.** `attemptWorktreeAdd` already embeds git's stderr via `formatErrorForMessage`, and `WorktreeLifecycleError` implements `errorDescription`, so the daemon log has it. It just travels by `os_log` rather than down the RPC, because `worktreeCreate` returns the pending row and does the work in a detached lane; the CLI only sees the row vanish.

So the fix is to name *where*:

```
Worktree creation failed and was rolled back. The daemon logged why:

  log show --predicate 'subsystem == "com.tbd.daemon"' --last 5m --info
```

Surfacing git's stderr also fixes the report's third sub-case for free — for a branch checked out elsewhere, git's own wording is `'x' is already used by worktree at <path>`, which names the directory. Asserted in a test.

**Remaining gap, deliberately not fixed here:** there's still no structured channel carrying the failure reason from the daemon back to the CLI. Doing it properly needs either a field on the archive delta or a failure state on the row — more than a bug fix, and worth its own decision. Named rather than quietly half-done.

## 3. `--repo <name>` — the reported diagnosis was wrong

Reported as *"`--repo acme-app` is ambiguous — two registered repos share the name."* It isn't ambiguous: **`--repo` never does name lookup at all.** A non-UUID is passed to `PathResolver.resolveRepoID(path:)` and resolved as a *path*, so a bare name resolves relative to cwd and simply misses. The old message ("Could not determine repository from path") then reads as a path-detection bug and sends you looking for one — which is what happened.

Now:

```
No registered repository at 'acme-app'.
--repo takes a repository UUID or a path, not a repo name.
Run `tbd repo list` for the registered repos and their IDs.
```

Adding real name lookup would be a feature, and would need a decision about ambiguity semantics — not in scope.

## Verification

- `swift build` clean
- `swift test --filter "ExistingBranch|NamedExisting|NamedAbsent|BranchCheckedOut|CreateWorktree|DeskSessionManager"` → **39 tests, 4 suites, all passed**
- `swiftlint --strict` clean
- **Mutation-checked:** disabling the new gate reds `testNamedExistingBranchIsCheckedOutWithoutTheFlag` and `testBranchCheckedOutElsewhereReportsTheHoldingPath` with the original bare `git worktree add failed after all attempts` — i.e. the tests reproduce the reported symptom exactly.

Local `swift test` runs via `~/Library/Developer/Toolchains/swift-latest.xctoolchain` (Swift 6.3.2) with the one remaining `import XCTest` file moved aside; the full ~4500-test population is CI's.

No feature flag: this is a bug fix on an existing path, no config column, no migration, no new subsystem.
