### PR TITLE
feat: add Codex to the worktree usage picker

### DIFF
--- a/Sources/TBDApp/AppState+CodexUsage.swift
+++ b/Sources/TBDApp/AppState+CodexUsage.swift
@@ -1,0 +1,14 @@
+import TBDShared
+
+extension AppState {
+    func loadCodexUsage() async {
+        guard !isLoadingCodexUsage else { return }
+        isLoadingCodexUsage = true
+        defer { isLoadingCodexUsage = false }
+        do {
+            codexUsage = try await daemonClient.fetchCodexUsage()
+        } catch {
+            codexUsage = CodexUsageResult(unavailableReason: "Usage unavailable")
+        }
+    }
+}

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -23,7 +23,7 @@ extension AppState {
     /// `model` is an optional per-spawn Claude model override (picker model
     /// buttons); it applies to the initial spawn only — later respawns fall
     /// back to the profile default.
-    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil, profileID: UUID? = nil, model: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, displayName: String? = nil) {
+    func createWorktree(repoID: UUID, parentWorktreeID: UUID? = nil, existingBranch: BranchInfo? = nil, profileID: UUID? = nil, model: String? = nil, primaryAgentPreference: PrimaryAgentPreference? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, displayName: String? = nil) {
         // Optimistic placeholder so the row appears instantly. When picking an
         // existing branch we use its local name so the placeholder name
         // doesn't briefly show a fake `tbd/*` value.
@@ -73,6 +73,7 @@ extension AppState {
                     useExistingBranch: existingBranch != nil,
                     profileID: profileID,
                     model: model,
+                    primaryAgentPreference: primaryAgentPreference,
                     prNumber: prNumber,
                     checkoutPRHead: checkoutPRHead
                 )

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -626,6 +626,10 @@ final class AppState: ObservableObject {
     @Published var prStatuses: [UUID: PRStatus] = [:]
     @Published var modelProfiles: [ModelProfileWithUsage] = []
     @Published var defaultProfileID: UUID? = nil
+    /// Ephemeral one-shot Codex account/usage snapshot loaded when the
+    /// worktree picker opens. It is intentionally neither polled nor persisted.
+    @Published var codexUsage: CodexUsageResult?
+    @Published var isLoadingCodexUsage = false
     @Published var primaryAgentPreference: PrimaryAgentPreference = .defaultValue
     /// Global free-form env overrides (config scope). Loaded from the daemon
     /// alongside `defaultProfileID` via `loadModelProfiles()`.

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -456,11 +456,18 @@ actor DaemonClient {
     /// When `useExistingBranch` is true, `branch` MUST be set to an existing
     /// ref name (local like `foo` or remote like `origin/foo`) — the daemon
     /// checks it out instead of creating a new `tbd/*` branch.
-    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false, profileID: UUID? = nil, model: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil) async throws -> Worktree {
+    func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, useExistingBranch: Bool = false, profileID: UUID? = nil, model: String? = nil, primaryAgentPreference: PrimaryAgentPreference? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil) async throws -> Worktree {
         return try await callAsync(
             method: RPCMethod.worktreeCreate,
-            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch, profileID: profileID, model: model, prNumber: prNumber, checkoutPRHead: checkoutPRHead),
+            params: WorktreeCreateParams(repoID: repoID, folder: folder, branch: branch, displayName: displayName, cols: cols, rows: rows, parentWorktreeID: parentWorktreeID, useExistingBranch: useExistingBranch, profileID: profileID, model: model, primaryAgentPreference: primaryAgentPreference, prNumber: prNumber, checkoutPRHead: checkoutPRHead),
             resultType: Worktree.self
+        )
+    }
+
+    func fetchCodexUsage() async throws -> CodexUsageResult {
+        try await callNoParamsAsync(
+            method: RPCMethod.codexUsageFetch,
+            resultType: CodexUsageResult.self
         )
     }
 

--- a/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeProfilePickerView.swift
@@ -68,6 +68,9 @@ struct WorktreeProfilePickerView: View {
             if appState.modelProfiles.isEmpty {
                 await appState.loadModelProfiles()
             }
+            // User-gesture-triggered, one-shot fetch. The daemon talks to the
+            // Codex app-server API; no background poller or persisted state.
+            await appState.loadCodexUsage()
         }
     }
 
@@ -108,7 +111,8 @@ struct WorktreeProfilePickerView: View {
                     // worktree pinned to an account that can't run. apiKey /
                     // bedrock rows report selectable and stay actionable.
                     let isSelectable = ProfileUsagePresentation.isSelectable(entry)
-                    let isTheDefault = entry.profile.id == appState.defaultProfileID
+                    let isTheDefault = appState.primaryAgentPreference == .claude
+                        && entry.profile.id == appState.defaultProfileID
                     Group {
                         if entry.profile.kind == .oauth && isSelectable {
                             // Selectable Claude account: always render the
@@ -121,10 +125,10 @@ struct WorktreeProfilePickerView: View {
                                 highlighted: isTheDefault && highlightDefaultProfile,
                                 subtitle: claudeRowSubtitle(for: entry),
                                 onSelectModel: { model in
-                                    pick(profileID: entry.profile.id, model: model)
+                                    pick(profileID: entry.profile.id, model: model, agent: .claude)
                                 }
                             ) {
-                                pick(profileID: entry.profile.id)
+                                pick(profileID: entry.profile.id, agent: .claude)
                             }
                         } else {
                             let line = ProfileUsagePresentation.menuLine(for: entry)
@@ -140,12 +144,24 @@ struct WorktreeProfilePickerView: View {
                                 // case (logged-in OAuth awaiting its first poll).
                                 showsSubtitleSkeleton: subtitle.showsSkeleton
                             ) {
-                                pick(profileID: entry.profile.id)
+                                pick(profileID: entry.profile.id, agent: .claude)
                             }
                         }
                     }
                     .disabled(!isSelectable)
                     .opacity(isSelectable ? 1 : 0.5)
+                }
+
+                Divider()
+                    .padding(.vertical, 2)
+
+                CodexPickerRow(
+                    usage: appState.codexUsage,
+                    isLoading: appState.isLoadingCodexUsage,
+                    highlighted: appState.primaryAgentPreference == .codex
+                        && highlightDefaultProfile
+                ) {
+                    pick(profileID: nil, agent: .codex)
                 }
             }
         }
