### PR TITLE
Remote sessions: show stale snapshots honestly

### DIFF
--- a/Sources/TBDApp/Remote/RemoteSessionActionMenu.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionActionMenu.swift
@@ -92,10 +92,14 @@ enum RemoteSessionActionMenu {
     ///
     /// The pin toggle is offered in BOTH branches, right beside Copy Session
     /// ID, because it shares Copy's defining property: it is a purely local
-    /// action needing no provider verb and no declared capability. A pinned
+    /// action needing no provider verb and no declared capability. When the
+    /// provider inventory is stale, inspection/local actions remain while
+    /// provider mutations are omitted. A pinned
     /// session that goes `gone` must stay unpinnable without the user having
     /// to dismiss it, which is why the collapsed branch carries it too.
-    static func items(capabilities: [String], gone: Bool, isPinned: Bool) -> [Item] {
+    static func items(
+        capabilities: [String], gone: Bool, snapshotFresh: Bool = true, isPinned: Bool
+    ) -> [Item] {
         let pinAction = isPinned
             ? Action(kind: .unpin, title: unpinLabel)
             : Action(kind: .pin, title: pinLabel)
@@ -108,22 +112,27 @@ enum RemoteSessionActionMenu {
             ]
         }
 
-        var actions: [Action] = [Action(kind: .rename, title: renameLabel)]
+        var actions: [Action] = []
+        if snapshotFresh {
+            actions.append(Action(kind: .rename, title: renameLabel))
+        }
         if capabilities.contains(attachCapability) {
             actions.append(Action(kind: .attach, title: attachLabel))
         }
         if capabilities.contains(logCapability) {
             actions.append(Action(kind: .viewLog, title: viewLogLabel))
         }
-        if capabilities.contains(sendCapability) {
+        if snapshotFresh, capabilities.contains(sendCapability) {
             actions.append(Action(kind: .sendText, title: sendTextLabel))
         }
         actions.append(Action(kind: .copySessionID, title: copySessionIDLabel))
         actions.append(pinAction)
 
         var items = actions.map(Item.action)
-        items.append(.divider)
-        items.append(.action(Action(kind: .stop, title: stopLabel, role: .destructive)))
+        if snapshotFresh {
+            items.append(.divider)
+            items.append(.action(Action(kind: .stop, title: stopLabel, role: .destructive)))
+        }
         return items
     }
 }

--- a/Sources/TBDApp/Remote/RemoteSessionDetailGates.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionDetailGates.swift
@@ -69,10 +69,12 @@ enum RemoteSessionDetailGates {
 
     /// Whether the Send footer renders. `gone` suppresses it for the same
     /// reason `available` drops Attach: sending input to a session the
-    /// provider no longer reports isn't meaningful, and this keeps the
-    /// detail view consistent with the context menu, which drops Send Text…
-    /// for gone rows too.
-    static func showsSendField(capabilities: [String], gone: Bool) -> Bool {
-        !gone && capabilities.contains(sendCapability)
+    /// provider no longer reports isn't meaningful, and mutating a session
+    /// from a stale snapshot is unsafe. This keeps the detail view consistent
+    /// with the context menu, which drops Send Text… in both cases.
+    static func showsSendField(
+        capabilities: [String], gone: Bool, snapshotFresh: Bool = true
+    ) -> Bool {
+        snapshotFresh && !gone && capabilities.contains(sendCapability)
     }
 }

--- a/Sources/TBDApp/Remote/RemoteSessionDetailView.swift
+++ b/Sources/TBDApp/Remote/RemoteSessionDetailView.swift
@@ -183,7 +183,10 @@ struct RemoteSessionDetailView: View {
 
             contentArea
 
-            if RemoteSessionDetailGates.showsSendField(capabilities: capabilities, gone: isGone) {
+            if RemoteSessionDetailGates.showsSendField(
+                capabilities: capabilities, gone: isGone,
+                snapshotFresh: providerStatus?.hasStaleSnapshot != true
+            ) {
                 Divider()
                 sendField
             }
@@ -284,7 +287,7 @@ struct RemoteSessionDetailView: View {
                     .fontWeight(.semibold)
                     .lineLimit(1)
                 Spacer()
-                if let session, !session.gone {
+                if let session, !session.gone, providerStatus?.hasStaleSnapshot != true {
                     Button("Stop", role: .destructive) { showStopConfirm = true }
                         .confirmationDialog(
                             "Stop \(displayName)?",
@@ -320,6 +323,19 @@ struct RemoteSessionDetailView: View {
                 Label("Session not found in the current mirror", systemImage: "questionmark.circle")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+
+            if let providerStatus,
+               let issue = RemoteProviderStatusPresentation.issueSummary(providerStatus) {
+                Label(issue, systemImage: "clock.badge.exclamationmark")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .lineLimit(2)
+                if providerStatus.hasStaleSnapshot {
+                    Text("Attach and logs remain available; changes are paused until inventory refresh recovers.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             if let session,

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -129,6 +129,34 @@ struct RemoteSectionView: View {
     }
 }
 
+/// Compact, testable status copy shared by the provider header and detail
+/// pane. `RemoteProviderManager` already bounds `errorMessage` before it
+/// crosses RPC; this composes that message with the last complete inventory
+/// age so the UI states what is stale, not merely that something failed.
+enum RemoteProviderStatusPresentation {
+    nonisolated static func issueSummary(
+        _ status: RemoteProviderStatus, now: Date = Date()
+    ) -> String? {
+        guard status.health != .ok else { return nil }
+        let message = status.errorMessage ?? fallback(for: status.health)
+        guard let lastSuccess = status.lastSuccessfulSnapshotAt else {
+            return "\(message) · no successful snapshot yet"
+        }
+        let age = ProfileUsagePresentation.ageText(since: lastSuccess, now: now)
+        let agePhrase = age == "just now" ? "last good just now" : "last good \(age) ago"
+        return "\(message) · \(agePhrase)"
+    }
+
+    private nonisolated static func fallback(for health: ProviderHealth) -> String {
+        switch health {
+        case .ok: return "Provider healthy"
+        case .stale: return "Inventory unavailable"
+        case .needsAuth: return "Authentication needed"
+        case .error: return "Provider error"
+        }
+    }
+}
+
 /// One provider's section header: name + a health-suffix icon when the
 /// provider isn't fully healthy, plus a `+` to create a new session on this
 /// provider (Task 10 — opens `RemoteCreateSheet` with no repo prefill; the
@@ -154,27 +182,44 @@ struct RemoteProviderHeaderRow: View {
     /// popover can't host a sheet of its own.
     @State private var runningRemediation: RemoteRemediationRun?
 
+    private var issueSummary: String? {
+        RemoteProviderStatusPresentation.issueSummary(provider)
+    }
+
     var body: some View {
-        HStack(spacing: 4) {
-            Text(provider.describe?.name ?? provider.config.name)
-                .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-            healthSuffix
-            Spacer()
-            Button {
-                showingCreateSheet = true
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 10, weight: .semibold))
+        VStack(alignment: .leading, spacing: -1) {
+            HStack(spacing: 4) {
+                Text(provider.describe?.name ?? provider.config.name)
+                    .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
-                    .frame(width: 16, height: 16)
-                    .contentShape(Rectangle())
+                    .lineLimit(1)
+                healthSuffix
+                Spacer()
+                Button {
+                    showingCreateSheet = true
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(provider.hasStaleSnapshot)
+                .help(provider.hasStaleSnapshot
+                      ? "Inventory is stale; refresh must recover before creating sessions"
+                      : "New \(provider.describe?.name ?? provider.config.name) session")
             }
-            .buttonStyle(.plain)
-            .help("New \(provider.describe?.name ?? provider.config.name) session")
+            if let issueSummary {
+                Text(issueSummary)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .help(issueSummary)
+            }
         }
-        .frame(height: 22, alignment: .bottom)
+        .frame(minHeight: 22, alignment: .bottom)
         .listRowInsets(EdgeInsets(top: 0, leading: -2, bottom: 0, trailing: 0))
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
@@ -209,7 +254,7 @@ struct RemoteProviderHeaderRow: View {
             Image(systemName: "clock.badge.exclamationmark")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-                .help("Provider unreachable — sessions may be stale")
+                .help(issueSummary ?? "Provider unreachable — sessions may be stale")
         case .needsAuth:
             // The indicator is a BUTTON here (unlike the other health cases,
             // which are passive): needing authentication is the one health
@@ -246,7 +291,7 @@ struct RemoteProviderHeaderRow: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 11))
                 .foregroundStyle(SuffixRowIndicator.error.color)
-                .help(provider.errorMessage ?? "Provider error")
+                .help(issueSummary ?? provider.errorMessage ?? "Provider error")
         case .ok:
             EmptyView()
         }
@@ -322,8 +367,8 @@ struct RemoteSessionRowView: View {
     /// the provider is unknown/unregistered — an edge case (the session's
     /// own provider vanished from the roster) that shouldn't paint every
     /// row with a staleness note it can't actually reason about.
-    private var providerHealth: ProviderHealth {
-        appState.remoteProviders.first { $0.config.name == session.provider }?.health ?? .ok
+    private var providerStatus: RemoteProviderStatus? {
+        appState.remoteProviders.first { $0.config.name == session.provider }
     }
 
     /// Pure `agentState` + unread-entry → suffix-slot mapping. Split out
@@ -468,7 +513,9 @@ struct RemoteSessionRowView: View {
                     if let caption = RemoteSessionRowView.caption(
                         state: session.payload.state, agentState: session.payload.agentState,
                         gone: session.gone, exitCode: session.payload.exitCode,
-                        staleness: RemoteSessionRowView.stalenessCaption(health: providerHealth, lastSeen: session.lastSeen)
+                        staleness: RemoteSessionRowView.stalenessCaption(
+                            health: providerStatus?.health ?? .ok,
+                            lastSuccessfulSnapshotAt: providerStatus?.lastSuccessfulSnapshotAt ?? session.lastSeen)
                     ) {
                         Text(caption)
                             .font(.caption)
@@ -495,10 +542,11 @@ struct RemoteSessionRowView: View {
             appState.selectRemoteSession(provider: session.provider, sessionID: session.payload.id)
         }
         .contextMenu {
-            let capabilities = appState.remoteProviders
-                .first { $0.config.name == session.provider }?.describe?.capabilities ?? []
+            let provider = appState.remoteProviders.first { $0.config.name == session.provider }
+            let capabilities = provider?.describe?.capabilities ?? []
             let items = RemoteSessionActionMenu.items(
                 capabilities: capabilities, gone: session.gone,
+                snapshotFresh: provider?.hasStaleSnapshot != true,
                 // Read from the mirror rather than this row's captured
                 // `session`, so a dock copy and a section copy of the same
                 // session always offer the same verb.
@@ -624,9 +672,11 @@ struct RemoteSessionRowView: View {
     /// this codebase already has ("just now"/"3m"/"2h"/"1d") — rather than
     /// inventing a second one. Returns nil when healthy so a fully-working
     /// provider's rows never carry the extra text.
-    nonisolated static func stalenessCaption(health: ProviderHealth, lastSeen: Date, now: Date = Date()) -> String? {
+    nonisolated static func stalenessCaption(
+        health: ProviderHealth, lastSuccessfulSnapshotAt: Date, now: Date = Date()
+    ) -> String? {
         guard health != .ok else { return nil }
-        let age = ProfileUsagePresentation.ageText(since: lastSeen, now: now)
+        let age = ProfileUsagePresentation.ageText(since: lastSuccessfulSnapshotAt, now: now)
         // `ageText`'s "just now" already reads as a complete phrase (see its
         // own callers in `ProfileUsagePresentation`) — appending "ago" to it
         // would read as "as of just now ago". Every other bucket ("3m",

--- a/Sources/TBDApp/Sidebar/RepoSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RepoSectionView.swift
@@ -400,12 +400,14 @@ struct RepoSectionView: View {
         if !appState.remoteProviders.isEmpty {
             if appState.remoteProviders.count == 1, let only = appState.remoteProviders.first {
                 Button("New Remote Session…") { openRemoteCreateSheet(for: only) }
+                    .disabled(only.hasStaleSnapshot)
             } else {
                 Menu("New Remote Session…") {
                     ForEach(appState.remoteProviders, id: \.config.name) { provider in
                         Button(provider.describe?.name ?? provider.config.name) {
                             openRemoteCreateSheet(for: provider)
                         }
+                        .disabled(provider.hasStaleSnapshot)
                     }
                 }
             }

--- a/Sources/TBDDaemon/Database/RemoteSessionStore.swift
+++ b/Sources/TBDDaemon/Database/RemoteSessionStore.swift
@@ -208,6 +208,16 @@ public struct RemoteSessionStore: Sendable {
                 changed = true
                 try row.update(db)
             }
+
+            // Persist the authoritative full-inventory observation in this
+            // same transaction. Event-stream upserts deliberately do not
+            // touch this key: a healthy single-session stream must never make
+            // a broken full-list path look fresh after daemon restart.
+            try db.execute(
+                sql: "INSERT INTO tbd_meta (key, value) VALUES (?, ?) "
+                    + "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                arguments: [Self.snapshotTimestampKey(provider: provider), String(now.timeIntervalSince1970)]
+            )
             return SnapshotOutcome(changed: changed, attention: attention)
         }
     }
@@ -258,20 +268,22 @@ public struct RemoteSessionStore: Sendable {
         }
     }
 
-    /// Best persisted approximation of a provider's last successful
-    /// inventory time. Every row observed in a complete snapshot receives
-    /// that snapshot's `now` as `lastSeen`, so the maximum survives daemon
-    /// restarts and lets provider health age an existing cache honestly.
-    /// An empty successful snapshot has no row from which to recover; that
-    /// case intentionally remains nil after restart rather than inventing a
-    /// timestamp.
-    public func latestLastSeen(provider: String) async throws -> Date? {
+    /// Exact persisted time of the provider's last complete inventory. This
+    /// is intentionally separate from row `lastSeen`, which can advance from
+    /// the independent events stream.
+    public func lastSuccessfulSnapshotAt(provider: String) async throws -> Date? {
         try await writer.read { db in
-            try Date.fetchOne(
-                db,
-                sql: "SELECT MAX(lastSeen) FROM remote_session WHERE provider = ?",
-                arguments: [provider])
+            guard let value = try String.fetchOne(
+                db, sql: "SELECT value FROM tbd_meta WHERE key = ?",
+                arguments: [Self.snapshotTimestampKey(provider: provider)]),
+                let seconds = TimeInterval(value)
+            else { return nil }
+            return Date(timeIntervalSince1970: seconds)
         }
+    }
+
+    private static func snapshotTimestampKey(provider: String) -> String {
+        "remote.last-successful-snapshot.\(provider)"
     }
 
     /// Returns whether a row actually changed (an unknown session, or one

--- a/Sources/TBDDaemon/Database/RemoteSessionStore.swift
+++ b/Sources/TBDDaemon/Database/RemoteSessionStore.swift
@@ -258,6 +258,22 @@ public struct RemoteSessionStore: Sendable {
         }
     }
 
+    /// Best persisted approximation of a provider's last successful
+    /// inventory time. Every row observed in a complete snapshot receives
+    /// that snapshot's `now` as `lastSeen`, so the maximum survives daemon
+    /// restarts and lets provider health age an existing cache honestly.
+    /// An empty successful snapshot has no row from which to recover; that
+    /// case intentionally remains nil after restart rather than inventing a
+    /// timestamp.
+    public func latestLastSeen(provider: String) async throws -> Date? {
+        try await writer.read { db in
+            try Date.fetchOne(
+                db,
+                sql: "SELECT MAX(lastSeen) FROM remote_session WHERE provider = ?",
+                arguments: [provider])
+        }
+    }
+
     /// Returns whether a row actually changed (an unknown session, or one
     /// already dismissed, changes nothing) — mirrors `markGone`'s contract so
     /// callers can skip a pointless UI broadcast.

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -19,6 +19,10 @@ public actor RemoteProviderManager {
     private var providers: [String: RemoteProviderConfig] = [:]
     private var describes: [String: ProviderDescribe] = [:]
     private var health: [String: (state: ProviderHealth, message: String?, remediation: ProviderRemediation?)] = [:]
+    /// Most recent complete inventory accepted for each provider. Kept
+    /// independently from generic verb health: a successful `log`/`attach`
+    /// proves that verb worked, not that the cached inventory is current.
+    private var lastSuccessfulSnapshotAt: [String: Date] = [:]
     private var loops: [String: Task<Void, Never>] = [:]
     private var supervisors: [String: ProviderEventsSupervisor] = [:]
     /// Guards `spawnPollLoops`'s compound stopAll()+startLoop() sequence
@@ -225,22 +229,25 @@ public actor RemoteProviderManager {
         do {
             let result = try await runner.run(provider, verb: ["list"], stdin: nil, timeout: 30)
             if let failure = result.failureClass {
-                recordFailure(provider: provider.name, class: failure, result: result)
+                await recordPollFailure(provider: provider.name, class: failure, result: result)
                 return
             }
             let envelope = try result.decoded(RemoteSessionListEnvelope.self)
-            try await apply(snapshot: envelope.sessions, provider: provider.name)
-            markHealthy(provider: provider.name)
+            let snapshotAt = Date()
+            try await apply(snapshot: envelope.sessions, provider: provider.name, now: snapshotAt)
         } catch {
             remoteLogger.debug("poll \(provider.name, privacy: .public) failed: \(String(describing: error), privacy: .public)")
+            await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider.name)
             setHealth(provider: provider.name, to: (.stale, String(describing: error), nil))
         }
     }
 
     /// Shared by the poll path and the events snapshot path (Task 6).
-    func apply(snapshot sessions: [RemoteSessionPayload], provider: String) async throws {
+    func apply(snapshot sessions: [RemoteSessionPayload], provider: String, now: Date = Date()) async throws {
         let outcome = try await db.remoteSessions.applySnapshot(
-            provider: provider, sessions: sessions, now: Date())
+            provider: provider, sessions: sessions, now: now)
+        lastSuccessfulSnapshotAt[provider] = now
+        markHealthy(provider: provider)
         if outcome.changed {
             subscriptions.broadcast(delta: .remoteSessionsChanged)
         }
@@ -309,8 +316,6 @@ public actor RemoteProviderManager {
         let result = try await runner.run(config, verb: verb, stdin: stdin, timeout: timeout)
         if let failure = result.failureClass {
             recordFailure(provider: providerName, class: failure, result: result)
-        } else {
-            markHealthy(provider: providerName)
         }
         return result
     }
@@ -338,10 +343,21 @@ public actor RemoteProviderManager {
             let h = health[config.name] ?? (.ok, nil, nil)
             return RemoteProviderStatus(
                 config: config, describe: describes[config.name],
-                health: h.state, errorMessage: h.message,
+                health: h.state, errorMessage: Self.boundedDisplayMessage(h.message),
                 remediationLabel: h.remediation?.label,
-                remediationCommand: h.remediation?.command)
+                remediationCommand: h.remediation?.command,
+                lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[config.name])
         }
+    }
+
+    /// Whether mutations that depend on the cached inventory should be
+    /// suppressed. Read-only inspection (`attach`, `log`) remains useful
+    /// during an inventory outage; create/stop/send/rename do not have a
+    /// trustworthy current-state basis once a previously-good snapshot is
+    /// stale.
+    func hasStaleSnapshot(provider name: String) -> Bool {
+        guard lastSuccessfulSnapshotAt[name] != nil else { return false }
+        return health[name]?.state != .ok
     }
 
     /// Correlates a locally-spawned `attach` exit (the app execs the provider
@@ -425,6 +441,41 @@ public actor RemoteProviderManager {
         case .permanent, .contractBug:
             setHealth(provider: provider, to: (.error, error?.message ?? result.stderr, nil))
         }
+    }
+
+    /// Poll failures need one extra piece of bookkeeping beyond generic
+    /// provider failures: if this manager restarted after the last success,
+    /// recover that timestamp from the mirror's last-seen rows before
+    /// publishing stale health. This keeps a persisted cached snapshot from
+    /// becoming confidently timeless after a daemon restart.
+    private func recordPollFailure(provider: String, class failureClass: ProviderFailureClass,
+                                   result: ProviderResult) async {
+        await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider)
+        recordFailure(provider: provider, class: failureClass, result: result)
+    }
+
+    private func recoverLastSuccessfulSnapshotAtIfNeeded(provider: String) async {
+        guard lastSuccessfulSnapshotAt[provider] == nil else { return }
+        if let recovered = try? await db.remoteSessions.latestLastSeen(provider: provider) {
+            lastSuccessfulSnapshotAt[provider] = recovered
+        }
+    }
+
+    /// The provider may return the entire truncated inventory inside its
+    /// error message. Keep the manager's internal health record unchanged for
+    /// diagnostics, but never put an unbounded wall of JSON on the RPC/UI
+    /// wire. The known
+    /// truncation shape receives safe copy rather than leaking a prompt from
+    /// the beginning of the embedded payload.
+    static func boundedDisplayMessage(_ message: String?, limit: Int = 240) -> String? {
+        guard let message else { return nil }
+        if message.localizedCaseInsensitiveContains("--output truncated--")
+            || message.localizedCaseInsensitiveContains("unparseable remote output") {
+            return "Provider inventory was truncated or malformed; showing the last successful snapshot."
+        }
+        guard message.count > limit else { return message }
+        let kept = max(0, limit - 1)
+        return String(message.prefix(kept)) + "…"
     }
 
     private func markHealthy(provider: String) {

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -47,6 +47,16 @@ public actor RemoteProviderManager {
     self.runner = runner
     self.registryURL = registryURL
     self.clock = clock
+    // RPC becomes available before `start()` runs, so seed the registry
+    // synchronously. The first status or mutation-gate read can then recover
+    // persisted freshness instead of briefly treating an existing mirror as
+    // current while the initial provider poll is pending.
+    if let configs = try? RemoteProviderRegistry.load(from: registryURL) {
+      for config in configs {
+        providers[config.name] = config
+        health[config.name] = (.ok, nil, nil)
+      }
+    }
   }
 
   /// Full boot path: load the registry, describe every provider, then
@@ -80,6 +90,7 @@ public actor RemoteProviderManager {
     for config in configs {
       guard !Task.isCancelled else { return }
       registerIfNeeded(config)
+      await recoverLastSuccessfulSnapshotAtIfNeeded(provider: config.name, markStale: true)
       await describeProvider(config)
     }
     subscriptions.broadcast(delta: .remoteSessionsChanged)
@@ -358,8 +369,11 @@ public actor RemoteProviderManager {
     if health[config.name] == nil { health[config.name] = (.ok, nil, nil) }
   }
 
-  func providerStatuses() -> [RemoteProviderStatus] {
-    providers.values.sorted { $0.name < $1.name }.map { config in
+  func providerStatuses() async -> [RemoteProviderStatus] {
+    for name in providers.keys {
+      await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)
+    }
+    return providers.values.sorted { $0.name < $1.name }.map { config in
       let h = health[config.name] ?? (.ok, nil, nil)
       return RemoteProviderStatus(
         config: config, describe: describes[config.name],
@@ -379,7 +393,8 @@ public actor RemoteProviderManager {
   /// during an inventory outage; create/stop/send/rename do not have a
   /// trustworthy current-state basis once a previously-good snapshot is
   /// stale.
-  func hasStaleSnapshot(provider name: String) -> Bool {
+  func hasStaleSnapshot(provider name: String) async -> Bool {
+    await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)
     guard lastSuccessfulSnapshotAt[name] != nil else { return false }
     return health[name]?.state != .ok
   }
@@ -486,11 +501,23 @@ public actor RemoteProviderManager {
     recordFailure(provider: provider, class: failureClass, result: result)
   }
 
-  private func recoverLastSuccessfulSnapshotAtIfNeeded(provider: String) async {
+  private func recoverLastSuccessfulSnapshotAtIfNeeded(
+    provider: String,
+    markStale: Bool = false
+  ) async {
     guard lastSuccessfulSnapshotAt[provider] == nil else { return }
-        if let recovered = try? await db.remoteSessions.lastSuccessfulSnapshotAt(provider: provider) {
-            lastSuccessfulSnapshotAt[provider] = recovered
-        }
+    if let recovered = try? await db.remoteSessions.lastSuccessfulSnapshotAt(provider: provider) {
+      lastSuccessfulSnapshotAt[provider] = recovered
+      if markStale, health[provider]?.state == .ok {
+        setHealth(
+          provider: provider,
+          to: (
+            .stale,
+            "Provider inventory has not refreshed since daemon restart.",
+            nil
+          ))
+      }
+    }
   }
 
   /// The provider may return the entire truncated inventory inside its

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -394,7 +394,8 @@ public actor RemoteProviderManager {
                 ),
                 remediationLabel: h.remediation?.label,
                 remediationCommand: h.remediation?.command,
-                lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[config.name])
+                lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[config.name],
+                freshnessUnreadable: snapshotFreshnessUnreadable.contains(config.name))
         }
     }
 
@@ -405,13 +406,14 @@ public actor RemoteProviderManager {
     /// stale.
     func hasStaleSnapshot(provider name: String) async -> Bool {
         await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)
-        // Unreadable freshness fails CLOSED. The fail-open branch below is
-        // justified only by positive knowledge that no snapshot was ever
-        // accepted; a failed read carries no such proof, so it must not be
-        // allowed to look like one.
-        if snapshotFreshnessUnreadable.contains(name) { return true }
-        guard lastSuccessfulSnapshotAt[name] != nil else { return false }
-        return health[name]?.state != .ok
+        // Same rule the wire DTO and every UI call site use, so the mutation
+        // gate and the display projection cannot disagree. Fails open only on
+        // positive knowledge that no snapshot was ever accepted; an unreadable
+        // read carries no such proof and gates.
+        return RemoteProviderStatus.isStaleSnapshot(
+            health: health[name]?.state ?? .ok,
+            lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[name],
+            freshnessUnreadable: snapshotFreshnessUnreadable.contains(name))
     }
 
     /// Correlates a locally-spawned `attach` exit (the app execs the provider

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -9,574 +9,574 @@ private let remoteLogger = Logger(subsystem: "com.tbd.daemon", category: "remote
 /// Source of truth for sessions is always the provider; this actor only
 /// maintains the mirror + broadcasts.
 public actor RemoteProviderManager {
-  private let db: TBDDatabase
-  private let subscriptions: StateSubscriptionManager
-  private let runner: any RemoteProviderInvoking
-  private let registryURL: URL
-  private let clock: any Clock<Duration>
-  static let pollInterval: TimeInterval = 60
+    private let db: TBDDatabase
+    private let subscriptions: StateSubscriptionManager
+    private let runner: any RemoteProviderInvoking
+    private let registryURL: URL
+    private let clock: any Clock<Duration>
+    static let pollInterval: TimeInterval = 60
 
-  private var providers: [String: RemoteProviderConfig] = [:]
-  private var describes: [String: ProviderDescribe] = [:]
-  private var health:
-    [String: (state: ProviderHealth, message: String?, remediation: ProviderRemediation?)] = [:]
-  /// Most recent complete inventory accepted for each provider. Kept
-  /// independently from generic verb health: a successful `log`/`attach`
-  /// proves that verb worked, not that the cached inventory is current.
-  private var lastSuccessfulSnapshotAt: [String: Date] = [:]
-  private var loops: [String: Task<Void, Never>] = [:]
-  private var supervisors: [String: ProviderEventsSupervisor] = [:]
-  /// Guards `spawnPollLoops`'s compound stopAll()+startLoop() sequence
-  /// against a second concurrent call to the same sequence (e.g. two
-  /// overlapping `start()`s). See the comment on `spawnPollLoops` for the
-  /// race this closes.
-  private var reconfiguring = false
-  private var reconfigureWaiters: [CheckedContinuation<Void, Never>] = []
-  /// Set by `shutdown()` while still holding the reconfigure lock, and
-  /// never cleared — shutdown is terminal for this actor's lifetime. See
-  /// `shutdown()`'s doc comment for the race this closes.
-  private var shuttingDown = false
+    private var providers: [String: RemoteProviderConfig] = [:]
+    private var describes: [String: ProviderDescribe] = [:]
+    private var health:
+        [String: (state: ProviderHealth, message: String?, remediation: ProviderRemediation?)] = [:]
+    /// Most recent complete inventory accepted for each provider. Kept
+    /// independently from generic verb health: a successful `log`/`attach`
+    /// proves that verb worked, not that the cached inventory is current.
+    private var lastSuccessfulSnapshotAt: [String: Date] = [:]
+    private var loops: [String: Task<Void, Never>] = [:]
+    private var supervisors: [String: ProviderEventsSupervisor] = [:]
+    /// Guards `spawnPollLoops`'s compound stopAll()+startLoop() sequence
+    /// against a second concurrent call to the same sequence (e.g. two
+    /// overlapping `start()`s). See the comment on `spawnPollLoops` for the
+    /// race this closes.
+    private var reconfiguring = false
+    private var reconfigureWaiters: [CheckedContinuation<Void, Never>] = []
+    /// Set by `shutdown()` while still holding the reconfigure lock, and
+    /// never cleared — shutdown is terminal for this actor's lifetime. See
+    /// `shutdown()`'s doc comment for the race this closes.
+    private var shuttingDown = false
 
-  init(
-    db: TBDDatabase, subscriptions: StateSubscriptionManager,
-    runner: any RemoteProviderInvoking, registryURL: URL,
-    clock: any Clock<Duration> = ContinuousClock()
-  ) {
-    self.db = db
-    self.subscriptions = subscriptions
-    self.runner = runner
-    self.registryURL = registryURL
-    self.clock = clock
-    // RPC becomes available before `start()` runs, so seed the registry
-    // synchronously. The first status or mutation-gate read can then recover
-    // persisted freshness instead of briefly treating an existing mirror as
-    // current while the initial provider poll is pending.
-    if let configs = try? RemoteProviderRegistry.load(from: registryURL) {
-      for config in configs {
-        providers[config.name] = config
-        health[config.name] = (.ok, nil, nil)
-      }
+    init(
+        db: TBDDatabase, subscriptions: StateSubscriptionManager,
+        runner: any RemoteProviderInvoking, registryURL: URL,
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.db = db
+        self.subscriptions = subscriptions
+        self.runner = runner
+        self.registryURL = registryURL
+        self.clock = clock
+        // RPC becomes available before `start()` runs, so seed the registry
+        // synchronously. The first status or mutation-gate read can then recover
+        // persisted freshness instead of briefly treating an existing mirror as
+        // current while the initial provider poll is pending.
+        if let configs = try? RemoteProviderRegistry.load(from: registryURL) {
+            for config in configs {
+                providers[config.name] = config
+                health[config.name] = (.ok, nil, nil)
+            }
+        }
     }
-  }
 
-  /// Full boot path: load the registry, describe every provider, then
-  /// spawn poll loops for the ones that negotiated a usable contract.
-  /// Composition of the two steps below — callers that only need
-  /// registry/describe state (e.g. verb-routing tests) should call
-  /// `loadRegistryAndDescribe()` alone so no background timer is armed.
-  func start() async {
-    await loadRegistryAndDescribe()
-    await spawnPollLoops()
-  }
+    /// Full boot path: load the registry, describe every provider, then
+    /// spawn poll loops for the ones that negotiated a usable contract.
+    /// Composition of the two steps below — callers that only need
+    /// registry/describe state (e.g. verb-routing tests) should call
+    /// `loadRegistryAndDescribe()` alone so no background timer is armed.
+    func start() async {
+        await loadRegistryAndDescribe()
+        await spawnPollLoops()
+    }
 
-  /// Loads the provider registry and runs `describe` against every entry,
-  /// populating `providers`/`describes`/`health`. Spawns no poll loops —
-  /// safe to call from tests that only want to exercise describe/invoke
-  /// routing without racing a real 60s timer.
-  ///
-  /// Checks `Task.isCancelled` before each provider's `describe` so a
-  /// caller cancelling the enclosing task (daemon shutdown racing boot)
-  /// bounds this to at most one `describe` child process in flight rather
-  /// than one per remaining provider.
-  func loadRegistryAndDescribe() async {
-    let configs: [RemoteProviderConfig]
-    do {
-      configs = try RemoteProviderRegistry.load(from: registryURL)
-    } catch {
-      remoteLogger.error(
-        "provider registry unreadable: \(String(describing: error), privacy: .public)")
-      return
+    /// Loads the provider registry and runs `describe` against every entry,
+    /// populating `providers`/`describes`/`health`. Spawns no poll loops —
+    /// safe to call from tests that only want to exercise describe/invoke
+    /// routing without racing a real 60s timer.
+    ///
+    /// Checks `Task.isCancelled` before each provider's `describe` so a
+    /// caller cancelling the enclosing task (daemon shutdown racing boot)
+    /// bounds this to at most one `describe` child process in flight rather
+    /// than one per remaining provider.
+    func loadRegistryAndDescribe() async {
+        let configs: [RemoteProviderConfig]
+        do {
+            configs = try RemoteProviderRegistry.load(from: registryURL)
+        } catch {
+            remoteLogger.error(
+                "provider registry unreadable: \(String(describing: error), privacy: .public)")
+            return
+        }
+        for config in configs {
+            guard !Task.isCancelled else { return }
+            registerIfNeeded(config)
+            await recoverLastSuccessfulSnapshotAtIfNeeded(provider: config.name, markStale: true)
+            await describeProvider(config)
+        }
+        subscriptions.broadcast(delta: .remoteSessionsChanged)
     }
-    for config in configs {
-      guard !Task.isCancelled else { return }
-      registerIfNeeded(config)
-      await recoverLastSuccessfulSnapshotAtIfNeeded(provider: config.name, markStale: true)
-      await describeProvider(config)
-    }
-    subscriptions.broadcast(delta: .remoteSessionsChanged)
-  }
 
-  /// Runs `describe` for one provider and records the outcome in
-  /// `describes`/`health`. Auth failures (exit 4) and other classified
-  /// failures route through the same `recordFailure` path `pollOnce` and
-  /// `invoke` use, so a provider that rejects credentials on its very
-  /// first contact still surfaces `needs_auth` with remediation instead of
-  /// a generic error. Only spawn/parse problems — which no failure class
-  /// can describe — fall back to a generic message, distinguished by text
-  /// from "it ran and rejected us".
-  private func describeProvider(_ config: RemoteProviderConfig) async {
-    let result: ProviderResult
-    do {
-      result = try await runner.run(config, verb: ["describe"], stdin: nil, timeout: 10)
-    } catch {
-      remoteLogger.error(
-        "describe \(config.name, privacy: .public) couldn't run: \(String(describing: error), privacy: .public)"
-      )
-      setHealth(provider: config.name, to: (.error, "couldn't run describe: \(error)", nil))
-      return
+    /// Runs `describe` for one provider and records the outcome in
+    /// `describes`/`health`. Auth failures (exit 4) and other classified
+    /// failures route through the same `recordFailure` path `pollOnce` and
+    /// `invoke` use, so a provider that rejects credentials on its very
+    /// first contact still surfaces `needs_auth` with remediation instead of
+    /// a generic error. Only spawn/parse problems — which no failure class
+    /// can describe — fall back to a generic message, distinguished by text
+    /// from "it ran and rejected us".
+    private func describeProvider(_ config: RemoteProviderConfig) async {
+        let result: ProviderResult
+        do {
+            result = try await runner.run(config, verb: ["describe"], stdin: nil, timeout: 10)
+        } catch {
+            remoteLogger.error(
+                "describe \(config.name, privacy: .public) couldn't run: \(String(describing: error), privacy: .public)"
+            )
+            setHealth(provider: config.name, to: (.error, "couldn't run describe: \(error)", nil))
+            return
+        }
+        if let failure = result.failureClass {
+            recordFailure(provider: config.name, class: failure, result: result)
+            return
+        }
+        guard let describe = try? result.decoded(ProviderDescribe.self) else {
+            setHealth(
+                provider: config.name, to: (.error, "describe returned an unparseable response", nil))
+            return
+        }
+        guard describe.contractVersions.contains(1) else {
+            setHealth(provider: config.name, to: (.error, "no common contract version", nil))
+            return
+        }
+        describes[config.name] = describe
     }
-    if let failure = result.failureClass {
-      recordFailure(provider: config.name, class: failure, result: result)
-      return
-    }
-    guard let describe = try? result.decoded(ProviderDescribe.self) else {
-      setHealth(
-        provider: config.name, to: (.error, "describe returned an unparseable response", nil))
-      return
-    }
-    guard describe.contractVersions.contains(1) else {
-      setHealth(provider: config.name, to: (.error, "no common contract version", nil))
-      return
-    }
-    describes[config.name] = describe
-  }
 
-  /// Spawns/re-spawns the 60s poll loop for every provider with a valid
-  /// `describe` on file. Cancels any existing loops (and stops any running
-  /// events supervisors) first so a second call can't orphan one that
-  /// `stopAll()` would no longer be able to reach (the stored handle would
-  /// just get overwritten).
-  /// The whole stopAll()+startLoop() sequence runs under `reconfiguring` so
-  /// two concurrent calls (e.g. overlapping `start()`s) can never
-  /// interleave. Without it: `startLoop` inserts a supervisor into
-  /// `supervisors` and then suspends at `await supervisor.start()` — a
-  /// different actor, so this actor's executor is released for that
-  /// window. A second call's `stopAll()` could run entirely in that
-  /// window: its `await supervisor.stop()` on the just-inserted supervisor
-  /// returns instantly (nothing has started yet) and `removeAll()` drops
-  /// it, then the first call resumes and arms `start()` on a supervisor
-  /// nothing holds — the provider's child process respawns on backoff for
-  /// the daemon's life with no handle able to stop it. The symmetric case
-  /// (a supervisor inserted during one of `stopAll()`'s own awaits, then
-  /// dropped by that call's `removeAll()`) is closed the same way, since
-  /// the two call sequences now can't overlap at all.
-  private func spawnPollLoops() async {
-    await acquireReconfigureLock()
-    defer { releaseReconfigureLock() }
-    // A call already parked in the FIFO waiter queue when `shutdown()`
-    // ran receives the baton right after `shutdown()` releases it — FIFO
-    // ordering alone doesn't stop that hand-off, only this flag does.
-    // Without it, this would respawn poll loops (and events supervisors)
-    // on a manager the daemon believes it already tore down.
-    guard !shuttingDown else { return }
-    await stopAll()
-    for name in describes.keys {
-      guard let config = providers[name] else { continue }
-      await startLoop(for: config)
+    /// Spawns/re-spawns the 60s poll loop for every provider with a valid
+    /// `describe` on file. Cancels any existing loops (and stops any running
+    /// events supervisors) first so a second call can't orphan one that
+    /// `stopAll()` would no longer be able to reach (the stored handle would
+    /// just get overwritten).
+    /// The whole stopAll()+startLoop() sequence runs under `reconfiguring` so
+    /// two concurrent calls (e.g. overlapping `start()`s) can never
+    /// interleave. Without it: `startLoop` inserts a supervisor into
+    /// `supervisors` and then suspends at `await supervisor.start()` — a
+    /// different actor, so this actor's executor is released for that
+    /// window. A second call's `stopAll()` could run entirely in that
+    /// window: its `await supervisor.stop()` on the just-inserted supervisor
+    /// returns instantly (nothing has started yet) and `removeAll()` drops
+    /// it, then the first call resumes and arms `start()` on a supervisor
+    /// nothing holds — the provider's child process respawns on backoff for
+    /// the daemon's life with no handle able to stop it. The symmetric case
+    /// (a supervisor inserted during one of `stopAll()`'s own awaits, then
+    /// dropped by that call's `removeAll()`) is closed the same way, since
+    /// the two call sequences now can't overlap at all.
+    private func spawnPollLoops() async {
+        await acquireReconfigureLock()
+        defer { releaseReconfigureLock() }
+        // A call already parked in the FIFO waiter queue when `shutdown()`
+        // ran receives the baton right after `shutdown()` releases it — FIFO
+        // ordering alone doesn't stop that hand-off, only this flag does.
+        // Without it, this would respawn poll loops (and events supervisors)
+        // on a manager the daemon believes it already tore down.
+        guard !shuttingDown else { return }
+        await stopAll()
+        for name in describes.keys {
+            guard let config = providers[name] else { continue }
+            await startLoop(for: config)
+        }
     }
-  }
 
-  private func acquireReconfigureLock() async {
-    if reconfiguring {
-      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-        reconfigureWaiters.append(continuation)
-      }
-    } else {
-      reconfiguring = true
+    private func acquireReconfigureLock() async {
+        if reconfiguring {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                reconfigureWaiters.append(continuation)
+            }
+        } else {
+            reconfiguring = true
+        }
     }
-  }
 
-  private func releaseReconfigureLock() {
-    if reconfigureWaiters.isEmpty {
-      reconfiguring = false
-    } else {
-      reconfigureWaiters.removeFirst().resume()
+    private func releaseReconfigureLock() {
+        if reconfigureWaiters.isEmpty {
+            reconfiguring = false
+        } else {
+            reconfigureWaiters.removeFirst().resume()
+        }
     }
-  }
 
-  func stopAll() async {
-    for task in loops.values { task.cancel() }
-    loops.removeAll()
-    for supervisor in supervisors.values { await supervisor.stop() }
-    supervisors.removeAll()
-  }
+    func stopAll() async {
+        for task in loops.values { task.cancel() }
+        loops.removeAll()
+        for supervisor in supervisors.values { await supervisor.stop() }
+        supervisors.removeAll()
+    }
 
-  /// Guarded daemon-shutdown entry point. `stopAll()` itself is not safe
-  /// to call directly from outside `spawnPollLoops` — it's the FIFO
-  /// reconfigure lock (see `spawnPollLoops`'s comment) that makes teardown
-  /// and a concurrent spawn mutually exclusive, and `stopAll()` on its own
-  /// doesn't take it.
-  ///
-  /// Taking the lock alone is NOT sufficient, and this does not merely
-  /// guard against "a `start()` still in flight at shutdown": FIFO means a
-  /// `spawnPollLoops()` call already parked in the waiter queue when this
-  /// runs receives the baton right after `shutdown()` releases the lock —
-  /// it would then respawn poll loops/supervisors on a manager the daemon
-  /// believes is torn down. `shuttingDown` (set here, before `stopAll()`,
-  /// and never cleared) makes shutdown terminal: every `spawnPollLoops()`
-  /// call that resumes after this one — queued or future — is a no-op.
-  func shutdown() async {
-    await acquireReconfigureLock()
-    defer { releaseReconfigureLock() }
-    shuttingDown = true
-    await stopAll()
-  }
+    /// Guarded daemon-shutdown entry point. `stopAll()` itself is not safe
+    /// to call directly from outside `spawnPollLoops` — it's the FIFO
+    /// reconfigure lock (see `spawnPollLoops`'s comment) that makes teardown
+    /// and a concurrent spawn mutually exclusive, and `stopAll()` on its own
+    /// doesn't take it.
+    ///
+    /// Taking the lock alone is NOT sufficient, and this does not merely
+    /// guard against "a `start()` still in flight at shutdown": FIFO means a
+    /// `spawnPollLoops()` call already parked in the waiter queue when this
+    /// runs receives the baton right after `shutdown()` releases the lock —
+    /// it would then respawn poll loops/supervisors on a manager the daemon
+    /// believes is torn down. `shuttingDown` (set here, before `stopAll()`,
+    /// and never cleared) makes shutdown terminal: every `spawnPollLoops()`
+    /// call that resumes after this one — queued or future — is a no-op.
+    func shutdown() async {
+        await acquireReconfigureLock()
+        defer { releaseReconfigureLock() }
+        shuttingDown = true
+        await stopAll()
+    }
 
-  /// The 60s `list` poll is the universal floor for every provider,
-  /// events-capable or not — it keeps running even when a stream is up,
-  /// since snapshot application is idempotent and this is what covers a
-  /// stream that's down or restarting. Providers that declared the
-  /// `events` capability in their cached `describe` additionally get a
-  /// supervised low-latency NDJSON stream.
-  private func startLoop(for config: RemoteProviderConfig) async {
-    if describes[config.name]?.capabilities.contains("events") == true {
-      let supervisor = ProviderEventsSupervisor(config: config, manager: self, clock: clock)
-      supervisors[config.name] = supervisor
-      // Awaiting `supervisor.start()` (a different actor) suspends this
-      // actor's executor, which by itself does NOT close the race
-      // described on `spawnPollLoops` — only that method's
-      // `reconfiguring` guard does, by making it impossible for a
-      // concurrent stopAll()/spawnPollLoops() call to run while this
-      // one is still in flight.
-      await supervisor.start()
+    /// The 60s `list` poll is the universal floor for every provider,
+    /// events-capable or not — it keeps running even when a stream is up,
+    /// since snapshot application is idempotent and this is what covers a
+    /// stream that's down or restarting. Providers that declared the
+    /// `events` capability in their cached `describe` additionally get a
+    /// supervised low-latency NDJSON stream.
+    private func startLoop(for config: RemoteProviderConfig) async {
+        if describes[config.name]?.capabilities.contains("events") == true {
+            let supervisor = ProviderEventsSupervisor(config: config, manager: self, clock: clock)
+            supervisors[config.name] = supervisor
+            // Awaiting `supervisor.start()` (a different actor) suspends this
+            // actor's executor, which by itself does NOT close the race
+            // described on `spawnPollLoops` — only that method's
+            // `reconfiguring` guard does, by making it impossible for a
+            // concurrent stopAll()/spawnPollLoops() call to run while this
+            // one is still in flight.
+            await supervisor.start()
+        }
+        loops[config.name] = Task { [weak self, clock] in
+            while !Task.isCancelled {
+                await self?.pollOnce(provider: config)
+                try? await clock.sleep(for: .seconds(Self.pollInterval))
+            }
+        }
     }
-    loops[config.name] = Task { [weak self, clock] in
-      while !Task.isCancelled {
-        await self?.pollOnce(provider: config)
-        try? await clock.sleep(for: .seconds(Self.pollInterval))
-      }
-    }
-  }
 
-  func pollOnce(provider: RemoteProviderConfig) async {
-    // pollOnce must work standalone, without start() having registered
-    // the provider first (mirror tests + Task 7's ad-hoc RPC lookups
-    // both call it directly) — register on first use so providerStatuses()
-    // reflects it.
-    registerIfNeeded(provider)
-    do {
-      let result = try await runner.run(provider, verb: ["list"], stdin: nil, timeout: 30)
-      if let failure = result.failureClass {
-        await recordPollFailure(provider: provider.name, class: failure, result: result)
-        return
-      }
-      let envelope = try result.decoded(RemoteSessionListEnvelope.self)
-      let snapshotAt = Date()
-      try await apply(snapshot: envelope.sessions, provider: provider.name, now: snapshotAt)
-    } catch {
-      remoteLogger.debug(
-        "poll \(provider.name, privacy: .public) failed: \(String(describing: error), privacy: .public)"
-      )
-      await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider.name)
-      setHealth(provider: provider.name, to: (.stale, String(describing: error), nil))
+    func pollOnce(provider: RemoteProviderConfig) async {
+        // pollOnce must work standalone, without start() having registered
+        // the provider first (mirror tests + Task 7's ad-hoc RPC lookups
+        // both call it directly) — register on first use so providerStatuses()
+        // reflects it.
+        registerIfNeeded(provider)
+        do {
+            let result = try await runner.run(provider, verb: ["list"], stdin: nil, timeout: 30)
+            if let failure = result.failureClass {
+                await recordPollFailure(provider: provider.name, class: failure, result: result)
+                return
+            }
+            let envelope = try result.decoded(RemoteSessionListEnvelope.self)
+            let snapshotAt = Date()
+            try await apply(snapshot: envelope.sessions, provider: provider.name, now: snapshotAt)
+        } catch {
+            remoteLogger.debug(
+                "poll \(provider.name, privacy: .public) failed: \(String(describing: error), privacy: .public)"
+            )
+            await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider.name)
+            setHealth(provider: provider.name, to: (.stale, String(describing: error), nil))
+        }
     }
-  }
 
-  /// Shared by the poll path and the events snapshot path (Task 6).
-  func apply(snapshot sessions: [RemoteSessionPayload], provider: String, now: Date = Date())
-    async throws
-  {
-    let outcome = try await db.remoteSessions.applySnapshot(
-      provider: provider, sessions: sessions, now: now)
-    lastSuccessfulSnapshotAt[provider] = now
-    markHealthy(provider: provider)
-    if outcome.changed {
-      subscriptions.broadcast(delta: .remoteSessionsChanged)
-    }
-    for session in outcome.attention {
-      subscriptions.broadcast(
-        delta: .remoteSessionAttention(
-          RemoteSessionAttentionDelta(
-            provider: provider, sessionID: session.id, title: session.title,
-            kind: session.agentState.rawValue, reason: session.agentStateReason,
-            exitCode: session.exitCode)))
-    }
-  }
-
-  /// Single-session upsert from an events `session` line. No absence
-  /// bookkeeping happens here — only `apply(snapshot:)` drives the
-  /// two-absence rule, since only a full snapshot can tell what's missing.
-  func applyUpsert(_ session: RemoteSessionPayload, provider: String) async {
-    let outcome: SnapshotOutcome
-    do {
-      outcome = try await db.remoteSessions.upsertOne(
-        provider: provider, session: session, now: Date())
-    } catch {
-      remoteLogger.error(
-        "events upsert failed for \(provider, privacy: .public)/\(session.id, privacy: .public): \(String(describing: error), privacy: .public)"
-      )
-      return
-    }
-    if outcome.changed {
-      subscriptions.broadcast(delta: .remoteSessionsChanged)
-    }
-    for session in outcome.attention {
-      subscriptions.broadcast(
-        delta: .remoteSessionAttention(
-          RemoteSessionAttentionDelta(
-            provider: provider, sessionID: session.id, title: session.title,
-            kind: session.agentState.rawValue, reason: session.agentStateReason,
-            exitCode: session.exitCode)))
-    }
-  }
-
-  /// Explicit removal from an events `removed` line. The provider is
-  /// authoritative about this — skip the two-absence rule entirely and
-  /// mark the row gone immediately.
-  func applyRemoval(sessionID: String, provider: String) async {
-    let changed: Bool
-    do {
-      changed = try await db.remoteSessions.markGone(
-        provider: provider, sessionID: sessionID)
-    } catch {
-      remoteLogger.error(
-        "events removal failed for \(provider, privacy: .public)/\(sessionID, privacy: .public): \(String(describing: error), privacy: .public)"
-      )
-      return
-    }
-    if changed {
-      subscriptions.broadcast(delta: .remoteSessionsChanged)
-    }
-  }
-
-  /// Test seam: whether a supervisor currently exists for `name` — used
-  /// only to make the events-vs-poll capability gate in `startLoop`
-  /// observable from tests without exposing `supervisors` itself.
-  func hasSupervisor(named name: String) -> Bool {
-    supervisors[name] != nil
-  }
-
-  func invoke(
-    providerName: String, verb: [String], stdin: Data?,
-    timeout: TimeInterval
-  ) async throws -> ProviderResult {
-    guard let config = providers[providerName] ?? loadAdHoc(named: providerName) else {
-      throw RemoteProviderError.unknownProvider(providerName)
-    }
-    let result = try await runner.run(config, verb: verb, stdin: stdin, timeout: timeout)
-    if let failure = result.failureClass {
-      recordFailure(provider: providerName, class: failure, result: result)
-    }
-    return result
-  }
-
-  /// Tests (and a pre-`start()` RPC call) can address providers straight
-  /// from the registry file.
-  private func loadAdHoc(named name: String) -> RemoteProviderConfig? {
-    guard let configs = try? RemoteProviderRegistry.load(from: registryURL),
-      let config = configs.first(where: { $0.name == name })
-    else { return nil }
-    registerIfNeeded(config)
-    return config
-  }
-
-  /// Registers a provider config (if not already known) and seeds a
-  /// default `ok` health entry (if not already present). Shared by every
-  /// entry point that can be a provider's first contact with this actor
-  /// (`loadRegistryAndDescribe`, `pollOnce`, `loadAdHoc`).
-  private func registerIfNeeded(_ config: RemoteProviderConfig) {
-    if providers[config.name] == nil { providers[config.name] = config }
-    if health[config.name] == nil { health[config.name] = (.ok, nil, nil) }
-  }
-
-  func providerStatuses() async -> [RemoteProviderStatus] {
-    for name in providers.keys {
-      await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)
-    }
-    return providers.values.sorted { $0.name < $1.name }.map { config in
-      let h = health[config.name] ?? (.ok, nil, nil)
-      return RemoteProviderStatus(
-        config: config, describe: describes[config.name],
-        health: h.state,
-        errorMessage: Self.boundedDisplayMessage(
-          h.message,
-          hasSuccessfulSnapshot: lastSuccessfulSnapshotAt[config.name] != nil
-        ),
-        remediationLabel: h.remediation?.label,
-        remediationCommand: h.remediation?.command,
-        lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[config.name])
-    }
-  }
-
-  /// Whether mutations that depend on the cached inventory should be
-  /// suppressed. Read-only inspection (`attach`, `log`) remains useful
-  /// during an inventory outage; create/stop/send/rename do not have a
-  /// trustworthy current-state basis once a previously-good snapshot is
-  /// stale.
-  func hasStaleSnapshot(provider name: String) async -> Bool {
-    await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)
-    guard lastSuccessfulSnapshotAt[name] != nil else { return false }
-    return health[name]?.state != .ok
-  }
-
-  /// Correlates a locally-spawned `attach` exit (the app execs the provider
-  /// on a terminal's own TTY, so its exit code never passes through this
-  /// actor's runner) with provider health.
-  ///
-  /// `attach`'s stdout is a PTY byte stream and MUST NOT be parsed
-  /// (`docs/remote-provider-contract.md` § `attach`), so the exit code is
-  /// the only signal — hence `error: nil` in the classification below.
-  ///
-  /// - Non-auth classes are deliberately ignored: an attach that died for
-  ///   transport reasons is already covered app-side by pending-reconnect
-  ///   backoff, and letting every dropped connection rewrite provider
-  ///   health would make one flaky viewer speak for the whole provider.
-  /// - The auth class marks the provider `.needsAuth` while PRESERVING any
-  ///   message/remediation already on file: an attach exit carries none of
-  ///   its own, and clobbering a parsed remediation with `nil` would
-  ///   downgrade a good CTA to a bare "authentication needed". Preservation
-  ///   is limited to an already-`.needsAuth` provider, for the reason
-  ///   spelled out in `recordFailure`'s auth branch — text written under
-  ///   `.stale`/`.error` explains a different condition and must not be
-  ///   relabelled as an authentication explanation. Carrying it here would
-  ///   also survive the probe below, which inherits from the state this
-  ///   line writes.
-  /// - It then triggers exactly ONE out-of-band `list` so the state is
-  ///   either confirmed with a freshly parsed remediation or cleared
-  ///   outright by a success. That probe is bounded by the
-  ///   already-`.needsAuth` check: at most one extra `list` per health
-  ///   transition, so a session flapping through repeated auth exits can
-  ///   never turn into a poll flood.
-  func recordAttachExit(provider name: String, exitCode: Int32) async throws {
-    guard let config = providers[name] ?? loadAdHoc(named: name) else {
-      throw RemoteProviderError.unknownProvider(name)
-    }
-    guard ProviderFailureClass.classify(exitCode: exitCode, error: nil) == .authNeeded else {
-      return
-    }
-    let previous = health[name]
-    let inheritable = previous?.state == .needsAuth ? previous : nil
-    setHealth(provider: name, to: (.needsAuth, inheritable?.message, inheritable?.remediation))
-    guard previous?.state != .needsAuth else { return }
-    await pollOnce(provider: config)
-  }
-
-  private func recordFailure(
-    provider: String, class failureClass: ProviderFailureClass,
-    result: ProviderResult
-  ) {
-    let error = result.decodedError
-    switch failureClass {
-    case .authNeeded:
-      // Preserve what's already on file when the new error supplies
-      // nothing — but ONLY while staying within `.needsAuth`.
-      //
-      // Why inherit at all: `recordAttachExit` deliberately keeps the
-      // existing message/remediation (an attach exit carries none of
-      // its own) and then fires a `list` probe through here — a probe
-      // that itself exits 4 with unparseable stdout would otherwise
-      // clobber that preserved remediation back to `nil`, downgrading
-      // a good CTA to a bare "authentication needed". A freshly parsed
-      // value still wins, so recovery-with-new-detail is unaffected.
-      //
-      // Why the asymmetry: text on file under `.ok`/`.stale`/`.error`
-      // describes a DIFFERENT condition. Inheriting it across a
-      // transition INTO `.needsAuth` would render, say, a transport
-      // timeout as the provider's authentication explanation — wrong
-      // words in the one string this CTA exists to deliver. On such a
-      // transition the fields go `nil` and the app renders its neutral
-      // fallback CTA instead. This still covers the path the
-      // inheritance was added for: `recordAttachExit` sets `.needsAuth`
-      // BEFORE firing its probe, so the probe's `recordFailure` sees a
-      // previous state of `.needsAuth`.
-      //
-      // Only this class inherits at all: `.stale`/`.error` messages
-      // describe THIS invocation and go stale the moment it changes.
-      let previous = health[provider]
-      let inheritable = previous?.state == .needsAuth ? previous : nil
-      setHealth(
-        provider: provider,
-        to: (
-          .needsAuth,
-          error?.message ?? inheritable?.message,
-          error?.remediation ?? inheritable?.remediation
-        ))
-    case .transient:
-      setHealth(provider: provider, to: (.stale, error?.message ?? result.stderr, nil))
-    case .permanent, .contractBug:
-      setHealth(provider: provider, to: (.error, error?.message ?? result.stderr, nil))
-    }
-  }
-
-  /// Poll failures need one extra piece of bookkeeping beyond generic
-  /// provider failures: if this manager restarted after the last success,
-  /// recover that timestamp from the mirror's last-seen rows before
-  /// publishing stale health. This keeps a persisted cached snapshot from
-  /// becoming confidently timeless after a daemon restart.
-  private func recordPollFailure(
-    provider: String, class failureClass: ProviderFailureClass,
-    result: ProviderResult
-  ) async {
-    await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider)
-    recordFailure(provider: provider, class: failureClass, result: result)
-  }
-
-  private func recoverLastSuccessfulSnapshotAtIfNeeded(
-    provider: String,
-    markStale: Bool = false
-  ) async {
-    guard lastSuccessfulSnapshotAt[provider] == nil else { return }
-    if let recovered = try? await db.remoteSessions.lastSuccessfulSnapshotAt(provider: provider) {
-      lastSuccessfulSnapshotAt[provider] = recovered
-      if markStale, health[provider]?.state == .ok {
-        setHealth(
-          provider: provider,
-          to: (
-            .stale,
-            "Provider inventory has not refreshed since daemon restart.",
-            nil
-          ))
-      }
-    }
-  }
-
-  /// The provider may return the entire truncated inventory inside its
-  /// error message. Keep the manager's internal health record unchanged for
-  /// diagnostics, but never put an unbounded wall of JSON on the RPC/UI
-  /// wire. The known
-  /// truncation shape receives safe copy rather than leaking a prompt from
-  /// the beginning of the embedded payload.
-  static func boundedDisplayMessage(
-    _ message: String?,
-    hasSuccessfulSnapshot: Bool = true,
-    limit: Int = 240
-  ) -> String? {
-    guard let message else { return nil }
-    if message.localizedCaseInsensitiveContains("--output truncated--")
-      || message.localizedCaseInsensitiveContains("unparseable remote output")
+    /// Shared by the poll path and the events snapshot path (Task 6).
+    func apply(snapshot sessions: [RemoteSessionPayload], provider: String, now: Date = Date())
+        async throws
     {
-      if hasSuccessfulSnapshot {
-        return
-          "Provider inventory was truncated or malformed; showing the last successful snapshot."
-      }
-      return
-        "Provider inventory was truncated or malformed; no successful snapshot is available yet."
+        let outcome = try await db.remoteSessions.applySnapshot(
+            provider: provider, sessions: sessions, now: now)
+        lastSuccessfulSnapshotAt[provider] = now
+        markHealthy(provider: provider)
+        if outcome.changed {
+            subscriptions.broadcast(delta: .remoteSessionsChanged)
+        }
+        for session in outcome.attention {
+            subscriptions.broadcast(
+                delta: .remoteSessionAttention(
+                    RemoteSessionAttentionDelta(
+                        provider: provider, sessionID: session.id, title: session.title,
+                        kind: session.agentState.rawValue, reason: session.agentStateReason,
+                        exitCode: session.exitCode)))
+        }
     }
-    guard message.count > limit else { return message }
-    let kept = max(0, limit - 1)
-    return String(message.prefix(kept)) + "…"
-  }
 
-  private func markHealthy(provider: String) {
-    setHealth(provider: provider, to: (.ok, nil, nil))
-  }
-
-  /// Records a provider's health and broadcasts when ANY of the three
-  /// fields the app renders changed — state, message, or remediation.
-  ///
-  /// State alone is not enough: the auth path routinely transitions
-  /// `.needsAuth` → `.needsAuth` while ADDING detail (`recordAttachExit`
-  /// flips health off a bare exit code with no message, then its probe
-  /// lands the parsed message + remediation). Broadcasting on state alone
-  /// dropped that payload on the floor and left the app rendering a
-  /// command-less fallback CTA for the whole outage, since every later
-  /// poll is also `.needsAuth` → `.needsAuth`.
-  ///
-  /// Equally deliberately, it does NOT broadcast unconditionally: a
-  /// healthy provider re-setting `(.ok, nil, nil)` every 60s poll would
-  /// otherwise put a delta on the wire per provider per minute forever.
-  private func setHealth(
-    provider: String,
-    to new: (ProviderHealth, String?, ProviderRemediation?)
-  ) {
-    let old = health[provider]
-    health[provider] = new
-    if old?.state != new.0 || old?.message != new.1 || old?.remediation != new.2 {
-      subscriptions.broadcast(delta: .remoteSessionsChanged)
+    /// Single-session upsert from an events `session` line. No absence
+    /// bookkeeping happens here — only `apply(snapshot:)` drives the
+    /// two-absence rule, since only a full snapshot can tell what's missing.
+    func applyUpsert(_ session: RemoteSessionPayload, provider: String) async {
+        let outcome: SnapshotOutcome
+        do {
+            outcome = try await db.remoteSessions.upsertOne(
+                provider: provider, session: session, now: Date())
+        } catch {
+            remoteLogger.error(
+                "events upsert failed for \(provider, privacy: .public)/\(session.id, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        if outcome.changed {
+            subscriptions.broadcast(delta: .remoteSessionsChanged)
+        }
+        for session in outcome.attention {
+            subscriptions.broadcast(
+                delta: .remoteSessionAttention(
+                    RemoteSessionAttentionDelta(
+                        provider: provider, sessionID: session.id, title: session.title,
+                        kind: session.agentState.rawValue, reason: session.agentStateReason,
+                        exitCode: session.exitCode)))
+        }
     }
-  }
+
+    /// Explicit removal from an events `removed` line. The provider is
+    /// authoritative about this — skip the two-absence rule entirely and
+    /// mark the row gone immediately.
+    func applyRemoval(sessionID: String, provider: String) async {
+        let changed: Bool
+        do {
+            changed = try await db.remoteSessions.markGone(
+                provider: provider, sessionID: sessionID)
+        } catch {
+            remoteLogger.error(
+                "events removal failed for \(provider, privacy: .public)/\(sessionID, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
+        if changed {
+            subscriptions.broadcast(delta: .remoteSessionsChanged)
+        }
+    }
+
+    /// Test seam: whether a supervisor currently exists for `name` — used
+    /// only to make the events-vs-poll capability gate in `startLoop`
+    /// observable from tests without exposing `supervisors` itself.
+    func hasSupervisor(named name: String) -> Bool {
+        supervisors[name] != nil
+    }
+
+    func invoke(
+        providerName: String, verb: [String], stdin: Data?,
+        timeout: TimeInterval
+    ) async throws -> ProviderResult {
+        guard let config = providers[providerName] ?? loadAdHoc(named: providerName) else {
+            throw RemoteProviderError.unknownProvider(providerName)
+        }
+        let result = try await runner.run(config, verb: verb, stdin: stdin, timeout: timeout)
+        if let failure = result.failureClass {
+            recordFailure(provider: providerName, class: failure, result: result)
+        }
+        return result
+    }
+
+    /// Tests (and a pre-`start()` RPC call) can address providers straight
+    /// from the registry file.
+    private func loadAdHoc(named name: String) -> RemoteProviderConfig? {
+        guard let configs = try? RemoteProviderRegistry.load(from: registryURL),
+            let config = configs.first(where: { $0.name == name })
+        else { return nil }
+        registerIfNeeded(config)
+        return config
+    }
+
+    /// Registers a provider config (if not already known) and seeds a
+    /// default `ok` health entry (if not already present). Shared by every
+    /// entry point that can be a provider's first contact with this actor
+    /// (`loadRegistryAndDescribe`, `pollOnce`, `loadAdHoc`).
+    private func registerIfNeeded(_ config: RemoteProviderConfig) {
+        if providers[config.name] == nil { providers[config.name] = config }
+        if health[config.name] == nil { health[config.name] = (.ok, nil, nil) }
+    }
+
+    func providerStatuses() async -> [RemoteProviderStatus] {
+        for name in providers.keys {
+            await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)
+        }
+        return providers.values.sorted { $0.name < $1.name }.map { config in
+            let h = health[config.name] ?? (.ok, nil, nil)
+            return RemoteProviderStatus(
+                config: config, describe: describes[config.name],
+                health: h.state,
+                errorMessage: Self.boundedDisplayMessage(
+                    h.message,
+                    hasSuccessfulSnapshot: lastSuccessfulSnapshotAt[config.name] != nil
+                ),
+                remediationLabel: h.remediation?.label,
+                remediationCommand: h.remediation?.command,
+                lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[config.name])
+        }
+    }
+
+    /// Whether mutations that depend on the cached inventory should be
+    /// suppressed. Read-only inspection (`attach`, `log`) remains useful
+    /// during an inventory outage; create/stop/send/rename do not have a
+    /// trustworthy current-state basis once a previously-good snapshot is
+    /// stale.
+    func hasStaleSnapshot(provider name: String) async -> Bool {
+        await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)
+        guard lastSuccessfulSnapshotAt[name] != nil else { return false }
+        return health[name]?.state != .ok
+    }
+
+    /// Correlates a locally-spawned `attach` exit (the app execs the provider
+    /// on a terminal's own TTY, so its exit code never passes through this
+    /// actor's runner) with provider health.
+    ///
+    /// `attach`'s stdout is a PTY byte stream and MUST NOT be parsed
+    /// (`docs/remote-provider-contract.md` § `attach`), so the exit code is
+    /// the only signal — hence `error: nil` in the classification below.
+    ///
+    /// - Non-auth classes are deliberately ignored: an attach that died for
+    ///   transport reasons is already covered app-side by pending-reconnect
+    ///   backoff, and letting every dropped connection rewrite provider
+    ///   health would make one flaky viewer speak for the whole provider.
+    /// - The auth class marks the provider `.needsAuth` while PRESERVING any
+    ///   message/remediation already on file: an attach exit carries none of
+    ///   its own, and clobbering a parsed remediation with `nil` would
+    ///   downgrade a good CTA to a bare "authentication needed". Preservation
+    ///   is limited to an already-`.needsAuth` provider, for the reason
+    ///   spelled out in `recordFailure`'s auth branch — text written under
+    ///   `.stale`/`.error` explains a different condition and must not be
+    ///   relabelled as an authentication explanation. Carrying it here would
+    ///   also survive the probe below, which inherits from the state this
+    ///   line writes.
+    /// - It then triggers exactly ONE out-of-band `list` so the state is
+    ///   either confirmed with a freshly parsed remediation or cleared
+    ///   outright by a success. That probe is bounded by the
+    ///   already-`.needsAuth` check: at most one extra `list` per health
+    ///   transition, so a session flapping through repeated auth exits can
+    ///   never turn into a poll flood.
+    func recordAttachExit(provider name: String, exitCode: Int32) async throws {
+        guard let config = providers[name] ?? loadAdHoc(named: name) else {
+            throw RemoteProviderError.unknownProvider(name)
+        }
+        guard ProviderFailureClass.classify(exitCode: exitCode, error: nil) == .authNeeded else {
+            return
+        }
+        let previous = health[name]
+        let inheritable = previous?.state == .needsAuth ? previous : nil
+        setHealth(provider: name, to: (.needsAuth, inheritable?.message, inheritable?.remediation))
+        guard previous?.state != .needsAuth else { return }
+        await pollOnce(provider: config)
+    }
+
+    private func recordFailure(
+        provider: String, class failureClass: ProviderFailureClass,
+        result: ProviderResult
+    ) {
+        let error = result.decodedError
+        switch failureClass {
+        case .authNeeded:
+            // Preserve what's already on file when the new error supplies
+            // nothing — but ONLY while staying within `.needsAuth`.
+            //
+            // Why inherit at all: `recordAttachExit` deliberately keeps the
+            // existing message/remediation (an attach exit carries none of
+            // its own) and then fires a `list` probe through here — a probe
+            // that itself exits 4 with unparseable stdout would otherwise
+            // clobber that preserved remediation back to `nil`, downgrading
+            // a good CTA to a bare "authentication needed". A freshly parsed
+            // value still wins, so recovery-with-new-detail is unaffected.
+            //
+            // Why the asymmetry: text on file under `.ok`/`.stale`/`.error`
+            // describes a DIFFERENT condition. Inheriting it across a
+            // transition INTO `.needsAuth` would render, say, a transport
+            // timeout as the provider's authentication explanation — wrong
+            // words in the one string this CTA exists to deliver. On such a
+            // transition the fields go `nil` and the app renders its neutral
+            // fallback CTA instead. This still covers the path the
+            // inheritance was added for: `recordAttachExit` sets `.needsAuth`
+            // BEFORE firing its probe, so the probe's `recordFailure` sees a
+            // previous state of `.needsAuth`.
+            //
+            // Only this class inherits at all: `.stale`/`.error` messages
+            // describe THIS invocation and go stale the moment it changes.
+            let previous = health[provider]
+            let inheritable = previous?.state == .needsAuth ? previous : nil
+            setHealth(
+                provider: provider,
+                to: (
+                    .needsAuth,
+                    error?.message ?? inheritable?.message,
+                    error?.remediation ?? inheritable?.remediation
+                ))
+        case .transient:
+            setHealth(provider: provider, to: (.stale, error?.message ?? result.stderr, nil))
+        case .permanent, .contractBug:
+            setHealth(provider: provider, to: (.error, error?.message ?? result.stderr, nil))
+        }
+    }
+
+    /// Poll failures need one extra piece of bookkeeping beyond generic
+    /// provider failures: if this manager restarted after the last success,
+    /// recover that timestamp from the mirror's last-seen rows before
+    /// publishing stale health. This keeps a persisted cached snapshot from
+    /// becoming confidently timeless after a daemon restart.
+    private func recordPollFailure(
+        provider: String, class failureClass: ProviderFailureClass,
+        result: ProviderResult
+    ) async {
+        await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider)
+        recordFailure(provider: provider, class: failureClass, result: result)
+    }
+
+    private func recoverLastSuccessfulSnapshotAtIfNeeded(
+        provider: String,
+        markStale: Bool = false
+    ) async {
+        guard lastSuccessfulSnapshotAt[provider] == nil else { return }
+        if let recovered = try? await db.remoteSessions.lastSuccessfulSnapshotAt(provider: provider) {
+            lastSuccessfulSnapshotAt[provider] = recovered
+            if markStale, health[provider]?.state == .ok {
+                setHealth(
+                    provider: provider,
+                    to: (
+                        .stale,
+                        "Provider inventory has not refreshed since daemon restart.",
+                        nil
+                    ))
+            }
+        }
+    }
+
+    /// The provider may return the entire truncated inventory inside its
+    /// error message. Keep the manager's internal health record unchanged for
+    /// diagnostics, but never put an unbounded wall of JSON on the RPC/UI
+    /// wire. The known
+    /// truncation shape receives safe copy rather than leaking a prompt from
+    /// the beginning of the embedded payload.
+    static func boundedDisplayMessage(
+        _ message: String?,
+        hasSuccessfulSnapshot: Bool = true,
+        limit: Int = 240
+    ) -> String? {
+        guard let message else { return nil }
+        if message.localizedCaseInsensitiveContains("--output truncated--")
+            || message.localizedCaseInsensitiveContains("unparseable remote output")
+        {
+            if hasSuccessfulSnapshot {
+                return
+                    "Provider inventory was truncated or malformed; showing the last successful snapshot."
+            }
+            return
+                "Provider inventory was truncated or malformed; no successful snapshot is available yet."
+        }
+        guard message.count > limit else { return message }
+        let kept = max(0, limit - 1)
+        return String(message.prefix(kept)) + "…"
+    }
+
+    private func markHealthy(provider: String) {
+        setHealth(provider: provider, to: (.ok, nil, nil))
+    }
+
+    /// Records a provider's health and broadcasts when ANY of the three
+    /// fields the app renders changed — state, message, or remediation.
+    ///
+    /// State alone is not enough: the auth path routinely transitions
+    /// `.needsAuth` → `.needsAuth` while ADDING detail (`recordAttachExit`
+    /// flips health off a bare exit code with no message, then its probe
+    /// lands the parsed message + remediation). Broadcasting on state alone
+    /// dropped that payload on the floor and left the app rendering a
+    /// command-less fallback CTA for the whole outage, since every later
+    /// poll is also `.needsAuth` → `.needsAuth`.
+    ///
+    /// Equally deliberately, it does NOT broadcast unconditionally: a
+    /// healthy provider re-setting `(.ok, nil, nil)` every 60s poll would
+    /// otherwise put a delta on the wire per provider per minute forever.
+    private func setHealth(
+        provider: String,
+        to new: (ProviderHealth, String?, ProviderRemediation?)
+    ) {
+        let old = health[provider]
+        health[provider] = new
+        if old?.state != new.0 || old?.message != new.1 || old?.remediation != new.2 {
+            subscriptions.broadcast(delta: .remoteSessionsChanged)
+        }
+    }
 }
 
 enum RemoteProviderError: Error {
-  case unknownProvider(String)
+    case unknownProvider(String)
 }

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -24,6 +24,13 @@ public actor RemoteProviderManager {
     /// independently from generic verb health: a successful `log`/`attach`
     /// proves that verb worked, not that the cached inventory is current.
     private var lastSuccessfulSnapshotAt: [String: Date] = [:]
+    /// Providers whose persisted freshness row could not be READ. This is not
+    /// the same condition as "no successful snapshot was ever recorded": there,
+    /// the daemon knows the mirror was never authoritative and deliberately
+    /// fails open (see `hasStaleSnapshot`); here it knows nothing at all, so it
+    /// must not spend that ignorance on a mutation. Cleared as soon as a read
+    /// succeeds or a live snapshot lands.
+    private var snapshotFreshnessUnreadable: Set<String> = []
     private var loops: [String: Task<Void, Never>] = [:]
     private var supervisors: [String: ProviderEventsSupervisor] = [:]
     /// Guards `spawnPollLoops`'s compound stopAll()+startLoop() sequence
@@ -269,6 +276,9 @@ public actor RemoteProviderManager {
         let outcome = try await db.remoteSessions.applySnapshot(
             provider: provider, sessions: sessions, now: now)
         lastSuccessfulSnapshotAt[provider] = now
+        // A live snapshot supersedes whatever the persisted row would have
+        // said, so an earlier unreadable read no longer gates anything.
+        snapshotFreshnessUnreadable.remove(provider)
         markHealthy(provider: provider)
         if outcome.changed {
             subscriptions.broadcast(delta: .remoteSessionsChanged)
@@ -395,6 +405,11 @@ public actor RemoteProviderManager {
     /// stale.
     func hasStaleSnapshot(provider name: String) async -> Bool {
         await recoverLastSuccessfulSnapshotAtIfNeeded(provider: name, markStale: true)
+        // Unreadable freshness fails CLOSED. The fail-open branch below is
+        // justified only by positive knowledge that no snapshot was ever
+        // accepted; a failed read carries no such proof, so it must not be
+        // allowed to look like one.
+        if snapshotFreshnessUnreadable.contains(name) { return true }
         guard lastSuccessfulSnapshotAt[name] != nil else { return false }
         return health[name]?.state != .ok
     }
@@ -506,17 +521,42 @@ public actor RemoteProviderManager {
         markStale: Bool = false
     ) async {
         guard lastSuccessfulSnapshotAt[provider] == nil else { return }
-        if let recovered = try? await db.remoteSessions.lastSuccessfulSnapshotAt(provider: provider) {
-            lastSuccessfulSnapshotAt[provider] = recovered
+        let recovered: Date?
+        do {
+            recovered = try await db.remoteSessions.lastSuccessfulSnapshotAt(provider: provider)
+        } catch {
+            // Unreadable, not absent. Record the distinction so the mutation
+            // gate can fail closed, and say so in the surfaced health text —
+            // "could not be read" is a different user-facing condition from
+            // "has not refreshed".
+            snapshotFreshnessUnreadable.insert(provider)
+            remoteLogger.error(
+                """
+                freshness recovery failed for provider \(provider, privacy: .public): \
+                \(String(describing: error), privacy: .public)
+                """)
             if markStale, health[provider]?.state == .ok {
                 setHealth(
                     provider: provider,
                     to: (
                         .stale,
-                        "Provider inventory has not refreshed since daemon restart.",
+                        "Provider freshness state could not be read.",
                         nil
                     ))
             }
+            return
+        }
+        snapshotFreshnessUnreadable.remove(provider)
+        guard let recovered else { return }
+        lastSuccessfulSnapshotAt[provider] = recovered
+        if markStale, health[provider]?.state == .ok {
+            setHealth(
+                provider: provider,
+                to: (
+                    .stale,
+                    "Provider inventory has not refreshed since daemon restart.",
+                    nil
+                ))
         }
     }
 

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -1,6 +1,6 @@
 import Foundation
-import os
 import TBDShared
+import os
 
 private let remoteLogger = Logger(subsystem: "com.tbd.daemon", category: "remote")
 
@@ -9,503 +9,547 @@ private let remoteLogger = Logger(subsystem: "com.tbd.daemon", category: "remote
 /// Source of truth for sessions is always the provider; this actor only
 /// maintains the mirror + broadcasts.
 public actor RemoteProviderManager {
-    private let db: TBDDatabase
-    private let subscriptions: StateSubscriptionManager
-    private let runner: any RemoteProviderInvoking
-    private let registryURL: URL
-    private let clock: any Clock<Duration>
-    static let pollInterval: TimeInterval = 60
+  private let db: TBDDatabase
+  private let subscriptions: StateSubscriptionManager
+  private let runner: any RemoteProviderInvoking
+  private let registryURL: URL
+  private let clock: any Clock<Duration>
+  static let pollInterval: TimeInterval = 60
 
-    private var providers: [String: RemoteProviderConfig] = [:]
-    private var describes: [String: ProviderDescribe] = [:]
-    private var health: [String: (state: ProviderHealth, message: String?, remediation: ProviderRemediation?)] = [:]
-    /// Most recent complete inventory accepted for each provider. Kept
-    /// independently from generic verb health: a successful `log`/`attach`
-    /// proves that verb worked, not that the cached inventory is current.
-    private var lastSuccessfulSnapshotAt: [String: Date] = [:]
-    private var loops: [String: Task<Void, Never>] = [:]
-    private var supervisors: [String: ProviderEventsSupervisor] = [:]
-    /// Guards `spawnPollLoops`'s compound stopAll()+startLoop() sequence
-    /// against a second concurrent call to the same sequence (e.g. two
-    /// overlapping `start()`s). See the comment on `spawnPollLoops` for the
-    /// race this closes.
-    private var reconfiguring = false
-    private var reconfigureWaiters: [CheckedContinuation<Void, Never>] = []
-    /// Set by `shutdown()` while still holding the reconfigure lock, and
-    /// never cleared — shutdown is terminal for this actor's lifetime. See
-    /// `shutdown()`'s doc comment for the race this closes.
-    private var shuttingDown = false
+  private var providers: [String: RemoteProviderConfig] = [:]
+  private var describes: [String: ProviderDescribe] = [:]
+  private var health:
+    [String: (state: ProviderHealth, message: String?, remediation: ProviderRemediation?)] = [:]
+  /// Most recent complete inventory accepted for each provider. Kept
+  /// independently from generic verb health: a successful `log`/`attach`
+  /// proves that verb worked, not that the cached inventory is current.
+  private var lastSuccessfulSnapshotAt: [String: Date] = [:]
+  private var loops: [String: Task<Void, Never>] = [:]
+  private var supervisors: [String: ProviderEventsSupervisor] = [:]
+  /// Guards `spawnPollLoops`'s compound stopAll()+startLoop() sequence
+  /// against a second concurrent call to the same sequence (e.g. two
+  /// overlapping `start()`s). See the comment on `spawnPollLoops` for the
+  /// race this closes.
+  private var reconfiguring = false
+  private var reconfigureWaiters: [CheckedContinuation<Void, Never>] = []
+  /// Set by `shutdown()` while still holding the reconfigure lock, and
+  /// never cleared — shutdown is terminal for this actor's lifetime. See
+  /// `shutdown()`'s doc comment for the race this closes.
+  private var shuttingDown = false
 
-    init(db: TBDDatabase, subscriptions: StateSubscriptionManager,
-         runner: any RemoteProviderInvoking, registryURL: URL,
-         clock: any Clock<Duration> = ContinuousClock()) {
-        self.db = db
-        self.subscriptions = subscriptions
-        self.runner = runner
-        self.registryURL = registryURL
-        self.clock = clock
+  init(
+    db: TBDDatabase, subscriptions: StateSubscriptionManager,
+    runner: any RemoteProviderInvoking, registryURL: URL,
+    clock: any Clock<Duration> = ContinuousClock()
+  ) {
+    self.db = db
+    self.subscriptions = subscriptions
+    self.runner = runner
+    self.registryURL = registryURL
+    self.clock = clock
+  }
+
+  /// Full boot path: load the registry, describe every provider, then
+  /// spawn poll loops for the ones that negotiated a usable contract.
+  /// Composition of the two steps below — callers that only need
+  /// registry/describe state (e.g. verb-routing tests) should call
+  /// `loadRegistryAndDescribe()` alone so no background timer is armed.
+  func start() async {
+    await loadRegistryAndDescribe()
+    await spawnPollLoops()
+  }
+
+  /// Loads the provider registry and runs `describe` against every entry,
+  /// populating `providers`/`describes`/`health`. Spawns no poll loops —
+  /// safe to call from tests that only want to exercise describe/invoke
+  /// routing without racing a real 60s timer.
+  ///
+  /// Checks `Task.isCancelled` before each provider's `describe` so a
+  /// caller cancelling the enclosing task (daemon shutdown racing boot)
+  /// bounds this to at most one `describe` child process in flight rather
+  /// than one per remaining provider.
+  func loadRegistryAndDescribe() async {
+    let configs: [RemoteProviderConfig]
+    do {
+      configs = try RemoteProviderRegistry.load(from: registryURL)
+    } catch {
+      remoteLogger.error(
+        "provider registry unreadable: \(String(describing: error), privacy: .public)")
+      return
     }
-
-    /// Full boot path: load the registry, describe every provider, then
-    /// spawn poll loops for the ones that negotiated a usable contract.
-    /// Composition of the two steps below — callers that only need
-    /// registry/describe state (e.g. verb-routing tests) should call
-    /// `loadRegistryAndDescribe()` alone so no background timer is armed.
-    func start() async {
-        await loadRegistryAndDescribe()
-        await spawnPollLoops()
+    for config in configs {
+      guard !Task.isCancelled else { return }
+      registerIfNeeded(config)
+      await describeProvider(config)
     }
+    subscriptions.broadcast(delta: .remoteSessionsChanged)
+  }
 
-    /// Loads the provider registry and runs `describe` against every entry,
-    /// populating `providers`/`describes`/`health`. Spawns no poll loops —
-    /// safe to call from tests that only want to exercise describe/invoke
-    /// routing without racing a real 60s timer.
-    ///
-    /// Checks `Task.isCancelled` before each provider's `describe` so a
-    /// caller cancelling the enclosing task (daemon shutdown racing boot)
-    /// bounds this to at most one `describe` child process in flight rather
-    /// than one per remaining provider.
-    func loadRegistryAndDescribe() async {
-        let configs: [RemoteProviderConfig]
-        do {
-            configs = try RemoteProviderRegistry.load(from: registryURL)
-        } catch {
-            remoteLogger.error("provider registry unreadable: \(String(describing: error), privacy: .public)")
-            return
-        }
-        for config in configs {
-            guard !Task.isCancelled else { return }
-            registerIfNeeded(config)
-            await describeProvider(config)
-        }
-        subscriptions.broadcast(delta: .remoteSessionsChanged)
+  /// Runs `describe` for one provider and records the outcome in
+  /// `describes`/`health`. Auth failures (exit 4) and other classified
+  /// failures route through the same `recordFailure` path `pollOnce` and
+  /// `invoke` use, so a provider that rejects credentials on its very
+  /// first contact still surfaces `needs_auth` with remediation instead of
+  /// a generic error. Only spawn/parse problems — which no failure class
+  /// can describe — fall back to a generic message, distinguished by text
+  /// from "it ran and rejected us".
+  private func describeProvider(_ config: RemoteProviderConfig) async {
+    let result: ProviderResult
+    do {
+      result = try await runner.run(config, verb: ["describe"], stdin: nil, timeout: 10)
+    } catch {
+      remoteLogger.error(
+        "describe \(config.name, privacy: .public) couldn't run: \(String(describing: error), privacy: .public)"
+      )
+      setHealth(provider: config.name, to: (.error, "couldn't run describe: \(error)", nil))
+      return
     }
+    if let failure = result.failureClass {
+      recordFailure(provider: config.name, class: failure, result: result)
+      return
+    }
+    guard let describe = try? result.decoded(ProviderDescribe.self) else {
+      setHealth(
+        provider: config.name, to: (.error, "describe returned an unparseable response", nil))
+      return
+    }
+    guard describe.contractVersions.contains(1) else {
+      setHealth(provider: config.name, to: (.error, "no common contract version", nil))
+      return
+    }
+    describes[config.name] = describe
+  }
 
-    /// Runs `describe` for one provider and records the outcome in
-    /// `describes`/`health`. Auth failures (exit 4) and other classified
-    /// failures route through the same `recordFailure` path `pollOnce` and
-    /// `invoke` use, so a provider that rejects credentials on its very
-    /// first contact still surfaces `needs_auth` with remediation instead of
-    /// a generic error. Only spawn/parse problems — which no failure class
-    /// can describe — fall back to a generic message, distinguished by text
-    /// from "it ran and rejected us".
-    private func describeProvider(_ config: RemoteProviderConfig) async {
-        let result: ProviderResult
-        do {
-            result = try await runner.run(config, verb: ["describe"], stdin: nil, timeout: 10)
-        } catch {
-            remoteLogger.error("describe \(config.name, privacy: .public) couldn't run: \(String(describing: error), privacy: .public)")
-            setHealth(provider: config.name, to: (.error, "couldn't run describe: \(error)", nil))
-            return
-        }
-        if let failure = result.failureClass {
-            recordFailure(provider: config.name, class: failure, result: result)
-            return
-        }
-        guard let describe = try? result.decoded(ProviderDescribe.self) else {
-            setHealth(provider: config.name, to: (.error, "describe returned an unparseable response", nil))
-            return
-        }
-        guard describe.contractVersions.contains(1) else {
-            setHealth(provider: config.name, to: (.error, "no common contract version", nil))
-            return
-        }
-        describes[config.name] = describe
+  /// Spawns/re-spawns the 60s poll loop for every provider with a valid
+  /// `describe` on file. Cancels any existing loops (and stops any running
+  /// events supervisors) first so a second call can't orphan one that
+  /// `stopAll()` would no longer be able to reach (the stored handle would
+  /// just get overwritten).
+  /// The whole stopAll()+startLoop() sequence runs under `reconfiguring` so
+  /// two concurrent calls (e.g. overlapping `start()`s) can never
+  /// interleave. Without it: `startLoop` inserts a supervisor into
+  /// `supervisors` and then suspends at `await supervisor.start()` — a
+  /// different actor, so this actor's executor is released for that
+  /// window. A second call's `stopAll()` could run entirely in that
+  /// window: its `await supervisor.stop()` on the just-inserted supervisor
+  /// returns instantly (nothing has started yet) and `removeAll()` drops
+  /// it, then the first call resumes and arms `start()` on a supervisor
+  /// nothing holds — the provider's child process respawns on backoff for
+  /// the daemon's life with no handle able to stop it. The symmetric case
+  /// (a supervisor inserted during one of `stopAll()`'s own awaits, then
+  /// dropped by that call's `removeAll()`) is closed the same way, since
+  /// the two call sequences now can't overlap at all.
+  private func spawnPollLoops() async {
+    await acquireReconfigureLock()
+    defer { releaseReconfigureLock() }
+    // A call already parked in the FIFO waiter queue when `shutdown()`
+    // ran receives the baton right after `shutdown()` releases it — FIFO
+    // ordering alone doesn't stop that hand-off, only this flag does.
+    // Without it, this would respawn poll loops (and events supervisors)
+    // on a manager the daemon believes it already tore down.
+    guard !shuttingDown else { return }
+    await stopAll()
+    for name in describes.keys {
+      guard let config = providers[name] else { continue }
+      await startLoop(for: config)
     }
+  }
 
-    /// Spawns/re-spawns the 60s poll loop for every provider with a valid
-    /// `describe` on file. Cancels any existing loops (and stops any running
-    /// events supervisors) first so a second call can't orphan one that
-    /// `stopAll()` would no longer be able to reach (the stored handle would
-    /// just get overwritten).
-    /// The whole stopAll()+startLoop() sequence runs under `reconfiguring` so
-    /// two concurrent calls (e.g. overlapping `start()`s) can never
-    /// interleave. Without it: `startLoop` inserts a supervisor into
-    /// `supervisors` and then suspends at `await supervisor.start()` — a
-    /// different actor, so this actor's executor is released for that
-    /// window. A second call's `stopAll()` could run entirely in that
-    /// window: its `await supervisor.stop()` on the just-inserted supervisor
-    /// returns instantly (nothing has started yet) and `removeAll()` drops
-    /// it, then the first call resumes and arms `start()` on a supervisor
-    /// nothing holds — the provider's child process respawns on backoff for
-    /// the daemon's life with no handle able to stop it. The symmetric case
-    /// (a supervisor inserted during one of `stopAll()`'s own awaits, then
-    /// dropped by that call's `removeAll()`) is closed the same way, since
-    /// the two call sequences now can't overlap at all.
-    private func spawnPollLoops() async {
-        await acquireReconfigureLock()
-        defer { releaseReconfigureLock() }
-        // A call already parked in the FIFO waiter queue when `shutdown()`
-        // ran receives the baton right after `shutdown()` releases it — FIFO
-        // ordering alone doesn't stop that hand-off, only this flag does.
-        // Without it, this would respawn poll loops (and events supervisors)
-        // on a manager the daemon believes it already tore down.
-        guard !shuttingDown else { return }
-        await stopAll()
-        for name in describes.keys {
-            guard let config = providers[name] else { continue }
-            await startLoop(for: config)
-        }
+  private func acquireReconfigureLock() async {
+    if reconfiguring {
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        reconfigureWaiters.append(continuation)
+      }
+    } else {
+      reconfiguring = true
     }
+  }
 
-    private func acquireReconfigureLock() async {
-        if reconfiguring {
-            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                reconfigureWaiters.append(continuation)
-            }
-        } else {
-            reconfiguring = true
-        }
+  private func releaseReconfigureLock() {
+    if reconfigureWaiters.isEmpty {
+      reconfiguring = false
+    } else {
+      reconfigureWaiters.removeFirst().resume()
     }
+  }
 
-    private func releaseReconfigureLock() {
-        if reconfigureWaiters.isEmpty {
-            reconfiguring = false
-        } else {
-            reconfigureWaiters.removeFirst().resume()
-        }
-    }
+  func stopAll() async {
+    for task in loops.values { task.cancel() }
+    loops.removeAll()
+    for supervisor in supervisors.values { await supervisor.stop() }
+    supervisors.removeAll()
+  }
 
-    func stopAll() async {
-        for task in loops.values { task.cancel() }
-        loops.removeAll()
-        for supervisor in supervisors.values { await supervisor.stop() }
-        supervisors.removeAll()
-    }
+  /// Guarded daemon-shutdown entry point. `stopAll()` itself is not safe
+  /// to call directly from outside `spawnPollLoops` — it's the FIFO
+  /// reconfigure lock (see `spawnPollLoops`'s comment) that makes teardown
+  /// and a concurrent spawn mutually exclusive, and `stopAll()` on its own
+  /// doesn't take it.
+  ///
+  /// Taking the lock alone is NOT sufficient, and this does not merely
+  /// guard against "a `start()` still in flight at shutdown": FIFO means a
+  /// `spawnPollLoops()` call already parked in the waiter queue when this
+  /// runs receives the baton right after `shutdown()` releases the lock —
+  /// it would then respawn poll loops/supervisors on a manager the daemon
+  /// believes is torn down. `shuttingDown` (set here, before `stopAll()`,
+  /// and never cleared) makes shutdown terminal: every `spawnPollLoops()`
+  /// call that resumes after this one — queued or future — is a no-op.
+  func shutdown() async {
+    await acquireReconfigureLock()
+    defer { releaseReconfigureLock() }
+    shuttingDown = true
+    await stopAll()
+  }
 
-    /// Guarded daemon-shutdown entry point. `stopAll()` itself is not safe
-    /// to call directly from outside `spawnPollLoops` — it's the FIFO
-    /// reconfigure lock (see `spawnPollLoops`'s comment) that makes teardown
-    /// and a concurrent spawn mutually exclusive, and `stopAll()` on its own
-    /// doesn't take it.
-    ///
-    /// Taking the lock alone is NOT sufficient, and this does not merely
-    /// guard against "a `start()` still in flight at shutdown": FIFO means a
-    /// `spawnPollLoops()` call already parked in the waiter queue when this
-    /// runs receives the baton right after `shutdown()` releases the lock —
-    /// it would then respawn poll loops/supervisors on a manager the daemon
-    /// believes is torn down. `shuttingDown` (set here, before `stopAll()`,
-    /// and never cleared) makes shutdown terminal: every `spawnPollLoops()`
-    /// call that resumes after this one — queued or future — is a no-op.
-    func shutdown() async {
-        await acquireReconfigureLock()
-        defer { releaseReconfigureLock() }
-        shuttingDown = true
-        await stopAll()
+  /// The 60s `list` poll is the universal floor for every provider,
+  /// events-capable or not — it keeps running even when a stream is up,
+  /// since snapshot application is idempotent and this is what covers a
+  /// stream that's down or restarting. Providers that declared the
+  /// `events` capability in their cached `describe` additionally get a
+  /// supervised low-latency NDJSON stream.
+  private func startLoop(for config: RemoteProviderConfig) async {
+    if describes[config.name]?.capabilities.contains("events") == true {
+      let supervisor = ProviderEventsSupervisor(config: config, manager: self, clock: clock)
+      supervisors[config.name] = supervisor
+      // Awaiting `supervisor.start()` (a different actor) suspends this
+      // actor's executor, which by itself does NOT close the race
+      // described on `spawnPollLoops` — only that method's
+      // `reconfiguring` guard does, by making it impossible for a
+      // concurrent stopAll()/spawnPollLoops() call to run while this
+      // one is still in flight.
+      await supervisor.start()
     }
+    loops[config.name] = Task { [weak self, clock] in
+      while !Task.isCancelled {
+        await self?.pollOnce(provider: config)
+        try? await clock.sleep(for: .seconds(Self.pollInterval))
+      }
+    }
+  }
 
-    /// The 60s `list` poll is the universal floor for every provider,
-    /// events-capable or not — it keeps running even when a stream is up,
-    /// since snapshot application is idempotent and this is what covers a
-    /// stream that's down or restarting. Providers that declared the
-    /// `events` capability in their cached `describe` additionally get a
-    /// supervised low-latency NDJSON stream.
-    private func startLoop(for config: RemoteProviderConfig) async {
-        if describes[config.name]?.capabilities.contains("events") == true {
-            let supervisor = ProviderEventsSupervisor(config: config, manager: self, clock: clock)
-            supervisors[config.name] = supervisor
-            // Awaiting `supervisor.start()` (a different actor) suspends this
-            // actor's executor, which by itself does NOT close the race
-            // described on `spawnPollLoops` — only that method's
-            // `reconfiguring` guard does, by making it impossible for a
-            // concurrent stopAll()/spawnPollLoops() call to run while this
-            // one is still in flight.
-            await supervisor.start()
-        }
-        loops[config.name] = Task { [weak self, clock] in
-            while !Task.isCancelled {
-                await self?.pollOnce(provider: config)
-                try? await clock.sleep(for: .seconds(Self.pollInterval))
-            }
-        }
+  func pollOnce(provider: RemoteProviderConfig) async {
+    // pollOnce must work standalone, without start() having registered
+    // the provider first (mirror tests + Task 7's ad-hoc RPC lookups
+    // both call it directly) — register on first use so providerStatuses()
+    // reflects it.
+    registerIfNeeded(provider)
+    do {
+      let result = try await runner.run(provider, verb: ["list"], stdin: nil, timeout: 30)
+      if let failure = result.failureClass {
+        await recordPollFailure(provider: provider.name, class: failure, result: result)
+        return
+      }
+      let envelope = try result.decoded(RemoteSessionListEnvelope.self)
+      let snapshotAt = Date()
+      try await apply(snapshot: envelope.sessions, provider: provider.name, now: snapshotAt)
+    } catch {
+      remoteLogger.debug(
+        "poll \(provider.name, privacy: .public) failed: \(String(describing: error), privacy: .public)"
+      )
+      await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider.name)
+      setHealth(provider: provider.name, to: (.stale, String(describing: error), nil))
     }
+  }
 
-    func pollOnce(provider: RemoteProviderConfig) async {
-        // pollOnce must work standalone, without start() having registered
-        // the provider first (mirror tests + Task 7's ad-hoc RPC lookups
-        // both call it directly) — register on first use so providerStatuses()
-        // reflects it.
-        registerIfNeeded(provider)
-        do {
-            let result = try await runner.run(provider, verb: ["list"], stdin: nil, timeout: 30)
-            if let failure = result.failureClass {
-                await recordPollFailure(provider: provider.name, class: failure, result: result)
-                return
-            }
-            let envelope = try result.decoded(RemoteSessionListEnvelope.self)
-            let snapshotAt = Date()
-            try await apply(snapshot: envelope.sessions, provider: provider.name, now: snapshotAt)
-        } catch {
-            remoteLogger.debug("poll \(provider.name, privacy: .public) failed: \(String(describing: error), privacy: .public)")
-            await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider.name)
-            setHealth(provider: provider.name, to: (.stale, String(describing: error), nil))
-        }
+  /// Shared by the poll path and the events snapshot path (Task 6).
+  func apply(snapshot sessions: [RemoteSessionPayload], provider: String, now: Date = Date())
+    async throws
+  {
+    let outcome = try await db.remoteSessions.applySnapshot(
+      provider: provider, sessions: sessions, now: now)
+    lastSuccessfulSnapshotAt[provider] = now
+    markHealthy(provider: provider)
+    if outcome.changed {
+      subscriptions.broadcast(delta: .remoteSessionsChanged)
     }
+    for session in outcome.attention {
+      subscriptions.broadcast(
+        delta: .remoteSessionAttention(
+          RemoteSessionAttentionDelta(
+            provider: provider, sessionID: session.id, title: session.title,
+            kind: session.agentState.rawValue, reason: session.agentStateReason,
+            exitCode: session.exitCode)))
+    }
+  }
 
-    /// Shared by the poll path and the events snapshot path (Task 6).
-    func apply(snapshot sessions: [RemoteSessionPayload], provider: String, now: Date = Date()) async throws {
-        let outcome = try await db.remoteSessions.applySnapshot(
-            provider: provider, sessions: sessions, now: now)
-        lastSuccessfulSnapshotAt[provider] = now
-        markHealthy(provider: provider)
-        if outcome.changed {
-            subscriptions.broadcast(delta: .remoteSessionsChanged)
-        }
-        for session in outcome.attention {
-            subscriptions.broadcast(delta: .remoteSessionAttention(RemoteSessionAttentionDelta(
-                provider: provider, sessionID: session.id, title: session.title,
-                kind: session.agentState.rawValue, reason: session.agentStateReason,
-                exitCode: session.exitCode)))
-        }
+  /// Single-session upsert from an events `session` line. No absence
+  /// bookkeeping happens here — only `apply(snapshot:)` drives the
+  /// two-absence rule, since only a full snapshot can tell what's missing.
+  func applyUpsert(_ session: RemoteSessionPayload, provider: String) async {
+    let outcome: SnapshotOutcome
+    do {
+      outcome = try await db.remoteSessions.upsertOne(
+        provider: provider, session: session, now: Date())
+    } catch {
+      remoteLogger.error(
+        "events upsert failed for \(provider, privacy: .public)/\(session.id, privacy: .public): \(String(describing: error), privacy: .public)"
+      )
+      return
     }
+    if outcome.changed {
+      subscriptions.broadcast(delta: .remoteSessionsChanged)
+    }
+    for session in outcome.attention {
+      subscriptions.broadcast(
+        delta: .remoteSessionAttention(
+          RemoteSessionAttentionDelta(
+            provider: provider, sessionID: session.id, title: session.title,
+            kind: session.agentState.rawValue, reason: session.agentStateReason,
+            exitCode: session.exitCode)))
+    }
+  }
 
-    /// Single-session upsert from an events `session` line. No absence
-    /// bookkeeping happens here — only `apply(snapshot:)` drives the
-    /// two-absence rule, since only a full snapshot can tell what's missing.
-    func applyUpsert(_ session: RemoteSessionPayload, provider: String) async {
-        let outcome: SnapshotOutcome
-        do {
-            outcome = try await db.remoteSessions.upsertOne(
-                provider: provider, session: session, now: Date())
-        } catch {
-            remoteLogger.error(
-                "events upsert failed for \(provider, privacy: .public)/\(session.id, privacy: .public): \(String(describing: error), privacy: .public)")
-            return
-        }
-        if outcome.changed {
-            subscriptions.broadcast(delta: .remoteSessionsChanged)
-        }
-        for session in outcome.attention {
-            subscriptions.broadcast(delta: .remoteSessionAttention(RemoteSessionAttentionDelta(
-                provider: provider, sessionID: session.id, title: session.title,
-                kind: session.agentState.rawValue, reason: session.agentStateReason,
-                exitCode: session.exitCode)))
-        }
+  /// Explicit removal from an events `removed` line. The provider is
+  /// authoritative about this — skip the two-absence rule entirely and
+  /// mark the row gone immediately.
+  func applyRemoval(sessionID: String, provider: String) async {
+    let changed: Bool
+    do {
+      changed = try await db.remoteSessions.markGone(
+        provider: provider, sessionID: sessionID)
+    } catch {
+      remoteLogger.error(
+        "events removal failed for \(provider, privacy: .public)/\(sessionID, privacy: .public): \(String(describing: error), privacy: .public)"
+      )
+      return
     }
+    if changed {
+      subscriptions.broadcast(delta: .remoteSessionsChanged)
+    }
+  }
 
-    /// Explicit removal from an events `removed` line. The provider is
-    /// authoritative about this — skip the two-absence rule entirely and
-    /// mark the row gone immediately.
-    func applyRemoval(sessionID: String, provider: String) async {
-        let changed: Bool
-        do {
-            changed = try await db.remoteSessions.markGone(
-                provider: provider, sessionID: sessionID)
-        } catch {
-            remoteLogger.error(
-                "events removal failed for \(provider, privacy: .public)/\(sessionID, privacy: .public): \(String(describing: error), privacy: .public)")
-            return
-        }
-        if changed {
-            subscriptions.broadcast(delta: .remoteSessionsChanged)
-        }
-    }
+  /// Test seam: whether a supervisor currently exists for `name` — used
+  /// only to make the events-vs-poll capability gate in `startLoop`
+  /// observable from tests without exposing `supervisors` itself.
+  func hasSupervisor(named name: String) -> Bool {
+    supervisors[name] != nil
+  }
 
-    /// Test seam: whether a supervisor currently exists for `name` — used
-    /// only to make the events-vs-poll capability gate in `startLoop`
-    /// observable from tests without exposing `supervisors` itself.
-    func hasSupervisor(named name: String) -> Bool {
-        supervisors[name] != nil
+  func invoke(
+    providerName: String, verb: [String], stdin: Data?,
+    timeout: TimeInterval
+  ) async throws -> ProviderResult {
+    guard let config = providers[providerName] ?? loadAdHoc(named: providerName) else {
+      throw RemoteProviderError.unknownProvider(providerName)
     }
+    let result = try await runner.run(config, verb: verb, stdin: stdin, timeout: timeout)
+    if let failure = result.failureClass {
+      recordFailure(provider: providerName, class: failure, result: result)
+    }
+    return result
+  }
 
-    func invoke(providerName: String, verb: [String], stdin: Data?,
-                timeout: TimeInterval) async throws -> ProviderResult {
-        guard let config = providers[providerName] ?? loadAdHoc(named: providerName) else {
-            throw RemoteProviderError.unknownProvider(providerName)
-        }
-        let result = try await runner.run(config, verb: verb, stdin: stdin, timeout: timeout)
-        if let failure = result.failureClass {
-            recordFailure(provider: providerName, class: failure, result: result)
-        }
-        return result
-    }
+  /// Tests (and a pre-`start()` RPC call) can address providers straight
+  /// from the registry file.
+  private func loadAdHoc(named name: String) -> RemoteProviderConfig? {
+    guard let configs = try? RemoteProviderRegistry.load(from: registryURL),
+      let config = configs.first(where: { $0.name == name })
+    else { return nil }
+    registerIfNeeded(config)
+    return config
+  }
 
-    /// Tests (and a pre-`start()` RPC call) can address providers straight
-    /// from the registry file.
-    private func loadAdHoc(named name: String) -> RemoteProviderConfig? {
-        guard let configs = try? RemoteProviderRegistry.load(from: registryURL),
-              let config = configs.first(where: { $0.name == name }) else { return nil }
-        registerIfNeeded(config)
-        return config
-    }
+  /// Registers a provider config (if not already known) and seeds a
+  /// default `ok` health entry (if not already present). Shared by every
+  /// entry point that can be a provider's first contact with this actor
+  /// (`loadRegistryAndDescribe`, `pollOnce`, `loadAdHoc`).
+  private func registerIfNeeded(_ config: RemoteProviderConfig) {
+    if providers[config.name] == nil { providers[config.name] = config }
+    if health[config.name] == nil { health[config.name] = (.ok, nil, nil) }
+  }
 
-    /// Registers a provider config (if not already known) and seeds a
-    /// default `ok` health entry (if not already present). Shared by every
-    /// entry point that can be a provider's first contact with this actor
-    /// (`loadRegistryAndDescribe`, `pollOnce`, `loadAdHoc`).
-    private func registerIfNeeded(_ config: RemoteProviderConfig) {
-        if providers[config.name] == nil { providers[config.name] = config }
-        if health[config.name] == nil { health[config.name] = (.ok, nil, nil) }
+  func providerStatuses() -> [RemoteProviderStatus] {
+    providers.values.sorted { $0.name < $1.name }.map { config in
+      let h = health[config.name] ?? (.ok, nil, nil)
+      return RemoteProviderStatus(
+        config: config, describe: describes[config.name],
+        health: h.state,
+        errorMessage: Self.boundedDisplayMessage(
+          h.message,
+          hasSuccessfulSnapshot: lastSuccessfulSnapshotAt[config.name] != nil
+        ),
+        remediationLabel: h.remediation?.label,
+        remediationCommand: h.remediation?.command,
+        lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[config.name])
     }
+  }
 
-    func providerStatuses() -> [RemoteProviderStatus] {
-        providers.values.sorted { $0.name < $1.name }.map { config in
-            let h = health[config.name] ?? (.ok, nil, nil)
-            return RemoteProviderStatus(
-                config: config, describe: describes[config.name],
-                health: h.state, errorMessage: Self.boundedDisplayMessage(h.message),
-                remediationLabel: h.remediation?.label,
-                remediationCommand: h.remediation?.command,
-                lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt[config.name])
-        }
-    }
+  /// Whether mutations that depend on the cached inventory should be
+  /// suppressed. Read-only inspection (`attach`, `log`) remains useful
+  /// during an inventory outage; create/stop/send/rename do not have a
+  /// trustworthy current-state basis once a previously-good snapshot is
+  /// stale.
+  func hasStaleSnapshot(provider name: String) -> Bool {
+    guard lastSuccessfulSnapshotAt[name] != nil else { return false }
+    return health[name]?.state != .ok
+  }
 
-    /// Whether mutations that depend on the cached inventory should be
-    /// suppressed. Read-only inspection (`attach`, `log`) remains useful
-    /// during an inventory outage; create/stop/send/rename do not have a
-    /// trustworthy current-state basis once a previously-good snapshot is
-    /// stale.
-    func hasStaleSnapshot(provider name: String) -> Bool {
-        guard lastSuccessfulSnapshotAt[name] != nil else { return false }
-        return health[name]?.state != .ok
+  /// Correlates a locally-spawned `attach` exit (the app execs the provider
+  /// on a terminal's own TTY, so its exit code never passes through this
+  /// actor's runner) with provider health.
+  ///
+  /// `attach`'s stdout is a PTY byte stream and MUST NOT be parsed
+  /// (`docs/remote-provider-contract.md` § `attach`), so the exit code is
+  /// the only signal — hence `error: nil` in the classification below.
+  ///
+  /// - Non-auth classes are deliberately ignored: an attach that died for
+  ///   transport reasons is already covered app-side by pending-reconnect
+  ///   backoff, and letting every dropped connection rewrite provider
+  ///   health would make one flaky viewer speak for the whole provider.
+  /// - The auth class marks the provider `.needsAuth` while PRESERVING any
+  ///   message/remediation already on file: an attach exit carries none of
+  ///   its own, and clobbering a parsed remediation with `nil` would
+  ///   downgrade a good CTA to a bare "authentication needed". Preservation
+  ///   is limited to an already-`.needsAuth` provider, for the reason
+  ///   spelled out in `recordFailure`'s auth branch — text written under
+  ///   `.stale`/`.error` explains a different condition and must not be
+  ///   relabelled as an authentication explanation. Carrying it here would
+  ///   also survive the probe below, which inherits from the state this
+  ///   line writes.
+  /// - It then triggers exactly ONE out-of-band `list` so the state is
+  ///   either confirmed with a freshly parsed remediation or cleared
+  ///   outright by a success. That probe is bounded by the
+  ///   already-`.needsAuth` check: at most one extra `list` per health
+  ///   transition, so a session flapping through repeated auth exits can
+  ///   never turn into a poll flood.
+  func recordAttachExit(provider name: String, exitCode: Int32) async throws {
+    guard let config = providers[name] ?? loadAdHoc(named: name) else {
+      throw RemoteProviderError.unknownProvider(name)
     }
+    guard ProviderFailureClass.classify(exitCode: exitCode, error: nil) == .authNeeded else {
+      return
+    }
+    let previous = health[name]
+    let inheritable = previous?.state == .needsAuth ? previous : nil
+    setHealth(provider: name, to: (.needsAuth, inheritable?.message, inheritable?.remediation))
+    guard previous?.state != .needsAuth else { return }
+    await pollOnce(provider: config)
+  }
 
-    /// Correlates a locally-spawned `attach` exit (the app execs the provider
-    /// on a terminal's own TTY, so its exit code never passes through this
-    /// actor's runner) with provider health.
-    ///
-    /// `attach`'s stdout is a PTY byte stream and MUST NOT be parsed
-    /// (`docs/remote-provider-contract.md` § `attach`), so the exit code is
-    /// the only signal — hence `error: nil` in the classification below.
-    ///
-    /// - Non-auth classes are deliberately ignored: an attach that died for
-    ///   transport reasons is already covered app-side by pending-reconnect
-    ///   backoff, and letting every dropped connection rewrite provider
-    ///   health would make one flaky viewer speak for the whole provider.
-    /// - The auth class marks the provider `.needsAuth` while PRESERVING any
-    ///   message/remediation already on file: an attach exit carries none of
-    ///   its own, and clobbering a parsed remediation with `nil` would
-    ///   downgrade a good CTA to a bare "authentication needed". Preservation
-    ///   is limited to an already-`.needsAuth` provider, for the reason
-    ///   spelled out in `recordFailure`'s auth branch — text written under
-    ///   `.stale`/`.error` explains a different condition and must not be
-    ///   relabelled as an authentication explanation. Carrying it here would
-    ///   also survive the probe below, which inherits from the state this
-    ///   line writes.
-    /// - It then triggers exactly ONE out-of-band `list` so the state is
-    ///   either confirmed with a freshly parsed remediation or cleared
-    ///   outright by a success. That probe is bounded by the
-    ///   already-`.needsAuth` check: at most one extra `list` per health
-    ///   transition, so a session flapping through repeated auth exits can
-    ///   never turn into a poll flood.
-    func recordAttachExit(provider name: String, exitCode: Int32) async throws {
-        guard let config = providers[name] ?? loadAdHoc(named: name) else {
-            throw RemoteProviderError.unknownProvider(name)
-        }
-        guard ProviderFailureClass.classify(exitCode: exitCode, error: nil) == .authNeeded else { return }
-        let previous = health[name]
-        let inheritable = previous?.state == .needsAuth ? previous : nil
-        setHealth(provider: name, to: (.needsAuth, inheritable?.message, inheritable?.remediation))
-        guard previous?.state != .needsAuth else { return }
-        await pollOnce(provider: config)
+  private func recordFailure(
+    provider: String, class failureClass: ProviderFailureClass,
+    result: ProviderResult
+  ) {
+    let error = result.decodedError
+    switch failureClass {
+    case .authNeeded:
+      // Preserve what's already on file when the new error supplies
+      // nothing — but ONLY while staying within `.needsAuth`.
+      //
+      // Why inherit at all: `recordAttachExit` deliberately keeps the
+      // existing message/remediation (an attach exit carries none of
+      // its own) and then fires a `list` probe through here — a probe
+      // that itself exits 4 with unparseable stdout would otherwise
+      // clobber that preserved remediation back to `nil`, downgrading
+      // a good CTA to a bare "authentication needed". A freshly parsed
+      // value still wins, so recovery-with-new-detail is unaffected.
+      //
+      // Why the asymmetry: text on file under `.ok`/`.stale`/`.error`
+      // describes a DIFFERENT condition. Inheriting it across a
+      // transition INTO `.needsAuth` would render, say, a transport
+      // timeout as the provider's authentication explanation — wrong
+      // words in the one string this CTA exists to deliver. On such a
+      // transition the fields go `nil` and the app renders its neutral
+      // fallback CTA instead. This still covers the path the
+      // inheritance was added for: `recordAttachExit` sets `.needsAuth`
+      // BEFORE firing its probe, so the probe's `recordFailure` sees a
+      // previous state of `.needsAuth`.
+      //
+      // Only this class inherits at all: `.stale`/`.error` messages
+      // describe THIS invocation and go stale the moment it changes.
+      let previous = health[provider]
+      let inheritable = previous?.state == .needsAuth ? previous : nil
+      setHealth(
+        provider: provider,
+        to: (
+          .needsAuth,
+          error?.message ?? inheritable?.message,
+          error?.remediation ?? inheritable?.remediation
+        ))
+    case .transient:
+      setHealth(provider: provider, to: (.stale, error?.message ?? result.stderr, nil))
+    case .permanent, .contractBug:
+      setHealth(provider: provider, to: (.error, error?.message ?? result.stderr, nil))
     }
+  }
 
-    private func recordFailure(provider: String, class failureClass: ProviderFailureClass,
-                               result: ProviderResult) {
-        let error = result.decodedError
-        switch failureClass {
-        case .authNeeded:
-            // Preserve what's already on file when the new error supplies
-            // nothing — but ONLY while staying within `.needsAuth`.
-            //
-            // Why inherit at all: `recordAttachExit` deliberately keeps the
-            // existing message/remediation (an attach exit carries none of
-            // its own) and then fires a `list` probe through here — a probe
-            // that itself exits 4 with unparseable stdout would otherwise
-            // clobber that preserved remediation back to `nil`, downgrading
-            // a good CTA to a bare "authentication needed". A freshly parsed
-            // value still wins, so recovery-with-new-detail is unaffected.
-            //
-            // Why the asymmetry: text on file under `.ok`/`.stale`/`.error`
-            // describes a DIFFERENT condition. Inheriting it across a
-            // transition INTO `.needsAuth` would render, say, a transport
-            // timeout as the provider's authentication explanation — wrong
-            // words in the one string this CTA exists to deliver. On such a
-            // transition the fields go `nil` and the app renders its neutral
-            // fallback CTA instead. This still covers the path the
-            // inheritance was added for: `recordAttachExit` sets `.needsAuth`
-            // BEFORE firing its probe, so the probe's `recordFailure` sees a
-            // previous state of `.needsAuth`.
-            //
-            // Only this class inherits at all: `.stale`/`.error` messages
-            // describe THIS invocation and go stale the moment it changes.
-            let previous = health[provider]
-            let inheritable = previous?.state == .needsAuth ? previous : nil
-            setHealth(provider: provider, to: (
-                .needsAuth,
-                error?.message ?? inheritable?.message,
-                error?.remediation ?? inheritable?.remediation
-            ))
-        case .transient:
-            setHealth(provider: provider, to: (.stale, error?.message ?? result.stderr, nil))
-        case .permanent, .contractBug:
-            setHealth(provider: provider, to: (.error, error?.message ?? result.stderr, nil))
-        }
-    }
+  /// Poll failures need one extra piece of bookkeeping beyond generic
+  /// provider failures: if this manager restarted after the last success,
+  /// recover that timestamp from the mirror's last-seen rows before
+  /// publishing stale health. This keeps a persisted cached snapshot from
+  /// becoming confidently timeless after a daemon restart.
+  private func recordPollFailure(
+    provider: String, class failureClass: ProviderFailureClass,
+    result: ProviderResult
+  ) async {
+    await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider)
+    recordFailure(provider: provider, class: failureClass, result: result)
+  }
 
-    /// Poll failures need one extra piece of bookkeeping beyond generic
-    /// provider failures: if this manager restarted after the last success,
-    /// recover that timestamp from the mirror's last-seen rows before
-    /// publishing stale health. This keeps a persisted cached snapshot from
-    /// becoming confidently timeless after a daemon restart.
-    private func recordPollFailure(provider: String, class failureClass: ProviderFailureClass,
-                                   result: ProviderResult) async {
-        await recoverLastSuccessfulSnapshotAtIfNeeded(provider: provider)
-        recordFailure(provider: provider, class: failureClass, result: result)
+  private func recoverLastSuccessfulSnapshotAtIfNeeded(provider: String) async {
+    guard lastSuccessfulSnapshotAt[provider] == nil else { return }
+    if let recovered = try? await db.remoteSessions.latestLastSeen(provider: provider) {
+      lastSuccessfulSnapshotAt[provider] = recovered
     }
+  }
 
-    private func recoverLastSuccessfulSnapshotAtIfNeeded(provider: String) async {
-        guard lastSuccessfulSnapshotAt[provider] == nil else { return }
-        if let recovered = try? await db.remoteSessions.latestLastSeen(provider: provider) {
-            lastSuccessfulSnapshotAt[provider] = recovered
-        }
+  /// The provider may return the entire truncated inventory inside its
+  /// error message. Keep the manager's internal health record unchanged for
+  /// diagnostics, but never put an unbounded wall of JSON on the RPC/UI
+  /// wire. The known
+  /// truncation shape receives safe copy rather than leaking a prompt from
+  /// the beginning of the embedded payload.
+  static func boundedDisplayMessage(
+    _ message: String?,
+    hasSuccessfulSnapshot: Bool = true,
+    limit: Int = 240
+  ) -> String? {
+    guard let message else { return nil }
+    if message.localizedCaseInsensitiveContains("--output truncated--")
+      || message.localizedCaseInsensitiveContains("unparseable remote output")
+    {
+      if hasSuccessfulSnapshot {
+        return
+          "Provider inventory was truncated or malformed; showing the last successful snapshot."
+      }
+      return
+        "Provider inventory was truncated or malformed; no successful snapshot is available yet."
     }
+    guard message.count > limit else { return message }
+    let kept = max(0, limit - 1)
+    return String(message.prefix(kept)) + "…"
+  }
 
-    /// The provider may return the entire truncated inventory inside its
-    /// error message. Keep the manager's internal health record unchanged for
-    /// diagnostics, but never put an unbounded wall of JSON on the RPC/UI
-    /// wire. The known
-    /// truncation shape receives safe copy rather than leaking a prompt from
-    /// the beginning of the embedded payload.
-    static func boundedDisplayMessage(_ message: String?, limit: Int = 240) -> String? {
-        guard let message else { return nil }
-        if message.localizedCaseInsensitiveContains("--output truncated--")
-            || message.localizedCaseInsensitiveContains("unparseable remote output") {
-            return "Provider inventory was truncated or malformed; showing the last successful snapshot."
-        }
-        guard message.count > limit else { return message }
-        let kept = max(0, limit - 1)
-        return String(message.prefix(kept)) + "…"
-    }
+  private func markHealthy(provider: String) {
+    setHealth(provider: provider, to: (.ok, nil, nil))
+  }
 
-    private func markHealthy(provider: String) {
-        setHealth(provider: provider, to: (.ok, nil, nil))
+  /// Records a provider's health and broadcasts when ANY of the three
+  /// fields the app renders changed — state, message, or remediation.
+  ///
+  /// State alone is not enough: the auth path routinely transitions
+  /// `.needsAuth` → `.needsAuth` while ADDING detail (`recordAttachExit`
+  /// flips health off a bare exit code with no message, then its probe
+  /// lands the parsed message + remediation). Broadcasting on state alone
+  /// dropped that payload on the floor and left the app rendering a
+  /// command-less fallback CTA for the whole outage, since every later
+  /// poll is also `.needsAuth` → `.needsAuth`.
+  ///
+  /// Equally deliberately, it does NOT broadcast unconditionally: a
+  /// healthy provider re-setting `(.ok, nil, nil)` every 60s poll would
+  /// otherwise put a delta on the wire per provider per minute forever.
+  private func setHealth(
+    provider: String,
+    to new: (ProviderHealth, String?, ProviderRemediation?)
+  ) {
+    let old = health[provider]
+    health[provider] = new
+    if old?.state != new.0 || old?.message != new.1 || old?.remediation != new.2 {
+      subscriptions.broadcast(delta: .remoteSessionsChanged)
     }
-
-    /// Records a provider's health and broadcasts when ANY of the three
-    /// fields the app renders changed — state, message, or remediation.
-    ///
-    /// State alone is not enough: the auth path routinely transitions
-    /// `.needsAuth` → `.needsAuth` while ADDING detail (`recordAttachExit`
-    /// flips health off a bare exit code with no message, then its probe
-    /// lands the parsed message + remediation). Broadcasting on state alone
-    /// dropped that payload on the floor and left the app rendering a
-    /// command-less fallback CTA for the whole outage, since every later
-    /// poll is also `.needsAuth` → `.needsAuth`.
-    ///
-    /// Equally deliberately, it does NOT broadcast unconditionally: a
-    /// healthy provider re-setting `(.ok, nil, nil)` every 60s poll would
-    /// otherwise put a delta on the wire per provider per minute forever.
-    private func setHealth(provider: String,
-                           to new: (ProviderHealth, String?, ProviderRemediation?)) {
-        let old = health[provider]
-        health[provider] = new
-        if old?.state != new.0 || old?.message != new.1 || old?.remediation != new.2 {
-            subscriptions.broadcast(delta: .remoteSessionsChanged)
-        }
-    }
+  }
 }
 
 enum RemoteProviderError: Error {
-    case unknownProvider(String)
+  case unknownProvider(String)
 }

--- a/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
+++ b/Sources/TBDDaemon/Remote/RemoteProviderManager.swift
@@ -488,9 +488,9 @@ public actor RemoteProviderManager {
 
   private func recoverLastSuccessfulSnapshotAtIfNeeded(provider: String) async {
     guard lastSuccessfulSnapshotAt[provider] == nil else { return }
-    if let recovered = try? await db.remoteSessions.latestLastSeen(provider: provider) {
-      lastSuccessfulSnapshotAt[provider] = recovered
-    }
+        if let recovered = try? await db.remoteSessions.lastSuccessfulSnapshotAt(provider: provider) {
+            lastSuccessfulSnapshotAt[provider] = recovered
+        }
   }
 
   /// The provider may return the entire truncated inventory inside its

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -18,6 +18,10 @@ extension RPCRouter {
     /// one call site is edited and the others aren't.
     private static let remoteBackendsDisabledResponse = RPCResponse(error: "remote backends disabled")
 
+    private static func staleSnapshotMutationResponse(provider: String) -> RPCResponse {
+        RPCResponse(error: "provider '\(provider)' inventory is stale; refresh must recover before changing remote sessions")
+    }
+
     private func remoteGate() async throws -> RemoteProviderManager? {
         guard try await db.config.get().remoteBackendsEnabled else { return nil }
         return remoteManager
@@ -58,12 +62,19 @@ extension RPCRouter {
     }
 
     func handleRemoteSessions() async throws -> RPCResponse {
-        guard try await remoteGate() != nil else {
+        guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
         }
+        let staleProviders = Set(
+            await manager.providerStatuses()
+                .filter(\.hasStaleSnapshot)
+                .map { $0.config.name })
         let rows = try await db.remoteSessions.list()
         let sessions = rows.compactMap { row -> RemoteSessionInfo? in
-            guard let payload = row.decodedPayload else { return nil }
+            guard var payload = row.decodedPayload else { return nil }
+            if staleProviders.contains(row.provider) {
+                payload = payload.projectedForStaleSnapshot()
+            }
             return RemoteSessionInfo(provider: row.provider, payload: payload,
                                      gone: row.gone, dismissed: row.dismissed,
                                      lastSeen: row.lastSeen, resolvedRepoID: row.resolvedRepoIDUUID,
@@ -77,6 +88,9 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteCreateParams.self, from: paramsData)
+        if await manager.hasStaleSnapshot(provider: params.provider) {
+            return Self.staleSnapshotMutationResponse(provider: params.provider)
+        }
         guard let paramsJSON = Self.normalizedParamsJSON(params.paramsJSON) else {
             return RPCResponse(error: "remote.create paramsJSON must be a JSON object; got: \(params.paramsJSON)")
         }
@@ -121,6 +135,9 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteStopParams.self, from: paramsData)
+        if await manager.hasStaleSnapshot(provider: params.provider) {
+            return Self.staleSnapshotMutationResponse(provider: params.provider)
+        }
         let result: ProviderResult
         do {
             result = try await manager.invoke(
@@ -146,6 +163,9 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteSendParams.self, from: paramsData)
+        if await manager.hasStaleSnapshot(provider: params.provider) {
+            return Self.staleSnapshotMutationResponse(provider: params.provider)
+        }
         let result: ProviderResult
         do {
             result = try await manager.invoke(
@@ -207,6 +227,9 @@ extension RPCRouter {
             return Self.remoteBackendsDisabledResponse
         }
         let params = try decoder.decode(RemoteRenameParams.self, from: paramsData)
+        if await manager.hasStaleSnapshot(provider: params.provider) {
+            return Self.staleSnapshotMutationResponse(provider: params.provider)
+        }
         let result: ProviderResult
         do {
             result = try await manager.invoke(

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -148,6 +148,23 @@ public struct RemoteSessionPayload: Codable, Sendable, Equatable {
         agentStateAt = try c.decodeIfPresent(String.self, forKey: .agentStateAt)
         meta = try c.decodeIfPresent([String: String].self, forKey: .meta)
     }
+
+    /// A presentation-safe projection for a cached row whose provider has
+    /// failed to produce a fresh inventory. The mirror keeps the last good
+    /// payload intact for recovery and diagnostics, but callers must not
+    /// continue asserting that an active terminal or agent is still alive.
+    ///
+    /// A previously observed terminal exit remains a valid historical fact;
+    /// only non-terminal/unknown rows are demoted. In every demoted case the
+    /// agent axis also becomes unknown so a cached `working` or
+    /// `waiting_input` value cannot keep rendering as current activity.
+    public func projectedForStaleSnapshot() -> RemoteSessionPayload {
+        guard state != .exited else { return self }
+        return RemoteSessionPayload(
+            id: id, title: title, createdAt: createdAt,
+            state: .unknown, exitCode: exitCode, agentState: .unknown,
+            agentStateReason: nil, agentStateAt: agentStateAt, meta: meta)
+    }
 }
 
 public struct RemoteSessionListEnvelope: Codable, Sendable {
@@ -263,11 +280,25 @@ public struct RemoteProviderStatus: Codable, Sendable, Identifiable {
     public let errorMessage: String?
     public let remediationLabel: String?
     public let remediationCommand: String?
+    /// Timestamp of the most recent complete `list` snapshot accepted into
+    /// the mirror. Nil means this manager has not observed (or recovered
+    /// from the mirror) a successful snapshot yet.
+    public let lastSuccessfulSnapshotAt: Date?
     public init(config: RemoteProviderConfig, describe: ProviderDescribe?, health: ProviderHealth,
-                errorMessage: String?, remediationLabel: String?, remediationCommand: String?) {
+                errorMessage: String?, remediationLabel: String?, remediationCommand: String?,
+                lastSuccessfulSnapshotAt: Date? = nil) {
         self.config = config; self.describe = describe; self.health = health
         self.errorMessage = errorMessage
         self.remediationLabel = remediationLabel; self.remediationCommand = remediationCommand
+        self.lastSuccessfulSnapshotAt = lastSuccessfulSnapshotAt
+    }
+
+    /// True only when the manager has a prior successful inventory that is
+    /// now known to be stale. This deliberately differs from a provider that
+    /// has never produced a snapshot, for which there are no cached rows to
+    /// project or stale controls to suppress.
+    public var hasStaleSnapshot: Bool {
+        health != .ok && lastSuccessfulSnapshotAt != nil
     }
 
     // Provider names are already the unique identity used everywhere else in

--- a/Sources/TBDShared/RemoteProvider.swift
+++ b/Sources/TBDShared/RemoteProvider.swift
@@ -284,21 +284,67 @@ public struct RemoteProviderStatus: Codable, Sendable, Identifiable {
     /// the mirror. Nil means this manager has not observed (or recovered
     /// from the mirror) a successful snapshot yet.
     public let lastSuccessfulSnapshotAt: Date?
+    /// True when the daemon could not READ the persisted freshness row, so it
+    /// cannot say whether a successful snapshot exists. Distinct from a nil
+    /// `lastSuccessfulSnapshotAt`, which by itself cannot tell "confirmed
+    /// never" apart from "unknown" — and only the former is safe to fail open
+    /// on. Carried on the wire so this DTO reaches the same verdict as the
+    /// daemon's authoritative `RemoteProviderManager.hasStaleSnapshot`; the two
+    /// disagreeing is how cached rows once kept rendering as confidently
+    /// running in exactly the case the daemon knew the least.
+    public let freshnessUnreadable: Bool
     public init(config: RemoteProviderConfig, describe: ProviderDescribe?, health: ProviderHealth,
                 errorMessage: String?, remediationLabel: String?, remediationCommand: String?,
-                lastSuccessfulSnapshotAt: Date? = nil) {
+                lastSuccessfulSnapshotAt: Date? = nil, freshnessUnreadable: Bool = false) {
         self.config = config; self.describe = describe; self.health = health
         self.errorMessage = errorMessage
         self.remediationLabel = remediationLabel; self.remediationCommand = remediationCommand
         self.lastSuccessfulSnapshotAt = lastSuccessfulSnapshotAt
+        self.freshnessUnreadable = freshnessUnreadable
     }
 
-    /// True only when the manager has a prior successful inventory that is
-    /// now known to be stale. This deliberately differs from a provider that
-    /// has never produced a snapshot, for which there are no cached rows to
-    /// project or stale controls to suppress.
+    private enum CodingKeys: String, CodingKey {
+        case config, describe, health, errorMessage, remediationLabel, remediationCommand
+        case lastSuccessfulSnapshotAt, freshnessUnreadable
+    }
+
+    /// Hand-written so `freshnessUnreadable` can default when absent: a
+    /// payload from a daemon predating the field must still decode, and
+    /// Swift's synthesized `init(from:)` ignores property default values.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        config = try c.decode(RemoteProviderConfig.self, forKey: .config)
+        describe = try c.decodeIfPresent(ProviderDescribe.self, forKey: .describe)
+        health = try c.decode(ProviderHealth.self, forKey: .health)
+        errorMessage = try c.decodeIfPresent(String.self, forKey: .errorMessage)
+        remediationLabel = try c.decodeIfPresent(String.self, forKey: .remediationLabel)
+        remediationCommand = try c.decodeIfPresent(String.self, forKey: .remediationCommand)
+        lastSuccessfulSnapshotAt = try c.decodeIfPresent(Date.self, forKey: .lastSuccessfulSnapshotAt)
+        freshnessUnreadable = try c.decodeIfPresent(Bool.self, forKey: .freshnessUnreadable) ?? false
+    }
+
+    /// True when there is cached state on screen that must stop being
+    /// presented as current. Two ways to get there: a prior successful
+    /// inventory that is now stale, or a freshness row the daemon could not
+    /// read at all. A provider confirmed never to have snapshotted is
+    /// deliberately excluded — there are no cached rows to project or stale
+    /// controls to suppress.
     public var hasStaleSnapshot: Bool {
-        health != .ok && lastSuccessfulSnapshotAt != nil
+        Self.isStaleSnapshot(
+            health: health,
+            lastSuccessfulSnapshotAt: lastSuccessfulSnapshotAt,
+            freshnessUnreadable: freshnessUnreadable)
+    }
+
+    /// The one definition of "stale snapshot", shared by this DTO and the
+    /// daemon's `RemoteProviderManager.hasStaleSnapshot(provider:)`. It lives
+    /// here as a static so the display projection and the RPC mutation gate
+    /// cannot answer differently: when they did, the mutation gate failed
+    /// closed while the session list went on rendering cached rows as running.
+    public static func isStaleSnapshot(
+        health: ProviderHealth, lastSuccessfulSnapshotAt: Date?, freshnessUnreadable: Bool
+    ) -> Bool {
+        health != .ok && (lastSuccessfulSnapshotAt != nil || freshnessUnreadable)
     }
 
     // Provider names are already the unique identity used everywhere else in

--- a/Tests/TBDAppTests/RemoteSectionViewTests.swift
+++ b/Tests/TBDAppTests/RemoteSectionViewTests.swift
@@ -181,11 +181,15 @@ struct RemoteSectionViewTests {
 
     // MARK: - shouldShowHeader(provider:sessions:knownRepoIDs:)
 
-    private func status(name: String = "acme", health: ProviderHealth) -> RemoteProviderStatus {
+    private func status(
+        name: String = "acme", health: ProviderHealth,
+        errorMessage: String? = nil, lastSuccess: Date? = nil
+    ) -> RemoteProviderStatus {
         RemoteProviderStatus(
             config: RemoteProviderConfig(name: name, exec: "/usr/bin/true"),
             describe: nil, health: health,
-            errorMessage: nil, remediationLabel: nil, remediationCommand: nil)
+            errorMessage: errorMessage, remediationLabel: nil, remediationCommand: nil,
+            lastSuccessfulSnapshotAt: lastSuccess)
     }
 
     @Test func shouldShowHeader_trueWhenHealthyWithUnmatchedSessions() {
@@ -389,25 +393,48 @@ struct RemoteSectionViewTests {
     // MARK: - RemoteSessionRowView.stalenessCaption(health:lastSeen:now:)
 
     @Test func stalenessCaption_nilWhenProviderIsHealthy() {
-        #expect(RemoteSessionRowView.stalenessCaption(health: .ok, lastSeen: Date(), now: Date()) == nil)
+        #expect(RemoteSessionRowView.stalenessCaption(
+            health: .ok, lastSuccessfulSnapshotAt: Date(), now: Date()) == nil)
     }
 
     @Test func stalenessCaption_reflectsRelativeAgeWhenStale() {
         let now = Date(timeIntervalSince1970: 10_000)
         let lastSeen = now.addingTimeInterval(-2 * 3600)
-        #expect(RemoteSessionRowView.stalenessCaption(health: .stale, lastSeen: lastSeen, now: now) == "as of 2h ago")
+        #expect(RemoteSessionRowView.stalenessCaption(
+            health: .stale, lastSuccessfulSnapshotAt: lastSeen, now: now) == "as of 2h ago")
     }
 
     @Test func stalenessCaption_justNowOmitsTheTrailingAgo() {
         let now = Date(timeIntervalSince1970: 10_000)
         let lastSeen = now.addingTimeInterval(-5)
-        #expect(RemoteSessionRowView.stalenessCaption(health: .error, lastSeen: lastSeen, now: now) == "as of just now")
+        #expect(RemoteSessionRowView.stalenessCaption(
+            health: .error, lastSuccessfulSnapshotAt: lastSeen, now: now) == "as of just now")
     }
 
     @Test func stalenessCaption_rendersForNeedsAuthHealthToo() {
         let now = Date(timeIntervalSince1970: 10_000)
         let lastSeen = now.addingTimeInterval(-5 * 60)
-        #expect(RemoteSessionRowView.stalenessCaption(health: .needsAuth, lastSeen: lastSeen, now: now) == "as of 5m ago")
+        #expect(RemoteSessionRowView.stalenessCaption(
+            health: .needsAuth, lastSuccessfulSnapshotAt: lastSeen, now: now) == "as of 5m ago")
+    }
+
+    @Test func providerIssueSummaryShowsBoundedErrorAndLastGoodAge() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let provider = status(
+            health: .stale, errorMessage: "Inventory response was truncated",
+            lastSuccess: now.addingTimeInterval(-2 * 3600))
+        #expect(RemoteProviderStatusPresentation.issueSummary(provider, now: now)
+                == "Inventory response was truncated · last good 2h ago")
+    }
+
+    @Test func providerIssueSummarySaysWhenNoSuccessfulSnapshotExists() {
+        let provider = status(health: .error, errorMessage: "Provider failed")
+        #expect(RemoteProviderStatusPresentation.issueSummary(provider)
+                == "Provider failed · no successful snapshot yet")
+    }
+
+    @Test func providerIssueSummaryIsNilWhenHealthy() {
+        #expect(RemoteProviderStatusPresentation.issueSummary(status(health: .ok)) == nil)
     }
 
     // MARK: - AppState.remoteUnreadType(kind:exitCode:)

--- a/Tests/TBDAppTests/RemoteSessionActionMenuTests.swift
+++ b/Tests/TBDAppTests/RemoteSessionActionMenuTests.swift
@@ -88,6 +88,16 @@ struct RemoteSessionActionMenuTests {
         #expect(kinds(items) == [.rename, .attach, .viewLog, .sendText, .copySessionID, .pin, nil, .stop])
     }
 
+    @Test func staleSnapshotKeepsInspectionAndDropsStateChangingActions() {
+        let items = RemoteSessionActionMenu.items(
+            capabilities: ["attach", "log", "send"], gone: false,
+            snapshotFresh: false, isPinned: false)
+        #expect(kinds(items) == [.attach, .viewLog, .copySessionID, .pin])
+        #expect(!kinds(items).contains(.rename))
+        #expect(!kinds(items).contains(.sendText))
+        #expect(!kinds(items).contains(.stop))
+    }
+
     /// Items are omitted, never disabled — `RemoteSessionActionMenu` carries
     /// no `isEnabled`/disabled-help concept the way `RowActionMenu.Action`
     /// does, so an absent capability simply never produces an `Action` at

--- a/Tests/TBDAppTests/RemoteSessionDetailGatesTests.swift
+++ b/Tests/TBDAppTests/RemoteSessionDetailGatesTests.swift
@@ -111,6 +111,11 @@ struct RemoteSessionDetailGatesTests {
         #expect(RemoteSessionDetailGates.showsSendField(capabilities: [], gone: true) == false)
         #expect(RemoteSessionDetailGates.showsSendField(capabilities: [], gone: false) == false)
     }
+
+    @Test func showsSendFieldIsFalseWhenSnapshotIsStale() {
+        #expect(RemoteSessionDetailGates.showsSendField(
+            capabilities: ["send"], gone: false, snapshotFresh: false) == false)
+    }
 }
 
 /// Tier 1: pure state-to-copy mapping with no I/O, clock, or process.

--- a/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
@@ -119,6 +119,58 @@ struct RPCRouterRemoteTests: ~Copyable {
         #expect(result.sessions.map(\.payload.id) == ["a"])
     }
 
+    @Test func sessionsProjectsCachedActiveRowsUnknownAfterInventoryFailure() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "inventory unavailable"),
+        ])
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await manager.pollOnce(provider: provider)
+        await manager.pollOnce(provider: provider)
+
+        let response = await call(router(manager: manager), "remote.sessions")
+        let result = try response.decodeResult(RemoteSessionsResult.self)
+        let projected = try #require(result.sessions.first?.payload)
+        #expect(projected.state == .unknown)
+        #expect(projected.agentState == .unknown)
+
+        // Projection is non-destructive: recovery still has the complete
+        // last-good payload to replace or inspect.
+        let rawRows = try await db.remoteSessions.list()
+        let raw = rawRows.first?.decodedPayload
+        #expect(raw?.state == .running)
+        #expect(raw?.agentState == .working)
+    }
+
+    @Test func staleInventoryBlocksMutationsButKeepsLogInspectionAvailable() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "inventory unavailable"),
+            providerOK("last output"),
+        ])
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await manager.pollOnce(provider: provider)
+        await manager.pollOnce(provider: provider)
+        let r = router(manager: manager)
+
+        let stop = await call(r, "remote.stop", #"{"provider":"fake","sessionID":"a"}"#)
+        #expect(stop.success == false)
+        #expect(stop.error?.contains("inventory is stale") == true)
+
+        let log = await call(r, "remote.log", #"{"provider":"fake","sessionID":"a"}"#)
+        #expect(log.success)
+        #expect(try log.decodeResult(RemoteLogResult.self).text == "last output")
+        #expect(invoker.calls == [["list"], ["list"], ["log", "a"]])
+        #expect(await manager.providerStatuses().first?.health == .stale,
+                "a successful read-only verb must not claim inventory recovered")
+    }
+
     /// `remote.sessions` must surface the daemon's pinned repo resolution on
     /// the wire, and the returned `id` must match the deterministic
     /// derivation the app keys sidebar rows by.

--- a/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
@@ -145,6 +145,42 @@ struct RPCRouterRemoteTests: ~Copyable {
         #expect(raw?.agentState == .working)
     }
 
+    /// The display projection and the mutation gate must agree even when the
+    /// persisted freshness row is unreadable. They previously did not: the gate
+    /// failed closed off the actor's own state while `remote.sessions` consulted
+    /// the DTO, whose `lastSuccessfulSnapshotAt` is nil after a failed read — so
+    /// cached rows kept rendering as confidently `running` in exactly the case
+    /// the daemon knew the least. Dropping `tbd_meta` makes the SELECT throw.
+    @Test func sessionsDemoteCachedRowsWhenFreshnessRowIsUnreadable() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake",
+            sessions: [RemoteSessionPayload(id: "a", state: .running, agentState: .working)],
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: "DROP TABLE tbd_meta")
+        }
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs,
+            runner: FakeProviderInvoker(script: [
+                ProviderResult(exitCode: 3, stdout: Data(), stderr: "inventory unavailable")
+            ]),
+            registryURL: registryURL)
+        await manager.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        let r = router(manager: manager)
+
+        let response = await call(r, "remote.sessions")
+        let result = try response.decodeResult(RemoteSessionsResult.self)
+        let projected = try #require(result.sessions.first?.payload)
+        #expect(projected.state == .unknown)
+        #expect(projected.agentState == .unknown)
+
+        // And the gate the projection is supposed to match still refuses.
+        let stop = await call(r, "remote.stop", #"{"provider":"fake","sessionID":"a"}"#)
+        #expect(stop.success == false)
+        #expect(stop.error?.contains("inventory is stale") == true)
+    }
+
     @Test func staleInventoryBlocksMutationsButKeepsLogInspectionAvailable() async throws {
         try await db.config.setRemoteBackendsEnabled(true)
         let invoker = FakeProviderInvoker(script: [

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -627,6 +627,26 @@ struct RemoteProviderManagerTests {
     #expect(status?.hasStaleSnapshot == true)
   }
 
+  @Test func restartHydratesAndGatesBeforeTheInitialProviderPoll() async throws {
+    let lastGood = Date(timeIntervalSince1970: 1_700_000_123)
+    _ = try await db.remoteSessions.applySnapshot(
+      provider: "fake",
+      sessions: [RemoteSessionPayload(id: "a", state: .running)],
+      now: lastGood)
+    let invoker = FakeProviderInvoker(script: [])
+    let m = manager(invoker)
+
+    // Do not call start() or pollOnce(). RPC is deliberately available
+    // before either can finish during daemon boot.
+    let status = await m.providerStatuses().first
+
+    #expect(status?.health == .stale)
+    #expect(status?.lastSuccessfulSnapshotAt == lastGood)
+    #expect(status?.hasStaleSnapshot == true)
+    #expect(await m.hasStaleSnapshot(provider: "fake"))
+    #expect(invoker.callsSnapshot().isEmpty)
+  }
+
   @Test func eventUpsertCannotMasqueradeAsFullSnapshotAfterRestart() async throws {
     let eventTime = Date(timeIntervalSince1970: 1_800_000_000)
     _ = try await db.remoteSessions.upsertOne(

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -122,6 +122,9 @@ struct RemoteProviderManagerTests {
         let rows = try await db.remoteSessions.list()
         #expect(rows.map(\.sessionID) == ["a"])
         #expect(invoker.calls == [["list"]])
+        let status = await m.providerStatuses().first
+        #expect(status?.health == .ok)
+        #expect(status?.lastSuccessfulSnapshotAt != nil)
     }
 
     @Test func authFailureMarksNeedsAuthAndSuccessClears() async throws {
@@ -480,6 +483,7 @@ struct RemoteProviderManagerTests {
         let provider = RemoteProviderConfig(name: "fake", exec: "/x")
 
         await m.pollOnce(provider: provider)
+        let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
         await m.pollOnce(provider: provider)
 
         let rows = try await db.remoteSessions.list()
@@ -490,7 +494,80 @@ struct RemoteProviderManagerTests {
         let status = await m.providerStatuses().first
         #expect(status?.health == .stale)
         #expect(status?.errorMessage == "provider transport overloaded")
+        #expect(status?.lastSuccessfulSnapshotAt == firstSuccess)
+        #expect(status?.hasStaleSnapshot == true)
         #expect(invoker.calls == [["list"], ["list"]])
+    }
+
+    @Test func truncatedInventoryErrorIsBoundedAndDoesNotExposeEmbeddedPayload() async throws {
+        let embedded = String(repeating: #"{"prompt":"sensitive"}"#, count: 100)
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
+            ProviderResult(
+                exitCode: 2, stdout: Data(),
+                stderr: "unparseable remote output: \(embedded)--output truncated--")
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        await m.pollOnce(provider: provider)
+
+        let message = await m.providerStatuses().first?.errorMessage
+        #expect(message == "Provider inventory was truncated or malformed; showing the last successful snapshot.")
+        #expect(message?.contains("sensitive") == false)
+    }
+
+    @Test func arbitraryProviderErrorIsCappedToTheWireLimit() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: String(repeating: "x", count: 1_000))
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        let message = await m.providerStatuses().first?.errorMessage
+        #expect(message?.count == 240)
+        #expect(message?.hasSuffix("…") == true)
+    }
+
+    @Test func successfulInventoryAfterFailureRestoresFreshHealthAndAdvancesTimestamp() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "temporary"),
+            providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
+        await m.pollOnce(provider: provider)
+        #expect(await m.hasStaleSnapshot(provider: "fake"))
+
+        await m.pollOnce(provider: provider)
+
+        let recovered = await m.providerStatuses().first
+        #expect(recovered?.health == .ok)
+        #expect(recovered?.hasStaleSnapshot == false)
+        #expect(recovered?.lastSuccessfulSnapshotAt != nil)
+        if let firstSuccess, let recoveredAt = recovered?.lastSuccessfulSnapshotAt {
+            #expect(recoveredAt >= firstSuccess)
+        }
+    }
+
+    @Test func failureAfterManagerRestartRecoversLastSuccessTimeFromMirror() async throws {
+        let lastGood = Date(timeIntervalSince1970: 1_700_000_000)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake",
+            sessions: [RemoteSessionPayload(id: "a", state: .running)],
+            now: lastGood)
+        let m = manager(FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
+        ]))
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        let status = await m.providerStatuses().first
+        #expect(status?.health == .stale)
+        #expect(status?.lastSuccessfulSnapshotAt == lastGood)
+        #expect(status?.hasStaleSnapshot == true)
     }
 
     @Test func invokeByNameRoutesToConfiguredProvider() async throws {

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -627,6 +627,25 @@ struct RemoteProviderManagerTests {
     #expect(status?.hasStaleSnapshot == true)
   }
 
+  @Test func eventUpsertCannotMasqueradeAsFullSnapshotAfterRestart() async throws {
+    let eventTime = Date(timeIntervalSince1970: 1_800_000_000)
+    _ = try await db.remoteSessions.upsertOne(
+      provider: "fake",
+      session: RemoteSessionPayload(id: "event-only", state: .running),
+      now: eventTime)
+    let m = manager(
+      FakeProviderInvoker(script: [
+        ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
+      ]))
+
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+    let status = await m.providerStatuses().first
+    #expect(status?.health == .stale)
+    #expect(status?.lastSuccessfulSnapshotAt == nil)
+    #expect(status?.hasStaleSnapshot == false)
+  }
+
   @Test func invokeByNameRoutesToConfiguredProvider() async throws {
     // Only exercises verb routing, so it calls loadRegistryAndDescribe()
     // (registry + describe, no poll loop) rather than start() — no

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -635,6 +635,11 @@ struct RemoteProviderManagerTests {
         // No timestamp is claimed — the daemon must not invent an age it
         // could not read.
         #expect(status?.lastSuccessfulSnapshotAt == nil)
+        // The wire DTO must reach the SAME verdict as the actor. When these
+        // disagreed, `handleRemoteSessions` skipped demotion and cached rows
+        // kept rendering as running while mutations were being refused.
+        #expect(status?.freshnessUnreadable == true)
+        #expect(status?.hasStaleSnapshot == true)
     }
 
     /// Tier 1. The unreadable state is not sticky: it is a cache of one failed
@@ -664,6 +669,8 @@ struct RemoteProviderManagerTests {
         let status = await m.providerStatuses().first
         #expect(status?.health == .ok)
         #expect(status?.lastSuccessfulSnapshotAt == Date(timeIntervalSince1970: 1_700_000_500))
+        #expect(status?.freshnessUnreadable == false)
+        #expect(status?.hasStaleSnapshot == false)
     }
 
     @Test func failureAfterManagerRestartRecoversLastSuccessTimeFromMirror() async throws {

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -1,5 +1,6 @@
-import Testing
 import Foundation
+import Testing
+
 @testable import TBDDaemonLib
 @testable import TBDShared
 
@@ -7,694 +8,758 @@ import Foundation
 /// `ProviderResult` or a simulated provider timeout. Not `private` for the
 /// same reason `FakeProviderInvoker` isn't.
 enum FakeProviderOutcome: Sendable {
-    case result(ProviderResult)
-    /// Throws `ProviderRunError.timeout(verb:)` for this call — scripts the
-    /// create-retry path (RPCRouterRemoteTests), which needs the FIRST
-    /// invocation to time out and the SECOND to succeed with the SAME stdin.
-    case timeout
+  case result(ProviderResult)
+  /// Throws `ProviderRunError.timeout(verb:)` for this call — scripts the
+  /// create-retry path (RPCRouterRemoteTests), which needs the FIRST
+  /// invocation to time out and the SECOND to succeed with the SAME stdin.
+  case timeout
 }
 
 /// Scriptable fake provider: each verb invocation pops the next canned
 /// outcome. Intentionally NOT `private` — a later task's RPC-handler tests
 /// reuse this against the same `RemoteProviderInvoking` protocol.
 final class FakeProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
-    private let lock = NSLock()
-    private var script: [FakeProviderOutcome]
-    private(set) var calls: [[String]] = []
-    /// stdin bytes for each call, same index as `calls`. `nil` entries are
-    /// calls made with no stdin (e.g. `stop`/`log`).
-    private(set) var stdins: [Data?] = []
+  private let lock = NSLock()
+  private var script: [FakeProviderOutcome]
+  private(set) var calls: [[String]] = []
+  /// stdin bytes for each call, same index as `calls`. `nil` entries are
+  /// calls made with no stdin (e.g. `stop`/`log`).
+  private(set) var stdins: [Data?] = []
 
-    init(script: [ProviderResult]) {
-        self.script = script.map { .result($0) }
-    }
+  init(script: [ProviderResult]) {
+    self.script = script.map { .result($0) }
+  }
 
-    /// Scriptable with timeouts interleaved among results.
-    init(outcomes: [FakeProviderOutcome]) {
-        self.script = outcomes
-    }
+  /// Scriptable with timeouts interleaved among results.
+  init(outcomes: [FakeProviderOutcome]) {
+    self.script = outcomes
+  }
 
-    func run(_ config: RemoteProviderConfig, verb: [String], stdin: Data?,
-             timeout: TimeInterval) async throws -> ProviderResult {
-        try popScript(verb, stdin: stdin)
-    }
+  func run(
+    _ config: RemoteProviderConfig, verb: [String], stdin: Data?,
+    timeout: TimeInterval
+  ) async throws -> ProviderResult {
+    try popScript(verb, stdin: stdin)
+  }
 
-    /// Synchronous helper so the NSLock critical section isn't taken from an
-    /// `async` context (recent Foundation marks `NSLock.lock`/`unlock` as
-    /// unavailable from async contexts to discourage blocking there).
-    private func popScript(_ verb: [String], stdin: Data?) throws -> ProviderResult {
-        lock.lock(); defer { lock.unlock() }
-        calls.append(verb)
-        stdins.append(stdin)
-        precondition(!script.isEmpty, "FakeProviderInvoker script exhausted for verb \(verb)")
-        switch script.removeFirst() {
-        case .result(let result):
-            return result
-        case .timeout:
-            throw ProviderRunError.timeout(verb: verb.first ?? "?")
-        }
+  /// Synchronous helper so the NSLock critical section isn't taken from an
+  /// `async` context (recent Foundation marks `NSLock.lock`/`unlock` as
+  /// unavailable from async contexts to discourage blocking there).
+  private func popScript(_ verb: [String], stdin: Data?) throws -> ProviderResult {
+    lock.lock()
+    defer { lock.unlock() }
+    calls.append(verb)
+    stdins.append(stdin)
+    precondition(!script.isEmpty, "FakeProviderInvoker script exhausted for verb \(verb)")
+    switch script.removeFirst() {
+    case .result(let result):
+      return result
+    case .timeout:
+      throw ProviderRunError.timeout(verb: verb.first ?? "?")
     }
+  }
 
-    /// Locked snapshot of `calls`, for tests that read it while a manager's
-    /// background poll `Task` may still be writing (the plain `calls`
-    /// getter is fine only when nothing concurrent is running).
-    func callsSnapshot() -> [[String]] {
-        lock.lock(); defer { lock.unlock() }
-        return calls
-    }
+  /// Locked snapshot of `calls`, for tests that read it while a manager's
+  /// background poll `Task` may still be writing (the plain `calls`
+  /// getter is fine only when nothing concurrent is running).
+  func callsSnapshot() -> [[String]] {
+    lock.lock()
+    defer { lock.unlock() }
+    return calls
+  }
 
-    /// Locked snapshot of `stdins`, same rationale as `callsSnapshot()`.
-    func stdinsSnapshot() -> [Data?] {
-        lock.lock(); defer { lock.unlock() }
-        return stdins
-    }
+  /// Locked snapshot of `stdins`, same rationale as `callsSnapshot()`.
+  func stdinsSnapshot() -> [Data?] {
+    lock.lock()
+    defer { lock.unlock() }
+    return stdins
+  }
 }
 
 /// Not `private` — reused by later provider-RPC tests in this target.
 func providerOK(_ json: String) -> ProviderResult {
-    ProviderResult(exitCode: 0, stdout: Data(json.utf8), stderr: "")
+  ProviderResult(exitCode: 0, stdout: Data(json.utf8), stderr: "")
 }
 
 /// Thread-safe collector for broadcast StateDeltas, mirroring the pattern in
 /// `RPCRouterWorktreeCreateBroadcastTests` / `GCHandlersTests`.
 private final class BroadcastDeltas: @unchecked Sendable {
-    private let lock = NSLock()
-    private var deltas: [StateDelta] = []
+  private let lock = NSLock()
+  private var deltas: [StateDelta] = []
 
-    func append(_ delta: StateDelta) {
-        lock.lock(); defer { lock.unlock() }
-        deltas.append(delta)
-    }
+  func append(_ delta: StateDelta) {
+    lock.lock()
+    defer { lock.unlock() }
+    deltas.append(delta)
+  }
 
-    func snapshot() -> [StateDelta] {
-        lock.lock(); defer { lock.unlock() }
-        return deltas
-    }
+  func snapshot() -> [StateDelta] {
+    lock.lock()
+    defer { lock.unlock() }
+    return deltas
+  }
 }
 
 @Suite("RemoteProviderManager")
 struct RemoteProviderManagerTests {
-    let db: TBDDatabase
-    let subs: StateSubscriptionManager
-    let registryURL: URL
+  let db: TBDDatabase
+  let subs: StateSubscriptionManager
+  let registryURL: URL
 
-    init() throws {
-        db = try TBDDatabase(inMemory: true)
-        subs = StateSubscriptionManager()
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("rpm-tests-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        registryURL = dir.appendingPathComponent("agent-providers.json")
-        try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
-            .write(to: registryURL, atomically: true, encoding: .utf8)
+  init() throws {
+    db = try TBDDatabase(inMemory: true)
+    subs = StateSubscriptionManager()
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("rpm-tests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    registryURL = dir.appendingPathComponent("agent-providers.json")
+    try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
+      .write(to: registryURL, atomically: true, encoding: .utf8)
+  }
+
+  private func manager(_ invoker: FakeProviderInvoker) -> RemoteProviderManager {
+    RemoteProviderManager(db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+  }
+
+  @Test func pollOnceAppliesSnapshotToMirror() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#)
+    ])
+    let m = manager(invoker)
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+    let rows = try await db.remoteSessions.list()
+    #expect(rows.map(\.sessionID) == ["a"])
+    #expect(invoker.calls == [["list"]])
+    let status = await m.providerStatuses().first
+    #expect(status?.health == .ok)
+    #expect(status?.lastSuccessfulSnapshotAt != nil)
+  }
+
+  @Test func authFailureMarksNeedsAuthAndSuccessClears() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(
+        exitCode: 4,
+        stdout: Data(
+          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "login", "command": "acme-provider login"}}}"#
+            .utf8),
+        stderr: ""),
+      providerOK(#"{"sessions": []}"#),
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+    await m.pollOnce(provider: provider)
+    var statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(statuses.first?.remediationCommand == "acme-provider login")
+    await m.pollOnce(provider: provider)
+    statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .ok)
+  }
+
+  /// The error object's `code` adds precision the exit class lacks: a
+  /// provider that names `auth_expired` while exiting 1 must still land in
+  /// `needs_auth` WITH its remediation, not in the dead-end `error` state
+  /// exit 1 alone would produce.
+  @Test func nonFourExitCarryingAnAuthCodeStillLandsNeedsAuthWithRemediation() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(
+        exitCode: 1,
+        stdout: Data(
+          #"{"error": {"code": "auth_expired", "message": "credentials expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+            .utf8),
+        stderr: "")
+    ])
+    let m = manager(invoker)
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(statuses.first?.errorMessage == "credentials expired")
+    #expect(statuses.first?.remediationLabel == "Sign in")
+    #expect(statuses.first?.remediationCommand == "acme-provider login")
+  }
+
+  /// A non-auth `code` on a non-auth exit must NOT be widened into an auth
+  /// state — the union rule only covers the contract's auth codes.
+  @Test func nonAuthCodeOnExitOneStaysErrorNotNeedsAuth() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(
+        exitCode: 1,
+        stdout: Data(
+          #"{"error": {"code": "credential_unresolvable", "message": "no such credential"}}"#.utf8),
+        stderr: "")
+    ])
+    let m = manager(invoker)
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .error)
+    #expect(statuses.first?.errorMessage == "no such credential")
+  }
+
+  // MARK: - attach-exit correlation
+
+  /// An auth-class `attach` exit (reported by the app, since the daemon
+  /// never spawns attach itself) marks the provider `needs_auth` and fires
+  /// exactly ONE out-of-band `list` — the authoritative probe that turns a
+  /// bare exit code into a message + remediation.
+  @Test func authAttachExitMarksNeedsAuthAndProbesOnce() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(
+        exitCode: 4,
+        stdout: Data(
+          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+            .utf8),
+        stderr: "")
+    ])
+    let m = manager(invoker)
+    try await m.recordAttachExit(provider: "fake", exitCode: 4)
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(
+      statuses.first?.remediationCommand == "acme-provider login",
+      "the out-of-band probe is what turns an exit code into a remediation")
+    #expect(invoker.calls == [["list"]], "exactly one probe per health transition")
+  }
+
+  /// The other branch of the same gate: an attach exit arriving while the
+  /// provider is ALREADY `needs_auth` must not fire another probe (a
+  /// flapping session would otherwise turn into a poll flood), and must
+  /// preserve the remediation already on file rather than clobbering it
+  /// with the nothing an attach exit carries.
+  @Test func authAttachExitWhileAlreadyNeedsAuthPreservesRemediationAndDoesNotReprobe() async throws
+  {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(
+        exitCode: 4,
+        stdout: Data(
+          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+            .utf8),
+        stderr: "")
+    ])
+    let m = manager(invoker)
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+    #expect(invoker.calls == [["list"]])
+
+    try await m.recordAttachExit(provider: "fake", exitCode: 4)
+
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(statuses.first?.errorMessage == "expired", "must not clobber a parsed message with nil")
+    #expect(statuses.first?.remediationCommand == "acme-provider login")
+    #expect(invoker.calls == [["list"]], "no second probe while already needs_auth")
+  }
+
+  /// Non-auth attach exits are the app's business (reconnect backoff), not
+  /// provider health's: one flaky viewer must never speak for the whole
+  /// provider.
+  @Test func nonAuthAttachExitChangesNothing() async throws {
+    let invoker = FakeProviderInvoker(script: [])
+    let m = manager(invoker)
+    try await m.recordAttachExit(provider: "fake", exitCode: 1)
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .ok)
+    #expect(invoker.calls.isEmpty, "a transport-class attach exit must not trigger a probe")
+  }
+
+  /// Recovery: the poll loop keeps running while `needs_auth`, and the
+  /// first successful `list` clears the state — no user gesture, no
+  /// persisted flag.
+  @Test func successfulPollAfterAnAttachAuthExitClearsNeedsAuth() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),  // the probe confirms
+      providerOK(#"{"sessions": []}"#),  // the next poll succeeds
+    ])
+    let m = manager(invoker)
+    try await m.recordAttachExit(provider: "fake", exitCode: 4)
+    #expect(await m.providerStatuses().first?.health == .needsAuth)
+
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+    #expect(await m.providerStatuses().first?.health == .ok)
+  }
+
+  /// Inheritance branch A — previous state IS `.needsAuth`, so the text on
+  /// file is carried across. `recordAttachExit` preserves the remediation
+  /// already on file, and the probe it fires must not undo that: a probe
+  /// whose `list` also exits 4 but returns nothing parseable supplies no
+  /// message/remediation of its own, and `recordFailure`'s auth branch
+  /// falls back to what's on file rather than clobbering it with nil.
+  @Test func aProbeWithUnparseableStdoutPreservesTheRemediationOnFile() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      // First poll parses a full error object → message + remediation.
+      ProviderResult(
+        exitCode: 4,
+        stdout: Data(
+          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+            .utf8),
+        stderr: ""),
+      // The attach-exit probe re-confirms auth-needed but says nothing.
+      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+    await m.pollOnce(provider: provider)
+    #expect(await m.providerStatuses().first?.remediationCommand == "acme-provider login")
+
+    // Health is already `.needsAuth`, so `recordAttachExit` fires no
+    // probe of its own — drive the probe-shaped call directly.
+    await m.pollOnce(provider: provider)
+
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(
+      statuses.first?.errorMessage == "expired",
+      "an empty probe must not clobber the message on file")
+    #expect(
+      statuses.first?.remediationCommand == "acme-provider login",
+      "an empty probe must not clobber the remediation on file")
+  }
+
+  /// Inheritance branch B — previous state is NOT `.needsAuth`, so nothing
+  /// is carried across. A transport failure leaves a message like
+  /// "connection timed out" on file under `.stale`; the auth failure that
+  /// follows must not relabel that sentence as the provider's
+  /// AUTHENTICATION explanation. With no parsed error of its own the CTA
+  /// falls back to the app's neutral copy, which is correct-but-vague
+  /// rather than confidently wrong.
+  @Test func anAuthFailureFromStaleDoesNotInheritTheTransportMessage() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      // Transient → .stale, message taken from stderr.
+      ProviderResult(exitCode: 3, stdout: Data(), stderr: "connection timed out"),
+      // Auth failure with nothing parseable in stdout.
+      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+    await m.pollOnce(provider: provider)
+    #expect(await m.providerStatuses().first?.errorMessage == "connection timed out")
+
+    await m.pollOnce(provider: provider)
+
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(
+      statuses.first?.errorMessage == nil,
+      "a transport message must not become the authentication explanation")
+    #expect(statuses.first?.remediationCommand == nil)
+  }
+
+  /// Same branch, entered from `.error` rather than `.stale` — the two
+  /// non-auth states reach the auth branch by different paths (permanent
+  /// vs transient classification), and neither may donate its text.
+  @Test func anAuthFailureFromErrorDoesNotInheritTheErrorMessage() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      // Permanent → .error, with a parsed message on file.
+      ProviderResult(
+        exitCode: 1,
+        stdout: Data(
+          #"{"error": {"code": "credential_unresolvable", "message": "no such credential"}}"#.utf8),
+        stderr: ""),
+      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+    await m.pollOnce(provider: provider)
+    #expect(await m.providerStatuses().first?.health == .error)
+
+    await m.pollOnce(provider: provider)
+
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(
+      statuses.first?.errorMessage == nil,
+      "a provisioning error must not become the authentication explanation")
+    #expect(statuses.first?.remediationCommand == nil)
+  }
+
+  /// The same gate on the attach path, whose `setHealth` is itself a
+  /// transition into `.needsAuth`. Were it to carry the stale transport
+  /// text across, the probe it fires would then inherit that text back
+  /// through `recordFailure` (which now sees a previous state of
+  /// `.needsAuth`) and the wrong words would survive the fix anyway.
+  @Test func attachExitFromStaleDoesNotLaunderTheTransportMessageThroughTheProbe() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(exitCode: 3, stdout: Data(), stderr: "connection timed out"),
+      // The out-of-band probe re-confirms auth-needed but says nothing.
+      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
+    ])
+    let m = manager(invoker)
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+    #expect(await m.providerStatuses().first?.health == .stale)
+
+    try await m.recordAttachExit(provider: "fake", exitCode: 4)
+
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(
+      statuses.first?.errorMessage == nil,
+      "the transport message must not survive into the auth CTA via the probe")
+    #expect(statuses.first?.remediationCommand == nil)
+    #expect(
+      invoker.calls == [["list"], ["list"]],
+      "the transition off .stale still fires exactly one probe")
+  }
+
+  /// The other branch of the same fallback: a newly parsed value always
+  /// wins over what's on file, so a provider that changes its remediation
+  /// mid-outage is reflected rather than pinned to the first one seen.
+  @Test func aFreshlyParsedRemediationWinsOverTheOneOnFile() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(
+        exitCode: 4,
+        stdout: Data(
+          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+            .utf8),
+        stderr: ""),
+      ProviderResult(
+        exitCode: 4,
+        stdout: Data(
+          #"{"error": {"code": "auth_expired", "message": "still expired", "remediation": {"label": "Sign in again", "command": "acme-provider login --renew"}}}"#
+            .utf8),
+        stderr: ""),
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+    await m.pollOnce(provider: provider)
+    await m.pollOnce(provider: provider)
+
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.errorMessage == "still expired")
+    #expect(statuses.first?.remediationCommand == "acme-provider login --renew")
+  }
+
+  // MARK: - Health broadcasting
+
+  /// The payload of this whole feature reaches the app on a
+  /// `needs_auth → needs_auth` transition: `recordAttachExit` flips health
+  /// off a bare exit code carrying no message, and its probe is what lands
+  /// the parsed message + remediation. Broadcasting on the health STATE
+  /// alone dropped that second step silently, leaving the app on a
+  /// command-less fallback CTA for the whole outage (every later poll is
+  /// also needs_auth → needs_auth).
+  @Test func addingARemediationWithoutAStateChangeStillBroadcasts() async throws {
+    let deltas = BroadcastDeltas()
+    subs.addSubscriber { data in
+      if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+        deltas.append(delta)
+      }
+      return true
     }
+    let withRemediation = ProviderResult(
+      exitCode: 4,
+      stdout: Data(
+        #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+          .utf8),
+      stderr: "")
+    let invoker = FakeProviderInvoker(script: [
+      // ok → needs_auth, message only, no remediation.
+      ProviderResult(
+        exitCode: 4,
+        stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired"}}"#.utf8),
+        stderr: ""),
+      // needs_auth → needs_auth, ADDING a remediation.
+      withRemediation,
+      // needs_auth → needs_auth, identical in all three fields.
+      withRemediation,
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
 
-    private func manager(_ invoker: FakeProviderInvoker) -> RemoteProviderManager {
-        RemoteProviderManager(db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
+    await m.pollOnce(provider: provider)
+    #expect(healthBroadcastCount(deltas) == 1, "ok → needs_auth broadcasts")
+
+    await m.pollOnce(provider: provider)
+    #expect(
+      healthBroadcastCount(deltas) == 2,
+      "a remediation arriving on an already-needs_auth provider must reach the app")
+
+    await m.pollOnce(provider: provider)
+    #expect(
+      healthBroadcastCount(deltas) == 2,
+      "a genuinely unchanged re-set must not broadcast (60s polls would flood the wire)")
+  }
+
+  private func healthBroadcastCount(_ deltas: BroadcastDeltas) -> Int {
+    deltas.snapshot().filter {
+      if case .remoteSessionsChanged = $0 { return true }
+      return false
+    }.count
+  }
+
+  @Test func attachExitForAnUnknownProviderThrows() async throws {
+    let m = manager(FakeProviderInvoker(script: []))
+    await #expect(throws: (any Error).self) {
+      try await m.recordAttachExit(provider: "nope", exitCode: 4)
     }
+  }
 
-    @Test func pollOnceAppliesSnapshotToMirror() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#)
-        ])
-        let m = manager(invoker)
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-        let rows = try await db.remoteSessions.list()
-        #expect(rows.map(\.sessionID) == ["a"])
-        #expect(invoker.calls == [["list"]])
-        let status = await m.providerStatuses().first
-        #expect(status?.health == .ok)
-        #expect(status?.lastSuccessfulSnapshotAt != nil)
+  @Test func transientFailureMarksStaleNotAuth() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(exitCode: 3, stdout: Data(), stderr: "flaky network")
+    ])
+    let m = manager(invoker)
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .stale)
+    // Stale poll must NOT touch the mirror (unreachable ≠ sessions dead).
+    let rows = try await db.remoteSessions.list()
+    #expect(rows.isEmpty)
+  }
+
+  /// Tier 1: in-memory GRDB and a scripted provider only.
+  @Test func structuredTransientPollPreservesTheLastSuccessfulSnapshot() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
+      ProviderResult(
+        exitCode: 3,
+        stdout: Data(
+          #"{"error": {"code": "unreachable", "message": "provider transport overloaded", "retryable": true}}"#
+            .utf8),
+        stderr: ""),
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+
+    await m.pollOnce(provider: provider)
+    let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
+    await m.pollOnce(provider: provider)
+
+    let rows = try await db.remoteSessions.list()
+    #expect(rows.map(\.sessionID) == ["a"])
+    #expect(rows.first?.decodedPayload?.state == .running)
+    #expect(rows.first?.gone == false)
+
+    let status = await m.providerStatuses().first
+    #expect(status?.health == .stale)
+    #expect(status?.errorMessage == "provider transport overloaded")
+    #expect(status?.lastSuccessfulSnapshotAt == firstSuccess)
+    #expect(status?.hasStaleSnapshot == true)
+    #expect(invoker.calls == [["list"], ["list"]])
+  }
+
+  @Test func truncatedInventoryErrorIsBoundedAndDoesNotExposeEmbeddedPayload() async throws {
+    let embedded = String(repeating: #"{"prompt":"sensitive"}"#, count: 100)
+    let invoker = FakeProviderInvoker(script: [
+      providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
+      ProviderResult(
+        exitCode: 2, stdout: Data(),
+        stderr: "unparseable remote output: \(embedded)--output truncated--"),
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+    await m.pollOnce(provider: provider)
+    await m.pollOnce(provider: provider)
+
+    let message = await m.providerStatuses().first?.errorMessage
+    #expect(
+      message
+        == "Provider inventory was truncated or malformed; showing the last successful snapshot.")
+    #expect(message?.contains("sensitive") == false)
+  }
+
+  @Test func firstTruncatedInventoryIsHonestWithoutSnapshot() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(
+        exitCode: 2, stdout: Data(),
+        stderr: "unparseable remote output: private--output truncated--")
+    ])
+    let m = manager(invoker)
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+    let message = await m.providerStatuses().first?.errorMessage
+    #expect(
+      message
+        == "Provider inventory was truncated or malformed; no successful snapshot is available yet."
+    )
+    #expect(message?.contains("private") == false)
+  }
+
+  @Test func arbitraryProviderErrorIsCappedToTheWireLimit() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(exitCode: 3, stdout: Data(), stderr: String(repeating: "x", count: 1_000))
+    ])
+    let m = manager(invoker)
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+    let message = await m.providerStatuses().first?.errorMessage
+    #expect(message?.count == 240)
+    #expect(message?.hasSuffix("…") == true)
+  }
+
+  @Test func successfulInventoryAfterFailureRestoresFreshHealthAndAdvancesTimestamp() async throws {
+    let invoker = FakeProviderInvoker(script: [
+      providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
+      ProviderResult(exitCode: 3, stdout: Data(), stderr: "temporary"),
+      providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
+    ])
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+    await m.pollOnce(provider: provider)
+    let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
+    await m.pollOnce(provider: provider)
+    #expect(await m.hasStaleSnapshot(provider: "fake"))
+
+    await m.pollOnce(provider: provider)
+
+    let recovered = await m.providerStatuses().first
+    #expect(recovered?.health == .ok)
+    #expect(recovered?.hasStaleSnapshot == false)
+    #expect(recovered?.lastSuccessfulSnapshotAt != nil)
+    if let firstSuccess, let recoveredAt = recovered?.lastSuccessfulSnapshotAt {
+      #expect(recoveredAt >= firstSuccess)
     }
+  }
 
