### PR TITLE
Continue Claude sessions through native Codex import

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -348,6 +348,41 @@ extension AppState {
         }
     }
 
+    /// Import a Claude transcript through Codex's native app-server surface,
+    /// then select the ordinary Codex tab created by the daemon.
+    func continueInCodex(sourceTerminalID: UUID) async {
+        guard let source = terminals.values
+            .flatMap({ $0 })
+            .first(where: { $0.id == sourceTerminalID }) else {
+            showAlert("Couldn't continue in Codex: source terminal not found.", isError: true)
+            return
+        }
+
+        do {
+            let result = try await daemonClient.continueInCodex(
+                terminalID: sourceTerminalID)
+            let rows = try await daemonClient.listTerminals(
+                worktreeID: source.worktreeID)
+            guard let terminal = rows.first(where: { $0.id == result.terminalID }) else {
+                throw DaemonClientError.invalidResponse
+            }
+            appendCreatedTerminal(terminal)
+            if let index = tabs[source.worktreeID]?.firstIndex(where: { tab in
+                (layouts[tab.id] ?? .pane(tab.content))
+                    .allTerminalIDs().contains(terminal.id)
+            }) {
+                setActiveTab(worktreeID: source.worktreeID, tabIndex: index)
+            }
+        } catch {
+            logger.error(
+                "Continue in Codex failed: \(error.localizedDescription, privacy: .public)")
+            showAlert(
+                "Couldn't continue in Codex: \(error.localizedDescription)",
+                isError: true)
+            handleConnectionError(error)
+        }
+    }
+
     /// Toggle pin state for a terminal.
     func setTerminalPin(id: UUID, pinned: Bool) async {
         // Optimistic local update

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -650,6 +650,16 @@ actor DaemonClient {
         )
     }
 