@@ -182,10 +198,20 @@ struct WorktreeProfilePickerView: View {
 
     /// `model` is an optional per-spawn Claude model override (the row's model
     /// rail); nil keeps the profile's default model.
-    private func pick(profileID: UUID?, model: String? = nil) {
+    private func pick(
+        profileID: UUID?,
+        model: String? = nil,
+        agent: PrimaryAgentPreference
+    ) {
         dismiss()
         onClose()
-        appState.createWorktree(repoID: repoID, parentWorktreeID: parentWorktreeID, profileID: profileID, model: model)
+        appState.createWorktree(
+            repoID: repoID,
+            parentWorktreeID: parentWorktreeID,
+            profileID: profileID,
+            model: model,
+            primaryAgentPreference: agent
+        )
     }
 
     /// Whether a profile row should render the two-bar usage meter (instead of
@@ -231,6 +257,139 @@ struct WorktreeProfilePickerView: View {
             }
             return (entry.profile.kindLabel, false)
         }
+    }
+}
+
+/// Codex account row backed by a one-shot app-server snapshot. The row stays
+/// selectable when usage or account metadata is unavailable: selection only
+/// chooses the agent; the CLI remains the authority on whether it can start.
+private struct CodexPickerRow: View {
+    let usage: CodexUsageResult?
+    let isLoading: Bool
+    var highlighted = false
+    let onSelect: () -> Void
+
+    @State private var isHovered = false
+
+    private var snapshot: CodexRateLimitSnapshot? {
+        usage?.rateLimits.first(where: { $0.limitId == "codex" })
+            ?? usage?.rateLimits.first
+    }
+
+    private var title: String {
+        if let email = usage?.account?.email, !email.isEmpty {
+            return "Codex — \(email)"
+        }
+        return "Codex"
+    }
+
+    private var subtitle: String {
+        if isLoading && usage == nil { return "Loading usage…" }
+        if let reason = usage?.unavailableReason { return reason }
+        if usage?.account == nil { return "Not logged in" }
+        if snapshot?.primary == nil && snapshot?.secondary == nil {
+            return usage?.account?.planType.map { "\($0.capitalized) plan" } ?? "Usage unavailable"
+        }
+        return ""
+    }
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                if let snapshot, snapshot.primary != nil || snapshot.secondary != nil {
+                    CodexUsageBarsView(snapshot: snapshot)
+                } else {
+                    Text(subtitle)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(isHovered || highlighted ? Color.accentColor.opacity(0.15) : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+    }
+}
+
+private struct CodexUsageBarsView: View {
+    let snapshot: CodexRateLimitSnapshot
+
+    var body: some View {
+        VStack(spacing: 2) {
+            if snapshot.rateLimitReachedType != nil || snapshot.spendControlReached == true {
+                Text("Limit reached")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            if let window = snapshot.primary {
+                bar(window)
+            }
+            if let window = snapshot.secondary {
+                bar(window)
+            }
+        }
+    }
+
+    private func bar(_ window: CodexRateLimitWindow) -> some View {
+        HStack(spacing: 5) {
+            Text(Self.durationLabel(window.windowDurationMins))
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .frame(width: 22, alignment: .leading)
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 2.5)
+                        .fill(Color.primary.opacity(0.08))
+                    RoundedRectangle(cornerRadius: 2.5)
+                        .fill(Self.color(window.usedPercent))
+                        .frame(width: geometry.size.width * min(Double(window.usedPercent) / 100, 1))
+                }
+            }
+            .frame(height: 7)
+            Text("\(window.usedPercent)%")
+                .font(.system(size: 10, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(Self.color(window.usedPercent))
+                .frame(width: 34, alignment: .trailing)
+            Text(Self.resetLabel(window.resetsAt))
+                .font(.system(size: 9, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(width: 74, alignment: .leading)
+        }
+    }
+
+    private static func durationLabel(_ minutes: Int?) -> String {
+        guard let minutes else { return "lim:" }
+        if minutes % (7 * 24 * 60) == 0 { return "\(minutes / (7 * 24 * 60))w:" }
+        if minutes % (24 * 60) == 0 { return "\(minutes / (24 * 60))d:" }
+        if minutes % 60 == 0 { return "\(minutes / 60)h:" }
+        return "\(minutes)m:"
+    }
+
+    private static func resetLabel(_ timestamp: Int?) -> String {
+        guard let timestamp else { return "" }
+        let date = Date(timeIntervalSince1970: TimeInterval(timestamp))
+        return "at " + date.formatted(date: .omitted, time: .shortened)
+    }
+
+    private static func color(_ percent: Int) -> Color {
+        if percent >= 90 { return .red }
+        if percent >= 70 { return .orange }
+        return .green
     }
 }
 

--- a/Sources/TBDDaemon/Codex/CodexUsageFetcher.swift
+++ b/Sources/TBDDaemon/Codex/CodexUsageFetcher.swift
@@ -1,0 +1,360 @@
+import Foundation
+import TBDShared
+import os
+
+enum CodexUsageParser {
+    private struct AccountResponse: Decodable {
+        let result: AccountResult?
+        let error: AppServerError?
+    }
+
+    private struct AccountResult: Decodable {
+        let account: CodexAccount?
+    }
+
+    private struct RateLimitsResponse: Decodable {
+        let result: RateLimitsResult?
+        let error: AppServerError?
+    }
+
+    private struct RateLimitsResult: Decodable {
+        let rateLimits: CodexRateLimitSnapshot
+        let rateLimitsByLimitId: [String: CodexRateLimitSnapshot]?
+    }
+
+    private struct AppServerError: Decodable {
+        let message: String?
+    }
+
+    static func account(from data: Data) throws -> CodexAccount? {
+        let response = try JSONDecoder().decode(AccountResponse.self, from: data)
+        if let message = response.error?.message {
+            throw CodexUsageFetchError.appServer(message)
+        }
+        return response.result?.account
+    }
+
+    static func rateLimits(from data: Data) throws -> [CodexRateLimitSnapshot] {
+        let response = try JSONDecoder().decode(RateLimitsResponse.self, from: data)
+        if let message = response.error?.message {
+            throw CodexUsageFetchError.appServer(message)
+        }
+        guard let result = response.result else { return [] }
+        if let buckets = result.rateLimitsByLimitId, !buckets.isEmpty {
+            return buckets.keys.sorted().compactMap { buckets[$0] }
+        }
+        return [result.rateLimits]
+    }
+}
+
+enum CodexUsageFetchError: Error {
+    case appServer(String)
+}
+
+/// Resolves the Codex CLI without relying on LaunchServices/launchd to provide
+/// an interactive-shell PATH. Existing PATH order wins, followed by the common
+/// user and package-manager install locations used on macOS.
+enum CodexExecutableResolver {
+    static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
+        isExecutable: (String) -> Bool = FileManager.default.isExecutableFile(atPath:)
+    ) -> String? {
+        let pathDirectories = (environment["PATH"] ?? "")
+            .split(separator: ":", omittingEmptySubsequences: true)
+            .map(String.init)
+        let fallbackDirectories = [
+            "\(homeDirectory)/.local/bin",
+            "\(homeDirectory)/.volta/bin",
+            "\(homeDirectory)/.cargo/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+        ]
+        var seen = Set<String>()
+        for directory in pathDirectories + fallbackDirectories where seen.insert(directory).inserted {
+            let candidate = URL(fileURLWithPath: directory, isDirectory: true)
+                .appendingPathComponent("codex", isDirectory: false)
+                .path
+            if isExecutable(candidate) {
+                return candidate
+            }
+        }
+        return nil
+    }
+}
+
+/// Runs a short-lived Codex app-server session and performs the documented
+/// initialize → account/read → account/rateLimits/read exchange. The process
+/// is bounded by both the daemon's starvation-resistant watchdog and an
+/// injected clock, and is terminated immediately after the final response.
+struct CodexUsageFetcher: Sendable {
+    /// nil resolves the production CLI path with `CodexExecutableResolver`;
+    /// tests can inject an exact executable and arguments.
+    var executable: String?
+    var arguments: [String]
+    var timeout: Duration = .seconds(5)
+    var clock: any Clock<Duration> = ContinuousClock()
+
+    init(
+        executable: String? = nil,
+        arguments: [String] = ["app-server", "--stdio"],
+        timeout: Duration = .seconds(5),
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.executable = executable
+        self.arguments = arguments
+        self.timeout = timeout
+        self.clock = clock
+    }
+
+    func fetch() async -> CodexUsageResult {
+        guard let executable = executable ?? CodexExecutableResolver.resolve() else {
+            return CodexUsageResult(unavailableReason: "Codex CLI unavailable")
+        }
+        let cancellation = CodexUsageCancellationRelay()
+        return await withTaskCancellationHandler(operation: {
+            await withCheckedContinuation { continuation in
+                let session = CodexUsageSession(
+                    executable: executable,
+                    arguments: arguments,
+                    timeout: timeout,
+                    clock: clock,
+                    continuation: continuation
+                )
+                cancellation.register { session.cancel() }
+                session.start()
+            }
+        }, onCancel: {
+            cancellation.cancel()
+        })
+    }
+}
+
+private final class CodexUsageCancellationRelay: @unchecked Sendable {
+    private struct State {
+        var action: (@Sendable () -> Void)?
+        var cancelled = false
+    }
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    func register(_ action: @escaping @Sendable () -> Void) {
+        let runNow = state.withLock { state -> Bool in
+            if state.cancelled { return true }
+            state.action = action
+            return false
+        }
+        if runNow { action() }
+    }
+
+    func cancel() {
+        let action = state.withLock { state -> (@Sendable () -> Void)? in
+            guard !state.cancelled else { return nil }
+            state.cancelled = true
+            return state.action
+        }
+        action?()
+    }
+}
+
+private final class CodexUsageSession: @unchecked Sendable {
+    private struct State {
+        var buffer = Data()
+        var account: CodexAccount?
+        var rateLimits: [CodexRateLimitSnapshot] = []
+        var completedResult: CodexUsageResult?
+        var finished = false
+        var watchdogToken: UInt64?
+        var clockTask: Task<Void, any Error>?
+    }
+
+    private let executable: String
+    private let arguments: [String]
+    private let timeout: Duration
+    private let clock: any Clock<Duration>
+    private let continuation: CheckedContinuation<CodexUsageResult, Never>
+    private let process = Process()
+    private let stdinPipe = Pipe()
+    private let stdoutPipe = Pipe()
+    private let stderrPipe = Pipe()
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    init(
+        executable: String,
+        arguments: [String],
+        timeout: Duration,
+        clock: any Clock<Duration>,
+        continuation: CheckedContinuation<CodexUsageResult, Never>
+    ) {
+        self.executable = executable
+        self.arguments = arguments
+        self.timeout = timeout
+        self.clock = clock
+        self.continuation = continuation
+    }
+
+    func start() {
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        stdoutPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            self?.consume(handle.availableData)
+        }
+        // Drain stderr so a verbose/broken child cannot fill its pipe.
+        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+            _ = handle.availableData
+        }
+        process.terminationHandler = { [weak self] process in
+            self?.terminated(status: process.terminationStatus)
+        }
+
+        let token = SubprocessWatchdog.shared.schedule(after: timeout) { [weak self] in
+            self?.timeOut()
+        }
+        state.withLock { $0.watchdogToken = token }
+        let clockTask = Task { [weak self, clock, timeout] in
+            try await clock.sleep(for: timeout)
+            self?.timeOut()
+        }
+        state.withLock { $0.clockTask = clockTask }
+
+        do {
+            try process.run()
+            try send(Self.initializeRequest)
+        } catch {
+            finish(CodexUsageResult(unavailableReason: "Codex CLI unavailable"))
+        }
+    }
+
+    func cancel() {
+        stopProcess()
+        finish(CodexUsageResult(unavailableReason: "Usage unavailable"))
+    }
+
+    private func consume(_ data: Data) {
+        guard !data.isEmpty else { return }
+        let lines = state.withLock { state -> [Data] in
+            state.buffer.append(data)
+            var lines: [Data] = []
+            while let newline = state.buffer.firstIndex(of: 0x0A) {
+                lines.append(state.buffer.prefix(upTo: newline))
+                state.buffer.removeSubrange(...newline)
+            }
+            return lines
+        }
+        for line in lines {
+            handle(line)
+        }
+    }
+
+    private func handle(_ line: Data) {
+        guard let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              let id = object["id"] as? Int else {
+            return // notification or an unknown future message
+        }
+        do {
+            switch id {
+            case 1:
+                try send(Self.initializedNotification)
+                try send(Self.accountRequest)
+            case 2:
+                let account = try CodexUsageParser.account(from: line)
+                state.withLock { $0.account = account }
+                try send(Self.rateLimitsRequest)
+            case 3:
+                let rateLimits = try CodexUsageParser.rateLimits(from: line)
+                let result = state.withLock { state -> CodexUsageResult in
+                    state.rateLimits = rateLimits
+                    let result = CodexUsageResult(account: state.account, rateLimits: rateLimits)
+                    state.completedResult = result
+                    return result
+                }
+                stopProcess()
+                // Process termination normally reaps the child and finishes.
+                // If it already exited between response and signal, finish now.
+                if !process.isRunning { finish(result) }
+            default:
+                break
+            }
+        } catch {
+            stopProcess()
+            finish(CodexUsageResult(unavailableReason: "Usage unavailable"))
+        }
+    }
+
+    private func send(_ data: Data) throws {
+        try stdinPipe.fileHandleForWriting.write(contentsOf: data)
+    }
+
+    private func terminated(status: Int32) {
+        let result = state.withLock { state -> CodexUsageResult in
+            if let completed = state.completedResult { return completed }
+            return CodexUsageResult(
+                account: state.account,
+                rateLimits: state.rateLimits,
+                unavailableReason: status == 0 ? "Usage unavailable" : "Codex CLI unavailable"
+            )
+        }
+        finish(result)
+    }
+
+    private func timeOut() {
+        stopProcess()
+        finish(CodexUsageResult(unavailableReason: "Usage timed out"))
+    }
+
+    private func stopProcess() {
+        stdinPipe.fileHandleForWriting.closeFile()
+        guard process.isRunning else { return }
+        let pid = process.processIdentifier
+        if pid > 0 {
+            kill(pid, SIGTERM)
+            SubprocessWatchdog.shared.schedule(after: .milliseconds(500)) { [weak process] in
+                if process?.isRunning == true { kill(pid, SIGKILL) }
+            }
+        }
+    }
+
+    private func finish(_ result: CodexUsageResult) {
+        let pending = state.withLock { state -> (Bool, UInt64?, Task<Void, any Error>?) in
+            guard !state.finished else { return (false, nil, nil) }
+            state.finished = true
+            return (true, state.watchdogToken, state.clockTask)
+        }
+        guard pending.0 else { return }
+        if let token = pending.1 { SubprocessWatchdog.shared.cancel(token) }
+        pending.2?.cancel()
+        stdoutPipe.fileHandleForReading.readabilityHandler = nil
+        stderrPipe.fileHandleForReading.readabilityHandler = nil
+        continuation.resume(returning: result)
+    }
+
+    private static let initializeRequest = line([
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": [
+            "clientInfo": ["name": "tbd", "title": "TBD", "version": "1"],
+            "capabilities": [:],
+        ],
+    ])
+    private static let initializedNotification = line([
+        "jsonrpc": "2.0", "method": "initialized", "params": [:],
+    ])
+    private static let accountRequest = line([
+        "jsonrpc": "2.0", "id": 2, "method": "account/read",
+        "params": ["refreshToken": false],
+    ])
+    private static let rateLimitsRequest = line([
+        "jsonrpc": "2.0", "id": 3, "method": "account/rateLimits/read", "params": [:],
+    ])
+
+    private static func line(_ object: [String: Any]) -> Data {
+        var data = try! JSONSerialization.data(withJSONObject: object)
+        data.append(0x0A)
+        return data
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -43,12 +43,12 @@ extension WorktreeLifecycle {
     ///
     /// This is the legacy all-in-one method. Prefer `beginCreateWorktree` +
     /// `completeCreateWorktree` for non-blocking creation.
-    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false, prNumber: Int? = nil, checkoutPRHead: Bool = false, claudeSettingsOverlay: String? = nil) async throws -> Worktree {
+    public func createWorktree(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, skipClaude: Bool = false, initialPrompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool = false, useExistingBranch: Bool = false, prNumber: Int? = nil, checkoutPRHead: Bool = false, primaryAgentPreference: PrimaryAgentPreference? = nil, claudeSettingsOverlay: String? = nil) async throws -> Worktree {
         let pending = try await beginCreateWorktree(repoID: repoID, folder: folder, branch: branch, displayName: displayName, skipClaude: skipClaude, parentWorktreeID: parentWorktreeID, siblingOfWorktreeID: siblingOfWorktreeID, callerWorktreeID: callerWorktreeID, suppressAutoParent: suppressAutoParent, useExistingBranch: useExistingBranch, prNumber: prNumber)
         // Pass the original branch ref (may include `origin/` prefix) through
         // so phase 2 can dispatch to the correct git command.
         let existingBranchRef = useExistingBranch ? branch : nil
-        let completion = try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef, checkoutPRHead: checkoutPRHead, claudeSettingsOverlay: claudeSettingsOverlay)
+        let completion = try await completeCreateWorktree(worktreeID: pending.id, skipClaude: skipClaude, initialPrompt: initialPrompt, userSpecifiedFolder: folder != nil, userSpecifiedBranch: branch != nil, cols: cols, rows: rows, existingBranchRef: existingBranchRef, checkoutPRHead: checkoutPRHead, primaryAgentPreference: primaryAgentPreference, claudeSettingsOverlay: claudeSettingsOverlay)
         // Legacy synchronous contract: the returned worktree is fully set up.
         // Await phase 3 inline when a preSession hook gated the primary spawn.
         if case .preSessionPending(let phase3) = completion {
@@ -222,7 +222,7 @@ extension WorktreeLifecycle {
     /// Set `retryGeneratedNameOnCollision` to false when callers have already
     /// rendered or persisted the pending row's generated identity.
     @discardableResult
-    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, checkoutPRHead: Bool = false, overrideProfileID: UUID? = nil, modelOverride: String? = nil, claudeSettingsOverlay: String? = nil, carryover: ConversationCarryover? = nil, retryGeneratedNameOnCollision: Bool = true) async throws -> WorktreeCreateCompletion {
+    public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, checkoutPRHead: Bool = false, overrideProfileID: UUID? = nil, modelOverride: String? = nil, primaryAgentPreference: PrimaryAgentPreference? = nil, claudeSettingsOverlay: String? = nil, carryover: ConversationCarryover? = nil, retryGeneratedNameOnCollision: Bool = true) async throws -> WorktreeCreateCompletion {
         guard let worktree = try await db.worktrees.get(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
@@ -379,6 +379,7 @@ extension WorktreeLifecycle {
                         completionAction: .markActive,
                         overrideProfileID: overrideProfileID,
                         modelOverride: modelOverride,
+                        primaryAgentPreference: primaryAgentPreference,
                         claudeSettingsOverlay: claudeSettingsOverlay,
                         carryover: carryover
                     )
@@ -407,6 +408,7 @@ extension WorktreeLifecycle {
                 preSessionTerminalID: nil,
                 overrideProfileID: overrideProfileID,
                 modelOverride: modelOverride,
+                primaryAgentPreference: primaryAgentPreference,
                 claudeSettingsOverlay: claudeSettingsOverlay,
                 carryover: carryover
             )
@@ -599,6 +601,7 @@ extension WorktreeLifecycle {
         preSessionTerminalID: UUID?,
         overrideProfileID: UUID? = nil,
         modelOverride: String? = nil,
+        primaryAgentPreference: PrimaryAgentPreference? = nil,
         claudeSettingsOverlay: String? = nil,
         carryover: ConversationCarryover? = nil
     ) async throws -> [(id: UUID, label: String)] {
@@ -611,7 +614,7 @@ extension WorktreeLifecycle {
             ? resolvePrimaryTerminalKind(
                 skipClaude: skipClaude,
                 archivedClaudeSessions: archivedClaudeSessions,
-                configuredPreference: config.primaryAgentPreference
+                configuredPreference: primaryAgentPreference ?? config.primaryAgentPreference
             )
             : .claude
         let archivedSessions = archivedClaudeSessions ?? []

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -283,6 +283,7 @@ extension WorktreeLifecycle {
         completionAction: PreSessionCompletionAction,
         overrideProfileID: UUID? = nil,
         modelOverride: String? = nil,
+        primaryAgentPreference: PrimaryAgentPreference? = nil,
         claudeSettingsOverlay: String? = nil,
         carryover: ConversationCarryover? = nil
     ) async {
@@ -353,6 +354,7 @@ extension WorktreeLifecycle {
                 preSessionTerminalID: succeeded ? nil : preSession.terminalID,
                 overrideProfileID: overrideProfileID,
                 modelOverride: modelOverride,
+                primaryAgentPreference: primaryAgentPreference,
                 claudeSettingsOverlay: claudeSettingsOverlay,
                 carryover: carryover
             )

--- a/Sources/TBDDaemon/Server/RPCRouter+CodexHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+CodexHandlers.swift
@@ -1,0 +1,7 @@
+import TBDShared
+
+extension RPCRouter {
+    func handleCodexUsageFetch() async throws -> RPCResponse {
+        try RPCResponse(result: await CodexUsageFetcher().fetch())
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -75,6 +75,9 @@ extension RPCRouter {
         // Per-spawn Claude model override (picker model buttons). Initial
         // spawn only — respawns fall back to the profile default.
         let modelOverride = params.model
+        // Explicit primary agent for this creation. nil preserves the global
+        // preference resolved by the lifecycle.
+        let primaryAgentPreference = params.primaryAgentPreference
         // General Claude settings passthrough, deep-merged into the per-session
         // --settings overlay on the fresh-primary spawn (see ClaudeHookOverlay).
         let claudeSettingsOverlay = params.claudeSettingsOverlay
@@ -88,7 +91,7 @@ extension RPCRouter {
                 // fetch from phase 1.5, or is a no-op if cached within the 60s TTL.
                 await fetchCache.fetchIfNeeded(repoPath: repoPath, branch: defaultBranch)
 
-                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, checkoutPRHead: checkoutPRHead, overrideProfileID: overrideProfileID, modelOverride: modelOverride, claudeSettingsOverlay: claudeSettingsOverlay)
+                let completion = try await lifecycle.completeCreateWorktree(worktreeID: pending.id, initialPrompt: initialPrompt, userSpecifiedFolder: userSpecifiedFolder, userSpecifiedBranch: userSpecifiedBranch, cols: cols, rows: rows, existingBranchRef: existingBranchRef, checkoutPRHead: checkoutPRHead, overrideProfileID: overrideProfileID, modelOverride: modelOverride, primaryAgentPreference: primaryAgentPreference, claudeSettingsOverlay: claudeSettingsOverlay)
                 switch completion {
                 case .ready:
                     subs.broadcast(delta: .worktreeCreated(WorktreeDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -307,6 +307,8 @@ public final class RPCRouter: Sendable {
                 return try await handleModelProfileSetGlobalDefault(request.paramsData)
             case RPCMethod.modelProfileSetPrimaryAgentPreference:
                 return try await handleModelProfileSetPrimaryAgentPreference(request.paramsData)
+            case RPCMethod.codexUsageFetch:
+                return try await handleCodexUsageFetch()
             case RPCMethod.modelProfileSetRepoOverride:
                 return try await handleModelProfileSetRepoOverride(request.paramsData)
             case RPCMethod.modelProfileReorder:

--- a/Sources/TBDShared/CodexUsage.swift
+++ b/Sources/TBDShared/CodexUsage.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// One-shot account and usage snapshot returned by Codex's machine-readable
+/// app-server API. All fields are optional so newer/older Codex versions can
+/// add or omit account metadata without breaking the picker.
+public struct CodexUsageResult: Codable, Sendable, Equatable {
+    public let account: CodexAccount?
+    public let rateLimits: [CodexRateLimitSnapshot]
+    public let unavailableReason: String?
+
+    public init(
+        account: CodexAccount? = nil,
+        rateLimits: [CodexRateLimitSnapshot] = [],
+        unavailableReason: String? = nil
+    ) {
+        self.account = account
+        self.rateLimits = rateLimits
+        self.unavailableReason = unavailableReason
+    }
+}
+
+public struct CodexAccount: Codable, Sendable, Equatable {
+    public let type: String
+    public let email: String?
+    public let planType: String?
+
+    public init(type: String, email: String? = nil, planType: String? = nil) {
+        self.type = type
+        self.email = email
+        self.planType = planType
+    }
+}
+
+public struct CodexRateLimitSnapshot: Codable, Sendable, Equatable, Identifiable {
+    public let limitId: String?
+    public let limitName: String?
+    public let planType: String?
+    public let rateLimitReachedType: String?
+    public let spendControlReached: Bool?
+    public let primary: CodexRateLimitWindow?
+    public let secondary: CodexRateLimitWindow?
+
+    public var id: String {
+        limitId ?? limitName ?? "codex"
+    }
+
+    public init(
+        limitId: String? = nil,
+        limitName: String? = nil,
+        planType: String? = nil,
+        rateLimitReachedType: String? = nil,
+        spendControlReached: Bool? = nil,
+        primary: CodexRateLimitWindow? = nil,
+        secondary: CodexRateLimitWindow? = nil
+    ) {
+        self.limitId = limitId
+        self.limitName = limitName
+        self.planType = planType
+        self.rateLimitReachedType = rateLimitReachedType
+        self.spendControlReached = spendControlReached
+        self.primary = primary
+        self.secondary = secondary
+    }
+}
+
+public struct CodexRateLimitWindow: Codable, Sendable, Equatable {
+    public let usedPercent: Int
+    public let windowDurationMins: Int?
+    public let resetsAt: Int?
+
+    public init(usedPercent: Int, windowDurationMins: Int? = nil, resetsAt: Int? = nil) {
+        self.usedPercent = usedPercent
+        self.windowDurationMins = windowDurationMins
+        self.resetsAt = resetsAt
+    }
+}

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -159,6 +159,7 @@ public enum RPCMethod {
     public static let modelProfileUpdateBedrock = "modelProfile.updateBedrock"
     public static let modelProfileSetGlobalDefault = "modelProfile.setGlobalDefault"
     public static let modelProfileSetPrimaryAgentPreference = "modelProfile.setPrimaryAgentPreference"
+    public static let codexUsageFetch = "codex.usage.fetch"
     public static let modelProfileSetRepoOverride = "modelProfile.setRepoOverride"
     public static let modelProfileReorder = "modelProfile.reorder"
     public static let modelProfileFetchUsage = "modelProfile.fetchUsage"
@@ -879,6 +880,9 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// profile default. nil preserves the profile's own model. Optional/
     /// defaulted for backward compatibility with older clients.
     public let model: String?
+    /// Explicit primary-agent override for this creation only. nil preserves
+    /// the configured global preference. Optional for backward compatibility.
+    public let primaryAgentPreference: PrimaryAgentPreference?
     /// Extra Claude Code settings (a JSON OBJECT string) deep-merged into TBD's
     /// per-session `--settings` overlay for this spawn's Claude agent. General
     /// passthrough — TBD does not interpret the contents. Optional/defaulted for
@@ -905,7 +909,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
     /// Optional/defaulted for backward compatibility (old daemons ignore the
     /// unknown key; old clients omit it).
     public let autoArchiveOnMerge: Bool?
-    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, model: String? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, autoArchiveOnMerge: Bool? = nil) {
+    public init(repoID: UUID, folder: String? = nil, branch: String? = nil, displayName: String? = nil, prompt: String? = nil, cols: Int? = nil, rows: Int? = nil, parentWorktreeID: UUID? = nil, siblingOfWorktreeID: UUID? = nil, callerWorktreeID: UUID? = nil, suppressAutoParent: Bool? = nil, useExistingBranch: Bool? = nil, profileID: UUID? = nil, model: String? = nil, primaryAgentPreference: PrimaryAgentPreference? = nil, claudeSettingsOverlay: String? = nil, prNumber: Int? = nil, checkoutPRHead: Bool? = nil, autoArchiveOnMerge: Bool? = nil) {
         self.repoID = repoID; self.folder = folder; self.branch = branch; self.displayName = displayName; self.prompt = prompt
         self.cols = cols; self.rows = rows
         self.parentWorktreeID = parentWorktreeID
@@ -915,6 +919,7 @@ public struct WorktreeCreateParams: Codable, Sendable {
         self.useExistingBranch = useExistingBranch
         self.profileID = profileID
         self.model = model
+        self.primaryAgentPreference = primaryAgentPreference
         self.claudeSettingsOverlay = claudeSettingsOverlay
         self.prNumber = prNumber
         self.checkoutPRHead = checkoutPRHead

--- a/Tests/TBDDaemonLiveTests/CodexUsageFetcherLifecycleTests.swift
+++ b/Tests/TBDDaemonLiveTests/CodexUsageFetcherLifecycleTests.swift
@@ -1,0 +1,138 @@
+import Clocks
+import Darwin
+import Foundation
+import Testing
+import TestSupport
+@testable import TBDDaemonLib
+
+/// Exercises CodexUsageFetcher's real child-process lifecycle with a controlled
+/// shell fake. Only the deadline is virtual.
+///
+/// **Tier 3** — spawns a real process and proves SIGTERM/SIGKILL teardown by
+/// polling the exact PID the child wrote to a unique marker. CI runs this
+/// target serially on an otherwise-idle machine.
+@Suite("Codex usage fetcher lifecycle", .serialized, .timeLimit(.minutes(1)))
+struct CodexUsageFetcherLifecycleTests {
+    /// Far beyond the suite limit, so only the TestClock can fire the timeout.
+    fileprivate static let unreachableTimeout: Duration = .seconds(600)
+
+    @Test func virtualTimeoutReturnsTimedOutAndKillsChild() async throws {
+        let fixture = try ProcessFixture()
+        defer { fixture.cleanup() }
+        let clock = TestClock()
+        let fetch = Task {
+            await fixture.fetcher(clock: clock).fetch()
+        }
+        defer { fetch.cancel() }
+        let pid = try await fixture.waitForPID()
+        defer { fixture.killIfStillAlive(pid) }
+
+        await clock.advanceWhenSuspended(by: Self.unreachableTimeout)
+        let result = await fetch.value
+
+        #expect(result.unavailableReason == "Usage timed out")
+        try await fixture.waitUntilDead(pid)
+    }
+
+    @Test func cancellationReturnsUnavailableAndKillsChild() async throws {
+        let fixture = try ProcessFixture()
+        defer { fixture.cleanup() }
+        let fetch = Task {
+            await fixture.fetcher(clock: TestClock()).fetch()
+        }
+        defer { fetch.cancel() }
+        let pid = try await fixture.waitForPID()
+        defer { fixture.killIfStillAlive(pid) }
+
+        fetch.cancel()
+        let result = await fetch.value
+
+        #expect(result.unavailableReason == "Usage unavailable")
+        try await fixture.waitUntilDead(pid)
+    }
+}
+
+private struct ProcessFixture {
+    private struct PollingFailure: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    let directory: URL
+    let pidMarker: URL
+    let blockingFIFO: URL
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-usage-lifecycle-\(UUID().uuidString)", isDirectory: true)
+        pidMarker = directory.appendingPathComponent("pid", isDirectory: false)
+        blockingFIFO = directory.appendingPathComponent("block", isDirectory: false)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        guard mkfifo(blockingFIFO.path, 0o600) == 0 else {
+            throw PollingFailure(description: "Could not create Codex usage lifecycle FIFO: errno \(errno)")
+        }
+    }
+
+    func fetcher(clock: any Clock<Duration>) -> CodexUsageFetcher {
+        CodexUsageFetcher(
+            executable: "/bin/sh",
+            arguments: [
+                "-c",
+                """
+                printf '%s' "$$" > "$1"
+                trap '' TERM
+                exec 3<> "$2"
+                IFS= read -r _ <&3
+                """,
+                "codex-usage-lifecycle",
+                pidMarker.path,
+                blockingFIFO.path,
+            ],
+            timeout: CodexUsageFetcherLifecycleTests.unreachableTimeout,
+            clock: clock
+        )
+    }
+
+    func waitForPID(
+        timeout: Duration = .seconds(10),
+        pollInterval: Duration = .milliseconds(20)
+    ) async throws -> pid_t {
+        let deadline = ContinuousClock.now + timeout
+        repeat {
+            if let contents = try? String(contentsOf: pidMarker, encoding: .utf8),
+               let pid = pid_t(contents.trimmingCharacters(in: .whitespacesAndNewlines)),
+               pid > 0 {
+                return pid
+            }
+            try await Task.sleep(for: pollInterval)
+        } while ContinuousClock.now < deadline
+        throw PollingFailure(description: "Codex usage child did not write its PID marker within \(timeout)")
+    }
+
+    func waitUntilDead(
+        _ pid: pid_t,
+        timeout: Duration = .seconds(10),
+        pollInterval: Duration = .milliseconds(20)
+    ) async throws {
+        let deadline = ContinuousClock.now + timeout
+        repeat {
+            if !isAlive(pid) { return }
+            try await Task.sleep(for: pollInterval)
+        } while ContinuousClock.now < deadline
+        throw PollingFailure(description: "Codex usage child PID \(pid) was still alive after \(timeout)")
+    }
+
+    func killIfStillAlive(_ pid: pid_t) {
+        if isAlive(pid) {
+            _ = kill(pid, SIGKILL)
+        }
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private func isAlive(_ pid: pid_t) -> Bool {
+        if kill(pid, 0) == 0 { return true }
+        return errno != ESRCH
+    }
+}

--- a/Tests/TBDDaemonTests/CodexUsageParserTests.swift
+++ b/Tests/TBDDaemonTests/CodexUsageParserTests.swift
@@ -79,7 +79,7 @@ struct CodexUsageParserTests {
 
     @Test func fallsBackToBaseRateLimitBucket() throws {
         let data = Data(#"""
-        {"id":3,"result":{"rateLimits":{"primary":{"usedPercent":42,"windowDurationMins":300,"resetsAt":123},"rateLimitsByLimitId":null}}
+        {"id":3,"result":{"rateLimits":{"primary":{"usedPercent":42,"windowDurationMins":300,"resetsAt":123}},"rateLimitsByLimitId":null}}
         """#.utf8)
         let limits = try CodexUsageParser.rateLimits(from: data)
         #expect(limits.first?.primary?.usedPercent == 42)

--- a/Tests/TBDDaemonTests/CodexUsageParserTests.swift
+++ b/Tests/TBDDaemonTests/CodexUsageParserTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("Codex usage app-server parsing")
+struct CodexUsageParserTests {
+    @Test func resolverPrefersCurrentPathThenUserFallbacks() {
+        let available: Set<String> = [
+            "/custom/bin/codex",
+            "/Users/test/.local/bin/codex",
+        ]
+        let fromPath = CodexExecutableResolver.resolve(
+            environment: ["PATH": "/custom/bin:/usr/bin"],
+            homeDirectory: "/Users/test",
+            isExecutable: { available.contains($0) }
+        )
+        #expect(fromPath == "/custom/bin/codex")
+
+        let fromFallback = CodexExecutableResolver.resolve(
+            environment: ["PATH": "/usr/bin:/bin"],
+            homeDirectory: "/Users/test",
+            isExecutable: { available.contains($0) }
+        )
+        #expect(fromFallback == "/Users/test/.local/bin/codex")
+    }
+
+    @Test func resolverCoversVoltaAndHomebrewAndReturnsNilWhenMissing() {
+        #expect(CodexExecutableResolver.resolve(
+            environment: [:],
+            homeDirectory: "/Users/test",
+            isExecutable: { $0 == "/Users/test/.volta/bin/codex" }
+        ) == "/Users/test/.volta/bin/codex")
+        #expect(CodexExecutableResolver.resolve(
+            environment: [:],
+            homeDirectory: "/Users/test",
+            isExecutable: { $0 == "/opt/homebrew/bin/codex" }
+        ) == "/opt/homebrew/bin/codex")
+        #expect(CodexExecutableResolver.resolve(
+            environment: [:],
+            homeDirectory: "/Users/test",
+            isExecutable: { _ in false }
+        ) == nil)
+    }
+
+    @Test func parsesChatGPTAccount() throws {
+        let data = Data(#"""
+        {"id":2,"result":{"account":{"type":"chatgpt","email":"person@example.com","planType":"pro"},"requiresOpenaiAuth":true}}
+        """#.utf8)
+        let parsed = try CodexUsageParser.account(from: data)
+        let account = try #require(parsed)
+        #expect(account.type == "chatgpt")
+        #expect(account.email == "person@example.com")
+        #expect(account.planType == "pro")
+    }
+
+    @Test func parsesLoggedOutAccount() throws {
+        let data = Data(#"{"id":2,"result":{"account":null,"requiresOpenaiAuth":true}}"#.utf8)
+        let account = try CodexUsageParser.account(from: data)
+        #expect(account == nil)
+    }
+
+    @Test func prefersNamedRateLimitBuckets() throws {
+        let data = Data(#"""
+        {"id":3,"result":{
+          "rateLimits":{"primary":{"usedPercent":1,"windowDurationMins":300,"resetsAt":123}},
+          "rateLimitsByLimitId":{"codex":{"limitId":"codex","limitName":"Codex","planType":"pro","rateLimitReachedType":"rate_limit_reached","spendControlReached":true,
+            "primary":{"usedPercent":8,"windowDurationMins":300,"resetsAt":123},
+            "secondary":{"usedPercent":20,"windowDurationMins":10080,"resetsAt":456}}}
+        }}
+        """#.utf8)
+        let limits = try CodexUsageParser.rateLimits(from: data)
+        let bucket = try #require(limits.first)
+        #expect(bucket.limitId == "codex")
+        #expect(bucket.primary?.usedPercent == 8)
+        #expect(bucket.secondary?.windowDurationMins == 10_080)
+        #expect(bucket.rateLimitReachedType == "rate_limit_reached")
+        #expect(bucket.spendControlReached == true)
+    }
+
+    @Test func fallsBackToBaseRateLimitBucket() throws {
+        let data = Data(#"""
+        {"id":3,"result":{"rateLimits":{"primary":{"usedPercent":42,"windowDurationMins":300,"resetsAt":123},"rateLimitsByLimitId":null}}
+        """#.utf8)
+        let limits = try CodexUsageParser.rateLimits(from: data)
+        #expect(limits.first?.primary?.usedPercent == 42)
+    }
+
+    @Test func surfacesAppServerErrors() {
+        let data = Data(#"{"id":2,"error":{"code":-32600,"message":"not initialized"}}"#.utf8)
+        #expect(throws: CodexUsageFetchError.self) {
+            try CodexUsageParser.account(from: data)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
@@ -39,6 +39,7 @@ struct WorktreeConversationCarryoverTests {
 
         let completion = try await lifecycle.completeCreateWorktree(
             worktreeID: pending.id,
+            primaryAgentPreference: .codex,
             carryover: carryover
         )
         guard case .ready = completion else {
@@ -85,6 +86,7 @@ struct WorktreeConversationCarryoverTests {
 
         let completion = try await lifecycle.completeCreateWorktree(
             worktreeID: pending.id,
+            primaryAgentPreference: .codex,
             carryover: carryover
         )
         guard case .preSessionPending(let phase3) = completion else {

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -51,6 +51,34 @@ import Testing
     #expect(!terminals.contains { $0.kind == .claude || $0.label == "Claude Code" })
 }
 
+@Test func testCreateWorktreeExplicitAgentOverrideWinsBothDirections() async throws {
+    let (tempDir, repoDir) = try await createTestRepo()
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let db = try TBDDatabase(inMemory: true)
+    let lifecycle = WorktreeLifecycle(
+        db: db,
+        git: GitManager(),
+        tmux: TmuxManager(dryRun: true),
+        hooks: HookResolver()
+    )
+    let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+    try await db.config.setPrimaryAgentPreference(.claude)
+    let codex = try await lifecycle.createWorktree(
+        repoID: repo.id,
+        primaryAgentPreference: .codex
+    )
+    #expect(try await db.terminals.list(worktreeID: codex.id).contains { $0.kind == .codex })
+
+    try await db.config.setPrimaryAgentPreference(.codex)
+    let claude = try await lifecycle.createWorktree(
+        repoID: repo.id,
+        primaryAgentPreference: .claude
+    )
+    #expect(try await db.terminals.list(worktreeID: claude.id).contains { $0.kind == .claude })
+}
+
 @Test func testCreateWorktreePersistsPrimaryAgentAsFirstAndActiveTab() async throws {
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/Tests/TBDSharedTests/ModelsTests.swift
+++ b/Tests/TBDSharedTests/ModelsTests.swift
@@ -450,7 +450,8 @@ import Testing
         branch: "feat/my-branch",
         displayName: "My Display Name",
         prompt: "Build the thing",
-        model: "claude-fable-5"
+        model: "claude-fable-5",
+        primaryAgentPreference: .codex
     )
     let data = try JSONEncoder().encode(params)
     let decoded = try JSONDecoder().decode(WorktreeCreateParams.self, from: data)
@@ -460,6 +461,7 @@ import Testing
     #expect(decoded.displayName == "My Display Name")
     #expect(decoded.prompt == "Build the thing")
     #expect(decoded.model == "claude-fable-5")
+    #expect(decoded.primaryAgentPreference == .codex)
 }
 
 @Test func testWorktreeCreateParamsRoundTripWithNilFields() throws {
@@ -473,6 +475,20 @@ import Testing
     #expect(decoded.displayName == nil)
     #expect(decoded.prompt == nil)
     #expect(decoded.model == nil)
+    #expect(decoded.primaryAgentPreference == nil)
+}
+
+@Test func worktreeCreateParamsDecodesWithoutPrimaryAgentOverride() throws {
+    let data = Data(#"{"repoID":"11111111-1111-1111-1111-111111111111"}"#.utf8)
+    let decoded = try JSONDecoder().decode(WorktreeCreateParams.self, from: data)
+    #expect(decoded.primaryAgentPreference == nil)
+}
+
+@Test func codexUsageResultDecodesWithoutOptionalMetadata() throws {
+    let data = Data(#"{"rateLimits":[]}"#.utf8)
+    let decoded = try JSONDecoder().decode(CodexUsageResult.self, from: data)
+    #expect(decoded.account == nil)
+    #expect(decoded.unavailableReason == nil)
 }
 
 @Test func repoDecodesLegacyJSONWithoutNewFields() throws {


### PR DESCRIPTION
## Summary

- add a Codex account row to the sidebar worktree `+` picker so a single click creates that worktree with Codex
- fetch the ambient Codex identity and quota windows on picker open through the Codex app-server machine protocol, then show email, dynamic usage bars, reset times, and limit-reached status beside the Claude accounts
- add a backward-compatible create-time primary-agent override, including the detached pre-session path, while preserving the global default for plain/branch creation and Claude carryover precedence
- explicitly mark Claude profile/model picks as Claude, fixing the existing case where a global Codex default silently ignored the selected Claude profile

## Codex API experiment

Tested with `codex-cli 0.146.0-alpha.9.2`:

- generated the default app-server JSON schema and confirmed `account/read` and `account/rateLimits/read` are included without experimental schema generation
- completed a live stdio handshake (`initialize` → `initialized` → account/limits reads)
- observed account email/plan plus the base `codex` quota bucket and a named model-scoped bucket, with used percent, window duration, and reset timestamp

TBD never reads `~/.codex/auth.json` or scrapes the TUI. The fetch is a bounded, short-lived child process and resolves Codex from PATH plus common launchd-safe install locations such as `~/.local/bin` and Homebrew.

This stays user-gesture-driven and ephemeral: no background poller, persistence, migration, config flag, or design spec is needed for this additive UI path.

## Verification

- `swift build` ✅
- `swift build --target TBDSharedTests` ✅
- `swift build --target TBDDaemonTests` ✅
- live Codex app-server account/rate-limit probe ✅
- `git diff --check` ✅
- `swift test` ⚠️ blocked before test execution by the local toolchain lacking `XCTest` for the existing `Tests/TBDAppTests/ArchiveTombstoneTests.swift`
- `swiftlint --strict` ⚠️ blocked locally because SourceKitten could not load `sourcekitdInProc.framework`