-    @Test func authFailureMarksNeedsAuthAndSuccessClears() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(
-                exitCode: 4,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "login", "command": "acme-provider login"}}}"#.utf8),
-                stderr: ""),
-            providerOK(#"{"sessions": []}"#),
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-        await m.pollOnce(provider: provider)
-        var statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.remediationCommand == "acme-provider login")
-        await m.pollOnce(provider: provider)
-        statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .ok)
+  @Test func failureAfterManagerRestartRecoversLastSuccessTimeFromMirror() async throws {
+    let lastGood = Date(timeIntervalSince1970: 1_700_000_000)
+    _ = try await db.remoteSessions.applySnapshot(
+      provider: "fake",
+      sessions: [RemoteSessionPayload(id: "a", state: .running)],
+      now: lastGood)
+    let m = manager(
+      FakeProviderInvoker(script: [
+        ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
+      ]))
+
+    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+    let status = await m.providerStatuses().first
+    #expect(status?.health == .stale)
+    #expect(status?.lastSuccessfulSnapshotAt == lastGood)
+    #expect(status?.hasStaleSnapshot == true)
+  }
+
+  @Test func invokeByNameRoutesToConfiguredProvider() async throws {
+    // Only exercises verb routing, so it calls loadRegistryAndDescribe()
+    // (registry + describe, no poll loop) rather than start() — no
+    // background task exists, so the script needs exactly one describe
+    // result plus the invoked verb's result, in that exact order.
+    let invoker = FakeProviderInvoker(script: [
+      providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+      providerOK(#"{"ok": true}"#),
+    ])
+    let m = manager(invoker)
+    await m.loadRegistryAndDescribe()
+    _ = try await m.invoke(providerName: "fake", verb: ["stop", "a"], stdin: nil, timeout: 30)
+    #expect(invoker.calls == [["describe"], ["stop", "a"]])
+  }
+
+  @Test func invokeUnknownProviderThrows() async throws {
+    let m = manager(FakeProviderInvoker(script: []))
+    await #expect(throws: (any Error).self) {
+      _ = try await m.invoke(providerName: "nope", verb: ["list"], stdin: nil, timeout: 30)
     }
+  }
 
