### PR TITLE
Fence Nightwatch judge authority with an exclusive lease

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -1695,6 +1695,8 @@ final class AppState: ObservableObject {
             applyTerminalActivityDelta(d)
         case .terminalProfileChanged(let d):
             applyTerminalProfileDelta(d)
+        case .watchDeskRolesChanged(let d):
+            Task { [weak self] in await self?.refreshTerminals(worktreeID: d.worktreeID) }
         case .terminalHibernationChanged(let d):
             applyTerminalHibernationDelta(d)
         case .worktreeMoved(let d):

--- a/Sources/TBDApp/TabBar.swift
+++ b/Sources/TBDApp/TabBar.swift
@@ -979,12 +979,17 @@ private struct TabBarItem: View {
     }
 
     private var tabLabel: String {
-        if let label = tab.label, !label.isEmpty {
-            return label
+        let roleSuffix: String = switch terminal?.watchDeskRole {
+        case .judge: " · Judge"
+        case .readOnlyCoordinator: " · Read-only"
+        case nil: ""
         }
-        switch tab.content {
+        let base: String
+        if let label = tab.label, !label.isEmpty {
+            base = label
+        } else { switch tab.content {
         case .terminal:
-            return AutoTabLabelResolver.terminalLabel(
+            base = AutoTabLabelResolver.terminalLabel(
                 terminal: terminal,
                 fallbackIndex: index,
                 modelProfiles: appState.modelProfiles,
@@ -992,18 +997,20 @@ private struct TabBarItem: View {
                 worktreeTerminals: appState.terminals[worktreeID] ?? []
             )
         case .webview(_, let url):
-            return url.host ?? "Web"
+            base = url.host ?? "Web"
         case .codeViewer(_, let path):
-            return URL(fileURLWithPath: path).lastPathComponent
+            base = URL(fileURLWithPath: path).lastPathComponent
         case .note(let noteID):
             let allNotes = appState.notes.values.flatMap { $0 }
             if let title = allNotes.first(where: { $0.id == noteID })?.title, !title.isEmpty {
-                return title
+                base = title
+            } else {
+                base = "Note \(index + 1)"
             }
-            return "Note \(index + 1)"
         case .liveTranscript:
-            return "Transcript"
-        }
+            base = "Transcript"
+        }}
+        return base + roleSuffix
     }
 }
 

--- a/Sources/TBDCLI/Commands/NightwatchCommand.swift
+++ b/Sources/TBDCLI/Commands/NightwatchCommand.swift
@@ -6,8 +6,127 @@ struct NightwatchCommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "nightwatch",
         abstract: "Manage nightwatch mode",
-        subcommands: [NightwatchSet.self, NightwatchStatus.self]
+        subcommands: [NightwatchSet.self, NightwatchStatus.self, NightwatchLease.self]
     )
+}
+
+struct NightwatchLease: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "lease",
+        abstract: "Inspect and manage exclusive Watch Desk judge ownership",
+        subcommands: [
+            NightwatchLeaseStatus.self, NightwatchLeaseAcquire.self,
+            NightwatchLeaseValidate.self,
+            NightwatchLeaseRenew.self, NightwatchLeaseTransfer.self,
+            NightwatchLeaseRelease.self,
+        ])
+}
+
+struct NightwatchLeaseAcquire: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "acquire",
+        abstract: "Choose the judge explicitly when an unowned desk has multiple candidates")
+    @Option(name: .long) var worktree: String
+    @Option(name: .long) var terminal: String
+    mutating func run() async throws {
+        let result: NightwatchLeaseAcquisitionResult = try SocketClient().call(
+            method: RPCMethod.nightwatchLeaseAcquire,
+            params: NightwatchLeaseAcquireParams(
+                worktreeID: try parseLeaseUUID(worktree, option: "--worktree"),
+                terminalID: try parseLeaseUUID(terminal, option: "--terminal")),
+            resultType: NightwatchLeaseAcquisitionResult.self)
+        printJSON(result)
+    }
+}
+
+struct LeaseCredentials: ParsableArguments {
+    @Option(name: .long, help: "Mode-0600 capability file issued by the daemon")
+    var credentialFile: String
+
+    func params() throws -> NightwatchLeaseCredentialsParams {
+        let credential: WatchDeskLeaseCredential
+        do {
+            credential = try WatchDeskLeaseCredentialFile.read(path: credentialFile)
+        } catch {
+            throw CLIError.invalidArgument(
+                "Cannot read --credential-file: \(error.localizedDescription)")
+        }
+        return NightwatchLeaseCredentialsParams(
+            worktreeID: credential.worktreeID,
+            terminalID: credential.terminalID,
+            token: credential.token,
+            generation: credential.generation)
+    }
+}
+
+private func parseLeaseUUID(_ value: String, option: String) throws -> UUID {
+    guard let id = UUID(uuidString: value) else {
+        throw CLIError.invalidArgument("Invalid UUID for \(option): \(value)")
+    }
+    return id
+}
+
+struct NightwatchLeaseStatus: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "status")
+    @Option(name: .long) var worktree: String
+    mutating func run() async throws {
+        let result: NightwatchLeaseStatusResult = try SocketClient().call(
+            method: RPCMethod.nightwatchLeaseStatus,
+            params: NightwatchLeaseStatusParams(
+                worktreeID: try parseLeaseUUID(worktree, option: "--worktree")),
+            resultType: NightwatchLeaseStatusResult.self)
+        printJSON(result)
+    }
+}
+
+struct NightwatchLeaseValidate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "validate")
+    @OptionGroup var credentials: LeaseCredentials
+    mutating func run() async throws {
+        let result: WatchDeskLeaseSnapshot = try SocketClient().call(
+            method: RPCMethod.nightwatchLeaseValidate, params: try credentials.params(),
+            resultType: WatchDeskLeaseSnapshot.self)
+        printJSON(result)
+    }
+}
+
+struct NightwatchLeaseRenew: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "renew")
+    @OptionGroup var credentials: LeaseCredentials
+    mutating func run() async throws {
+        let result: WatchDeskLeaseSnapshot = try SocketClient().call(
+            method: RPCMethod.nightwatchLeaseRenew, params: try credentials.params(),
+            resultType: WatchDeskLeaseSnapshot.self)
+        printJSON(result)
+    }
+}
+
+struct NightwatchLeaseTransfer: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "transfer")
+    @OptionGroup var credentials: LeaseCredentials
+    @Option(name: .long) var toTerminal: String
+    mutating func run() async throws {
+        let source = try credentials.params()
+        let result: NightwatchLeaseAcquisitionResult = try SocketClient().call(
+            method: RPCMethod.nightwatchLeaseTransfer,
+            params: NightwatchLeaseTransferParams(
+                worktreeID: source.worktreeID,
+                fromTerminalID: source.terminalID,
+                toTerminalID: try parseLeaseUUID(toTerminal, option: "--to-terminal"),
+                token: source.token, generation: source.generation),
+            resultType: NightwatchLeaseAcquisitionResult.self)
+        printJSON(result)
+    }
+}
+
+struct NightwatchLeaseRelease: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "release")
+    @OptionGroup var credentials: LeaseCredentials
+    mutating func run() async throws {
+        try SocketClient().callVoid(
+            method: RPCMethod.nightwatchLeaseRelease, params: try credentials.params())
+        print("Nightwatch judge lease released")
+    }
 }
 
 // MARK: - nightwatch set

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -27,6 +27,7 @@ public final class TBDDatabase: Sendable {
     public let terminalHistory: TerminalHistoryStore
     public let panelSurface: PanelSurfaceStore
     public let remoteSessions: RemoteSessionStore
+    public let watchDeskLeases: WatchDeskLeaseStore
 
     private static let logger = Logger(subsystem: "com.tbd.daemon", category: "migrations")
 
@@ -66,6 +67,7 @@ public final class TBDDatabase: Sendable {
         self.terminalHistory = TerminalHistoryStore(writer: pool, historyDir: terminalHistoryDir)
         self.panelSurface = PanelSurfaceStore(writer: pool)
         self.remoteSessions = RemoteSessionStore(writer: pool)
+        self.watchDeskLeases = WatchDeskLeaseStore(writer: pool)
 
         let migrator = Self.buildMigrator()
         if fileExisted {
@@ -105,6 +107,7 @@ public final class TBDDatabase: Sendable {
         self.terminalHistory = TerminalHistoryStore(writer: queue, historyDir: terminalHistoryDir)
         self.panelSurface = PanelSurfaceStore(writer: queue)
         self.remoteSessions = RemoteSessionStore(writer: queue)
+        self.watchDeskLeases = WatchDeskLeaseStore(writer: queue)
         try Self.buildMigrator().migrate(queue)
     }
 
@@ -1166,6 +1169,25 @@ public final class TBDDatabase: Sendable {
             try db.addColumnIfMissing(
                 table: "worktree", column: "foreign_head",
                 type: .boolean, defaults: false)
+        }
+
+        migrator.registerMigration("v68_watch_desk_judge_lease") { db in
+            try db.addColumnIfMissing(
+                table: "terminal", column: "watch_desk_role", type: .text,
+                defaults: DatabaseValue.null)
+            try db.createTableIfNotExists("watch_desk_judge_lease") { t in
+                t.primaryKey("worktree_id", .text).notNull()
+                    .references("worktree", onDelete: .cascade)
+                // Deliberately not an FK: a dead terminal row may be deleted,
+                // but its generation tombstone must survive so fencing tokens
+                // are never reused for this desk.
+                t.column("terminal_id", .text).notNull()
+                t.column("token", .text).notNull()
+                t.column("generation", .integer).notNull()
+                t.column("acquired_at", .datetime).notNull()
+                t.column("renewed_at", .datetime).notNull()
+                t.column("expires_at", .datetime).notNull()
+            }
         }
 
         return migrator

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -183,16 +183,6 @@ public struct TerminalStore: Sendable {
         }
     }
 
-    public func setWatchDeskRole(id: UUID, role: WatchDeskRole?) async throws {
-        try await writer.write { db in
-            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
-                throw DatabaseError(message: "Terminal not found")
-            }
-            record.watch_desk_role = role?.rawValue
-            try record.update(db)
-        }
-    }
-
     /// Set or clear the pinned timestamp for a terminal.
     public func setPin(id: UUID, pinned: Bool, at date: Date = Date()) async throws {
         try await writer.write { db in

--- a/Sources/TBDDaemon/Database/TerminalStore.swift
+++ b/Sources/TBDDaemon/Database/TerminalStore.swift
@@ -27,6 +27,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var hibernateReason: String?
     var keepWarm: Bool?
     var pendingResumeAt: Date?
+    var watch_desk_role: String?
 
     init(from terminal: Terminal) {
         self.id = terminal.id.uuidString
@@ -47,6 +48,7 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.hibernateReason = terminal.hibernateReason?.rawValue
         self.keepWarm = terminal.keepWarm
         self.pendingResumeAt = terminal.pendingResumeAt
+        self.watch_desk_role = terminal.watchDeskRole?.rawValue
     }
 
     /// Failable decode: skips (returns nil after a logged warning) rather than
@@ -79,7 +81,10 @@ struct TerminalRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             hibernatedAt: hibernatedAt,
             hibernateReason: hibernateReason.flatMap(HibernateReason.init(rawValue:)),
             keepWarm: keepWarm ?? false,
-            pendingResumeAt: pendingResumeAt
+            pendingResumeAt: pendingResumeAt,
+            watchDeskRole: watch_desk_role.map {
+                WatchDeskRole(rawValue: $0) ?? .readOnlyCoordinator
+            }
         )
     }
 }
@@ -175,6 +180,16 @@ public struct TerminalStore: Sendable {
             try TerminalRecord
                 .filter(Column("worktreeID") == worktreeID.uuidString)
                 .deleteAll(db)
+        }
+    }
+
+    public func setWatchDeskRole(id: UUID, role: WatchDeskRole?) async throws {
+        try await writer.write { db in
+            guard var record = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+                throw DatabaseError(message: "Terminal not found")
+            }
+            record.watch_desk_role = role?.rawValue
+            try record.update(db)
         }
     }
 

