### PR TITLE
Compound: Require a spec unless it's a bug fix -- and make the rule reachable from Codex

### DIFF
--- a/.claude/hooks/guardrails/rules/brainstorming_skill.py
+++ b/.claude/hooks/guardrails/rules/brainstorming_skill.py
@@ -2,10 +2,10 @@
 
 TBD vendors an adapted copy of superpowers' brainstorming skill at
 `.claude/skills/tbd-brainstorming/`. The adaptations are load-bearing: it writes
-specs to `docs/specs/`, carries TBD's blast-radius triggers and the
-"a human answers the questions" rule, and does not hand off to a skill whose own
-file would trip this repo's plans-guard. Running the upstream skill instead
-silently loses all of that.
+specs to `docs/specs/`, carries TBD's "required unless it is a bug fix or a minor
+UI change" scope and the "a human answers the questions" rule, and does not hand
+off to a skill whose own file would trip this repo's plans-guard. Running the
+upstream skill instead silently loses all of that.
 
 Unlike inferring *whether* a brainstorm happened — which no hook can see — this
 is a string comparison, so it is safe to deny rather than merely inform: the
@@ -24,8 +24,9 @@ _REDIRECTED = frozenset({"brainstorming", "superpowers:brainstorming"})
 _MESSAGE = (
     "[brainstorming-skill] Blocked: use TBD's vendored `tbd-brainstorming` skill, "
     "not the upstream one. TBD's copy writes the spec to docs/specs/, carries the "
-    "blast-radius triggers, and enforces that a human — not you — answers the "
-    "brainstorming questions. Fix: invoke the skill `tbd-brainstorming` instead."
+    "rule that a spec is required for anything that is not a bug fix or a minor UI "
+    "change, and enforces that a human — not you — answers the brainstorming "
+    "questions. Fix: invoke the skill `tbd-brainstorming` instead."
 )
 
 

--- a/.claude/skills/tbd-brainstorming/SKILL.md
+++ b/.claude/skills/tbd-brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tbd-brainstorming
-description: REQUIRED in TBD before implementing anything that is not a bug fix or a minor UI change — features, new subsystems, feature flags or config columns, database migrations, replacing a load-bearing path, or any change to how the system or product is meant to work. Explores intent, constraints, and alternatives with a human, then writes a spec to docs/specs/. Use instead of superpowers:brainstorming in this repo.
+description: REQUIRED in TBD before implementing anything that is not a bug fix or a minor UI change — features, new subsystems, feature flags or config columns, database migrations, or replacing a load-bearing path. Explores intent, constraints, and alternatives with a human, then writes a spec to docs/specs/. Use instead of superpowers:brainstorming in this repo.
 ---
 
 <!-- vendored from obra/superpowers v6.1.1 @ 5a0f8953, MIT (c) 2025 Jesse Vincent -->

--- a/.claude/skills/tbd-brainstorming/SKILL.md
+++ b/.claude/skills/tbd-brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tbd-brainstorming
-description: REQUIRED before implementing blast-radius work in TBD — anything adding a subsystem, adding or changing a feature flag or config column, a database migration, or replacing a load-bearing path. Explores intent, constraints, and alternatives with a human, then writes a spec to docs/specs/. Use instead of superpowers:brainstorming in this repo.
+description: REQUIRED in TBD before implementing anything that is not a bug fix or a minor UI change — features, new subsystems, feature flags or config columns, database migrations, replacing a load-bearing path, or any change to how the system or product is meant to work. Explores intent, constraints, and alternatives with a human, then writes a spec to docs/specs/. Use instead of superpowers:brainstorming in this repo.
 ---
 
 <!-- vendored from obra/superpowers v6.1.1 @ 5a0f8953, MIT (c) 2025 Jesse Vincent -->
@@ -21,13 +21,22 @@ Do NOT invoke any implementation skill, write any code, scaffold any project, or
 
 ## When this is REQUIRED in TBD
 
-Run this before implementing work that:
-- adds a new subsystem — a new directory under `Sources/`, or a new actor/service that owns state
-- adds or changes a feature flag or `config` column
-- adds a database migration
-- wholesale-replaces a load-bearing path (rendering, input routing, persistence)
+Decisions must be examinable — changes to our theory of the system or the product most of all. Code
+expresses a theory; a diff shows what changed, not why the theory did.
 