-    /// The error object's `code` adds precision the exit class lacks: a
-    /// provider that names `auth_expired` while exiting 1 must still land in
-    /// `needs_auth` WITH its remediation, not in the dead-end `error` state
-    /// exit 1 alone would produce.
-    @Test func nonFourExitCarryingAnAuthCodeStillLandsNeedsAuthWithRemediation() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(
-                exitCode: 1,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "credentials expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#.utf8),
-                stderr: ""),
-        ])
-        let m = manager(invoker)
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.errorMessage == "credentials expired")
-        #expect(statuses.first?.remediationLabel == "Sign in")
-        #expect(statuses.first?.remediationCommand == "acme-provider login")
+  @Test func repeatedIdenticalFailureBroadcastsHealthOnce() async throws {
+    let deltas = BroadcastDeltas()
+    subs.addSubscriber { data in
+      if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+        deltas.append(delta)
+      }
+      return true
     }
-
-    /// A non-auth `code` on a non-auth exit must NOT be widened into an auth
-    /// state — the union rule only covers the contract's auth codes.
-    @Test func nonAuthCodeOnExitOneStaysErrorNotNeedsAuth() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(
-                exitCode: 1,
-                stdout: Data(#"{"error": {"code": "credential_unresolvable", "message": "no such credential"}}"#.utf8),
-                stderr: ""),
-        ])
-        let m = manager(invoker)
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .error)
-        #expect(statuses.first?.errorMessage == "no such credential")
+    let invoker = FakeProviderInvoker(
+      script: Array(
+        repeating: ProviderResult(exitCode: 3, stdout: Data(), stderr: "flaky network"),
+        count: 4))
+    let m = manager(invoker)
+    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+    for _ in 0..<4 {
+      await m.pollOnce(provider: provider)
     }