+    /// Import one Claude terminal's native transcript into Codex and open the
+    /// returned thread as an ordinary Codex terminal.
+    func continueInCodex(terminalID: UUID) async throws
+        -> TerminalContinueInCodexResult {
+        try await callAsync(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: terminalID),
+            resultType: TerminalContinueInCodexResult.self)
+    }
+
     /// List terminals, optionally filtered by worktree.
     func listTerminals(worktreeID: UUID? = nil) async throws -> [Terminal] {
         return try await callAsync(

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -514,6 +514,13 @@ enum TabParkMenuModel {
 
 // MARK: - TabBarItem
 
+enum ContinueInCodexMenu {
+    static func isVisible(for terminal: Terminal?) -> Bool {
+        terminal?.isClaudeResumable == true
+            && terminal?.transcriptPath?.isEmpty == false
+    }
+}
+
 private struct TabBarItem: View {
     let tab: TBDShared.Tab
     let index: Int
@@ -885,6 +892,18 @@ private struct TabBarItem: View {
                 swapProfileMenuItems(mode: .fork)
             } label: {
                 Label("Fork Session", systemImage: "arrow.triangle.branch")
+            }
+
+            if ContinueInCodexMenu.isVisible(for: terminal) {
+                Button {
+                    guard let terminalID = terminal?.id else { return }
+                    Task {
+                        await appState.continueInCodex(
+                            sourceTerminalID: terminalID)
+                    }
+                } label: {
+                    Label("Continue in Codex", systemImage: "arrow.right.circle")
+                }
             }
 
             // Park (formerly the Suspend/Resume play/pause button) lives here

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -6,7 +6,7 @@ struct TerminalCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "terminal",
         abstract: "Manage terminals",
-        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalWake.self, TerminalClose.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self, TerminalPin.self, TerminalUnpin.self, TerminalSwapProfile.self]
+        subcommands: [TerminalCreate.self, TerminalList.self, TerminalSend.self, TerminalWake.self, TerminalClose.self, TerminalOutput.self, TerminalConversation.self, TerminalFocus.self, TerminalPin.self, TerminalUnpin.self, TerminalSwapProfile.self, TerminalContinueInCodex.self]
     )
 }
 
@@ -514,6 +514,40 @@ struct TerminalSwapProfile: AsyncParsableCommand {
             } else {
                 print("Respawned under '\(targetLabel)'.")
             }
+        }
+    }
+}
+
+// MARK: - terminal continue-in-codex
+
+struct TerminalContinueInCodex: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "continue-in-codex",
+        abstract: "Import a Claude terminal's conversation and open it in Codex"
+    )
+
+    @Argument(help: "Claude terminal ID (UUID)")
+    var terminal: String
+
+    @Flag(name: .long, help: "Output JSON")
+    var json = false
+
+    mutating func run() async throws {
+        guard let terminalID = UUID(uuidString: terminal) else {
+            throw CLIError.invalidArgument("Invalid terminal ID: \(terminal)")
+        }
+
+        let result: TerminalContinueInCodexResult = try SocketClient().call(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: terminalID),
+            resultType: TerminalContinueInCodexResult.self)
+
+        if json {
+            printJSON(result)
+        } else {
+            print("Continued in Codex:")
+            print("  Terminal: \(result.terminalID)")
+            print("  Thread:   \(result.threadID)")
         }
     }
 }

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -180,7 +180,6 @@ enum CodexPluginWriter {
 
 enum CodexProfileWriter {
     static let profileFileName = "\(CodexPlugin.profileName).config.toml"
-    static let shadcnServerHeader = "[mcp_servers.shadcn]"
 
     static func profilePath(in codexHome: URL) -> URL {
         codexHome.appendingPathComponent(profileFileName, isDirectory: false)
@@ -189,9 +188,7 @@ enum CodexProfileWriter {
     static func ensureProfile(in codexHome: URL) throws {
         let path = profilePath(in: codexHome)
         let current = (try? String(contentsOf: path, encoding: .utf8)) ?? ""
-        let updated = ensureShadcnDisabled(
-            in: ensurePluginEnabled(in: current)
-        )
+        let updated = ensurePluginEnabled(in: current)
 
         guard updated != current else {
             return
@@ -210,22 +207,6 @@ enum CodexProfileWriter {
             in: toml,
             header: header,
             settings: [("enabled", "true")]
-        )
-    }
-
-    /// TBD Codex sessions can start in many worktrees at once. Disable the
-    /// project-discovered shadcn MCP server in TBD's profile so those sessions
-    /// do not fan out one resident stdio server each. This is profile-scoped:
-    /// it does not alter the user's default Codex configuration.
-    static func ensureShadcnDisabled(in toml: String) -> String {
-        ensureSettings(
-            in: toml,
-            header: shadcnServerHeader,
-            settings: [
-                ("command", #""npx""#),
-                ("args", #"["shadcn@latest", "mcp"]"#),
-                ("enabled", "false"),
-            ]
         )
     }
 

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -180,6 +180,7 @@ enum CodexPluginWriter {
 
 enum CodexProfileWriter {
     static let profileFileName = "\(CodexPlugin.profileName).config.toml"
+    static let shadcnServerHeader = "[mcp_servers.shadcn]"
 
     static func profilePath(in codexHome: URL) -> URL {
         codexHome.appendingPathComponent(profileFileName, isDirectory: false)
@@ -188,7 +189,9 @@ enum CodexProfileWriter {
     static func ensureProfile(in codexHome: URL) throws {
         let path = profilePath(in: codexHome)
         let current = (try? String(contentsOf: path, encoding: .utf8)) ?? ""
-        let updated = ensurePluginEnabled(in: current)
+        let updated = ensureShadcnDisabled(
+            in: ensurePluginEnabled(in: current)
+        )
 
         guard updated != current else {
             return
@@ -203,7 +206,34 @@ enum CodexProfileWriter {
 
     static func ensurePluginEnabled(in toml: String) -> String {
         let header = #"[plugins."\#(CodexPlugin.pluginKey)"]"#
+        return ensureSettings(
+            in: toml,
+            header: header,
+            settings: [("enabled", "true")]
+        )
+    }
 
+    /// TBD Codex sessions can start in many worktrees at once. Disable the
+    /// project-discovered shadcn MCP server in TBD's profile so those sessions
+    /// do not fan out one resident stdio server each. This is profile-scoped:
+    /// it does not alter the user's default Codex configuration.
+    static func ensureShadcnDisabled(in toml: String) -> String {
+        ensureSettings(
+            in: toml,
+            header: shadcnServerHeader,
+            settings: [
+                ("command", #""npx""#),
+                ("args", #"["shadcn@latest", "mcp"]"#),
+                ("enabled", "false"),
+            ]
+        )
+    }
+
+    private static func ensureSettings(
+        in toml: String,
+        header: String,
+        settings: [(key: String, value: String)]
+    ) -> String {
         // Normalize line endings to `\n` before splitting. A CRLF-terminated
         // `tbd.config.toml` would otherwise leave a trailing `\r` on every
         // line: `CharacterSet.whitespaces` does NOT include `\r`, so the
@@ -240,11 +270,12 @@ enum CodexProfileWriter {
             if !updated.isEmpty {
                 updated += "\n"
             }
-            updated += "\(header)\nenabled = true\n"
+            let settingLines = settings.map { "\($0.key) = \($0.value)" }
+            updated += ([header] + settingLines).joined(separator: "\n") + "\n"
             return updated
         }
 
-        let nextSectionIndex = lines[(headerIndex + 1)...]
+        var nextSectionIndex = lines[(headerIndex + 1)...]
             .firstIndex { line in
                 // A section header is a line that trims to `[...]` and is not
                 // a key/value assignment — reject lines containing `=` so a
@@ -254,21 +285,216 @@ enum CodexProfileWriter {
                 return trimmed.hasPrefix("[") && trimmed.hasSuffix("]") && !trimmed.contains("=")
             } ?? lines.endIndex
 
-        if let enabledIndex = lines[(headerIndex + 1)..<nextSectionIndex]
-            .firstIndex(where: { line in
-                // Match the exact `enabled` key, not prefixes like
-                // `enabled_features` which would otherwise be clobbered.
-                let key = line.trimmingCharacters(in: .whitespaces)
-                    .prefix { $0 != "=" }
-                    .trimmingCharacters(in: .whitespaces)
-                return key == "enabled"
-            }) {
-            lines[enabledIndex] = "enabled = true"
-        } else {
-            lines.insert("enabled = true", at: headerIndex + 1)
+        var missingSettings: [(key: String, value: String)] = []
+        for setting in settings {
+            let matchingIndices = lines[(headerIndex + 1)..<nextSectionIndex]
+                .indices
+                .filter { index in
+                    // Match the exact key, not prefixes like
+                    // `enabled_features` which would otherwise be clobbered.
+                    let key = lines[index].trimmingCharacters(in: .whitespaces)
+                        .prefix { $0 != "=" }
+                        .trimmingCharacters(in: .whitespaces)
+                    return key == setting.key
+                }
+
+            guard let firstIndex = matchingIndices.first else {
+                missingSettings.append(setting)
+                continue
+            }
+
+            lines[firstIndex] = "\(setting.key) = \(setting.value)"
+            for duplicateIndex in matchingIndices.dropFirst().reversed() {
+                lines.remove(at: duplicateIndex)
+                nextSectionIndex -= 1
+            }
+        }
+
+        if !missingSettings.isEmpty {
+            lines.insert(
+                contentsOf: missingSettings.map { "\($0.key) = \($0.value)" },
+                at: headerIndex + 1
+            )
         }
 
         return lines.joined(separator: "\n") + (hadTrailingNewline ? "\n" : "")
+    }
+}
+
+enum CodexExecutableResolutionError: LocalizedError, Equatable {
+    case invalidOverride(environmentKey: String, value: String, reason: String)
+    case notFound(searchPath: String, fallbackPath: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidOverride(let environmentKey, let value, let reason):
+            return """
+                Invalid \(environmentKey) override "\(value)": \(reason). Set \
+                \(environmentKey) to the absolute path of an executable Codex \
+                CLI, or unset it, then restart TBD.
+                """
+        case .notFound(let searchPath, let fallbackPath):
+            let renderedSearchPath = searchPath.isEmpty ? "(empty)" : searchPath
+            return """
+                Could not find an executable Codex CLI. Searched PATH \
+                (\(renderedSearchPath)) and \(fallbackPath). Set \
+                \(CodexExecutableResolver.executableOverrideEnvironmentKey) to \
+                an absolute Codex executable path, install or update \
+                ChatGPT.app, or add the Codex CLI to PATH, then restart TBD.
+                """
+        }
+    }
+}
+
+/// Resolves the Codex CLI before TBD creates a tmux window or terminal row.
+///
+/// A configured `TBD_CODEX_EXECUTABLE` absolute path wins, followed by every
+/// absolute PATH entry in order. Relative and empty PATH entries are ignored:
+/// resolving them against the daemon's current directory could execute an
+/// untrusted worktree-local `codex`. ChatGPT.app's bundled CLI is the fallback because
+/// GUI-launched daemons often have a minimal PATH that cannot name it even
+/// though the app (and the user's existing global Codex login) is installed.
+/// The returned path is always absolute so the later interactive shell does
+/// not repeat PATH lookup with a different environment.
+enum CodexExecutableResolver {
+    static let executableOverrideEnvironmentKey = "TBD_CODEX_EXECUTABLE"
+    static let chatGPTBundlePath = "/Applications/ChatGPT.app/Contents/Resources/codex"
+
+    static func resolve(
+        configuredOverride: String? = ProcessInfo.processInfo.environment["TBD_CODEX_EXECUTABLE"],
+        searchPath: String = ProcessInfo.processInfo.environment["PATH"] ?? "",
+        currentDirectory: String = FileManager.default.currentDirectoryPath,
+        fallbackPath: String = chatGPTBundlePath,
+        isExecutable: (String) -> Bool = {
+            isUsableExecutable(atPath: $0)
+        }
+    ) throws -> String {
+        let currentDirectoryURL = URL(
+            fileURLWithPath: currentDirectory,
+            isDirectory: true
+        ).standardizedFileURL
+
+        func absolutePath(_ path: String) -> String {
+            if path.hasPrefix("/") {
+                return URL(fileURLWithPath: path).standardizedFileURL.path
+            }
+            return URL(
+                fileURLWithPath: path,
+                relativeTo: currentDirectoryURL
+            ).standardizedFileURL.path
+        }
+
+        var seen = Set<String>()
+        if let configuredOverride, !configuredOverride.isEmpty {
+            guard (configuredOverride as NSString).isAbsolutePath else {
+                throw CodexExecutableResolutionError.invalidOverride(
+                    environmentKey: executableOverrideEnvironmentKey,
+                    value: configuredOverride,
+                    reason: "the path must be absolute"
+                )
+            }
+
+            let absoluteOverride = absolutePath(configuredOverride)
+            guard isExecutable(absoluteOverride) else {
+                throw CodexExecutableResolutionError.invalidOverride(
+                    environmentKey: executableOverrideEnvironmentKey,
+                    value: configuredOverride,
+                    reason: "the path is not executable"
+                )
+            }
+            return absoluteOverride
+        }
+
+        let pathEntries = searchPath.split(
+            separator: ":",
+            omittingEmptySubsequences: false
+        )
+        for entry in pathEntries {
+            let directory = String(entry)
+            guard !directory.isEmpty,
+                  (directory as NSString).isAbsolutePath else {
+                continue
+            }
+            let candidate = absolutePath(
+                (directory as NSString).appendingPathComponent("codex")
+            )
+            guard seen.insert(candidate).inserted else { continue }
+            if isExecutable(candidate) {
+                return candidate
+            }
+        }
+
+        let absoluteFallback = absolutePath(fallbackPath)
+        if seen.insert(absoluteFallback).inserted, isExecutable(absoluteFallback) {
+            return absoluteFallback
+        }
+
+        throw CodexExecutableResolutionError.notFound(
+            searchPath: searchPath,
+            fallbackPath: absoluteFallback
+        )
+    }
+
+    /// Best-effort lookup for non-launching features such as usage display.
+    ///
+    /// Spawn paths must call the throwing `resolve` API so an invalid override
+    /// or missing CLI reaches the user as an actionable error. Usage probing
+    /// can degrade to an unavailable state, and also checks common absolute
+    /// user/package-manager locations that a launchd PATH may omit.
+    static func resolveIfAvailable(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
+        isExecutable: (String) -> Bool = {
+            isUsableExecutable(atPath: $0)
+        }
+    ) -> String? {
+        let fallbackDirectories = [
+            "\(homeDirectory)/.local/bin",
+            "\(homeDirectory)/.volta/bin",
+            "\(homeDirectory)/.cargo/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+        ]
+        let augmentedSearchPath = ([environment["PATH"]].compactMap { $0 }
+            + fallbackDirectories).joined(separator: ":")
+
+        return try? resolve(
+            configuredOverride: environment[executableOverrideEnvironmentKey],
+            searchPath: augmentedSearchPath,
+            fallbackPath: chatGPTBundlePath,
+            isExecutable: isExecutable
+        )
+    }
+
+    private static func isUsableExecutable(atPath path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(
+            atPath: path, isDirectory: &isDirectory
+        ), !isDirectory.boolValue else {
+            return false
+        }
+        return FileManager.default.isExecutableFile(atPath: path)
+    }
+}
+
+struct CodexLaunchPreparation: Sendable {
+    let executablePath: String
+    let codexHome: URL
+
+    static func prepare(
+        executableResolver: @Sendable () throws -> String,
+        homeEnsurer: @Sendable () throws -> URL
+    ) throws -> CodexLaunchPreparation {
+        // Keep this order explicit: executable resolution is read-only and
+        // should fail before the profile writer touches the global Codex home.
+        let executablePath = try executableResolver()
+        let codexHome = try homeEnsurer()
+        return CodexLaunchPreparation(
+            executablePath: executablePath,
+            codexHome: codexHome
+        )
     }
 }
 
@@ -285,13 +511,40 @@ enum CodexSpawnCommandBuilder {
         build(initialPrompt: initialPrompt, profileFlag: detectedProfileFlag)
     }
 
+    static func command(executablePath: String) -> String {
+        let profileFlag = detectProfileFlag(executablePath: executablePath) { arguments in
+            commandOutput(arguments: arguments, timeout: 3)
+        }
+        return baseCommand(executablePath: executablePath, profileFlag: profileFlag)
+    }
+
+    static func build(
+        initialPrompt: String?,
+        resumeThreadID: String? = nil,
+        executablePath: String
+    ) -> String {
+        let profileFlag = detectProfileFlag(executablePath: executablePath) { arguments in
+            commandOutput(arguments: arguments, timeout: 3)
+        }
+        return build(
+            initialPrompt: initialPrompt,
+            resumeThreadID: resumeThreadID,
+            executablePath: executablePath,
+            profileFlag: profileFlag
+        )
+    }
+
     static func build(
         initialPrompt: String?,
         codexHelpOutput: String? = nil,
-        codexVersionOutput: String? = nil
+        codexVersionOutput: String? = nil,
+        resumeThreadID: String? = nil,
+        executablePath: String = "codex"
     ) -> String {
         build(
             initialPrompt: initialPrompt,
+            resumeThreadID: resumeThreadID,
+            executablePath: executablePath,
             profileFlag: profileFlag(codexHelpOutput: codexHelpOutput, codexVersionOutput: codexVersionOutput)
         )
     }
@@ -304,8 +557,35 @@ enum CodexSpawnCommandBuilder {
         return "\(command) \(SystemPromptBuilder.shellEscape(initialPrompt))"
     }
 
+    static func build(
+        initialPrompt: String?,
+        resumeThreadID: String?,
+        executablePath: String,
+        profileFlag: String
+    ) -> String {
+        let command = baseCommand(
+            executablePath: executablePath,
+            profileFlag: profileFlag,
+            resumeThreadID: resumeThreadID)
+        guard let initialPrompt, !initialPrompt.isEmpty else {
+            return command
+        }
+        return "\(command) \(SystemPromptBuilder.shellEscape(initialPrompt))"
+    }
+
     private static func baseCommand(profileFlag: String) -> String {
         return "unset CODEX_CI CODEX_THREAD_ID; codex \(profileFlag) tbd --dangerously-bypass-approvals-and-sandbox"
+    }
+
+    private static func baseCommand(
+        executablePath: String,
+        profileFlag: String,
+        resumeThreadID: String? = nil
+    ) -> String {
+        let executable = SystemPromptBuilder.shellEscape(executablePath)
+        let base = "unset CODEX_CI CODEX_THREAD_ID; \(executable) \(profileFlag) tbd --dangerously-bypass-approvals-and-sandbox"
+        guard let resumeThreadID, !resumeThreadID.isEmpty else { return base }
+        return "\(base) resume \(SystemPromptBuilder.shellEscape(resumeThreadID))"
     }
 
     static func profileFlag(codexHelpOutput: String?, codexVersionOutput: String?) -> String {
@@ -334,6 +614,21 @@ enum CodexSpawnCommandBuilder {
         return profileFlag(
             codexHelpOutput: helpOutput,
             codexVersionOutput: commandOutput(["codex", "--version"])
+        )
+    }
+
+    static func detectProfileFlag(
+        executablePath: String,
+        commandOutput: ([String]) -> String?
+    ) -> String {
+        let helpOutput = commandOutput([executablePath, "--help"])
+        if let helpOutput, helpOutput.contains("--profile-v2") || helpOutput.contains("--profile") {
+            return profileFlag(codexHelpOutput: helpOutput, codexVersionOutput: nil)
+        }
+
+        return profileFlag(
+            codexHelpOutput: helpOutput,
+            codexVersionOutput: commandOutput([executablePath, "--version"])
         )
     }
 

--- a/Sources/TBDDaemon/Codex/CodexSessionImporter.swift
+++ b/Sources/TBDDaemon/Codex/CodexSessionImporter.swift
@@ -1,0 +1,454 @@
+import Foundation
+import os
+
+private let codexImportLogger = Logger(
+    subsystem: "com.tbd.daemon", category: "codex-session-import")
+
+enum CodexSessionImportError: LocalizedError, Equatable {
+    case appServer(String)
+    case malformedResponse(String)
+    case processExited(Int32)
+    case timedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .appServer(let message):
+            return "Codex could not import this session: \(message)"
+        case .malformedResponse(let detail):
+            return "Codex returned an invalid session-import response: \(detail)"
+        case .processExited(let status):
+            return "Codex app-server exited before the session import completed (status \(status))."
+        case .timedOut:
+            return "Codex did not finish importing the session before the deadline."
+        }
+    }
+}
+
+protocol CodexAppServerConnection: Sendable {
+    func send(_ line: Data) throws
+    func receive() async throws -> Data
+    func close()
+}
+
+protocol CodexAppServerTransport: Sendable {
+    func connect(executablePath: String, codexHome: URL) async throws
+        -> any CodexAppServerConnection
+}
+
+/// Imports one Claude transcript through Codex's native app-server protocol.
+///
+/// The public operation accepts a single session, not arbitrary migration
+/// items. That type boundary prevents callers from forwarding `detect` output,
+/// whose sibling item types can rewrite Codex configuration, hooks, and skills.
+struct CodexSessionImporter: Sendable {
+    let executablePath: String
+    let codexHome: URL
+    let transport: any CodexAppServerTransport
+    let timeout: Duration
+    let clock: any Clock<Duration>
+
+    init(
+        executablePath: String,
+        codexHome: URL,
+        transport: any CodexAppServerTransport = ProcessCodexAppServerTransport(),
+        timeout: Duration = .seconds(10),
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.executablePath = executablePath
+        self.codexHome = codexHome
+        self.transport = transport
+        self.timeout = timeout
+        self.clock = clock
+    }
+
+    func importSession(
+        transcriptPath: String,
+        cwd: String,
+        title: String? = nil
+    ) async throws -> String {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await performImport(
+                    transcriptPath: transcriptPath,
+                    cwd: cwd,
+                    title: title)
+            }
+            group.addTask {
+                try await clock.sleep(for: timeout)
+                throw CodexSessionImportError.timedOut
+            }
+
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw CodexSessionImportError.malformedResponse(
+                    "the app-server conversation ended without a result")
+            }
+            return result
+        }
+    }
+
+    private func performImport(
+        transcriptPath: String,
+        cwd: String,
+        title: String?
+    ) async throws -> String {
+        let connection = try await transport.connect(
+            executablePath: executablePath,
+            codexHome: codexHome)
+        return try await withTaskCancellationHandler(operation: {
+            defer { connection.close() }
+
+            try connection.send(try Self.initializeRequest())
+            try await expectResponse(id: 1, from: connection)
+            try connection.send(try Self.initializedNotification())
+            try connection.send(try Self.importRequest(
+                transcriptPath: transcriptPath,
+                cwd: cwd,
+                title: title))
+
+            let importID = try await expectImportResponse(from: connection)
+            while true {
+                let line = try await connection.receive()
+                if let target = try Self.importTarget(
+                    from: line,
+                    matchingImportID: importID) {
+                    codexImportLogger.info(
+                        "Imported Claude transcript into Codex thread \(target, privacy: .public)")
+                    return target
+                }
+            }
+        }, onCancel: {
+            connection.close()
+        })
+    }
+
+    private func expectResponse(
+        id: Int,
+        from connection: any CodexAppServerConnection
+    ) async throws {
+        while true {
+            let object = try Self.object(from: try await connection.receive())
+            guard Self.integerID(in: object) == id else { continue }
+            if let message = Self.errorMessage(in: object) {
+                throw CodexSessionImportError.appServer(message)
+            }
+            guard object["result"] != nil else {
+                throw CodexSessionImportError.malformedResponse(
+                    "request \(id) had neither a result nor an error")
+            }
+            return
+        }
+    }
+
+    private func expectImportResponse(
+        from connection: any CodexAppServerConnection
+    ) async throws -> String {
+        while true {
+            let object = try Self.object(from: try await connection.receive())
+            guard Self.integerID(in: object) == 2 else { continue }
+            if let message = Self.errorMessage(in: object) {
+                throw CodexSessionImportError.appServer(message)
+            }
+            guard let result = object["result"] as? [String: Any],
+                  let importID = result["importId"] as? String,
+                  !importID.isEmpty else {
+                throw CodexSessionImportError.malformedResponse(
+                    "the import response did not contain importId")
+            }
+            return importID
+        }
+    }
+
+    static func importTarget(
+        from data: Data,
+        matchingImportID: String
+    ) throws -> String? {
+        let object = try object(from: data)
+        guard object["method"] as? String
+                == "externalAgentConfig/import/completed",
+              let params = object["params"] as? [String: Any],
+              params["importId"] as? String == matchingImportID,
+              let results = params["itemTypeResults"] as? [[String: Any]] else {
+            return nil
+        }
+
+        for result in results where result["itemType"] as? String == "SESSIONS" {
+            if let failures = result["failures"] as? [[String: Any]],
+               let failure = failures.first {
+                let message = failure["message"] as? String
+                    ?? "Codex reported an unspecified session-import failure"
+                throw CodexSessionImportError.appServer(message)
+            }
+
+            guard let successes = result["successes"] as? [[String: Any]] else {
+                continue
+            }
+            // Codex 0.146 repeats `itemType` on each success. The 0.145
+            // response observed during the original design omitted it and
+            // relied on the enclosing SESSIONS result. Accept both shapes,
+            // while rejecting an explicitly different item type.
+            for success in successes {
+                if let itemType = success["itemType"] as? String,
+                   itemType != "SESSIONS" {
+                    continue
+                }
+                if let target = success["target"] as? String, !target.isEmpty {
+                    return target
+                }
+            }
+        }
+
+        throw CodexSessionImportError.malformedResponse(
+            "the completed notification contained no successful SESSIONS target")
+    }
+
+    static func initializeRequest() throws -> Data {
+        try jsonLine([
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": [
+                "clientInfo": [
+                    "name": "tbd",
+                    "title": "TBD",
+                    "version": "1",
+                ],
+                "capabilities": ["experimentalApi": true],
+            ],
+        ])
+    }
+
+    static func initializedNotification() throws -> Data {
+        try jsonLine([
+            "jsonrpc": "2.0",
+            "method": "initialized",
+            "params": [:],
+        ])
+    }
+
+    static func importRequest(
+        transcriptPath: String,
+        cwd: String,
+        title: String?
+    ) throws -> Data {
+        var session: [String: Any] = [
+            "path": transcriptPath,
+            "cwd": cwd,
+        ]
+        if let title, !title.isEmpty {
+            session["title"] = title
+        }
+
+        return try jsonLine([
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "externalAgentConfig/import",
+            "params": [
+                "migrationItems": [[
+                    "itemType": "SESSIONS",
+                    "description": "Continue one Claude session in Codex",
+                    "details": ["sessions": [session]],
+                ]],
+                "source": "tbd",
+            ],
+        ])
+    }
+
+    private static func jsonLine(_ object: [String: Any]) throws -> Data {
+        var data = try JSONSerialization.data(
+            withJSONObject: object, options: [.sortedKeys])
+        data.append(0x0A)
+        return data
+    }
+
+    private static func object(from data: Data) throws -> [String: Any] {
+        do {
+            guard let object = try JSONSerialization.jsonObject(with: data)
+                    as? [String: Any] else {
+                throw CodexSessionImportError.malformedResponse(
+                    "expected a JSON object")
+            }
+            return object
+        } catch let error as CodexSessionImportError {
+            throw error
+        } catch {
+            throw CodexSessionImportError.malformedResponse(
+                "invalid JSON: \(error.localizedDescription)")
+        }
+    }
+
+    private static func integerID(in object: [String: Any]) -> Int? {
+        (object["id"] as? NSNumber)?.intValue
+    }
+
+    private static func errorMessage(in object: [String: Any]) -> String? {
+        guard let error = object["error"] as? [String: Any] else { return nil }
+        return error["message"] as? String ?? "Codex returned an unspecified error"
+    }
+}
+
+struct ProcessCodexAppServerTransport: CodexAppServerTransport {
+    func connect(executablePath: String, codexHome: URL) async throws
+        -> any CodexAppServerConnection {
+        try ProcessCodexAppServerConnection.start(
+            executablePath: executablePath,
+            codexHome: codexHome)
+    }
+}
+
+private actor CodexAppServerLineInbox {
+    private var lines: [Data] = []
+    private var waiter: CheckedContinuation<Data, any Error>?
+    private var terminalError: (any Error)?
+
+    func yield(_ line: Data) {
+        if let waiter {
+            self.waiter = nil
+            waiter.resume(returning: line)
+        } else {
+            lines.append(line)
+        }
+    }
+
+    func finish(_ error: any Error) {
+        terminalError = error
+        if let waiter {
+            self.waiter = nil
+            waiter.resume(throwing: error)
+        }
+    }
+
+    func next() async throws -> Data {
+        if !lines.isEmpty { return lines.removeFirst() }
+        if let terminalError { throw terminalError }
+        return try await withCheckedThrowingContinuation { continuation in
+            waiter = continuation
+        }
+    }
+}
+
+private final class ProcessCodexAppServerConnection: CodexAppServerConnection,
+    @unchecked Sendable {
+    private struct ReadState {
+        var buffer = Data()
+        var closed = false
+    }
+
+    private let process: Process
+    private let stdinPipe: Pipe
+    private let stdoutPipe: Pipe
+    private let stderrPipe: Pipe
+    private let inbox = CodexAppServerLineInbox()
+    private let readState = OSAllocatedUnfairLock(initialState: ReadState())
+    private let writeLock = NSLock()
+
+    private init(
+        process: Process,
+        stdinPipe: Pipe,
+        stdoutPipe: Pipe,
+        stderrPipe: Pipe
+    ) {
+        self.process = process
+        self.stdinPipe = stdinPipe
+        self.stdoutPipe = stdoutPipe
+        self.stderrPipe = stderrPipe
+    }
+
+    static func start(executablePath: String, codexHome: URL) throws
+        -> ProcessCodexAppServerConnection {
+        let process = Process()
+        let stdinPipe = Pipe()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        let connection = ProcessCodexAppServerConnection(
+            process: process,
+            stdinPipe: stdinPipe,
+            stdoutPipe: stdoutPipe,
+            stderrPipe: stderrPipe)
+
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = ["app-server", "--stdio"]
+        process.standardInput = stdinPipe
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        var environment = ProcessInfo.processInfo.environment
+        environment["CODEX_HOME"] = codexHome.path
+        process.environment = environment
+
+        stdoutPipe.fileHandleForReading.readabilityHandler = { [weak connection] handle in
+            connection?.consume(handle.availableData)
+        }
+        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty,
+                  let message = String(data: data, encoding: .utf8) else { return }
+            codexImportLogger.debug(
+                "Codex app-server stderr: \(message, privacy: .private)")
+        }
+        process.terminationHandler = { [weak connection] process in
+            connection?.finish(status: process.terminationStatus)
+        }
+
+        do {
+            try process.run()
+            return connection
+        } catch {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            throw error
+        }
+    }
+
+    func send(_ line: Data) throws {
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        try stdinPipe.fileHandleForWriting.write(contentsOf: line)
+    }
+
+    func receive() async throws -> Data {
+        try await inbox.next()
+    }
+
+    func close() {
+        let shouldClose = readState.withLock { state in
+            guard !state.closed else { return false }
+            state.closed = true
+            return true
+        }
+        guard shouldClose else { return }
+
+        stdoutPipe.fileHandleForReading.readabilityHandler = nil
+        stderrPipe.fileHandleForReading.readabilityHandler = nil
+        try? stdinPipe.fileHandleForWriting.close()
+        Task { await inbox.finish(CancellationError()) }
+        if process.isRunning { process.terminate() }
+    }
+
+    private func consume(_ data: Data) {
+        guard !data.isEmpty else { return }
+        let lines = readState.withLock { state -> [Data] in
+            guard !state.closed else { return [] }
+            state.buffer.append(data)
+            var complete: [Data] = []
+            while let newline = state.buffer.firstIndex(of: 0x0A) {
+                let line = Data(state.buffer[..<newline])
+                state.buffer.removeSubrange(...newline)
+                if !line.isEmpty { complete.append(line) }
+            }
+            return complete
+        }
+        for line in lines {
+            Task { await inbox.yield(line) }
+        }
+    }
+
+    private func finish(status: Int32) {
+        let wasClosed = readState.withLock { state -> Bool in
+            let previous = state.closed
+            state.closed = true
+            return previous
+        }
+        guard !wasClosed else { return }
+        Task { await inbox.finish(CodexSessionImportError.processExited(status)) }
+    }
+}

--- a/Sources/TBDDaemon/Codex/CodexUsageFetcher.swift
+++ b/Sources/TBDDaemon/Codex/CodexUsageFetcher.swift
@@ -46,43 +46,8 @@ enum CodexUsageParser {
         return [result.rateLimits]
     }
 }
-
 enum CodexUsageFetchError: Error {
     case appServer(String)
-}
-
-/// Resolves the Codex CLI without relying on LaunchServices/launchd to provide
-/// an interactive-shell PATH. Existing PATH order wins, followed by the common
-/// user and package-manager install locations used on macOS.
-enum CodexExecutableResolver {
-    static func resolve(
-        environment: [String: String] = ProcessInfo.processInfo.environment,
-        homeDirectory: String = FileManager.default.homeDirectoryForCurrentUser.path,
-        isExecutable: (String) -> Bool = FileManager.default.isExecutableFile(atPath:)
-    ) -> String? {
-        let pathDirectories = (environment["PATH"] ?? "")
-            .split(separator: ":", omittingEmptySubsequences: true)
-            .map(String.init)
-        let fallbackDirectories = [
-            "\(homeDirectory)/.local/bin",
-            "\(homeDirectory)/.volta/bin",
-            "\(homeDirectory)/.cargo/bin",
-            "/opt/homebrew/bin",
-            "/usr/local/bin",
-            "/usr/bin",
-            "/bin",
-        ]
-        var seen = Set<String>()
-        for directory in pathDirectories + fallbackDirectories where seen.insert(directory).inserted {
-            let candidate = URL(fileURLWithPath: directory, isDirectory: true)
-                .appendingPathComponent("codex", isDirectory: false)
-                .path
-            if isExecutable(candidate) {
-                return candidate
-            }
-        }
-        return nil
-    }
 }
 
 /// Runs a short-lived Codex app-server session and performs the documented
@@ -110,7 +75,7 @@ struct CodexUsageFetcher: Sendable {
     }
 
     func fetch() async -> CodexUsageResult {
-        guard let executable = executable ?? CodexExecutableResolver.resolve() else {
+        guard let executable = executable ?? CodexExecutableResolver.resolveIfAvailable() else {
             return CodexUsageResult(unavailableReason: "Codex CLI unavailable")
         }
         let cancellation = CodexUsageCancellationRelay()

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -234,6 +234,24 @@ extension WorktreeLifecycle {
         do {
             let clock = ContinuousClock()
             let phaseStart = clock.now
+            let creationConfig = try await db.config.get()
+            let creationPrimaryKind: TerminalKind = carryover == nil
+                ? resolvePrimaryTerminalKind(
+                    skipClaude: skipClaude,
+                    archivedClaudeSessions: nil,
+                    configuredPreference:
+                        primaryAgentPreference ?? creationConfig.primaryAgentPreference
+                )
+                : .claude
+            // Preflight the full Codex launch before creating a directory,
+            // checking out a worktree, or starting a pre-session pane. Passing
+            // the prepared values through phase 3 also prevents a second,
+            // post-mutation resolution attempt after a long-running hook.
+            let preparedCodexLaunch = creationPrimaryKind == .codex
+                ? try CodexLaunchPreparation.prepare(
+                    executableResolver: codexExecutableResolver,
+                    homeEnsurer: codexHomeEnsurer)
+                : nil
 
             // 1. Create parent directory
             let createDirStart = clock.now
@@ -381,7 +399,8 @@ extension WorktreeLifecycle {
                         modelOverride: modelOverride,
                         primaryAgentPreference: primaryAgentPreference,
                         claudeSettingsOverlay: claudeSettingsOverlay,
-                        carryover: carryover
+                        carryover: carryover,
+                        preparedCodexLaunch: preparedCodexLaunch
                     )
                     // Fresh creates get an initial note tab, appended after the
                     // primary spawn set the tab order. Create path only — a
@@ -410,7 +429,8 @@ extension WorktreeLifecycle {
                 modelOverride: modelOverride,
                 primaryAgentPreference: primaryAgentPreference,
                 claudeSettingsOverlay: claudeSettingsOverlay,
-                carryover: carryover
+                carryover: carryover,
+                preparedCodexLaunch: preparedCodexLaunch
             )
             let terminalSpawnElapsedMs = terminalSpawnStart.duration(to: clock.now) / .milliseconds(1)
             timingLogger.debug("terminal-spawn \(worktreeID.uuidString, privacy: .public) \(Int(terminalSpawnElapsedMs))ms")
@@ -642,7 +662,8 @@ extension WorktreeLifecycle {
         modelOverride: String? = nil,
         primaryAgentPreference: PrimaryAgentPreference? = nil,
         claudeSettingsOverlay: String? = nil,
-        carryover: ConversationCarryover? = nil
+        carryover: ConversationCarryover? = nil,
+        preparedCodexLaunch: CodexLaunchPreparation? = nil
     ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
@@ -657,6 +678,21 @@ extension WorktreeLifecycle {
             )
             : .claude
         let archivedSessions = archivedClaudeSessions ?? []
+        // Resolve Codex before `ensureServer` creates tmux state. `new-window`
+        // can succeed even when its child shell cannot find a bare `codex`
+        // command, which would leave a terminal row whose pane already exited.
+        let codexLaunch: CodexLaunchPreparation?
+        if primaryTerminalKind == .codex {
+            if let preparedCodexLaunch {
+                codexLaunch = preparedCodexLaunch
+            } else {
+                codexLaunch = try CodexLaunchPreparation.prepare(
+                    executableResolver: codexExecutableResolver,
+                    homeEnsurer: codexHomeEnsurer)
+            }
+        } else {
+            codexLaunch = nil
+        }
         // Resolve a usable size: prefer caller's value, otherwise fall back to
         // TmuxManager's defaults. tmux's own 80x24 default would let Claude
         // render into hard-wrapped scrollback that can never be reflowed when
@@ -720,12 +756,17 @@ extension WorktreeLifecycle {
             primaryProfileID = nil
             primaryLabel = TerminalLabel.shell
         case .codex:
-            let codexHome = try CodexHomeManager().ensureProfilePlugin()
-            primaryCommand = CodexSpawnCommandBuilder.build(initialPrompt: initialPrompt)
+            guard let codexLaunch else {
+                preconditionFailure(
+                    "Codex launch must be prepared before the Codex spawn branch")
+            }
+            primaryCommand = CodexSpawnCommandBuilder.build(
+                initialPrompt: initialPrompt,
+                executablePath: codexLaunch.executablePath)
             primaryEnv = [
                 "TBD_WORKTREE_ID": worktreeID.uuidString,
                 "TBD_TERMINAL_ID": plannedTerminalID1.uuidString,
-                "CODEX_HOME": codexHome.path,
+                "CODEX_HOME": codexLaunch.codexHome.path,
             ]
             // omz-update suppression rides `-e` (process env before .zshrc)
             // so the update prompt can't block the codex command; FORCED over

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -285,7 +285,8 @@ extension WorktreeLifecycle {
         modelOverride: String? = nil,
         primaryAgentPreference: PrimaryAgentPreference? = nil,
         claudeSettingsOverlay: String? = nil,
-        carryover: ConversationCarryover? = nil
+        carryover: ConversationCarryover? = nil,
+        preparedCodexLaunch: CodexLaunchPreparation? = nil
     ) async {
         let outcome = await waitForPreSessionCompletion(
             preSession: preSession, tmuxServer: worktree.tmuxServer
@@ -356,7 +357,8 @@ extension WorktreeLifecycle {
                 modelOverride: modelOverride,
                 primaryAgentPreference: primaryAgentPreference,
                 claudeSettingsOverlay: claudeSettingsOverlay,
-                carryover: carryover
+                carryover: carryover,
+                preparedCodexLaunch: preparedCodexLaunch
             )
             for terminal in created {
                 subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -71,6 +71,12 @@ public struct WorktreeLifecycle: Sendable {
     /// Reaper grace knobs (kept small in tests to avoid real sleeps).
     public let reaperGraceAttempts: Int
     public let reaperPollInterval: Duration
+    /// Resolves the Codex CLI before lifecycle code creates tmux or DB state.
+    /// Stored as a seam so tests do not require Codex or ChatGPT.app installed.
+    let codexExecutableResolver: @Sendable () throws -> String
+    /// Prepares TBD's profile in the user's existing global Codex home before
+    /// lifecycle code creates tmux or terminal state.
+    let codexHomeEnsurer: @Sendable () throws -> URL
     /// Dirty gate for the periodic conflict sweep (see `refreshGitStatuses`).
     /// An actor reference, so every copy of this struct shares one cache.
     public let conflictSweepCache = ConflictSweepCache()
@@ -120,7 +126,9 @@ public struct WorktreeLifecycle: Sendable {
         preSessionPollInterval: TimeInterval = 0.5,
         processSignaller: ProcessSignaller = ProductionProcessSignaller(),
         reaperGraceAttempts: Int = 30,
-        reaperPollInterval: Duration = .milliseconds(100)
+        reaperPollInterval: Duration = .milliseconds(100),
+        codexExecutableResolver: (@Sendable () throws -> String)? = nil,
+        codexHomeEnsurer: (@Sendable () throws -> URL)? = nil
     ) {
         self.db = db
         self.git = git
@@ -136,6 +144,12 @@ public struct WorktreeLifecycle: Sendable {
         self.processSignaller = processSignaller
         self.reaperGraceAttempts = reaperGraceAttempts
         self.reaperPollInterval = reaperPollInterval
+        self.codexExecutableResolver = codexExecutableResolver ?? {
+            try CodexExecutableResolver.resolve()
+        }
+        self.codexHomeEnsurer = codexHomeEnsurer ?? {
+            try CodexHomeManager().ensureProfilePlugin()
+        }
     }
 
     /// Projects root for a revive spawn's resolved profile config dir path,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -145,10 +145,14 @@ public struct WorktreeLifecycle: Sendable {
         self.reaperGraceAttempts = reaperGraceAttempts
         self.reaperPollInterval = reaperPollInterval
         self.codexExecutableResolver = codexExecutableResolver ?? {
-            try CodexExecutableResolver.resolve()
+            if tmux.dryRun { return "/opt/tbd-test/bin/codex" }
+            return try CodexExecutableResolver.resolve()
         }
         self.codexHomeEnsurer = codexHomeEnsurer ?? {
-            try CodexHomeManager().ensureProfilePlugin()
+            if tmux.dryRun {
+                return URL(fileURLWithPath: "/tmp/tbd-dry-run-codex-home", isDirectory: true)
+            }
+            return try CodexHomeManager().ensureProfilePlugin()
         }
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
@@ -1,0 +1,155 @@
+import Foundation
+import os
+import TBDShared
+
+private let continueInCodexLogger = Logger(
+    subsystem: "com.tbd.daemon", category: "continue-in-codex")
+
+private enum ContinueInCodexHandlerError: LocalizedError {
+    case userFacing(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .userFacing(let message): return message
+        }
+    }
+}
+
+extension RPCRouter {
+    func handleTerminalContinueInCodex(_ paramsData: Data) async throws
+        -> RPCResponse {
+        let params = try decoder.decode(
+            TerminalContinueInCodexParams.self, from: paramsData)
+
+        // Complete every source and launch preflight before the app-server
+        // import. Import is the first operation that can create Codex state.
+        guard let source = try await db.terminals.get(id: params.terminalID) else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "Source terminal not found: \(params.terminalID)")
+        }
+        let isLegacyClaude = source.kind == nil
+            && source.claudeSessionID != nil
+            && !source.isCodexTerminal
+        guard source.kind == .claude || isLegacyClaude else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "Continue in Codex requires a Claude terminal.")
+        }
+        guard let transcriptPath = source.transcriptPath,
+              !transcriptPath.isEmpty else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "The selected Claude terminal has no transcript path yet.")
+        }
+        guard (transcriptPath as NSString).isAbsolutePath else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "The selected Claude terminal has an invalid transcript path.")
+        }
+        var transcriptIsDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(
+                atPath: transcriptPath,
+                isDirectory: &transcriptIsDirectory),
+              !transcriptIsDirectory.boolValue,
+              FileManager.default.isReadableFile(atPath: transcriptPath) else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "The selected Claude transcript is missing or unreadable: \(transcriptPath)")
+        }
+        guard let worktree = try await db.worktrees.get(id: source.worktreeID) else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "Worktree not found for source terminal \(source.id).")
+        }
+        guard worktree.status == .active || worktree.status == .main else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "Worktree is not active: \(worktree.displayName). Revive or finish creating it before continuing the session.")
+        }
+        var worktreeIsDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(
+                atPath: worktree.path,
+                isDirectory: &worktreeIsDirectory),
+              worktreeIsDirectory.boolValue else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "Worktree directory is missing on disk: \(worktree.path)")
+        }
+
+        let preparation = try CodexLaunchPreparation.prepare(
+            executableResolver: codexExecutableResolver,
+            homeEnsurer: codexHomeEnsurer)
+        let profileFlag = codexProfileFlagResolver(preparation.executablePath)
+
+        let threadID = try await codexSessionImport(
+            preparation.executablePath,
+            preparation.codexHome,
+            transcriptPath,
+            worktree.path,
+            nil)
+        guard !threadID.isEmpty else {
+            throw ContinueInCodexHandlerError.userFacing(
+                "Codex imported the session but returned an empty thread ID.")
+        }
+
+        let repo: Repo?
+        if let repoID = worktree.repoID {
+            repo = try await db.repos.get(id: repoID)
+        } else {
+            repo = nil
+        }
+        let config = try? await db.config.get()
+        let plannedTerminalID = UUID()
+        let codexEnv: [String: String] = [
+            "TBD_WORKTREE_ID": worktree.id.uuidString,
+            "TBD_TERMINAL_ID": plannedTerminalID.uuidString,
+            "CODEX_HOME": preparation.codexHome.path,
+        ]
+        let sensitiveEnv = EnvOverrideResolver.merge(
+            global: config?.envOverrides,
+            repo: repo?.envOverrides,
+            profile: nil
+        ).merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
+        let command = CodexSpawnCommandBuilder.build(
+            initialPrompt: nil,
+            resumeThreadID: threadID,
+            executablePath: preparation.executablePath,
+            profileFlag: profileFlag)
+
+        _ = try await tmux.ensureServer(
+            server: worktree.tmuxServer,
+            session: "main",
+            cwd: worktree.path,
+            cols: TmuxManager.defaultCols,
+            rows: TmuxManager.defaultRows)
+        await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
+        let window = try await tmux.createWindow(
+            server: worktree.tmuxServer,
+            session: "main",
+            cwd: worktree.path,
+            shellCommand: command,
+            env: codexEnv,
+            sensitiveEnv: sensitiveEnv,
+            cols: TmuxManager.defaultCols,
+            rows: TmuxManager.defaultRows)
+
+        let terminal: Terminal
+        do {
+            terminal = try await db.terminals.create(
+                id: plannedTerminalID,
+                worktreeID: worktree.id,
+                tmuxWindowID: window.windowID,
+                tmuxPaneID: window.paneID,
+                label: TerminalLabel.codex,
+                kind: .codex)
+        } catch {
+            try? await tmux.killWindow(
+                server: worktree.tmuxServer,
+                windowID: window.windowID)
+            throw error
+        }
+
+        subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
+            terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
+            label: terminal.label)))
+        continueInCodexLogger.info(
+            "Continued Claude terminal \(source.id, privacy: .public) in Codex terminal \(terminal.id, privacy: .public)")
+        return try RPCResponse(result: TerminalContinueInCodexResult(
+            terminalID: terminal.id,
+            threadID: threadID))
+    }
+}

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -94,6 +94,15 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree directory missing on disk: \(worktree.path). Cannot create a terminal there.")
         }
 