--- a/Sources/TBDDaemon/Database/WatchDeskLeaseStore.swift
+++ b/Sources/TBDDaemon/Database/WatchDeskLeaseStore.swift
@@ -1,0 +1,221 @@
+import Foundation
+import GRDB
+import TBDShared
+
+public struct WatchDeskLease: Codable, Sendable, Equatable {
+    public let worktreeID: UUID
+    public let terminalID: UUID
+    public let token: UUID
+    public let generation: Int64
+    public let acquiredAt: Date
+    public let renewedAt: Date
+    public let expiresAt: Date
+
+    public func isValid(at date: Date) -> Bool { expiresAt > date }
+}
+
+public enum WatchDeskLeaseError: Error, LocalizedError, Equatable {
+    case contended(holder: UUID, generation: Int64, expiresAt: Date)
+    case notHeld
+    case fenced
+    case terminalNotFound
+    case terminalOutsideDesk
+
+    public var errorDescription: String? {
+        switch self {
+        case .contended(let holder, let generation, let expiry):
+            return "Watch Desk judge lease is held by terminal \(holder) at generation \(generation) until \(expiry)"
+        case .notHeld: return "Watch Desk judge lease is not held"
+        case .fenced: return "Watch Desk judge lease credentials are stale"
+        case .terminalNotFound: return "Watch Desk terminal not found"
+        case .terminalOutsideDesk: return "Terminal does not belong to this Watch Desk"
+        }
+    }
+}
+
+private struct WatchDeskLeaseRecord: Codable, FetchableRecord, PersistableRecord {
+    static let databaseTableName = "watch_desk_judge_lease"
+    var worktree_id: String
+    var terminal_id: String
+    var token: String
+    var generation: Int64
+    var acquired_at: Date
+    var renewed_at: Date
+    var expires_at: Date
+
+    func model() -> WatchDeskLease? {
+        guard let worktreeID = UUID(uuidString: worktree_id),
+              let terminalID = UUID(uuidString: terminal_id),
+              let token = UUID(uuidString: token) else { return nil }
+        return WatchDeskLease(
+            worktreeID: worktreeID, terminalID: terminalID, token: token,
+            generation: generation, acquiredAt: acquired_at,
+            renewedAt: renewed_at, expiresAt: expires_at)
+    }
+}
+
+public struct WatchDeskLeaseStore: Sendable {
+    /// Longer than both the 15-minute scheduler interval and the 10-minute
+    /// overlap guard. The daemon refreshes it on every heartbeat; an agent also
+    /// renews immediately before a mutation.
+    public static let defaultLifetime: TimeInterval = 20 * 60
+    let writer: any DatabaseWriter
+
+    init(writer: any DatabaseWriter) { self.writer = writer }
+
+    public func status(worktreeID: UUID) async throws -> WatchDeskLease? {
+        try await writer.read { db in
+            try WatchDeskLeaseRecord.fetchOne(db, key: worktreeID.uuidString)?.model()
+        }
+    }
+
+    /// Acquires an absent/expired lease. An unexpired holder must authenticate
+    /// through renew instead. Every takeover increments generation.
+    public func acquire(
+        worktreeID: UUID, terminalID: UUID, now: Date = Date(),
+        lifetime: TimeInterval = defaultLifetime,
+        token: UUID = UUID()
+    ) async throws -> WatchDeskLease {
+        try await writer.write { db in
+            try Self.requireTerminal(terminalID, belongsTo: worktreeID, db: db)
+            let old = try WatchDeskLeaseRecord.fetchOne(db, key: worktreeID.uuidString)
+            if let old, old.expires_at > now, old.terminal_id != terminalID.uuidString {
+                guard let holder = UUID(uuidString: old.terminal_id) else { throw WatchDeskLeaseError.fenced }
+                throw WatchDeskLeaseError.contended(
+                    holder: holder, generation: old.generation, expiresAt: old.expires_at)
+            }
+            if let old, old.expires_at > now, old.terminal_id == terminalID.uuidString {
+                guard let holder = UUID(uuidString: old.terminal_id) else {
+                    throw WatchDeskLeaseError.fenced
+                }
+                // Acquire is recovery, not an unauthenticated renewal path.
+                throw WatchDeskLeaseError.contended(
+                    holder: holder, generation: old.generation, expiresAt: old.expires_at)
+            }
+            let generation = (old?.generation ?? 0) + 1
+            let record = WatchDeskLeaseRecord(
+                worktree_id: worktreeID.uuidString,
+                terminal_id: terminalID.uuidString,
+                token: token.uuidString,
+                generation: generation,
+                acquired_at: now,
+                renewed_at: now,
+                expires_at: now.addingTimeInterval(lifetime))
+            try record.save(db)
+            try Self.setRoles(owner: terminalID, worktreeID: worktreeID, db: db)
+            return record.model()!
+        }
+    }
+
+    public func validate(
+        worktreeID: UUID, terminalID: UUID, token: UUID, generation: Int64,
+        now: Date = Date()
+    ) async throws -> WatchDeskLease {
+        try await writer.read { db in
+            guard let record = try WatchDeskLeaseRecord.fetchOne(db, key: worktreeID.uuidString) else {
+                throw WatchDeskLeaseError.notHeld
+            }
+            guard record.terminal_id == terminalID.uuidString,
+                  record.token == token.uuidString,
+                  record.generation == generation,
+                  record.expires_at > now else { throw WatchDeskLeaseError.fenced }
+            return record.model()!
+        }
+    }
+
+    public func renew(
+        worktreeID: UUID, terminalID: UUID, token: UUID, generation: Int64,
+        now: Date = Date(), lifetime: TimeInterval = defaultLifetime
+    ) async throws -> WatchDeskLease {
+        try await writer.write { db in
+            guard var record = try WatchDeskLeaseRecord.fetchOne(db, key: worktreeID.uuidString) else {
+                throw WatchDeskLeaseError.notHeld
+            }
+            guard record.terminal_id == terminalID.uuidString,
+                  record.token == token.uuidString,
+                  record.generation == generation,
+                  record.expires_at > now else { throw WatchDeskLeaseError.fenced }
+            record.renewed_at = now
+            record.expires_at = now.addingTimeInterval(lifetime)
+            try record.update(db)
+            // Terminals can be created after acquisition. Reassert roles on
+            // renewal so every additional desk agent is visibly read-only.
+            try Self.setRoles(owner: terminalID, worktreeID: worktreeID, db: db)
+            return record.model()!
+        }
+    }
+
+    public func transfer(
+        worktreeID: UUID, fromTerminalID: UUID, toTerminalID: UUID,
+        token: UUID, generation: Int64, now: Date = Date(),
+        lifetime: TimeInterval = defaultLifetime,
+        replacementToken: UUID = UUID()
+    ) async throws -> WatchDeskLease {
+        try await writer.write { db in
+            try Self.requireTerminal(toTerminalID, belongsTo: worktreeID, db: db)
+            guard var record = try WatchDeskLeaseRecord.fetchOne(db, key: worktreeID.uuidString) else {
+                throw WatchDeskLeaseError.notHeld
+            }
+            guard record.terminal_id == fromTerminalID.uuidString,
+                  record.token == token.uuidString,
+                  record.generation == generation,
+                  record.expires_at > now else { throw WatchDeskLeaseError.fenced }
+            record.terminal_id = toTerminalID.uuidString
+            record.token = replacementToken.uuidString
+            record.generation += 1
+            record.acquired_at = now
+            record.renewed_at = now
+            record.expires_at = now.addingTimeInterval(lifetime)
+            try record.update(db)
+            try Self.setRoles(owner: toTerminalID, worktreeID: worktreeID, db: db)
+            return record.model()!
+        }
+    }
+
+    public func release(
+        worktreeID: UUID, terminalID: UUID, token: UUID, generation: Int64
+    ) async throws {
+        try await writer.write { db in
+            guard let record = try WatchDeskLeaseRecord.fetchOne(db, key: worktreeID.uuidString) else {
+                throw WatchDeskLeaseError.notHeld
+            }
+            guard record.terminal_id == terminalID.uuidString,
+                  record.token == token.uuidString,
+                  record.generation == generation else { throw WatchDeskLeaseError.fenced }
+            var tombstone = record
+            tombstone.expires_at = Date.distantPast
+            try tombstone.update(db)
+            try db.execute(
+                sql: "UPDATE terminal SET watch_desk_role = NULL WHERE worktreeID = ?",
+                arguments: [worktreeID.uuidString])
+        }
+    }
+
+    public func revoke(worktreeID: UUID) async throws {
+        try await writer.write { db in
+            if var record = try WatchDeskLeaseRecord.fetchOne(db, key: worktreeID.uuidString) {
+                record.expires_at = Date.distantPast
+                try record.update(db)
+            }
+            try db.execute(
+                sql: "UPDATE terminal SET watch_desk_role = NULL WHERE worktreeID = ?",
+                arguments: [worktreeID.uuidString])
+        }
+    }
+
+    private static func requireTerminal(_ id: UUID, belongsTo worktreeID: UUID, db: Database) throws {
+        guard let terminal = try TerminalRecord.fetchOne(db, key: id.uuidString) else {
+            throw WatchDeskLeaseError.terminalNotFound
+        }
+        guard terminal.worktreeID == worktreeID.uuidString else {
+            throw WatchDeskLeaseError.terminalOutsideDesk
+        }
+    }
+
+    private static func setRoles(owner: UUID, worktreeID: UUID, db: Database) throws {
+        try db.execute(
+            sql: "UPDATE terminal SET watch_desk_role = CASE WHEN id = ? THEN ? ELSE ? END WHERE worktreeID = ?",
+            arguments: [owner.uuidString, WatchDeskRole.judge.rawValue,
+                        WatchDeskRole.readOnlyCoordinator.rawValue, worktreeID.uuidString])
+    }
+}

--- a/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
+++ b/Sources/TBDDaemon/Nightwatch/DaywatchRunner.swift
@@ -191,6 +191,7 @@ public actor DaywatchRunner {
 
             if let desker = deskSessionManager, let deskID = deskWorktreeID {
                 await desker.postShiftWrapUp(worktreeID: deskID)
+                await desker.releaseJudgeLease(worktreeID: deskID)
             }
             deskWorktreeID = nil
 
@@ -241,6 +242,13 @@ public actor DaywatchRunner {
                     logger.warning("Desk session ensure failed on tick retry (first failure): \(error.localizedDescription, privacy: .public)")
                 }
             }
+        }
+
+        // Lease maintenance is model-free and runs on every scheduler heartbeat,
+        // including ticks that queue no judgment and therefore send no nudge.
+        if let desker = deskSessionManager, let deskID = deskWorktreeID,
+           effectiveMode != .off {
+            await desker.maintainJudgeLease(worktreeID: deskID)
         }
 
         // Run one tick

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -11,6 +11,13 @@ public protocol DeskSessionManaging: Sendable {
     func nudgeDeskSession(worktreeID: UUID, act: Bool) async
     func postShiftWrapUp(worktreeID: UUID) async
     func closeDeskSession() async
+    func releaseJudgeLease(worktreeID: UUID) async
+    func maintainJudgeLease(worktreeID: UUID) async
+}
+
+public extension DeskSessionManaging {
+    func releaseJudgeLease(worktreeID: UUID) async {}
+    func maintainJudgeLease(worktreeID: UUID) async {}
 }
 
 /// Manages the persistent "Watch Desk" scratch space for daywatch/nightwatch operations.
@@ -83,6 +90,10 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// Internal rather than private so tests can assert the transition; it is state
     /// the manager needs regardless.
     private(set) var lastNudgedMode: NightwatchMode?
+
+    /// Deduplicates the fail-closed notification for one conflicting owner
+    /// generation. A new generation is a new incident and notifies again.
+    private var notifiedContentionGeneration: Int64?
 
     // MARK: - Init
 
@@ -234,8 +245,8 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// `TerminalStore.list` orders by `createdAt` ascending, so the previous
     /// `terminals.first(where:)` deterministically returned the OLDEST row —
     /// not a race, a guarantee. Desk terminal rows outlive their
-    /// panes: a session that dies, or is killed out-of-band (the nightwatch judge handoff
-    /// `kill-window`s its predecessor directly, so the daemon never removes the row),
+    /// panes: a session that dies, or was killed out-of-band by an older
+    /// Nightwatch handoff that bypassed TBD's terminal-close path,
     /// leaves its row behind forever. The oldest row is therefore the one *most* likely
     /// to be dead, and every handoff inserted another corpse ahead of the live desk.
     ///
@@ -255,11 +266,11 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// prompt there would execute it as shell input.
     ///
     /// - Returns: The newest matching agent terminal whose tmux window is still alive, or nil.