-
-    // MARK: - attach-exit correlation
-
-    /// An auth-class `attach` exit (reported by the app, since the daemon
-    /// never spawns attach itself) marks the provider `needs_auth` and fires
-    /// exactly ONE out-of-band `list` — the authoritative probe that turns a
-    /// bare exit code into a message + remediation.
-    @Test func authAttachExitMarksNeedsAuthAndProbesOnce() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(
-                exitCode: 4,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#.utf8),
-                stderr: ""),
-        ])
-        let m = manager(invoker)
-        try await m.recordAttachExit(provider: "fake", exitCode: 4)
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.remediationCommand == "acme-provider login",
-                "the out-of-band probe is what turns an exit code into a remediation")
-        #expect(invoker.calls == [["list"]], "exactly one probe per health transition")
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .stale)
+    let healthBroadcasts = deltas.snapshot().filter {
+      if case .remoteSessionsChanged = $0 { return true }
+      return false
     }
+    #expect(
+      healthBroadcasts.count == 1,
+      "four identical failures must broadcast exactly once (ok→stale), not on every poll")
+  }
 
-    /// The other branch of the same gate: an attach exit arriving while the
-    /// provider is ALREADY `needs_auth` must not fire another probe (a
-    /// flapping session would otherwise turn into a poll flood), and must
-    /// preserve the remediation already on file rather than clobbering it
-    /// with the nothing an attach exit carries.
-    @Test func authAttachExitWhileAlreadyNeedsAuthPreservesRemediationAndDoesNotReprobe() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(
-                exitCode: 4,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#.utf8),
-                stderr: ""),
-        ])
-        let m = manager(invoker)
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-        #expect(invoker.calls == [["list"]])
+  @Test func describeExitFourRoutesThroughFailurePathWithRemediation() async throws {
+    // A provider that rejects credentials on its very first contact
+    // (describe itself, before any poll ever runs) must still surface
+    // needs_auth with remediation — describeProvider routes exit-4
+    // through the same recordFailure path pollOnce/invoke use, not a
+    // generic "couldn't parse describe" error.
+    let invoker = FakeProviderInvoker(script: [
+      ProviderResult(
+        exitCode: 4,
+        stdout: Data(
+          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "login", "command": "fake login"}}}"#
+            .utf8),
+        stderr: "")
+    ])
+    let m = manager(invoker)
+    await m.loadRegistryAndDescribe()
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .needsAuth)
+    #expect(statuses.first?.remediationLabel == "login")
+    #expect(statuses.first?.remediationCommand == "fake login")
+    #expect(invoker.calls == [["describe"]])
+  }
 