+        // Resolve Codex before creating any tmux state. A GUI-launched daemon
+        // can have a minimal PATH, and a resolution failure must not leave an
+        // orphan window or terminal row behind.
+        let codexPreparation = params.type == .codex
+            ? try CodexLaunchPreparation.prepare(
+                executableResolver: codexExecutableResolver,
+                homeEnsurer: codexHomeEnsurer)
+            : nil
+
         // Resolve initial size: caller-supplied → TmuxManager defaults to avoid
         // tmux's 80x24 default producing un-reflowable hard-wrapped scrollback.
         let resolvedCols = params.cols ?? TmuxManager.defaultCols
@@ -151,7 +160,10 @@ extension RPCRouter {
         // a Claude-centric host and would be misleading noise inside a
         // Codex pane.
         if params.type == .codex {
-            let codexHome = try CodexHomeManager().ensureProfilePlugin()
+            guard let codexPreparation else {
+                return RPCResponse(
+                    error: "Codex launch preparation unexpectedly returned no result.")
+            }
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
             codexEnv["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
@@ -159,7 +171,7 @@ extension RPCRouter {
             // the design's allowed "set the global path" option — not leftover
             // per-repo isolation: it pins deterministic behavior and lets the
             // TBD_TEST_CODEX_HOME test-isolation override flow through.
-            codexEnv["CODEX_HOME"] = codexHome.path
+            codexEnv["CODEX_HOME"] = codexPreparation.codexHome.path
             // COLORFGBG isn't Claude-specific — Codex shells benefit from it too,
             // so include it at spawn time. (Live updates also reach Codex via
             // `tmux setenv -g COLORFGBG` fanned out by handleAppearanceUpdateColorFgBg.)
@@ -183,7 +195,9 @@ extension RPCRouter {
                 server: worktree.tmuxServer,
                 session: "main",
                 cwd: worktree.path,
-                shellCommand: CodexSpawnCommandBuilder.build(initialPrompt: params.prompt),
+                shellCommand: CodexSpawnCommandBuilder.build(
+                    initialPrompt: params.prompt,
+                    executablePath: codexPreparation.executablePath),
                 env: codexEnv,
                 sensitiveEnv: codexEnvOverrides,
                 cols: resolvedCols,
@@ -813,6 +827,17 @@ extension RPCRouter {
             return RPCResponse(error: "Worktree directory missing on disk: \(worktree.path). Cannot recreate the terminal window.")
         }
 
+        // Resolve and prepare Codex before killing a recreatable pane. A bad
+        // executable override must leave the existing terminal untouched.
+        let codexPreparation: CodexLaunchPreparation?
+        if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
+            codexPreparation = try CodexLaunchPreparation.prepare(
+                executableResolver: codexExecutableResolver,
+                homeEnsurer: codexHomeEnsurer)
+        } else {
+            codexPreparation = nil
+        }
+
         // Kill the old window if it still exists (avoids orphans)
         try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
 
@@ -832,7 +857,9 @@ extension RPCRouter {
         // Branch on terminal kind: codex stays codex; shell/claude become shell
         if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
             // Recreate as codex — preserve identity
-            let codexHome = try CodexHomeManager().ensureProfilePlugin()
+            guard let codexPreparation else {
+                return RPCResponse(error: "Codex launch preparation was unavailable")
+            }
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = worktree.id.uuidString
             codexEnv["TBD_TERMINAL_ID"] = terminal.id.uuidString
@@ -840,7 +867,7 @@ extension RPCRouter {
             // the design's allowed "set the global path" option — not leftover
             // per-repo isolation: it pins deterministic behavior and lets the
             // TBD_TEST_CODEX_HOME test-isolation override flow through.
-            codexEnv["CODEX_HOME"] = codexHome.path
+            codexEnv["CODEX_HOME"] = codexPreparation.codexHome.path
 
             // Codex: re-apply the merged free-form overrides (global < repo) so a
             // recreated Codex pane keeps them, plus omz-update suppression via
@@ -863,7 +890,8 @@ extension RPCRouter {
                 server: worktree.tmuxServer,
                 session: "main",
                 cwd: worktree.path,
-                shellCommand: CodexSpawnCommandBuilder.command,
+                shellCommand: CodexSpawnCommandBuilder.command(
+                    executablePath: codexPreparation.executablePath),
                 env: codexEnv,
                 sensitiveEnv: codexEnvOverrides,
                 cols: resolvedCols,

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -70,6 +70,34 @@ public final class RPCRouter: Sendable {
     /// re-implement gating. Broadcasts through the same `subscriptions`
     /// channel every other mutating handler uses.
     public let panelCoordinator: PanelCoordinator
+    /// Native Claude-to-Codex import seams. Production uses the installed
+    /// Codex app-server; tests replace these before invoking the handler.
+    nonisolated(unsafe) var codexExecutableResolver: @Sendable () throws -> String = {
+        try CodexExecutableResolver.resolve()
+    }
+    nonisolated(unsafe) var codexHomeEnsurer: @Sendable () throws -> URL = {
+        try CodexHomeManager().ensureProfilePlugin()
+    }
+    nonisolated(unsafe) var codexProfileFlagResolver: @Sendable (String) -> String = { executable in
+        CodexSpawnCommandBuilder.detectProfileFlag(executablePath: executable) { arguments in
+            CodexSpawnCommandBuilder.commandOutput(arguments: arguments, timeout: 3)
+        }
+    }
+    nonisolated(unsafe) var codexSessionImport: @Sendable (
+        _ executablePath: String,
+        _ codexHome: URL,
+        _ transcriptPath: String,
+        _ cwd: String,
+        _ title: String?
+    ) async throws -> String = { executablePath, codexHome, transcriptPath, cwd, title in
+        try await CodexSessionImporter(
+            executablePath: executablePath,
+            codexHome: codexHome
+        ).importSession(
+            transcriptPath: transcriptPath,
+            cwd: cwd,
+            title: title)
+    }
 
     /// Single-flights concurrent `pr.list` RPCs so a poll storm collapses into
     /// one git enumeration + gh fetch instead of N overlapping ones.
@@ -205,6 +233,8 @@ public final class RPCRouter: Sendable {
                 return try await handleWorktreeForget(request.paramsData)
             case RPCMethod.terminalCreate:
                 return try await handleTerminalCreate(request.paramsData)
+            case RPCMethod.terminalContinueInCodex:
+                return try await handleTerminalContinueInCodex(request.paramsData)
             case RPCMethod.terminalList:
                 return try await handleTerminalList(request.paramsData)
             case RPCMethod.terminalSend:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -72,12 +72,8 @@ public final class RPCRouter: Sendable {
     public let panelCoordinator: PanelCoordinator
     /// Native Claude-to-Codex import seams. Production uses the installed
     /// Codex app-server; tests replace these before invoking the handler.
-    nonisolated(unsafe) var codexExecutableResolver: @Sendable () throws -> String = {
-        try CodexExecutableResolver.resolve()
-    }
-    nonisolated(unsafe) var codexHomeEnsurer: @Sendable () throws -> URL = {
-        try CodexHomeManager().ensureProfilePlugin()
-    }
+    nonisolated(unsafe) var codexExecutableResolver: @Sendable () throws -> String
+    nonisolated(unsafe) var codexHomeEnsurer: @Sendable () throws -> URL
     nonisolated(unsafe) var codexProfileFlagResolver: @Sendable (String) -> String = { executable in
         CodexSpawnCommandBuilder.detectProfileFlag(executablePath: executable) { arguments in
             CodexSpawnCommandBuilder.commandOutput(arguments: arguments, timeout: 3)
@@ -133,7 +129,9 @@ public final class RPCRouter: Sendable {
         configDirManager: ClaudeProfileConfigDirManager = ClaudeProfileConfigDirManager(),
         claudeCredentialsKeychain: ClaudeCredentialsKeychainDeleting = SecItemClaudeCredentialsKeychain(),
         loginSessions: LoginSessionCoordinator = LoginSessionCoordinator(),
-        remoteManager: RemoteProviderManager? = nil
+        remoteManager: RemoteProviderManager? = nil,
+        codexExecutableResolver: (@Sendable () throws -> String)? = nil,
+        codexHomeEnsurer: (@Sendable () throws -> URL)? = nil
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -162,6 +160,16 @@ public final class RPCRouter: Sendable {
         self.panelCoordinator = PanelCoordinator(
             db: db, broadcast: { [subscriptions] delta in subscriptions.broadcast(delta: delta) })
         self.remoteManager = remoteManager
+        self.codexExecutableResolver = codexExecutableResolver ?? {
+            if tmux.dryRun { return "/opt/tbd-test/bin/codex" }
+            return try CodexExecutableResolver.resolve()
+        }
+        self.codexHomeEnsurer = codexHomeEnsurer ?? {
+            if tmux.dryRun {
+                return URL(fileURLWithPath: "/tmp/tbd-dry-run-codex-home", isDirectory: true)
+            }
+            return try CodexHomeManager().ensureProfilePlugin()
+        }
     }
 
     /// Handle a raw JSON Data blob representing an RPCRequest.

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -112,6 +112,7 @@ public enum RPCMethod {
     public static let worktreeMove = "worktree.move"
     public static let worktreeForget = "worktree.forget"
     public static let terminalCreate = "terminal.create"
+    public static let terminalContinueInCodex = "terminal.continueInCodex"
     public static let terminalList = "terminal.list"
     public static let terminalSend = "terminal.send"
     public static let terminalFocus = "terminal.focus"
@@ -1367,6 +1368,24 @@ public struct TerminalCreateParams: Codable, Sendable {
         self.loginSession = loginSession
         self.cols = cols; self.rows = rows; self.colorFgBg = colorFgBg
         self.claudeSettingsOverlay = claudeSettingsOverlay
+    }
+}
+
+public struct TerminalContinueInCodexParams: Codable, Sendable {
+    public let terminalID: UUID
+
+    public init(terminalID: UUID) {
+        self.terminalID = terminalID
+    }
+}
+
+public struct TerminalContinueInCodexResult: Codable, Sendable, Equatable {
+    public let terminalID: UUID
+    public let threadID: String
+
+    public init(terminalID: UUID, threadID: String) {
+        self.terminalID = terminalID
+        self.threadID = threadID
     }
 }
 

--- a/Tests/TBDAppTests/ContinueInCodexMenuTests.swift
+++ b/Tests/TBDAppTests/ContinueInCodexMenuTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+@Suite("Continue in Codex menu visibility")
+struct ContinueInCodexMenuTests {
+    private func terminal(
+        kind: TerminalKind,
+        transcriptPath: String? = nil
+    ) -> Terminal {
+        Terminal(
+            worktreeID: UUID(),
+            tmuxWindowID: "@1",
+            tmuxPaneID: "%1",
+            claudeSessionID: kind == .claude ? "session-1" : nil,
+            transcriptPath: transcriptPath,
+            kind: kind)
+    }
+
+    @Test("visible for a Claude tab with a transcript")
+    func visibleForImportableClaude() {
+        #expect(ContinueInCodexMenu.isVisible(for: terminal(
+            kind: .claude,
+            transcriptPath: "/tmp/session.jsonl")))
+    }
+
+    @Test("hidden until Claude publishes a transcript path")
+    func hiddenWithoutTranscript() {
+        #expect(!ContinueInCodexMenu.isVisible(for: terminal(kind: .claude)))
+        #expect(!ContinueInCodexMenu.isVisible(for: terminal(
+            kind: .claude,
+            transcriptPath: "")))
+    }
+
+    @Test("hidden for Codex and shell tabs")
+    func hiddenForOtherTerminalKinds() {
+        #expect(!ContinueInCodexMenu.isVisible(for: terminal(
+            kind: .codex,
+            transcriptPath: "/tmp/session.jsonl")))
+        #expect(!ContinueInCodexMenu.isVisible(for: terminal(
+            kind: .shell,
+            transcriptPath: "/tmp/session.jsonl")))
+        #expect(!ContinueInCodexMenu.isVisible(for: nil))
+    }
+}

--- a/Tests/TBDCLITests/TerminalContinueInCodexCommandTests.swift
+++ b/Tests/TBDCLITests/TerminalContinueInCodexCommandTests.swift
@@ -1,0 +1,31 @@
+import ArgumentParser
+import Testing
+@testable import TBDCLI
+
+@Suite("tbd terminal continue-in-codex parsing")
+struct TerminalContinueInCodexCommandTests {
+    @Test("accepts a positional terminal ID")
+    func parsesTerminalID() throws {
+        let id = "2D5B06CC-4930-445D-B562-7BF7C1706418"
+        let command = try TerminalContinueInCodex.parse([id])
+
+        #expect(command.terminal == id)
+        #expect(!command.json)
+    }
+
+    @Test("accepts JSON output")
+    func parsesJSONFlag() throws {
+        let id = "2D5B06CC-4930-445D-B562-7BF7C1706418"
+        let command = try TerminalContinueInCodex.parse([id, "--json"])
+
+        #expect(command.terminal == id)
+        #expect(command.json)
+    }
+
+    @Test("requires a terminal ID")
+    func requiresTerminalID() {
+        #expect(throws: (any Error).self) {
+            _ = try TerminalContinueInCodex.parse([])
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -118,6 +118,10 @@ import TBDShared
         )
         #expect(profile.contains(#"[plugins."tbd@tbd"]"#))
         #expect(profile.contains("enabled = true"))
+        #expect(profile.contains(CodexProfileWriter.shadcnServerHeader))
+        #expect(profile.contains(#"command = "npx""#))
+        #expect(profile.contains(#"args = ["shadcn@latest", "mcp"]"#))
+        #expect(profile.contains("enabled = false"))
     }
 
     @Test func ensurePluginEnabledPreservesProfileAndEnablesExistingSection() {
@@ -169,6 +173,35 @@ import TBDShared
         }
     }
 