-    private func liveAgentTerminal(
+    private func liveAgentTerminals(
         worktreeID: UUID,
         server: String,
         kind: TerminalKind
-    ) async throws -> Terminal? {
+    ) async throws -> [Terminal] {
         let candidates = try await db.terminals.list(worktreeID: worktreeID)
             .filter {
                 $0.suspendedAt == nil
@@ -270,6 +281,7 @@ public actor DeskSessionManager: DeskSessionManaging {
             // createdAt, so without it the winner between same-instant rows is arbitrary.
             .sorted { ($0.createdAt, $0.id.uuidString) > ($1.createdAt, $1.id.uuidString) }
 
+        var live: [Terminal] = []
         for terminal in candidates {
             guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
                 logger.notice("""
@@ -290,9 +302,98 @@ public actor DeskSessionManager: DeskSessionManaging {
                     continue
                 }
             }
-            return terminal
+            live.append(terminal)
         }
-        return nil
+        return live
+    }
+
+    private func liveAgentTerminal(
+        worktreeID: UUID,
+        server: String,
+        kind: TerminalKind
+    ) async throws -> Terminal? {
+        try await liveAgentTerminals(
+            worktreeID: worktreeID, server: server, kind: kind).first
+    }
+
+    private func liveJudgeCandidates(worktree: Worktree) async throws -> [Terminal] {
+        let claude = try await liveAgentTerminals(
+            worktreeID: worktree.id, server: worktree.tmuxServer, kind: .claude)
+        let codex = try await liveAgentTerminals(
+            worktreeID: worktree.id, server: worktree.tmuxServer, kind: .codex)
+        return (claude + codex).sorted {
+            ($0.createdAt, $0.id.uuidString) > ($1.createdAt, $1.id.uuidString)
+        }
+    }
+
+    /// Resolve the sole mutable judge. Existing valid ownership wins even when
+    /// observers are present. With no lease, multiple candidates are ambiguous
+    /// and fail closed rather than selecting by recency.
+    private func leasedJudgeTerminal(
+        worktree: Worktree
+    ) async throws -> (Terminal, WatchDeskLease, String)? {
+        var candidates = try await liveJudgeCandidates(worktree: worktree)
+        let now = now()
+
+        if let lease = try await db.watchDeskLeases.status(worktreeID: worktree.id),
+           lease.isValid(at: now) {
+            if let owner = candidates.first(where: { $0.id == lease.terminalID }) {
+                let renewed = try await db.watchDeskLeases.renew(
+                    worktreeID: worktree.id, terminalID: owner.id,
+                    token: lease.token, generation: lease.generation, now: now)
+                let credentialFile = try WatchDeskLeaseCredentialFile.ensure(WatchDeskLeaseCredential(
+                    worktreeID: renewed.worktreeID, terminalID: renewed.terminalID,
+                    token: renewed.token, generation: renewed.generation))
+                notifiedContentionGeneration = nil
+                return (owner, renewed, credentialFile)
+            }
+            logger.warning("Revoking Watch Desk judge lease generation \(lease.generation): owner pane is gone")
+            try await db.watchDeskLeases.revoke(worktreeID: worktree.id)
+            subscriptions?.broadcast(delta: .watchDeskRolesChanged(
+                WorktreeIDDelta(worktreeID: worktree.id)))
+            candidates = try await liveJudgeCandidates(worktree: worktree)
+        }
+
+        guard candidates.count <= 1 else {
+            // Generation 0 denotes pre-lease ambiguity. Once a real lease has
+            // existed, its persisted generation makes subsequent incidents distinct.
+            let generation = try await db.watchDeskLeases.status(worktreeID: worktree.id)?.generation ?? 0
+            if notifiedContentionGeneration != generation {
+                let candidatesList = candidates.map(\.id.uuidString).joined(separator: ", ")
+                let notification = try await db.notifications.create(
+                    worktreeID: worktree.id,
+                    type: .error,
+                    message: "Watch Desk has multiple live judge candidates (\(candidatesList)). Mutable Nightwatch actions are paused. Recover with `tbd nightwatch lease acquire --worktree \(worktree.id.uuidString) --terminal <chosen-terminal-id>`."
+                )
+                subscriptions?.broadcast(delta: .notificationReceived(NotificationDelta(
+                    notificationID: notification.id,
+                    worktreeID: notification.worktreeID,
+                    type: notification.type,
+                    message: notification.message,
+                    terminalID: notification.terminalID,
+                    activate: false
+                )))
+                notifiedContentionGeneration = generation
+            }
+            logger.error("Watch Desk judge contention: \(candidates.count) live agent candidates; no nudge sent")
+            return nil
+        }
+        guard let candidate = candidates.first else { return nil }
+        let lease = try await db.watchDeskLeases.acquire(
+            worktreeID: worktree.id, terminalID: candidate.id, now: now)
+        let credentialFile: String
+        do {
+            credentialFile = try WatchDeskLeaseCredentialFile.ensure(WatchDeskLeaseCredential(
+                worktreeID: lease.worktreeID, terminalID: lease.terminalID,
+                token: lease.token, generation: lease.generation))
+        } catch {
+            try? await db.watchDeskLeases.revoke(worktreeID: worktree.id)
+            throw error
+        }
+        subscriptions?.broadcast(delta: .watchDeskRolesChanged(
+            WorktreeIDDelta(worktreeID: worktree.id)))
+        notifiedContentionGeneration = nil
+        return (candidate, lease, credentialFile)
     }
 
     static func agentCommand(_ command: String, matches kind: TerminalKind) -> Bool {
@@ -340,13 +441,10 @@ public actor DeskSessionManager: DeskSessionManaging {
                 return
             }
 
-            let preferredKind = try await preferredAgentKind()
-            guard let agentTerminal = try await liveAgentTerminal(
-                worktreeID: worktreeID,
-                server: worktree.tmuxServer,
-                kind: preferredKind
+            guard let (agentTerminal, _, _) = try await leasedJudgeTerminal(
+                worktree: worktree
             ) else {
-                logger.warning("No live \(preferredKind.rawValue, privacy: .public) terminal in Watch Desk; skipping wrap-up prompt")
+                logger.warning("No uniquely owned live terminal in Watch Desk; skipping wrap-up prompt")
                 return
             }
 
@@ -409,12 +507,9 @@ public actor DeskSessionManager: DeskSessionManaging {
             }
 
             var preferredKind = try await preferredAgentKind()
-            var agentTerminal = try await liveAgentTerminal(
-                worktreeID: worktreeID,
-                server: worktree.tmuxServer,
-                kind: preferredKind
-            )
-            if agentTerminal == nil {
+            var judge = try await leasedJudgeTerminal(worktree: worktree)
+            if judge == nil,
+               try await liveJudgeCandidates(worktree: worktree).isEmpty {
                 // A terminal row can survive a process/pane exit. Recover in the
                 // nudge path itself so one failed launch does not turn into a
                 // silent all-night outage waiting for a mode toggle or daemon
@@ -426,17 +521,13 @@ public actor DeskSessionManager: DeskSessionManaging {
                     try await spawnDeskTerminal(worktree: worktree, mode: mode)
                     // Re-read in case the preference changed while spawning.
                     preferredKind = try await preferredAgentKind()
-                    agentTerminal = try await liveAgentTerminal(
-                        worktreeID: worktreeID,
-                        server: worktree.tmuxServer,
-                        kind: preferredKind
-                    )
+                    judge = try await leasedJudgeTerminal(worktree: worktree)
                 } catch {
                     logger.warning("Failed to recover Watch Desk terminal before nudge: \(error.localizedDescription, privacy: .public)")
                 }
             }
 
-            guard let agentTerminal else {
+            guard let (agentTerminal, lease, credentialFile) = judge else {
                 // Deliberately does NOT stamp lastNudgeTime: a nudge that never
                 // reached a pane must not start the 10-minute overlap cooldown,
                 // or one dead desk would suppress the next recovery attempt.
@@ -455,7 +546,9 @@ public actor DeskSessionManager: DeskSessionManaging {
             // stale instructions is a bad night; a judge holding a pointer to
             // nothing is a silent one.
             let prompt: String
-            if let instructionsPath = writeJudgeInstructions(deskPath: worktree.path, mode: mode) {
+            if let instructionsPath = writeJudgeInstructions(
+                deskPath: worktree.path, mode: mode, lease: lease,
+                credentialFile: credentialFile) {
                 // A mode flip rewrites the file under a judge that was told to read
                 // it once. Nothing on the judge's side can see that happen, so the
                 // daemon — the only party that knows both the old and new mode —
@@ -540,6 +633,36 @@ public actor DeskSessionManager: DeskSessionManaging {
         deskWorktreeID = nil
     }
 
+    public func releaseJudgeLease(worktreeID: UUID) async {
+        do {
+            guard let lease = try await db.watchDeskLeases.status(worktreeID: worktreeID) else { return }
+            try await db.watchDeskLeases.release(
+                worktreeID: worktreeID, terminalID: lease.terminalID,
+                token: lease.token, generation: lease.generation)
+            WatchDeskLeaseCredentialFile.remove(terminalID: lease.terminalID)
+            notifiedContentionGeneration = nil
+            subscriptions?.broadcast(delta: .watchDeskRolesChanged(
+                WorktreeIDDelta(worktreeID: worktreeID)))
+            logger.info("Released Watch Desk judge lease generation \(lease.generation)")
+        } catch {
+            logger.error("Failed to release Watch Desk judge lease: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Fifteen-minute scheduler heartbeat. It renews/reconciles ownership
+    /// without sending a model prompt, so the lease cannot expire behind the
+    /// ten-minute nudge overlap guard during an otherwise quiet shift.
+    public func maintainJudgeLease(worktreeID: UUID) async {
+        await gateAcquire()
+        defer { gateRelease() }
+        do {
+            guard let worktree = try await db.worktrees.get(id: worktreeID) else { return }
+            _ = try await leasedJudgeTerminal(worktree: worktree)
+        } catch {
+            logger.error("Failed to maintain Watch Desk judge lease: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     // MARK: - Private Helpers
 
     /// Write the mode-specific judge instructions into the desk worktree.
@@ -548,10 +671,34 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// `nil` as "fall back to the inline prompt" rather than proceeding with a
     /// pointer to a file that may not exist. Deliberately non-throwing: a desk
     /// that cannot write a file must still get nudged.
-    private func writeJudgeInstructions(deskPath: String, mode: NightwatchMode) -> String? {
+    private func writeJudgeInstructions(
+        deskPath: String, mode: NightwatchMode, lease: WatchDeskLease? = nil,
+        credentialFile: String? = nil
+    ) -> String? {
         let url = URL(fileURLWithPath: deskPath)
             .appendingPathComponent(NightwatchDeskPrompts.judgeInstructionsFileName)
-        let body = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir)
+        var body = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir)
+        if let lease, let credentialFile {
+            body += """
+
+
+            ## Exclusive judge lease (mandatory)
+
+            You are the sole mutable judge only while this lease validates:
+            - worktree: `\(lease.worktreeID.uuidString)`
+            - terminal: `\(lease.terminalID.uuidString)`
+            - generation: `\(lease.generation)`
+            - capability file: `\(credentialFile)`
+
+            Immediately before every merge/enqueue, infrastructure apply, archive,
+            wake/nudge, or worker spawn, renew the lease. Renewal also validates
+            the exact terminal, token, generation, and unexpired authority:
+
+            `tbd nightwatch lease renew --credential-file \(credentialFile)`
+
+            If renewal fails, stop mutating. Read-only inspection and reporting remain allowed.
+            """
+        }
         do {
             try body.write(to: url, atomically: true, encoding: .utf8)
             return url.path

--- a/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
@@ -2,6 +2,14 @@ import Foundation
 import TBDShared
 
 extension RPCRouter {
+    private func leaseSnapshot(_ lease: WatchDeskLease, now: Date = Date()) -> WatchDeskLeaseSnapshot {
+        WatchDeskLeaseSnapshot(
+            worktreeID: lease.worktreeID, terminalID: lease.terminalID,
+            generation: lease.generation,
+            acquiredAt: lease.acquiredAt, renewedAt: lease.renewedAt,
+            expiresAt: lease.expiresAt, valid: lease.isValid(at: now))
+    }
+
     func handleSetNightwatchMode(_ data: Data) async throws -> RPCResponse {
         let params = try decoder.decode(NightwatchSetModeParams.self, from: data)
         try await db.config.setNightwatchMode(params.mode)
@@ -11,6 +19,99 @@ extension RPCRouter {
         }
         // Reuse the existing config-change channel so the app reloads Config.
         subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
+    func handleNightwatchLeaseStatus(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NightwatchLeaseStatusParams.self, from: data)
+        let lease = try await db.watchDeskLeases.status(worktreeID: params.worktreeID)
+        return try RPCResponse(result: NightwatchLeaseStatusResult(
+            held: lease?.isValid(at: Date()) == true,
+            lease: lease.map { leaseSnapshot($0) }))
+    }
+
+    func handleNightwatchLeaseAcquire(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NightwatchLeaseAcquireParams.self, from: data)
+        let lease = try await db.watchDeskLeases.acquire(
+            worktreeID: params.worktreeID, terminalID: params.terminalID)
+        let credential = WatchDeskLeaseCredential(
+            worktreeID: lease.worktreeID, terminalID: lease.terminalID,
+            token: lease.token, generation: lease.generation)
+        let credentialFile: String
+        do {
+            credentialFile = try WatchDeskLeaseCredentialFile.ensure(credential)
+        } catch {
+            // Never leave an authoritative row whose owner received no capability.
+            try? await db.watchDeskLeases.revoke(worktreeID: params.worktreeID)
+            throw error
+        }
+        subscriptions.broadcast(delta: .watchDeskRolesChanged(
+            WorktreeIDDelta(worktreeID: params.worktreeID)))
+        return try RPCResponse(result: NightwatchLeaseAcquisitionResult(
+            lease: leaseSnapshot(lease), credentialFile: credentialFile))
+    }
+
+    func handleNightwatchLeaseValidate(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NightwatchLeaseCredentialsParams.self, from: data)
+        let lease = try await db.watchDeskLeases.validate(
+            worktreeID: params.worktreeID, terminalID: params.terminalID,
+            token: params.token, generation: params.generation)
+        return try RPCResponse(result: leaseSnapshot(lease))
+    }
+
+    func handleNightwatchLeaseRenew(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NightwatchLeaseCredentialsParams.self, from: data)
+        let lease = try await db.watchDeskLeases.renew(
+            worktreeID: params.worktreeID, terminalID: params.terminalID,
+            token: params.token, generation: params.generation)
+        return try RPCResponse(result: leaseSnapshot(lease))
+    }
+
+    func handleNightwatchLeaseTransfer(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NightwatchLeaseTransferParams.self, from: data)
+        // Authenticate the predecessor before touching any successor capability
+        // path. The store validates again inside the transfer transaction.
+        _ = try await db.watchDeskLeases.validate(
+            worktreeID: params.worktreeID, terminalID: params.fromTerminalID,
+            token: params.token, generation: params.generation)
+        let replacementToken = UUID()
+        let successorCredential = WatchDeskLeaseCredential(
+            worktreeID: params.worktreeID, terminalID: params.toTerminalID,
+            token: replacementToken, generation: params.generation + 1)
+        // Prepare the successor capability first. If transfer fails it is inert
+        // and removed; if the RPC response/delivery fails after commit, the
+        // successor can still recover from its already-present file.
+        let credentialFile = try WatchDeskLeaseCredentialFile.write(successorCredential)
+        let lease: WatchDeskLease
+        do {
+            lease = try await db.watchDeskLeases.transfer(
+                worktreeID: params.worktreeID, fromTerminalID: params.fromTerminalID,
+                toTerminalID: params.toTerminalID, token: params.token,
+                generation: params.generation, replacementToken: replacementToken)
+        } catch {
+            // Remove only this attempt's inert capability. A concurrent winning
+            // transfer to the same terminal may already have written its own,
+            // differently named credential.
+            WatchDeskLeaseCredentialFile.remove(path: credentialFile)
+            throw error
+        }
+        WatchDeskLeaseCredentialFile.remove(
+            terminalID: params.toTerminalID, except: credentialFile)
+        WatchDeskLeaseCredentialFile.remove(terminalID: params.fromTerminalID)
+        subscriptions.broadcast(delta: .watchDeskRolesChanged(
+            WorktreeIDDelta(worktreeID: params.worktreeID)))
+        return try RPCResponse(result: NightwatchLeaseAcquisitionResult(
+            lease: leaseSnapshot(lease), credentialFile: credentialFile))
+    }
+
+    func handleNightwatchLeaseRelease(_ data: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(NightwatchLeaseCredentialsParams.self, from: data)
+        try await db.watchDeskLeases.release(
+            worktreeID: params.worktreeID, terminalID: params.terminalID,
+            token: params.token, generation: params.generation)
+        WatchDeskLeaseCredentialFile.remove(terminalID: params.terminalID)
+        subscriptions.broadcast(delta: .watchDeskRolesChanged(
+            WorktreeIDDelta(worktreeID: params.worktreeID)))
         return .ok()
     }
 }

--- a/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+NightwatchHandlers.swift
@@ -3,11 +3,16 @@ import TBDShared
 
 extension RPCRouter {
     private func leaseSnapshot(_ lease: WatchDeskLease, now: Date = Date()) -> WatchDeskLeaseSnapshot {
-        WatchDeskLeaseSnapshot(
+        let valid = lease.isValid(at: now)
+        return WatchDeskLeaseSnapshot(
             worktreeID: lease.worktreeID, terminalID: lease.terminalID,
             generation: lease.generation,
             acquiredAt: lease.acquiredAt, renewedAt: lease.renewedAt,
-            expiresAt: lease.expiresAt, valid: lease.isValid(at: now))
+            expiresAt: lease.expiresAt, valid: valid,
+            // A tombstoned or expired row still names its last holder, so the
+            // reported role has to follow validity rather than the row's mere
+            // existence. Only an unexpired holder is the judge.
+            role: valid ? .judge : .readOnlyCoordinator)
     }
 
     func handleSetNightwatchMode(_ data: Data) async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -380,6 +380,18 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetScratchProfileOverride(request.paramsData)
             case RPCMethod.nightwatchSetMode:
                 return try await handleSetNightwatchMode(request.paramsData)
+            case RPCMethod.nightwatchLeaseStatus:
+                return try await handleNightwatchLeaseStatus(request.paramsData)
+            case RPCMethod.nightwatchLeaseAcquire:
+                return try await handleNightwatchLeaseAcquire(request.paramsData)
+            case RPCMethod.nightwatchLeaseValidate:
+                return try await handleNightwatchLeaseValidate(request.paramsData)
+            case RPCMethod.nightwatchLeaseRenew:
+                return try await handleNightwatchLeaseRenew(request.paramsData)
+            case RPCMethod.nightwatchLeaseTransfer:
+                return try await handleNightwatchLeaseTransfer(request.paramsData)
+            case RPCMethod.nightwatchLeaseRelease:
+                return try await handleNightwatchLeaseRelease(request.paramsData)
             case RPCMethod.terminalHibernate:
                 return try await handleTerminalHibernate(request.paramsData)
             case RPCMethod.terminalWake:

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -316,6 +316,23 @@ public enum HibernateReason: String, Codable, Sendable {
         self = HibernateReason(rawValue: raw) ?? .auto
     }
 }
+public enum WatchDeskRole: String, Codable, Sendable, Equatable {
+    case judge
+    case readOnlyCoordinator = "read_only_coordinator"
+
+    public init(from decoder: any Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        // A role introduced by a newer daemon must never acquire mutable
+        // semantics in an older app. Render it as read-only and keep decoding.
+        self = Self(rawValue: raw) ?? .readOnlyCoordinator
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
 public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     public var worktreeID: UUID
@@ -357,6 +374,9 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
     /// row). Drives the "⏳ resumes 1:01pm" tab badge. Optional for
     /// decode-compat with pre-v43 rows/JSON.
     public var pendingResumeAt: Date?
+    /// Explicit Watch Desk authority. Nil means an ordinary terminal.
+    /// The lease row, not this display marker, is authoritative for mutation.
+    public var watchDeskRole: WatchDeskRole?
 
     public init(id: UUID = UUID(), worktreeID: UUID, tmuxWindowID: String,
                 tmuxPaneID: String, label: String? = nil, createdAt: Date = Date(),
@@ -369,7 +389,8 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
                 hibernatedAt: Date? = nil,
                 hibernateReason: HibernateReason? = nil,
                 keepWarm: Bool = false,
-                pendingResumeAt: Date? = nil) {
+                pendingResumeAt: Date? = nil,
+                watchDeskRole: WatchDeskRole? = nil) {
         self.id = id
         self.worktreeID = worktreeID
         self.tmuxWindowID = tmuxWindowID
@@ -388,13 +409,14 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         self.hibernateReason = hibernateReason
         self.keepWarm = keepWarm
         self.pendingResumeAt = pendingResumeAt
+        self.watchDeskRole = watchDeskRole
     }
 
     enum CodingKeys: String, CodingKey {
         case id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt
         case pinnedAt, claudeSessionID, suspendedAt, suspendedSnapshot, profileID, transcriptPath, kind
         case activityState
-        case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt
+        case hibernatedAt, hibernateReason, keepWarm, pendingResumeAt, watchDeskRole
     }
 
     public init(from decoder: Decoder) throws {
@@ -417,6 +439,7 @@ public struct Terminal: Codable, Sendable, Identifiable, Equatable {
         hibernateReason = try c.decodeIfPresent(HibernateReason.self, forKey: .hibernateReason)
         keepWarm = try c.decodeIfPresent(Bool.self, forKey: .keepWarm) ?? false
         pendingResumeAt = try c.decodeIfPresent(Date.self, forKey: .pendingResumeAt)
+        watchDeskRole = try c.decodeIfPresent(WatchDeskRole.self, forKey: .watchDeskRole)
     }
 }
 

--- a/Sources/TBDShared/NightwatchDeskPrompts.swift
+++ b/Sources/TBDShared/NightwatchDeskPrompts.swift
@@ -18,6 +18,10 @@ public enum NightwatchDeskPrompts {
         return """
         You are TBD's \(modeLabel) Judge — monitoring merge-gate decisions with the configured profile model.
 
+        **Authority starts at the first lease-bearing nudge.** Until a tick message
+        arrives and the lease command in `\(judgeInstructionsFileName)` succeeds,
+        you are read-only: do not merge/enqueue, apply, archive, wake/nudge, or spawn.
+
         **Your workspace:**
         - You're running in: \(skillDir)
         - Decision queue: \(queueDir)/decisions.jsonl (JSONL file of pending judgment items)
@@ -81,7 +85,7 @@ public enum NightwatchDeskPrompts {
 
         **Next step:**
         Read the Nightwatch skill docs for the full merge-gate policy, clearance types, and acting procedures.
-        When you receive a nudge message, process queue/decisions.jsonl and output actions.
+        Wait for the first lease-bearing nudge; then process queue/decisions.jsonl and output actions.
         """
     }
 

--- a/Sources/TBDShared/NightwatchSkillContent.swift
+++ b/Sources/TBDShared/NightwatchSkillContent.swift
@@ -142,8 +142,9 @@ they are wrong; this rule wins.)
 1000k Opus window that forced a relay roughly every two hours, so the desk spent its shift
 handing off instead of judging. `handoff.py --check` is the authority — don't eyeball it.)
 Do not "flag for respawn" and keep working, and
-do NOT use `tbd terminal close --all` — **that command does not exist** (there is no
-`tbd terminal close` subcommand at all; the only real close is killing the tmux window).
+do NOT use `tbd terminal close --all` — **that command does not exist**. The relay uses
+the supported single-terminal `tbd terminal close --terminal <id>`, which preserves
+Closed Terminals history and never touches independently spawned child work.
 The working relay is `scripts/handoff.py`:
 
 ```
@@ -263,7 +264,7 @@ Usage:
 Exit 0 always (a wake plan is informational); per-item status is in the output
 and queue/wake-plan.json.
 """
-import subprocess, os, re, json, time, sys
+import subprocess, os, re, json, time, sys, glob
 
 HOME = os.path.expanduser("~")
 DB = f"{HOME}/tbd/state.db"
@@ -287,6 +288,35 @@ def sh(args, t=20, cwd=None):
 def gh(args, t=25, cwd=None):
     # gh transits the cache proxy via the shell function, not env — plain exec is direct.
     return sh(["gh", *args], t=t, cwd=cwd)
+
+
+def lease_credential_file(tid):
+    root = os.environ.get("TBD_HOME") or os.path.expanduser("~/tbd")
+    matches = glob.glob(os.path.join(
+        root, "runtime", "nightwatch-leases", f"{tid}-*.json"))
+    if len(matches) != 1:
+        sys.exit(f"refusing mutation: expected one capability file, found {len(matches)}")
+    return matches[0]
+
+
+def require_judge_lease():
+    """Renew exact desk authority immediately before one mutable wake."""
+    tid, wid = os.environ.get("TBD_TERMINAL_ID"), os.environ.get("TBD_WORKTREE_ID")
+    if not tid or not wid:
+        sys.exit("refusing wake: missing TBD terminal/worktree identity")
+    status, rc = sh(["tbd", "nightwatch", "lease", "status", "--worktree", wid])
+    try:
+        lease = (json.loads(status) or {}).get("lease") if rc == 0 else None
+    except Exception:
+        lease = None
+    if not lease or not lease.get("valid") or lease.get("terminalID") != tid:
+        sys.exit("refusing wake: this terminal does not hold the valid judge lease")
+    credential = lease_credential_file(tid)
+    _, rc = sh([
+        "tbd", "nightwatch", "lease", "renew", "--credential-file", credential,
+    ])
+    if rc != 0:
+        sys.exit("refusing wake: judge lease renewal failed")
 
 
 ANSI = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
@@ -559,6 +589,7 @@ def main():
         print(f"  ▸ {it['name']} ({it['tid'][:8]}): {v['classification']} — "
               + ("; ".join(v["facts"])[:110] or "-"))
         if act:
+            require_judge_lease()
             # The wake text rides `tbd terminal wake --prompt` as an argv to
             # `claude --resume` — atomic with the respawn. NEVER `terminal
             # send`: send pastes into whatever the pane currently runs (a bare
@@ -1084,6 +1115,14 @@ DEFAULT_THRESHOLD = 600_000
 SUCCESSOR_MODEL = "opus"
 
 
+def lease_credential_file(tid):
+    root = pathlib.Path(os.environ.get("TBD_HOME") or os.path.expanduser("~/tbd"))
+    matches = list((root / "runtime" / "nightwatch-leases").glob(f"{tid}-*.json"))
+    if len(matches) != 1:
+        sys.exit(f"refusing mutation: expected one capability file, found {len(matches)}")
+    return str(matches[0])
+
+
 def _run(cmd, **kw):
     return subprocess.run(cmd, capture_output=True, text=True, **kw)
 
@@ -1173,10 +1212,28 @@ to you rather than getting truncated mid-shift.
 
 FIRST, before anything else:
 1. Read the handoff document: {doc_path}
-2. Close the predecessor — it is idle and waiting for you to do this:
+2. WAIT until the daemon-issued capability both exists AND renews. The file is
+   prepared before the database transfer, so existence alone is not authority;
+   this bounded loop covers that small commit race and also works if the
+   predecessor's follow-up message never arrives:
+     python3 - <<'PY'
+     import glob, os, subprocess, time
+     root = os.environ.get("TBD_HOME") or os.path.expanduser("~/tbd")
+     ok = False
+     for _ in range(60):
+         paths = glob.glob(os.path.join(root, "runtime", "nightwatch-leases", os.environ["TBD_TERMINAL_ID"] + "-*.json"))
+         if len(paths) == 1 and subprocess.call(["tbd", "nightwatch", "lease", "renew", "--credential-file", paths[0]]) == 0:
+             ok = True
+             break
+         time.sleep(1)
+     raise SystemExit(0 if ok else 2)
+     PY
+   Do not merge, apply, archive, wake/nudge, spawn, or close the predecessor
+   before that command passes.
+3. Close the predecessor — it is idle and waiting for you to do this:
      python3 "{pathlib.Path(__file__).resolve()}" --close-predecessor {pred_tid}
    (predecessor terminal {pred_tid}, tmux window {pred_window} on server {server})
-3. Confirm in your first message what you picked up and what you closed.
+4. Confirm in your first message what you picked up and what you closed.
 
 STANDING INSTRUCTION — this applies to YOU now, and to every session you spawn:
 When your own context passes {threshold:,} tokens, do not push through it. Run
@@ -1196,6 +1253,22 @@ def cmd_act(args):
     server = tmux_server()
     used = context_tokens(row.get("transcriptPath", ""))
     ts = int(time.time())
+
+    credential = lease_credential_file(tid)
+    lease_status = _run(["tbd", "nightwatch", "lease", "status", "--worktree", wid])
+    if lease_status.returncode != 0:
+        sys.exit(f"cannot verify judge lease before handoff: {lease_status.stderr.strip()}")
+    try:
+        current_lease = (json.loads(lease_status.stdout) or {}).get("lease") or {}
+    except json.JSONDecodeError:
+        sys.exit("cannot verify judge lease before handoff: unparseable status")
+    if not current_lease.get("valid") or current_lease.get("terminalID") != tid:
+        sys.exit("refusing handoff: this terminal does not hold the valid judge lease")
+    renewal = _run([
+        "tbd", "nightwatch", "lease", "renew", "--credential-file", credential,
+    ])
+    if renewal.returncode != 0:
+        sys.exit(f"refusing handoff: judge lease renewal failed: {renewal.stderr.strip()}")
 
     notes = pathlib.Path(args.notes_file).read_text() if args.notes_file else ""
     if not notes.strip():
@@ -1240,14 +1313,37 @@ Transcript: {row.get('transcriptPath')}
     except json.JSONDecodeError:
         new_id = spawn.stdout.strip() or "?"
 
+    transfer = _run([
+        "tbd", "nightwatch", "lease", "transfer",
+        "--credential-file", credential,
+        "--to-terminal", new_id,
+    ])
+    if transfer.returncode != 0:
+        sys.exit(f"lease transfer FAILED; predecessor remains authoritative and successor must stay read-only: {transfer.stderr.strip()}")
+    try:
+        transfer_result = json.loads(transfer.stdout)
+        successor_lease = transfer_result["lease"]
+        successor_credential = transfer_result["credentialFile"]
+    except json.JSONDecodeError:
+        sys.exit("lease transferred but response was unparseable; both sessions must stop mutating")
+
+    renew = f"tbd nightwatch lease renew --credential-file {successor_credential}"
+    delivery = _run([
+        "tbd", "terminal", "send", "--terminal", new_id, "--submit", "--text",
+        "Exclusive judge lease transferred to you. Before every mutable action run: " + renew,
+    ])
+    if delivery.returncode != 0:
+        print("warning: successor notification failed; its prewritten capability file remains recoverable", file=sys.stderr)
+
     print(f"handoff written: {doc}")
     print(f"successor spawned: {new_id} (model={SUCCESSOR_MODEL})")
+    print(f"judge lease transferred: generation {successor_lease['generation']}")
     print("go idle now — the successor closes this terminal once it has read the doc.")
     return 0
 
 
 def cmd_close(args):
-    """Close a predecessor terminal by killing its tmux window."""
+    """Close one predecessor through TBD so transcript/history are preserved."""
     target = args.close_predecessor
     r = _run(["tbd", "terminal", "list", os.environ.get("TBD_WORKTREE_ID", ""), "--json"])
     # A FAILED lookup is not an absent terminal. Collapsing the two would report
@@ -1266,14 +1362,22 @@ def cmd_close(args):
     if target == os.environ.get("TBD_TERMINAL_ID"):
         sys.exit("refusing to close myself — pass the PREDECESSOR's terminal id")
 
-    window = row.get("tmuxWindowID")
-    server = tmux_server()
-    if not window or not server:
-        sys.exit(f"cannot resolve tmux window/server for {target}")
-    kill = _run(["tmux", "-L", server, "kill-window", "-t", window])
-    if kill.returncode != 0 and "can't find" not in (kill.stderr or ""):
-        sys.exit(f"kill-window failed: {kill.stderr.strip()}")
-    print(f"closed predecessor {target} (window {window} on {server})")
+    # Closing a terminal is a mutable desk action too. The successor must prove
+    # it owns the transferred capability before force-closing its predecessor.
+    self_tid = os.environ.get("TBD_TERMINAL_ID", "")
+    credential = lease_credential_file(self_tid)
+    renewal = _run([
+        "tbd", "nightwatch", "lease", "renew", "--credential-file", credential,
+    ])
+    if renewal.returncode != 0:
+        sys.exit("refusing to close predecessor: this terminal does not hold the judge lease")
+
+    close = _run([
+        "tbd", "terminal", "close", "--terminal", target, "--force", "--json",
+    ])
+    if close.returncode != 0:
+        sys.exit(f"terminal close failed: {close.stderr.strip()}")
+    print(f"closed predecessor {target} through TBD (history preserved)")
     return 0
 
 
@@ -1384,7 +1488,7 @@ Default is dry-run (prints the plan, touches nothing). `--prs` also gates open P
 (makes gh calls — skip during a GitHub-rate crunch). Dedupes + clears the queue on a
 successful --act drain.
 """
-import subprocess, os, json, time, sys
+import subprocess, os, json, time, sys, glob
 
 HOME = os.path.expanduser("~")
 DB = f"{HOME}/tbd/state.db"
@@ -1395,6 +1499,36 @@ REPO = "longeye-ai/monorepo"
 def sh(args, t=20):
     try: return subprocess.run(args, capture_output=True, text=True, timeout=t).stdout
     except Exception: return ""
+
+def lease_credential_file(tid):
+    root = os.environ.get("TBD_HOME") or os.path.expanduser("~/tbd")
+    matches = glob.glob(os.path.join(
+        root, "runtime", "nightwatch-leases", f"{tid}-*.json"))
+    if len(matches) != 1:
+        sys.exit(f"refusing mutation: expected one capability file, found {len(matches)}")
+    return matches[0]
+
+
+def require_judge_lease():
+    """Renew exact desk authority immediately before one mutable dispatch."""
+    tid, wid = os.environ.get("TBD_TERMINAL_ID"), os.environ.get("TBD_WORKTREE_ID")
+    if not tid or not wid:
+        sys.exit("refusing dispatch: missing TBD terminal/worktree identity")
+    try:
+        status = subprocess.run(
+            ["tbd", "nightwatch", "lease", "status", "--worktree", wid],
+            capture_output=True, text=True, timeout=20)
+        lease = (json.loads(status.stdout) or {}).get("lease") if status.returncode == 0 else None
+    except Exception:
+        lease = None
+    if not lease or not lease.get("valid") or lease.get("terminalID") != tid:
+        sys.exit("refusing dispatch: this terminal does not hold the valid judge lease")
+    credential = lease_credential_file(tid)
+    renewal = subprocess.run([
+        "tbd", "nightwatch", "lease", "renew", "--credential-file", credential,
+    ], capture_output=True, text=True, timeout=20)
+    if renewal.returncode != 0:
+        sys.exit("refusing dispatch: judge lease renewal failed")
 
 def gh(*a, t=20):
     for k in ("HTTPS_PROXY","HTTP_PROXY","https_proxy","http_proxy"): os.environ.pop(k, None)
@@ -1414,6 +1548,7 @@ def saturated(rep):
 def dispatch(tid, text, act):
     """Run the repo's bound skill in the owner's terminal (or describe it in dry-run)."""
     if not act or not tid: return False
+    require_judge_lease()
     sh(["tbd", "terminal", "send", "--terminal", tid, "--submit", "--text", text])
     return True
 
@@ -1502,6 +1637,7 @@ def main():
         for x in for_adam: f.write(f"- {x}\n")
     print(f"\nactions dispatched: {acted}   human items → queue/for-adam.md ({len(for_adam)})")
     if act and not sat:
+        require_judge_lease()
         open(qf, "w").close(); print("drained decisions.jsonl")
     else:
         print("(dry-run or saturated — queue left intact)")

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -302,10 +302,14 @@ public struct WatchDeskLeaseSnapshot: Codable, Sendable {
     public let expiresAt: Date
     public let valid: Bool
     public let role: WatchDeskRole
+    /// `role` defaults to the powerless role for the same reason
+    /// `WatchDeskRole`'s decoder falls back to it: an unstated role must never
+    /// be reported as mutable authority. Callers that know the lease is valid
+    /// pass `.judge` explicitly.
     public init(
         worktreeID: UUID, terminalID: UUID, generation: Int64,
         acquiredAt: Date, renewedAt: Date, expiresAt: Date, valid: Bool,
-        role: WatchDeskRole = .judge
+        role: WatchDeskRole = .readOnlyCoordinator
     ) {
         self.worktreeID = worktreeID; self.terminalID = terminalID
         self.generation = generation; self.acquiredAt = acquiredAt

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -213,6 +213,12 @@ public enum RPCMethod {
     public static let scratchArchive = "scratch.archive"
     public static let scratchRevive = "scratch.revive"
     public static let nightwatchSetMode = "nightwatch.setMode"
+    public static let nightwatchLeaseStatus = "nightwatch.lease.status"
+    public static let nightwatchLeaseAcquire = "nightwatch.lease.acquire"
+    public static let nightwatchLeaseValidate = "nightwatch.lease.validate"
+    public static let nightwatchLeaseRenew = "nightwatch.lease.renew"
+    public static let nightwatchLeaseTransfer = "nightwatch.lease.transfer"
+    public static let nightwatchLeaseRelease = "nightwatch.lease.release"
     public static let terminalCancelScheduledResume = "terminal.cancelScheduledResume"
     public static let configSetControlMode = "config.setControlMode"
     public static let configSetHibernateInputVeto = "config.setHibernateInputVeto"
@@ -236,6 +242,85 @@ public enum RPCMethod {
     public static let panelGet = "panel.get"
     public static let panelApply = "panel.apply"
     public static let panelImportLegacy = "panel.importLegacy"
+}
+
+public struct NightwatchLeaseStatusParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public init(worktreeID: UUID) { self.worktreeID = worktreeID }
+}
+
+public struct NightwatchLeaseAcquireParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let terminalID: UUID
+    public init(worktreeID: UUID, terminalID: UUID) {
+        self.worktreeID = worktreeID
+        self.terminalID = terminalID
+    }
+}
+
+public struct NightwatchLeaseCredentialsParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let terminalID: UUID
+    public let token: UUID
+    public let generation: Int64
+    public init(worktreeID: UUID, terminalID: UUID, token: UUID, generation: Int64) {
+        self.worktreeID = worktreeID; self.terminalID = terminalID
+        self.token = token; self.generation = generation
+    }
+}
+
+public struct NightwatchLeaseTransferParams: Codable, Sendable {
+    public let worktreeID: UUID
+    public let fromTerminalID: UUID
+    public let toTerminalID: UUID
+    public let token: UUID
+    public let generation: Int64
+    public init(
+        worktreeID: UUID, fromTerminalID: UUID, toTerminalID: UUID,
+        token: UUID, generation: Int64
+    ) {
+        self.worktreeID = worktreeID; self.fromTerminalID = fromTerminalID
+        self.toTerminalID = toTerminalID; self.token = token
+        self.generation = generation
+    }
+}
+
+public struct NightwatchLeaseStatusResult: Codable, Sendable {
+    public let held: Bool
+    public let lease: WatchDeskLeaseSnapshot?
+    public init(held: Bool, lease: WatchDeskLeaseSnapshot?) {
+        self.held = held; self.lease = lease
+    }
+}
+
+public struct WatchDeskLeaseSnapshot: Codable, Sendable {
+    public let worktreeID: UUID
+    public let terminalID: UUID
+    public let generation: Int64
+    public let acquiredAt: Date
+    public let renewedAt: Date
+    public let expiresAt: Date
+    public let valid: Bool
+    public let role: WatchDeskRole
+    public init(
+        worktreeID: UUID, terminalID: UUID, generation: Int64,
+        acquiredAt: Date, renewedAt: Date, expiresAt: Date, valid: Bool,
+        role: WatchDeskRole = .judge
+    ) {
+        self.worktreeID = worktreeID; self.terminalID = terminalID
+        self.generation = generation; self.acquiredAt = acquiredAt
+        self.renewedAt = renewedAt; self.expiresAt = expiresAt; self.valid = valid
+        self.role = role
+    }
+}
+
+public struct NightwatchLeaseAcquisitionResult: Codable, Sendable {
+    public let lease: WatchDeskLeaseSnapshot
+    public let credentialFile: String
+    public init(lease: WatchDeskLeaseSnapshot, credentialFile: String) {
+        self.lease = lease
+        self.credentialFile = credentialFile
+    }
 }
 
 // MARK: - Branch Listing

--- a/Sources/TBDShared/StateDelta.swift
+++ b/Sources/TBDShared/StateDelta.swift
@@ -24,6 +24,9 @@ public enum StateDelta: Codable, Sendable {
     case terminalSessionUpdated(TerminalSessionDelta)
     case terminalActivityUpdated(TerminalActivityDelta)
     case terminalProfileChanged(TerminalProfileDelta)
+    /// Explicit Watch Desk Judge/Read-only role markers changed. The app
+    /// refetches that worktree's terminal rows; lease credentials stay daemon-side.
+    case watchDeskRolesChanged(WorktreeIDDelta)
     case worktreeMoved(WorktreeMovedDelta)
     case terminalHibernationChanged(TerminalHibernationDelta)
     case controlModeInputHealthChanged(ControlModeInputHealthDelta)

--- a/Sources/TBDShared/WatchDeskLeaseCredential.swift
+++ b/Sources/TBDShared/WatchDeskLeaseCredential.swift
@@ -1,0 +1,140 @@
+import Darwin
+import Foundation
+
+/// Opaque capability material for one Watch Desk judge terminal.
+///
+/// This intentionally lives outside the shared Watch Desk worktree and never
+/// rides status RPCs. The daemon writes it mode 0600; the owning terminal passes
+/// only this path to lease commands, keeping the token out of argv, prompts, and
+/// transcripts.
+public struct WatchDeskLeaseCredential: Codable, Sendable, Equatable {
+    public let worktreeID: UUID
+    public let terminalID: UUID
+    public let token: UUID
+    public let generation: Int64
+
+    public init(worktreeID: UUID, terminalID: UUID, token: UUID, generation: Int64) {
+        self.worktreeID = worktreeID
+        self.terminalID = terminalID
+        self.token = token
+        self.generation = generation
+    }
+}
+
+public enum WatchDeskLeaseCredentialFile {
+    public static func directory(environment: [String: String]) -> URL {
+        TBDConstants.configDir(environment: environment)
+            .appendingPathComponent("runtime", isDirectory: true)
+            .appendingPathComponent("nightwatch-leases", isDirectory: true)
+    }
+
+    public static func read(path: String) throws -> WatchDeskLeaseCredential {
+        try JSONDecoder().decode(
+            WatchDeskLeaseCredential.self,
+            from: Data(contentsOf: URL(fileURLWithPath: path)))
+    }
+
+    public static func write(
+        _ credential: WatchDeskLeaseCredential,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> String {
+        let destination = directory(environment: environment)
+            .appendingPathComponent(
+                "\(credential.terminalID.uuidString)-\(UUID().uuidString).json")
+        try write(credential, to: destination, environment: environment)
+        return destination.path
+    }
+
+    /// Refresh the sole capability already issued to a terminal, or repair an
+    /// ambiguous/stale set by replacing it with one fresh locator. The locator
+    /// is deliberately independent of the secret token so a path may safely be
+    /// mentioned in judge instructions and transcripts.
+    public static func ensure(
+        _ credential: WatchDeskLeaseCredential,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> String {
+        let existing = paths(terminalID: credential.terminalID, environment: environment)
+        let destination: URL
+        if existing.count == 1 {
+            destination = URL(fileURLWithPath: existing[0])
+        } else {
+            remove(terminalID: credential.terminalID, environment: environment)
+            destination = directory(environment: environment)
+                .appendingPathComponent(
+                    "\(credential.terminalID.uuidString)-\(UUID().uuidString).json")
+        }
+        try write(credential, to: destination, environment: environment)
+        return destination.path
+    }
+
+    public static func paths(
+        terminalID: UUID,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String] {
+        let directory = directory(environment: environment)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil) else { return [] }
+        let prefix = terminalID.uuidString + "-"
+        return entries
+            .filter { $0.lastPathComponent.hasPrefix(prefix) }
+            .map(\.path)
+            .sorted()
+    }
+
+    private static func write(
+        _ credential: WatchDeskLeaseCredential,
+        to destination: URL,
+        environment: [String: String]
+    ) throws {
+        let directory = directory(environment: environment)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        // createDirectory does not apply attributes to an existing directory.
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700], ofItemAtPath: directory.path)
+
+        // Foundation's generic atomic writer does not promise the temporary
+        // file's mode. Create the temporary capability as 0600 first, then use
+        // an atomic rename so the secret is never visible through a 0644 window.
+        let encoded = try JSONEncoder().encode(credential)
+        let temporary = directory.appendingPathComponent(".\(UUID().uuidString).tmp")
+        guard FileManager.default.createFile(
+            atPath: temporary.path, contents: encoded,
+            attributes: [.posixPermissions: 0o600]) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        guard Darwin.rename(temporary.path, destination.path) == 0 else {
+            let code = POSIXErrorCode(rawValue: errno) ?? .EIO
+            try? FileManager.default.removeItem(at: temporary)
+            throw POSIXError(code)
+        }
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600], ofItemAtPath: destination.path)
+    }
+
+    public static func remove(
+        path: String
+    ) {
+        try? FileManager.default.removeItem(atPath: path)
+    }
+
+    public static func remove(
+        terminalID: UUID,
+        except retainedPath: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        let directory = directory(environment: environment)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil) else { return }
+        let prefix = terminalID.uuidString + "-"
+        let retainedCanonical = retainedPath.map {
+            URL(fileURLWithPath: $0).resolvingSymlinksInPath().path
+        }
+        for entry in entries
+        where entry.lastPathComponent.hasPrefix(prefix)
+            && entry.resolvingSymlinksInPath().path != retainedCanonical {
+            try? FileManager.default.removeItem(at: entry)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -403,8 +403,22 @@ extension TBDHomeSerialized {
             await manager.nudgeDeskSession(worktreeID: desk.id, act: true)
 
             let written = try String(contentsOf: instructions, encoding: .utf8)
-            #expect(written == NightwatchDeskPrompts.judgePrompt(mode: .nightwatch, skillDir: skillDir),
-                    "instructions file does not match the nightwatch judge prompt the pointer promises")
+            #expect(written.hasPrefix(NightwatchDeskPrompts.judgePrompt(mode: .nightwatch, skillDir: skillDir)),
+                    "instructions file does not begin with the nightwatch judge prompt the pointer promises")
+            #expect(written.contains("## Exclusive judge lease (mandatory)"))
+            #expect(written.contains("tbd nightwatch lease renew"))
+            let lease = try #require(
+                try await db.watchDeskLeases.status(worktreeID: desk.id))
+            #expect(!written.contains(lease.token.uuidString),
+                    "shared Watch Desk instructions must never disclose the capability")
+            let credentialPaths = WatchDeskLeaseCredentialFile.paths(
+                terminalID: lease.terminalID)
+            #expect(credentialPaths.count == 1)
+            let credentialPath = try #require(credentialPaths.first)
+            #expect(FileManager.default.fileExists(atPath: credentialPath))
+            #expect(!credentialPath.contains(lease.token.uuidString))
+            let attributes = try FileManager.default.attributesOfItem(atPath: credentialPath)
+            #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
             #expect(written.contains("you MAY run `gh pr merge"),
                     "act=true wrote the daywatch body; the judge would be told it may not merge")
         }
@@ -870,6 +884,11 @@ extension TBDHomeSerialized {
                 worktreeID: desk.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
                 label: TerminalLabel.claudeCode)
 
+            // Explicit ownership, not recency, selects the mutable judge when
+            // more than one live candidate exists.
+            _ = try await f.db.watchDeskLeases.acquire(
+                worktreeID: desk.id, terminalID: newest.id)
+
             // Asserted, not assumed: if the clock ever ties these two, the recency
             // assertion below proves nothing, so fail where the cause is legible.
             #expect(newest.createdAt > oldest.createdAt, "fixture must yield distinct createdAt")
@@ -1035,6 +1054,96 @@ extension TBDHomeSerialized {
                 Array(f.recorder.pastedPanes.dropFirst(before)) == [replacement.tmuxPaneID],
                 "recovery must nudge the replacement, never the shell-backed stale row"
             )
+        }
+
+        @Test("two live unowned judge candidates fail closed and notify once")
+        func twoLiveCandidatesFailClosed() async throws {
+            let f = try makeDeskFixture(tag: "judge-contention")
+            defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .nightwatch)
+            _ = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@other", tmuxPaneID: "%other",
+                label: TerminalLabel.claudeCode, kind: .claude)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            #expect(Array(f.recorder.pastedPanes.dropFirst(before)).isEmpty)
+            let notifications = try await f.db.notifications.unread(worktreeID: desk.id)
+            #expect(notifications.filter { $0.message?.contains("multiple live judge") == true }.count == 1)
+        }
+
+        @Test("successor spawned before transfer stays read-only and predecessor remains judge")
+        func spawnBeforeTransferKeepsPredecessor() async throws {
+            let f = try makeDeskFixture(tag: "judge-half-handoff")
+            defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .nightwatch)
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            let lease = try #require(
+                try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+            let owner = try #require(try await f.db.terminals.get(id: lease.terminalID))
+            let successor = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@half", tmuxPaneID: "%half",
+                label: TerminalLabel.codex, kind: .codex)
+            f.commands.set("codex", for: successor.tmuxPaneID)
+
+            let laterManager = DeskSessionManager(
+                db: f.db,
+                lifecycle: WorktreeLifecycle(
+                    db: f.db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+                tmux: TmuxManager(
+                    dryRun: true,
+                    dryRunRecorder: { f.recorder.record($0) },
+                    dryRunWindowIsDead: { f.dead.isDead($0) },
+                    dryRunPaneCurrentCommand: { _, pane in f.commands.command(for: pane) }),
+                skillDir: f.home.appendingPathComponent("skills/nightwatch").path)
+            _ = try await laterManager.ensureDeskSession(mode: .nightwatch)
+            let before = f.recorder.pastedPanes.count
+            await laterManager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            #expect(Array(f.recorder.pastedPanes.dropFirst(before)) == [owner.tmuxPaneID])
+            #expect(
+                try await f.db.terminals.get(id: successor.id)?.watchDeskRole
+                    == .readOnlyCoordinator)
+            #expect(
+                try await f.db.watchDeskLeases.status(worktreeID: desk.id)?.terminalID
+                    == owner.id)
+        }
+
+        @Test("dead lease owner is fenced and the sole live successor takes a higher generation")
+        func deadOwnerRecovery() async throws {
+            let f = try makeDeskFixture(tag: "judge-owner-loss")
+            defer { unsetenv("TBD_HOME"); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .nightwatch)
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+            let first = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+            let owner = try #require(try await f.db.terminals.get(id: first.terminalID))
+            f.dead.markDead(owner.tmuxWindowID)
+            let successor = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@successor", tmuxPaneID: "%successor",
+                label: TerminalLabel.claudeCode, kind: .claude)
+
+            // Avoid the ordinary ten-minute nudge overlap hiding owner-loss recovery.
+            let laterManager = DeskSessionManager(
+                db: f.db,
+                lifecycle: WorktreeLifecycle(
+                    db: f.db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+                tmux: TmuxManager(
+                    dryRun: true,
+                    dryRunRecorder: { f.recorder.record($0) },
+                    dryRunWindowIsDead: { f.dead.isDead($0) },
+                    dryRunPaneCurrentCommand: { _, pane in f.commands.command(for: pane) }),
+                skillDir: f.home.appendingPathComponent("skills/nightwatch").path)
+            _ = try await laterManager.ensureDeskSession(mode: .nightwatch)
+            await laterManager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            let recovered = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+            #expect(recovered.terminalID == successor.id)
+            #expect(recovered.generation == first.generation + 1)
         }
     }
 }

--- a/Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift
@@ -220,8 +220,13 @@ struct RPCRouterNightwatchLeaseTests {
         #expect(transferred.lease.role == .judge)
 
         // The successor holds exactly one capability, and it is the returned one.
+        // Canonicalize both sides: the directory listing resolves /var to
+        // /private/var while the handler returns the path it composed.
         let successorPaths = WatchDeskLeaseCredentialFile.paths(terminalID: f.codex.id)
-        #expect(successorPaths == [transferred.credentialFile])
+            .map { URL(fileURLWithPath: $0).resolvingSymlinksInPath().path }
+        let returnedPath = URL(fileURLWithPath: transferred.credentialFile)
+            .resolvingSymlinksInPath().path
+        #expect(successorPaths == [returnedPath])
         // The predecessor's capability is gone, and its old triple is fenced.
         #expect(WatchDeskLeaseCredentialFile.paths(terminalID: f.claude.id).isEmpty)
         let fencedRenew = await f.router.handle(try RPCRequest(

--- a/Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift
@@ -1,0 +1,327 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: the lease handlers write capability files
+// through `WatchDeskLeaseCredentialFile`, which resolves its directory from the
+// process-global TBD_HOME. See TBDHomeSerializedSuites.swift.
+extension TBDHomeSerialized {
+@Suite("nightwatch.lease RPC handlers")
+struct RPCRouterNightwatchLeaseTests {
+    private func isolateTBDHome() -> (URL, () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-lease-rpc-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(
+            at: home, withIntermediateDirectories: true)
+        setenv("TBD_HOME", home.path, 1)
+        return (home, {
+            unsetenv("TBD_HOME")
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let router: RPCRouter
+        let desk: Worktree
+        let claude: Terminal
+        let codex: Terminal
+    }
+
+    private func fixture() async throws -> Fixture {
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true), startTime: Date())
+        let desk = try await db.worktrees.createScratch(
+            name: "watch-desk", displayName: "Watch Desk",
+            path: "/tmp/watch-desk-\(UUID())", tmuxServer: "test")
+        let claude = try await db.terminals.create(
+            worktreeID: desk.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, kind: .claude)
+        let codex = try await db.terminals.create(
+            worktreeID: desk.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: TerminalLabel.codex, kind: .codex)
+        return Fixture(db: db, router: router, desk: desk, claude: claude, codex: codex)
+    }
+
+    private func acquire(
+        _ f: Fixture, terminal: Terminal
+    ) async throws -> NightwatchLeaseAcquisitionResult {
+        let response = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseAcquire,
+            params: NightwatchLeaseAcquireParams(
+                worktreeID: f.desk.id, terminalID: terminal.id)))
+        return try response.decodeResult(NightwatchLeaseAcquisitionResult.self)
+    }
+
+    private func credentials(
+        _ path: String
+    ) throws -> NightwatchLeaseCredentialsParams {
+        let credential = try WatchDeskLeaseCredentialFile.read(path: path)
+        return NightwatchLeaseCredentialsParams(
+            worktreeID: credential.worktreeID, terminalID: credential.terminalID,
+            token: credential.token, generation: credential.generation)
+    }
+
+    // MARK: - acquire
+
+    @Test("acquire issues a 0600 capability outside the desk and reports judge")
+    func acquireIssuesCapability() async throws {
+        let (home, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+
+        let result = try await acquire(f, terminal: f.claude)
+
+        #expect(result.lease.terminalID == f.claude.id)
+        #expect(result.lease.generation == 1)
+        #expect(result.lease.valid)
+        #expect(result.lease.role == .judge)
+
+        // The capability lives under TBD_HOME, never inside the shared desk.
+        #expect(result.credentialFile.hasPrefix(home.path))
+        #expect(!result.credentialFile.hasPrefix(f.desk.path))
+        let mode = try FileManager.default
+            .attributesOfItem(atPath: result.credentialFile)[.posixPermissions]
+        #expect((mode as? NSNumber)?.intValue == 0o600)
+
+        // The token rides the file, never the RPC result.
+        let encoded = try #require(
+            String(data: try JSONEncoder().encode(result.lease), encoding: .utf8))
+        let token = try WatchDeskLeaseCredentialFile.read(
+            path: result.credentialFile).token
+        #expect(!encoded.contains(token.uuidString))
+        #expect(!encoded.lowercased().contains("token"))
+    }
+
+    @Test("acquire refuses a desk that already has an unexpired holder")
+    func acquireRefusesUnexpiredHolder() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+        _ = try await acquire(f, terminal: f.claude)
+
+        let second = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseAcquire,
+            params: NightwatchLeaseAcquireParams(
+                worktreeID: f.desk.id, terminalID: f.codex.id)))
+
+        #expect(!second.success)
+        let held = try #require(
+            try await f.db.watchDeskLeases.status(worktreeID: f.desk.id))
+        #expect(held.terminalID == f.claude.id)
+        #expect(held.generation == 1)
+    }
+
+    /// The handler's stated guarantee: never leave an authoritative row whose
+    /// owner received no capability.
+    @Test("acquire revokes the row it just wrote when the capability cannot be written")
+    func acquireRevokesWhenCapabilityWriteFails() async throws {
+        let (home, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+
+        // Occupy `runtime` with a regular file so creating the leases directory
+        // underneath it fails deterministically.
+        let runtime = home.appendingPathComponent("runtime")
+        try? FileManager.default.removeItem(at: runtime)
+        try Data().write(to: runtime)
+
+        let response = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseAcquire,
+            params: NightwatchLeaseAcquireParams(
+                worktreeID: f.desk.id, terminalID: f.claude.id)))
+
+        #expect(!response.success)
+        // A row may exist, but it must not be authoritative.
+        let lease = try await f.db.watchDeskLeases.status(worktreeID: f.desk.id)
+        #expect(lease?.isValid(at: Date()) != true)
+    }
+
+    // MARK: - validate / renew / status
+
+    @Test("validate and renew demand the exact unexpired triple")
+    func validateAndRenewDemandExactTriple() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+        let acquired = try await acquire(f, terminal: f.claude)
+        let good = try credentials(acquired.credentialFile)
+
+        let validated = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseValidate, params: good))
+        #expect(validated.success)
+        let validatedSnapshot = try validated.decodeResult(WatchDeskLeaseSnapshot.self)
+        #expect(validatedSnapshot.role == .judge)
+
+        let renewed = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseRenew, params: good))
+        #expect(renewed.success)
+        let snapshot = try renewed.decodeResult(WatchDeskLeaseSnapshot.self)
+        // Renewal extends authority; it never mints a new generation.
+        #expect(snapshot.generation == acquired.lease.generation)
+        #expect(snapshot.expiresAt >= acquired.lease.expiresAt)
+
+        let staleGeneration = NightwatchLeaseCredentialsParams(
+            worktreeID: good.worktreeID, terminalID: good.terminalID,
+            token: good.token, generation: good.generation + 1)
+        let staleRenew = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseRenew, params: staleGeneration))
+        #expect(!staleRenew.success)
+
+        let foreignToken = NightwatchLeaseCredentialsParams(
+            worktreeID: good.worktreeID, terminalID: good.terminalID,
+            token: UUID(), generation: good.generation)
+        let foreignValidate = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseValidate, params: foreignToken))
+        #expect(!foreignValidate.success)
+    }
+
+    @Test("status reports the holder without disclosing the capability")
+    func statusReportsHolderOnly() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+        let acquired = try await acquire(f, terminal: f.claude)
+
+        let response = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseStatus,
+            params: NightwatchLeaseStatusParams(worktreeID: f.desk.id)))
+        let status = try response.decodeResult(NightwatchLeaseStatusResult.self)
+
+        #expect(status.held)
+        #expect(status.lease?.terminalID == f.claude.id)
+        let token = try WatchDeskLeaseCredentialFile.read(
+            path: acquired.credentialFile).token
+        let encoded = try #require(
+            String(data: try JSONEncoder().encode(status), encoding: .utf8))
+        #expect(!encoded.contains(token.uuidString))
+    }
+
+    // MARK: - transfer
+
+    @Test("transfer moves authority, swaps capabilities, and fences the predecessor")
+    func transferMovesAuthority() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+        let acquired = try await acquire(f, terminal: f.claude)
+        let source = try credentials(acquired.credentialFile)
+
+        let response = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseTransfer,
+            params: NightwatchLeaseTransferParams(
+                worktreeID: source.worktreeID, fromTerminalID: source.terminalID,
+                toTerminalID: f.codex.id, token: source.token,
+                generation: source.generation)))
+        let transferred = try response.decodeResult(NightwatchLeaseAcquisitionResult.self)
+
+        #expect(transferred.lease.terminalID == f.codex.id)
+        #expect(transferred.lease.generation == acquired.lease.generation + 1)
+        #expect(transferred.lease.role == .judge)
+
+        // The successor holds exactly one capability, and it is the returned one.
+        let successorPaths = WatchDeskLeaseCredentialFile.paths(terminalID: f.codex.id)
+        #expect(successorPaths == [transferred.credentialFile])
+        // The predecessor's capability is gone, and its old triple is fenced.
+        #expect(WatchDeskLeaseCredentialFile.paths(terminalID: f.claude.id).isEmpty)
+        let fencedRenew = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseRenew, params: source))
+        #expect(!fencedRenew.success)
+
+        // The successor's fresh capability is a different secret.
+        let successorToken = try WatchDeskLeaseCredentialFile.read(
+            path: transferred.credentialFile).token
+        #expect(successorToken != source.token)
+    }
+
+    /// The prepared-then-committed ordering must not strand an inert capability
+    /// when the store rejects the transfer.
+    @Test("a rejected transfer leaves the successor no capability and the predecessor authoritative")
+    func rejectedTransferLeavesNoInertCapability() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+        let acquired = try await acquire(f, terminal: f.claude)
+        let source = try credentials(acquired.credentialFile)
+
+        // A terminal on a different desk: the handler authenticates and writes
+        // the successor capability before the store rejects it as off-desk.
+        let otherDesk = try await f.db.worktrees.createScratch(
+            name: "other-desk", displayName: "Other Desk",
+            path: "/tmp/other-desk-\(UUID())", tmuxServer: "test")
+        let outsider = try await f.db.terminals.create(
+            worktreeID: otherDesk.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
+            label: TerminalLabel.claudeCode, kind: .claude)
+
+        let response = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseTransfer,
+            params: NightwatchLeaseTransferParams(
+                worktreeID: source.worktreeID, fromTerminalID: source.terminalID,
+                toTerminalID: outsider.id, token: source.token,
+                generation: source.generation)))
+
+        #expect(!response.success)
+        #expect(WatchDeskLeaseCredentialFile.paths(terminalID: outsider.id).isEmpty)
+
+        // The predecessor keeps working at its original generation.
+        let still = try #require(
+            try await f.db.watchDeskLeases.status(worktreeID: f.desk.id))
+        #expect(still.terminalID == f.claude.id)
+        #expect(still.generation == acquired.lease.generation)
+        let predecessorRenew = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseRenew, params: source))
+        #expect(predecessorRenew.success)
+    }
+
+    @Test("transfer with stale credentials never writes a successor capability")
+    func staleTransferWritesNothing() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+        let acquired = try await acquire(f, terminal: f.claude)
+
+        let response = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseTransfer,
+            params: NightwatchLeaseTransferParams(
+                worktreeID: f.desk.id, fromTerminalID: f.claude.id,
+                toTerminalID: f.codex.id, token: UUID(),
+                generation: acquired.lease.generation)))
+
+        #expect(!response.success)
+        #expect(WatchDeskLeaseCredentialFile.paths(terminalID: f.codex.id).isEmpty)
+    }
+
+    // MARK: - release
+
+    @Test("release tombstones the lease, drops the capability, and clears roles")
+    func releaseClearsEverything() async throws {
+        let (_, cleanup) = isolateTBDHome(); defer { cleanup() }
+        let f = try await fixture()
+        let acquired = try await acquire(f, terminal: f.claude)
+        let held = try credentials(acquired.credentialFile)
+
+        let released = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseRelease, params: held))
+        #expect(released.success)
+
+        #expect(WatchDeskLeaseCredentialFile.paths(terminalID: f.claude.id).isEmpty)
+
+        let response = await f.router.handle(try RPCRequest(
+            method: RPCMethod.nightwatchLeaseStatus,
+            params: NightwatchLeaseStatusParams(worktreeID: f.desk.id)))
+        let status = try response.decodeResult(NightwatchLeaseStatusResult.self)
+        #expect(!status.held)
+        // The row survives so the generation is never reused, but it reports no
+        // mutable authority.
+        #expect(status.lease?.valid == false)
+        #expect(status.lease?.role == .readOnlyCoordinator)
+
+        for terminal in [f.claude, f.codex] {
+            let row = try #require(try await f.db.terminals.get(id: terminal.id))
+            #expect(row.watchDeskRole == nil)
+        }
+
+        // A successor acquires above the released generation.
+        let next = try await acquire(f, terminal: f.codex)
+        #expect(next.lease.generation == acquired.lease.generation + 1)
+    }
+}
+}

--- a/Tests/TBDDaemonTests/WatchDeskLeaseStoreTests.swift
+++ b/Tests/TBDDaemonTests/WatchDeskLeaseStoreTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("Watch Desk judge lease store")
+struct WatchDeskLeaseStoreTests {
+    private func fixture() async throws -> (TBDDatabase, Worktree, Terminal, Terminal) {
+        let db = try TBDDatabase(inMemory: true)
+        let desk = try await db.worktrees.createScratch(
+            name: "watch-desk", displayName: "Watch Desk",
+            path: "/tmp/watch-desk-\(UUID())", tmuxServer: "test")
+        let claude = try await db.terminals.create(
+            worktreeID: desk.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, kind: .claude)
+        let codex = try await db.terminals.create(
+            worktreeID: desk.id, tmuxWindowID: "@2", tmuxPaneID: "%2",
+            label: TerminalLabel.codex, kind: .codex)
+        return (db, desk, claude, codex)
+    }
+
+    @Test("two candidates race and only one acquires")
+    func contention() async throws {
+        let (db, desk, claude, codex) = try await fixture()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let claudeAttempt = Task {
+            try? await db.watchDeskLeases.acquire(
+                worktreeID: desk.id, terminalID: claude.id, now: now)
+        }
+        let codexAttempt = Task {
+            try? await db.watchDeskLeases.acquire(
+                worktreeID: desk.id, terminalID: codex.id, now: now)
+        }
+        let winners = await [claudeAttempt.value, codexAttempt.value].compactMap { $0 }
+        #expect(winners.count == 1)
+        #expect(try await db.watchDeskLeases.status(worktreeID: desk.id) == winners.first)
+    }
+
+    @Test("renewal preserves credentials and extends expiry")
+    func renewal() async throws {
+        let (db, desk, claude, _) = try await fixture()
+        let start = Date(timeIntervalSince1970: 2_000)
+        let first = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: claude.id, now: start)
+        let renewed = try await db.watchDeskLeases.renew(
+            worktreeID: desk.id, terminalID: claude.id,
+            token: first.token, generation: first.generation,
+            now: start.addingTimeInterval(30))
+        #expect(renewed.token == first.token)
+        #expect(renewed.generation == first.generation)
+        #expect(renewed.expiresAt > first.expiresAt)
+    }
+
+    @Test("acquire cannot recover or disclose an unexpired holder capability")
+    func acquireDoesNotRenewCurrentHolder() async throws {
+        let (db, desk, claude, _) = try await fixture()
+        let start = Date(timeIntervalSince1970: 2_500)
+        _ = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: claude.id, now: start)
+        await #expect(throws: WatchDeskLeaseError.self) {
+            try await db.watchDeskLeases.acquire(
+                worktreeID: desk.id, terminalID: claude.id,
+                now: start.addingTimeInterval(1))
+        }
+    }
+
+    @Test("expired owner is replaced at a higher generation")
+    func expiryTakeover() async throws {
+        let (db, desk, claude, codex) = try await fixture()
+        let start = Date(timeIntervalSince1970: 3_000)
+        let first = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: claude.id, now: start, lifetime: 10)
+        let successor = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: codex.id,
+            now: start.addingTimeInterval(11))
+        #expect(successor.generation == first.generation + 1)
+        #expect(successor.token != first.token)
+        await #expect(throws: WatchDeskLeaseError.self) {
+            try await db.watchDeskLeases.validate(
+                worktreeID: desk.id, terminalID: claude.id,
+                token: first.token, generation: first.generation,
+                now: start.addingTimeInterval(11))
+        }
+    }
+
+    @Test("atomic transfer fences predecessor and assigns explicit roles")
+    func transfer() async throws {
+        let (db, desk, claude, codex) = try await fixture()
+        let start = Date(timeIntervalSince1970: 4_000)
+        let first = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: claude.id, now: start)
+        let next = try await db.watchDeskLeases.transfer(
+            worktreeID: desk.id, fromTerminalID: claude.id, toTerminalID: codex.id,
+            token: first.token, generation: first.generation,
+            now: start.addingTimeInterval(1))
+        #expect(next.generation == first.generation + 1)
+        await #expect(throws: WatchDeskLeaseError.self) {
+            try await db.watchDeskLeases.validate(
+                worktreeID: desk.id, terminalID: claude.id,
+                token: first.token, generation: first.generation,
+                now: start.addingTimeInterval(2))
+        }
+        let terminals = try await db.terminals.list(worktreeID: desk.id)
+        #expect(terminals.first(where: { $0.id == codex.id })?.watchDeskRole == .judge)
+        #expect(terminals.first(where: { $0.id == claude.id })?.watchDeskRole == .readOnlyCoordinator)
+    }
+
+    @Test("reverse transfer supports Codex to Claude and fences Codex")
+    func reverseTransfer() async throws {
+        let (db, desk, claude, codex) = try await fixture()
+        let start = Date(timeIntervalSince1970: 4_500)
+        let first = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: codex.id, now: start)
+        let next = try await db.watchDeskLeases.transfer(
+            worktreeID: desk.id, fromTerminalID: codex.id, toTerminalID: claude.id,
+            token: first.token, generation: first.generation,
+            now: start.addingTimeInterval(1))
+        #expect(next.terminalID == claude.id)
+        #expect(next.generation == first.generation + 1)
+        await #expect(throws: WatchDeskLeaseError.self) {
+            try await db.watchDeskLeases.validate(
+                worktreeID: desk.id, terminalID: codex.id,
+                token: first.token, generation: first.generation,
+                now: start.addingTimeInterval(2))
+        }
+    }
+
+    @Test("renewal marks terminals created after acquisition read-only")
+    func renewalLabelsLateObserver() async throws {
+        let (db, desk, claude, _) = try await fixture()
+        let first = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: claude.id)
+        let late = try await db.terminals.create(
+            worktreeID: desk.id, tmuxWindowID: "@late", tmuxPaneID: "%late",
+            label: TerminalLabel.codex, kind: .codex)
+        _ = try await db.watchDeskLeases.renew(
+            worktreeID: desk.id, terminalID: claude.id,
+            token: first.token, generation: first.generation)
+        #expect(try await db.terminals.get(id: late.id)?.watchDeskRole == .readOnlyCoordinator)
+    }
+
+    @Test("release removes authority without deleting terminals")
+    func release() async throws {
+        let (db, desk, claude, _) = try await fixture()
+        let lease = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: claude.id)
+        try await db.watchDeskLeases.release(
+            worktreeID: desk.id, terminalID: claude.id,
+            token: lease.token, generation: lease.generation)
+        #expect(try await db.watchDeskLeases.status(worktreeID: desk.id)?.isValid(at: Date()) == false)
+        #expect(try await db.terminals.get(id: claude.id)?.watchDeskRole == nil)
+    }
+
+    @Test("owner loss revocation preserves generation tombstone for recovery")
+    func ownerLoss() async throws {
+        let (db, desk, claude, codex) = try await fixture()
+        let first = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: claude.id)
+        try await db.watchDeskLeases.revoke(worktreeID: desk.id)
+        let recovered = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: codex.id)
+        #expect(recovered.generation == first.generation + 1)
+    }
+
+    @Test("read-only observer cannot validate mutable authority")
+    func observerDenied() async throws {
+        let (db, desk, claude, codex) = try await fixture()
+        let lease = try await db.watchDeskLeases.acquire(
+            worktreeID: desk.id, terminalID: claude.id)
+        await #expect(throws: WatchDeskLeaseError.self) {
+            try await db.watchDeskLeases.validate(
+                worktreeID: desk.id, terminalID: codex.id,
+                token: lease.token, generation: lease.generation)
+        }
+    }
+}

--- a/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
+++ b/Tests/TBDSharedTests/NightwatchDeskPromptsTests.swift
@@ -32,12 +32,12 @@ struct NightwatchDeskPromptsTests {
         ]
     }
 
-    @Test("No prompt references a `tbd terminal close` subcommand", arguments: liveModes)
+    @Test("No prompt references nonexistent `tbd terminal close --all`", arguments: liveModes)
     func noPhantomCloseCommand(mode: NightwatchMode) {
         for (label, text) in prompts(mode: mode, skillDir: "/skill") {
             #expect(
-                !text.contains("terminal close"),
-                "\(mode) \(label) references `tbd terminal close`, which does not exist"
+                !text.contains("terminal close --all"),
+                "\(mode) \(label) references unsupported multi-terminal close"
             )
         }
     }
@@ -282,6 +282,38 @@ struct NightwatchDeskPromptsTests {
             }
             #expect(py.contains("refusing to close myself"),
                     "handoff.py lost the self-close guard the relay depends on")
+            #expect(py.contains("tbd\", \"terminal\", \"close\""),
+                    "handoff.py must close through TBD so terminal history is preserved")
+            #expect(!py.contains("kill-window"),
+                    "handoff.py must not bypass TBD's close/history path")
+            #expect(py.contains("tbd nightwatch lease renew"),
+                    "successor must renew and validate authority before mutating")
+            #expect(py.contains("refusing handoff: judge lease renewal failed"))
+            #expect(py.contains("--credential-file"))
+            #expect(!py.contains("--token"),
+                    "handoff must not expose the capability in argv or transcript text")
+            #expect(py.contains("refusing to close predecessor: this terminal does not hold the judge lease"),
+                    "successor close must be fenced by its transferred capability")
+        }
+
+        @Test("mutable shipped scripts renew judge authority before acting")
+        func mutableScriptsGuardActions() {
+            let wake = NightwatchSkillContent.wakePy
+            #expect(wake.contains("def require_judge_lease():"))
+            #expect(wake.contains("if act:\n            require_judge_lease()"))
+
+            let judge = NightwatchSkillContent.judgePy
+            #expect(judge.contains("def require_judge_lease():"))
+            #expect(judge.contains("if not act or not tid: return False\n    require_judge_lease()"))
+        }
+
+        @Test("initial desk prompt is read-only until lease-bearing nudge")
+        func initialPromptWaitsForLease() {
+            for mode in NightwatchDeskPromptsTests.liveModes {
+                let prompt = NightwatchDeskPrompts.initialPrompt(mode: mode, skillDir: "/skill")
+                #expect(prompt.contains("Authority starts at the first lease-bearing nudge"))
+                #expect(prompt.contains("you are read-only"))
+            }
         }
 
         /// The ceiling is the one number in this skill that both prompts quote in

--- a/Tests/TBDSharedTests/WatchDeskLeaseCredentialTests.swift
+++ b/Tests/TBDSharedTests/WatchDeskLeaseCredentialTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+@Suite("Watch Desk lease capability wire and file safety")
+struct WatchDeskLeaseCredentialTests {
+    @Test("status snapshot is redacted")
+    func statusSnapshotRedactsToken() throws {
+        let snapshot = WatchDeskLeaseSnapshot(
+            worktreeID: UUID(), terminalID: UUID(), generation: 7,
+            acquiredAt: Date(), renewedAt: Date(), expiresAt: Date(), valid: true)
+        let encoded = try JSONEncoder().encode(snapshot)
+        let json = try #require(String(data: encoded, encoding: .utf8))
+        #expect(!json.contains("token"))
+    }
+
+    @Test("capability file round-trips outside the worktree at mode 0600")
+    func capabilityFile() throws {
+        let home = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-lease-capability-\(UUID())")
+        let environment = ["TBD_HOME": home.path]
+        defer { try? FileManager.default.removeItem(at: home) }
+        let credential = WatchDeskLeaseCredential(
+            worktreeID: UUID(), terminalID: UUID(), token: UUID(), generation: 3)
+        let path = try WatchDeskLeaseCredentialFile.write(
+            credential, environment: environment)
+        #expect(!path.contains(credential.token.uuidString))
+        #expect(try WatchDeskLeaseCredentialFile.read(path: path) == credential)
+        let attributes = try FileManager.default.attributesOfItem(atPath: path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+        let directoryAttributes = try FileManager.default.attributesOfItem(
+            atPath: WatchDeskLeaseCredentialFile.directory(environment: environment).path)
+        #expect((directoryAttributes[.posixPermissions] as? NSNumber)?.intValue == 0o700)
+
+        let refreshed = WatchDeskLeaseCredential(
+            worktreeID: credential.worktreeID, terminalID: credential.terminalID,
+            token: credential.token, generation: 4)
+        let refreshedPath = try WatchDeskLeaseCredentialFile.ensure(
+            refreshed, environment: environment)
+        #expect(URL(fileURLWithPath: refreshedPath).resolvingSymlinksInPath()
+            == URL(fileURLWithPath: path).resolvingSymlinksInPath())
+        #expect(try WatchDeskLeaseCredentialFile.read(path: path) == refreshed)
+    }
+}

--- a/Tests/TBDSharedTests/WatchDeskRoleTests.swift
+++ b/Tests/TBDSharedTests/WatchDeskRoleTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+import TBDShared
+
+@Suite("Watch Desk role compatibility")
+struct WatchDeskRoleTests {
+    @Test("older terminal JSON without a role remains ordinary")
+    func absentRoleDefaultsToOrdinary() throws {
+        let terminal = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+            kind: .claude)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(terminal))
+                as? [String: Any])
+        object.removeValue(forKey: "watchDeskRole")
+
+        let decoded = try JSONDecoder().decode(
+            Terminal.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(decoded.watchDeskRole == nil)
+    }
+
+    @Test("an unknown future role fails closed as read-only")
+    func unknownRoleIsReadOnly() throws {
+        let data = try JSONSerialization.data(withJSONObject: "future_observer")
+        #expect(try JSONDecoder().decode(WatchDeskRole.self, from: data) == .readOnlyCoordinator)
+    }
+}

--- a/Tests/TBDSharedTests/WatchDeskRoleTests.swift
+++ b/Tests/TBDSharedTests/WatchDeskRoleTests.swift
@@ -21,7 +21,26 @@ struct WatchDeskRoleTests {
 
     @Test("an unknown future role fails closed as read-only")
     func unknownRoleIsReadOnly() throws {
-        let data = try JSONSerialization.data(withJSONObject: "future_observer")
-        #expect(try JSONDecoder().decode(WatchDeskRole.self, from: data) == .readOnlyCoordinator)
+        // A bare string is not a valid top-level JSON value for
+        // JSONSerialization, so wrap the role the way the wire does: decoding
+        // still lands on WatchDeskRole's singleValueContainer.
+        let data = try JSONSerialization.data(withJSONObject: ["future_observer"])
+        let decoded = try JSONDecoder().decode([WatchDeskRole].self, from: data)
+        #expect(decoded == [.readOnlyCoordinator])
+    }
+
+    @Test("an unknown future role on a terminal fails closed as read-only")
+    func unknownRoleOnTerminalIsReadOnly() throws {
+        let terminal = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+            kind: .claude, watchDeskRole: .judge)
+        var object = try #require(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(terminal))
+                as? [String: Any])
+        object["watchDeskRole"] = "future_observer"
+
+        let decoded = try JSONDecoder().decode(
+            Terminal.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(decoded.watchDeskRole == .readOnlyCoordinator)
     }
 }

--- a/docs/specs/2026-08-01-nightwatch-exclusive-judge-lease-design.md
+++ b/docs/specs/2026-08-01-nightwatch-exclusive-judge-lease-design.md
@@ -1,0 +1,44 @@
+# Nightwatch exclusive judge lease
+
+**Status:** approved in issue #567; materialized for implementation on 2026-08-01.
+
+## Problem and invariant
+
+A Watch Desk may have several live terminals, but exactly one may hold mutable judge authority. Agent kind, tab label, creation time, and pane liveness are discovery signals, not authority. A second live terminal must remain an observer until ownership transfers atomically.
+
+## Chosen design
+
+The daemon owns a durable, generation-fenced lease per Watch Desk. A new SQLite table stores the desk worktree, holder terminal, opaque token, monotonically increasing generation, and expiry. Acquisition, renewal, transfer, release, and validation execute in one database transaction. An expired lease can be acquired by a successor; an unexpired lease can only be renewed or transferred by its current token and generation. Every transfer increments the generation and replaces the token, so a predecessor is fenced immediately.
+
+Terminal rows gain an explicit `watchRole`: `judge`, `readOnlyCoordinator`, or no role. This is persisted and returned over RPC so the app can label Judge and Read-only tabs without inferring authority. Lease state is authoritative if a stale role marker disagrees with it.
+
+The production desk manager acquires a lease for the live configured-agent terminal before sending a judge nudge. If another unexpired holder exists, it fails closed: no prompt is sent and one notification identifies the conflict. If a holder's pane or process disappears, the manager revokes it before selecting a successor. Normal observer terminals remain untouched, including their transcripts and independently spawned children.
+
+The CLI exposes `tbd nightwatch lease status|validate|renew|transfer|release`. Judge instructions carry the terminal, token, and generation and require validation immediately before merge, apply, archive, wake/nudge, or worker-spawn actions. Handoff uses atomic transfer after the successor terminal exists; the successor may not act until it receives the returned token and generation. Direct external commands cannot be intercepted by TBD, so this version combines a daemon-enforced single nudge target with an explicit fail-closed validation command at each mutation boundary.
+
+## Recovery and timing
+
+The default lease lifetime is two minutes. A valid holder renews on every nudge and through explicit CLI renewal while working. A crash therefore becomes recoverable after at most two minutes without killing the terminal row or transcript. An operator may transfer an unexpired lease only with the current credentials. Turning watch mode off releases the lease after posting the shift wrap-up.
+
+All expiry comparisons use an injected `now` closure. Generation is never reset or reused for a desk, including after expiry or release.
+
+## Observability
+
+Lease status reports desk, terminal, role, generation, acquisition/renewal/expiry timestamps, and whether it is currently valid. Contention produces one deduplicated task notification per conflicting lease generation and an OS log entry. Tabs display a compact `Judge` or `Read-only` suffix.
+
+## Failure behavior
+
+- Two acquisition attempts serialize in SQLite; only one receives the lease.
+- Renewal with an old token or generation fails without extending the lease.
+- Transfer commits the successor and fences the predecessor in the same transaction.
+- A missing/dead owner is revoked by the desk manager; a stale database row is never sufficient.
+- If lease persistence or validation fails, the desk does not nudge or mutate.
+- Read-only observers can inspect status but cannot validate mutable authority.
+
+## Tests
+
+Store tests cover contention, renewal, expiry takeover, stale-token rejection, atomic transfer, release, and observer denial. Desk tests cover two live candidates, dead-owner recovery, Claude-to-Codex and Codex-to-Claude transfer semantics, stale rows, exactly one nudge target, and deduplicated conflict notification. Shared-model and CLI tests cover backward-compatible role decoding and machine-readable status/validation output.
+
+## Scope
+
+This change does not enable a second Watch Desk, alter live desk state, merge or apply anything, or broaden Nightwatch's existing protected-PR rules. It establishes ownership and fencing for the existing single-desk architecture from #562.

--- a/docs/specs/2026-08-01-nightwatch-exclusive-judge-lease-design.md
+++ b/docs/specs/2026-08-01-nightwatch-exclusive-judge-lease-design.md
@@ -10,15 +10,17 @@ A Watch Desk may have several live terminals, but exactly one may hold mutable j
 
 The daemon owns a durable, generation-fenced lease per Watch Desk. A new SQLite table stores the desk worktree, holder terminal, opaque token, monotonically increasing generation, and expiry. Acquisition, renewal, transfer, release, and validation execute in one database transaction. An expired lease can be acquired by a successor; an unexpired lease can only be renewed or transferred by its current token and generation. Every transfer increments the generation and replaces the token, so a predecessor is fenced immediately.
 
-Terminal rows gain an explicit `watchRole`: `judge`, `readOnlyCoordinator`, or no role. This is persisted and returned over RPC so the app can label Judge and Read-only tabs without inferring authority. Lease state is authoritative if a stale role marker disagrees with it.
+Terminal rows gain an explicit `watchDeskRole`: `judge`, `readOnlyCoordinator`, or no role. This is persisted and returned over RPC so the app can label Judge and Read-only tabs without inferring authority. Lease state is authoritative if a stale role marker disagrees with it.
 
 The production desk manager acquires a lease for the live configured-agent terminal before sending a judge nudge. If another unexpired holder exists, it fails closed: no prompt is sent and one notification identifies the conflict. If a holder's pane or process disappears, the manager revokes it before selecting a successor. Normal observer terminals remain untouched, including their transcripts and independently spawned children.
 
-The CLI exposes `tbd nightwatch lease status|validate|renew|transfer|release`. Judge instructions carry the terminal, token, and generation and require validation immediately before merge, apply, archive, wake/nudge, or worker-spawn actions. Handoff uses atomic transfer after the successor terminal exists; the successor may not act until it receives the returned token and generation. Direct external commands cannot be intercepted by TBD, so this version combines a daemon-enforced single nudge target with an explicit fail-closed validation command at each mutation boundary.
+The CLI exposes `tbd nightwatch lease status|acquire|validate|renew|transfer|release`. `acquire` is the explicit deterministic recovery command for an unowned desk with multiple live candidates; it never overrides or renews an unexpired owner. Status is observability-only and redacts the capability. Judge instructions carry the terminal, generation, and owner-specific capability-file path and require renewal (which also validates the exact unexpired authority) immediately before merge, apply, archive, wake/nudge, or worker-spawn actions. Handoff prepares the successor capability before atomic transfer after the successor terminal exists; the successor may not act until renewal succeeds. Direct external commands cannot be intercepted by TBD, so this version combines a daemon-enforced single nudge target with fail-closed guards in every shipped mutation helper and an explicit renewal rule for direct tools.
 
 ## Recovery and timing
 
-The default lease lifetime is two minutes. A valid holder renews on every nudge and through explicit CLI renewal while working. A crash therefore becomes recoverable after at most two minutes without killing the terminal row or transcript. An operator may transfer an unexpired lease only with the current credentials. Turning watch mode off releases the lease after posting the shift wrap-up.
+The default lease lifetime is twenty minutes, longer than the fifteen-minute scheduler heartbeat and ten-minute nudge overlap guard. The daemon renews the lease on every model-free heartbeat and nudge; a valid holder also renews immediately before each mutable action through the CLI. A crash therefore becomes recoverable after at most twenty minutes without killing the terminal row or transcript. An operator may transfer an unexpired lease only with the current credentials. Turning watch mode off releases the lease after posting the shift wrap-up.
+
+The opaque capability never appears in status RPCs, prompts, argv, filenames, or shared worktree files. The daemon writes it to a mode-0600 per-terminal file inside a mode-0700 directory under TBD's runtime directory; the filename uses an unrelated random locator. Lease commands accept that file path, and transfer prepares the successor file before atomically changing the database owner, so an RPC or follow-up-message failure cannot strand an unrecoverable owner.
 
 All expiry comparisons use an injected `now` closure. Generation is never reset or reused for a desk, including after expiry or release.
 
@@ -33,7 +35,8 @@ Lease status reports desk, terminal, role, generation, acquisition/renewal/expir
 - Transfer commits the successor and fences the predecessor in the same transaction.
 - A missing/dead owner is revoked by the desk manager; a stale database row is never sufficient.
 - If lease persistence or validation fails, the desk does not nudge or mutate.
-- Read-only observers can inspect status but cannot validate mutable authority.
+- Read-only observers can inspect status but cannot validate mutable authority for their terminal.
+- Handoff closes only the predecessor through TBD's single-terminal close path, preserving Closed Terminals history and leaving independently spawned child terminals untouched.
 
 ## Tests
 
@@ -42,3 +45,7 @@ Store tests cover contention, renewal, expiry takeover, stale-token rejection, a
 ## Scope
 
 This change does not enable a second Watch Desk, alter live desk state, merge or apply anything, or broaden Nightwatch's existing protected-PR rules. It establishes ownership and fencing for the existing single-desk architecture from #562.
+
+The filesystem capability prevents accidental, stale, or cooperative observers from acting and keeps the secret out of normal telemetry. It is not a sandbox against deliberately hostile code running as the same macOS user, which can enumerate and read any same-user mode-0600 file. Hard adversarial isolation would require a daemon-bound client identity, separately privileged OS principals, or equivalent process isolation. TBD also cannot intercept a judge that invokes external mutation tools directly; those remain covered by the renewal rule rather than structural mediation.
+
+This is a safety correction to already-enabled autonomous Watch Desk behavior, not a new autonomous capability. It therefore does not sit behind a default-off feature flag: leaving the guard off would preserve the double-judge risk the change exists to remove.


### PR DESCRIPTION
## Summary
- add a durable generation-fenced per-desk Judge lease and explicit Judge/Read-only roles
- keep the unguessable capability out of status, prompts, argv, filenames, and shared worktrees
- use a 20-minute lease with model-free heartbeat and fail-closed wake/judge/handoff helpers
- pre-provision successor authority before handoff and require successor renewal before closing the predecessor through TBD history-aware close

## Validation
- `swift build --target TBDDaemonLib`, `--target TBDDaemonTests`, `--target TBDCLI`, `--target TBDApp`, `--target TBDSharedTests`
- embedded Python syntax checks
- wake offline self-tests: 9/9
- handoff offline self-tests: 7/7
- runtime credential mode/roundtrip check
- `git diff --check`

Hosted CI is authoritative for test execution. Locally, `swift test` cannot run: the host has no Xcode, and the Command Line Tools toolchain ships neither `Testing` nor `XCTest`. Compilation was verified against the matching Swift 6.3.2 toolchain.

## Review response (`75ff726`, `043941e`)

**Hosted `test` failure — fixed.** `WatchDeskRoleTests.unknownRoleIsReadOnly` called `JSONSerialization.data(withJSONObject: "future_observer")`. A bare string is not a valid top-level JSON value, so Foundation raised `NSInvalidArgumentException` — uncatchable from Swift. The fast parallel pass aborted with signal 6 and took the rest of pass 2 down with it, which is why the tier-3 and build steps were skipped. The role is now wrapped the way the wire wraps it, and a second test covers the realistic path: an unknown role arriving on a `Terminal` payload must fail closed to read-only.

**Medium — RPC handler layer had no coverage — fixed.** `Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift` adds 9 tests over all six handlers. It targets the two guarantees that only this layer implements and that nothing previously proved:
- *acquire never leaves an authoritative row whose owner received no capability* — the capability directory is made unwritable, and the test asserts the RPC fails **and** the row is left non-authoritative.
- *a rejected transfer strands no inert successor capability* — the successor is a terminal on a different desk, so the handler authenticates and writes the successor file before the store rejects it as off-desk, exercising the cleanup path rather than the early-return one. A separate test covers stale credentials, where the file must never be written at all.

Also covered: capability file mode `0600` and its location outside the desk, the token's absence from every RPC result, exact-triple enforcement on validate/renew, generation stability across renewal, capability swap and predecessor fencing on transfer, and release tombstoning without generation reuse.

The suite nests under `TBDHomeSerialized` because these handlers resolve their capability directory from the process-global `TBD_HOME`.

**Minor — dead code — fixed.** `TerminalStore.setWatchDeskRole` had no callers; role mutation goes through `WatchDeskLeaseStore`. Removed.

**Minor — misleading `role` in status output — fixed.** `WatchDeskLeaseSnapshot.role` defaulted to `.judge` and was never populated, so `tbd nightwatch lease status` reported `"role":"judge"` for expired and tombstoned rows. It now follows lease validity, and the default is `.readOnlyCoordinator` — an unstated role must never read as mutable authority, the same reason `WatchDeskRole`'s decoder falls back to it.

## Boundary
This is cooperative same-user fencing, not a hostile same-UID sandbox. Direct external mutation commands remain governed by the lease policy because TBD cannot intercept arbitrary external binaries. No live desk restart, handoff, merge, archive, or other runtime mutation was performed.