-        try await m.recordAttachExit(provider: "fake", exitCode: 4)
+  @Test func eventsCapabilityCreatesSupervisor() async throws {
+    // A provider whose `describe` declares the `events` capability must
+    // get a supervisor spawned for it alongside the always-on poll loop
+    // — the low-latency path is entirely gated on this string match, so
+    // a typo here would silently disable it for real providers.
+    let invoker = FakeProviderInvoker(script: [
+      providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": ["events"]}"#),
+      providerOK(#"{"sessions": []}"#),  // in case the 60s poll's first tick fires before teardown
+    ])
+    let m = manager(invoker)
+    await m.start()
+    #expect(
+      await m.hasSupervisor(named: "fake"),
+      "describe declaring the events capability must spawn a supervisor")
+    await m.stopAll()
+  }
 
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.errorMessage == "expired", "must not clobber a parsed message with nil")
-        #expect(statuses.first?.remediationCommand == "acme-provider login")
-        #expect(invoker.calls == [["list"]], "no second probe while already needs_auth")
+  @Test func noEventsCapabilityPollsWithoutSupervisor() async throws {
+    // The mirror-image branch: no `events` capability means no
+    // supervisor, but the 60s `list` poll fallback must still cover the
+    // provider (it's the universal floor, events-capable or not).
+    let invoker = FakeProviderInvoker(script: [
+      providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+      providerOK(#"{"sessions": []}"#),
+    ])
+    let m = manager(invoker)
+    await m.start()
+    #expect(
+      await !m.hasSupervisor(named: "fake"),
+      "describe without the events capability must not spawn a supervisor")
+
+    // The poll loop's first tick fires with no initial delay but runs on
+    // a background Task, so bound-poll for it rather than asserting
+    // immediately.
+    let deadline = Date().addingTimeInterval(2)
+    while Date() < deadline {
+      if invoker.callsSnapshot().contains(["list"]) { break }
+      try await Task.sleep(for: .milliseconds(10))
     }
+    #expect(
+      invoker.callsSnapshot().contains(["list"]),
+      "provider without events capability must still be covered by the 60s list poll; observed calls=\(invoker.callsSnapshot())"
+    )
+    await m.stopAll()
+  }
 