-Not required for bug fixes, small additive UI, or refactors.
+So run this before implementing anything that is not a bug fix or a minor UI change. A bug fix
+restores the system to its existing theory; the work that needs a spec is the work that revises it.
+Work that always qualifies:
+
+- a new subsystem — a new directory under `Sources/`, or a new actor/service that owns state
+- adding or changing a feature flag or `config` column
+- a database migration
+- wholesale-replacing a load-bearing path (rendering, input routing, persistence)
+- a new heuristic, format, or protocol — anything encoding a claim about how something behaves
+
+**Prior design does not exempt.** If the thinking already happened — in prototypes, a report,
+another repo, or an earlier session — the spec is a transcription, not new work, and it is *more*
+necessary rather than less: none of that material is in this repo, so no reviewer can read it.
 
 **A human answers these questions. You may not answer your own.** A spec you both asked and
 answered contains no human judgement while looking like diligence. If no human is available to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,13 +36,15 @@ Mechanics: daemon-side behavior gates on a `config` column added by migration (f
 
 Cautionary precedent: `auto_hibernate_enabled` shipped default-ON in `v39_session_hibernation` and had to be force-disabled in `v50` once the eat-typed-input risk was understood. Because `ADD COLUMN ... DEFAULT` backfills existing rows, flipping a default later needs a forcing `UPDATE` migration (a Swift-side default change alone is a no-op for existing installs) — and after the force-off, a user's deliberate opt-in is indistinguishable from the backfilled value, so it got reset too. Shipping default-OFF first avoids all of this. Good precedents: `control_mode_enabled`, `hibernate_input_veto_enabled` (v51).
 
-### Blast-radius work starts with a brainstormed spec
+### Work starts with a brainstormed spec
 
-Work that trips the triggers above — a new subsystem, adding or changing a feature flag or `config` column, a database migration, a wholesale replacement of a load-bearing path — runs `/tbd-brainstorming` **before** implementation and commits the spec to `docs/specs/<date>-<topic>-design.md`. If it needs a flag, it needs a spec.
+Decisions must be examinable — changes to our theory of the system or the product most of all. Code expresses a theory; a diff shows what changed, not why the theory did. So anything that is not a bug fix or a minor UI change runs `/tbd-brainstorming` **before** implementation and commits the spec to `docs/specs/<date>-<topic>-design.md`. If it needs a flag, it needs a spec.
 
-**A human answers the brainstorming questions.** An agent may not answer its own. If no human is available, stop — do not proceed on assumed answers. Agents, including the nightwatch desk, may not originate feature work; file it for a human instead.
+**Prior design does not exempt.** Thinking done in prototypes, a report, another repo, or an earlier session makes the spec a cheap transcription — not an unnecessary one. Reviewers here cannot read that material, so those decisions are the ones that most need writing down.
 
-Not required for bug fixes, small additive UI, or refactors. If a trigger fires but a brainstorm is genuinely unnecessary, say so in the PR description. This is convention, not a gate — no linter can see whether thinking happened. Use `/tbd-brainstorming`, not `superpowers:brainstorming`; a guardrail redirects the wrong one.
+**A human answers the brainstorming questions.** An agent may not answer its own. If none is available, stop — do not proceed on assumed answers. Agents, including the nightwatch desk, may not originate feature work; file it for a human instead.
+
+Bug fixes and minor UI changes need no spec — a bug fix restores the system to its existing theory, while the work that needs a spec is the work that revises it. If a larger change genuinely needs none, say so in the PR description. This is convention, not a gate — no linter can see whether thinking happened. In Claude Code use `/tbd-brainstorming`, not `superpowers:brainstorming`; a guardrail redirects the wrong one. Codex has no slash command for it — read `.claude/skills/tbd-brainstorming/SKILL.md` and follow it directly.
 
 ### Restart must use the worktree's own script
 Always run `scripts/restart.sh` (relative, from the worktree cwd), never an absolute path to the main project's copy. Using `/Users/chang/projects/tbd/scripts/restart.sh` builds and starts binaries from the main branch, leaving old worktree processes running and causing "Unknown method" RPC errors. After any restart, verify with:

--- a/docs/research/2026-07-31-codex-session-import/findings.md
+++ b/docs/research/2026-07-31-codex-session-import/findings.md
@@ -75,9 +75,16 @@ worktree.
 
 ### Each detected session carries a usable title
 
-Session entries are `{path, cwd, title}`. Titles are human-readable summaries of the conversation —
-observed examples include `"Investigate PR 561 brainstorming skip"` and
-`"Call-level triage actions: flag, log, dismiss"`. A picker can be built from `detect` alone.
+Session entries are `{path, cwd, title}`. Titles are human-readable summaries of the conversation
+rather than filenames or ids — this investigation's own session came back as
+`"Investigate PR 561 brainstorming skip"`. A picker can be built from `detect` alone.
+
+The other 48 are not reproduced here, and that is itself the finding: because session detection is
+home-scoped, the list spans every repository on the machine, and a title is a one-line description
+of what that work was about. Any picker built on `detect` will therefore show a user titles from
+unrelated projects — including, on a shared or work machine, ones that are confidential to another
+org. Filtering to the current worktree is a client-side concern with a confidentiality dimension,
+not just an ergonomic one.
 
 ### `import` returns the created thread id, so no client ledger is needed
 

--- a/docs/research/2026-07-31-codex-session-import/findings.md
+++ b/docs/research/2026-07-31-codex-session-import/findings.md
@@ -105,6 +105,39 @@ SHA256 to recover the same id; that is redundant for a client reading the notifi
 `session_meta.originator` records the `clientInfo.name` the caller sent at `initialize`, so imports
 are attributable to the tool that made them.
 
+### Conversion keeps intent and caps bulk
+
+Codex does not reproduce Claude's tool structure. Tool activity is transcoded into text inside
+assistant messages, delimited by markers:
+
+```text
+[external_agent_tool_call: WebSearch]
+input: {"query":"…"}
+[/external_agent_tool_call]
+[external_agent_tool_result]
+…result text…
+[/external_agent_tool_result]
+```
+
+There are no native `function_call` / `function_call_output` items in the result, so a resumed agent
+reads tool history as prose rather than as structured turns.
+
+Measured on a 156-line source that carried 20 `tool_use` and 20 `tool_result` blocks:
+
+- all 20 tool calls survive, with tool name and full input JSON
+- 17 result blocks survive, one of them empty — so 16 carry content, and 3 are lost outright
+- results are capped at 4,000 characters each, and truncation is largely silent: 16,703 characters
+  retained from 77,836, with two "truncated" markers and no ellipses
+- conversation prose survives intact
+
+About 79% of tool-result bulk is therefore discarded. What survives is which tools ran, with what
+arguments, in what order, plus the head of each result — the shape of the work rather than its
+output. For a handoff into the same worktree this is a reasonable trade: a truncated file read can
+simply be re-run, whereas lost intent could not be reconstructed.
+
+The conversion is literal enough to carry interface noise. A usage-limit notice rendered in the
+source session was imported as an assistant turn.
+
 ### `import/readHistories` is an audit log
 
 `ExternalAgentConfigImportHistoriesReadResponse` is `{connectors, data}`, where each `data` entry is
@@ -129,10 +162,6 @@ The command accepts `--source <claude-jsonl>`, so it is not restricted to the se
 
 ## Unknowns
 
-- **Fidelity of the conversion.** The imported thread had 107 lines against the source's 156. Some
-  of that gap is expected — Claude JSONL carries `attachment`, `ai-title`, `permission-mode` and
-  similar entries with no Codex equivalent — but whether tool calls and their results survive was
-  not examined. This bears directly on how useful an imported thread is.
 - **Idempotency.** Whether importing the same session twice yields one thread or two, and what
   Codex's `external_agent_session_imports.json` does once the source transcript grows after import.
 - Whether `migrationSource` selects agents other than Claude Code, and what values it accepts. The

--- a/docs/research/2026-07-31-codex-session-import/findings.md
+++ b/docs/research/2026-07-31-codex-session-import/findings.md
@@ -1,8 +1,9 @@
 # Importing a Claude session into Codex: the `externalAgentConfig` app-server surface
 
 **Status:** Investigated, not implemented
-**Tested:** 2026-07-31 by driving `codex app-server` over stdio with codex-cli 0.145.0
-**Plugin surface inspected:** `openai/codex-plugin-cc` 1.0.4 (installed) and 1.0.6 (`db52e28`, upstream HEAD)
+**Tested:** 2026-07-31 by driving `codex app-server` over stdio with codex-cli 0.145.0 — `detect` and a
+single-session `import` were both executed against a live server
+**Plugin surface inspected:** `openai/codex-plugin-cc` 1.0.6 (`db52e28`, upstream HEAD)
 
 ## Summary
 
@@ -78,20 +79,31 @@ Session entries are `{path, cwd, title}`. Titles are human-readable summaries of
 observed examples include `"Investigate PR 561 brainstorming skip"` and
 `"Call-level triage actions: flag, log, dismiss"`. A picker can be built from `detect` alone.
 
-### `import` takes a path, and returns an import id — not a thread id
+### `import` returns the created thread id, so no client ledger is needed
 
-`SessionMigration` requires `{cwd, path}` with optional `title`. `ExternalAgentConfigImportResponse`
-is `{importId}`. The `externalAgentConfig/import/completed` notification is
-`{importId, itemTypeResults[]}`, keyed by item *type* rather than by imported item.
+`SessionMigration` requires `{cwd, path}` with optional `title`. The request returns
+`{importId}` — an id for the import *operation*. The thread id arrives in the
+`externalAgentConfig/import/progress` and `.../completed` notifications, whose per-item success
+entries pair the input with the output:
 
-Nothing in that chain returns a resumable thread id. `codex-plugin-cc` recovers one after the fact
-from its own ledger, matching the source file's canonical path and SHA256. Thread resolution is
-therefore client bookkeeping, not a protocol guarantee.
+```jsonc
+{"itemType":"SESSIONS",
+ "cwd":null,
+ "source":"/Users/…/.claude/projects/<slug>/<session-id>.jsonl",
+ "target":"019fb9d4-f45a-7061-8953-d377b660dba3"}
+```
 
-`ExternalAgentConfigImportItemTypeSuccess` does carry an optional `target` alongside `itemType`,
-`cwd` and `source`. Whether `target` names the created thread for a `SESSIONS` import is the single
-open question that would decide whether a caller needs a ledger at all. One `import` call settles
-it; `import` mutates Codex state, so it was not run.
+`target` is a resumable Codex session. The import above produced
+`~/.codex/sessions/2026/07/31/rollout-<ts>-019fb9d4-….jsonl`, 96 KB, whose `session_meta` carries
+`session_id` equal to `target` and the source session's `cwd`. Codex records the import in its own
+`~/.codex/external_agent_session_imports.json`. Round trip was roughly 60 ms.
+
+A caller therefore goes from a Claude transcript path to a resumable Codex thread with no
+bookkeeping of its own. `codex-plugin-cc` maintains a private ledger keyed by source path and
+SHA256 to recover the same id; that is redundant for a client reading the notification.
+
+`session_meta.originator` records the `clientInfo.name` the caller sent at `initialize`, so imports
+are attributable to the tool that made them.
 
 ### `import/readHistories` is an audit log
 
@@ -117,10 +129,12 @@ The command accepts `--source <claude-jsonl>`, so it is not restricted to the se
 
 ## Unknowns
 
-- `import` was never executed. Everything about import results, including whether `target` names the
-  created thread, is unverified.
-- Whether a session imported twice produces one thread or two, and what the path + SHA256 ledger
-  implies once a transcript grows after import.
+- **Fidelity of the conversion.** The imported thread had 107 lines against the source's 156. Some
+  of that gap is expected — Claude JSONL carries `attachment`, `ai-title`, `permission-mode` and
+  similar entries with no Codex equivalent — but whether tool calls and their results survive was
+  not examined. This bears directly on how useful an imported thread is.
+- **Idempotency.** Whether importing the same session twice yields one thread or two, and what
+  Codex's `external_agent_session_imports.json` does once the source transcript grows after import.
 - Whether `migrationSource` selects agents other than Claude Code, and what values it accepts. The
   schema documents only that unrecognized values fall back to a default.
 - Behavior of `/codex:transfer` against an exhausted Claude quota.
@@ -131,8 +145,15 @@ The command accepts `--source <claude-jsonl>`, so it is not restricted to the se
 TBD is well positioned for exactly one part of this, and it is not the part a handoff feature would
 normally focus on. `detect` returns a global, unordered list of every recent Claude session. TBD
 already knows which worktree, which tab, and which session id the user means, so it can collapse
-that list to a single entry without a picker. The transcript problem — fidelity, truncation,
-summarization — does not exist on this path, because TBD never reads the transcript.
+that list to a single entry — and can skip `detect` altogether, constructing the `SessionMigration`
+from the `transcriptPath` it already stores on the terminal row. The transcript problem —
+truncation, excerpting, summarization — does not exist on this path, because TBD never reads the
+transcript.
+
+Because the imported thread already contains the conversation, there is no handoff document to read
+and therefore no initial prompt to send. A Codex terminal resumed on `target` opens with history and
+an empty composer, spending no turn. That is the behavior a generated-summary design has to work to
+approximate.
 
 Two constraints bound any such integration.
 

--- a/docs/research/2026-07-31-codex-session-import/findings.md
+++ b/docs/research/2026-07-31-codex-session-import/findings.md
@@ -1,0 +1,166 @@
+# Importing a Claude session into Codex: the `externalAgentConfig` app-server surface
+
+**Status:** Investigated, not implemented
+**Tested:** 2026-07-31 by driving `codex app-server` over stdio with codex-cli 0.145.0
+**Plugin surface inspected:** `openai/codex-plugin-cc` 1.0.4 (installed) and 1.0.6 (`db52e28`, upstream HEAD)
+
+## Summary
+
+Codex can ingest a Claude Code session transcript natively. The conversion is performed by Codex
+from a filesystem path; no caller needs to parse Claude's JSONL, and no model turn is consumed on
+either side.
+
+The capability is an app-server protocol surface, not a CLI subcommand and not a plugin feature.
+`codex --help` has no `import`. The `codex-plugin-cc` `/codex:transfer` command is a convenience
+wrapper over the same protocol, so an integration does not depend on that plugin being installed.
+
+Two properties make this materially different from writing a handoff summary. Fidelity is not a
+design question — Codex reads the whole transcript rather than a caller-chosen excerpt. And the
+path is reachable with no Claude process running, so it works when the source session is out of
+quota, which a Claude-side command cannot be.
+
+The surface is experimental and moving. `codex app-server` is marked `[experimental]`, and the
+entire client path landed upstream between plugin 1.0.4 and 1.0.6.
+
+## Reproducing
+
+Bare `codex app-server` speaks newline-delimited JSON-RPC on stdio. (A socket form,
+`codex app-server --listen unix://…`, is documented in
+[the channels findings](../2026-07-26-claude-code-channels/findings.md).)
+
+```jsonc
+>> {"jsonrpc":"2.0","id":1,"method":"initialize",
+    "params":{"clientInfo":{"name":"probe","title":"probe","version":"0.0.1"}}}
+<< {"id":1,"result":{"userAgent":"probe/0.145.0 (Mac OS 26.1.0; arm64) …",
+    "codexHome":"/Users/…/.codex","platformFamily":"unix","platformOs":"macos"}}
+
+>> {"jsonrpc":"2.0","method":"initialized","params":{}}
+>> {"jsonrpc":"2.0","id":2,"method":"externalAgentConfig/detect",
+    "params":{"cwds":["/path/to/a/worktree"],"includeHome":true}}
+<< {"id":2,"result":{"items":[ … ]}}
+```
+
+The full protocol schema can be generated locally, without running a server:
+
+```sh
+codex app-server generate-json-schema --out <dir>   # --out is required
+```
+
+## Observed facts
+
+### `detect` is a setup-migration API; sessions are one item type of ten
+
+`ExternalAgentConfigMigrationItemType` is an enum of `AGENTS_MD`, `CONFIG`, `SKILLS`, `PLUGINS`,
+`MCP_SERVER_CONFIG`, `SUBAGENTS`, `HOOKS`, `COMMANDS`, `MEMORY`, `SESSIONS`.
+
+A single `detect` call on a developer machine returned ten items. Alongside `SESSIONS`, it proposed
+migrating `~/.claude/CLAUDE.md` to `~/.codex/AGENTS.md`, hooks from `~/.claude` into
+`~/.codex/hooks.json`, skills and commands into `~/.agents/skills`, MCP servers into
+`~/.codex/config.toml`, and enabled plugins from `~/.claude/settings.json`.
+
+This framing is the origin of the context-parity concerns that surround Claude-to-Codex handoff
+generally: the same mechanism that moves a conversation also moves — or offers to move — the
+agent's whole configuration.
+
+### Session detection is home-scoped; config detection is repo-scoped
+
+Passing `cwds` produced repo-scoped `HOOKS`, `SKILLS` and `AGENTS_MD` items carrying that `cwd`.
+The `SESSIONS` item came back with `cwd: null` and covered **49 recent sessions from
+`~/.claude/projects`** regardless of the `cwds` argument.
+
+Restricting sessions to a working directory is therefore a client-side filter over the returned
+list, not a server-side query. In the observed sample, 7 of 49 sessions had a `cwd` under a TBD
+worktree.
+
+### Each detected session carries a usable title
+
+Session entries are `{path, cwd, title}`. Titles are human-readable summaries of the conversation —
+observed examples include `"Investigate PR 561 brainstorming skip"` and
+`"Call-level triage actions: flag, log, dismiss"`. A picker can be built from `detect` alone.
+
+### `import` takes a path, and returns an import id — not a thread id
+
+`SessionMigration` requires `{cwd, path}` with optional `title`. `ExternalAgentConfigImportResponse`
+is `{importId}`. The `externalAgentConfig/import/completed` notification is
+`{importId, itemTypeResults[]}`, keyed by item *type* rather than by imported item.
+
+Nothing in that chain returns a resumable thread id. `codex-plugin-cc` recovers one after the fact
+from its own ledger, matching the source file's canonical path and SHA256. Thread resolution is
+therefore client bookkeeping, not a protocol guarantee.
+
+`ExternalAgentConfigImportItemTypeSuccess` does carry an optional `target` alongside `itemType`,
+`cwd` and `source`. Whether `target` names the created thread for a `SESSIONS` import is the single
+open question that would decide whether a caller needs a ledger at all. One `import` call settles
+it; `import` mutates Codex state, so it was not run.
+
+### `import/readHistories` is an audit log
+
+`ExternalAgentConfigImportHistoriesReadResponse` is `{connectors, data}`, where each `data` entry is
+`{importId, completedAtMs, successes[], failures[]}`. It reports past import operations. It does not
+enumerate available Claude sessions — `detect` is the discovery call.
+
+## Plugin surface
+
+`/codex:transfer` exists in `codex-plugin-cc` **1.0.6** and not in **1.0.4**; 1.0.4's
+`scripts/lib/codex.mjs` contains no `externalAgentConfig` references at all. An installed copy is
+not evidence the command is available.
+
+Its frontmatter sets `disable-model-invocation: true`, which removes the command from the model's
+SlashCommand tool and its metadata from context. It does not mean the command runs without a model
+turn: the body pairs a `!`-prefixed bash invocation with the instruction *"Present the command
+output to the user exactly as returned"*, so a turn is spent rendering the printed
+`codex resume <session-id>`. A source session that is out of quota is therefore not served by the
+command, even though the underlying import needs nothing from Claude. This reasoning follows from
+the command definition; behavior under an exhausted quota was not observed.
+
+The command accepts `--source <claude-jsonl>`, so it is not restricted to the session invoking it.
+
+## Unknowns
+
+- `import` was never executed. Everything about import results, including whether `target` names the
+  created thread, is unverified.
+- Whether a session imported twice produces one thread or two, and what the path + SHA256 ledger
+  implies once a transcript grows after import.
+- Whether `migrationSource` selects agents other than Claude Code, and what values it accepts. The
+  schema documents only that unrecognized values fall back to a default.
+- Behavior of `/codex:transfer` against an exhausted Claude quota.
+- `codex app-server` is experimental; none of these contracts are stable.
+
+## Implication for TBD
+
+TBD is well positioned for exactly one part of this, and it is not the part a handoff feature would
+normally focus on. `detect` returns a global, unordered list of every recent Claude session. TBD
+already knows which worktree, which tab, and which session id the user means, so it can collapse
+that list to a single entry without a picker. The transcript problem — fidelity, truncation,
+summarization — does not exist on this path, because TBD never reads the transcript.
+
+Two constraints bound any such integration.
+
+The destructive one: `import` is a migration call whose sibling item types overwrite
+`~/.codex/AGENTS.md`, `~/.codex/hooks.json`, `~/.codex/config.toml`, and installed skills and
+plugins. A caller must construct `migrationItems` containing only the `SESSIONS` entry it intends. A
+malformed array rewrites a user's Codex configuration.
+
+The stability one: the protocol is experimental, and the client surface for it appeared upstream
+within a single quarter. Committing daemon code against it means tracking a target that is still
+moving.
+
+Both point the same way under existing repo convention: such work ships behind a default-off flag,
+and needs a spec before implementation.
+
+## Relation to PR #561
+
+`feat: add Continue in Codex handoffs` implements Claude-to-Codex handoff by generating a summary
+document instead of using this surface. Its `DeterministicCodexHandoffGenerator` reads the last
+64 KB of the session JSONL, keeps only `user` and `assistant` entries with non-empty text, renders
+at most 8 KB of that, and caps the document at 16 KB.
+
+On a representative long session — 2.7 MB across 1,655 lines — the 64 KB window is 2.3% of the
+transcript, taken from the tail. The slice grows least representative exactly as sessions grow
+longest, which is when a handoff is most wanted. The filter also discards structured entries that
+answer "what is this session doing" more directly than the prose does: `ai-title` (a one-line
+summary Claude Code maintains), `last-prompt` (the most recent instruction), `file-history-delta`
+and `file-history-snapshot` (files touched), and `pr-link`.
+
+Codex's own `detect` surfaces an equivalent one-line title per session without any of that
+machinery, and `import` consumes the entire transcript rather than a window of it.

--- a/docs/specs/2026-07-31-brainstorming-gate-reachability-design.md
+++ b/docs/specs/2026-07-31-brainstorming-gate-reachability-design.md
@@ -21,15 +21,16 @@ permits any reason ("if a trigger fires but a brainstorm is genuinely unnecessar
 description"). But it is precisely the failure the gate exists to prevent: the 2026-07-26 design's
 own Why section condemns design thinking that "lived in a session scratchpad." Six prototypes and a
 parity report are a session scratchpad by another name — none of that material is in this repo, so
-no reviewer of #561 could inspect the decisions it encodes.
+no reviewer of #561 could examine the decisions it encodes.
 
-The concrete cost is visible in the diff. `DeterministicCodexHandoffGenerator` decides that a
-Claude session's context is best represented by the last 64 KB of its JSONL, filtered to `user` and
-`assistant` entries with non-empty text, truncated to 8 KB. Nothing else in TBD parses transcripts
-this way. On a real 2.7 MB session that tail is 2.3% of the file and yields a mid-thought fragment,
-while the JSONL's own typed fields — `ai-title`, `last-prompt`, `file-history-delta`, `pr-link` —
-are discarded. Whether that is the right trade is arguable either way; the problem is that it was
-never written down anywhere it could be argued with.
+The concrete cost is visible in the diff. `DeterministicCodexHandoffGenerator` embeds a theory:
+that what a Claude session was doing is best represented by the last 64 KB of its JSONL, filtered
+to `user` and `assistant` entries with non-empty text, truncated to 8 KB. Nothing else in TBD parses
+transcripts this way. On a real 2.7 MB session that tail is 2.3% of the file and yields a
+mid-thought fragment, while the JSONL's own typed fields — `ai-title`, `last-prompt`,
+`file-history-delta`, `pr-link` — are discarded. Whether that theory is right is arguable either
+way. The problem is that it arrived as code, where the diff shows the filter but not the claim, and
+so was never anywhere it could be argued with.
 
 **Cause 2 — the gate is unreachable from Codex, and #561 was written from Codex.** See
 "Reachability" below. `/tbd-brainstorming` does not exist in a Codex session. The rule instructs
@@ -40,10 +41,12 @@ Codex readers to invoke a skill they cannot invoke.
 Three edits, replacing the `### Blast-radius work starts with a brainstormed spec` section of
 `CLAUDE.md`.
 
-- **State the purpose.** The rule opens with why it exists: decisions about product behaviour and
-  architecture must be inspectable by reviewers separately from the code that implements them. A
-  purpose is something an author can reason *from*; the previous trigger list was something to
-  match against.
+- **State the purpose.** The rule opens with why it exists: decisions must be examinable, and
+  changes to our theory of the system or the product most of all. Code expresses a theory; a diff
+  shows what changed, not why the theory did. A purpose is something an author can reason *from*;
+  the previous trigger list was something to match against. This is also the sharpest test of
+  whether a change is exempt — a bug fix restores the system to its existing theory, while the work
+  that needs a spec is the work that revises it.
 - **Invert the default.** From "required when one of four triggers fires" to "required unless this
   is a bug fix or a minor UI change." Refactors leave the exemption list: "wholesale-replaces a
   load-bearing path" and "this is just a refactor" describe the same diff from two angles, and the
@@ -57,10 +60,10 @@ New text:
 ```markdown
 ### Work starts with a brainstormed spec
 
-Decisions about product behaviour and architecture must be inspectable by reviewers separately
-from the code that implements them. So anything that is not a bug fix or a minor UI change runs
-`/tbd-brainstorming` **before** implementation and commits the spec to
-`docs/specs/<date>-<topic>-design.md`. If it needs a flag, it needs a spec.
+Decisions must be examinable — changes to our theory of the system or the product most of all.
+Code expresses a theory; a diff shows what changed, not why the theory did. So anything that is
+not a bug fix or a minor UI change runs `/tbd-brainstorming` **before** implementation and commits
+the spec to `docs/specs/<date>-<topic>-design.md`. If it needs a flag, it needs a spec.
 
 **Prior design does not exempt.** Thinking done in prototypes, a report, another repo, or an
 earlier session makes the spec a cheap transcription — not an unnecessary one. Reviewers here

--- a/docs/specs/2026-07-31-brainstorming-gate-reachability-design.md
+++ b/docs/specs/2026-07-31-brainstorming-gate-reachability-design.md
@@ -1,0 +1,186 @@
+# Brainstorming gate: inverted default, and reachability from Codex
+
+**Status:** designed 2026-07-31; supersedes the trigger wording in
+[`2026-07-26-brainstorming-gate-design.md`](2026-07-26-brainstorming-gate-design.md), which otherwise stands
+**Date:** 2026-07-31
+
+## Why
+
+PR #561 (`feat: add Continue in Codex handoffs`) shipped a new daemon subsystem, a new RPC, a new
+CLI verb, a new on-disk store, and a bespoke transcript-parsing heuristic — with no spec. It is the
+first substantial test of the gate that shipped five days earlier, and the gate did not fire. Two
+independent causes, one social and one mechanical.
+
+**Cause 1 — the escape hatch accepted "the design already happened elsewhere."** The PR states:
+
+> The design was already constrained by the six successful live prototypes and the supplied parity
+> report; this PR implements that bounded MVP without adding a separate brainstorming spec.
+
+That is not a trigger-matching error. The author gave a substantive reason, and the rule's text
+permits any reason ("if a trigger fires but a brainstorm is genuinely unnecessary, say so in the PR
+description"). But it is precisely the failure the gate exists to prevent: the 2026-07-26 design's
+own Why section condemns design thinking that "lived in a session scratchpad." Six prototypes and a
+parity report are a session scratchpad by another name — none of that material is in this repo, so
+no reviewer of #561 could inspect the decisions it encodes.
+
+The concrete cost is visible in the diff. `DeterministicCodexHandoffGenerator` decides that a
+Claude session's context is best represented by the last 64 KB of its JSONL, filtered to `user` and
+`assistant` entries with non-empty text, truncated to 8 KB. Nothing else in TBD parses transcripts
+this way. On a real 2.7 MB session that tail is 2.3% of the file and yields a mid-thought fragment,
+while the JSONL's own typed fields — `ai-title`, `last-prompt`, `file-history-delta`, `pr-link` —
+are discarded. Whether that is the right trade is arguable either way; the problem is that it was
+never written down anywhere it could be argued with.
+
+**Cause 2 — the gate is unreachable from Codex, and #561 was written from Codex.** See
+"Reachability" below. `/tbd-brainstorming` does not exist in a Codex session. The rule instructs
+Codex readers to invoke a skill they cannot invoke.
+
+## Rule changes
+
+Three edits, replacing the `### Blast-radius work starts with a brainstormed spec` section of
+`CLAUDE.md`.
+
+- **State the purpose.** The rule opens with why it exists: decisions about product behaviour and
+  architecture must be inspectable by reviewers separately from the code that implements them. A
+  purpose is something an author can reason *from*; the previous trigger list was something to
+  match against.
+- **Invert the default.** From "required when one of four triggers fires" to "required unless this
+  is a bug fix or a minor UI change." Refactors leave the exemption list: "wholesale-replaces a
+  load-bearing path" and "this is just a refactor" describe the same diff from two angles, and the
+  refactor label is the easiest place to hide blast radius.
+- **Close the prior-design hole.** Design done in prototypes, a report, another repo, or an earlier
+  session makes the spec a cheap transcription — not an unnecessary one. Reviewers here cannot read
+  that material, so those decisions are the ones that most need writing down.
+
+New text:
+
+```markdown
+### Work starts with a brainstormed spec
+
+Decisions about product behaviour and architecture must be inspectable by reviewers separately
+from the code that implements them. So anything that is not a bug fix or a minor UI change runs
+`/tbd-brainstorming` **before** implementation and commits the spec to
+`docs/specs/<date>-<topic>-design.md`. If it needs a flag, it needs a spec.
+
+**Prior design does not exempt.** Thinking done in prototypes, a report, another repo, or an
+earlier session makes the spec a cheap transcription — not an unnecessary one. Reviewers here
+cannot read that material, so those decisions are the ones that most need writing down.
+
+**A human answers the brainstorming questions.** An agent may not answer its own. If none is
+available, stop — do not proceed on assumed answers. Agents, including the nightwatch desk, may
+not originate feature work; file it for a human instead.
+
+Bug fixes and minor UI changes need no spec. If a larger change genuinely needs none, say so in
+the PR description. This is convention, not a gate — no linter can see whether thinking happened.
+Claude Code: use `/tbd-brainstorming`, not `superpowers:brainstorming`; a guardrail redirects the
+wrong one. Codex has no slash command for it — read
+`.claude/skills/tbd-brainstorming/SKILL.md` and follow it directly.
+```
+
+### Deliberate choices
+
+- **The heading drops "Blast-radius."** That framing named the trigger list; with an inverted
+  default the rule covers all work, so the word would contradict the body.
+- **The default-off-flag rule keeps its own four triggers, unchanged.** Today the brainstorm rule
+  opens "Work that trips the triggers above," coupling the two. #561's Scope paragraph shows the
+  hazard: a sound flag-exemption argument sits adjacent to a spec-exemption argument and lends it
+  credibility. Decoupled, the one-way link survives as "if it needs a flag, it needs a spec."
+- **The free-form escape hatch stays.** Narrowed by the prior-design clause, which rules out the
+  specific argument #561 used, but still open to arguments we have not anticipated. Requiring
+  authors to name a category from a closed list was considered and not adopted; it is close to the
+  PR-time check the 2026-07-26 design rejected.
+- **Companion artifacts move in the same commit.** `.claude/skills/tbd-brainstorming/SKILL.md`
+  carries the trigger list twice — in its frontmatter `description:` and in its "When this is
+  REQUIRED in TBD" section. The description is what the model matches when deciding whether to
+  invoke the skill at all, and the 2026-07-26 design's Known Gaps warns skill descriptions are
+  truncated in a crowded roster. Inverting `CLAUDE.md` while the skill still advertises itself as
+  blast-radius-only leaves the invocation trigger narrow. `brainstorming_skill.py`'s docstring and
+  deny message also say "blast-radius triggers" and should stay accurate.
+
+## Reachability
+
+### What a Codex session actually sees
+
+Measured with `codex debug prompt-input`, which renders the model-visible prompt as JSON without
+running a model turn — no quota, no side effects. This is the cheapest way to answer "what does an
+agent actually receive here," and is worth reaching for before theorising.
+
+- **`CLAUDE.md` reaches Codex.** `.codex/config.toml` sets
+  `project_doc_fallback_filenames = ["CLAUDE.md"]`, and the rule text appears in the rendered
+  prompt. It appears **even in a TBD worktree**, which is absent from the `[projects.*]
+  trust_level` list in `~/.codex/config.toml`. This closes the 2026-07-26 design's "Codex trust
+  gating is unverified" known gap with a positive result.
+- **No brainstorming skill of any kind is reachable.** The catalog in this repo is `imagegen`,
+  `openai-docs`, `plugin-creator`, `skill-creator`, `skill-installer`, `agent-channels:channels`,
+  `cua-driver-rs`, `find-skills`, `open-prose`. `tbd-brainstorming` is absent because
+  `.claude/skills/` is a Claude Code mechanism. `superpowers:brainstorming` is *also* absent,
+  despite `[plugins."superpowers@openai-curated"] enabled = true` in `~/.codex/config.toml`.
+- **The redirect guardrail cannot fire.** `.claude/hooks/guardrails/rules/brainstorming_skill.py`
+  is a Claude Code `Skill`-matcher wired through `.claude/settings.json`. Codex runs its own hook
+  system and never sees it.
+
+So the current sentence — "Use `/tbd-brainstorming`, not `superpowers:brainstorming`; a guardrail
+redirects the wrong one" — is actively misleading to a Codex reader. It names a skill that does not
+exist, forbids one that also does not exist, and promises a guardrail that cannot run. A
+conscientious Codex session following it has no legal move.
+
+### The fix in this change
+
+Tell Codex to read the file. `CLAUDE.md` already reaches Codex, the skill is a tracked repo file,
+and reading it is exactly what a skill invocation does anyway — the SKILL.md is self-contained
+prose with a checklist. This travels with the repo, needs no machine setup, works in every
+worktree and for every contributor, and leaks nothing into other repos.
+
+### Rejected here
+
+- **Ship the skill in TBD's Codex plugin** (`CodexPluginWriter`, which already writes
+  `skills/tbd/SKILL.md`). That plugin installs into every TBD user's `~/.codex`. TBD's brainstorming
+  gate is a convention of *this repo*, not of TBD-the-product; shipping it globally is the
+  multi-tenant leak `CLAUDE.md` forbids.
+- **Symlink into `~/.codex/skills/`** from `scripts/install-hooks.sh`. `$CODEX_HOME/skills` is
+  genuinely auto-discovered (verified), but this is machine-level user state a PR cannot write, so
+  a contributor who never runs setup hits the same dead end that produced #561. It also pollutes
+  unrelated repos on that machine, and a link into a worktree path dangles when the worktree is
+  archived.
+- **Add an `AGENTS.md`.** Redundant — `project_doc_fallback_filenames` already routes Codex to
+  `CLAUDE.md`, and a second copy would drift.
+- **A per-spawn config override.** There is none. `SkillsConfig` is `{bundled,
+  include_instructions}`; no config key or CLI flag adds a skill root. "Extra roots" exist only as
+  an app-server RPC (`skills/extraRoots/set`) that a tmux-spawned CLI cannot reach.
+
+## Filed follow-up: per-spawn Codex skill overlay
+
+Not in this change. TBD spawns Claude with `--plugin-dir`, so repo-relevant skills reach Claude
+sessions only. Codex has no equivalent flag, but `CODEX_HOME` is an env var TBD sets per spawn, and
+`$CODEX_HOME/skills/<name>/SKILL.md` **is** auto-discovered — verified by copying the vendored skill
+into a temporary `CODEX_HOME`, after which `tbd-brainstorming` appeared in the rendered catalog.
+
+That makes a TBD-managed `CODEX_HOME` the true `--plugin-dir` analogue: per-spawn, repo-scoped,
+nothing installed at user level. It is a new subsystem and needs its own brainstorm, because the
+hard part is everything else that lives in `CODEX_HOME`:
+
+- **Auth.** A fresh `CODEX_HOME` has no `auth.json`. `cli_auth_credentials_store` accepts only
+  `file | keyring | auto | ephemeral` — not a path — so the clean route depends on keyring-backed
+  credentials. Symlinking `auth.json` is the obvious alternative and is fragile: atomic
+  write-and-rename replaces a symlink with a regular file, silently detaching TBD sessions from the
+  user's real credentials on the next token refresh.
+- **What else must be mirrored** — `config.toml`, the plugin cache, marketplaces, sessions,
+  history — and which of those must stay shared with the user's real home rather than forked.
+- **Which skills get overlaid** — a repo's `.claude/skills/` wholesale, or an opt-in list. This is
+  a generic TBD capability ("repo-defined skills reach Codex sessions too"), not a TBD-repo
+  feature, and must be designed as one.
+
+The existing Codex integration deliberately avoided an isolated `CODEX_HOME` for exactly these
+reasons, choosing a profile overlay in the real `~/.codex` instead. Reversing that is a real
+design question, not an implementation detail.
+
+## Known gaps
+
+- **Human contributors still get no enforcement.** Unchanged from 2026-07-26; this remains an
+  agent-side convention. #561 is evidence that the gap has teeth.
+- **A Codex session must choose to read the file.** There is no roster entry making
+  `tbd-brainstorming` discoverable by description-matching the way a real skill is. The follow-up
+  above is what closes this.
+- **The nightwatch desk-prompt follow-up never landed.** The 2026-07-26 design left it pending on
+  PR #506 and nothing in `Sources/` matches it today. Its decided text reuses "the same four
+  blast-radius triggers"; whoever lands it should use the inverted definition instead.

--- a/docs/specs/2026-07-31-brainstorming-gate-reachability-design.md
+++ b/docs/specs/2026-07-31-brainstorming-gate-reachability-design.md
@@ -177,6 +177,26 @@ The existing Codex integration deliberately avoided an isolated `CODEX_HOME` for
 reasons, choosing a profile overlay in the real `~/.codex` instead. Reversing that is a real
 design question, not an implementation detail.
 
+Codex also has a native surface that touches repo skills, and the follow-up must account for it
+rather than reinvent it. `externalAgentConfig/detect` on the app-server returns a repo-scoped
+`SKILLS` item carrying the passed `cwd`, one of ten migration item types alongside `AGENTS_MD`,
+`HOOKS`, `COMMANDS` and `SESSIONS` — see
+[`docs/research/2026-07-31-codex-session-import/findings.md`](../research/2026-07-31-codex-session-import/findings.md).
+It is not a substitute for a per-spawn overlay, and the distinction is the whole design:
+
+- **It migrates, where we need to overlay.** Import writes skills to the home-level
+  `~/.agents/skills` and rewrites the user's Codex configuration. That is one-way, persistent and
+  machine-wide — the same "installed at user level" outcome rejected above, arrived at through a
+  different door. An overlay must be per-spawn and leave no trace outside the session.
+- **It moves far more than skills.** The same call that offers a repo's skills also offers to
+  migrate `CLAUDE.md` to `~/.codex/AGENTS.md`, hooks into `~/.codex/hooks.json`, and MCP servers
+  into `~/.codex/config.toml`. Any TBD use of this surface must be explicit about what it declines.
+- **It is experimental.** `codex app-server` is marked experimental and the client path moved
+  between two adjacent plugin releases. A load-bearing TBD dependency on it needs a fallback.
+
+The useful read is that detect proves Codex already models "this repo has skills" as a first-class
+concept — the gap is that nothing surfaces them to a session without a machine-level migration.
+
 ## Known gaps
 
 - **Human contributors still get no enforcement.** Unchanged from 2026-07-26; this remains an

--- a/docs/specs/2026-07-31-continue-in-codex-design.md
+++ b/docs/specs/2026-07-31-continue-in-codex-design.md
@@ -1,0 +1,202 @@
+# Continue in Codex
+
+**Status:** designed, not implemented
+**Date:** 2026-07-31
+
+## Problem
+
+You are working in a Claude session and want the same work to continue in Codex — because Claude
+hit a usage limit, because the next stretch suits Codex better, or because you want a second
+opinion running beside the first. Today you open a Codex tab and retype the context, or paste a
+summary you wrote by hand.
+
+The obvious implementation is to generate a handoff document from the Claude transcript. That
+approach forces TBD to own a summarizer: which turns matter, how much fits, what to do when a
+session is long. Every answer is a heuristic, and a heuristic in the app is a decision nobody
+revisits.
+
+## Solution
+
+Codex already ingests Claude transcripts. `externalAgentConfig/import` on the Codex app-server
+takes a path to a Claude session JSONL plus a working directory, performs the conversion itself,
+and reports the id of the thread it created. TBD reads that id and opens a Codex terminal resumed
+on it.
+
+TBD therefore never parses a transcript. It contributes the one thing only it knows: which session
+you meant.
+
+```
+worktree  flow-fix
+   ├─ ✳ Claude   session 9392D590…        ← keeps running, untouched
+   │     │  "Continue in Codex"
+   │     ▼
+   │  externalAgentConfig/import { path, cwd }  ──▶  codex app-server
+   │                                    target ◀──
+   └─ ❯ Codex    codex resume 019fb9d4…   ← full history, empty composer
+```
+
+Protocol contracts, the executed verification, and the measured conversion fidelity are recorded in
+[`docs/research/2026-07-31-codex-session-import/findings.md`](../research/2026-07-31-codex-session-import/findings.md).
+This spec does not restate them.
+
+## Decisions
+
+- **Import, do not summarize.** Codex owns the conversion, so TBD owns no excerpting policy and no
+  handoff artifact. A generated summary can only ever carry a fraction of a long session; the
+  import carries the conversation in order.
+
+- **Skip `detect`.** The discovery call returns every recent Claude session with no way to know
+  which one is meant. TBD already stores `transcriptPath` on the terminal row and knows the
+  worktree path, so it constructs the `SessionMigration` directly.
+
+- **Fork, not link.** Each invocation imports and opens a new thread. TBD stores no source→target
+  mapping and does not deduplicate. The source transcript keeps growing after an import, so
+  "reuse the existing thread" would hand back a thread frozen at first-import time — helpful-looking
+  and quietly stale. Two visible tabs are more legible than one silently out of date, and wanting
+  two is a real case when comparing approaches. The cost is a spare session to close after a
+  mis-click.
+
+- **No initial prompt.** The imported thread already contains the conversation, so there is nothing
+  to point the agent at. The Codex tab opens with history and an empty composer, spending no turn.
+  Your first message sets direction.
+
+- **The source Claude session keeps running.** Working both agents in parallel is a supported use.
+
+- **Concurrent agents in one worktree are not policed.** Both sessions share a working tree and can
+  edit the same files. TBD has never policed concurrent tabs and does not start here; either
+  session can be told about the other. Sending no initial prompt matters to this: nothing instructs
+  the Codex session to resume the plan, so it does not act until asked.
+
+- **No feature flag.** The action is an explicit user gesture that is additive and non-destructive,
+  acts on no timer, sends input to no session, and replaces no load-bearing path — it trips none of
+  the triggers in "Large or risky new behavior ships behind a default-off flag", and that rule ends
+  with "don't sprawl flags". The two temptations are worth naming so they are not re-litigated: a
+  malformed `migrationItems` array would damage the user's Codex configuration, but that is a bug
+  risk that correct construction and a test address, not something a switch protects; and the
+  app-server being experimental argues for tolerating failure, not for a toggle, since a protocol
+  change surfaces as a failed action rather than as damage. No flag means no `config` column and no
+  migration.
+
+## Daemon flow
+
+A new `CodexSessionImporter` in `Sources/TBDDaemon/Codex/` owns the app-server conversation. It is
+the only new type.
+
+1. Resolve the Codex executable before any mutation, reusing the existing resolution order
+   (`TBD_CODEX_EXECUTABLE`, then an absolute PATH entry, then the ChatGPT app-bundle binary).
+2. Spawn `codex app-server` and speak newline-delimited JSON-RPC on stdio.
+3. `initialize` with `clientInfo.name = "tbd"`. Codex records this as `session_meta.originator`, so
+   imported threads are attributable to TBD.
+4. Send `externalAgentConfig/import` with **exactly one** migration item (see Safety below).
+5. Read `target` from the first `externalAgentConfig/import/completed` notification whose
+   `itemTypeResults` contains a `SESSIONS` success. Treat a `failures` entry as an error.
+6. Terminate the app-server process.
+
+The importer returns the thread id, or throws. It persists nothing.
+
+Waiting for the completed notification needs a deadline, so the importer takes
+`clock: any Clock<Duration> = ContinuousClock()` as its last initializer parameter, per the injected
+clock rule. The observed round trip is roughly 60 ms; the deadline exists for a wedged server, not
+for normal latency.
+
+### Safety: exactly one `SESSIONS` item
+
+`externalAgentConfig/import` is a setup-migration call. Its item-type enum includes `AGENTS_MD`,
+`HOOKS`, `SKILLS`, `PLUGINS`, `MCP_SERVER_CONFIG` and `COMMANDS`, and a request carrying those
+rewrites the user's `~/.codex/AGENTS.md`, `hooks.json`, `config.toml` and installed skills.
+
+TBD constructs the array itself and never forwards a `detect` result. The importer's signature
+accepts a single session, not a list of migration items, so no caller can widen it:
+
+```swift
+func importSession(transcriptPath: String, cwd: String, title: String?) async throws -> String
+```
+
+A test must assert the emitted request contains one item, of type `SESSIONS`, with one session.
+
+## Terminal creation
+
+The resulting terminal is an ordinary Codex terminal with a resume argument.
+`CodexSpawnCommandBuilder` gains a `resumeThreadID: String?` parameter defaulting to nil, which
+appends `resume <id>` to the command. Everything else — `CODEX_HOME` from
+`CodexHomeManager().ensureProfilePlugin()`, `DISABLE_AUTO_UPDATE`, env overrides — is unchanged from
+the existing `.codex` spawn path.
+
+The new terminal belongs to the same worktree as the source.
+
+## RPC and CLI
+
+`RPCMethod.terminalContinueInCodex = "terminal.continueInCodex"`, with the params and result added
+to `Sources/TBDShared/RPCProtocol.swift`:
+
+```swift
+public struct TerminalContinueInCodexParams: Codable, Sendable {
+    public let terminalID: UUID
+}
+
+public struct TerminalContinueInCodexResult: Codable, Sendable {
+    public let terminalID: UUID     // the new Codex terminal
+    public let threadID: String     // the imported Codex session id
+}
+```
+
+The handler reads `transcriptPath` and the worktree path from the source terminal's row, calls the
+importer, then creates the terminal. It fails before creating anything if the source terminal is
+not a Claude terminal or has no `transcriptPath`.
+
+`tbd terminal continue-in-codex <terminal-id>` exposes the same call and prints the new terminal id
+and thread id.
+
+## App
+
+A `Continue in Codex` item in the Claude-tab context menu in `Sources/TBDApp/TabBar.swift`, placed
+as a sibling of `Fork Session` rather than inside it — the `Swap profile` and `Fork Session`
+submenus list profiles, and this is not a profile.
+
+The item is hidden when the terminal is not a Claude terminal or has no `transcriptPath`, matching
+how the menu already gates its Claude-only items.
+
+Success selects the new tab. Failure surfaces the daemon's error message.
+
+## Errors
+
+Every failure happens before any terminal or database row is created, so there is no partial state
+to unwind:
+
+- Codex executable not found — report it; do not spawn.
+- app-server fails to start, or `initialize` fails — report it.
+- The import returns a `SESSIONS` failure, or no success entry arrives before the deadline — report
+  it. Codex may have created a thread; TBD does not attempt to find or remove it.
+- Source terminal has no `transcriptPath` — the menu item is hidden, and the RPC rejects it.
+
+## Testing
+
+- The importer emits a request with exactly one item, typed `SESSIONS`, carrying one session with
+  the expected `path` and `cwd`. This is the safety-critical assertion.
+- `target` is extracted from a `completed` notification containing a `SESSIONS` success.
+- A `failures` entry becomes a thrown error.
+- The deadline fires against a stub that never notifies, using a test clock.
+- `CodexSpawnCommandBuilder` appends `resume <id>` when given a thread id, and is unchanged when
+  not.
+- The RPC rejects a non-Claude terminal and a terminal with no `transcriptPath`, and creates no
+  terminal in either case.
+- The menu item is absent for Codex and shell tabs.
+
+Tests must not reach a real app-server; the importer takes its transport as an injected seam.
+
+## Known limitations
+
+**Conversion drops tool-result bulk.** Tool calls survive with their arguments, and results are
+capped at roughly 4 KB each with largely silent truncation. The receiving agent learns what was
+attempted and in what order, but not the full output. Since it is working in the same worktree, a
+truncated read can be re-run. Measurements are in the findings doc.
+
+**Re-importing a grown transcript is unverified.** Fork semantics mean TBD does not care, but the
+behavior of Codex's own import ledger under a changed source file has not been observed.
+
+**The app-server protocol is experimental.** A breaking change surfaces as a failed menu action.
+
+## Not built
+
+No handoff generator, no handoff file or store, no source→target mapping table, no dedup keying, no
+initial prompt, no feature flag, no migration, and no `detect` call.


### PR DESCRIPTION
## Summary

PR #561 shipped a new daemon subsystem, an RPC, a CLI verb, an on-disk store and a bespoke transcript heuristic with no spec. It was the first real test of the brainstorming gate that landed five days earlier, and the gate did not fire. Investigating why turned up two independent causes — one social, one mechanical — and neither is what I expected going in.

**The escape hatch accepted "the design already happened elsewhere."** #561's exemption was not a trigger-matching mistake. It gave a substantive reason: *"the design was already constrained by the six successful live prototypes and the supplied parity report."* The old rule permitted any reason. But six prototypes and a parity report are a session scratchpad by another name — none of that material is in this repo, so no reviewer could examine the decisions it encodes. The rule now states its purpose (decisions must be examinable, changes to our theory of the system or the product most of all), inverts the default to *required unless this is a bug fix or a minor UI change*, and says prior design makes a spec a cheap transcription rather than an unnecessary one. Refactors leave the exemption list: "wholesale-replaces a load-bearing path" and "this is just a refactor" describe the same diff from two angles.

**The gate was unreachable from Codex, and #561 was written from Codex.** `/tbd-brainstorming` lives in `.claude/skills/`, which Codex never reads. The old sentence — *"Use `/tbd-brainstorming`, not `superpowers:brainstorming`; a guardrail redirects the wrong one"* — named a skill Codex cannot invoke, forbade one that is also absent from its catalog despite being enabled, and promised a guardrail that only runs in Claude Code. A conscientious Codex session following it had no legal move. Codex readers are now pointed at the `SKILL.md` path directly, which works because `.codex/config.toml` already routes them to `CLAUDE.md`.

The trigger list lived in three places, so all three move together — including the skill's frontmatter `description:`, which is what the model matches to decide whether to invoke at all.

Also on this branch, from a parallel session: research into Codex's native `externalAgentConfig/import` surface and a Continue-in-Codex spec built on it. Codex ingests a Claude transcript itself and returns the created thread id, so TBD never parses a transcript and owns no excerpting policy — which is a direct answer to the heuristic #561 introduced. The gate spec's follow-up cites that research, which is why the two ship together.

Relates to #561.

## Test plan

- [x] `codex debug prompt-input` in this worktree shows all four new elements reaching a Codex session — purpose statement, inverted default, prior-design clause, `SKILL.md` pointer — and the old heading gone
- [x] The same probe confirms `CLAUDE.md` reaches Codex even in a worktree absent from `[projects.*] trust_level`, closing an open question from the 2026-07-26 gate design
- [x] Guardrail tests pass (7) after the deny-message rewording
- [x] `scripts/check-no-committed-plans.sh` clean — the 2026-07-26 spec tripped this on its own first commit
- [x] The skill roster reloaded mid-session with the new description, confirming the frontmatter change is live
- [ ] Reviewer sanity-check on the frontmatter `description:` — it went from a specific trigger list to a broader statement, and broad descriptions match *worse* in a crowded roster

## Notes for review

No code changes; `CLAUDE.md`, a vendored skill, a guardrail rule's wording, and docs.

Two things this deliberately does **not** do. It adds no mechanical enforcement — the 2026-07-26 design rejected a PR-time spec check as "too late," and that reasoning still holds. And it leaves the free-form escape hatch in place, narrowed by the prior-design clause rather than replaced by a closed list of exemption categories.

Known gap, unchanged and now with evidence: this is an agent-side convention, and human contributors get no enforcement at all.

[🔍 Investigate PR561 Brainstorm](https://cheapsteak.github.io/tbd/open/?worktree=994F568C-F1D9-47FB-944D-546E8F1AFE1D)