+    @Test func ensureShadcnDisabledPreservesProfileAndIsIdempotent() {
+        let input = """
+        model = "gpt-5.1"
+
+        [mcp_servers.shadcn]
+        enabled = true
+        command = "wrong-command"
+        args = ["wrong-argument"]
+        enabled = true
+
+        [tools]
+        web_search = true
+        """
+
+        let first = CodexProfileWriter.ensureShadcnDisabled(in: input)
+        let second = CodexProfileWriter.ensureShadcnDisabled(in: first)
+
+        #expect(first.contains(#"model = "gpt-5.1""#))
+        #expect(first.contains(#"command = "npx""#))
+        #expect(first.contains(#"args = ["shadcn@latest", "mcp"]"#))
+        #expect(first.contains("[tools]"))
+        #expect(first.contains("enabled = false"))
+        #expect(!first.contains("wrong-command"))
+        #expect(!first.contains("wrong-argument"))
+        #expect(!first.contains("enabled = true"))
+        #expect(first.components(separatedBy: "enabled = false").count == 2)
+        #expect(second == first, "shadcn profile override must be idempotent")
+    }
+
     @Test func ensureProfileIsIdempotentAndDoesNotRewrite() throws {
         let codexHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-profile-idem-\(UUID().uuidString)", isDirectory: true)
@@ -185,8 +218,53 @@ import TBDShared
         let secondModified = try FileManager.default
             .attributesOfItem(atPath: path.path)[.modificationDate] as? Date
 
+        #expect(firstContent.contains(CodexProfileWriter.shadcnServerHeader))
+        #expect(firstContent.contains(#"command = "npx""#))
+        #expect(firstContent.contains(#"args = ["shadcn@latest", "mcp"]"#))
+        #expect(firstContent.contains("enabled = false"))
         #expect(firstContent == secondContent, "profile content must be byte-identical after second run")
         #expect(firstModified == secondModified, "second ensureProfile run must not rewrite the file")
+    }
+
+    @Test func generatedProfileParsesWithInstalledCodexAndOmitsDisabledShadcn() throws {
+        guard let executable = try? CodexExecutableResolver.resolve() else {
+            return
+        }
+        #expect(executable.hasPrefix("/"))
+
+        let codexHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "tbd-codex-profile-parse-\(UUID().uuidString)",
+                isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: codexHome) }
+        _ = try CodexHomeManager(codexHome: codexHome).ensureProfilePlugin()
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        let profileFlag = CodexSpawnCommandBuilder.detectProfileFlag(
+            executablePath: executable
+        ) { arguments in
+            CodexSpawnCommandBuilder.commandOutput(
+                arguments: arguments,
+                timeout: 3)
+        }
+        process.arguments = [profileFlag, CodexPlugin.profileName, "mcp", "list"]
+        var environment = ProcessInfo.processInfo.environment
+        environment["CODEX_HOME"] = codexHome.path
+        process.environment = environment
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+        try process.run()
+        process.waitUntilExit()
+
+        let output = String(
+            decoding: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+            as: UTF8.self
+        )
+        #expect(process.terminationStatus == 0, "Codex rejected the generated profile: \(output)")
+        #expect(!output.localizedCaseInsensitiveContains("shadcn"))
     }
 
     @Test func ensurePluginEnabledPreservesEnabledPrefixedKeys() {
@@ -257,8 +335,15 @@ import TBDShared
 
         let headerCount = firstContent.components(separatedBy: #"[plugins."tbd@tbd"]"#).count - 1
         #expect(headerCount == 1, "exactly one [plugins.\"tbd@tbd\"] table after rewrite")
-        #expect(firstContent.contains("enabled = true"))
-        #expect(!firstContent.contains("enabled = false"))
+        let shadcnRange = try #require(
+            firstContent.range(of: CodexProfileWriter.shadcnServerHeader))
+        let pluginSection = String(firstContent[..<shadcnRange.lowerBound])
+        let shadcnSection = String(firstContent[shadcnRange.lowerBound...])
+        #expect(pluginSection.contains("enabled = true"))
+        #expect(!pluginSection.contains("enabled = false"))
+        #expect(shadcnSection.contains(#"command = "npx""#))
+        #expect(shadcnSection.contains(#"args = ["shadcn@latest", "mcp"]"#))
+        #expect(shadcnSection.contains("enabled = false"))
         #expect(!firstContent.contains("\r"), "rewritten profile must use LF endings")
 
         try CodexProfileWriter.ensureProfile(in: codexHome)

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -118,10 +118,6 @@ import TBDShared
         )
         #expect(profile.contains(#"[plugins."tbd@tbd"]"#))
         #expect(profile.contains("enabled = true"))