-    /// Non-auth attach exits are the app's business (reconnect backoff), not
-    /// provider health's: one flaky viewer must never speak for the whole
-    /// provider.
-    @Test func nonAuthAttachExitChangesNothing() async throws {
-        let invoker = FakeProviderInvoker(script: [])
-        let m = manager(invoker)
-        try await m.recordAttachExit(provider: "fake", exitCode: 1)
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .ok)
-        #expect(invoker.calls.isEmpty, "a transport-class attach exit must not trigger a probe")
-    }
-
-    /// Recovery: the poll loop keeps running while `needs_auth`, and the
-    /// first successful `list` clears the state — no user gesture, no
-    /// persisted flag.
-    @Test func successfulPollAfterAnAttachAuthExitClearsNeedsAuth() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),   // the probe confirms
-            providerOK(#"{"sessions": []}"#),                          // the next poll succeeds
-        ])
-        let m = manager(invoker)
-        try await m.recordAttachExit(provider: "fake", exitCode: 4)
-        #expect(await m.providerStatuses().first?.health == .needsAuth)
-
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-
-        #expect(await m.providerStatuses().first?.health == .ok)
-    }
-
-    /// Inheritance branch A — previous state IS `.needsAuth`, so the text on
-    /// file is carried across. `recordAttachExit` preserves the remediation
-    /// already on file, and the probe it fires must not undo that: a probe
-    /// whose `list` also exits 4 but returns nothing parseable supplies no
-    /// message/remediation of its own, and `recordFailure`'s auth branch
-    /// falls back to what's on file rather than clobbering it with nil.
-    @Test func aProbeWithUnparseableStdoutPreservesTheRemediationOnFile() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            // First poll parses a full error object → message + remediation.
-            ProviderResult(
-                exitCode: 4,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#.utf8),
-                stderr: ""),
-            // The attach-exit probe re-confirms auth-needed but says nothing.
-            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-        await m.pollOnce(provider: provider)
-        #expect(await m.providerStatuses().first?.remediationCommand == "acme-provider login")
-
-        // Health is already `.needsAuth`, so `recordAttachExit` fires no
-        // probe of its own — drive the probe-shaped call directly.
-        await m.pollOnce(provider: provider)
-
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.errorMessage == "expired", "an empty probe must not clobber the message on file")
-        #expect(statuses.first?.remediationCommand == "acme-provider login",
-                "an empty probe must not clobber the remediation on file")
-    }
-
-    /// Inheritance branch B — previous state is NOT `.needsAuth`, so nothing
-    /// is carried across. A transport failure leaves a message like
-    /// "connection timed out" on file under `.stale`; the auth failure that
-    /// follows must not relabel that sentence as the provider's
-    /// AUTHENTICATION explanation. With no parsed error of its own the CTA
-    /// falls back to the app's neutral copy, which is correct-but-vague
-    /// rather than confidently wrong.
-    @Test func anAuthFailureFromStaleDoesNotInheritTheTransportMessage() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            // Transient → .stale, message taken from stderr.
-            ProviderResult(exitCode: 3, stdout: Data(), stderr: "connection timed out"),
-            // Auth failure with nothing parseable in stdout.
-            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-        await m.pollOnce(provider: provider)
-        #expect(await m.providerStatuses().first?.errorMessage == "connection timed out")
-
-        await m.pollOnce(provider: provider)
-
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.errorMessage == nil,
-                "a transport message must not become the authentication explanation")
-        #expect(statuses.first?.remediationCommand == nil)
-    }
-
-    /// Same branch, entered from `.error` rather than `.stale` — the two
-    /// non-auth states reach the auth branch by different paths (permanent
-    /// vs transient classification), and neither may donate its text.
-    @Test func anAuthFailureFromErrorDoesNotInheritTheErrorMessage() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            // Permanent → .error, with a parsed message on file.
-            ProviderResult(
-                exitCode: 1,
-                stdout: Data(#"{"error": {"code": "credential_unresolvable", "message": "no such credential"}}"#.utf8),
-                stderr: ""),
-            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-        await m.pollOnce(provider: provider)
-        #expect(await m.providerStatuses().first?.health == .error)
-
-        await m.pollOnce(provider: provider)
-
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.errorMessage == nil,
-                "a provisioning error must not become the authentication explanation")
-        #expect(statuses.first?.remediationCommand == nil)
-    }
-
-    /// The same gate on the attach path, whose `setHealth` is itself a
-    /// transition into `.needsAuth`. Were it to carry the stale transport
-    /// text across, the probe it fires would then inherit that text back
-    /// through `recordFailure` (which now sees a previous state of
-    /// `.needsAuth`) and the wrong words would survive the fix anyway.
-    @Test func attachExitFromStaleDoesNotLaunderTheTransportMessageThroughTheProbe() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(exitCode: 3, stdout: Data(), stderr: "connection timed out"),
-            // The out-of-band probe re-confirms auth-needed but says nothing.
-            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
-        ])
-        let m = manager(invoker)
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-        #expect(await m.providerStatuses().first?.health == .stale)
-
-        try await m.recordAttachExit(provider: "fake", exitCode: 4)
-
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.errorMessage == nil,
-                "the transport message must not survive into the auth CTA via the probe")
-        #expect(statuses.first?.remediationCommand == nil)
-        #expect(invoker.calls == [["list"], ["list"]],
-                "the transition off .stale still fires exactly one probe")
-    }
-
-    /// The other branch of the same fallback: a newly parsed value always
-    /// wins over what's on file, so a provider that changes its remediation
-    /// mid-outage is reflected rather than pinned to the first one seen.
-    @Test func aFreshlyParsedRemediationWinsOverTheOneOnFile() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(
-                exitCode: 4,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#.utf8),
-                stderr: ""),
-            ProviderResult(
-                exitCode: 4,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "still expired", "remediation": {"label": "Sign in again", "command": "acme-provider login --renew"}}}"#.utf8),
-                stderr: ""),
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-        await m.pollOnce(provider: provider)
-        await m.pollOnce(provider: provider)
-
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.errorMessage == "still expired")
-        #expect(statuses.first?.remediationCommand == "acme-provider login --renew")
-    }
-
-    // MARK: - Health broadcasting
-
-    /// The payload of this whole feature reaches the app on a
-    /// `needs_auth → needs_auth` transition: `recordAttachExit` flips health
-    /// off a bare exit code carrying no message, and its probe is what lands
-    /// the parsed message + remediation. Broadcasting on the health STATE
-    /// alone dropped that second step silently, leaving the app on a
-    /// command-less fallback CTA for the whole outage (every later poll is
-    /// also needs_auth → needs_auth).
-    @Test func addingARemediationWithoutAStateChangeStillBroadcasts() async throws {
-        let deltas = BroadcastDeltas()
-        subs.addSubscriber { data in
-            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
-                deltas.append(delta)
-            }
-            return true
-        }
-        let withRemediation = ProviderResult(
-            exitCode: 4,
-            stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#.utf8),
-            stderr: "")
-        let invoker = FakeProviderInvoker(script: [
-            // ok → needs_auth, message only, no remediation.
-            ProviderResult(
-                exitCode: 4,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired"}}"#.utf8),
-                stderr: ""),
-            // needs_auth → needs_auth, ADDING a remediation.
-            withRemediation,
-            // needs_auth → needs_auth, identical in all three fields.
-            withRemediation,
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-
-        await m.pollOnce(provider: provider)
-        #expect(healthBroadcastCount(deltas) == 1, "ok → needs_auth broadcasts")
-
-        await m.pollOnce(provider: provider)
-        #expect(healthBroadcastCount(deltas) == 2,
-                "a remediation arriving on an already-needs_auth provider must reach the app")
-
-        await m.pollOnce(provider: provider)
-        #expect(healthBroadcastCount(deltas) == 2,
-                "a genuinely unchanged re-set must not broadcast (60s polls would flood the wire)")
-    }
-
-    private func healthBroadcastCount(_ deltas: BroadcastDeltas) -> Int {
-        deltas.snapshot().filter {
-            if case .remoteSessionsChanged = $0 { return true }
-            return false
-        }.count
-    }
-
-    @Test func attachExitForAnUnknownProviderThrows() async throws {
-        let m = manager(FakeProviderInvoker(script: []))
-        await #expect(throws: (any Error).self) {
-            try await m.recordAttachExit(provider: "nope", exitCode: 4)
-        }
-    }
-
-    @Test func transientFailureMarksStaleNotAuth() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(exitCode: 3, stdout: Data(), stderr: "flaky network")
-        ])
-        let m = manager(invoker)
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .stale)
-        // Stale poll must NOT touch the mirror (unreachable ≠ sessions dead).
-        let rows = try await db.remoteSessions.list()
-        #expect(rows.isEmpty)
-    }
-
-    /// Tier 1: in-memory GRDB and a scripted provider only.
-    @Test func structuredTransientPollPreservesTheLastSuccessfulSnapshot() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
-            ProviderResult(
-                exitCode: 3,
-                stdout: Data(
-                    #"{"error": {"code": "unreachable", "message": "provider transport overloaded", "retryable": true}}"#
-                        .utf8),
-                stderr: ""),
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-
-        await m.pollOnce(provider: provider)
-        let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
-        await m.pollOnce(provider: provider)
-
-        let rows = try await db.remoteSessions.list()
-        #expect(rows.map(\.sessionID) == ["a"])
-        #expect(rows.first?.decodedPayload?.state == .running)
-        #expect(rows.first?.gone == false)
-
-        let status = await m.providerStatuses().first
-        #expect(status?.health == .stale)
-        #expect(status?.errorMessage == "provider transport overloaded")
-        #expect(status?.lastSuccessfulSnapshotAt == firstSuccess)
-        #expect(status?.hasStaleSnapshot == true)
-        #expect(invoker.calls == [["list"], ["list"]])
-    }
-
-    @Test func truncatedInventoryErrorIsBoundedAndDoesNotExposeEmbeddedPayload() async throws {
-        let embedded = String(repeating: #"{"prompt":"sensitive"}"#, count: 100)
-        let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
-            ProviderResult(
-                exitCode: 2, stdout: Data(),
-                stderr: "unparseable remote output: \(embedded)--output truncated--")
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-        await m.pollOnce(provider: provider)
-        await m.pollOnce(provider: provider)
-
-        let message = await m.providerStatuses().first?.errorMessage
-        #expect(message == "Provider inventory was truncated or malformed; showing the last successful snapshot.")
-        #expect(message?.contains("sensitive") == false)
-    }
-
-    @Test func arbitraryProviderErrorIsCappedToTheWireLimit() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(exitCode: 3, stdout: Data(), stderr: String(repeating: "x", count: 1_000))
-        ])
-        let m = manager(invoker)
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-        let message = await m.providerStatuses().first?.errorMessage
-        #expect(message?.count == 240)
-        #expect(message?.hasSuffix("…") == true)
-    }
-
-    @Test func successfulInventoryAfterFailureRestoresFreshHealthAndAdvancesTimestamp() async throws {
-        let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
-            ProviderResult(exitCode: 3, stdout: Data(), stderr: "temporary"),
-            providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
-        ])
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-        await m.pollOnce(provider: provider)
-        let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
-        await m.pollOnce(provider: provider)
-        #expect(await m.hasStaleSnapshot(provider: "fake"))
-
-        await m.pollOnce(provider: provider)
-
-        let recovered = await m.providerStatuses().first
-        #expect(recovered?.health == .ok)
-        #expect(recovered?.hasStaleSnapshot == false)
-        #expect(recovered?.lastSuccessfulSnapshotAt != nil)
-        if let firstSuccess, let recoveredAt = recovered?.lastSuccessfulSnapshotAt {
-            #expect(recoveredAt >= firstSuccess)
-        }
-    }
-
-    @Test func failureAfterManagerRestartRecoversLastSuccessTimeFromMirror() async throws {
-        let lastGood = Date(timeIntervalSince1970: 1_700_000_000)
-        _ = try await db.remoteSessions.applySnapshot(
-            provider: "fake",
-            sessions: [RemoteSessionPayload(id: "a", state: .running)],
-            now: lastGood)
-        let m = manager(FakeProviderInvoker(script: [
-            ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
-        ]))
-
-        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-
-        let status = await m.providerStatuses().first
-        #expect(status?.health == .stale)
-        #expect(status?.lastSuccessfulSnapshotAt == lastGood)
-        #expect(status?.hasStaleSnapshot == true)
-    }
-
-    @Test func invokeByNameRoutesToConfiguredProvider() async throws {
-        // Only exercises verb routing, so it calls loadRegistryAndDescribe()
-        // (registry + describe, no poll loop) rather than start() — no
-        // background task exists, so the script needs exactly one describe
-        // result plus the invoked verb's result, in that exact order.
-        let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
-            providerOK(#"{"ok": true}"#),
-        ])
-        let m = manager(invoker)
-        await m.loadRegistryAndDescribe()
-        _ = try await m.invoke(providerName: "fake", verb: ["stop", "a"], stdin: nil, timeout: 30)
-        #expect(invoker.calls == [["describe"], ["stop", "a"]])
-    }
-
-    @Test func invokeUnknownProviderThrows() async throws {
-        let m = manager(FakeProviderInvoker(script: []))
-        await #expect(throws: (any Error).self) {
-            _ = try await m.invoke(providerName: "nope", verb: ["list"], stdin: nil, timeout: 30)
-        }
-    }
-
-    @Test func repeatedIdenticalFailureBroadcastsHealthOnce() async throws {
-        let deltas = BroadcastDeltas()
-        subs.addSubscriber { data in
-            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
-                deltas.append(delta)
-            }
-            return true
-        }
-        let invoker = FakeProviderInvoker(script: Array(
-            repeating: ProviderResult(exitCode: 3, stdout: Data(), stderr: "flaky network"),
-            count: 4))
-        let m = manager(invoker)
-        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-        for _ in 0..<4 {
-            await m.pollOnce(provider: provider)
-        }
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .stale)
-        let healthBroadcasts = deltas.snapshot().filter {
-            if case .remoteSessionsChanged = $0 { return true }
-            return false
-        }
-        #expect(healthBroadcasts.count == 1,
-                "four identical failures must broadcast exactly once (ok→stale), not on every poll")
-    }
-
-    @Test func describeExitFourRoutesThroughFailurePathWithRemediation() async throws {
-        // A provider that rejects credentials on its very first contact
-        // (describe itself, before any poll ever runs) must still surface
-        // needs_auth with remediation — describeProvider routes exit-4
-        // through the same recordFailure path pollOnce/invoke use, not a
-        // generic "couldn't parse describe" error.
-        let invoker = FakeProviderInvoker(script: [
-            ProviderResult(
-                exitCode: 4,
-                stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "login", "command": "fake login"}}}"#.utf8),
-                stderr: ""),
-        ])
-        let m = manager(invoker)
-        await m.loadRegistryAndDescribe()
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .needsAuth)
-        #expect(statuses.first?.remediationLabel == "login")
-        #expect(statuses.first?.remediationCommand == "fake login")
-        #expect(invoker.calls == [["describe"]])
-    }
-
-    @Test func eventsCapabilityCreatesSupervisor() async throws {
-        // A provider whose `describe` declares the `events` capability must
-        // get a supervisor spawned for it alongside the always-on poll loop
-        // — the low-latency path is entirely gated on this string match, so
-        // a typo here would silently disable it for real providers.
-        let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": ["events"]}"#),
-            providerOK(#"{"sessions": []}"#),   // in case the 60s poll's first tick fires before teardown
-        ])
-        let m = manager(invoker)
-        await m.start()
-        #expect(await m.hasSupervisor(named: "fake"),
-                "describe declaring the events capability must spawn a supervisor")
-        await m.stopAll()
-    }
-
-    @Test func noEventsCapabilityPollsWithoutSupervisor() async throws {
-        // The mirror-image branch: no `events` capability means no
-        // supervisor, but the 60s `list` poll fallback must still cover the
-        // provider (it's the universal floor, events-capable or not).
-        let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
-            providerOK(#"{"sessions": []}"#),
-        ])
-        let m = manager(invoker)
-        await m.start()
-        #expect(await !m.hasSupervisor(named: "fake"),
-                "describe without the events capability must not spawn a supervisor")
-
-        // The poll loop's first tick fires with no initial delay but runs on
-        // a background Task, so bound-poll for it rather than asserting
-        // immediately.
-        let deadline = Date().addingTimeInterval(2)
-        while Date() < deadline {
-            if invoker.callsSnapshot().contains(["list"]) { break }
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        #expect(invoker.callsSnapshot().contains(["list"]),
-                "provider without events capability must still be covered by the 60s list poll; observed calls=\(invoker.callsSnapshot())")
-        await m.stopAll()
-    }
-
-    @Test func versionMismatchNeverPolls() async throws {
-        // describe negotiates no common contract version (provider only
-        // speaks v2) — start() must surface a health error and must never
-        // spawn a poll loop for this provider, so no `list` call is ever
-        // recorded, not even after start() returns and would otherwise have
-        // spawned loops for every successfully-described provider.
-        let invoker = FakeProviderInvoker(script: [
-            providerOK(#"{"contract_versions": [2], "name": "fake"}"#)
-        ])
-        let m = manager(invoker)
-        await m.start()
-        let statuses = await m.providerStatuses()
-        #expect(statuses.first?.health == .error)
-        #expect(statuses.first?.errorMessage == "no common contract version")
-        #expect(invoker.calls == [["describe"]])
-    }
+  @Test func versionMismatchNeverPolls() async throws {
+    // describe negotiates no common contract version (provider only
+    // speaks v2) — start() must surface a health error and must never
+    // spawn a poll loop for this provider, so no `list` call is ever
+    // recorded, not even after start() returns and would otherwise have
+    // spawned loops for every successfully-described provider.
+    let invoker = FakeProviderInvoker(script: [
+      providerOK(#"{"contract_versions": [2], "name": "fake"}"#)
+    ])
+    let m = manager(invoker)
+    await m.start()
+    let statuses = await m.providerStatuses()
+    #expect(statuses.first?.health == .error)
+    #expect(statuses.first?.errorMessage == "no common contract version")
+    #expect(invoker.calls == [["describe"]])
+  }
 }

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -608,6 +608,64 @@ struct RemoteProviderManagerTests {
         }
     }
 
