### PR TITLE
fix: supervise Codex from Nightwatch

### DIFF
--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -107,19 +107,26 @@ public actor DeskSessionManager: DeskSessionManaging {
 
     /// Idempotent: ensure a Watch Desk scratch space exists.
     /// Returns existing desk worktree if already created, otherwise creates one.
-    /// On recovery, respawns a Claude terminal if one doesn't exist (H1 fix: desk dead after off→on cycle).
+    /// On recovery, respawns the configured primary agent if it has no live pane
+    /// (H1 fix: desk dead after off→on cycle).
     /// - Parameter mode: The current nightwatch mode (daywatch or nightwatch)
     /// - Returns: The Worktree for the desk session
     public func ensureDeskSession(mode: NightwatchMode) async throws -> Worktree {
         await gateAcquire()
         defer { gateRelease() }
-        // Validate cached desk session: must be active AND have a live Claude terminal
+        let preferredKind = try await preferredAgentKind()
+
+        // Validate cached desk session: the row alone is not enough. Agent
+        // processes can exit before their terminal row is removed, so require a
+        // live pane owned by the currently configured primary agent.
         if let cachedID = deskWorktreeID,
            let existing = try await db.worktrees.get(id: cachedID),
            existing.status == .active {
-            // Check if it has a live Claude terminal
-            let terminals = try await db.terminals.list(worktreeID: existing.id)
-            if terminals.first(where: { $0.label == TerminalLabel.claudeCode }) != nil {
+            if try await liveAgentTerminal(
+                worktreeID: existing.id,
+                server: existing.tmuxServer,
+                kind: preferredKind
+            ) != nil {
                 // Fast path: cached desk is alive and valid.
                 // Mode switches (daywatch ↔ nightwatch) intentionally REUSE the existing desk and terminal.
                 // The desk is NOT respawned on mode switch because every tick re-derives the mode and
@@ -141,10 +148,14 @@ public actor DeskSessionManager: DeskSessionManaging {
         if let existing = activeWorktrees.first(where: { $0.displayName == NightwatchDeskPrompts.deskDisplayName && $0.isScratch }) {
             deskWorktreeID = existing.id
 
-            // Ensure the recovered desk has a live Claude terminal; respawn if missing
-            let terminals = try await db.terminals.list(worktreeID: existing.id)
-            if terminals.first(where: { $0.label == TerminalLabel.claudeCode }) == nil {
-                logger.info("Recovered Watch Desk \(existing.id, privacy: .public) but no Claude terminal; respawning")
+            // Ensure the recovered desk has a live configured agent; respawn if
+            // its row is missing OR its pane exited.
+            if try await liveAgentTerminal(
+                worktreeID: existing.id,
+                server: existing.tmuxServer,
+                kind: preferredKind
+            ) == nil {
+                logger.info("Recovered Watch Desk \(existing.id, privacy: .public) but no live \(preferredKind.rawValue, privacy: .public) terminal; respawning")
                 do {
                     _ = try await spawnDeskTerminal(worktree: existing, mode: mode)
                 } catch {
@@ -199,7 +210,7 @@ public actor DeskSessionManager: DeskSessionManaging {
             throw error
         }
 
-        // Spawn a Claude terminal configured for nightwatch operations
+        // Spawn the configured primary agent for nightwatch operations.
         do {
             _ = try await spawnDeskTerminal(worktree: wt, mode: mode)
         } catch {
@@ -218,11 +229,11 @@ public actor DeskSessionManager: DeskSessionManaging {
         return wt
     }
 
-    /// Resolve the Watch Desk's *live* Claude terminal, newest first.
+    /// Resolve the Watch Desk's *live* configured agent terminal, newest first.
     ///
     /// `TerminalStore.list` orders by `createdAt` ascending, so the previous
-    /// `terminals.first(where: { $0.label == .claudeCode })` deterministically returned
-    /// the OLDEST Claude row — not a race, a guarantee. Desk terminal rows outlive their
+    /// `terminals.first(where:)` deterministically returned the OLDEST row —
+    /// not a race, a guarantee. Desk terminal rows outlive their
     /// panes: a session that dies, or is killed out-of-band (the nightwatch judge handoff
     /// `kill-window`s its predecessor directly, so the daemon never removes the row),
     /// leaves its row behind forever. The oldest row is therefore the one *most* likely
@@ -239,24 +250,78 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// unrelated session*, which would then receive a pasted judge prompt plus Enter. That
     /// is issue #384, and picking the newest row alone would not prevent it.
     ///
-    /// - Returns: The newest Claude terminal whose tmux window is still alive, or nil.
-    private func liveClaudeTerminal(worktreeID: UUID, server: String) async throws -> Terminal? {
+    /// Hibernated/suspended rows are excluded even if their tmux window still
+    /// exists: their pane contains a shell, not an agent, and pasting a judge
+    /// prompt there would execute it as shell input.
+    ///
+    /// - Returns: The newest matching agent terminal whose tmux window is still alive, or nil.
+    private func liveAgentTerminal(
+        worktreeID: UUID,
+        server: String,
+        kind: TerminalKind
+    ) async throws -> Terminal? {
         let candidates = try await db.terminals.list(worktreeID: worktreeID)
-            .filter { $0.label == TerminalLabel.claudeCode }
+            .filter {
+                $0.suspendedAt == nil
+                    && $0.hibernatedAt == nil
+                    && terminal($0, matches: kind)
+            }
             // Secondary key on id: Swift's sort is not stable, and two rows can share a
             // createdAt, so without it the winner between same-instant rows is arbitrary.
             .sorted { ($0.createdAt, $0.id.uuidString) > ($1.createdAt, $1.id.uuidString) }
 
         for terminal in candidates {
-            if await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) {
-                return terminal
+            guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
+                logger.notice("""
+                    Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
+                    window \(terminal.tmuxWindowID, privacy: .public) no longer exists
+                    """)
+                continue
             }
-            logger.notice("""
-                Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
-                window \(terminal.tmuxWindowID, privacy: .public) no longer exists
-                """)
+            if tmux.verifiesPaneCurrentCommand {
+                guard let command = try? await tmux.paneCurrentCommand(
+                    server: server,
+                    paneID: terminal.tmuxPaneID
+                ), Self.agentCommand(command, matches: kind) else {
+                    logger.notice("""
+                        Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
+                        pane exists but no \(kind.rawValue, privacy: .public) process is running
+                        """)
+                    continue
+                }
+            }
+            return terminal
         }
         return nil
+    }
+
+    static func agentCommand(_ command: String, matches kind: TerminalKind) -> Bool {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch kind {
+        case .claude:
+            return ClaudeStateDetector.isClaudeProcess(trimmed)
+                || URL(fileURLWithPath: trimmed).lastPathComponent == "claude"
+        case .codex:
+            return URL(fileURLWithPath: trimmed).lastPathComponent == "codex"
+        case .shell:
+            return false
+        }
+    }
+
+    private func preferredAgentKind() async throws -> TerminalKind {
+        try await db.config.get().primaryAgentPreference.terminalKind
+    }
+
+    private func terminal(_ terminal: Terminal, matches kind: TerminalKind) -> Bool {
+        switch kind {
+        case .codex:
+            return terminal.isCodexTerminal
+        case .claude:
+            return !terminal.isCodexTerminal
+                && (terminal.kind == .claude || terminal.label == TerminalLabel.claudeCode)
+        case .shell:
+            return false
+        }
     }
 
     /// Post a shift wrap-up prompt to the desk session and fire a completion notification.
@@ -275,24 +340,27 @@ public actor DeskSessionManager: DeskSessionManaging {
                 return
             }
 
-            guard let claudeTerminal = try await liveClaudeTerminal(
-                worktreeID: worktreeID, server: worktree.tmuxServer
+            let preferredKind = try await preferredAgentKind()
+            guard let agentTerminal = try await liveAgentTerminal(
+                worktreeID: worktreeID,
+                server: worktree.tmuxServer,
+                kind: preferredKind
             ) else {
-                logger.warning("No live Claude terminal in Watch Desk; skipping wrap-up prompt")
+                logger.warning("No live \(preferredKind.rawValue, privacy: .public) terminal in Watch Desk; skipping wrap-up prompt")
                 return
             }
 
             // Paste the wrap-up prompt text
             try await tmux.pasteText(
                 server: worktree.tmuxServer,
-                paneID: claudeTerminal.tmuxPaneID,
+                paneID: agentTerminal.tmuxPaneID,
                 bytes: Data(NightwatchDeskPrompts.wrapUpPrompt.utf8)
             )
 
             // Send Enter to submit
             try await tmux.sendKey(
                 server: worktree.tmuxServer,
-                paneID: claudeTerminal.tmuxPaneID,
+                paneID: agentTerminal.tmuxPaneID,
                 key: "Enter"
             )
 
@@ -340,13 +408,39 @@ public actor DeskSessionManager: DeskSessionManaging {
                 return
             }
 
-            guard let claudeTerminal = try await liveClaudeTerminal(
-                worktreeID: worktreeID, server: worktree.tmuxServer
-            ) else {
-                // Deliberately does NOT stamp lastNudgeTime: a nudge that never reached a
-                // pane must not start the 10-minute overlap cooldown, or one dead desk
-                // would suppress the retry that recovers it.
-                logger.warning("No live Claude terminal in Watch Desk; skipping nudge")
+            var preferredKind = try await preferredAgentKind()
+            var agentTerminal = try await liveAgentTerminal(
+                worktreeID: worktreeID,
+                server: worktree.tmuxServer,
+                kind: preferredKind
+            )
+            if agentTerminal == nil {
+                // A terminal row can survive a process/pane exit. Recover in the
+                // nudge path itself so one failed launch does not turn into a
+                // silent all-night outage waiting for a mode toggle or daemon
+                // restart. spawnPrimaryTerminals uses the same configured
+                // primary-agent preference and production launch path as normal
+                // worktrees.
+                logger.notice("No live \(preferredKind.rawValue, privacy: .public) Watch Desk terminal; retrying spawn before nudge")
+                do {
+                    try await spawnDeskTerminal(worktree: worktree, mode: mode)
+                    // Re-read in case the preference changed while spawning.
+                    preferredKind = try await preferredAgentKind()
+                    agentTerminal = try await liveAgentTerminal(
+                        worktreeID: worktreeID,
+                        server: worktree.tmuxServer,
+                        kind: preferredKind
+                    )
+                } catch {
+                    logger.warning("Failed to recover Watch Desk terminal before nudge: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+
+            guard let agentTerminal else {
+                // Deliberately does NOT stamp lastNudgeTime: a nudge that never
+                // reached a pane must not start the 10-minute overlap cooldown,
+                // or one dead desk would suppress the next recovery attempt.
+                logger.warning("No live \(preferredKind.rawValue, privacy: .public) terminal in Watch Desk after retry; skipping nudge")
                 return
             }
 
@@ -380,14 +474,14 @@ public actor DeskSessionManager: DeskSessionManaging {
             // Paste the prompt text (matches handleTerminalSend pattern for reliability)
             try await tmux.pasteText(
                 server: worktree.tmuxServer,
-                paneID: claudeTerminal.tmuxPaneID,
+                paneID: agentTerminal.tmuxPaneID,
                 bytes: Data(prompt.utf8)
             )
 
             // Send Enter to submit
             try await tmux.sendKey(
                 server: worktree.tmuxServer,
-                paneID: claudeTerminal.tmuxPaneID,
+                paneID: agentTerminal.tmuxPaneID,
                 key: "Enter"
             )
 
@@ -467,7 +561,8 @@ public actor DeskSessionManager: DeskSessionManaging {
         }
     }
 
-    /// Spawn a Claude terminal in the desk worktree using lifecycle.spawnPrimaryTerminals.
+    /// Spawn the configured primary agent in the desk worktree using
+    /// lifecycle.spawnPrimaryTerminals.
     /// This reuses the production spawn path which handles trust seeding, overlay injection, etc.
     /// Note: Model selection (daywatch=Sonnet, nightwatch=Opus) requires per-profile configuration.
     /// The resolved profile's model is what gets used; mode affects behavior (conservative vs. free-acting),

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -68,6 +68,14 @@ public struct TmuxManager: Sendable {
     /// command string without relying on tmux's actual pane_current_command.
     public let realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)?
 
+    /// Whether callers should treat `paneCurrentCommand` as a meaningful
+    /// process-liveness signal. Plain dry-run fixtures intentionally return a
+    /// synthetic `zsh`; tests that inject `dryRunPaneCurrentCommand` opt back
+    /// into command verification.
+    var verifiesPaneCurrentCommand: Bool {
+        !dryRun || dryRunPaneCurrentCommand != nil
+    }
+
     // Thread-safe counter for generating unique mock IDs
     private final class Counter: Sendable {
         private let _value = OSAllocatedUnfairLock(initialState: 0)

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -775,22 +775,40 @@ def daemon_health():
     return {"ok": True, "absent": True, "age_s": None,
             "reason": "not-checked (this skill ships no daemon; a machine-local one may exist)"}
 
+def codex_state(activity):
+    """Classify Codex from TBD's hook-backed machine state, never its TUI."""
+    return {
+        "working": ("WORKING", "Codex hook state: working"),
+        "waiting_for_user": ("DECISION", "Codex is waiting for user input"),
+        "idle": ("IDLE", "Codex hook state: idle"),
+        "unknown": ("IDLE", "Codex activity is not known yet"),
+    }.get(activity or "unknown", ("IDLE", f"Codex hook state: {activity}"))
+
 def fleet():
     rows = sh(["sqlite3","-separator","\t",DB,
-      "SELECT t.tmuxPaneID, w.displayName, w.tmuxServer, t.id, w.repoID "
-      "FROM worktree w JOIN terminal t ON t.worktreeID=w.id AND t.kind='claude' AND t.suspendedAt IS NULL "
+      "SELECT t.tmuxPaneID, w.displayName, w.tmuxServer, t.id, w.repoID, t.kind, "
+      "COALESCE(t.activityState,'unknown') "
+      "FROM worktree w JOIN terminal t ON t.worktreeID=w.id "
+      "AND t.kind IN ('claude','codex') AND t.suspendedAt IS NULL AND t.hibernatedAt IS NULL "
       "WHERE w.status='active' ORDER BY w.tmuxServer, w.displayName;"])
     out = []
     for l in rows.splitlines():
         p = l.split("\t")
-        if len(p) < 5: continue
-        pane, name, srv, tid, rid = p
-        # -e keeps the escapes: dimness is the only thing distinguishing a ghost
-        # suggestion from typed input, and it's gone by the time tmux strips ANSI.
-        cap_raw = sh(["tmux","-L",srv,"capture-pane","-p","-e","-t",pane])
-        cap = ANSI_RE.sub("", cap_raw)
-        state, note = classify(cap, cap_raw)
-        ctx_pct, is_1m, burn = burn_risk(cap)
+        if len(p) < 7: continue
+        pane, name, srv, tid, rid, kind, activity = p
+        if kind == "codex":
+            # Codex installs TBD hooks that publish activityState. Its rendered
+            # terminal is not Claude's UI and must not be interpreted with the
+            # grandfathered Claude-only screen classifier.
+            state, note = codex_state(activity)
+            ctx_pct, is_1m, burn = None, False, False
+        else:
+            # -e keeps the escapes: dimness is the only thing distinguishing a ghost
+            # suggestion from typed input, and it's gone by the time tmux strips ANSI.
+            cap_raw = sh(["tmux","-L",srv,"capture-pane","-p","-e","-t",pane])
+            cap = ANSI_RE.sub("", cap_raw)
+            state, note = classify(cap, cap_raw)
+            ctx_pct, is_1m, burn = burn_risk(cap)
         hook = POLICIES.get(rid, {})
         pol = hook.get("policy", {})
         # priorities/dont-touch are the UNION of global config + the repo's own hook
@@ -799,7 +817,8 @@ def fleet():
         protect = (any(d in pane or d.lower() in name.lower() for d in DONT_TOUCH)
                    or any(d.lower() in name.lower() for d in pol.get("dont_touch", [])))
         out.append({"pane": pane, "name": name, "server": srv, "tid": tid,
-                    "state": state, "note": note, "priority": prio, "protected": protect,
+                    "kind": kind, "state": state, "note": note,
+                    "priority": prio, "protected": protect,
                     "repo": hook.get("name"), "gate": pol.get("gate", {}).get("ready_when"),
                     "advance_skill": pol.get("advance_skill"), "deploy_skill": pol.get("deploy_skill"),
                     "ctx_pct": ctx_pct, "is_1m": is_1m, "burn_risk": burn})
@@ -882,7 +901,14 @@ def selftest():
     check("working outranks composer", classify(working, working)[0], "WORKING")
     check("empty pane", classify("", ""), ("EMPTY", ""))
 
-    print(f"selftest: {n}/{n} composer ghost-guard scenarios passed")
+    check("codex working comes from hook state",
+          codex_state("working"), ("WORKING", "Codex hook state: working"))
+    check("codex waiting is judgment, not scraped composer input",
+          codex_state("waiting_for_user"), ("DECISION", "Codex is waiting for user input"))
+    check("codex unknown fails quiet",
+          codex_state("unknown"), ("IDLE", "Codex activity is not known yet"))
+
+    print(f"selftest: {n}/{n} agent-state scenarios passed")
 
 
 def main():
@@ -1403,7 +1429,8 @@ def main():
     by_branch = {}
     for l in sh(["sqlite3","-separator","\t",DB,
                  "SELECT w.branch,t.tmuxPaneID,t.id,r.displayName FROM worktree w "
-                 "JOIN terminal t ON t.worktreeID=w.id AND t.kind='claude' AND t.suspendedAt IS NULL "
+                 "JOIN terminal t ON t.worktreeID=w.id "
+                 "AND t.kind IN ('claude','codex') AND t.suspendedAt IS NULL AND t.hibernatedAt IS NULL "
                  "JOIN repo r ON w.repoID=r.id WHERE w.status='active';"]).splitlines():
         p = l.split("\t")
         if len(p) >= 4: by_branch[p[0]] = {"pane": p[1], "tid": p[2], "repo": p[3]}

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -70,6 +70,27 @@ private final class PaneCommands: @unchecked Sendable {
     }
 }
 
+private final class SpawnFailureSwitch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var failing = false
+
+    func setFailing(_ value: Bool) {
+        lock.lock(); defer { lock.unlock() }
+        failing = value
+    }
+
+    func error() -> Error? {
+        lock.lock(); defer { lock.unlock() }
+        return failing
+            ? TmuxError.commandFailed(
+                command: "new-window",
+                status: 1,
+                output: "simulated desk spawn failure"
+            )
+            : nil
+    }
+}
+
 extension TBDHomeSerialized {
     @Suite("DeskSessionManager — TBD_HOME isolated")
     struct DeskSessionManagerTests {
@@ -796,7 +817,7 @@ extension TBDHomeSerialized {
         private func makeDeskFixture(tag: String) throws -> (
             db: TBDDatabase, manager: DeskSessionManager,
             recorder: DeskTmuxRecorder, dead: DeadWindows,
-            commands: PaneCommands, home: URL
+            commands: PaneCommands, spawnFailures: SpawnFailureSwitch, home: URL
         ) {
             let home = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent("tbd-desk-\(tag)-\(UUID().uuidString)", isDirectory: true)
@@ -807,10 +828,17 @@ extension TBDHomeSerialized {
             let recorder = DeskTmuxRecorder()
             let dead = DeadWindows()
             let commands = PaneCommands(defaultCommand: "1.2.3")
+            let spawnFailures = SpawnFailureSwitch()
             let manager = DeskSessionManager(
                 db: db,
                 lifecycle: WorktreeLifecycle(
-                    db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+                    db: db,
+                    git: GitManager(),
+                    tmux: TmuxManager(
+                        dryRun: true,
+                        dryRunCreateWindowError: { _ in spawnFailures.error() }
+                    ),
+                    hooks: HookResolver()
                 ),
                 tmux: TmuxManager(
                     dryRun: true,
@@ -820,7 +848,7 @@ extension TBDHomeSerialized {
                 ),
                 skillDir: home.appendingPathComponent("skills/nightwatch").path
             )
-            return (db, manager, recorder, dead, commands, home)
+            return (db, manager, recorder, dead, commands, spawnFailures, home)
         }
 
         /// The regression: `TerminalStore.list` orders createdAt ASC, so resolving the desk
@@ -892,6 +920,7 @@ extension TBDHomeSerialized {
             let seeded = try await f.db.terminals.list(worktreeID: desk.id)
             let original = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
             f.dead.markDead(original.tmuxWindowID)
+            f.spawnFailures.setFailing(true)
 
             let before = f.recorder.pastedPanes.count
             await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
@@ -900,6 +929,7 @@ extension TBDHomeSerialized {
                 "no live terminal means nothing should be pasted anywhere")
 
             // Desk comes back; the next nudge must fire immediately.
+            f.spawnFailures.setFailing(false)
             _ = try await f.db.terminals.create(
                 worktreeID: desk.id, tmuxWindowID: "@revived", tmuxPaneID: "%7",
                 label: TerminalLabel.claudeCode)

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -45,6 +45,31 @@ private final class DeadWindows: @unchecked Sendable {
     }
 }
 
+private final class PaneCommands: @unchecked Sendable {
+    private let lock = NSLock()
+    private var commands: [String: String] = [:]
+    private var defaultCommand: String
+
+    init(defaultCommand: String) {
+        self.defaultCommand = defaultCommand
+    }
+
+    func set(_ command: String, for paneID: String) {
+        lock.lock(); defer { lock.unlock() }
+        commands[paneID] = command
+    }
+
+    func setDefault(_ command: String) {
+        lock.lock(); defer { lock.unlock() }
+        defaultCommand = command
+    }
+
+    func command(for paneID: String) -> String {
+        lock.lock(); defer { lock.unlock() }
+        return commands[paneID] ?? defaultCommand
+    }
+}
+
 extension TBDHomeSerialized {
     @Suite("DeskSessionManager — TBD_HOME isolated")
     struct DeskSessionManagerTests {
@@ -770,7 +795,8 @@ extension TBDHomeSerialized {
         /// Caller owns cleanup of `home` and TBD_HOME.
         private func makeDeskFixture(tag: String) throws -> (
             db: TBDDatabase, manager: DeskSessionManager,
-            recorder: DeskTmuxRecorder, dead: DeadWindows, home: URL
+            recorder: DeskTmuxRecorder, dead: DeadWindows,
+            commands: PaneCommands, home: URL
         ) {
             let home = URL(fileURLWithPath: NSTemporaryDirectory())
                 .appendingPathComponent("tbd-desk-\(tag)-\(UUID().uuidString)", isDirectory: true)
@@ -780,6 +806,7 @@ extension TBDHomeSerialized {
             let db = try TBDDatabase(inMemory: true)
             let recorder = DeskTmuxRecorder()
             let dead = DeadWindows()
+            let commands = PaneCommands(defaultCommand: "1.2.3")
             let manager = DeskSessionManager(
                 db: db,
                 lifecycle: WorktreeLifecycle(
@@ -788,11 +815,12 @@ extension TBDHomeSerialized {
                 tmux: TmuxManager(
                     dryRun: true,
                     dryRunRecorder: { recorder.record($0) },
-                    dryRunWindowIsDead: { dead.isDead($0) }
+                    dryRunWindowIsDead: { dead.isDead($0) },
+                    dryRunPaneCurrentCommand: { _, paneID in commands.command(for: paneID) }
                 ),
                 skillDir: home.appendingPathComponent("skills/nightwatch").path
             )
-            return (db, manager, recorder, dead, home)
+            return (db, manager, recorder, dead, commands, home)
         }
 
         /// The regression: `TerminalStore.list` orders createdAt ASC, so resolving the desk
@@ -909,6 +937,74 @@ extension TBDHomeSerialized {
             #expect(
                 notifications.contains(where: { $0.type == .taskComplete }),
                 "wrap-up should still fire its completion notification")
+        }
+
+        @Test("agent command matching distinguishes Claude, Codex, and a fallen-back shell")
+        func agentCommandMatching() {
+            #expect(DeskSessionManager.agentCommand("1.2.3", matches: .claude))
+            #expect(DeskSessionManager.agentCommand("/usr/local/bin/claude", matches: .claude))
+            #expect(DeskSessionManager.agentCommand("/opt/bin/codex", matches: .codex))
+            #expect(!DeskSessionManager.agentCommand("zsh", matches: .codex))
+            #expect(!DeskSessionManager.agentCommand("codex-helper", matches: .codex))
+            #expect(!DeskSessionManager.agentCommand("codex", matches: .claude))
+        }
+
+        @Test("Watch Desk creates and nudges a Codex terminal when Codex is preferred")
+        func codexDeskCreateAndNudge() async throws {
+            let f = try makeDeskFixture(tag: "codex-create")
+            let codexHome = f.home.appendingPathComponent("codex-home", isDirectory: true)
+            setenv("TBD_TEST_CODEX_HOME", codexHome.path, 1)
+            defer {
+                unsetenv("TBD_TEST_CODEX_HOME")
+                unsetenv("TBD_HOME")
+                try? FileManager.default.removeItem(at: f.home)
+            }
+            try await f.db.config.setPrimaryAgentPreference(.codex)
+            f.commands.setDefault("codex")
+
+            let desk = try await f.manager.ensureDeskSession(mode: .nightwatch)
+            let terminals = try await f.db.terminals.list(worktreeID: desk.id)
+            let codex = try #require(terminals.first(where: {
+                $0.kind == .codex && $0.label == TerminalLabel.codex
+            }))
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            #expect(Array(f.recorder.pastedPanes.dropFirst(before)) == [codex.tmuxPaneID])
+            #expect(!terminals.contains { $0.kind == .claude })
+        }
+
+        @Test("a live Codex row whose process fell back to zsh is respawned before nudge")
+        func codexShellFallbackRecoversBeforeNudge() async throws {
+            let f = try makeDeskFixture(tag: "codex-retry")
+            let codexHome = f.home.appendingPathComponent("codex-home", isDirectory: true)
+            setenv("TBD_TEST_CODEX_HOME", codexHome.path, 1)
+            defer {
+                unsetenv("TBD_TEST_CODEX_HOME")
+                unsetenv("TBD_HOME")
+                try? FileManager.default.removeItem(at: f.home)
+            }
+            try await f.db.config.setPrimaryAgentPreference(.codex)
+            f.commands.setDefault("codex")
+
+            let desk = try await f.manager.ensureDeskSession(mode: .nightwatch)
+            let initial = try #require(
+                try await f.db.terminals.list(worktreeID: desk.id)
+                    .first(where: { $0.kind == .codex })
+            )
+            f.commands.set("zsh", for: initial.tmuxPaneID)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            let codexRows = try await f.db.terminals.list(worktreeID: desk.id)
+                .filter { $0.kind == .codex }
+            #expect(codexRows.count == 2, "dead Codex row should be preserved but replaced")
+            let replacement = try #require(codexRows.first(where: { $0.id != initial.id }))
+            #expect(
+                Array(f.recorder.pastedPanes.dropFirst(before)) == [replacement.tmuxPaneID],
+                "recovery must nudge the replacement, never the shell-backed stale row"
+            )
         }
     }
 }

--- a/Tests/TBDDaemonTests/PluginDirWriterTests.swift
+++ b/Tests/TBDDaemonTests/PluginDirWriterTests.swift
@@ -118,7 +118,7 @@ struct PluginDirWriterTests {
     /// `--selftest` short-circuits before tick.py's machine-global flock, so a
     /// live tick running concurrently can't turn this into a silent exit 0.
     /// The `scenarios passed` assertion is the backstop for that regardless.
-    @Test("tick.py --selftest passes: composer ghost-guard matrix (no DB/tmux invoked)")
+    @Test("tick.py --selftest passes: agent-state matrix (no DB/tmux invoked)")
     func tickPySelftest() throws {
         let tempRoot = NSTemporaryDirectory() + "tbd-plugin-test-\(UUID().uuidString)"
         defer { try? FileManager.default.removeItem(atPath: tempRoot) }
@@ -134,7 +134,7 @@ struct PluginDirWriterTests {
         proc.waitUntilExit()
         let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
         #expect(proc.terminationStatus == 0, "tick.py --selftest failed:\n\(output)")
-        #expect(output.contains("composer ghost-guard scenarios passed"), "unexpected output:\n\(output)")
+        #expect(output.contains("agent-state scenarios passed"), "unexpected output:\n\(output)")
     }
 
     /// The relay decides whether a desk shift survives its context ceiling, so

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -260,6 +260,19 @@ struct NightwatchDeskPromptsTests {
             #expect(!tick.contains("DAEMON_LOG"))
         }
 
+        @Test("tick and judge include Codex without scraping the Codex TUI")
+        func codexFleetRoutingUsesHookState() {
+            let tick = NightwatchSkillContent.tickPy
+            #expect(tick.contains("t.kind IN ('claude','codex')"))
+            #expect(tick.contains("def codex_state(activity)"))
+            #expect(tick.contains("state, note = codex_state(activity)"))
+            #expect(tick.contains("if kind == \"codex\""))
+            #expect(tick.contains("COALESCE(t.activityState,'unknown')"))
+
+            let judge = NightwatchSkillContent.judgePy
+            #expect(judge.contains("t.kind IN ('claude','codex')"))
+        }
+
         @Test("handoff.py is shipped and exposes the three relay verbs")
         func handoffShipped() {
             #expect(NightwatchSkillContent.scripts.contains { $0.name == "handoff.py" })


### PR DESCRIPTION
## Summary

- make Watch Desk terminal discovery agent-kind-aware for Claude and Codex
- require both a live tmux window and a matching agent process, then retry a failed desk spawn before nudging
- include Codex terminals in Nightwatch fleet/PR routing using TBD hook-backed `activityState` instead of scraping the Codex TUI
- preserve Claude-only wake/handoff behavior where resume semantics are Claude-specific

## Dependency

Depends on #561 for robust absolute Codex executable preflight and the valid profile-scoped shadcn MCP disable override (`command` + `args` + `enabled = false`). This PR deliberately does not duplicate or edit those files, so the two changes can land independently without conflicts. Nightwatch becomes fully robust once both are merged.

## Validation

- `swift build --target TBDDaemonLib`
- extracted shipped `tick.py --selftest`: 14/14 agent-state scenarios passed
- `git diff --check`
- added regression coverage for Codex desk creation/nudge, stale shell-backed Codex rows, agent command matching, stale/live row selection, and hook-state fleet routing

The local Apple 6.2.1 toolchain cannot import the standard `Testing` module, so local `swift test` and the aggregate `swift build` stop while compiling existing test targets. Source compilation succeeds; CI is the authoritative full-suite run.

## Existing safety gate

This is a bug fix inside the existing Nightwatch mode, which already defaults to `off` and runs only after the operator enables daywatch/nightwatch. It does not add a new autonomous subsystem or broaden Nightwatch authorization; it makes the already-authorized desk select and recover the configured agent kind.