-        #expect(profile.contains(CodexProfileWriter.shadcnServerHeader))
-        #expect(profile.contains(#"command = "npx""#))
-        #expect(profile.contains(#"args = ["shadcn@latest", "mcp"]"#))
-        #expect(profile.contains("enabled = false"))
     }
 
     @Test func ensurePluginEnabledPreservesProfileAndEnablesExistingSection() {
@@ -173,35 +169,6 @@ import TBDShared
         }
     }
 
-    @Test func ensureShadcnDisabledPreservesProfileAndIsIdempotent() {
-        let input = """
-        model = "gpt-5.1"
-
-        [mcp_servers.shadcn]
-        enabled = true
-        command = "wrong-command"
-        args = ["wrong-argument"]
-        enabled = true
-
-        [tools]
-        web_search = true
-        """
-
-        let first = CodexProfileWriter.ensureShadcnDisabled(in: input)
-        let second = CodexProfileWriter.ensureShadcnDisabled(in: first)
-
-        #expect(first.contains(#"model = "gpt-5.1""#))
-        #expect(first.contains(#"command = "npx""#))
-        #expect(first.contains(#"args = ["shadcn@latest", "mcp"]"#))
-        #expect(first.contains("[tools]"))
-        #expect(first.contains("enabled = false"))
-        #expect(!first.contains("wrong-command"))
-        #expect(!first.contains("wrong-argument"))
-        #expect(!first.contains("enabled = true"))
-        #expect(first.components(separatedBy: "enabled = false").count == 2)
-        #expect(second == first, "shadcn profile override must be idempotent")
-    }
-
     @Test func ensureProfileIsIdempotentAndDoesNotRewrite() throws {
         let codexHome = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-profile-idem-\(UUID().uuidString)", isDirectory: true)
@@ -218,53 +185,8 @@ import TBDShared
         let secondModified = try FileManager.default
             .attributesOfItem(atPath: path.path)[.modificationDate] as? Date
 
-        #expect(firstContent.contains(CodexProfileWriter.shadcnServerHeader))
-        #expect(firstContent.contains(#"command = "npx""#))
-        #expect(firstContent.contains(#"args = ["shadcn@latest", "mcp"]"#))
-        #expect(firstContent.contains("enabled = false"))
         #expect(firstContent == secondContent, "profile content must be byte-identical after second run")
         #expect(firstModified == secondModified, "second ensureProfile run must not rewrite the file")
-    }
-
-    @Test func generatedProfileParsesWithInstalledCodexAndOmitsDisabledShadcn() throws {
-        guard let executable = try? CodexExecutableResolver.resolve() else {
-            return
-        }
-        #expect(executable.hasPrefix("/"))
-
-        let codexHome = FileManager.default.temporaryDirectory
-            .appendingPathComponent(
-                "tbd-codex-profile-parse-\(UUID().uuidString)",
-                isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: codexHome) }
-        _ = try CodexHomeManager(codexHome: codexHome).ensureProfilePlugin()
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
-        let profileFlag = CodexSpawnCommandBuilder.detectProfileFlag(
-            executablePath: executable
-        ) { arguments in
-            CodexSpawnCommandBuilder.commandOutput(
-                arguments: arguments,
-                timeout: 3)
-        }
-        process.arguments = [profileFlag, CodexPlugin.profileName, "mcp", "list"]
-        var environment = ProcessInfo.processInfo.environment
-        environment["CODEX_HOME"] = codexHome.path
-        process.environment = environment
-
-        let outputPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = outputPipe
-        try process.run()
-        process.waitUntilExit()
-
-        let output = String(
-            decoding: outputPipe.fileHandleForReading.readDataToEndOfFile(),
-            as: UTF8.self
-        )
-        #expect(process.terminationStatus == 0, "Codex rejected the generated profile: \(output)")
-        #expect(!output.localizedCaseInsensitiveContains("shadcn"))
     }
 
     @Test func ensurePluginEnabledPreservesEnabledPrefixedKeys() {
@@ -335,15 +257,8 @@ import TBDShared
 
         let headerCount = firstContent.components(separatedBy: #"[plugins."tbd@tbd"]"#).count - 1
         #expect(headerCount == 1, "exactly one [plugins.\"tbd@tbd\"] table after rewrite")
-        let shadcnRange = try #require(
-            firstContent.range(of: CodexProfileWriter.shadcnServerHeader))
-        let pluginSection = String(firstContent[..<shadcnRange.lowerBound])
-        let shadcnSection = String(firstContent[shadcnRange.lowerBound...])
-        #expect(pluginSection.contains("enabled = true"))
-        #expect(!pluginSection.contains("enabled = false"))
-        #expect(shadcnSection.contains(#"command = "npx""#))
-        #expect(shadcnSection.contains(#"args = ["shadcn@latest", "mcp"]"#))
-        #expect(shadcnSection.contains("enabled = false"))
+        #expect(firstContent.contains("enabled = true"))
+        #expect(!firstContent.contains("enabled = false"))
         #expect(!firstContent.contains("\r"), "rewritten profile must use LF endings")
 
         try CodexProfileWriter.ensureProfile(in: codexHome)

--- a/Tests/TBDDaemonTests/CodexSessionImporterTests.swift
+++ b/Tests/TBDDaemonTests/CodexSessionImporterTests.swift
@@ -1,0 +1,213 @@
+import Clocks
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+
+@Suite("CodexSessionImporter", .clockDriven)
+struct CodexSessionImporterTests {
+    private final class FakeConnection: CodexAppServerConnection,
+        @unchecked Sendable {
+        private struct State {
+            var responses: [Result<Data, any Error>]
+            var sent: [Data] = []
+            var waiter: CheckedContinuation<Data, any Error>?
+            var closed = false
+        }
+
+        private let lock: NSLock
+        private var state: State
+
+        init(responses: [Data]) {
+            lock = NSLock()
+            state = State(responses: responses.map(Result.success))
+        }
+
+        func send(_ line: Data) throws {
+            lock.lock()
+            state.sent.append(line)
+            lock.unlock()
+        }
+
+        func receive() async throws -> Data {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                if !state.responses.isEmpty {
+                    let response = state.responses.removeFirst()
+                    lock.unlock()
+                    continuation.resume(with: response)
+                } else if state.closed {
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    state.waiter = continuation
+                    lock.unlock()
+                }
+            }
+        }
+
+        func close() {
+            lock.lock()
+            state.closed = true
+            let waiter = state.waiter
+            state.waiter = nil
+            lock.unlock()
+            waiter?.resume(throwing: CancellationError())
+        }
+
+        var sentLines: [Data] {
+            lock.lock()
+            defer { lock.unlock() }
+            return state.sent
+        }
+
+        var isClosed: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return state.closed
+        }
+    }
+
+    private struct FakeTransport: CodexAppServerTransport {
+        let connection: FakeConnection
+
+        func connect(executablePath: String, codexHome: URL) async throws
+            -> any CodexAppServerConnection {
+            connection
+        }
+    }
+
+    @Test("emits exactly one SESSIONS item and captures its target")
+    func importsExactlyOneSession() async throws {
+        let connection = FakeConnection(responses: [
+            json(["jsonrpc": "2.0", "id": 1, "result": [:]]),
+            json([
+                "jsonrpc": "2.0", "id": 2,
+                "result": ["importId": "import-1"],
+            ]),
+            json([
+                "jsonrpc": "2.0",
+                "method": "externalAgentConfig/import/completed",
+                "params": [
+                    "importId": "import-1",
+                    "itemTypeResults": [[
+                        "itemType": "SESSIONS",
+                        "successes": [[
+                            "source": "/tmp/source.jsonl",
+                            "target": "thread-123",
+                        ]],
+                        "failures": [],
+                    ]],
+                ],
+            ]),
+        ])
+        let importer = CodexSessionImporter(
+            executablePath: "/opt/bin/codex",
+            codexHome: URL(fileURLWithPath: "/tmp/codex-home"),
+            transport: FakeTransport(connection: connection))
+
+        let target = try await importer.importSession(
+            transcriptPath: "/tmp/source.jsonl",
+            cwd: "/tmp/worktree",
+            title: "Session title")
+
+        #expect(target == "thread-123")
+        #expect(connection.isClosed)
+        #expect(connection.sentLines.count == 3)
+        let methods = try connection.sentLines.map(method(from:))
+        #expect(methods == [
+            "initialize", "initialized", "externalAgentConfig/import",
+        ])
+        #expect(!methods.contains("externalAgentConfig/detect"))
+
+        let request = try object(from: connection.sentLines[2])
+        let params = try #require(request["params"] as? [String: Any])
+        let items = try #require(params["migrationItems"] as? [[String: Any]])
+        #expect(items.count == 1)
+        #expect(items[0]["itemType"] as? String == "SESSIONS")
+        let details = try #require(items[0]["details"] as? [String: Any])
+        let sessions = try #require(details["sessions"] as? [[String: Any]])
+        #expect(sessions.count == 1)
+        #expect(sessions[0]["path"] as? String == "/tmp/source.jsonl")
+        #expect(sessions[0]["cwd"] as? String == "/tmp/worktree")
+        #expect(sessions[0]["title"] as? String == "Session title")
+        #expect(Set(details.keys) == ["sessions"])
+    }
+
+    @Test("a SESSIONS failure becomes an actionable error")
+    func surfacesSessionFailure() async {
+        let connection = FakeConnection(responses: [
+            json(["jsonrpc": "2.0", "id": 1, "result": [:]]),
+            json([
+                "jsonrpc": "2.0", "id": 2,
+                "result": ["importId": "import-2"],
+            ]),
+            json([
+                "jsonrpc": "2.0",
+                "method": "externalAgentConfig/import/completed",
+                "params": [
+                    "importId": "import-2",
+                    "itemTypeResults": [[
+                        "itemType": "SESSIONS",
+                        "successes": [],
+                        "failures": [[
+                            "itemType": "SESSIONS",
+                            "failureStage": "conversion",
+                            "message": "source transcript is unreadable",
+                        ]],
+                    ]],
+                ],
+            ]),
+        ])
+        let importer = CodexSessionImporter(
+            executablePath: "/opt/bin/codex",
+            codexHome: URL(fileURLWithPath: "/tmp/codex-home"),
+            transport: FakeTransport(connection: connection))
+
+        await #expect(throws: CodexSessionImportError.appServer(
+            "source transcript is unreadable")) {
+            try await importer.importSession(
+                transcriptPath: "/tmp/source.jsonl",
+                cwd: "/tmp/worktree")
+        }
+        #expect(connection.isClosed)
+    }
+
+    @Test("a silent app-server times out on the injected clock")
+    func timeoutUsesInjectedClock() async {
+        let clock = TestClock<Duration>()
+        let connection = FakeConnection(responses: [])
+        let importer = CodexSessionImporter(
+            executablePath: "/opt/bin/codex",
+            codexHome: URL(fileURLWithPath: "/tmp/codex-home"),
+            transport: FakeTransport(connection: connection),
+            timeout: .seconds(5),
+            clock: clock)
+        let task = Task {
+            try await importer.importSession(
+                transcriptPath: "/tmp/source.jsonl",
+                cwd: "/tmp/worktree")
+        }
+
+        await clock.advanceWhenSuspended(by: .seconds(5))
+
+        await #expect(throws: CodexSessionImportError.timedOut) {
+            try await task.value
+        }
+        #expect(connection.isClosed)
+    }
+
+    private func json(_ object: [String: Any]) -> Data {
+        // Test fixture is static and valid by construction.
+        try! JSONSerialization.data(withJSONObject: object)
+    }
+
+    private func object(from data: Data) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func method(from data: Data) throws -> String {
+        let value = try object(from: data)["method"] as? String
+        return try #require(value)
+    }
+}