+    /// Tier 1. An unreadable freshness row must gate mutations, because the
+    /// daemon cannot prove the cached mirror was never authoritative. Contrast
+    /// `eventUpsertCannotMasqueradeAsFullSnapshotAfterRestart`, where the read
+    /// SUCCEEDS and returns "never" — that is positive knowledge and is allowed
+    /// to fail open. Dropping `tbd_meta` makes the SELECT throw, which is the
+    /// only way to reach the catch branch through the real store.
+    @Test func unreadableFreshnessStateGatesMutationsInsteadOfFailingOpen() async throws {
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake",
+            sessions: [RemoteSessionPayload(id: "a", state: .running)],
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: "DROP TABLE tbd_meta")
+        }
+        let m = manager(
+            FakeProviderInvoker(script: [
+                ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
+            ]))
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        #expect(await m.hasStaleSnapshot(provider: "fake"))
+        let status = await m.providerStatuses().first
+        #expect(status?.health == .stale)
+        // No timestamp is claimed — the daemon must not invent an age it
+        // could not read.
+        #expect(status?.lastSuccessfulSnapshotAt == nil)
+    }
+
+    /// Tier 1. The unreadable state is not sticky: it is a cache of one failed
+    /// read, so a later successful snapshot must clear the gate rather than
+    /// wedging the provider until daemon restart.
+    @Test func unreadableFreshnessStateClearsOnceASnapshotSucceeds() async throws {
+        try await db.writerForTests.write { conn in
+            try conn.execute(sql: "DROP TABLE tbd_meta")
+        }
+        let m = manager(
+            FakeProviderInvoker(script: [
+                ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
+            ]))
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        #expect(await m.hasStaleSnapshot(provider: "fake"))
+
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: "CREATE TABLE tbd_meta (key TEXT PRIMARY KEY NOT NULL, value TEXT NOT NULL)")
+        }
+        try await m.apply(
+            snapshot: [RemoteSessionPayload(id: "a", state: .running)],
+            provider: "fake",
+            now: Date(timeIntervalSince1970: 1_700_000_500))
+
+        #expect(await m.hasStaleSnapshot(provider: "fake") == false)
+        let status = await m.providerStatuses().first
+        #expect(status?.health == .ok)
+        #expect(status?.lastSuccessfulSnapshotAt == Date(timeIntervalSince1970: 1_700_000_500))
+    }
+
     @Test func failureAfterManagerRestartRecoversLastSuccessTimeFromMirror() async throws {
         let lastGood = Date(timeIntervalSince1970: 1_700_000_000)
         _ = try await db.remoteSessions.applySnapshot(

--- a/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
+++ b/Tests/TBDDaemonTests/RemoteProviderManagerTests.swift
@@ -8,797 +8,797 @@ import Testing
 /// `ProviderResult` or a simulated provider timeout. Not `private` for the
 /// same reason `FakeProviderInvoker` isn't.
 enum FakeProviderOutcome: Sendable {
-  case result(ProviderResult)
-  /// Throws `ProviderRunError.timeout(verb:)` for this call — scripts the
-  /// create-retry path (RPCRouterRemoteTests), which needs the FIRST
-  /// invocation to time out and the SECOND to succeed with the SAME stdin.
-  case timeout
+    case result(ProviderResult)
+    /// Throws `ProviderRunError.timeout(verb:)` for this call — scripts the
+    /// create-retry path (RPCRouterRemoteTests), which needs the FIRST
+    /// invocation to time out and the SECOND to succeed with the SAME stdin.
+    case timeout
 }
 
 /// Scriptable fake provider: each verb invocation pops the next canned
 /// outcome. Intentionally NOT `private` — a later task's RPC-handler tests
 /// reuse this against the same `RemoteProviderInvoking` protocol.
 final class FakeProviderInvoker: RemoteProviderInvoking, @unchecked Sendable {
-  private let lock = NSLock()
-  private var script: [FakeProviderOutcome]
-  private(set) var calls: [[String]] = []
-  /// stdin bytes for each call, same index as `calls`. `nil` entries are
-  /// calls made with no stdin (e.g. `stop`/`log`).
-  private(set) var stdins: [Data?] = []
+    private let lock = NSLock()
+    private var script: [FakeProviderOutcome]
+    private(set) var calls: [[String]] = []
+    /// stdin bytes for each call, same index as `calls`. `nil` entries are
+    /// calls made with no stdin (e.g. `stop`/`log`).
+    private(set) var stdins: [Data?] = []
 
-  init(script: [ProviderResult]) {
-    self.script = script.map { .result($0) }
-  }
-
-  /// Scriptable with timeouts interleaved among results.
-  init(outcomes: [FakeProviderOutcome]) {
-    self.script = outcomes
-  }
-
-  func run(
-    _ config: RemoteProviderConfig, verb: [String], stdin: Data?,
-    timeout: TimeInterval
-  ) async throws -> ProviderResult {
-    try popScript(verb, stdin: stdin)
-  }
-
-  /// Synchronous helper so the NSLock critical section isn't taken from an
-  /// `async` context (recent Foundation marks `NSLock.lock`/`unlock` as
-  /// unavailable from async contexts to discourage blocking there).
-  private func popScript(_ verb: [String], stdin: Data?) throws -> ProviderResult {
-    lock.lock()
-    defer { lock.unlock() }
-    calls.append(verb)
-    stdins.append(stdin)
-    precondition(!script.isEmpty, "FakeProviderInvoker script exhausted for verb \(verb)")
-    switch script.removeFirst() {
-    case .result(let result):
-      return result
-    case .timeout:
-      throw ProviderRunError.timeout(verb: verb.first ?? "?")
+    init(script: [ProviderResult]) {
+        self.script = script.map { .result($0) }
     }
-  }
 
-  /// Locked snapshot of `calls`, for tests that read it while a manager's
-  /// background poll `Task` may still be writing (the plain `calls`
-  /// getter is fine only when nothing concurrent is running).
-  func callsSnapshot() -> [[String]] {
-    lock.lock()
-    defer { lock.unlock() }
-    return calls
-  }
+    /// Scriptable with timeouts interleaved among results.
+    init(outcomes: [FakeProviderOutcome]) {
+        self.script = outcomes
+    }
 
-  /// Locked snapshot of `stdins`, same rationale as `callsSnapshot()`.
-  func stdinsSnapshot() -> [Data?] {
-    lock.lock()
-    defer { lock.unlock() }
-    return stdins
-  }
+    func run(
+        _ config: RemoteProviderConfig, verb: [String], stdin: Data?,
+        timeout: TimeInterval
+    ) async throws -> ProviderResult {
+        try popScript(verb, stdin: stdin)
+    }
+
+    /// Synchronous helper so the NSLock critical section isn't taken from an
+    /// `async` context (recent Foundation marks `NSLock.lock`/`unlock` as
+    /// unavailable from async contexts to discourage blocking there).
+    private func popScript(_ verb: [String], stdin: Data?) throws -> ProviderResult {
+        lock.lock()
+        defer { lock.unlock() }
+        calls.append(verb)
+        stdins.append(stdin)
+        precondition(!script.isEmpty, "FakeProviderInvoker script exhausted for verb \(verb)")
+        switch script.removeFirst() {
+        case .result(let result):
+            return result
+        case .timeout:
+            throw ProviderRunError.timeout(verb: verb.first ?? "?")
+        }
+    }
+
+    /// Locked snapshot of `calls`, for tests that read it while a manager's
+    /// background poll `Task` may still be writing (the plain `calls`
+    /// getter is fine only when nothing concurrent is running).
+    func callsSnapshot() -> [[String]] {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    /// Locked snapshot of `stdins`, same rationale as `callsSnapshot()`.
+    func stdinsSnapshot() -> [Data?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return stdins
+    }
 }
 
 /// Not `private` — reused by later provider-RPC tests in this target.
 func providerOK(_ json: String) -> ProviderResult {
-  ProviderResult(exitCode: 0, stdout: Data(json.utf8), stderr: "")
+    ProviderResult(exitCode: 0, stdout: Data(json.utf8), stderr: "")
 }
 
 /// Thread-safe collector for broadcast StateDeltas, mirroring the pattern in
 /// `RPCRouterWorktreeCreateBroadcastTests` / `GCHandlersTests`.
 private final class BroadcastDeltas: @unchecked Sendable {
-  private let lock = NSLock()
-  private var deltas: [StateDelta] = []
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
 
-  func append(_ delta: StateDelta) {
-    lock.lock()
-    defer { lock.unlock() }
-    deltas.append(delta)
-  }
+    func append(_ delta: StateDelta) {
+        lock.lock()
+        defer { lock.unlock() }
+        deltas.append(delta)
+    }
 
-  func snapshot() -> [StateDelta] {
-    lock.lock()
-    defer { lock.unlock() }
-    return deltas
-  }
+    func snapshot() -> [StateDelta] {
+        lock.lock()
+        defer { lock.unlock() }
+        return deltas
+    }
 }
 
 @Suite("RemoteProviderManager")
 struct RemoteProviderManagerTests {
-  let db: TBDDatabase
-  let subs: StateSubscriptionManager
-  let registryURL: URL
+    let db: TBDDatabase
+    let subs: StateSubscriptionManager
+    let registryURL: URL
 
-  init() throws {
-    db = try TBDDatabase(inMemory: true)
-    subs = StateSubscriptionManager()
-    let dir = FileManager.default.temporaryDirectory
-      .appendingPathComponent("rpm-tests-\(UUID().uuidString)")
-    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    registryURL = dir.appendingPathComponent("agent-providers.json")
-    try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
-      .write(to: registryURL, atomically: true, encoding: .utf8)
-  }
-
-  private func manager(_ invoker: FakeProviderInvoker) -> RemoteProviderManager {
-    RemoteProviderManager(db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
-  }
-
-  @Test func pollOnceAppliesSnapshotToMirror() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#)
-    ])
-    let m = manager(invoker)
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-    let rows = try await db.remoteSessions.list()
-    #expect(rows.map(\.sessionID) == ["a"])
-    #expect(invoker.calls == [["list"]])
-    let status = await m.providerStatuses().first
-    #expect(status?.health == .ok)
-    #expect(status?.lastSuccessfulSnapshotAt != nil)
-  }
-
-  @Test func authFailureMarksNeedsAuthAndSuccessClears() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(
-        exitCode: 4,
-        stdout: Data(
-          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "login", "command": "acme-provider login"}}}"#
-            .utf8),
-        stderr: ""),
-      providerOK(#"{"sessions": []}"#),
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-    await m.pollOnce(provider: provider)
-    var statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(statuses.first?.remediationCommand == "acme-provider login")
-    await m.pollOnce(provider: provider)
-    statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .ok)
-  }
-
-  /// The error object's `code` adds precision the exit class lacks: a
-  /// provider that names `auth_expired` while exiting 1 must still land in
-  /// `needs_auth` WITH its remediation, not in the dead-end `error` state
-  /// exit 1 alone would produce.
-  @Test func nonFourExitCarryingAnAuthCodeStillLandsNeedsAuthWithRemediation() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(
-        exitCode: 1,
-        stdout: Data(
-          #"{"error": {"code": "auth_expired", "message": "credentials expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
-            .utf8),
-        stderr: "")
-    ])
-    let m = manager(invoker)
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(statuses.first?.errorMessage == "credentials expired")
-    #expect(statuses.first?.remediationLabel == "Sign in")
-    #expect(statuses.first?.remediationCommand == "acme-provider login")
-  }
-
-  /// A non-auth `code` on a non-auth exit must NOT be widened into an auth
-  /// state — the union rule only covers the contract's auth codes.
-  @Test func nonAuthCodeOnExitOneStaysErrorNotNeedsAuth() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(
-        exitCode: 1,
-        stdout: Data(
-          #"{"error": {"code": "credential_unresolvable", "message": "no such credential"}}"#.utf8),
-        stderr: "")
-    ])
-    let m = manager(invoker)
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .error)
-    #expect(statuses.first?.errorMessage == "no such credential")
-  }
-
-  // MARK: - attach-exit correlation
-
-  /// An auth-class `attach` exit (reported by the app, since the daemon
-  /// never spawns attach itself) marks the provider `needs_auth` and fires
-  /// exactly ONE out-of-band `list` — the authoritative probe that turns a
-  /// bare exit code into a message + remediation.
-  @Test func authAttachExitMarksNeedsAuthAndProbesOnce() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(
-        exitCode: 4,
-        stdout: Data(
-          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
-            .utf8),
-        stderr: "")
-    ])
-    let m = manager(invoker)
-    try await m.recordAttachExit(provider: "fake", exitCode: 4)
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(
-      statuses.first?.remediationCommand == "acme-provider login",
-      "the out-of-band probe is what turns an exit code into a remediation")
-    #expect(invoker.calls == [["list"]], "exactly one probe per health transition")
-  }
-
-  /// The other branch of the same gate: an attach exit arriving while the
-  /// provider is ALREADY `needs_auth` must not fire another probe (a
-  /// flapping session would otherwise turn into a poll flood), and must
-  /// preserve the remediation already on file rather than clobbering it
-  /// with the nothing an attach exit carries.
-  @Test func authAttachExitWhileAlreadyNeedsAuthPreservesRemediationAndDoesNotReprobe() async throws
-  {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(
-        exitCode: 4,
-        stdout: Data(
-          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
-            .utf8),
-        stderr: "")
-    ])
-    let m = manager(invoker)
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-    #expect(invoker.calls == [["list"]])
-
-    try await m.recordAttachExit(provider: "fake", exitCode: 4)
-
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(statuses.first?.errorMessage == "expired", "must not clobber a parsed message with nil")
-    #expect(statuses.first?.remediationCommand == "acme-provider login")
-    #expect(invoker.calls == [["list"]], "no second probe while already needs_auth")
-  }
-
-  /// Non-auth attach exits are the app's business (reconnect backoff), not
-  /// provider health's: one flaky viewer must never speak for the whole
-  /// provider.
-  @Test func nonAuthAttachExitChangesNothing() async throws {
-    let invoker = FakeProviderInvoker(script: [])
-    let m = manager(invoker)
-    try await m.recordAttachExit(provider: "fake", exitCode: 1)
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .ok)
-    #expect(invoker.calls.isEmpty, "a transport-class attach exit must not trigger a probe")
-  }
-
-  /// Recovery: the poll loop keeps running while `needs_auth`, and the
-  /// first successful `list` clears the state — no user gesture, no
-  /// persisted flag.
-  @Test func successfulPollAfterAnAttachAuthExitClearsNeedsAuth() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),  // the probe confirms
-      providerOK(#"{"sessions": []}"#),  // the next poll succeeds
-    ])
-    let m = manager(invoker)
-    try await m.recordAttachExit(provider: "fake", exitCode: 4)
-    #expect(await m.providerStatuses().first?.health == .needsAuth)
-
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-
-    #expect(await m.providerStatuses().first?.health == .ok)
-  }
-
-  /// Inheritance branch A — previous state IS `.needsAuth`, so the text on
-  /// file is carried across. `recordAttachExit` preserves the remediation
-  /// already on file, and the probe it fires must not undo that: a probe
-  /// whose `list` also exits 4 but returns nothing parseable supplies no
-  /// message/remediation of its own, and `recordFailure`'s auth branch
-  /// falls back to what's on file rather than clobbering it with nil.
-  @Test func aProbeWithUnparseableStdoutPreservesTheRemediationOnFile() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      // First poll parses a full error object → message + remediation.
-      ProviderResult(
-        exitCode: 4,
-        stdout: Data(
-          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
-            .utf8),
-        stderr: ""),
-      // The attach-exit probe re-confirms auth-needed but says nothing.
-      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-    await m.pollOnce(provider: provider)
-    #expect(await m.providerStatuses().first?.remediationCommand == "acme-provider login")
-
-    // Health is already `.needsAuth`, so `recordAttachExit` fires no
-    // probe of its own — drive the probe-shaped call directly.
-    await m.pollOnce(provider: provider)
-
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(
-      statuses.first?.errorMessage == "expired",
-      "an empty probe must not clobber the message on file")
-    #expect(
-      statuses.first?.remediationCommand == "acme-provider login",
-      "an empty probe must not clobber the remediation on file")
-  }
-
-  /// Inheritance branch B — previous state is NOT `.needsAuth`, so nothing
-  /// is carried across. A transport failure leaves a message like
-  /// "connection timed out" on file under `.stale`; the auth failure that
-  /// follows must not relabel that sentence as the provider's
-  /// AUTHENTICATION explanation. With no parsed error of its own the CTA
-  /// falls back to the app's neutral copy, which is correct-but-vague
-  /// rather than confidently wrong.
-  @Test func anAuthFailureFromStaleDoesNotInheritTheTransportMessage() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      // Transient → .stale, message taken from stderr.
-      ProviderResult(exitCode: 3, stdout: Data(), stderr: "connection timed out"),
-      // Auth failure with nothing parseable in stdout.
-      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-    await m.pollOnce(provider: provider)
-    #expect(await m.providerStatuses().first?.errorMessage == "connection timed out")
-
-    await m.pollOnce(provider: provider)
-
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(
-      statuses.first?.errorMessage == nil,
-      "a transport message must not become the authentication explanation")
-    #expect(statuses.first?.remediationCommand == nil)
-  }
-
-  /// Same branch, entered from `.error` rather than `.stale` — the two
-  /// non-auth states reach the auth branch by different paths (permanent
-  /// vs transient classification), and neither may donate its text.
-  @Test func anAuthFailureFromErrorDoesNotInheritTheErrorMessage() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      // Permanent → .error, with a parsed message on file.
-      ProviderResult(
-        exitCode: 1,
-        stdout: Data(
-          #"{"error": {"code": "credential_unresolvable", "message": "no such credential"}}"#.utf8),
-        stderr: ""),
-      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-    await m.pollOnce(provider: provider)
-    #expect(await m.providerStatuses().first?.health == .error)
-
-    await m.pollOnce(provider: provider)
-
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(
-      statuses.first?.errorMessage == nil,
-      "a provisioning error must not become the authentication explanation")
-    #expect(statuses.first?.remediationCommand == nil)
-  }
-
-  /// The same gate on the attach path, whose `setHealth` is itself a
-  /// transition into `.needsAuth`. Were it to carry the stale transport
-  /// text across, the probe it fires would then inherit that text back
-  /// through `recordFailure` (which now sees a previous state of
-  /// `.needsAuth`) and the wrong words would survive the fix anyway.
-  @Test func attachExitFromStaleDoesNotLaunderTheTransportMessageThroughTheProbe() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(exitCode: 3, stdout: Data(), stderr: "connection timed out"),
-      // The out-of-band probe re-confirms auth-needed but says nothing.
-      ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
-    ])
-    let m = manager(invoker)
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-    #expect(await m.providerStatuses().first?.health == .stale)
-
-    try await m.recordAttachExit(provider: "fake", exitCode: 4)
-
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(
-      statuses.first?.errorMessage == nil,
-      "the transport message must not survive into the auth CTA via the probe")
-    #expect(statuses.first?.remediationCommand == nil)
-    #expect(
-      invoker.calls == [["list"], ["list"]],
-      "the transition off .stale still fires exactly one probe")
-  }
-
-  /// The other branch of the same fallback: a newly parsed value always
-  /// wins over what's on file, so a provider that changes its remediation
-  /// mid-outage is reflected rather than pinned to the first one seen.
-  @Test func aFreshlyParsedRemediationWinsOverTheOneOnFile() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(
-        exitCode: 4,
-        stdout: Data(
-          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
-            .utf8),
-        stderr: ""),
-      ProviderResult(
-        exitCode: 4,
-        stdout: Data(
-          #"{"error": {"code": "auth_expired", "message": "still expired", "remediation": {"label": "Sign in again", "command": "acme-provider login --renew"}}}"#
-            .utf8),
-        stderr: ""),
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-    await m.pollOnce(provider: provider)
-    await m.pollOnce(provider: provider)
-
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.errorMessage == "still expired")
-    #expect(statuses.first?.remediationCommand == "acme-provider login --renew")
-  }
-
-  // MARK: - Health broadcasting
-
-  /// The payload of this whole feature reaches the app on a
-  /// `needs_auth → needs_auth` transition: `recordAttachExit` flips health
-  /// off a bare exit code carrying no message, and its probe is what lands
-  /// the parsed message + remediation. Broadcasting on the health STATE
-  /// alone dropped that second step silently, leaving the app on a
-  /// command-less fallback CTA for the whole outage (every later poll is
-  /// also needs_auth → needs_auth).
-  @Test func addingARemediationWithoutAStateChangeStillBroadcasts() async throws {
-    let deltas = BroadcastDeltas()
-    subs.addSubscriber { data in
-      if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
-        deltas.append(delta)
-      }
-      return true
+    init() throws {
+        db = try TBDDatabase(inMemory: true)
+        subs = StateSubscriptionManager()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rpm-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        registryURL = dir.appendingPathComponent("agent-providers.json")
+        try #"[{"name": "fake", "exec": "/nonexistent/fake"}]"#
+            .write(to: registryURL, atomically: true, encoding: .utf8)
     }
-    let withRemediation = ProviderResult(
-      exitCode: 4,
-      stdout: Data(
-        #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
-          .utf8),
-      stderr: "")
-    let invoker = FakeProviderInvoker(script: [
-      // ok → needs_auth, message only, no remediation.
-      ProviderResult(
-        exitCode: 4,
-        stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired"}}"#.utf8),
-        stderr: ""),
-      // needs_auth → needs_auth, ADDING a remediation.
-      withRemediation,
-      // needs_auth → needs_auth, identical in all three fields.
-      withRemediation,
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
 
-    await m.pollOnce(provider: provider)
-    #expect(healthBroadcastCount(deltas) == 1, "ok → needs_auth broadcasts")
-
-    await m.pollOnce(provider: provider)
-    #expect(
-      healthBroadcastCount(deltas) == 2,
-      "a remediation arriving on an already-needs_auth provider must reach the app")
-
-    await m.pollOnce(provider: provider)
-    #expect(
-      healthBroadcastCount(deltas) == 2,
-      "a genuinely unchanged re-set must not broadcast (60s polls would flood the wire)")
-  }
-
-  private func healthBroadcastCount(_ deltas: BroadcastDeltas) -> Int {
-    deltas.snapshot().filter {
-      if case .remoteSessionsChanged = $0 { return true }
-      return false
-    }.count
-  }
-
-  @Test func attachExitForAnUnknownProviderThrows() async throws {
-    let m = manager(FakeProviderInvoker(script: []))
-    await #expect(throws: (any Error).self) {
-      try await m.recordAttachExit(provider: "nope", exitCode: 4)
+    private func manager(_ invoker: FakeProviderInvoker) -> RemoteProviderManager {
+        RemoteProviderManager(db: db, subscriptions: subs, runner: invoker, registryURL: registryURL)
     }
-  }
 
-  @Test func transientFailureMarksStaleNotAuth() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(exitCode: 3, stdout: Data(), stderr: "flaky network")
-    ])
-    let m = manager(invoker)
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .stale)
-    // Stale poll must NOT touch the mirror (unreachable ≠ sessions dead).
-    let rows = try await db.remoteSessions.list()
-    #expect(rows.isEmpty)
-  }
-
-  /// Tier 1: in-memory GRDB and a scripted provider only.
-  @Test func structuredTransientPollPreservesTheLastSuccessfulSnapshot() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
-      ProviderResult(
-        exitCode: 3,
-        stdout: Data(
-          #"{"error": {"code": "unreachable", "message": "provider transport overloaded", "retryable": true}}"#
-            .utf8),
-        stderr: ""),
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-
-    await m.pollOnce(provider: provider)
-    let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
-    await m.pollOnce(provider: provider)
-
-    let rows = try await db.remoteSessions.list()
-    #expect(rows.map(\.sessionID) == ["a"])
-    #expect(rows.first?.decodedPayload?.state == .running)
-    #expect(rows.first?.gone == false)
-
-    let status = await m.providerStatuses().first
-    #expect(status?.health == .stale)
-    #expect(status?.errorMessage == "provider transport overloaded")
-    #expect(status?.lastSuccessfulSnapshotAt == firstSuccess)
-    #expect(status?.hasStaleSnapshot == true)
-    #expect(invoker.calls == [["list"], ["list"]])
-  }
-
-  @Test func truncatedInventoryErrorIsBoundedAndDoesNotExposeEmbeddedPayload() async throws {
-    let embedded = String(repeating: #"{"prompt":"sensitive"}"#, count: 100)
-    let invoker = FakeProviderInvoker(script: [
-      providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
-      ProviderResult(
-        exitCode: 2, stdout: Data(),
-        stderr: "unparseable remote output: \(embedded)--output truncated--"),
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-    await m.pollOnce(provider: provider)
-    await m.pollOnce(provider: provider)
-
-    let message = await m.providerStatuses().first?.errorMessage
-    #expect(
-      message
-        == "Provider inventory was truncated or malformed; showing the last successful snapshot.")
-    #expect(message?.contains("sensitive") == false)
-  }
-
-  @Test func firstTruncatedInventoryIsHonestWithoutSnapshot() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(
-        exitCode: 2, stdout: Data(),
-        stderr: "unparseable remote output: private--output truncated--")
-    ])
-    let m = manager(invoker)
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-
-    let message = await m.providerStatuses().first?.errorMessage
-    #expect(
-      message
-        == "Provider inventory was truncated or malformed; no successful snapshot is available yet."
-    )
-    #expect(message?.contains("private") == false)
-  }
-
-  @Test func arbitraryProviderErrorIsCappedToTheWireLimit() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(exitCode: 3, stdout: Data(), stderr: String(repeating: "x", count: 1_000))
-    ])
-    let m = manager(invoker)
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-    let message = await m.providerStatuses().first?.errorMessage
-    #expect(message?.count == 240)
-    #expect(message?.hasSuffix("…") == true)
-  }
-
-  @Test func successfulInventoryAfterFailureRestoresFreshHealthAndAdvancesTimestamp() async throws {
-    let invoker = FakeProviderInvoker(script: [
-      providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
-      ProviderResult(exitCode: 3, stdout: Data(), stderr: "temporary"),
-      providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
-    ])
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-    await m.pollOnce(provider: provider)
-    let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
-    await m.pollOnce(provider: provider)
-    #expect(await m.hasStaleSnapshot(provider: "fake"))
-
-    await m.pollOnce(provider: provider)
-
-    let recovered = await m.providerStatuses().first
-    #expect(recovered?.health == .ok)
-    #expect(recovered?.hasStaleSnapshot == false)
-    #expect(recovered?.lastSuccessfulSnapshotAt != nil)
-    if let firstSuccess, let recoveredAt = recovered?.lastSuccessfulSnapshotAt {
-      #expect(recoveredAt >= firstSuccess)
+    @Test func pollOnceAppliesSnapshotToMirror() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#)
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.map(\.sessionID) == ["a"])
+        #expect(invoker.calls == [["list"]])
+        let status = await m.providerStatuses().first
+        #expect(status?.health == .ok)
+        #expect(status?.lastSuccessfulSnapshotAt != nil)
     }
-  }
 
-  @Test func failureAfterManagerRestartRecoversLastSuccessTimeFromMirror() async throws {
-    let lastGood = Date(timeIntervalSince1970: 1_700_000_000)
-    _ = try await db.remoteSessions.applySnapshot(
-      provider: "fake",
-      sessions: [RemoteSessionPayload(id: "a", state: .running)],
-      now: lastGood)
-    let m = manager(
-      FakeProviderInvoker(script: [
-        ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
-      ]))
-
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-
-    let status = await m.providerStatuses().first
-    #expect(status?.health == .stale)
-    #expect(status?.lastSuccessfulSnapshotAt == lastGood)
-    #expect(status?.hasStaleSnapshot == true)
-  }
-
-  @Test func restartHydratesAndGatesBeforeTheInitialProviderPoll() async throws {
-    let lastGood = Date(timeIntervalSince1970: 1_700_000_123)
-    _ = try await db.remoteSessions.applySnapshot(
-      provider: "fake",
-      sessions: [RemoteSessionPayload(id: "a", state: .running)],
-      now: lastGood)
-    let invoker = FakeProviderInvoker(script: [])
-    let m = manager(invoker)
-
-    // Do not call start() or pollOnce(). RPC is deliberately available
-    // before either can finish during daemon boot.
-    let status = await m.providerStatuses().first
-
-    #expect(status?.health == .stale)
-    #expect(status?.lastSuccessfulSnapshotAt == lastGood)
-    #expect(status?.hasStaleSnapshot == true)
-    #expect(await m.hasStaleSnapshot(provider: "fake"))
-    #expect(invoker.callsSnapshot().isEmpty)
-  }
-
-  @Test func eventUpsertCannotMasqueradeAsFullSnapshotAfterRestart() async throws {
-    let eventTime = Date(timeIntervalSince1970: 1_800_000_000)
-    _ = try await db.remoteSessions.upsertOne(
-      provider: "fake",
-      session: RemoteSessionPayload(id: "event-only", state: .running),
-      now: eventTime)
-    let m = manager(
-      FakeProviderInvoker(script: [
-        ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
-      ]))
-
-    await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
-
-    let status = await m.providerStatuses().first
-    #expect(status?.health == .stale)
-    #expect(status?.lastSuccessfulSnapshotAt == nil)
-    #expect(status?.hasStaleSnapshot == false)
-  }
-
-  @Test func invokeByNameRoutesToConfiguredProvider() async throws {
-    // Only exercises verb routing, so it calls loadRegistryAndDescribe()
-    // (registry + describe, no poll loop) rather than start() — no
-    // background task exists, so the script needs exactly one describe
-    // result plus the invoked verb's result, in that exact order.
-    let invoker = FakeProviderInvoker(script: [
-      providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
-      providerOK(#"{"ok": true}"#),
-    ])
-    let m = manager(invoker)
-    await m.loadRegistryAndDescribe()
-    _ = try await m.invoke(providerName: "fake", verb: ["stop", "a"], stdin: nil, timeout: 30)
-    #expect(invoker.calls == [["describe"], ["stop", "a"]])
-  }
-
-  @Test func invokeUnknownProviderThrows() async throws {
-    let m = manager(FakeProviderInvoker(script: []))
-    await #expect(throws: (any Error).self) {
-      _ = try await m.invoke(providerName: "nope", verb: ["list"], stdin: nil, timeout: 30)
+    @Test func authFailureMarksNeedsAuthAndSuccessClears() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 4,
+                stdout: Data(
+                    #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "login", "command": "acme-provider login"}}}"#
+                        .utf8),
+                stderr: ""),
+            providerOK(#"{"sessions": []}"#),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        var statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(statuses.first?.remediationCommand == "acme-provider login")
+        await m.pollOnce(provider: provider)
+        statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .ok)
     }
-  }
 
-  @Test func repeatedIdenticalFailureBroadcastsHealthOnce() async throws {
-    let deltas = BroadcastDeltas()
-    subs.addSubscriber { data in
-      if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
-        deltas.append(delta)
-      }
-      return true
+    /// The error object's `code` adds precision the exit class lacks: a
+    /// provider that names `auth_expired` while exiting 1 must still land in
+    /// `needs_auth` WITH its remediation, not in the dead-end `error` state
+    /// exit 1 alone would produce.
+    @Test func nonFourExitCarryingAnAuthCodeStillLandsNeedsAuthWithRemediation() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 1,
+                stdout: Data(
+                    #"{"error": {"code": "auth_expired", "message": "credentials expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+                        .utf8),
+                stderr: "")
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(statuses.first?.errorMessage == "credentials expired")
+        #expect(statuses.first?.remediationLabel == "Sign in")
+        #expect(statuses.first?.remediationCommand == "acme-provider login")
     }
-    let invoker = FakeProviderInvoker(
-      script: Array(
-        repeating: ProviderResult(exitCode: 3, stdout: Data(), stderr: "flaky network"),
-        count: 4))
-    let m = manager(invoker)
-    let provider = RemoteProviderConfig(name: "fake", exec: "/x")
-    for _ in 0..<4 {
-      await m.pollOnce(provider: provider)
+
+    /// A non-auth `code` on a non-auth exit must NOT be widened into an auth
+    /// state — the union rule only covers the contract's auth codes.
+    @Test func nonAuthCodeOnExitOneStaysErrorNotNeedsAuth() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 1,
+                stdout: Data(
+                    #"{"error": {"code": "credential_unresolvable", "message": "no such credential"}}"#.utf8),
+                stderr: "")
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .error)
+        #expect(statuses.first?.errorMessage == "no such credential")
     }
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .stale)
-    let healthBroadcasts = deltas.snapshot().filter {
-      if case .remoteSessionsChanged = $0 { return true }
-      return false
+
+    // MARK: - attach-exit correlation
+
+    /// An auth-class `attach` exit (reported by the app, since the daemon
+    /// never spawns attach itself) marks the provider `needs_auth` and fires
+    /// exactly ONE out-of-band `list` — the authoritative probe that turns a
+    /// bare exit code into a message + remediation.
+    @Test func authAttachExitMarksNeedsAuthAndProbesOnce() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 4,
+                stdout: Data(
+                    #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+                        .utf8),
+                stderr: "")
+        ])
+        let m = manager(invoker)
+        try await m.recordAttachExit(provider: "fake", exitCode: 4)
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(
+            statuses.first?.remediationCommand == "acme-provider login",
+            "the out-of-band probe is what turns an exit code into a remediation")
+        #expect(invoker.calls == [["list"]], "exactly one probe per health transition")
     }
-    #expect(
-      healthBroadcasts.count == 1,
-      "four identical failures must broadcast exactly once (ok→stale), not on every poll")
-  }
 
-  @Test func describeExitFourRoutesThroughFailurePathWithRemediation() async throws {
-    // A provider that rejects credentials on its very first contact
-    // (describe itself, before any poll ever runs) must still surface
-    // needs_auth with remediation — describeProvider routes exit-4
-    // through the same recordFailure path pollOnce/invoke use, not a
-    // generic "couldn't parse describe" error.
-    let invoker = FakeProviderInvoker(script: [
-      ProviderResult(
-        exitCode: 4,
-        stdout: Data(
-          #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "login", "command": "fake login"}}}"#
-            .utf8),
-        stderr: "")
-    ])
-    let m = manager(invoker)
-    await m.loadRegistryAndDescribe()
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .needsAuth)
-    #expect(statuses.first?.remediationLabel == "login")
-    #expect(statuses.first?.remediationCommand == "fake login")
-    #expect(invoker.calls == [["describe"]])
-  }
+    /// The other branch of the same gate: an attach exit arriving while the
+    /// provider is ALREADY `needs_auth` must not fire another probe (a
+    /// flapping session would otherwise turn into a poll flood), and must
+    /// preserve the remediation already on file rather than clobbering it
+    /// with the nothing an attach exit carries.
+    @Test func authAttachExitWhileAlreadyNeedsAuthPreservesRemediationAndDoesNotReprobe() async throws
+    {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 4,
+                stdout: Data(
+                    #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+                        .utf8),
+                stderr: "")
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        #expect(invoker.calls == [["list"]])
 
-  @Test func eventsCapabilityCreatesSupervisor() async throws {
-    // A provider whose `describe` declares the `events` capability must
-    // get a supervisor spawned for it alongside the always-on poll loop
-    // — the low-latency path is entirely gated on this string match, so
-    // a typo here would silently disable it for real providers.
-    let invoker = FakeProviderInvoker(script: [
-      providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": ["events"]}"#),
-      providerOK(#"{"sessions": []}"#),  // in case the 60s poll's first tick fires before teardown
-    ])
-    let m = manager(invoker)
-    await m.start()
-    #expect(
-      await m.hasSupervisor(named: "fake"),
-      "describe declaring the events capability must spawn a supervisor")
-    await m.stopAll()
-  }
+        try await m.recordAttachExit(provider: "fake", exitCode: 4)
 
-  @Test func noEventsCapabilityPollsWithoutSupervisor() async throws {
-    // The mirror-image branch: no `events` capability means no
-    // supervisor, but the 60s `list` poll fallback must still cover the
-    // provider (it's the universal floor, events-capable or not).
-    let invoker = FakeProviderInvoker(script: [
-      providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
-      providerOK(#"{"sessions": []}"#),
-    ])
-    let m = manager(invoker)
-    await m.start()
-    #expect(
-      await !m.hasSupervisor(named: "fake"),
-      "describe without the events capability must not spawn a supervisor")
-
-    // The poll loop's first tick fires with no initial delay but runs on
-    // a background Task, so bound-poll for it rather than asserting
-    // immediately.
-    let deadline = Date().addingTimeInterval(2)
-    while Date() < deadline {
-      if invoker.callsSnapshot().contains(["list"]) { break }
-      try await Task.sleep(for: .milliseconds(10))
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(statuses.first?.errorMessage == "expired", "must not clobber a parsed message with nil")
+        #expect(statuses.first?.remediationCommand == "acme-provider login")
+        #expect(invoker.calls == [["list"]], "no second probe while already needs_auth")
     }
-    #expect(
-      invoker.callsSnapshot().contains(["list"]),
-      "provider without events capability must still be covered by the 60s list poll; observed calls=\(invoker.callsSnapshot())"
-    )
-    await m.stopAll()
-  }
 
