### PR TITLE
Provider Desk: read-only fleet overview

### DIFF
--- a/Sources/TBDApp/AppState+Navigation.swift
+++ b/Sources/TBDApp/AppState+Navigation.swift
@@ -235,6 +235,7 @@ extension AppState {
             if let leavingRepoID { clearRevivingArchived(repoID: leavingRepoID) }
             selectedRepoID = nil
             selectedScratchSection = false
+            selectedRemoteProvider = nil
             selectedRemoteSession = nil
             selectedWorktreeIDs = Set(ids)
             selectionOrder = ids // must come after; didSet above rebuilds from unordered Set
@@ -245,6 +246,7 @@ extension AppState {
             selectedWorktreeIDs = []
             selectedRepoID = id
             selectedScratchSection = false
+            selectedRemoteProvider = nil
             selectedRemoteSession = nil
             Task { await refreshArchivedWorktrees(repoID: id) }
             Task { await refreshReapRecords(repoID: id) }
@@ -306,6 +308,18 @@ extension AppState {
         recordNavigation(.remoteSession(selection))
     }
 
+    /// Select a provider header without attaching to a session. The desk is a
+    /// read-only projection of data already mirrored in AppState.
+    func selectRemoteProvider(_ provider: String) {
+        highlightedArchivedWorktreeID = nil
+        selectedWorktreeIDs = []
+        selectedRepoID = nil
+        selectedScratchSection = false
+        selectedRemoteSession = nil
+        remoteSessionRequestedTab = nil
+        selectedRemoteProvider = provider
+    }
+
     /// Shared state transition for landing on a remote-session selection —
     /// used by both a plain click/context-menu action (`selectRemoteSession`,
     /// which additionally records a navigation entry) and back/forward
@@ -339,6 +353,7 @@ extension AppState {
         selectedWorktreeIDs = []
         selectedRepoID = nil
         selectedScratchSection = false
+        selectedRemoteProvider = nil
         selectedRemoteSession = selection
         remoteSessionRequestedTab = tab
         unreadByRemoteSession[selection] = nil

--- a/Sources/TBDApp/AppState+Remote.swift
+++ b/Sources/TBDApp/AppState+Remote.swift
@@ -44,6 +44,10 @@ extension AppState {
             let sessions = try await remoteSessionsFetcher()
             remoteProviders = providers.providers
             remoteSessions = sessions.sessions
+            if let selectedRemoteProvider,
+               !providers.providers.contains(where: { $0.config.name == selectedRemoteProvider }) {
+                self.selectedRemoteProvider = nil
+            }
             pruneRemoteSessionState(toKnownSessions: sessions.sessions)
         } catch {
             switch AppState.classifyRemoteRefreshFailure(error) {

--- a/Sources/TBDApp/AppState+Worktrees.swift
+++ b/Sources/TBDApp/AppState+Worktrees.swift
@@ -563,6 +563,7 @@ extension AppState {
         selectedWorktreeIDs = []
         selectedRepoID = repoID
         selectedScratchSection = false
+        selectedRemoteProvider = nil
         selectedRemoteSession = nil
         archivedWorktrees[repoID] = archived.filter { $0.repoID == repoID }
         archivedWorktreesHasMore[repoID] = false
@@ -619,6 +620,7 @@ extension AppState {
         selectedWorktreeIDs = []
         selectedRepoID = id
         selectedScratchSection = false
+        selectedRemoteProvider = nil
         selectedRemoteSession = nil
         Task { await refreshArchivedWorktrees(repoID: id) }
     }
@@ -651,6 +653,7 @@ extension AppState {
         selectedWorktreeIDs = []
         selectedRepoID = nil
         selectedScratchSection = true
+        selectedRemoteProvider = nil
         selectedRemoteSession = nil
     }
 

--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -186,6 +186,7 @@ final class AppState: ObservableObject {
                 if let leaving = selectedRepoID { clearRevivingArchived(repoID: leaving) }
                 selectedRepoID = nil
                 selectedScratchSection = false
+                selectedRemoteProvider = nil
                 selectedRemoteSession = nil
                 recordNavigation(.worktrees(selectionOrder))
                 // Feed the jump menu's Recent section. Insertion-order LRU,
@@ -240,6 +241,11 @@ final class AppState: ObservableObject {
     /// content pane. Parallel to `selectedRepoID` but with no `NavigationEntry`
     /// integration for v1 (documented scope cut — see `selectScratchSection()`).
     @Published var selectedScratchSection: Bool = false
+    /// Selected provider header, showing its read-only Provider Desk. This is
+    /// mutually exclusive with worktree, repo, scratch, and remote-session
+    /// selection, but intentionally stays out of back/forward history for the
+    /// first desk slice.
+    @Published var selectedRemoteProvider: String?
     /// Selected — set when a `RemoteSectionView` session row is clicked, shows
     /// `RemoteSessionDetailView` (Task 10) in the content pane. Parallel to
     /// `selectedScratchSection` but keyed by the provider/session composite id

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -353,6 +353,12 @@ struct ContentView: View {
 /// never reassigned: the same "stable identity, reactive interior" shape
 /// `WorktreePager`/`RemoteAttachPager` already use for their own tab items.
 struct DetailSectionHostPager: NSViewControllerRepresentable {
+    enum RemoteHostContent: Equatable {
+        case provider(String)
+        case session(RemoteSessionSelection)
+        case none
+    }
+
     @Binding var showFilePanel: Bool
     @Binding var filePanelWidth: Double
 
@@ -396,7 +402,9 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
         }
 
         let showingRemote = Self.showsRemoteTab(
-            isConnected: appState.isConnected, selectedRemoteSession: appState.selectedRemoteSession
+            isConnected: appState.isConnected,
+            selectedRemoteSession: appState.selectedRemoteSession,
+            selectedRemoteProvider: appState.selectedRemoteProvider
         )
         let targetID = showingRemote ? Self.remoteTabID : Self.otherTabID
         if let idx = vc.tabViewItems.firstIndex(where: { $0.identifier as? String == targetID }),
@@ -412,8 +420,23 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
     /// disconnected, regardless of whatever remote session was selected
     /// before the daemon dropped. Pure and `nonisolated` so it's directly
     /// unit-testable without an `NSTabViewController`.
-    nonisolated static func showsRemoteTab(isConnected: Bool, selectedRemoteSession: RemoteSessionSelection?) -> Bool {
-        isConnected && selectedRemoteSession != nil
+    nonisolated static func showsRemoteTab(
+        isConnected: Bool,
+        selectedRemoteSession: RemoteSessionSelection?,
+        selectedRemoteProvider: String? = nil
+    ) -> Bool {
+        isConnected && (selectedRemoteSession != nil || selectedRemoteProvider != nil)
+    }
+
+    /// Chooses what the persistent remote host renders. An explicit provider
+    /// selection must beat the recently-attached session fallback.
+    nonisolated static func remoteHostContent(
+        selectedRemoteProvider: String?,
+        remoteSessionHostSelection: RemoteSessionSelection?
+    ) -> RemoteHostContent {
+        if let selectedRemoteProvider { return .provider(selectedRemoteProvider) }
+        if let remoteSessionHostSelection { return .session(remoteSessionHostSelection) }
+        return .none
     }
 }
 
@@ -429,9 +452,17 @@ private struct RemoteSessionHostSlot: View {
     @EnvironmentObject var appState: AppState
 
     var body: some View {
-        if let selection = appState.remoteSessionHostSelection {
+        switch DetailSectionHostPager.remoteHostContent(
+            selectedRemoteProvider: appState.selectedRemoteProvider,
+            remoteSessionHostSelection: appState.remoteSessionHostSelection
+        ) {
+        case .provider(let providerName):
+            if let provider = appState.remoteProviders.first(where: { $0.config.name == providerName }) {
+                RemoteProviderDeskView(provider: provider)
+            }
+        case .session(let selection):
             RemoteSessionDetailView(selection: selection)
-        } else {
+        case .none:
             EmptyView()
         }
     }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -313,13 +313,24 @@ struct ContentView: View {
 // MARK: - DetailSectionHostPager
 
 /// NSViewControllerRepresentable hosting `ContentView`'s entire `detail:`
-/// content as exactly two `NSTabViewController` tab items: `.remote` (the
+/// content as exactly three `NSTabViewController` tab items: `.remote` (the
 /// sticky `RemoteSessionDetailView` host — mounted once a remote session
-/// has ever been selected and NEVER removed afterward) and `.other`
+/// has ever been selected and NEVER removed afterward), `.providerDesk`
+/// (the read-only `RemoteProviderDeskView`), and `.other`
 /// (whichever worktree/repo/scratch/empty/disconnected content currently
 /// applies — cheap to recreate on every switch, exactly as before; local
 /// worktree reattach is already instant via the daemon's own tmux sessions,
 /// so that half never needed keep-alive).
+///
+/// The Provider Desk is a SEPARATE tab rather than a second thing the
+/// `.remote` tab can render, and that is load-bearing: swapping the
+/// `.remote` slot's root view between `RemoteSessionDetailView` and the
+/// desk would structurally remove the detail view, dismantling the
+/// `RemoteAttachPager` it hosts and tearing down EVERY live attach
+/// connection — precisely the teardown the next paragraph explains this
+/// whole pager exists to prevent. Selecting a provider is a read-only
+/// glance at the fleet; it must not cost a full SSM/ssh reconnect on the
+/// way back.
 ///
 /// This exists because navigating OUT of remote-session mode (selecting a
 /// worktree/repo/scratch section) used to unmount `RemoteSessionDetailView`
@@ -353,10 +364,11 @@ struct ContentView: View {
 /// never reassigned: the same "stable identity, reactive interior" shape
 /// `WorktreePager`/`RemoteAttachPager` already use for their own tab items.
 struct DetailSectionHostPager: NSViewControllerRepresentable {
-    enum RemoteHostContent: Equatable {
-        case provider(String)
-        case session(RemoteSessionSelection)
-        case none
+    /// Which of the three tab items should be in front.
+    enum DetailTab: String, Equatable {
+        case remote
+        case providerDesk
+        case other
     }
 
     @Binding var showFilePanel: Bool
@@ -366,8 +378,9 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
     @EnvironmentObject var appearance: AppearanceSettings
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
 
-    private static let remoteTabID = "remote"
-    private static let otherTabID = "other"
+    private static let remoteTabID = DetailTab.remote.rawValue
+    private static let providerDeskTabID = DetailTab.providerDesk.rawValue
+    private static let otherTabID = DetailTab.other.rawValue
 
     func makeNSViewController(context: Context) -> NSTabViewController {
         let vc = NSTabViewController()
@@ -390,6 +403,17 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
             vc.addTabViewItem(item)
         }
 
+        if !currentIDs.contains(Self.providerDeskTabID) {
+            let host = NSHostingController(
+                rootView: ProviderDeskHostSlot()
+                    .environmentObject(appState)
+                    .environmentObject(appearance)
+            )
+            let item = NSTabViewItem(viewController: host)
+            item.identifier = Self.providerDeskTabID
+            vc.addTabViewItem(item)
+        }
+
         if !currentIDs.contains(Self.otherTabID) {
             let host = NSHostingController(
                 rootView: OtherSectionContent(showFilePanel: $showFilePanel, filePanelWidth: $filePanelWidth)
@@ -401,12 +425,11 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
             vc.addTabViewItem(item)
         }
 
-        let showingRemote = Self.showsRemoteTab(
+        let targetID = Self.targetTab(
             isConnected: appState.isConnected,
             selectedRemoteSession: appState.selectedRemoteSession,
             selectedRemoteProvider: appState.selectedRemoteProvider
-        )
-        let targetID = showingRemote ? Self.remoteTabID : Self.otherTabID
+        ).rawValue
         if let idx = vc.tabViewItems.firstIndex(where: { $0.identifier as? String == targetID }),
            vc.selectedTabViewItemIndex != idx {
             vc.selectedTabViewItemIndex = idx
@@ -418,25 +441,20 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
     /// `OtherSectionContent` renders the disconnected message itself, so
     /// this just makes sure that's the tab actually in front while
     /// disconnected, regardless of whatever remote session was selected
-    /// before the daemon dropped. Pure and `nonisolated` so it's directly
-    /// unit-testable without an `NSTabViewController`.
-    nonisolated static func showsRemoteTab(
+    /// before the daemon dropped. A session selection outranks a provider
+    /// selection; the two are already mutually exclusive in `AppState`, so
+    /// the order only decides an unreachable tie deterministically. Pure and
+    /// `nonisolated` so it's directly unit-testable without an
+    /// `NSTabViewController`.
+    nonisolated static func targetTab(
         isConnected: Bool,
         selectedRemoteSession: RemoteSessionSelection?,
-        selectedRemoteProvider: String? = nil
-    ) -> Bool {
-        isConnected && (selectedRemoteSession != nil || selectedRemoteProvider != nil)
-    }
-
-    /// Chooses what the persistent remote host renders. An explicit provider
-    /// selection must beat the recently-attached session fallback.
-    nonisolated static func remoteHostContent(
-        selectedRemoteProvider: String?,
-        remoteSessionHostSelection: RemoteSessionSelection?
-    ) -> RemoteHostContent {
-        if let selectedRemoteProvider { return .provider(selectedRemoteProvider) }
-        if let remoteSessionHostSelection { return .session(remoteSessionHostSelection) }
-        return .none
+        selectedRemoteProvider: String?
+    ) -> DetailTab {
+        guard isConnected else { return .other }
+        if selectedRemoteSession != nil { return .remote }
+        if selectedRemoteProvider != nil { return .providerDesk }
+        return .other
     }
 }
 
@@ -452,17 +470,31 @@ private struct RemoteSessionHostSlot: View {
     @EnvironmentObject var appState: AppState
 
     var body: some View {
-        switch DetailSectionHostPager.remoteHostContent(
-            selectedRemoteProvider: appState.selectedRemoteProvider,
-            remoteSessionHostSelection: appState.remoteSessionHostSelection
-        ) {
-        case .provider(let providerName):
-            if let provider = appState.remoteProviders.first(where: { $0.config.name == providerName }) {
-                RemoteProviderDeskView(provider: provider)
-            }
-        case .session(let selection):
+        if let selection = appState.remoteSessionHostSelection {
             RemoteSessionDetailView(selection: selection)
-        case .none:
+        } else {
+            EmptyView()
+        }
+    }
+}
+
+/// The `.providerDesk` tab's content. Internally reactive for the same
+/// reason `RemoteSessionHostSlot` is — `DetailSectionHostPager` creates this
+/// `NSHostingController` once and never reassigns its `rootView`.
+///
+/// Renders nothing when the selected provider is no longer in the roster.
+/// `AppState.refreshRemote()` clears `selectedRemoteProvider` when a
+/// provider disappears from a successful inventory, so this is a transient
+/// window rather than a resting state — and the desk has no honest content
+/// to show for a provider TBD no longer knows about.
+private struct ProviderDeskHostSlot: View {
+    @EnvironmentObject var appState: AppState
+
+    var body: some View {
+        if let name = appState.selectedRemoteProvider,
+           let provider = appState.remoteProviders.first(where: { $0.config.name == name }) {
+            RemoteProviderDeskView(provider: provider)
+        } else {
             EmptyView()
         }
     }

--- a/Sources/TBDApp/Remote/RemoteProviderDeskSummary.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskSummary.swift
@@ -1,0 +1,67 @@
+import Foundation
+import TBDShared
+
+/// A deterministic, read-only projection of TBD's existing remote-session
+/// mirror for one provider. The provider's reachability never rewrites these
+/// counts: terminal liveness and agent activity remain independent axes.
+struct RemoteProviderDeskSummary: Equatable {
+    struct TerminalCounts: Equatable {
+        var starting = 0
+        var running = 0
+        var exited = 0
+        var gone = 0
+        var unknown = 0
+    }
+
+    struct AgentCounts: Equatable {
+        var working = 0
+        var waitingInput = 0
+        var idle = 0
+        var exited = 0
+        var unknown = 0
+    }
+
+    let sessions: [RemoteSessionInfo]
+    let terminal: TerminalCounts
+    let agent: AgentCounts
+    let latestMirrorUpdate: Date?
+
+    var total: Int { sessions.count }
+
+    init(provider: String, sessions allSessions: [RemoteSessionInfo]) {
+        sessions = allSessions
+            .filter { $0.provider == provider && !$0.dismissed }
+            .sorted {
+                if $0.lastSeen != $1.lastSeen { return $0.lastSeen > $1.lastSeen }
+                return $0.payload.id.localizedStandardCompare($1.payload.id) == .orderedAscending
+            }
+
+        var terminal = TerminalCounts()
+        var agent = AgentCounts()
+
+        for session in sessions {
+            if session.gone {
+                terminal.gone += 1
+            } else {
+                switch session.payload.state {
+                case .starting: terminal.starting += 1
+                case .running: terminal.running += 1
+                case .exited: terminal.exited += 1
+                case .unknown: terminal.unknown += 1
+                }
+            }
+
+            switch session.payload.agentState {
+            case .working: agent.working += 1
+            case .waitingInput: agent.waitingInput += 1
+            case .idle: agent.idle += 1
+            case .exited: agent.exited += 1
+            case .unknown: agent.unknown += 1
+            }
+        }
+
+        self.terminal = terminal
+        self.agent = agent
+        latestMirrorUpdate = sessions.first?.lastSeen
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteProviderDeskSummary.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskSummary.swift
@@ -40,6 +40,33 @@ struct RemoteProviderDeskSummary: Equatable {
         return age == "just now" ? age : "\(age) ago"
     }
 
+    /// What the desk is allowed to claim about freshness.
+    ///
+    /// `RemoteProviderStatus.lastSuccessfulSnapshotAt` is the provider-wide
+    /// fact — the last COMPLETE inventory the mirror accepted — so it is the
+    /// honest answer whenever the daemon has one, and it is what the sidebar
+    /// caption and the session detail pane already quote. Per-row `lastSeen`
+    /// is only a lower bound derived from whichever rows happened to appear:
+    /// it cannot tell a successful EMPTY snapshot from no snapshot at all,
+    /// and a provider whose rows all stopped being reported would keep
+    /// quoting an age that no longer describes any inventory.
+    ///
+    /// The row-derived value stays as a labelled fallback (an older daemon
+    /// sends no snapshot timestamp), but it is never called an inventory.
+    nonisolated static func freshnessLabel(
+        lastSuccessfulSnapshotAt: Date?,
+        latestMirrorUpdate: Date?,
+        now: Date = Date()
+    ) -> String {
+        if let snapshot = lastSuccessfulSnapshotAt {
+            return "Inventory as of \(agePhrase(since: snapshot, now: now))"
+        }
+        if let latest = latestMirrorUpdate {
+            return "Latest mirror update \(agePhrase(since: latest, now: now))"
+        }
+        return "No successful inventory yet"
+    }
+
     init(provider: String, sessions allSessions: [RemoteSessionInfo]) {
         sessions = allSessions
             .filter { $0.provider == provider && !$0.dismissed }

--- a/Sources/TBDApp/Remote/RemoteProviderDeskSummary.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskSummary.swift
@@ -28,6 +28,18 @@ struct RemoteProviderDeskSummary: Equatable {
 
     var total: Int { sessions.count }
 
+    /// "just now" / "2h ago" — the same freshness vocabulary every other
+    /// staleness surface in the app already speaks
+    /// (`ProfileUsagePresentation.ageText`, `RemoteSessionRowView.stalenessCaption`),
+    /// rather than SwiftUI's `Text(_, style: .relative)`, which renders a
+    /// bare magnitude with no direction ("Latest mirror update 2 minutes").
+    /// `ageText`'s "just now" is already a complete phrase, so it never
+    /// takes the trailing "ago".
+    nonisolated static func agePhrase(since date: Date, now: Date = Date()) -> String {
+        let age = ProfileUsagePresentation.ageText(since: date, now: now)
+        return age == "just now" ? age : "\(age) ago"
+    }
+
     init(provider: String, sessions allSessions: [RemoteSessionInfo]) {
         sessions = allSessions
             .filter { $0.provider == provider && !$0.dismissed }

--- a/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
@@ -1,0 +1,431 @@
+import SwiftUI
+import TBDShared
+
+/// Read-only provider-level control surface from issue #565 milestone 2.
+/// Every value comes from the provider/session mirror already held by
+/// `AppState`; this view never infers capacity or invokes a remote command.
+struct RemoteProviderDeskView: View {
+    let provider: RemoteProviderStatus
+
+    @EnvironmentObject private var appState: AppState
+    @State private var isRefreshing = false
+    @State private var runningRemediation: RemoteRemediationRun?
+
+    private var displayName: String { provider.describe?.name ?? provider.config.name }
+
+    private var summary: RemoteProviderDeskSummary {
+        RemoteProviderDeskSummary(provider: provider.config.name, sessions: appState.remoteSessions)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                masthead
+                healthNotice
+                stateStrips
+                sessionLedger
+            }
+            .frame(maxWidth: 1080, alignment: .leading)
+            .padding(.horizontal, 28)
+            .padding(.vertical, 24)
+        }
+        .background(Color(nsColor: .windowBackgroundColor))
+        .navigationTitle(displayName)
+        .sheet(item: $runningRemediation) { run in
+            RemoteRemediationTerminalSheet(run: run)
+        }
+    }
+
+    private var masthead: some View {
+        HStack(alignment: .center, spacing: 14) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(healthTint.opacity(0.12))
+                Image(systemName: healthSymbol)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(healthTint)
+            }
+            .frame(width: 42, height: 42)
+            .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(displayName)
+                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                HStack(spacing: 7) {
+                    Text(healthTitle)
+                    if let latest = summary.latestMirrorUpdate {
+                        Text("·")
+                        Text("Latest mirror update \(latest, style: .relative)")
+                    } else {
+                        Text("· No mirrored sessions")
+                    }
+                }
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 16)
+
+            Button {
+                refresh()
+            } label: {
+                Label(isRefreshing ? "Refreshing…" : "Refresh", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.bordered)
+            .disabled(isRefreshing)
+            .keyboardShortcut("r", modifiers: .command)
+            .help("Refresh provider and mirrored session state")
+            .accessibilityLabel(isRefreshing ? "Refreshing provider" : "Refresh provider")
+        }
+    }
+
+    @ViewBuilder
+    private var healthNotice: some View {
+        switch provider.health {
+        case .ok:
+            EmptyView()
+        case .needsAuth:
+            if let presentation = RemoteProviderAuthPresentation.make(from: provider) {
+                RemoteProviderAuthCTAView(
+                    presentation: presentation,
+                    showsSessionReassurance: false,
+                    onRun: { runningRemediation = RemoteRemediationRun(presentation) }
+                )
+                .padding(16)
+                .background(healthTint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+        case .stale, .error:
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: healthSymbol)
+                    .foregroundStyle(healthTint)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(healthTitle).fontWeight(.semibold)
+                    Text(healthDetail)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .font(.callout)
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(healthTint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        }
+    }
+
+    private var stateStrips: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Work at a glance")
+                .font(.headline)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .top, spacing: 12) {
+                    terminalStrip
+                    agentStrip
+                }
+                VStack(spacing: 12) {
+                    terminalStrip
+                    agentStrip
+                }
+            }
+        }
+    }
+
+    private var terminalStrip: some View {
+        ProviderStateStrip(
+            title: "Terminal",
+            subtitle: "Process state",
+            metrics: [
+                .init(label: "Starting", value: summary.terminal.starting, tint: .secondary),
+                .init(label: "Running", value: summary.terminal.running, tint: .green),
+                .init(label: "Exited", value: summary.terminal.exited, tint: .secondary),
+                .init(label: "Gone", value: summary.terminal.gone, tint: .orange),
+                .init(label: "Unknown", value: summary.terminal.unknown, tint: .secondary),
+            ]
+        )
+    }
+
+    private var agentStrip: some View {
+        ProviderStateStrip(
+            title: "Agent",
+            subtitle: "Attention state",
+            metrics: [
+                .init(label: "Working", value: summary.agent.working, tint: .blue),
+                .init(label: "Waiting", value: summary.agent.waitingInput, tint: .orange),
+                .init(label: "Idle", value: summary.agent.idle, tint: .secondary),
+                .init(label: "Exited", value: summary.agent.exited, tint: .secondary),
+                .init(label: "Unknown", value: summary.agent.unknown, tint: .secondary),
+            ]
+        )
+    }
+
+    private var sessionLedger: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Sessions").font(.headline)
+                Text("\(summary.total)")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("Select a row for attach, log, and session actions")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            if summary.sessions.isEmpty {
+                VStack(spacing: 10) {
+                    Image(systemName: "rectangle.stack.badge.minus")
+                        .font(.system(size: 28))
+                        .foregroundStyle(.tertiary)
+                    Text("No mirrored sessions")
+                        .font(.headline)
+                    Text("Use the + button beside \(displayName) in the sidebar to create one.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 38)
+                .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            } else {
+                LazyVStack(spacing: 1) {
+                    ForEach(summary.sessions) { session in
+                        ProviderSessionLedgerRow(session: session) {
+                            appState.selectRemoteSession(
+                                provider: session.provider,
+                                sessionID: session.payload.id
+                            )
+                        }
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(Color.primary.opacity(0.09))
+                }
+            }
+        }
+    }
+
+    private var healthTitle: String {
+        switch provider.health {
+        case .ok: "Provider responding"
+        case .stale: "Provider unreachable"
+        case .needsAuth: "Authentication needed"
+        case .error: "Provider error"
+        }
+    }
+
+    private var healthDetail: String {
+        switch provider.health {
+        case .stale: provider.errorMessage ?? "Mirrored sessions may be stale. Their last reported states remain unchanged."
+        case .error: provider.errorMessage ?? "The provider reported an error."
+        case .ok, .needsAuth: ""
+        }
+    }
+
+    private var healthSymbol: String {
+        switch provider.health {
+        case .ok: "checkmark.circle.fill"
+        case .stale: "clock.badge.exclamationmark"
+        case .needsAuth: "key.slash"
+        case .error: "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var healthTint: Color {
+        switch provider.health {
+        case .ok: .green
+        case .stale: .secondary
+        case .needsAuth: SuffixRowIndicator.attention.color
+        case .error: SuffixRowIndicator.error.color
+        }
+    }
+
+    private func refresh() {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        Task {
+            await appState.refreshRemote()
+            isRefreshing = false
+        }
+    }
+}
+
+private struct ProviderStateMetric: Identifiable {
+    let label: String
+    let value: Int
+    let tint: Color
+    var id: String { label }
+}
+
+private struct ProviderStateStrip: View {
+    let title: String
+    let subtitle: String
+    let metrics: [ProviderStateMetric]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+
+            HStack(spacing: 0) {
+                ForEach(metrics) { metric in
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("\(metric.value)")
+                            .font(.system(size: 20, weight: .semibold, design: .rounded).monospacedDigit())
+                            .foregroundStyle(metric.value == 0 ? Color.secondary : metric.tint)
+                        Text(metric.label)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("\(metric.label): \(metric.value)")
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}
+
+private struct ProviderSessionLedgerRow: View {
+    let session: RemoteSessionInfo
+    let onSelect: () -> Void
+
+    private var title: String { session.payload.title ?? session.payload.id }
+    private var repo: String { session.payload.meta?["repo"] ?? "No repository" }
+    private var branch: String { session.payload.meta?["branch"] ?? "No branch" }
+    private var createdDate: Date? {
+        guard let raw = session.payload.createdAt else { return nil }
+        return ISO8601DateFormatter().date(from: raw)
+    }
+
+    var body: some View {
+        Button(action: onSelect) {
+            ViewThatFits(in: .horizontal) {
+                wideRow
+                narrowRow
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilitySummary)
+        .help("Open \(title)")
+    }
+
+    private var wideRow: some View {
+        HStack(spacing: 16) {
+            titleBlock
+                .frame(minWidth: 190, maxWidth: .infinity, alignment: .leading)
+            Text(repo)
+                .frame(width: 150, alignment: .leading)
+                .lineLimit(1)
+            Text(branch)
+                .frame(width: 150, alignment: .leading)
+                .lineLimit(1)
+            stateBlock
+                .frame(width: 190, alignment: .leading)
+            Text(session.lastSeen, style: .relative)
+                .frame(width: 88, alignment: .trailing)
+                .foregroundStyle(.secondary)
+        }
+        .font(.callout)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(rowBackground)
+    }
+
+    private var narrowRow: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            titleBlock
+            HStack(spacing: 6) {
+                Label(repo, systemImage: "shippingbox")
+                Text("·")
+                Label(branch, systemImage: "arrow.triangle.branch")
+            }
+            .lineLimit(1)
+            .foregroundStyle(.secondary)
+            stateBlock
+        }
+        .font(.callout)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(rowBackground)
+    }
+
+    private var titleBlock: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .fontWeight(session.payload.agentState == .waitingInput ? .semibold : .regular)
+                .lineLimit(1)
+            Text(session.payload.id)
+                .font(.caption.monospaced())
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+            if let createdDate {
+                Text("Created \(createdDate, style: .relative)")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private var stateBlock: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(stateTint)
+                    .frame(width: 7, height: 7)
+                Text(terminalLabel)
+                Text("·")
+                Text(RemoteSessionStatePresentation.agentLabel(session.payload.agentState))
+            }
+            .lineLimit(1)
+            if let reason = session.payload.agentStateReason, !reason.isEmpty {
+                Text(reason)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            } else {
+                Text("Updated \(session.lastSeen, style: .relative)")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private var terminalLabel: String {
+        session.gone ? "Gone" : RemoteSessionStatePresentation.terminalLabel(session.payload.state)
+    }
+
+    private var stateTint: Color {
+        if session.gone { return .orange }
+        switch session.payload.agentState {
+        case .working: return .blue
+        case .waitingInput: return .orange
+        case .idle: return .secondary
+        case .exited: return .secondary
+        case .unknown:
+            return session.payload.state == .running ? .green : .secondary
+        }
+    }
+
+    private var rowBackground: Color {
+        session.payload.agentState == .waitingInput
+            ? Color.orange.opacity(0.055)
+            : Color.primary.opacity(0.025)
+    }
+
+    private var accessibilitySummary: String {
+        let agent = RemoteSessionStatePresentation.agentLabel(session.payload.agentState)
+        return "\(title), \(repo), \(branch), terminal \(terminalLabel), agent \(agent)"
+    }
+}

--- a/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
@@ -53,12 +53,8 @@ struct RemoteProviderDeskView: View {
                     .font(.system(size: 24, weight: .semibold, design: .rounded))
                 HStack(spacing: 7) {
                     Text(healthTitle)
-                    if let latest = summary.latestMirrorUpdate {
-                        Text("·")
-                        Text("Latest mirror update \(RemoteProviderDeskSummary.agePhrase(since: latest))")
-                    } else {
-                        Text("· No mirrored sessions")
-                    }
+                    Text("·")
+                    Text(freshnessLabel)
                 }
                 .font(.callout)
                 .foregroundStyle(.secondary)
@@ -175,9 +171,14 @@ struct RemoteProviderDeskView: View {
                     Image(systemName: "rectangle.stack.badge.minus")
                         .font(.system(size: 28))
                         .foregroundStyle(.tertiary)
-                    Text("No mirrored sessions")
+                    Text(provider.hasStaleSnapshot ? "No sessions in the last good inventory" : "No mirrored sessions")
                         .font(.headline)
-                    Text("Use the + button beside \(displayName) in the sidebar to create one.")
+                    // Don't send the user to a control this provider's own
+                    // state has disabled: `RemoteProviderHeaderRow` gates `+`
+                    // on `hasStaleSnapshot` until a full inventory recovers.
+                    Text(provider.hasStaleSnapshot
+                         ? "This provider's inventory is stale, so creating sessions is unavailable until a refresh succeeds."
+                         : "Use the + button beside \(displayName) in the sidebar to create one.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -203,6 +204,13 @@ struct RemoteProviderDeskView: View {
                 }
             }
         }
+    }
+
+    private var freshnessLabel: String {
+        RemoteProviderDeskSummary.freshnessLabel(
+            lastSuccessfulSnapshotAt: provider.lastSuccessfulSnapshotAt,
+            latestMirrorUpdate: summary.latestMirrorUpdate
+        )
     }
 
     private var healthTitle: String {

--- a/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
+++ b/Sources/TBDApp/Remote/RemoteProviderDeskView.swift
@@ -55,7 +55,7 @@ struct RemoteProviderDeskView: View {
                     Text(healthTitle)
                     if let latest = summary.latestMirrorUpdate {
                         Text("·")
-                        Text("Latest mirror update \(latest, style: .relative)")
+                        Text("Latest mirror update \(RemoteProviderDeskSummary.agePhrase(since: latest))")
                     } else {
                         Text("· No mirrored sessions")
                     }
@@ -302,9 +302,12 @@ private struct ProviderSessionLedgerRow: View {
     private var title: String { session.payload.title ?? session.payload.id }
     private var repo: String { session.payload.meta?["repo"] ?? "No repository" }
     private var branch: String { session.payload.meta?["branch"] ?? "No branch" }
+    /// Shared with the repo section's session ordering. A default-options
+    /// `ISO8601DateFormatter` rejects the fractional-seconds form a
+    /// conforming provider may legally emit, which silently dropped the
+    /// "Created …" line for those rows — see `parsedCreatedAt`'s own comment.
     private var createdDate: Date? {
-        guard let raw = session.payload.createdAt else { return nil }
-        return ISO8601DateFormatter().date(from: raw)
+        RepoSectionView.parsedCreatedAt(session.payload.createdAt)
     }
 
     var body: some View {
@@ -332,7 +335,7 @@ private struct ProviderSessionLedgerRow: View {
                 .lineLimit(1)
             stateBlock
                 .frame(width: 190, alignment: .leading)
-            Text(session.lastSeen, style: .relative)
+            Text(RemoteProviderDeskSummary.agePhrase(since: session.lastSeen))
                 .frame(width: 88, alignment: .trailing)
                 .foregroundStyle(.secondary)
         }
@@ -371,7 +374,7 @@ private struct ProviderSessionLedgerRow: View {
                 .foregroundStyle(.tertiary)
                 .lineLimit(1)
             if let createdDate {
-                Text("Created \(createdDate, style: .relative)")
+                Text("Created \(RemoteProviderDeskSummary.agePhrase(since: createdDate))")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
@@ -395,15 +398,19 @@ private struct ProviderSessionLedgerRow: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             } else {
-                Text("Updated \(session.lastSeen, style: .relative)")
+                Text("Updated \(RemoteProviderDeskSummary.agePhrase(since: session.lastSeen))")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }
         }
     }
 
+    /// `RemoteSessionStatePresentation.terminalLabel` already returns a
+    /// self-describing "Terminal: …" phrase, so the mirror-only `gone`
+    /// condition carries the same prefix rather than reading as a bare
+    /// "Gone" beside a fully-qualified agent label.
     private var terminalLabel: String {
-        session.gone ? "Gone" : RemoteSessionStatePresentation.terminalLabel(session.payload.state)
+        session.gone ? "Terminal: Gone" : RemoteSessionStatePresentation.terminalLabel(session.payload.state)
     }
 
     private var stateTint: Color {
@@ -424,8 +431,12 @@ private struct ProviderSessionLedgerRow: View {
             : Color.primary.opacity(0.025)
     }
 
+    /// Both presentation strings are already prefixed ("Terminal: Running",
+    /// "Agent: Working"), so adding "terminal"/"agent" here made VoiceOver
+    /// read "terminal Terminal: Running, agent Agent: Working".
     private var accessibilitySummary: String {
         let agent = RemoteSessionStatePresentation.agentLabel(session.payload.agentState)
-        return "\(title), \(repo), \(branch), terminal \(terminalLabel), agent \(agent)"
+        return "\(title), \(repo), \(branch), \(terminalLabel), \(agent), "
+            + "updated \(RemoteProviderDeskSummary.agePhrase(since: session.lastSeen))"
     }
 }

--- a/Sources/TBDApp/Sidebar/RemoteSectionView.swift
+++ b/Sources/TBDApp/Sidebar/RemoteSectionView.swift
@@ -17,13 +17,10 @@ private let remoteRowLogger = Logger(subsystem: "com.tbd.app", category: "remote
 /// below the repo `ForEach` in `SidebarView` (not above — position shouldn't
 /// make remoteness focal).
 ///
-/// A provider's header (and rows) are hidden entirely when it has nothing
-/// left to show here — see `shouldShowHeader` for the one exception (an
-/// unhealthy provider stays visible even with zero unmatched rows, so its
-/// health glyph can't go dark just because grouping absorbed every session).
-/// The whole section renders nothing when there are no registered providers
-/// at all — see `AppState.remoteSectionVisible(providers:)`, which
-/// `SidebarView` checks before mounting this view.
+/// Every registered provider keeps a header here even when all of its sessions
+/// are grouped under repositories. The header is now the stable entry point to
+/// its Provider Desk. The whole section renders nothing when no providers are
+/// registered — see `AppState.remoteSectionVisible(providers:)`.
 struct RemoteSectionView: View {
     @EnvironmentObject var appState: AppState
 
@@ -31,7 +28,11 @@ struct RemoteSectionView: View {
         let knownRepoIDs = RemoteSectionView.knownRepoIDs(repos: appState.repos, repoFilter: appState.repoFilter)
         ForEach(
             appState.remoteProviders.filter {
-                RemoteSectionView.shouldShowHeader(provider: $0, sessions: appState.remoteSessions, knownRepoIDs: knownRepoIDs)
+                RemoteSectionView.shouldShowHeader(
+                    provider: $0,
+                    sessions: appState.remoteSessions,
+                    knownRepoIDs: knownRepoIDs
+                )
             },
             id: \.config.name
         ) { provider in
@@ -46,19 +47,12 @@ struct RemoteSectionView: View {
         }
     }
 
-    /// Whether to show a provider's header+rows in this section: yes when it
-    /// has at least one unmatched session to list, OR its health isn't
-    /// `.ok`. An unhealthy provider (auth expired, unreachable, contract
-    /// error) must stay visible even when every one of its sessions happens
-    /// to be matched into a repo section — otherwise flipping every session
-    /// of a broken provider into "matched" would make its health banner
-    /// disappear at exactly the moment it matters most. A fully-matched,
-    /// fully-healthy provider has nothing left to say here, so it renders
-    /// nothing rather than an empty floating header.
+    /// Providers are first-class selectable places, so a registered provider
+    /// always keeps a header regardless of health or session grouping.
     nonisolated static func shouldShowHeader(
-        provider: RemoteProviderStatus, sessions allSessions: [RemoteSessionInfo], knownRepoIDs: Set<UUID>
+        provider _: RemoteProviderStatus, sessions _: [RemoteSessionInfo], knownRepoIDs _: Set<UUID>
     ) -> Bool {
-        provider.health != .ok || !sessions(in: allSessions, forProvider: provider.config.name, knownRepoIDs: knownRepoIDs).isEmpty
+        true
     }
 
     /// Repo ids treated as "has its own rendered section" when deciding
@@ -164,15 +158,16 @@ enum RemoteProviderStatusPresentation {
 /// Styled consistently with `RepoSectionView`'s header (12pt semibold name,
 /// 22pt bottom-aligned row) — a provider is the section-level analogue of a
 /// repo, so it wears the same weight of chrome rather than
-/// `ScratchSectionView`'s `.headline`. No tap/selection on the row itself —
-/// there's no provider-level detail view (Task 10 only routes session
-/// selections). Provider health never dims the rows below it: per the
-/// contract, an unreachable provider never means its sessions are dead, only
-/// that the local mirror may be stale — health is section-level state shown
-/// here, the same way a `.missing` repo dims only its own header/chevron in
-/// `RepoSectionView`, not an unrelated signal painted onto every row.
+/// `ScratchSectionView`'s `.headline`. The name is a keyboard-accessible
+/// button that opens the Provider Desk. Provider health never dims the rows
+/// below it: per the contract, an unreachable provider never means its
+/// sessions are dead, only that the local mirror may be stale — health is
+/// section-level state shown here, the same way a `.missing` repo dims only
+/// its own header/chevron in `RepoSectionView`, not an unrelated signal
+/// painted onto every row.
 struct RemoteProviderHeaderRow: View {
     let provider: RemoteProviderStatus
+    @EnvironmentObject var appState: AppState
     @State private var showingCreateSheet = false
     /// Whether the auth CTA popover (opened from the `.needsAuth` indicator)
     /// is showing.
@@ -189,12 +184,26 @@ struct RemoteProviderHeaderRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: -1) {
             HStack(spacing: 4) {
-                Text(provider.describe?.name ?? provider.config.name)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                // The name spans the row's free width instead of a trailing
+                // `Spacer()`, so the whole empty stretch is the desk's hit
+                // target rather than dead chrome.
+                Button {
+                    appState.selectRemoteProvider(provider.config.name)
+                } label: {
+                    Text(provider.describe?.name ?? provider.config.name)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(
+                            appState.selectedRemoteProvider == provider.config.name
+                                ? HierarchicalShapeStyle.primary
+                                : HierarchicalShapeStyle.secondary
+                        )
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open \(provider.describe?.name ?? provider.config.name) provider desk")
                 healthSuffix
-                Spacer()
                 Button {
                     showingCreateSheet = true
                 } label: {
@@ -222,7 +231,11 @@ struct RemoteProviderHeaderRow: View {
         .frame(minHeight: 22, alignment: .bottom)
         .listRowInsets(EdgeInsets(top: 0, leading: -2, bottom: 0, trailing: 0))
         .listRowSeparator(.hidden)
-        .listRowBackground(Color.clear)
+        .listRowBackground(
+            appState.selectedRemoteProvider == provider.config.name
+                ? Color.accentColor.opacity(0.13)
+                : Color.clear
+        )
         .sheet(isPresented: $showingCreateSheet) {
             RemoteCreateSheet(provider: provider.config, describe: provider.describe, repoPrefill: nil)
         }

--- a/Tests/TBDAppTests/DetailSectionHostPagerTests.swift
+++ b/Tests/TBDAppTests/DetailSectionHostPagerTests.swift
@@ -1,61 +1,74 @@
 import Testing
 @testable import TBDApp
 
-/// `DetailSectionHostPager.showsRemoteTab` is the pure decision behind which
-/// of the two always-mounted tabs (`.remote`/`.other`) is in front — see
-/// that type's doc comment for why the `.remote` tab stays mounted (rather
-/// than torn down) when not showing. Covers both inputs' branches.
+/// `DetailSectionHostPager.targetTab` is the pure decision behind which of
+/// the three always-mounted tabs (`.remote`/`.providerDesk`/`.other`) is in
+/// front — see that type's doc comment for why each stays mounted (rather
+/// than torn down) when not showing. Covers every input's branches.
 @Suite("DetailSectionHostPager tab selection")
 struct DetailSectionHostPagerTests {
     private let selection = RemoteSessionSelection(provider: "acme", sessionID: "s1")
 
     @Test("connected with a selected remote session shows the remote tab")
     func connectedWithSelectionShowsRemote() {
-        #expect(DetailSectionHostPager.showsRemoteTab(isConnected: true, selectedRemoteSession: selection))
+        #expect(DetailSectionHostPager.targetTab(
+            isConnected: true, selectedRemoteSession: selection, selectedRemoteProvider: nil
+        ) == .remote)
     }
 
-    @Test("connected with no selected remote session shows the other tab")
+    @Test("connected with no selection at all shows the other tab")
     func connectedWithoutSelectionShowsOther() {
-        #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: true, selectedRemoteSession: nil))
+        #expect(DetailSectionHostPager.targetTab(
+            isConnected: true, selectedRemoteSession: nil, selectedRemoteProvider: nil
+        ) == .other)
     }
 
-    @Test("connected with a selected provider shows the remote tab")
-    func connectedWithProviderShowsRemote() {
-        #expect(DetailSectionHostPager.showsRemoteTab(
+    @Test("connected with a selected provider shows the provider desk tab")
+    func connectedWithProviderShowsDesk() {
+        #expect(DetailSectionHostPager.targetTab(
             isConnected: true, selectedRemoteSession: nil, selectedRemoteProvider: "acme-cloud"
-        ))
+        ) == .providerDesk)
     }
 
     @Test("disconnected with a selected remote session still shows the other tab")
     func disconnectedWithSelectionShowsOther() {
-        #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: false, selectedRemoteSession: selection))
+        #expect(DetailSectionHostPager.targetTab(
+            isConnected: false, selectedRemoteSession: selection, selectedRemoteProvider: nil
+        ) == .other)
     }
 
-    @Test("disconnected with no selected remote session shows the other tab")
+    @Test("disconnected with no selection shows the other tab")
     func disconnectedWithoutSelectionShowsOther() {
-        #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: false, selectedRemoteSession: nil))
+        #expect(DetailSectionHostPager.targetTab(
+            isConnected: false, selectedRemoteSession: nil, selectedRemoteProvider: nil
+        ) == .other)
     }
 
     @Test("disconnected with a selected provider still shows the other tab")
     func disconnectedWithProviderShowsOther() {
-        #expect(!DetailSectionHostPager.showsRemoteTab(
+        #expect(DetailSectionHostPager.targetTab(
             isConnected: false, selectedRemoteSession: nil, selectedRemoteProvider: "acme-cloud"
-        ))
+        ) == .other)
     }
 
-    @Test("explicit provider selection beats the recently attached session fallback")
-    func providerSelectionWinsRemoteHost() {
-        #expect(DetailSectionHostPager.remoteHostContent(
-            selectedRemoteProvider: "acme-cloud",
-            remoteSessionHostSelection: selection
-        ) == .provider("acme-cloud"))
+    /// The Provider Desk must never displace the `.remote` tab's content:
+    /// that tab hosts `RemoteAttachPager`, and rendering the desk in its
+    /// place would dismantle every live attach connection. A provider
+    /// selection therefore resolves to its OWN tab, leaving `.remote`
+    /// mounted-but-detached exactly as a worktree excursion does.
+    @Test("a provider selection never resolves to the attach-hosting remote tab")
+    func providerSelectionNeverTakesOverRemoteTab() {
+        #expect(DetailSectionHostPager.targetTab(
+            isConnected: true, selectedRemoteSession: nil, selectedRemoteProvider: "acme-cloud"
+        ) != .remote)
     }
 
-    @Test("remote host preserves a session when no provider is selected")
-    func sessionSelectionUsesRemoteHost() {
-        #expect(DetailSectionHostPager.remoteHostContent(
-            selectedRemoteProvider: nil,
-            remoteSessionHostSelection: selection
-        ) == .session(selection))
+    /// The two selections are mutually exclusive in `AppState`; this pins
+    /// the tie-break so an unreachable both-set state is still deterministic.
+    @Test("a session selection outranks a provider selection")
+    func sessionOutranksProvider() {
+        #expect(DetailSectionHostPager.targetTab(
+            isConnected: true, selectedRemoteSession: selection, selectedRemoteProvider: "acme-cloud"
+        ) == .remote)
     }
 }

--- a/Tests/TBDAppTests/DetailSectionHostPagerTests.swift
+++ b/Tests/TBDAppTests/DetailSectionHostPagerTests.swift
@@ -19,6 +19,13 @@ struct DetailSectionHostPagerTests {
         #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: true, selectedRemoteSession: nil))
     }
 
+    @Test("connected with a selected provider shows the remote tab")
+    func connectedWithProviderShowsRemote() {
+        #expect(DetailSectionHostPager.showsRemoteTab(
+            isConnected: true, selectedRemoteSession: nil, selectedRemoteProvider: "acme-cloud"
+        ))
+    }
+
     @Test("disconnected with a selected remote session still shows the other tab")
     func disconnectedWithSelectionShowsOther() {
         #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: false, selectedRemoteSession: selection))
@@ -27,5 +34,28 @@ struct DetailSectionHostPagerTests {
     @Test("disconnected with no selected remote session shows the other tab")
     func disconnectedWithoutSelectionShowsOther() {
         #expect(!DetailSectionHostPager.showsRemoteTab(isConnected: false, selectedRemoteSession: nil))
+    }
+
+    @Test("disconnected with a selected provider still shows the other tab")
+    func disconnectedWithProviderShowsOther() {
+        #expect(!DetailSectionHostPager.showsRemoteTab(
+            isConnected: false, selectedRemoteSession: nil, selectedRemoteProvider: "acme-cloud"
+        ))
+    }
+
+    @Test("explicit provider selection beats the recently attached session fallback")
+    func providerSelectionWinsRemoteHost() {
+        #expect(DetailSectionHostPager.remoteHostContent(
+            selectedRemoteProvider: "acme-cloud",
+            remoteSessionHostSelection: selection
+        ) == .provider("acme-cloud"))
+    }
+
+    @Test("remote host preserves a session when no provider is selected")
+    func sessionSelectionUsesRemoteHost() {
+        #expect(DetailSectionHostPager.remoteHostContent(
+            selectedRemoteProvider: nil,
+            remoteSessionHostSelection: selection
+        ) == .session(selection))
     }
 }

--- a/Tests/TBDAppTests/RemoteProviderDeskSummaryTests.swift
+++ b/Tests/TBDAppTests/RemoteProviderDeskSummaryTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+import TBDShared
+@testable import TBDApp
+
+@Suite("Provider Desk summary")
+struct RemoteProviderDeskSummaryTests {
+    private let provider = "acme-cloud"
+
+    @Test("terminal and agent states are counted independently")
+    func countsIndependentStateAxes() {
+        let now = Date(timeIntervalSince1970: 2_000)
+        let sessions = [
+            session(id: "working", terminal: .running, agent: .working, seen: now),
+            session(id: "waiting", terminal: .running, agent: .waitingInput, seen: now.addingTimeInterval(-1)),
+            session(id: "finished", terminal: .exited, agent: .exited, seen: now.addingTimeInterval(-2)),
+            session(id: "unknown", terminal: .starting, agent: .unknown, seen: now.addingTimeInterval(-3)),
+        ]
+
+        let summary = RemoteProviderDeskSummary(provider: provider, sessions: sessions)
+
+        #expect(summary.terminal.starting == 1)
+        #expect(summary.terminal.running == 2)
+        #expect(summary.terminal.exited == 1)
+        #expect(summary.terminal.gone == 0)
+        #expect(summary.agent.working == 1)
+        #expect(summary.agent.waitingInput == 1)
+        #expect(summary.agent.exited == 1)
+        #expect(summary.agent.unknown == 1)
+    }
+
+    @Test("gone overrides the payload terminal state")
+    func goneOverridesTerminalPayload() {
+        let mirror = session(id: "gone", terminal: .running, agent: .unknown, gone: true)
+
+        let summary = RemoteProviderDeskSummary(provider: provider, sessions: [mirror])
+
+        #expect(summary.terminal.running == 0)
+        #expect(summary.terminal.gone == 1)
+        #expect(summary.agent.unknown == 1)
+    }
+
+    @Test("only visible sessions from the selected provider contribute")
+    func filtersProviderAndDismissedRows() {
+        let visible = session(id: "visible", terminal: .running, agent: .idle)
+        let dismissed = session(id: "dismissed", terminal: .exited, agent: .exited, dismissed: true)
+        let other = session(id: "other", provider: "other-cloud", terminal: .running, agent: .working)
+
+        let summary = RemoteProviderDeskSummary(provider: provider, sessions: [dismissed, other, visible])
+
+        #expect(summary.sessions.map(\.payload.id) == ["visible"])
+        #expect(summary.total == 1)
+    }
+
+    @Test("freshness is the latest visible mirror update")
+    func derivesLatestMirrorUpdate() {
+        let older = Date(timeIntervalSince1970: 1_000)
+        let newer = Date(timeIntervalSince1970: 2_000)
+        let hidden = Date(timeIntervalSince1970: 3_000)
+
+        let summary = RemoteProviderDeskSummary(provider: provider, sessions: [
+            session(id: "older", terminal: .running, agent: .idle, seen: older),
+            session(id: "newer", terminal: .running, agent: .working, seen: newer),
+            session(id: "hidden", terminal: .running, agent: .working, dismissed: true, seen: hidden),
+        ])
+
+        #expect(summary.latestMirrorUpdate == newer)
+        #expect(summary.sessions.map(\.payload.id) == ["newer", "older"])
+    }
+
+    private func session(
+        id: String,
+        provider: String? = nil,
+        terminal: RemoteProcessState,
+        agent: RemoteAgentState,
+        gone: Bool = false,
+        dismissed: Bool = false,
+        seen: Date = Date(timeIntervalSince1970: 1_000)
+    ) -> RemoteSessionInfo {
+        RemoteSessionInfo(
+            provider: provider ?? self.provider,
+            payload: RemoteSessionPayload(
+                id: id,
+                title: id.capitalized,
+                createdAt: "2026-08-01T12:00:00Z",
+                state: terminal,
+                agentState: agent,
+                meta: ["repo": "acme/api", "branch": "feature/\(id)"]
+            ),
+            gone: gone,
+            dismissed: dismissed,
+            lastSeen: seen
+        )
+    }
+}

--- a/Tests/TBDAppTests/RemoteProviderDeskSummaryTests.swift
+++ b/Tests/TBDAppTests/RemoteProviderDeskSummaryTests.swift
@@ -90,6 +90,50 @@ struct RemoteProviderDeskSummaryTests {
             since: now.addingTimeInterval(-3 * 86_400), now: now) == "3d ago")
     }
 
+    @Test("freshness prefers the provider-wide inventory timestamp over row lastSeen")
+    func freshnessPrefersTheSuccessfulSnapshot() {
+        let now = Date(timeIntervalSince1970: 100_000)
+
+        // The trap #571 exists to close: rows can look recent while the last
+        // COMPLETE inventory is hours old. The desk must quote the inventory.
+        #expect(RemoteProviderDeskSummary.freshnessLabel(
+            lastSuccessfulSnapshotAt: now.addingTimeInterval(-2 * 3600),
+            latestMirrorUpdate: now.addingTimeInterval(-60),
+            now: now
+        ) == "Inventory as of 2h ago")
+    }
+
+    @Test("freshness falls back to row lastSeen without calling it an inventory")
+    func freshnessFallsBackToMirrorRows() {
+        let now = Date(timeIntervalSince1970: 100_000)
+
+        #expect(RemoteProviderDeskSummary.freshnessLabel(
+            lastSuccessfulSnapshotAt: nil,
+            latestMirrorUpdate: now.addingTimeInterval(-5 * 60),
+            now: now
+        ) == "Latest mirror update 5m ago")
+    }
+
+    @Test("freshness invents no timestamp when nothing has ever succeeded")
+    func freshnessInventsNothing() {
+        #expect(RemoteProviderDeskSummary.freshnessLabel(
+            lastSuccessfulSnapshotAt: nil, latestMirrorUpdate: nil
+        ) == "No successful inventory yet")
+    }
+
+    /// A successful EMPTY snapshot is exactly the case row `lastSeen` cannot
+    /// represent: zero rows to derive an age from, yet the inventory is current.
+    @Test("an empty but successful inventory still reports its own freshness")
+    func emptySuccessfulInventoryReportsFreshness() {
+        let now = Date(timeIntervalSince1970: 100_000)
+
+        #expect(RemoteProviderDeskSummary.freshnessLabel(
+            lastSuccessfulSnapshotAt: now.addingTimeInterval(-30),
+            latestMirrorUpdate: nil,
+            now: now
+        ) == "Inventory as of just now")
+    }
+
     private func session(
         id: String,
         provider: String? = nil,

--- a/Tests/TBDAppTests/RemoteProviderDeskSummaryTests.swift
+++ b/Tests/TBDAppTests/RemoteProviderDeskSummaryTests.swift
@@ -68,6 +68,28 @@ struct RemoteProviderDeskSummaryTests {
         #expect(summary.sessions.map(\.payload.id) == ["newer", "older"])
     }
 
+    @Test("an empty provider reports no mirror timestamp rather than inventing one")
+    func emptyProviderHasNoMirrorUpdate() {
+        let summary = RemoteProviderDeskSummary(provider: provider, sessions: [])
+
+        #expect(summary.latestMirrorUpdate == nil)
+        #expect(summary.total == 0)
+    }
+
+    @Test("age phrasing carries a direction and never reads 'just now ago'")
+    func agePhraseMatchesTheAppsFreshnessVocabulary() {
+        let now = Date(timeIntervalSince1970: 100_000)
+
+        #expect(RemoteProviderDeskSummary.agePhrase(
+            since: now.addingTimeInterval(-5), now: now) == "just now")
+        #expect(RemoteProviderDeskSummary.agePhrase(
+            since: now.addingTimeInterval(-5 * 60), now: now) == "5m ago")
+        #expect(RemoteProviderDeskSummary.agePhrase(
+            since: now.addingTimeInterval(-2 * 3600), now: now) == "2h ago")
+        #expect(RemoteProviderDeskSummary.agePhrase(
+            since: now.addingTimeInterval(-3 * 86_400), now: now) == "3d ago")
+    }
+
     private func session(
         id: String,
         provider: String? = nil,

--- a/Tests/TBDAppTests/RemoteSectionViewTests.swift
+++ b/Tests/TBDAppTests/RemoteSectionViewTests.swift
@@ -197,16 +197,14 @@ struct RemoteSectionViewTests {
         #expect(RemoteSectionView.shouldShowHeader(provider: status(health: .ok), sessions: sessions, knownRepoIDs: []))
     }
 
-    /// The case this feature exists to fix: every one of the provider's
-    /// sessions matched a repo, so there's nothing left to list here — but a
-    /// healthy provider with nothing to say renders no header at all.
-    @Test func shouldShowHeader_falseWhenHealthyAndFullyMatched() {
+    /// A fully matched provider remains the stable entry point to its desk.
+    @Test func shouldShowHeader_trueWhenHealthyAndFullyMatched() {
         let repoID = UUID()
         let sessions = [
             RemoteSessionInfo(provider: "acme", payload: RemoteSessionPayload(id: "s1", state: .running),
                               gone: false, dismissed: false, lastSeen: Date(), resolvedRepoID: repoID),
         ]
-        #expect(!RemoteSectionView.shouldShowHeader(provider: status(health: .ok), sessions: sessions, knownRepoIDs: [repoID]))
+        #expect(RemoteSectionView.shouldShowHeader(provider: status(health: .ok), sessions: sessions, knownRepoIDs: [repoID]))
     }
 
     /// The health-visibility guarantee: even with every session matched, an
@@ -226,8 +224,8 @@ struct RemoteSectionViewTests {
         #expect(RemoteSectionView.shouldShowHeader(provider: status(health: .error), sessions: [], knownRepoIDs: []))
     }
 
-    @Test func shouldShowHeader_falseWhenHealthyWithNoSessionsAtAll() {
-        #expect(!RemoteSectionView.shouldShowHeader(provider: status(health: .ok), sessions: [], knownRepoIDs: []))
+    @Test func shouldShowHeader_trueWhenHealthyWithNoSessionsAtAll() {
+        #expect(RemoteSectionView.shouldShowHeader(provider: status(health: .ok), sessions: [], knownRepoIDs: []))
     }
 
     // MARK: - RowStatusIndicator.leading — `.remote` case + precedence

--- a/docs/specs/2026-08-01-provider-desk-read-only-design.md
+++ b/docs/specs/2026-08-01-provider-desk-read-only-design.md
@@ -65,10 +65,23 @@ rows. Counts are pure projections:
 terminal state in the terminal totals. Provider health never rewrites a
 session's state.
 
-The existing mirror exposes `lastSeen` per session but no provider-wide
-`observed_at`. The desk labels the newest session `lastSeen` as **Latest mirror
-update**. It does not call that time a provider refresh or health check. Empty
-providers display “No mirrored sessions” rather than inventing a timestamp.
+Freshness comes from `RemoteProviderStatus.lastSuccessfulSnapshotAt` — the
+provider-wide timestamp of the last complete inventory the mirror accepted,
+added by #571 — shown as **Inventory as of 2h ago**. This is the same fact the
+sidebar caption and session detail pane quote, so no two surfaces can disagree
+about how stale a provider is.
+
+Per-session `lastSeen` is only a fallback for a daemon old enough not to send
+that timestamp, and it is labelled **Latest mirror update** rather than being
+called an inventory. It is deliberately not the primary source: it is a lower
+bound over whichever rows happened to appear, so it cannot tell a successful
+*empty* snapshot from no snapshot at all, and a provider whose rows all stopped
+being reported would keep quoting an age that describes no inventory. When
+neither exists the desk says “No successful inventory yet” rather than
+inventing a timestamp.
+
+Because #571 also gates session creation on `hasStaleSnapshot`, the empty state
+stops pointing at the sidebar `+` while that gate is closed.
 
 Provider health copy comes from `RemoteProviderStatus`:
 

--- a/docs/specs/2026-08-01-provider-desk-read-only-design.md
+++ b/docs/specs/2026-08-01-provider-desk-read-only-design.md
@@ -1,0 +1,126 @@
+# Provider Desk read-only overview
+
+**Date:** 2026-08-01  
+**Status:** Approved in issue #565; implementation scope is milestone 2 only.  
+**Issue:** [#565 — Provider Desk](https://github.com/cheapsteak/tbd/issues/565)
+
+## Summary
+
+Selecting a remote provider header opens a read-only Provider Desk. The desk
+answers three questions from data TBD already mirrors: Is this provider
+reachable? How much work does it own? Which sessions need attention?
+
+This slice adds no provider verbs, background work, database state, or remote
+execution. It does not implement status telemetry or typed jobs. Those remain
+separate milestones because their facts do not exist in the current provider
+contract.
+
+## Chosen approach
+
+Issue #565 considered a provider-level detail surface, a provider status
+capability, and a typed job capability. This slice chooses the smallest useful
+boundary: a deterministic projection of `RemoteProviderStatus` and
+`RemoteSessionInfo` into a selectable desk.
+
+Two broader approaches are deferred:
+
+- Extending the provider contract with `status` would provide capacity and
+  resource telemetry, but requires daemon and provider changes plus freshness
+  semantics. It belongs to milestone 3.
+- Adding Local CI controls would require typed `job-*` verbs and provider-owned
+  isolation, concurrency, logs, and cancellation. It belongs to milestone 4.
+  Calling a shell command from this desk would violate the approved contract.
+
+## Experience
+
+The provider header becomes a normal selectable sidebar row. Selecting it
+clears worktree, repository, scratch, and remote-session selections and opens
+the Provider Desk without attaching to a session.
+
+The desk uses a compact operational layout:
+
+1. A provider masthead shows its display name, health, and a refresh action.
+2. A two-axis status strip counts terminal states and agent states separately.
+3. A session ledger lists title, repository, branch, terminal state, agent
+   state or reason, age, and last mirror update.
+
+The status strip is the design signature: two parallel rows make it impossible
+to collapse process liveness and agent activity into one misleading status.
+The surrounding interface stays quiet and uses TBD's native materials, system
+type, spacing, and status colors.
+
+On narrow windows, summary groups wrap vertically and session metadata flows
+under the title. The row remains keyboard accessible, and every icon-only
+control has an accessibility label and help text.
+
+## Data and freshness
+
+The desk filters `AppState.remoteSessions` by provider and excludes dismissed
+rows. Counts are pure projections:
+
+- terminal: starting, running, exited, gone, and unknown;
+- agent: working, waiting for input, idle, exited, and unknown.
+
+`gone` is a mirror condition and therefore takes precedence over the payload's
+terminal state in the terminal totals. Provider health never rewrites a
+session's state.
+
+The existing mirror exposes `lastSeen` per session but no provider-wide
+`observed_at`. The desk labels the newest session `lastSeen` as **Latest mirror
+update**. It does not call that time a provider refresh or health check. Empty
+providers display “No mirrored sessions” rather than inventing a timestamp.
+
+Provider health copy comes from `RemoteProviderStatus`:
+
+- healthy: “Provider responding”;
+- stale: “Provider unreachable; mirrored sessions may be stale”;
+- needs authentication: the existing auth remediation component;
+- error: the provider's reported message when available.
+
+The refresh button calls the existing `refreshRemote()` RPC sequence. No new
+poller or timer is introduced.
+
+## Session navigation
+
+Selecting a ledger row uses the existing `selectRemoteSession` path. Attach,
+log, send, stop, rename, and pin remain in the existing session detail and
+action menu; the desk does not create a second action vocabulary.
+
+The provider selection is app-local view state. It participates in mutual
+exclusion with existing top-level selections. Back/forward support is deferred
+because adding a new persisted navigation entry expands the slice without
+improving the desk's core read-only value.
+
+## Error and empty states
+
+An unreachable or unauthenticated provider remains selectable. Its mirrored
+sessions stay visible and keep their last reported states. Authentication uses
+the existing provider remediation UI; generic errors remain informational.
+
+An empty provider shows its health and a directed empty state. It does not
+offer session creation in the desk. The sidebar's existing `+` action remains
+the creation path.
+
+## Testing
+
+Focused tests cover the pure projection:
+
+- terminal and agent totals remain independent;
+- `gone` overrides the payload's terminal state;
+- dismissed rows are excluded;
+- latest mirror update is derived only from visible rows;
+- provider selection chooses the remote host without a session selection.
+
+Build validation is `swift build`. The implementation adds no daemon or shared
+model behavior, so the focused app tests are sufficient before the full build.
+
+## Deferred decisions
+
+- Provider capacity and resource cards require milestone 3's typed `status`
+  contract.
+- Local CI visibility, kickoff, logs, and cancellation require milestone 4's
+  typed job contract.
+- A local-provider aggregate that treats local worktrees as a provider needs a
+  separate product decision; issue #565 describes registered remote providers.
+- Back/forward history for provider-level selection may be added when the
+  navigation model gains a provider entry.


### PR DESCRIPTION
## Summary

Implements issue #565 milestone 2: a selectable, read-only provider-level desk using TBD’s existing mirrored provider/session state.

- keeps provider headers visible and selectable
- reports provider health and mirror freshness honestly
- separates terminal process totals from agent attention totals
- adds a responsive session ledger routed to existing attach/log/actions
- preserves existing authentication remediation and refresh paths

## Boundaries

No provider verbs, remote shell, worker creation, Local CI dispatch, capacity inference, new persistence, restart, or merge behavior. Typed status/jobs and local-as-provider aggregation remain later #565 milestones.

## Validation

- `swift build --target TBDApp` passed locally
- focused pure projection/navigation tests added
- hosted macOS suite requested by this PR

No merge requested.