--- a/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/CodexSpawnCommandBuilderTests.swift
@@ -2,6 +2,197 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 
+@Suite("CodexExecutableResolver")
+struct CodexExecutableResolverTests {
+    @Test("configured absolute executable override wins before PATH and fallback")
+    func configuredOverrideWins() throws {
+        var checked: [String] = []
+
+        let result = try CodexExecutableResolver.resolve(
+            configuredOverride: "/opt/tbd/bin/codex",
+            searchPath: "/first/bin:/second/bin",
+            currentDirectory: "/worktree",
+            fallbackPath: "/Applications/ChatGPT.app/Contents/Resources/codex",
+            isExecutable: { candidate in
+                checked.append(candidate)
+                return true
+            }
+        )
+
+        #expect(result == "/opt/tbd/bin/codex")
+        #expect(checked == ["/opt/tbd/bin/codex"])
+    }
+
+    @Test("relative configured override fails without falling back to PATH")
+    func relativeConfiguredOverrideFails() {
+        var checked: [String] = []
+
+        do {
+            _ = try CodexExecutableResolver.resolve(
+                configuredOverride: "tools/codex",
+                searchPath: "/usr/bin:/bin",
+                currentDirectory: "/worktree",
+                isExecutable: { candidate in
+                    checked.append(candidate)
+                    return true
+                }
+            )
+            Issue.record("Expected relative Codex executable override to fail")
+        } catch let error as CodexExecutableResolutionError {
+            #expect(error == .invalidOverride(
+                environmentKey: CodexExecutableResolver.executableOverrideEnvironmentKey,
+                value: "tools/codex",
+                reason: "the path must be absolute"
+            ))
+            #expect(error.localizedDescription.contains("absolute"))
+            #expect(error.localizedDescription.contains("unset it"))
+            #expect(error.localizedDescription.contains("restart TBD"))
+            #expect(checked.isEmpty)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("non-executable configured override fails without falling back")
+    func nonExecutableConfiguredOverrideFails() {
+        var checked: [String] = []
+
+        do {
+            _ = try CodexExecutableResolver.resolve(
+                configuredOverride: "/missing/codex",
+                searchPath: "/usr/bin:/bin",
+                currentDirectory: "/worktree",
+                isExecutable: { candidate in
+                    checked.append(candidate)
+                    return candidate == "/usr/bin/codex"
+                }
+            )
+            Issue.record("Expected non-executable Codex override to fail")
+        } catch let error as CodexExecutableResolutionError {
+            #expect(error == .invalidOverride(
+                environmentKey: CodexExecutableResolver.executableOverrideEnvironmentKey,
+                value: "/missing/codex",
+                reason: "the path is not executable"
+            ))
+            #expect(error.localizedDescription.contains("TBD_CODEX_EXECUTABLE"))
+            #expect(error.localizedDescription.contains("executable"))
+            #expect(checked == ["/missing/codex"])
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("empty configured override behaves as unset")
+    func emptyConfiguredOverrideUsesPath() throws {
+        let result = try CodexExecutableResolver.resolve(
+            configuredOverride: "",
+            searchPath: "/usr/bin",
+            currentDirectory: "/worktree",
+            isExecutable: { $0 == "/usr/bin/codex" }
+        )
+
+        #expect(result == "/usr/bin/codex")
+    }
+
+    @Test("an executable directory is rejected as an override")
+    func executableDirectoryIsRejected() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "tbd-codex-directory-\(UUID().uuidString)",
+                isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        do {
+            _ = try CodexExecutableResolver.resolve(
+                configuredOverride: directory.path,
+                searchPath: "",
+                currentDirectory: directory.deletingLastPathComponent().path)
+            Issue.record("Expected a directory override to be rejected")
+        } catch let error as CodexExecutableResolutionError {
+            #expect(error == .invalidOverride(
+                environmentKey: CodexExecutableResolver.executableOverrideEnvironmentKey,
+                value: directory.path,
+                reason: "the path is not executable"
+            ))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test("PATH entries win over the ChatGPT.app fallback")
+    func pathEntriesWinInOrder() throws {
+        var checked: [String] = []
+
+        let result = try CodexExecutableResolver.resolve(
+            searchPath: "/first/bin:/second/bin",
+            currentDirectory: "/worktree",
+            fallbackPath: "/Applications/ChatGPT.app/Contents/Resources/codex",
+            isExecutable: { candidate in
+                checked.append(candidate)
+                return candidate == "/second/bin/codex"
+            }
+        )
+
+        #expect(result == "/second/bin/codex")
+        #expect(checked == ["/first/bin/codex", "/second/bin/codex"])
+    }
+
+    @Test("ChatGPT.app CLI is used when PATH has no executable Codex")
+    func fallsBackToChatGPTBundle() throws {
+        let result = try CodexExecutableResolver.resolve(
+            searchPath: "/usr/bin:/bin",
+            currentDirectory: "/worktree",
+            isExecutable: { $0 == CodexExecutableResolver.chatGPTBundlePath }
+        )
+
+        #expect(result == CodexExecutableResolver.chatGPTBundlePath)
+    }
+
+    @Test("relative and empty PATH entries cannot resolve a worktree-local executable")
+    func relativeAndEmptyPathEntriesAreIgnored() throws {
+        var checked: [String] = []
+        let result = try CodexExecutableResolver.resolve(
+            searchPath: "tools::/usr/bin",
+            currentDirectory: "/tmp/project",
+            isExecutable: { candidate in
+                checked.append(candidate)
+                return candidate == CodexExecutableResolver.chatGPTBundlePath
+            }
+        )
+
+        #expect(result == CodexExecutableResolver.chatGPTBundlePath)
+        #expect(!checked.contains("/tmp/project/tools/codex"))
+        #expect(!checked.contains("/tmp/project/codex"))
+        #expect(checked.contains("/usr/bin/codex"))
+    }
+
+    @Test("non-executable candidates produce an actionable error")
+    func missingExecutableIsActionable() {
+        do {
+            _ = try CodexExecutableResolver.resolve(
+                searchPath: "/usr/bin:/bin",
+                currentDirectory: "/worktree",
+                isExecutable: { _ in false }
+            )
+            Issue.record("Expected Codex executable resolution to fail")
+        } catch let error as CodexExecutableResolutionError {
+            #expect(error == .notFound(
+                searchPath: "/usr/bin:/bin",
+                fallbackPath: CodexExecutableResolver.chatGPTBundlePath
+            ))
+            let message = error.localizedDescription
+            #expect(message.contains("ChatGPT.app"))
+            #expect(message.contains("PATH"))
+            #expect(message.contains("TBD_CODEX_EXECUTABLE"))
+            #expect(message.contains("restart TBD"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}
+
 @Suite("CodexSpawnCommandBuilder")
 struct CodexSpawnCommandBuilderTests {
     @Test("Codex 0.134 and newer use the renamed --profile flag")
@@ -12,11 +203,11 @@ struct CodexSpawnCommandBuilderTests {
                 codexHelpOutput: "  -p, --profile <CONFIG_PROFILE_V2>",
                 codexVersionOutput: "codex-cli 0.134.0"
             )
-                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
+                == "unset CODEX_CI CODEX_THREAD_ID; 'codex' --profile tbd --dangerously-bypass-approvals-and-sandbox"
         )
         #expect(
             CodexSpawnCommandBuilder.build(initialPrompt: nil, codexVersionOutput: "codex-cli 0.135.0-alpha.1")