-  @Test func versionMismatchNeverPolls() async throws {
-    // describe negotiates no common contract version (provider only
-    // speaks v2) — start() must surface a health error and must never
-    // spawn a poll loop for this provider, so no `list` call is ever
-    // recorded, not even after start() returns and would otherwise have
-    // spawned loops for every successfully-described provider.
-    let invoker = FakeProviderInvoker(script: [
-      providerOK(#"{"contract_versions": [2], "name": "fake"}"#)
-    ])
-    let m = manager(invoker)
-    await m.start()
-    let statuses = await m.providerStatuses()
-    #expect(statuses.first?.health == .error)
-    #expect(statuses.first?.errorMessage == "no common contract version")
-    #expect(invoker.calls == [["describe"]])
-  }
+    /// Non-auth attach exits are the app's business (reconnect backoff), not
+    /// provider health's: one flaky viewer must never speak for the whole
+    /// provider.
+    @Test func nonAuthAttachExitChangesNothing() async throws {
+        let invoker = FakeProviderInvoker(script: [])
+        let m = manager(invoker)
+        try await m.recordAttachExit(provider: "fake", exitCode: 1)
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .ok)
+        #expect(invoker.calls.isEmpty, "a transport-class attach exit must not trigger a probe")
+    }
+
+    /// Recovery: the poll loop keeps running while `needs_auth`, and the
+    /// first successful `list` clears the state — no user gesture, no
+    /// persisted flag.
+    @Test func successfulPollAfterAnAttachAuthExitClearsNeedsAuth() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),  // the probe confirms
+            providerOK(#"{"sessions": []}"#),  // the next poll succeeds
+        ])
+        let m = manager(invoker)
+        try await m.recordAttachExit(provider: "fake", exitCode: 4)
+        #expect(await m.providerStatuses().first?.health == .needsAuth)
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        #expect(await m.providerStatuses().first?.health == .ok)
+    }
+
+    /// Inheritance branch A — previous state IS `.needsAuth`, so the text on
+    /// file is carried across. `recordAttachExit` preserves the remediation
+    /// already on file, and the probe it fires must not undo that: a probe
+    /// whose `list` also exits 4 but returns nothing parseable supplies no
+    /// message/remediation of its own, and `recordFailure`'s auth branch
+    /// falls back to what's on file rather than clobbering it with nil.
+    @Test func aProbeWithUnparseableStdoutPreservesTheRemediationOnFile() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            // First poll parses a full error object → message + remediation.
+            ProviderResult(
+                exitCode: 4,
+                stdout: Data(
+                    #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+                        .utf8),
+                stderr: ""),
+            // The attach-exit probe re-confirms auth-needed but says nothing.
+            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        #expect(await m.providerStatuses().first?.remediationCommand == "acme-provider login")
+
+        // Health is already `.needsAuth`, so `recordAttachExit` fires no
+        // probe of its own — drive the probe-shaped call directly.
+        await m.pollOnce(provider: provider)
+
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(
+            statuses.first?.errorMessage == "expired",
+            "an empty probe must not clobber the message on file")
+        #expect(
+            statuses.first?.remediationCommand == "acme-provider login",
+            "an empty probe must not clobber the remediation on file")
+    }
+
+    /// Inheritance branch B — previous state is NOT `.needsAuth`, so nothing
+    /// is carried across. A transport failure leaves a message like
+    /// "connection timed out" on file under `.stale`; the auth failure that
+    /// follows must not relabel that sentence as the provider's
+    /// AUTHENTICATION explanation. With no parsed error of its own the CTA
+    /// falls back to the app's neutral copy, which is correct-but-vague
+    /// rather than confidently wrong.
+    @Test func anAuthFailureFromStaleDoesNotInheritTheTransportMessage() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            // Transient → .stale, message taken from stderr.
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "connection timed out"),
+            // Auth failure with nothing parseable in stdout.
+            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        #expect(await m.providerStatuses().first?.errorMessage == "connection timed out")
+
+        await m.pollOnce(provider: provider)
+
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(
+            statuses.first?.errorMessage == nil,
+            "a transport message must not become the authentication explanation")
+        #expect(statuses.first?.remediationCommand == nil)
+    }
+
+    /// Same branch, entered from `.error` rather than `.stale` — the two
+    /// non-auth states reach the auth branch by different paths (permanent
+    /// vs transient classification), and neither may donate its text.
+    @Test func anAuthFailureFromErrorDoesNotInheritTheErrorMessage() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            // Permanent → .error, with a parsed message on file.
+            ProviderResult(
+                exitCode: 1,
+                stdout: Data(
+                    #"{"error": {"code": "credential_unresolvable", "message": "no such credential"}}"#.utf8),
+                stderr: ""),
+            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        #expect(await m.providerStatuses().first?.health == .error)
+
+        await m.pollOnce(provider: provider)
+
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(
+            statuses.first?.errorMessage == nil,
+            "a provisioning error must not become the authentication explanation")
+        #expect(statuses.first?.remediationCommand == nil)
+    }
+
+    /// The same gate on the attach path, whose `setHealth` is itself a
+    /// transition into `.needsAuth`. Were it to carry the stale transport
+    /// text across, the probe it fires would then inherit that text back
+    /// through `recordFailure` (which now sees a previous state of
+    /// `.needsAuth`) and the wrong words would survive the fix anyway.
+    @Test func attachExitFromStaleDoesNotLaunderTheTransportMessageThroughTheProbe() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "connection timed out"),
+            // The out-of-band probe re-confirms auth-needed but says nothing.
+            ProviderResult(exitCode: 4, stdout: Data(), stderr: ""),
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        #expect(await m.providerStatuses().first?.health == .stale)
+
+        try await m.recordAttachExit(provider: "fake", exitCode: 4)
+
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(
+            statuses.first?.errorMessage == nil,
+            "the transport message must not survive into the auth CTA via the probe")
+        #expect(statuses.first?.remediationCommand == nil)
+        #expect(
+            invoker.calls == [["list"], ["list"]],
+            "the transition off .stale still fires exactly one probe")
+    }
+
+    /// The other branch of the same fallback: a newly parsed value always
+    /// wins over what's on file, so a provider that changes its remediation
+    /// mid-outage is reflected rather than pinned to the first one seen.
+    @Test func aFreshlyParsedRemediationWinsOverTheOneOnFile() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 4,
+                stdout: Data(
+                    #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+                        .utf8),
+                stderr: ""),
+            ProviderResult(
+                exitCode: 4,
+                stdout: Data(
+                    #"{"error": {"code": "auth_expired", "message": "still expired", "remediation": {"label": "Sign in again", "command": "acme-provider login --renew"}}}"#
+                        .utf8),
+                stderr: ""),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        await m.pollOnce(provider: provider)
+
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.errorMessage == "still expired")
+        #expect(statuses.first?.remediationCommand == "acme-provider login --renew")
+    }
+
+    // MARK: - Health broadcasting
+
+    /// The payload of this whole feature reaches the app on a
+    /// `needs_auth → needs_auth` transition: `recordAttachExit` flips health
+    /// off a bare exit code carrying no message, and its probe is what lands
+    /// the parsed message + remediation. Broadcasting on the health STATE
+    /// alone dropped that second step silently, leaving the app on a
+    /// command-less fallback CTA for the whole outage (every later poll is
+    /// also needs_auth → needs_auth).
+    @Test func addingARemediationWithoutAStateChangeStillBroadcasts() async throws {
+        let deltas = BroadcastDeltas()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let withRemediation = ProviderResult(
+            exitCode: 4,
+            stdout: Data(
+                #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "Sign in", "command": "acme-provider login"}}}"#
+                    .utf8),
+            stderr: "")
+        let invoker = FakeProviderInvoker(script: [
+            // ok → needs_auth, message only, no remediation.
+            ProviderResult(
+                exitCode: 4,
+                stdout: Data(#"{"error": {"code": "auth_expired", "message": "expired"}}"#.utf8),
+                stderr: ""),
+            // needs_auth → needs_auth, ADDING a remediation.
+            withRemediation,
+            // needs_auth → needs_auth, identical in all three fields.
+            withRemediation,
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+
+        await m.pollOnce(provider: provider)
+        #expect(healthBroadcastCount(deltas) == 1, "ok → needs_auth broadcasts")
+
+        await m.pollOnce(provider: provider)
+        #expect(
+            healthBroadcastCount(deltas) == 2,
+            "a remediation arriving on an already-needs_auth provider must reach the app")
+
+        await m.pollOnce(provider: provider)
+        #expect(
+            healthBroadcastCount(deltas) == 2,
+            "a genuinely unchanged re-set must not broadcast (60s polls would flood the wire)")
+    }
+
+    private func healthBroadcastCount(_ deltas: BroadcastDeltas) -> Int {
+        deltas.snapshot().filter {
+            if case .remoteSessionsChanged = $0 { return true }
+            return false
+        }.count
+    }
+
+    @Test func attachExitForAnUnknownProviderThrows() async throws {
+        let m = manager(FakeProviderInvoker(script: []))
+        await #expect(throws: (any Error).self) {
+            try await m.recordAttachExit(provider: "nope", exitCode: 4)
+        }
+    }
+
+    @Test func transientFailureMarksStaleNotAuth() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "flaky network")
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .stale)
+        // Stale poll must NOT touch the mirror (unreachable ≠ sessions dead).
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.isEmpty)
+    }
+
+    /// Tier 1: in-memory GRDB and a scripted provider only.
+    @Test func structuredTransientPollPreservesTheLastSuccessfulSnapshot() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
+            ProviderResult(
+                exitCode: 3,
+                stdout: Data(
+                    #"{"error": {"code": "unreachable", "message": "provider transport overloaded", "retryable": true}}"#
+                        .utf8),
+                stderr: ""),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+
+        await m.pollOnce(provider: provider)
+        let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
+        await m.pollOnce(provider: provider)
+
+        let rows = try await db.remoteSessions.list()
+        #expect(rows.map(\.sessionID) == ["a"])
+        #expect(rows.first?.decodedPayload?.state == .running)
+        #expect(rows.first?.gone == false)
+
+        let status = await m.providerStatuses().first
+        #expect(status?.health == .stale)
+        #expect(status?.errorMessage == "provider transport overloaded")
+        #expect(status?.lastSuccessfulSnapshotAt == firstSuccess)
+        #expect(status?.hasStaleSnapshot == true)
+        #expect(invoker.calls == [["list"], ["list"]])
+    }
+
+    @Test func truncatedInventoryErrorIsBoundedAndDoesNotExposeEmbeddedPayload() async throws {
+        let embedded = String(repeating: #"{"prompt":"sensitive"}"#, count: 100)
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
+            ProviderResult(
+                exitCode: 2, stdout: Data(),
+                stderr: "unparseable remote output: \(embedded)--output truncated--"),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        await m.pollOnce(provider: provider)
+
+        let message = await m.providerStatuses().first?.errorMessage
+        #expect(
+            message
+                == "Provider inventory was truncated or malformed; showing the last successful snapshot.")
+        #expect(message?.contains("sensitive") == false)
+    }
+
+    @Test func firstTruncatedInventoryIsHonestWithoutSnapshot() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 2, stdout: Data(),
+                stderr: "unparseable remote output: private--output truncated--")
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        let message = await m.providerStatuses().first?.errorMessage
+        #expect(
+            message
+                == "Provider inventory was truncated or malformed; no successful snapshot is available yet."
+        )
+        #expect(message?.contains("private") == false)
+    }
+
+    @Test func arbitraryProviderErrorIsCappedToTheWireLimit() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: String(repeating: "x", count: 1_000))
+        ])
+        let m = manager(invoker)
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+        let message = await m.providerStatuses().first?.errorMessage
+        #expect(message?.count == 240)
+        #expect(message?.hasSuffix("…") == true)
+    }
+
+    @Test func successfulInventoryAfterFailureRestoresFreshHealthAndAdvancesTimestamp() async throws {
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"sessions": [{"id": "a", "state": "running"}]}"#),
+            ProviderResult(exitCode: 3, stdout: Data(), stderr: "temporary"),
+            providerOK(#"{"sessions": [{"id": "a", "state": "running", "agent_state": "working"}]}"#),
+        ])
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        await m.pollOnce(provider: provider)
+        let firstSuccess = await m.providerStatuses().first?.lastSuccessfulSnapshotAt
+        await m.pollOnce(provider: provider)
+        #expect(await m.hasStaleSnapshot(provider: "fake"))
+
+        await m.pollOnce(provider: provider)
+
+        let recovered = await m.providerStatuses().first
+        #expect(recovered?.health == .ok)
+        #expect(recovered?.hasStaleSnapshot == false)
+        #expect(recovered?.lastSuccessfulSnapshotAt != nil)
+        if let firstSuccess, let recoveredAt = recovered?.lastSuccessfulSnapshotAt {
+            #expect(recoveredAt >= firstSuccess)
+        }
+    }
+
+    @Test func failureAfterManagerRestartRecoversLastSuccessTimeFromMirror() async throws {
+        let lastGood = Date(timeIntervalSince1970: 1_700_000_000)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake",
+            sessions: [RemoteSessionPayload(id: "a", state: .running)],
+            now: lastGood)
+        let m = manager(
+            FakeProviderInvoker(script: [
+                ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
+            ]))
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        let status = await m.providerStatuses().first
+        #expect(status?.health == .stale)
+        #expect(status?.lastSuccessfulSnapshotAt == lastGood)
+        #expect(status?.hasStaleSnapshot == true)
+    }
+
+    @Test func restartHydratesAndGatesBeforeTheInitialProviderPoll() async throws {
+        let lastGood = Date(timeIntervalSince1970: 1_700_000_123)
+        _ = try await db.remoteSessions.applySnapshot(
+            provider: "fake",
+            sessions: [RemoteSessionPayload(id: "a", state: .running)],
+            now: lastGood)
+        let invoker = FakeProviderInvoker(script: [])
+        let m = manager(invoker)
+
+        // Do not call start() or pollOnce(). RPC is deliberately available
+        // before either can finish during daemon boot.
+        let status = await m.providerStatuses().first
+
+        #expect(status?.health == .stale)
+        #expect(status?.lastSuccessfulSnapshotAt == lastGood)
+        #expect(status?.hasStaleSnapshot == true)
+        #expect(await m.hasStaleSnapshot(provider: "fake"))
+        #expect(invoker.callsSnapshot().isEmpty)
+    }
+
+    @Test func eventUpsertCannotMasqueradeAsFullSnapshotAfterRestart() async throws {
+        let eventTime = Date(timeIntervalSince1970: 1_800_000_000)
+        _ = try await db.remoteSessions.upsertOne(
+            provider: "fake",
+            session: RemoteSessionPayload(id: "event-only", state: .running),
+            now: eventTime)
+        let m = manager(
+            FakeProviderInvoker(script: [
+                ProviderResult(exitCode: 3, stdout: Data(), stderr: "offline")
+            ]))
+
+        await m.pollOnce(provider: RemoteProviderConfig(name: "fake", exec: "/x"))
+
+        let status = await m.providerStatuses().first
+        #expect(status?.health == .stale)
+        #expect(status?.lastSuccessfulSnapshotAt == nil)
+        #expect(status?.hasStaleSnapshot == false)
+    }
+
+    @Test func invokeByNameRoutesToConfiguredProvider() async throws {
+        // Only exercises verb routing, so it calls loadRegistryAndDescribe()
+        // (registry + describe, no poll loop) rather than start() — no
+        // background task exists, so the script needs exactly one describe
+        // result plus the invoked verb's result, in that exact order.
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            providerOK(#"{"ok": true}"#),
+        ])
+        let m = manager(invoker)
+        await m.loadRegistryAndDescribe()
+        _ = try await m.invoke(providerName: "fake", verb: ["stop", "a"], stdin: nil, timeout: 30)
+        #expect(invoker.calls == [["describe"], ["stop", "a"]])
+    }
+
+    @Test func invokeUnknownProviderThrows() async throws {
+        let m = manager(FakeProviderInvoker(script: []))
+        await #expect(throws: (any Error).self) {
+            _ = try await m.invoke(providerName: "nope", verb: ["list"], stdin: nil, timeout: 30)
+        }
+    }
+
+    @Test func repeatedIdenticalFailureBroadcastsHealthOnce() async throws {
+        let deltas = BroadcastDeltas()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        let invoker = FakeProviderInvoker(
+            script: Array(
+                repeating: ProviderResult(exitCode: 3, stdout: Data(), stderr: "flaky network"),
+                count: 4))
+        let m = manager(invoker)
+        let provider = RemoteProviderConfig(name: "fake", exec: "/x")
+        for _ in 0..<4 {
+            await m.pollOnce(provider: provider)
+        }
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .stale)
+        let healthBroadcasts = deltas.snapshot().filter {
+            if case .remoteSessionsChanged = $0 { return true }
+            return false
+        }
+        #expect(
+            healthBroadcasts.count == 1,
+            "four identical failures must broadcast exactly once (ok→stale), not on every poll")
+    }
+
+    @Test func describeExitFourRoutesThroughFailurePathWithRemediation() async throws {
+        // A provider that rejects credentials on its very first contact
+        // (describe itself, before any poll ever runs) must still surface
+        // needs_auth with remediation — describeProvider routes exit-4
+        // through the same recordFailure path pollOnce/invoke use, not a
+        // generic "couldn't parse describe" error.
+        let invoker = FakeProviderInvoker(script: [
+            ProviderResult(
+                exitCode: 4,
+                stdout: Data(
+                    #"{"error": {"code": "auth_expired", "message": "expired", "remediation": {"label": "login", "command": "fake login"}}}"#
+                        .utf8),
+                stderr: "")
+        ])
+        let m = manager(invoker)
+        await m.loadRegistryAndDescribe()
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .needsAuth)
+        #expect(statuses.first?.remediationLabel == "login")
+        #expect(statuses.first?.remediationCommand == "fake login")
+        #expect(invoker.calls == [["describe"]])
+    }
+
+    @Test func eventsCapabilityCreatesSupervisor() async throws {
+        // A provider whose `describe` declares the `events` capability must
+        // get a supervisor spawned for it alongside the always-on poll loop
+        // — the low-latency path is entirely gated on this string match, so
+        // a typo here would silently disable it for real providers.
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"contract_versions": [1], "name": "fake", "capabilities": ["events"]}"#),
+            providerOK(#"{"sessions": []}"#),  // in case the 60s poll's first tick fires before teardown
+        ])
+        let m = manager(invoker)
+        await m.start()
+        #expect(
+            await m.hasSupervisor(named: "fake"),
+            "describe declaring the events capability must spawn a supervisor")
+        await m.stopAll()
+    }
+
+    @Test func noEventsCapabilityPollsWithoutSupervisor() async throws {
+        // The mirror-image branch: no `events` capability means no
+        // supervisor, but the 60s `list` poll fallback must still cover the
+        // provider (it's the universal floor, events-capable or not).
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"contract_versions": [1], "name": "fake"}"#),
+            providerOK(#"{"sessions": []}"#),
+        ])
+        let m = manager(invoker)
+        await m.start()
+        #expect(
+            await !m.hasSupervisor(named: "fake"),
+            "describe without the events capability must not spawn a supervisor")
+
+        // The poll loop's first tick fires with no initial delay but runs on
+        // a background Task, so bound-poll for it rather than asserting
+        // immediately.
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            if invoker.callsSnapshot().contains(["list"]) { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(
+            invoker.callsSnapshot().contains(["list"]),
+            "provider without events capability must still be covered by the 60s list poll; observed calls=\(invoker.callsSnapshot())"
+        )
+        await m.stopAll()
+    }
+
+    @Test func versionMismatchNeverPolls() async throws {
+        // describe negotiates no common contract version (provider only
+        // speaks v2) — start() must surface a health error and must never
+        // spawn a poll loop for this provider, so no `list` call is ever
+        // recorded, not even after start() returns and would otherwise have
+        // spawned loops for every successfully-described provider.
+        let invoker = FakeProviderInvoker(script: [
+            providerOK(#"{"contract_versions": [2], "name": "fake"}"#)
+        ])
+        let m = manager(invoker)
+        await m.start()
+        let statuses = await m.providerStatuses()
+        #expect(statuses.first?.health == .error)
+        #expect(statuses.first?.errorMessage == "no common contract version")
+        #expect(invoker.calls == [["describe"]])
+    }
 }

--- a/Tests/TBDSharedTests/RemoteProviderTests.swift
+++ b/Tests/TBDSharedTests/RemoteProviderTests.swift
@@ -221,6 +221,43 @@ struct RemoteProviderTests {
         #expect(decoded.pinnedAt == pinnedAt)
     }
 
+    // MARK: - RemoteProviderStatus — freshnessUnreadable wire defaults
+
+    /// A status payload from a daemon predating the field must decode as
+    /// "readable", not fail. `RemoteProviderStatus` hand-writes `init(from:)`
+    /// precisely because Swift's synthesized one ignores property defaults.
+    @Test func providerStatusDecodesWhenFreshnessUnreadableIsAbsent() throws {
+        let json = """
+        {"config": {"name": "acme", "exec": "/x"}, "health": "stale",
+         "errorMessage": "inventory unavailable"}
+        """.data(using: .utf8)!
+        let status = try JSONDecoder().decode(RemoteProviderStatus.self, from: json)
+        #expect(status.freshnessUnreadable == false)
+        // No snapshot on file and not unreadable — nothing cached to
+        // misrepresent, so this must not gate.
+        #expect(status.hasStaleSnapshot == false)
+    }
+
+    @Test func providerStatusRoundTripsFreshnessUnreadable() throws {
+        let status = RemoteProviderStatus(
+            config: RemoteProviderConfig(name: "acme", exec: "/x"), describe: nil,
+            health: .stale, errorMessage: nil, remediationLabel: nil, remediationCommand: nil,
+            lastSuccessfulSnapshotAt: nil, freshnessUnreadable: true)
+        let decoded = try JSONDecoder().decode(
+            RemoteProviderStatus.self, from: try JSONEncoder().encode(status))
+        #expect(decoded.freshnessUnreadable)
+        // An unreadable freshness row gates even with no timestamp on file.
+        #expect(decoded.hasStaleSnapshot)
+    }
+
+    /// The gate is about cached rows being misrepresented, so a HEALTHY
+    /// provider never gates regardless of how the freshness row read.
+    @Test func providerStatusHealthyNeverCountsAsStaleSnapshot() throws {
+        #expect(
+            RemoteProviderStatus.isStaleSnapshot(
+                health: .ok, lastSuccessfulSnapshotAt: Date(), freshnessUnreadable: true) == false)
+    }
+
     @Test func setPinParamsRoundTrip() throws {
         let params = RemoteSetPinParams(provider: "acme", sessionID: "s1", pinned: true)
         let decoded = try JSONDecoder().decode(

--- a/Tests/TBDSharedTests/RemoteProviderTests.swift
+++ b/Tests/TBDSharedTests/RemoteProviderTests.swift
@@ -32,6 +32,32 @@ struct RemoteProviderTests {
         #expect(s.agentState == .unknown)
     }
 
+    @Test func staleProjectionDemotesActiveStateWithoutMutatingTheSnapshot() {
+        let original = RemoteSessionPayload(
+            id: "x", title: "worker", state: .running,
+            agentState: .working, agentStateReason: "tool")
+        let projected = original.projectedForStaleSnapshot()
+
+        #expect(projected.state == .unknown)
+        #expect(projected.agentState == .unknown)
+        #expect(projected.agentStateReason == nil)
+        #expect(original.state == .running)
+        #expect(original.agentState == .working)
+    }
+
+    @Test func staleProjectionPreservesAConfirmedExit() {
+        let exited = RemoteSessionPayload(
+            id: "x", state: .exited, exitCode: 0, agentState: .exited)
+        #expect(exited.projectedForStaleSnapshot() == exited)
+    }
+
+    @Test func providerStatusWithoutNewTimestampStillDecodes() throws {
+        let json = #"{"config":{"name":"acme","exec":"/x"},"health":"ok"}"#.data(using: .utf8)!
+        let status = try JSONDecoder().decode(RemoteProviderStatus.self, from: json)
+        #expect(status.lastSuccessfulSnapshotAt == nil)
+        #expect(status.hasStaleSnapshot == false)
+    }
+
     @Test func describeDecodesCreateParams() throws {
         let json = """
         {"contract_versions": [1], "name": "example", "provider_version": "0.1.0",

--- a/docs/specs/2026-08-01-agentbox-stale-snapshot-design.md
+++ b/docs/specs/2026-08-01-agentbox-stale-snapshot-design.md
@@ -1,0 +1,50 @@
+# Agent Box stale-snapshot visibility
+
+## Problem
+
+TBD persists the last successful remote-session inventory so users can still
+inspect and attach to known sessions after a provider error. Before this
+change, a failed full-list refresh left those cached rows looking live and
+kept inventory-dependent mutations enabled. An AWS/SSM output truncation could
+therefore make a healthy Agent Box feel broken while TBD presented stale state
+with false confidence.
+
+## Decision
+
+The provider manager owns one inventory-health boundary. Every successful full
+snapshot records its time. After a later full-list failure, persisted active
+rows are projected as unknown and the provider status includes the last
+successful snapshot time. A daemon restart recovers that time from the newest
+persisted `lastSeen` value before publishing degraded health.
+
+While a previously successful inventory is stale, TBD keeps read-only and
+recovery actions available: Attach, Log, Copy, and Pin. It blocks Create, Stop,
+Send, and Rename in both the app and daemon RPC layer because each mutation
+depends on inventory state that TBD can no longer verify. A first-ever provider
+failure has no cached snapshot to misrepresent and retains the prior behavior.
+
+Successful non-list verbs do not clear inventory degradation; only a complete
+full-list refresh can re-establish authoritative state. Provider errors shown
+in the UI are bounded and redact the known oversized/truncated payload shape.
+
+## Boundaries
+
+- No provider protocol, credential, or Agent Box host changes.
+- No automatic retry, restart, stop, or other remote mutation.
+- No TUI screen scraping.
+- Cached rows remain attachable because provider session IDs are still useful
+  even when their liveness is unknown.
+- The daemon gate is authoritative; app disabling is explanatory defense in
+  depth.
+
+## Verification
+
+- A healthy snapshot followed by a list failure demotes cached active rows and
+  records snapshot age.
+- Restart recovery reconstructs the last successful timestamp.
+- Full-list recovery restores authoritative status.
+- Non-list successes cannot clear stale inventory health.
+- Create, Stop, Send, and Rename fail closed at the RPC boundary while Attach
+  and Log remain usable.
+- First-ever malformed output says that no successful snapshot exists rather
+  than claiming that one is displayed.

--- a/docs/specs/2026-08-01-agentbox-stale-snapshot-design.md
+++ b/docs/specs/2026-08-01-agentbox-stale-snapshot-design.md
@@ -12,7 +12,10 @@ with false confidence.
 ## Decision
 
 The provider manager owns one inventory-health boundary. Every successful full
-snapshot records its time. After a later full-list failure, persisted active
+snapshot records its time in the same database transaction as the mirror update.
+The timestamp is separate from per-session `lastSeen`, because the independent
+events stream can update rows without proving that the full inventory works.
+After a later full-list failure, persisted active
 rows are projected as unknown and the provider status includes the last
 successful snapshot time. A daemon restart recovers that time from the newest
 persisted `lastSeen` value before publishing degraded health.

--- a/docs/specs/2026-08-01-agentbox-stale-snapshot-design.md
+++ b/docs/specs/2026-08-01-agentbox-stale-snapshot-design.md
@@ -17,8 +17,8 @@ The timestamp is separate from per-session `lastSeen`, because the independent
 events stream can update rows without proving that the full inventory works.
 After a later full-list failure, persisted active
 rows are projected as unknown and the provider status includes the last
-successful snapshot time. A daemon restart recovers that time from the newest
-persisted `lastSeen` value before publishing degraded health.
+successful snapshot time. A daemon restart recovers that time from the dedicated
+persisted `tbd_meta` snapshot timestamp before publishing degraded health.
 
 While a previously successful inventory is stale, TBD keeps read-only and
 recovery actions available: Attach, Log, Copy, and Pin. It blocks Create, Stop,

--- a/docs/specs/2026-08-01-remote-stale-snapshot-design.md
+++ b/docs/specs/2026-08-01-remote-stale-snapshot-design.md
@@ -31,6 +31,19 @@ Successful non-list verbs do not clear inventory degradation; only a complete
 full-list refresh can re-establish authoritative state. Provider errors shown
 in the UI are bounded and redact the known oversized/truncated payload shape.
 
+One "stale snapshot" rule serves both the mutation gate and the display
+projection, and it lives in one place (`RemoteProviderStatus.isStaleSnapshot`)
+that the daemon actor and the wire DTO both call. Two same-named
+implementations had already drifted once: the gate refused mutations while the
+session list went on rendering cached rows as running.
+
+Accepted tradeoff: `health` is a single per-provider slot shared by every verb,
+so a transient non-`list` failure (a `log`, a `send`) marks the provider
+degraded and therefore gates mutations and demotes rows until the next
+successful poll, up to one poll interval later. It self-heals and errs toward
+blocking, so it is UX noise rather than a safety hole. Separating list-health
+from verb-health is the real fix and is deliberately out of scope here.
+
 Fail direction is decided by what the daemon can prove, not by convenience.
 "No successful snapshot was ever recorded" is positive knowledge — the mirror
 was never authoritative, so there is nothing to misrepresent and mutations

--- a/docs/specs/2026-08-01-remote-stale-snapshot-design.md
+++ b/docs/specs/2026-08-01-remote-stale-snapshot-design.md
@@ -1,13 +1,14 @@
-# Agent Box stale-snapshot visibility
+# Remote provider stale-snapshot visibility
 
 ## Problem
 
 TBD persists the last successful remote-session inventory so users can still
 inspect and attach to known sessions after a provider error. Before this
 change, a failed full-list refresh left those cached rows looking live and
-kept inventory-dependent mutations enabled. An AWS/SSM output truncation could
-therefore make a healthy Agent Box feel broken while TBD presented stale state
-with false confidence.
+kept inventory-dependent mutations enabled. A remote host can be healthy while
+its unbounded `list` response is truncated by the transport, so a
+provider-path failure was indistinguishable from real remote work: TBD
+presented stale state with false confidence.
 
 ## Decision
 
@@ -30,9 +31,18 @@ Successful non-list verbs do not clear inventory degradation; only a complete
 full-list refresh can re-establish authoritative state. Provider errors shown
 in the UI are bounded and redact the known oversized/truncated payload shape.
 
+Fail direction is decided by what the daemon can prove, not by convenience.
+"No successful snapshot was ever recorded" is positive knowledge — the mirror
+was never authoritative, so there is nothing to misrepresent and mutations
+stay enabled. A freshness read that *fails* proves nothing, so it gates
+instead: it is recorded distinctly from a confirmed absence, reports its own
+health text, and clears as soon as a read succeeds or a live snapshot lands.
+Conflating the two would let a database error silently buy back the exact
+false confidence this change removes.
+
 ## Boundaries
 
-- No provider protocol, credential, or Agent Box host changes.
+- No provider protocol, credential, or remote host changes.
 - No automatic retry, restart, stop, or other remote mutation.
 - No TUI screen scraping.
 - Cached rows remain attachable because provider session IDs are still useful
@@ -51,3 +61,5 @@ in the UI are bounded and redact the known oversized/truncated payload shape.
   and Log remain usable.
 - First-ever malformed output says that no successful snapshot exists rather
   than claiming that one is displayed.
+- An unreadable persisted freshness row gates mutations and claims no age,
+  and stops gating once a snapshot succeeds.


### PR DESCRIPTION
## Summary

- demote cached active remote sessions to terminal/agent `unknown` after a previously healthy provider inventory fails
- expose the last successful snapshot age and a bounded, redacted provider error instead of preserving phantom `running` state
- keep Attach, Log, Copy ID, and Pin available for inspection while hiding and daemon-gating Create, Stop, Send, and Rename until a full inventory succeeds
- recover last-good time across daemon restarts from mirrored rows and automatically restore normal controls after recovery

## Why

A remote host can be healthy while its unbounded `list` response is truncated by the transport. TBD kept cached sessions looking confidently active, which made a provider-path failure indistinguishable from real remote work.

This is the bounded TBD-local reliability slice. It does not change the remote host, provider deployment, pagination protocol, or start any remote workers.

## Fail direction

The gate is decided by what the daemon can prove, not by convenience:

| Condition | Mutations | Why |
| --- | --- | --- |
| Snapshot exists, now stale | **gated** | Cached rows are making unverifiable claims. |
| Read succeeded, returned "never" | open | Positive knowledge the mirror was never authoritative — nothing to misrepresent, and a first-ever failure keeps prior behavior. |
| Freshness read **threw** | **gated** | A database error proves nothing. |

That third row is new since the last review. `recoverLastSuccessfulSnapshotAtIfNeeded` previously swallowed the read error with `try?`, which collapsed it into the "never" case and let every gated verb through — a database error silently bought back the exact false confidence this PR removes. It now gates, reports "could not be read" rather than "has not refreshed", claims no snapshot age, and clears as soon as a read succeeds or a live snapshot lands.

Both sides of that decision now come from **one** definition,
`RemoteProviderStatus.isStaleSnapshot`, called by the daemon actor and the wire DTO alike. They were previously two same-named checks, and they had drifted: with an unreadable freshness row the gate refused mutations while `handleRemoteSessions` and every app call site — which read the DTO — went on rendering cached rows as confidently `running`. `freshnessUnreadable` now travels on the wire so the DTO can reach the same verdict; it decodes to `false` when absent, via a hand-written `init(from:)` because synthesized decoding ignores property defaults.

### Accepted tradeoff

`health` is a single per-provider slot shared by every verb, so a transient non-`list` failure (a `log`, a `send`) marks the provider degraded and therefore gates mutations and demotes rows until the next successful poll — up to one poll interval. It self-heals and errs toward blocking, so it is UX noise rather than a safety hole. Separating list-health from verb-health is the real fix and is deliberately out of scope; noted in the spec.

## Review feedback addressed

- **Deployment-specific naming scrubbed.** The spec, its filename, and this PR's title/body no longer name a particular host or attribute the truncation to a specific transport. (For the record, the reviewer's premise that the term was new to this PR was not quite right — `agentbox` already appears on `main` in the merged `docs/specs/2026-07-24-remote-agent-backends-design.md`. The genuinely new surface was tying it to a concrete failure mode, and that is what has been generalized.)
- **Whitespace-only reformat reverted.** An earlier commit reindented `RemoteProviderManager.swift` and `RemoteProviderManagerTests.swift` from 4-space to 2-space, diverging from the tree (26507 four-space lines vs 36) and inflating the diff by ~1900 lines. Restored in `85a105b`, which is whitespace-only by construction: both files are byte-identical to their prior contents once leading whitespace is stripped. The two files now show 208 and 293 changed lines instead of 930 and 1371.
- **Stale footnote removed.** The old "Follow-up" claim that a health table was needed to preserve an empty successful snapshot's timestamp was wrong — `applySnapshot()` already writes the `tbd_meta` timestamp unconditionally.

## Validation

- `swift build` ✅
- `swiftlint --strict` — 0 violations in 642 files ✅
- all commits SSH-signed ✅
- `swift test` still cannot run on this host: the active CommandLineTools toolchain has no Swift `Testing` module (production targets build fine; only the test targets fail to compile). **CI's `test` job runs the full suite and is the gate** — it passed on the previous head and covers the two new tests here.

## Tests added

- `unreadableFreshnessStateGatesMutationsInsteadOfFailingOpen` — drops `tbd_meta` so the real store's `SELECT` throws; asserts the gate closes, no snapshot age is claimed, and the DTO agrees (`hasStaleSnapshot == true`).
- `unreadableFreshnessStateClearsOnceASnapshotSucceeds` — asserts the unreadable state is a cache of one failed read, not a latch that wedges the provider.
- `sessionsDemoteCachedRowsWhenFreshnessRowIsUnreadable` — RPC-level: `remote.sessions` demotes to `.unknown` **and** `remote.stop` is refused, in the same test, so the projection and the gate can't diverge again unnoticed.
- `providerStatusDecodesWhenFreshnessUnreadableIsAbsent` / `providerStatusRoundTripsFreshnessUnreadable` / `providerStatusHealthyNeverCountsAsStaleSnapshot` — wire defaults and the rule's boundaries.

## Follow-up, not in this PR

Provider-side pagination/chunking or summary+describe fallback remains the root-cause fix.