-                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
+                == "unset CODEX_CI CODEX_THREAD_ID; 'codex' --profile tbd --dangerously-bypass-approvals-and-sandbox"
         )
     }
 
@@ -31,7 +222,7 @@ struct CodexSpawnCommandBuilderTests {
                 """,
                 codexVersionOutput: nil
             )
-                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
+                == "unset CODEX_CI CODEX_THREAD_ID; 'codex' --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
         )
     }
 
@@ -39,7 +230,7 @@ struct CodexSpawnCommandBuilderTests {
     func olderCodexUsesProfileV2Flag() {
         #expect(
             CodexSpawnCommandBuilder.build(initialPrompt: nil, codexVersionOutput: "codex-cli 0.133.0")
-                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
+                == "unset CODEX_CI CODEX_THREAD_ID; 'codex' --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox"
         )
     }
 
@@ -47,7 +238,7 @@ struct CodexSpawnCommandBuilderTests {
     func missingVersionFallsBackToProfileFlag() {
         #expect(
             CodexSpawnCommandBuilder.build(initialPrompt: nil, codexVersionOutput: nil)
-                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox"
+                == "unset CODEX_CI CODEX_THREAD_ID; 'codex' --profile tbd --dangerously-bypass-approvals-and-sandbox"
         )
     }
 
@@ -80,6 +271,34 @@ struct CodexSpawnCommandBuilderTests {
         #expect(probedArguments == [["codex", "--help"], ["codex", "--version"]])
     }
 
+    @Test("runtime detection probes the resolved absolute executable")
+    func detectionUsesResolvedExecutable() {
+        var probedArguments: [[String]] = []
+        let executable = "/Applications/ChatGPT.app/Contents/Resources/codex"
+
+        let flag = CodexSpawnCommandBuilder.detectProfileFlag(
+            executablePath: executable
+        ) { arguments in
+            probedArguments.append(arguments)
+            return "  -p, --profile <CONFIG_PROFILE_V2>"
+        }
+
+        #expect(flag == "--profile")
+        #expect(probedArguments == [[executable, "--help"]])
+    }
+
+    @Test("resolved executable is shell escaped in the spawn command")
+    func shellEscapesResolvedExecutable() {
+        #expect(
+            CodexSpawnCommandBuilder.build(
+                initialPrompt: nil,
+                codexHelpOutput: "  -p, --profile <CONFIG_PROFILE_V2>",
+                executablePath: "/Applications/ChatGPT Preview.app/Contents/Resources/codex"
+            )
+                == "unset CODEX_CI CODEX_THREAD_ID; '/Applications/ChatGPT Preview.app/Contents/Resources/codex' --profile tbd --dangerously-bypass-approvals-and-sandbox"
+        )
+    }
+
     @Test("initial prompt is appended as a shell-escaped trailing argument")
     func appendsInitialPrompt() {
         #expect(
@@ -87,8 +306,36 @@ struct CodexSpawnCommandBuilderTests {
                 initialPrompt: "fix the failing test",
                 codexVersionOutput: "codex-cli 0.134.0"
             )
-                == "unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox 'fix the failing test'"
+                == "unset CODEX_CI CODEX_THREAD_ID; 'codex' --profile tbd --dangerously-bypass-approvals-and-sandbox 'fix the failing test'"
         )
+    }
+
+    @Test("resume thread is appended without an initial prompt")
+    func appendsResumeThread() {
+        #expect(
+            CodexSpawnCommandBuilder.build(
+                initialPrompt: nil,
+                codexHelpOutput: "  -p, --profile <CONFIG_PROFILE_V2>",
+                resumeThreadID: "thread-123",
+                executablePath: "/opt/bin/codex"
+            )
+                == "unset CODEX_CI CODEX_THREAD_ID; '/opt/bin/codex' --profile tbd --dangerously-bypass-approvals-and-sandbox resume 'thread-123'"
+        )
+    }
+
+    @Test("nil resume thread preserves the ordinary launch command")
+    func nilResumePreservesLaunch() {
+        let ordinary = CodexSpawnCommandBuilder.build(
+            initialPrompt: nil,
+            codexHelpOutput: "  -p, --profile <CONFIG_PROFILE_V2>",
+            executablePath: "/opt/bin/codex")
+        let explicitNil = CodexSpawnCommandBuilder.build(
+            initialPrompt: nil,
+            codexHelpOutput: "  -p, --profile <CONFIG_PROFILE_V2>",
+            resumeThreadID: nil,
+            executablePath: "/opt/bin/codex")
+
+        #expect(explicitNil == ordinary)
     }
 
     @Test("command output helper returns stdout and stderr")

--- a/Tests/TBDDaemonTests/CodexUsageParserTests.swift
+++ b/Tests/TBDDaemonTests/CodexUsageParserTests.swift
@@ -9,14 +9,14 @@ struct CodexUsageParserTests {
             "/custom/bin/codex",
             "/Users/test/.local/bin/codex",
         ]
-        let fromPath = CodexExecutableResolver.resolve(
+        let fromPath = CodexExecutableResolver.resolveIfAvailable(
             environment: ["PATH": "/custom/bin:/usr/bin"],
             homeDirectory: "/Users/test",
             isExecutable: { available.contains($0) }
         )
         #expect(fromPath == "/custom/bin/codex")
 
-        let fromFallback = CodexExecutableResolver.resolve(
+        let fromFallback = CodexExecutableResolver.resolveIfAvailable(
             environment: ["PATH": "/usr/bin:/bin"],
             homeDirectory: "/Users/test",
             isExecutable: { available.contains($0) }
@@ -25,17 +25,17 @@ struct CodexUsageParserTests {
     }
 
     @Test func resolverCoversVoltaAndHomebrewAndReturnsNilWhenMissing() {
-        #expect(CodexExecutableResolver.resolve(
+        #expect(CodexExecutableResolver.resolveIfAvailable(
             environment: [:],
             homeDirectory: "/Users/test",
             isExecutable: { $0 == "/Users/test/.volta/bin/codex" }
         ) == "/Users/test/.volta/bin/codex")
-        #expect(CodexExecutableResolver.resolve(
+        #expect(CodexExecutableResolver.resolveIfAvailable(
             environment: [:],
             homeDirectory: "/Users/test",
             isExecutable: { $0 == "/opt/homebrew/bin/codex" }
         ) == "/opt/homebrew/bin/codex")
-        #expect(CodexExecutableResolver.resolve(
+        #expect(CodexExecutableResolver.resolveIfAvailable(
             environment: [:],
             homeDirectory: "/Users/test",
             isExecutable: { _ in false }

--- a/Tests/TBDDaemonTests/ContinueInCodexRPCTests.swift
+++ b/Tests/TBDDaemonTests/ContinueInCodexRPCTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite("terminal.continueInCodex RPC")
+struct ContinueInCodexRPCTests {
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var commandStorage: [[String]] = []
+        private var eventStorage: [String] = []
+
+        func command(_ arguments: [String]) {
+            lock.lock()
+            commandStorage.append(arguments)
+            lock.unlock()
+        }
+
+        func event(_ value: String) {
+            lock.lock()
+            eventStorage.append(value)
+            lock.unlock()
+        }
+
+        var commands: [[String]] {
+            lock.lock()
+            defer { lock.unlock() }
+            return commandStorage
+        }
+
+        var events: [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return eventStorage
+        }
+    }
+
+    private struct Fixture {
+        let root: URL
+        let db: TBDDatabase
+        let router: RPCRouter
+        let recorder: Recorder
+        let worktree: Worktree
+    }
+
+    private func makeFixture() async throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "tbd-native-continue-\(UUID().uuidString)",
+                isDirectory: true)
+        let worktreePath = root.appendingPathComponent(
+            "worktree", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: worktreePath, withIntermediateDirectories: true)
+
+        let db = try TBDDatabase(inMemory: true)
+        let recorder = Recorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.command($0) })
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: tmux,
+                hooks: HookResolver()),
+            tmux: tmux)
+        router.codexExecutableResolver = {
+            recorder.event("resolve")
+            return "/opt/test/bin/codex"
+        }
+        router.codexHomeEnsurer = {
+            recorder.event("profile")
+            return root.appendingPathComponent("codex-home", isDirectory: true)
+        }
+        router.codexProfileFlagResolver = { _ in
+            recorder.event("profile-flag")
+            return "--profile"
+        }
+        router.codexSessionImport = { executable, home, transcript, cwd, title in
+            recorder.event("import:\(executable):\(home.path):\(transcript):\(cwd):\(title ?? "nil")")
+            return "thread-native-123"
+        }
+
+        let repo = try await db.repos.create(
+            path: worktreePath.path,
+            displayName: "sample-repo",
+            defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id,
+            name: "sample-worktree",
+            branch: "feature/native-import",
+            path: worktreePath.path,
+            tmuxServer: "tbd-native-continue-test")
+        return Fixture(
+            root: root,
+            db: db,
+            router: router,
+            recorder: recorder,
+            worktree: worktree)
+    }
+
+    private func createClaudeSource(in fixture: Fixture) async throws
+        -> Terminal {
+        let transcript = fixture.root.appendingPathComponent("source.jsonl")
+        try #"{"type":"user","message":{"content":"continue this"}}"#
+            .write(to: transcript, atomically: true, encoding: .utf8)
+        let source = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id,
+            tmuxWindowID: "@source",
+            tmuxPaneID: "%source",
+            label: TerminalLabel.claudeCode,
+            claudeSessionID: "claude-session",
+            kind: .claude)
+        try await fixture.db.terminals.updateSession(
+            id: source.id,
+            sessionID: "claude-session",
+            transcriptPath: transcript.path)
+        return try #require(try await fixture.db.terminals.get(id: source.id))
+    }
+
+    @Test("imports first, preserves the source, and opens one resumed Codex terminal")
+    func createsResumedCodexTerminal() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let source = try await createClaudeSource(in: fixture)
+        let request = try RPCRequest(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: source.id))
+
+        let response = await fixture.router.handle(request)
+
+        #expect(response.success)
+        let result = try response.decodeResult(
+            TerminalContinueInCodexResult.self)
+        #expect(result.threadID == "thread-native-123")
+        let target = try #require(
+            try await fixture.db.terminals.get(id: result.terminalID))
+        #expect(target.isCodexTerminal)
+        #expect(target.worktreeID == source.worktreeID)
+        #expect(try await fixture.db.terminals.get(id: source.id) == source)
+        #expect(Array(fixture.recorder.events.prefix(3)) == [
+            "resolve", "profile", "profile-flag",
+        ])
+        #expect(fixture.recorder.events.count == 4)
+        #expect(fixture.recorder.events[3].hasPrefix("import:"))
+
+        let newWindows = fixture.recorder.commands.filter {
+            $0.contains("new-window")
+        }
+        #expect(newWindows.count == 1)
+        let launch = try #require(newWindows.first?.last)
+        #expect(launch.contains("resume 'thread-native-123'"))
+        #expect(!launch.contains("continue this"))
+        #expect(!fixture.recorder.commands.contains { $0.contains("send-keys") })
+        #expect(!fixture.recorder.commands.contains { $0.contains("paste-buffer") })
+    }
+
+    @Test("non-Claude source fails before every launch and import seam")
+    func rejectsNonClaudeBeforeMutation() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let shell = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id,
+            tmuxWindowID: "@shell",
+            tmuxPaneID: "%shell",
+            label: TerminalLabel.shell,
+            kind: .shell)
+        let before = try await fixture.db.terminals.list(
+            worktreeID: fixture.worktree.id)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: shell.id)))
+
+        #expect(!response.success)
+        #expect(response.error?.contains("requires a Claude terminal") == true)
+        #expect(fixture.recorder.events.isEmpty)
+        #expect(fixture.recorder.commands.isEmpty)
+        #expect(try await fixture.db.terminals.list(
+            worktreeID: fixture.worktree.id) == before)
+    }
+
+    @Test("missing transcript fails before resolver, profile, import, and tmux")
+    func rejectsMissingTranscriptBeforeMutation() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let source = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id,
+            tmuxWindowID: "@source",
+            tmuxPaneID: "%source",
+            label: TerminalLabel.claudeCode,
+            claudeSessionID: "claude-session",
+            kind: .claude)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: source.id)))
+
+        #expect(!response.success)
+        #expect(response.error?.contains("no transcript path") == true)
+        #expect(fixture.recorder.events.isEmpty)
+        #expect(fixture.recorder.commands.isEmpty)
+    }
+
+    @Test("executable failure precedes profile writes, import, and tmux")
+    func resolverFailurePrecedesMutation() async throws {
+        enum Expected: Error { case failure }
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let source = try await createClaudeSource(in: fixture)
+        fixture.router.codexExecutableResolver = {
+            fixture.recorder.event("resolve")
+            throw Expected.failure
+        }
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: source.id)))
+
+        #expect(!response.success)
+        #expect(fixture.recorder.events == ["resolve"])
+        #expect(fixture.recorder.commands.isEmpty)
+        #expect(try await fixture.db.terminals.list(
+            worktreeID: fixture.worktree.id) == [source])
+    }
+
+    @Test("inactive worktree fails before every launch and import seam")
+    func rejectsInactiveWorktreeBeforeMutation() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let source = try await createClaudeSource(in: fixture)
+        try await fixture.db.worktrees.updateStatus(
+            id: fixture.worktree.id, status: .failed)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: source.id)))
+
+        #expect(!response.success)
+        #expect(response.error?.contains("not active") == true)
+        #expect(fixture.recorder.events.isEmpty)
+        #expect(fixture.recorder.commands.isEmpty)
+    }
+
+    @Test("import failure creates no tmux window or terminal row")
+    func importFailureIsAtomicForTBDState() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let source = try await createClaudeSource(in: fixture)
+        fixture.router.codexSessionImport = { _, _, _, _, _ in
+            fixture.recorder.event("import-failed")
+            throw CodexSessionImportError.appServer("conversion failed")
+        }
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalContinueInCodex,
+            params: TerminalContinueInCodexParams(terminalID: source.id)))
+
+        #expect(!response.success)
+        #expect(response.error?.contains("conversion failed") == true)
+        #expect(fixture.recorder.commands.isEmpty)
+        #expect(try await fixture.db.terminals.list(
+            worktreeID: fixture.worktree.id) == [source])
+    }
+}

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -23,6 +23,7 @@ private func isolatedConfigDirManager() -> ClaudeProfileConfigDirManager {
 extension TBDHomeSerialized {
 @Suite("Claude Token Spawn + Swap")
 struct ModelProfileSpawnTests {
+    private struct ExpectedCodexPreparationFailure: Error {}
 
     /// Recorder for tmux argv lists invoked during dryRun.
     final class TmuxRecorder: @unchecked Sendable {
@@ -187,6 +188,75 @@ struct ModelProfileSpawnTests {
         #expect(!recorder.joinedAll.contains("CLAUDE_CODE_OAUTH_TOKEN"))
     }
 
+    @Test("terminal.create prepares Codex home before tmux or terminal mutation")
+    func terminalCreateCodexHomeFailurePrecedesMutation() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        router.codexExecutableResolver = { "/opt/test/bin/codex" }
+        router.codexHomeEnsurer = {
+            throw ExpectedCodexPreparationFailure()
+        }
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .codex)))
+
+        #expect(!response.success)
+        #expect(recorder.calls.isEmpty)
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
+    }
+
+    @Test("terminal.create spawns the injected absolute Codex executable")
+    func terminalCreateUsesResolvedAbsoluteCodexExecutable() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        router.codexExecutableResolver = { "/opt/TBD Codex/bin/codex" }
+        router.codexHomeEnsurer = {
+            FileManager.default.temporaryDirectory.appendingPathComponent(
+                "tbd-test-codex-home-\(UUID().uuidString)", isDirectory: true)
+        }
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: wt.id, type: .codex)))
+
+        #expect(response.success)
+        #expect(recorder.shellBodies.contains("'/opt/TBD Codex/bin/codex'"))
+        #expect(!recorder.shellBodies.contains("; codex --profile"))
+        #expect(!recorder.shellBodies.contains("; codex --profile-v2"))
+    }
+
+    @Test("terminal.recreate prepares Codex home before killing the old window")
+    func terminalRecreateCodexHomeFailurePreservesOldWindowAndRow() async throws {
+        let (router, db, recorder) = makeFixture()
+        defer { Task { await cleanup(db) } }
+        let (_, wt) = try await seedRepoAndWorktree(db)
+        let terminal = try await db.terminals.create(
+            worktreeID: wt.id,
+            tmuxWindowID: "@old-codex",
+            tmuxPaneID: "%old-codex",
+            label: TerminalLabel.codex,
+            kind: .codex)
+        router.codexExecutableResolver = { "/opt/test/bin/codex" }
+        router.codexHomeEnsurer = {
+            throw ExpectedCodexPreparationFailure()
+        }
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalRecreateWindow,
+            params: TerminalRecreateWindowParams(terminalID: terminal.id)))
+
+        #expect(!response.success)
+        #expect(recorder.calls.isEmpty)
+        let unchanged = try #require(
+            try await db.terminals.get(id: terminal.id))
+        #expect(unchanged.tmuxWindowID == terminal.tmuxWindowID)
+        #expect(unchanged.tmuxPaneID == terminal.tmuxPaneID)
+        #expect(unchanged.kind == .codex)
+    }
+
     // MARK: - Spawn: Codex free-form env overrides (branch-test rule)
 
     /// Build a lifecycle + recorder fixture. Unlike `makeFixture`, this exposes
@@ -195,7 +265,15 @@ struct ModelProfileSpawnTests {
     /// `ModelProfileResolver` is attached so the Claude branch resolves the
     /// worktree's effective profile (Codex tests ignore it — Codex resolves no
     /// profile).
-    private func makeLifecycleFixture() -> (WorktreeLifecycle, TBDDatabase, TmuxRecorder) {
+    private func makeLifecycleFixture(
+        codexExecutableResolver: @escaping @Sendable () throws -> String = {
+            "/usr/bin/true"
+        },
+        codexHomeEnsurer: @escaping @Sendable () throws -> URL = {
+            FileManager.default.temporaryDirectory.appendingPathComponent(
+                "tbd-test-codex-home-\(UUID().uuidString)", isDirectory: true)
+        }
+    ) -> (WorktreeLifecycle, TBDDatabase, TmuxRecorder) {
         let recorder = TmuxRecorder()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { args in recorder.record(args) })
         let db = try! TBDDatabase(inMemory: true)
@@ -205,7 +283,9 @@ struct ModelProfileSpawnTests {
         let lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
             modelProfileResolver: resolver,
-            configDirManager: isolatedConfigDirManager()
+            configDirManager: isolatedConfigDirManager(),
+            codexExecutableResolver: codexExecutableResolver,
+            codexHomeEnsurer: codexHomeEnsurer
         )
         return (lifecycle, db, recorder)
     }
@@ -285,6 +365,29 @@ struct ModelProfileSpawnTests {
         #expect(codexCall.contains("DISABLE_AUTO_UPDATE=true"),
                 "codex window must suppress the oh-my-zsh update prompt via -e")
         #expect(!recorder.joinedAll.contains("FOO=bar"))
+    }
+
+    @Test("spawn: missing Codex executable fails before tmux or terminal mutation")
+    func codexResolutionFailurePrecedesSpawnMutation() async throws {
+        let expected = CodexExecutableResolutionError.notFound(
+            searchPath: "/missing",
+            fallbackPath: CodexExecutableResolver.chatGPTBundlePath)
+        let (lifecycle, db, recorder) = makeLifecycleFixture(
+            codexExecutableResolver: { throw expected })
+        defer { Task { await cleanup(db) } }
+        let (repo, wt) = try await seedRepoAndWorktree(db)
+        try await db.config.setPrimaryAgentPreference(.codex)
+
+        await #expect(throws: expected) {
+            _ = try await lifecycle.spawnPrimaryTerminals(
+                worktree: wt,
+                repo: repo,
+                skipClaude: false,
+                preSessionTerminalID: nil)
+        }
+
+        #expect(recorder.calls.isEmpty)
+        #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty)
     }
 
     // MARK: - Spawn: Claude free-form env overrides (branch-test rule)

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -41,9 +41,14 @@ private func newWindowBodies(_ recorded: [[String]]) -> [String] {
     }
 }
 
+private let codexDryRunExecutable = "/opt/tbd-test/bin/codex"
+
 private func containsCodexProfileLaunch(_ body: String) -> Bool {
-    body.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile tbd --dangerously-bypass-approvals-and-sandbox")
-        || body.contains("unset CODEX_CI CODEX_THREAD_ID; codex --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
+    let executable = SystemPromptBuilder.shellEscape(codexDryRunExecutable)
+    return body.contains(
+        "unset CODEX_CI CODEX_THREAD_ID; \(executable) --profile tbd --dangerously-bypass-approvals-and-sandbox")
+        || body.contains(
+            "unset CODEX_CI CODEX_THREAD_ID; \(executable) --profile-v2 tbd --dangerously-bypass-approvals-and-sandbox")
 }
 
 private let codexTestHomePath: String = {


### PR DESCRIPTION
## Summary

- call `codex app-server` directly and import exactly one stored Claude transcript as one `SESSIONS` migration item
- capture the returned Codex thread ID and open an ordinary resumed Codex terminal in the same worktree, with no summary file and no initial prompt
- expose the flow through daemon RPC, `tbd terminal continue-in-codex`, and a Claude-tab context-menu action
- preserve executable/profile safety from #561 and extend preflight-before-mutation to ordinary Codex create, recreate, and worktree lifecycle paths

## Why

TBD already knows the exact terminal transcript and worktree. Codex owns the native conversion, so TBD should not parse or summarize a tail window of the conversation. This remains usable when the source Claude session is out of quota and carries the session's full intent/tool history subject to Codex's own conversion limits.

This implements the approved design from #568 and supersedes the generated-handoff implementation in #561.

## Safety invariants

- constructs exactly one `SESSIONS` item; never calls `detect` or forwards arbitrary migration data
- imports only after source terminal, transcript, worktree, executable, and Codex profile preflight succeed
- creates tmux/DB state only after import succeeds; DB failure cleans the new tmux window
- never copies credentials or rewrites Codex configuration
- never sends an initial prompt; the source Claude terminal remains untouched
- accepts both the Codex 0.146 success shape and the observed 0.145 shape where inner `itemType` was absent
- app-server stderr remains private in unified logging

## Validation

- `swift build --target TBDDaemonLib` ✅
- `swift build --target TBDCLI` ✅
- `swift build --target TBDApp` ✅
- focused native import/RPC/menu/CLI/builder suite: 36 tests across 6 suites ✅
- lifecycle/preflight safety suite: 12 tests across 4 suites ✅
- latest focused RPC suite: 6/6 ✅
- `git diff --check` ✅
- commit is GitHub-signed and verified ✅
- generated and compared against installed Codex 0.146 app-server schema ✅

## Protocol boundary

`externalAgentConfig/import` remains experimental. A protocol break fails the explicit user action without creating a TBD terminal. No default-off flag is added per the approved spec because this is additive, user-initiated, non-autonomous, and fail-closed.

Closes #568.
Supersedes #561.