### PR TITLE
fix: serialize local Swift builds

### DIFF
--- a/.claude/hooks/guardrails/rules/swift_build_admission.py
+++ b/.claude/hooks/guardrails/rules/swift_build_admission.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shlex
 
 from guardrails.lib.rule import Decision, Rule
@@ -10,8 +11,9 @@ from guardrails.lib.rule import Decision, Rule
 
 _COMPILE_SUBCOMMANDS = {"build", "package", "run", "test"}
 _DISPLAY_COMMANDS = {"awk", "cat", "echo", "grep", "printf", "rg", "sed"}
+_SHELL_COMMANDS = {"bash", "dash", "sh", "zsh"}
 _BOUNDARIES = {"&", "&&", "(", ")", ";", "|", "||"}
-_SAFE_RUNNER = "scripts/swift-safe"
+_MAX_NESTED_SHELL_DEPTH = 4
 _DENY_REASON = (
     "[swift-build-admission] Blocked raw SwiftPM compilation. Multiple TBD "
     "worktrees once launched concurrent default -j12 builds, filled 15 GB of "
@@ -39,9 +41,53 @@ def _segments(command: str) -> list[list[str]]:
     return [segment for segment in segments if segment]
 
 
-def _contains_raw_swift_compile(segment: list[str]) -> bool:
-    if any(token.endswith(_SAFE_RUNNER) for token in segment):
-        return False
+def _nested_shell_payloads(segment: list[str]):
+    for shell_index, token in enumerate(segment[:-1]):
+        if os.path.basename(token) not in _SHELL_COMMANDS:
+            continue
+        for option_index in range(shell_index + 1, len(segment) - 1):
+            option = segment[option_index]
+            if not option.startswith("-"):
+                break
+            if "c" in option[1:]:
+                yield segment[option_index + 1]
+                break
+
+
+def _command_substitution_payloads(token: str):
+    start = 0
+    while True:
+        opening = token.find("$(", start)
+        if opening < 0:
+            break
+        depth = 1
+        cursor = opening + 2
+        while cursor < len(token) and depth:
+            if token.startswith("$(", cursor):
+                depth += 1
+                cursor += 2
+                continue
+            if token[cursor] == ")":
+                depth -= 1
+                if depth == 0:
+                    yield token[opening + 2 : cursor]
+                    start = cursor + 1
+                    break
+            cursor += 1
+        else:
+            break
+    yield from re.findall(r"`([^`]*)`", token)
+
+
+def _contains_raw_swift_compile(segment: list[str], depth: int = 0) -> bool:
+    if depth < _MAX_NESTED_SHELL_DEPTH:
+        for token in segment:
+            for payload in _command_substitution_payloads(token):
+                if _command_contains_raw_swift_compile(payload, depth + 1):
+                    return True
+        for payload in _nested_shell_payloads(segment):
+            if _command_contains_raw_swift_compile(payload, depth + 1):
+                return True
     if segment and os.path.basename(segment[0]) in _DISPLAY_COMMANDS:
         return False
     for index, token in enumerate(segment[:-1]):
@@ -50,6 +96,16 @@ def _contains_raw_swift_compile(segment: list[str]) -> bool:
         if segment[index + 1] in _COMPILE_SUBCOMMANDS:
             return True
     return False
+
+
+def _command_contains_raw_swift_compile(command: str, depth: int = 0) -> bool:
+    if depth < _MAX_NESTED_SHELL_DEPTH:
+        for payload in _command_substitution_payloads(command):
+            if _command_contains_raw_swift_compile(payload, depth + 1):
+                return True
+    return any(
+        _contains_raw_swift_compile(segment, depth) for segment in _segments(command)
+    )
 
 
 class SwiftBuildAdmissionRule(Rule):
@@ -62,7 +118,7 @@ class SwiftBuildAdmissionRule(Rule):
 
     def check(self, tool_input: dict, _ctx: dict):
         command = tool_input.get("command", "") or ""
-        if any(_contains_raw_swift_compile(segment) for segment in _segments(command)):
+        if _command_contains_raw_swift_compile(command):
             return Decision.deny(_DENY_REASON)
         return None
 

--- a/.claude/hooks/guardrails/rules/swift_build_admission.py
+++ b/.claude/hooks/guardrails/rules/swift_build_admission.py
@@ -11,6 +11,7 @@ from guardrails.lib.rule import Decision, Rule
 
 _COMPILE_SUBCOMMANDS = {"build", "run", "test"}
 _DISPLAY_COMMANDS = {"awk", "cat", "echo", "grep", "printf", "rg", "sed"}
+_EVAL_COMMANDS = {"eval"}
 _SHELL_COMMANDS = {"bash", "dash", "sh", "zsh"}
 _BOUNDARIES = {"&", "&&", "(", ")", ";", "|", "||"}
 _MAX_NESTED_SHELL_DEPTH = 4
@@ -41,7 +42,11 @@ def _segments(command: str) -> list[list[str]]:
     return [segment for segment in segments if segment]
 
 
-def _nested_shell_payloads(segment: list[str]):
+def _nested_interpreter_payloads(segment: list[str]):
+    for eval_index, token in enumerate(segment[:-1]):
+        if os.path.basename(token) in _EVAL_COMMANDS:
+            yield segment[eval_index + 1]
+
     for shell_index, token in enumerate(segment[:-1]):
         if os.path.basename(token) not in _SHELL_COMMANDS:
             continue
@@ -85,7 +90,7 @@ def _contains_raw_swift_compile(segment: list[str], depth: int = 0) -> bool:
             for payload in _command_substitution_payloads(token):
                 if _command_contains_raw_swift_compile(payload, depth + 1):
                     return True
-        for payload in _nested_shell_payloads(segment):
+        for payload in _nested_interpreter_payloads(segment):
             if _command_contains_raw_swift_compile(payload, depth + 1):
                 return True
     if segment and os.path.basename(segment[0]) in _DISPLAY_COMMANDS:

--- a/.claude/hooks/guardrails/rules/swift_build_admission.py
+++ b/.claude/hooks/guardrails/rules/swift_build_admission.py
@@ -1,0 +1,70 @@
+"""Require local SwiftPM compilation to use the shared admission governor."""
+
+from __future__ import annotations
+
+import os
+import shlex
+
+from guardrails.lib.rule import Decision, Rule
+
+
+_COMPILE_SUBCOMMANDS = {"build", "package", "run", "test"}
+_DISPLAY_COMMANDS = {"awk", "cat", "echo", "grep", "printf", "rg", "sed"}
+_BOUNDARIES = {"&", "&&", "(", ")", ";", "|", "||"}
+_SAFE_RUNNER = "scripts/swift-safe"
+_DENY_REASON = (
+    "[swift-build-admission] Blocked raw SwiftPM compilation. Multiple TBD "
+    "worktrees once launched concurrent default -j12 builds, filled 15 GB of "
+    "swap, and left swift-test parents respawning killed swift-frontends. "
+    "Fix: run `scripts/swift-safe <build|test|run|package> ...`; it holds one "
+    "machine-global build slot and defaults compilation to two jobs."
+)
+
+
+def _segments(command: str) -> list[list[str]]:
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        return []
+
+    segments: list[list[str]] = [[]]
+    for token in tokens:
+        if token in _BOUNDARIES:
+            if segments[-1]:
+                segments.append([])
+            continue
+        segments[-1].append(token)
+    return [segment for segment in segments if segment]
+
+
+def _contains_raw_swift_compile(segment: list[str]) -> bool:
+    if any(token.endswith(_SAFE_RUNNER) for token in segment):
+        return False
+    if segment and os.path.basename(segment[0]) in _DISPLAY_COMMANDS:
+        return False
+    for index, token in enumerate(segment[:-1]):
+        if os.path.basename(token) != "swift":
+            continue
+        if segment[index + 1] in _COMPILE_SUBCOMMANDS:
+            return True
+    return False
+
+
+class SwiftBuildAdmissionRule(Rule):
+    id = "swift-build-admission"
+    description = (
+        "Require Swift build/test/run/package commands to use scripts/swift-safe "
+        "for a machine-global build slot and bounded compiler jobs."
+    )
+    tools = {"Bash"}
+
+    def check(self, tool_input: dict, _ctx: dict):
+        command = tool_input.get("command", "") or ""
+        if any(_contains_raw_swift_compile(segment) for segment in _segments(command)):
+            return Decision.deny(_DENY_REASON)
+        return None
+
+
+RULES = [SwiftBuildAdmissionRule()]

--- a/.claude/hooks/guardrails/rules/swift_build_admission.py
+++ b/.claude/hooks/guardrails/rules/swift_build_admission.py
@@ -9,7 +9,7 @@ import shlex
 from guardrails.lib.rule import Decision, Rule
 
 
-_COMPILE_SUBCOMMANDS = {"build", "package", "run", "test"}
+_COMPILE_SUBCOMMANDS = {"build", "run", "test"}
 _DISPLAY_COMMANDS = {"awk", "cat", "echo", "grep", "printf", "rg", "sed"}
 _SHELL_COMMANDS = {"bash", "dash", "sh", "zsh"}
 _BOUNDARIES = {"&", "&&", "(", ")", ";", "|", "||"}
@@ -18,7 +18,7 @@ _DENY_REASON = (
     "[swift-build-admission] Blocked raw SwiftPM compilation. Multiple TBD "
     "worktrees once launched concurrent default -j12 builds, filled 15 GB of "
     "swap, and left swift-test parents respawning killed swift-frontends. "
-    "Fix: run `scripts/swift-safe <build|test|run|package> ...`; it holds one "
+    "Fix: run `scripts/swift-safe <build|test|run> ...`; it holds one "
     "machine-global build slot and defaults compilation to two jobs."
 )
 
@@ -111,7 +111,7 @@ def _command_contains_raw_swift_compile(command: str, depth: int = 0) -> bool:
 class SwiftBuildAdmissionRule(Rule):
     id = "swift-build-admission"
     description = (
-        "Require Swift build/test/run/package commands to use scripts/swift-safe "
+        "Require Swift build/test/run commands to use scripts/swift-safe "
         "for a machine-global build slot and bounded compiler jobs."
     )
     tools = {"Bash"}

--- a/.claude/hooks/guardrails/tests/test_swift_build_admission.py
+++ b/.claude/hooks/guardrails/tests/test_swift_build_admission.py
@@ -51,6 +51,31 @@ class SwiftBuildAdmissionTests(unittest.TestCase):
         self.assertIsNotNone(decision)
         self.assertEqual(decision.action, "deny")
 
+    def test_nested_shell_commands_cannot_bypass_admission(self):
+        commands = [
+            'bash -c "swift build"',
+            "sh -c 'swift test -j 12'",
+            "/bin/zsh -lc 'cd /tmp && /usr/bin/swift package resolve'",
+            "env FOO=bar bash -ec 'swift run TBDApp'",
+            "echo \"$(bash -c 'swift build')\"",
+            'printf "%s\\n" "$(swift test)"',
+            "echo `swift package resolve`",
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                decision = _check(command)
+                self.assertIsNotNone(decision)
+                self.assertEqual(decision.action, "deny")
+
+    def test_nested_shell_may_call_the_governed_runner(self):
+        commands = [
+            'bash -c "scripts/swift-safe build"',
+            "zsh -lc './scripts/swift-safe test --filter Foo'",
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIsNone(_check(command))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/guardrails/tests/test_swift_build_admission.py
+++ b/.claude/hooks/guardrails/tests/test_swift_build_admission.py
@@ -1,0 +1,56 @@
+"""Pin the shared Swift build-admission guardrail."""
+
+import os
+import sys
+import unittest
+
+_HOOKS_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+from guardrails.rules.swift_build_admission import SwiftBuildAdmissionRule  # noqa: E402
+
+
+def _check(command):
+    return SwiftBuildAdmissionRule().check({"command": command}, {})
+
+
+class SwiftBuildAdmissionTests(unittest.TestCase):
+    def test_denies_raw_compile_commands(self):
+        commands = [
+            "swift build",
+            "swift test --filter TranscriptPresentation",
+            "cd /tmp && /usr/bin/swift test -j 12",
+            "xcrun swift run TBDApp",
+            "swift package resolve",
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                decision = _check(command)
+                self.assertIsNotNone(decision)
+                self.assertEqual(decision.action, "deny")
+                self.assertIn("scripts/swift-safe", decision.reason)
+
+    def test_allows_governed_and_non_compile_commands(self):
+        commands = [
+            "scripts/swift-safe build",
+            "./scripts/swift-safe test --filter TranscriptPresentation",
+            "swift --version",
+            'echo "swift build"',
+            "rg 'swift test' docs",
+            "git diff -- Tests/TBDAppTests",
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIsNone(_check(command))
+
+    def test_safe_and_raw_commands_in_one_chain_still_deny(self):
+        decision = _check("scripts/swift-safe build && swift test")
+        self.assertIsNotNone(decision)
+        self.assertEqual(decision.action, "deny")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/guardrails/tests/test_swift_build_admission.py
+++ b/.claude/hooks/guardrails/tests/test_swift_build_admission.py
@@ -24,7 +24,6 @@ class SwiftBuildAdmissionTests(unittest.TestCase):
             "swift test --filter TranscriptPresentation",
             "cd /tmp && /usr/bin/swift test -j 12",
             "xcrun swift run TBDApp",
-            "swift package resolve",
         ]
         for command in commands:
             with self.subTest(command=command):
@@ -41,6 +40,8 @@ class SwiftBuildAdmissionTests(unittest.TestCase):
             'echo "swift build"',
             "rg 'swift test' docs",
             "git diff -- Tests/TBDAppTests",
+            "swift package resolve",
+            "swift package dump-package",
         ]
         for command in commands:
             with self.subTest(command=command):
@@ -55,11 +56,11 @@ class SwiftBuildAdmissionTests(unittest.TestCase):
         commands = [
             'bash -c "swift build"',
             "sh -c 'swift test -j 12'",
-            "/bin/zsh -lc 'cd /tmp && /usr/bin/swift package resolve'",
+            "/bin/zsh -lc 'cd /tmp && /usr/bin/swift run TBDApp'",
             "env FOO=bar bash -ec 'swift run TBDApp'",
             "echo \"$(bash -c 'swift build')\"",
             'printf "%s\\n" "$(swift test)"',
-            "echo `swift package resolve`",
+            "echo `swift build`",
         ]
         for command in commands:
             with self.subTest(command=command):

--- a/.claude/hooks/guardrails/tests/test_swift_build_admission.py
+++ b/.claude/hooks/guardrails/tests/test_swift_build_admission.py
@@ -68,6 +68,22 @@ class SwiftBuildAdmissionTests(unittest.TestCase):
                 self.assertIsNotNone(decision)
                 self.assertEqual(decision.action, "deny")
 
+    def test_eval_cannot_bypass_admission(self):
+        commands = [
+            'eval "swift build"',
+            "eval 'swift test --filter TranscriptPresentation'",
+            'eval "/usr/bin/swift run TBDApp"',
+            'bash -c \'eval "swift build"\'',
+        ]
+        for command in commands:
+            with self.subTest(command=command):
+                decision = _check(command)
+                self.assertIsNotNone(decision)
+                self.assertEqual(decision.action, "deny")
+
+    def test_eval_may_call_the_governed_runner(self):
+        self.assertIsNone(_check('eval "scripts/swift-safe build"'))
+
     def test_nested_shell_may_call_the_governed_runner(self):
         commands = [
             'bash -c "scripts/swift-safe build"',

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Check for committed implementation plans
         run: scripts/check-no-committed-plans.sh
 
+      - name: Test agent guardrails and Swift admission wrapper
+        run: |
+          python3 .claude/hooks/guardrails/dispatch.py --self-test
+          python3 scripts/test-swift-safe.py
+
   test:
     runs-on: macos-26
     # All three test steps below append their `.flaky(issue:)` retry records

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ The main chat session agent should not write code directly. Delegate all impleme
 - Verify your changes compile (`scripts/swift-safe build`) before committing.
 - Run `scripts/swift-safe test` if you changed daemon or shared code. The wrapper
   serializes SwiftPM across TBD worktrees and defaults to two compiler jobs;
-  raw `swift build/test/run/package` is blocked by the repo guardrail because
+  raw `swift build/test/run` is blocked by the repo guardrail because
   concurrent default `-j12` builds can exhaust this development machine.
 - When adding a branching conditional that gates behavior (feature flags, toggles, mode switches), add a test for each branch. Verify the gated behavior is off when the flag is off, and that ungated behavior still works.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,11 @@ The main chat session agent should not write code directly. Delegate all impleme
 - Always commit after completing work. Don't wait to be asked.
 - Use conventional commit messages: `feat:`, `fix:`, `docs:`, `refactor:`
 - Banned words — never use these in code or in PR titles, descriptions, or commit messages: "blessed", "golden"
-- Verify your changes compile (`swift build`) before committing.
-- Run `swift test` if you changed daemon or shared code.
+- Verify your changes compile (`scripts/swift-safe build`) before committing.
+- Run `scripts/swift-safe test` if you changed daemon or shared code. The wrapper
+  serializes SwiftPM across TBD worktrees and defaults to two compiler jobs;
+  raw `swift build/test/run/package` is blocked by the repo guardrail because
+  concurrent default `-j12` builds can exhaust this development machine.
 - When adding a branching conditional that gates behavior (feature flags, toggles, mode switches), add a test for each branch. Verify the gated behavior is off when the flag is off, and that ungated behavior still works.
 
 ### Large or risky new behavior ships behind a default-off flag
@@ -132,8 +135,8 @@ Enforced mechanically by two SwiftLint custom rules in `.swiftlint.yml` (`no_tui
 
 ## Quick Reference
 
-- **Build**: `swift build`
-- **Test**: `swift test`
+- **Build**: `scripts/swift-safe build`
+- **Test**: `scripts/swift-safe test`
 - **Restart**: `scripts/restart.sh`
 - **Install git hooks** (one-time setup after cloning): `scripts/install-hooks.sh`
 - **Diagnostics**: see [`docs/diagnostics-strategy.md`](docs/diagnostics-strategy.md). Quick recipes:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Three components communicate over a Unix socket using a JSON RPC protocol:
 
 ```bash
 # Build everything
-swift build
+scripts/swift-safe build
 
 # Run the daemon
 .build/debug/tbdd
@@ -40,7 +40,7 @@ swift build
 
 # Run the app (or open in Xcode)
 open TBDApp.xcodeproj  # if applicable, or:
-swift build --product TBDApp && .build/debug/TBDApp
+scripts/swift-safe build --product TBDApp && .build/debug/TBDApp
 ```
 
 A convenience script rebuilds and restarts the daemon + app:
@@ -54,7 +54,7 @@ scripts/restart.sh --quick  # skip build
 ## Test
 
 ```bash
-swift test
+scripts/swift-safe test
 ```
 
 ## Migrating from Conductor

--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -122,10 +122,13 @@ Everything else is removed by default. Use `--dry-run` to preview. See the Env v
 
 ## Swift build admission
 
-All local SwiftPM compilation goes through `scripts/swift-safe`. It holds a
+Local SwiftPM `build`, `test`, and `run` compilation goes through
+`scripts/swift-safe`. It holds a
 kernel-managed, machine-global lock at `~/tbd/runtime/swift-build.lock`, so a
 fleet of TBD worktrees cannot compile simultaneously. Compile commands default
-to two jobs and reject more than four unless a developer explicitly opts out.
+to two jobs and rejects an explicit job count above that configured limit unless
+a developer opts out. Non-compiling `swift package` metadata and resolution
+commands do not enter the governor.
 
 - `TBD_SWIFT_JOBS` sets the default and maximum job count (default `2`).
 - `TBD_SWIFT_LOCK_TIMEOUT_SECONDS` sets the wait timeout (default `1800`).
@@ -133,8 +136,9 @@ to two jobs and reject more than four unless a developer explicitly opts out.
 - `TBD_SWIFT_ALLOW_HIGH_JOBS=1` permits an explicit higher job count on an
   otherwise idle machine.
 
-The repository guardrail rejects raw `swift build`, `swift test`, `swift run`,
-and `swift package` commands issued by agents. CI remains unaffected.
+The repository guardrail rejects raw `swift build`, `swift test`, and `swift
+run` commands issued by agents. CI and non-compiling package commands remain
+unaffected.
 
 ## Shared module cache
 

--- a/docs/reclaim-build.md
+++ b/docs/reclaim-build.md
@@ -120,13 +120,29 @@ A scratchpad is **kept** when either:
 
 Everything else is removed by default. Use `--dry-run` to preview. See the Env vars section above for `SWEEP_BASE`, `SWEEP_LSOF_CMD`, and `SWEEP_DAYS`.
 
+## Swift build admission
+
+All local SwiftPM compilation goes through `scripts/swift-safe`. It holds a
+kernel-managed, machine-global lock at `~/tbd/runtime/swift-build.lock`, so a
+fleet of TBD worktrees cannot compile simultaneously. Compile commands default
+to two jobs and reject more than four unless a developer explicitly opts out.
+
+- `TBD_SWIFT_JOBS` sets the default and maximum job count (default `2`).
+- `TBD_SWIFT_LOCK_TIMEOUT_SECONDS` sets the wait timeout (default `1800`).
+- `TBD_SWIFT_LOCK_PATH` overrides the shared lock path for isolated testing.
+- `TBD_SWIFT_ALLOW_HIGH_JOBS=1` permits an explicit higher job count on an
+  otherwise idle machine.
+
+The repository guardrail rejects raw `swift build`, `swift test`, `swift run`,
+and `swift package` commands issued by agents. CI remains unaffected.
+
 ## Shared module cache
 
-`scripts/restart.sh` passes every `swift build` through a **shared clang/Swift
-module cache** at `$HOME/Library/Caches/tbd/swift-module-cache`:
+`scripts/restart.sh` passes every governed Swift build through a **shared
+clang/Swift module cache** at `$HOME/Library/Caches/tbd/swift-module-cache`:
 
 ```sh
-swift build -Xswiftc -module-cache-path -Xswiftc "$SHARED" -Xcc -fmodules-cache-path="$SHARED"
+scripts/swift-safe build -Xswiftc -module-cache-path -Xswiftc "$SHARED" -Xcc -fmodules-cache-path="$SHARED"
 ```
 
 Without it, every worktree's `.build` accumulates its own ~640 MB
@@ -145,8 +161,8 @@ Notes:
   writers; parallel builds from multiple worktrees against the shared cache
   were tested with zero lock errors.
 - **Stickiness (expected, not a bug).** SwiftPM bakes the cache path into
-  `.build/debug.yaml` at plan time. A plain `swift build` after a flagged one
-  silently keeps using the shared cache — and conversely, the first build
+  `.build/debug.yaml` at plan time. A later build after a flagged one silently
+  keeps using the shared cache — and conversely, the first build
   after a manifest re-plan only picks the shared cache up if it runs with the
   flags (i.e. via `restart.sh`). Flag alternation does not trigger
   recompilation; worst case is a ~14 s re-plan.

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -50,7 +50,7 @@ up() {
     [ -f "$fixture" ] || { echo "No fixture: $fixture" >&2; exit 1; }
 
     echo "Building..."
-    (cd "$REPO_ROOT" && swift build) 2>&1 | tail -3
+    (cd "$REPO_ROOT" && scripts/swift-safe build) 2>&1 | tail -3
 
     down_quiet
     rm -rf "$MOCK_HOME"          # fresh DB each `up`; re-seeding an existing state.db collides on UNIQUE (now fail-loud)
@@ -100,6 +100,6 @@ case "$cmd" in
     up)      up "${1:-default}" ;;
     down)    down ;;
     shot)    shot "${1:-}" ;;
-    restart) (cd "$REPO_ROOT" && swift build) 2>&1 | tail -3; down; up "${1:-default}" ;;
+    restart) (cd "$REPO_ROOT" && scripts/swift-safe build) 2>&1 | tail -3; down; up "${1:-default}" ;;
     *) echo "usage: mock.sh {up [scenario]|down|shot <name>|restart [scenario]}" >&2; exit 1 ;;
 esac

--- a/scripts/nightly-flake-stress.sh
+++ b/scripts/nightly-flake-stress.sh
@@ -198,7 +198,8 @@ run_target() {
     load_before="$(loadavg)"
     local rc=0
     # shellcheck disable=SC2086 # $filter is a deliberately word-split arg list
-    run_with_deadline "$ITERATION_DEADLINE_S" "$log" swift test $filter || rc=$?
+    run_with_deadline "$ITERATION_DEADLINE_S" "$log" \
+      "$REPO_ROOT/scripts/swift-safe" test $filter || rc=$?
     verdict="$(judge_iteration "$rc" "$log" "$floor")"
     if [[ "$verdict" == PASS* ]]; then
       pass_counts+=("${verdict#PASS }")
@@ -266,8 +267,9 @@ main() {
   # Build ONCE up front so the first iteration's timing is not dominated by the
   # compile. `swift build` alone does NOT build test targets — `--build-tests` does.
   echo
-  echo "building test targets (swift build --build-tests -j 2)…"
-  if ! run_with_deadline 1800 "$work_dir/build.log" swift build --build-tests -j 2; then
+  echo "building test targets (swift-safe build --build-tests -j 2)…"
+  if ! run_with_deadline 1800 "$work_dir/build.log" \
+    "$REPO_ROOT/scripts/swift-safe" build --build-tests -j 2; then
     echo "nightly-flake-stress: BUILD FAILED — see $work_dir/build.log" >&2
     tail -30 "$work_dir/build.log" >&2
     exit 2

--- a/scripts/nightly-flake-stress.sh
+++ b/scripts/nightly-flake-stress.sh
@@ -60,6 +60,9 @@ DEFAULT_ITERATIONS=10
 # its own much smaller count. Sized from the step budget, not from ambition.
 WHOLE_TARGET_ITERATIONS=3
 ITERATION_DEADLINE_S=600
+BUILD_DEADLINE_S=1800
+SWIFT_LOCK_TIMEOUT_S=1800
+SWIFT_DEADLINE_GRACE_S=30
 
 SPINNER_PIDS=()
 REPORT_DIR=""
@@ -134,6 +137,22 @@ run_with_deadline() {
   return $?
 }
 
+governed_outer_deadline() {
+  local command_deadline_s="$1"
+  echo $((SWIFT_LOCK_TIMEOUT_S + command_deadline_s + SWIFT_DEADLINE_GRACE_S))
+}
+
+# The command deadline starts only after swift-safe wins the machine-global
+# compile slot. The outer harness deadline must therefore cover both phases;
+# otherwise ordinary contention is mislabeled as a wedged test.
+run_governed_swift() {
+  local command_deadline_s="$1" log="$2"; shift 2
+  local outer_deadline_s; outer_deadline_s="$(governed_outer_deadline "$command_deadline_s")"
+  run_with_deadline "$outer_deadline_s" "$log" env \
+    TBD_SWIFT_LOCK_TIMEOUT_SECONDS="$SWIFT_LOCK_TIMEOUT_S" \
+    "$REPO_ROOT/scripts/swift-safe" "$@"
+}
+
 # The 1-MINUTE load average, which LAGS: measured here, the first iterations
 # after starting 6 spinners still reported ~7 while the run finished at ~24. It
 # is reported as `load1m` everywhere so nobody reads an early figure as the load
@@ -151,7 +170,7 @@ judge_iteration() {
   count="$(grep -oE 'Test run with [0-9]+ tests?' "$log" | grep -oE '[0-9]+' | head -1)"
 
   if [[ "$rc" -eq 124 ]]; then
-    echo "FAIL wedged — no completion within ${ITERATION_DEADLINE_S}s (killed by the harness deadline)"
+    echo "FAIL wedged — no completion within the governed outer deadline (lock wait + ${ITERATION_DEADLINE_S}s execution budget + grace)"
     return
   fi
   # A TRUNCATED LOG IS A FAILURE, NOT A PASS. A wedged run exits with no summary
@@ -198,8 +217,7 @@ run_target() {
     load_before="$(loadavg)"
     local rc=0
     # shellcheck disable=SC2086 # $filter is a deliberately word-split arg list
-    run_with_deadline "$ITERATION_DEADLINE_S" "$log" \
-      "$REPO_ROOT/scripts/swift-safe" test $filter || rc=$?
+    run_governed_swift "$ITERATION_DEADLINE_S" "$log" test $filter || rc=$?
     verdict="$(judge_iteration "$rc" "$log" "$floor")"
     if [[ "$verdict" == PASS* ]]; then
       pass_counts+=("${verdict#PASS }")
@@ -224,7 +242,7 @@ run_target() {
     echo "- Machine: $(sysctl -n hw.ncpu 2>/dev/null || nproc) cores, ${#SPINNER_PIDS[@]} induced spinners, load1m now: $(loadavg)"
     echo "  (\`load1m\` is the 1-minute average and LAGS the induced load — early iterations under-report it. The spinner count is the reliable half.)"
     echo "- Filter: \`swift test $filter\`, executed-test floor $floor"
-    echo "- Iteration deadline: ${ITERATION_DEADLINE_S}s (an outer timeout — \`.clockDriven\` was measured NOT bounding a hang)"
+    echo "- Execution budget: ${ITERATION_DEADLINE_S}s after admission; lock wait: up to ${SWIFT_LOCK_TIMEOUT_S}s; outer backstop: $(governed_outer_deadline "$ITERATION_DEADLINE_S")s"
     echo
     echo "Signatures:"
     echo
@@ -268,8 +286,8 @@ main() {
   # compile. `swift build` alone does NOT build test targets — `--build-tests` does.
   echo
   echo "building test targets (swift-safe build --build-tests -j 2)…"
-  if ! run_with_deadline 1800 "$work_dir/build.log" \
-    "$REPO_ROOT/scripts/swift-safe" build --build-tests -j 2; then
+  if ! run_governed_swift "$BUILD_DEADLINE_S" "$work_dir/build.log" \
+    build --build-tests -j 2; then
     echo "nightly-flake-stress: BUILD FAILED — see $work_dir/build.log" >&2
     tail -30 "$work_dir/build.log" >&2
     exit 2

--- a/scripts/nightly-flake-stress.test.sh
+++ b/scripts/nightly-flake-stress.test.sh
@@ -190,6 +190,32 @@ test_run_with_deadline_passes_through_a_fast_commands_status() {
   rm -rf "$d"
 }
 
+test_governed_swift_deadline_covers_lock_wait_and_command() {
+  local d; d="$(mktmpd)"
+  local fake_repo="$d/repo" args_file="$d/args"
+  mkdir -p "$fake_repo/scripts"
+  cat > "$fake_repo/scripts/swift-safe" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$TBD_SWIFT_LOCK_TIMEOUT_SECONDS|$*" > "$ARGS_FILE"
+EOF
+  chmod +x "$fake_repo/scripts/swift-safe"
+
+  local old_repo_root="${REPO_ROOT:-}" old_lock="$SWIFT_LOCK_TIMEOUT_S"
+  REPO_ROOT="$fake_repo"
+  SWIFT_LOCK_TIMEOUT_S=7
+  assert_eq "outer deadline includes lock wait, command budget, and grace" \
+    "48" "$(governed_outer_deadline 11)"
+  ARGS_FILE="$args_file" run_governed_swift 11 "$d/out.log" test --filter Foo
+
+  assert_eq "governed command receives the explicit lock timeout" \
+    "7|test --filter Foo" "$(cat "$args_file")"
+  assert_eq "governed command completes without consuming its outer deadline" \
+    "" "$(cat "$d/out.log")"
+  REPO_ROOT="$old_repo_root"
+  SWIFT_LOCK_TIMEOUT_S="$old_lock"
+  rm -rf "$d"
+}
+
 # ---------------------------------------------------------------------------
 # Target table
 # ---------------------------------------------------------------------------

--- a/scripts/reclaim-build.test.sh
+++ b/scripts/reclaim-build.test.sh
@@ -396,7 +396,7 @@ test_restart_sh_launches_reclaim_async_and_silent() {
   # shellcheck disable=SC2016
   nohup_ln="$(grep -nF 'nohup "$RECLAIM_SCRIPT"' "$restart" | head -1 | cut -d: -f1)"
   # shellcheck disable=SC2016
-  build_ln="$(grep -nF '(cd "$REPO_ROOT" && swift build' "$restart" | head -1 | cut -d: -f1)"
+  build_ln="$(grep -nF '(cd "$REPO_ROOT" && scripts/swift-safe build' "$restart" | head -1 | cut -d: -f1)"
   local order="unknown"
   if [[ -n "$nohup_ln" && -n "$build_ln" ]] && (( nohup_ln < build_ln )); then order="before"; fi
   assert_eq "reclaim launch (line ${nohup_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"
@@ -419,9 +419,10 @@ test_restart_sh_uses_shared_module_cache() {
   # The build line itself must carry the flags.
   local build_line
   # shellcheck disable=SC2016
-  build_line="$(grep -F '(cd "$REPO_ROOT" && swift build' "$restart")"
+  build_line="$(grep -F '(cd "$REPO_ROOT" && scripts/swift-safe build' "$restart")"
   # shellcheck disable=SC2016
-  assert_contains "build line passes the module-cache flags" "$build_line" 'swift build "${MODULE_CACHE_FLAGS[@]}"'
+  assert_contains "build line uses admission wrapper" "$build_line" 'scripts/swift-safe build'
+  assert_contains "build line passes the module-cache flags" "$build_line" 'build "${MODULE_CACHE_FLAGS[@]}"'
 
   # mkdir must precede the build so the first flagged build never races a
   # missing parent directory.
@@ -429,7 +430,7 @@ test_restart_sh_uses_shared_module_cache() {
   # shellcheck disable=SC2016
   mkdir_ln="$(grep -nF 'mkdir -p "$SHARED_MODULE_CACHE"' "$restart" | head -1 | cut -d: -f1)"
   # shellcheck disable=SC2016
-  build_ln="$(grep -nF '(cd "$REPO_ROOT" && swift build' "$restart" | head -1 | cut -d: -f1)"
+  build_ln="$(grep -nF '(cd "$REPO_ROOT" && scripts/swift-safe build' "$restart" | head -1 | cut -d: -f1)"
   local order="unknown"
   if [[ -n "$mkdir_ln" && -n "$build_ln" ]] && (( mkdir_ln < build_ln )); then order="before"; fi
   assert_eq "shared cache mkdir (line ${mkdir_ln:-?}) precedes swift build (line ${build_ln:-?})" "before" "$order"

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -125,7 +125,7 @@ fi
 # local ModuleCache drops to ~0 MB with this flag combo.
 #
 # Stickiness note: SwiftPM bakes the cache path into .build/debug.yaml at plan
-# time, so a later plain `swift build` in this worktree silently keeps using
+# time, so a later build in this worktree silently keeps using
 # the shared cache until a manifest re-plan — expected, not a bug. See
 # docs/reclaim-build.md ("Shared module cache").
 SHARED_MODULE_CACHE="$HOME/Library/Caches/tbd/swift-module-cache"
@@ -138,7 +138,7 @@ MODULE_CACHE_FLAGS=(
 if [ "$skip_build" = false ]; then
     echo "Building..."
     t0=$SECONDS
-    (cd "$REPO_ROOT" && swift build "${MODULE_CACHE_FLAGS[@]}") 2>&1 | tail -3
+    (cd "$REPO_ROOT" && scripts/swift-safe build "${MODULE_CACHE_FLAGS[@]}") 2>&1 | tail -3
     echo "  Build: $((SECONDS - t0))s"
 fi
 
@@ -147,7 +147,7 @@ fi
 # macOS resolves tbd:// URLs via LaunchServices, which requires a
 # CFBundleURLTypes entry in an Info.plist inside a .app bundle. We assemble
 # a minimal bundle in .build/debug/TBD.app whose binary is a symlink to
-# .build/debug/TBDApp, so swift build continues to update it directly.
+# .build/debug/TBDApp, so the governed Swift build updates it directly.
 
 BUNDLE_DIR="$BUILD_DIR/TBD.app"
 BUNDLE_MACOS="$BUNDLE_DIR/Contents/MacOS"
@@ -168,7 +168,7 @@ APP_EXEC_PATH="$(/usr/bin/readlink -f "$BUILD_DIR/TBDApp")"
 # .build/.../TBDApp with no surrounding .app, so APIs that depend on
 # CFBundleIdentifier (UNUserNotificationCenter for banners, etc.) silently
 # fail. A hard link shares the same inode as the swift-build output —
-# zero extra disk and `swift build` continues to update it directly —
+# zero extra disk and the governed Swift build updates it directly —
 # while keeping the kernel-reported exec path inside the .app bundle.
 # `ln -f` replaces any existing entry (including a stale symlink from
 # previous restart.sh versions) idempotently.

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Run SwiftPM behind a machine-global admission lock and bounded job count.
+
+Every TBD worktree shares the same default lock under ``~/tbd/runtime``.  This
+prevents otherwise-independent Claude sessions from each starting a full
+Swift compiler swarm on the same laptop.  The file may remain on disk: flock
+ownership is kernel-managed and is released when this process exits.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+
+
+DEFAULT_JOBS = 2
+MAX_JOBS = 4
+DEFAULT_TIMEOUT_SECONDS = 1_800.0
+COMPILE_SUBCOMMANDS = {"build", "run", "test"}
+SUPPORTED_SUBCOMMANDS = COMPILE_SUBCOMMANDS | {"package"}
+
+
+def _positive_number(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        raise SystemExit(f"{name} must be a positive number, got {raw!r}")
+    if value <= 0:
+        raise SystemExit(f"{name} must be positive, got {raw!r}")
+    return value
+
+
+def _positive_integer(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise SystemExit(f"{name} must be a positive integer, got {raw!r}")
+    if value <= 0:
+        raise SystemExit(f"{name} must be positive, got {raw!r}")
+    return value
+
+
+def _job_limit() -> int:
+    value = _positive_integer("TBD_SWIFT_JOBS", DEFAULT_JOBS)
+    if value > MAX_JOBS and os.environ.get("TBD_SWIFT_ALLOW_HIGH_JOBS") != "1":
+        raise SystemExit(
+            f"TBD_SWIFT_JOBS={value} exceeds the safe local ceiling {MAX_JOBS}; "
+            "set TBD_SWIFT_ALLOW_HIGH_JOBS=1 only for an isolated machine"
+        )
+    return value
+
+
+def _requested_jobs(arguments: list[str]) -> int | None:
+    for index, argument in enumerate(arguments):
+        if argument in {"-j", "--jobs"}:
+            if index + 1 >= len(arguments):
+                raise SystemExit(f"{argument} requires a numeric value")
+            try:
+                return int(arguments[index + 1])
+            except ValueError:
+                raise SystemExit(f"{argument} requires a numeric value")
+        if argument.startswith("--jobs="):
+            try:
+                return int(argument.split("=", 1)[1])
+            except ValueError:
+                raise SystemExit("--jobs requires a numeric value")
+        if argument.startswith("-j") and len(argument) > 2:
+            try:
+                return int(argument[2:])
+            except ValueError:
+                continue
+    return None
+
+
+def _bounded_arguments(subcommand: str, arguments: list[str]) -> list[str]:
+    result = [subcommand, *arguments]
+    if subcommand not in COMPILE_SUBCOMMANDS:
+        return result
+
+    limit = _job_limit()
+    requested = _requested_jobs(arguments)
+    if requested is None:
+        return [*result, "--jobs", str(limit)]
+    if requested <= 0:
+        raise SystemExit("SwiftPM --jobs must be positive")
+    if requested > limit and os.environ.get("TBD_SWIFT_ALLOW_HIGH_JOBS") != "1":
+        raise SystemExit(
+            f"requested SwiftPM --jobs {requested} exceeds TBD_SWIFT_JOBS={limit}; "
+            "lower the command or explicitly set TBD_SWIFT_ALLOW_HIGH_JOBS=1"
+        )
+    return result
+
+
+def _lock_path() -> Path:
+    explicit = os.environ.get("TBD_SWIFT_LOCK_PATH")
+    if explicit:
+        return Path(explicit).expanduser()
+    tbd_home = Path(os.environ.get("TBD_HOME", Path.home() / "tbd")).expanduser()
+    return tbd_home / "runtime" / "swift-build.lock"
+
+
+def _acquire(lock_file, timeout_seconds: float) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    announced = False
+    while True:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return
+        except BlockingIOError:
+            if not announced:
+                print(
+                    "swift-safe: another TBD worktree is compiling; waiting for "
+                    "the shared build slot",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                announced = True
+            if time.monotonic() >= deadline:
+                raise TimeoutError
+            time.sleep(min(0.25, max(0.01, deadline - time.monotonic())))
+
+
+def main(arguments: list[str]) -> int:
+    if not arguments or arguments[0] not in SUPPORTED_SUBCOMMANDS:
+        supported = "|".join(sorted(SUPPORTED_SUBCOMMANDS))
+        print(
+            f"usage: scripts/swift-safe <{supported}> [swift arguments...]",
+            file=sys.stderr,
+        )
+        return 64
+
+    subcommand, *swift_arguments = arguments
+    bounded = _bounded_arguments(subcommand, swift_arguments)
+    swift = os.environ.get("TBD_SWIFT_BIN") or shutil.which("swift")
+    if not swift:
+        print("swift-safe: swift executable not found", file=sys.stderr)
+        return 69
+
+    path = _lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    timeout = _positive_number(
+        "TBD_SWIFT_LOCK_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS
+    )
+
+    with path.open("a+", encoding="utf-8") as lock_file:
+        try:
+            _acquire(lock_file, timeout)
+        except TimeoutError:
+            print(
+                f"swift-safe: timed out after {timeout:g}s waiting for {path}",
+                file=sys.stderr,
+            )
+            return 75
+
+        lock_file.seek(0)
+        lock_file.truncate()
+        lock_file.write(
+            f"pid={os.getpid()}\ncwd={os.getcwd()}\ncommand=swift {' '.join(bounded)}\n"
+        )
+        lock_file.flush()
+        os.fsync(lock_file.fileno())
+        return subprocess.run([swift, *bounded], check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -13,7 +13,6 @@ import fcntl
 import os
 from pathlib import Path
 import shutil
-import subprocess
 import sys
 import time
 
@@ -22,7 +21,39 @@ DEFAULT_JOBS = 2
 MAX_JOBS = 4
 DEFAULT_TIMEOUT_SECONDS = 1_800.0
 COMPILE_SUBCOMMANDS = {"build", "run", "test"}
-SUPPORTED_SUBCOMMANDS = COMPILE_SUBCOMMANDS | {"package"}
+SUPPORTED_SUBCOMMANDS = COMPILE_SUBCOMMANDS
+RUN_OPTIONS_WITH_VALUES = {
+    "--build-system",
+    "--cache-path",
+    "--config-path",
+    "--configuration",
+    "--default-registry-url",
+    "--explicit-target-dependency-import-check",
+    "--jobs",
+    "--manifest-cache",
+    "--netrc-file",
+    "--package-path",
+    "--pkg-config-path",
+    "--resolver-fingerprint-checking",
+    "--resolver-signing-entity-checking",
+    "--sanitize",
+    "--scratch-path",
+    "--sdk",
+    "--security-path",
+    "--swift-sdk",
+    "--swift-sdks-path",
+    "--toolchain",
+    "--toolset",
+    "--traits",
+    "--triple",
+    "-Xcc",
+    "-Xcxx",
+    "-Xlinker",
+    "-Xswiftc",
+    "-c",
+    "-debug-info-format",
+    "-j",
+}
 
 
 def _positive_number(name: str, default: float) -> float:
@@ -83,14 +114,41 @@ def _requested_jobs(arguments: list[str]) -> int | None:
     return None
 
 
+def _run_swiftpm_arguments(arguments: list[str]) -> list[str]:
+    """Return only `swift run` options before the executable and app args."""
+    prefix: list[str] = []
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--":
+            break
+        if not argument.startswith("-"):
+            break
+        prefix.append(argument)
+        option = argument.split("=", 1)[0]
+        if option in RUN_OPTIONS_WITH_VALUES and "=" not in argument:
+            if index + 1 >= len(arguments):
+                break
+            prefix.append(arguments[index + 1])
+            index += 2
+            continue
+        index += 1
+    return prefix
+
+
 def _bounded_arguments(subcommand: str, arguments: list[str]) -> list[str]:
     result = [subcommand, *arguments]
     if subcommand not in COMPILE_SUBCOMMANDS:
         return result
 
     limit = _job_limit()
-    requested = _requested_jobs(arguments)
+    job_arguments = (
+        _run_swiftpm_arguments(arguments) if subcommand == "run" else arguments
+    )
+    requested = _requested_jobs(job_arguments)
     if requested is None:
+        if subcommand == "run":
+            return [subcommand, "--jobs", str(limit), *arguments]
         return [*result, "--jobs", str(limit)]
     if requested <= 0:
         raise SystemExit("SwiftPM --jobs must be positive")
@@ -170,7 +228,15 @@ def main(arguments: list[str]) -> int:
         )
         lock_file.flush()
         os.fsync(lock_file.fileno())
-        return subprocess.run([swift, *bounded], check=False).returncode
+        # Keep the kernel lock on the exact process that becomes SwiftPM. A
+        # wrapper subprocess would release the flock if killed while leaving
+        # an orphaned compiler alive, allowing the next worktree to overlap it.
+        os.set_inheritable(lock_file.fileno(), True)
+        try:
+            os.execv(swift, [swift, *bounded])
+        except OSError as error:
+            print(f"swift-safe: could not exec {swift}: {error}", file=sys.stderr)
+            return 71
 
 
 if __name__ == "__main__":

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -57,6 +57,16 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "test --filter Foo --jobs 2")
 
+    def test_run_puts_jobs_before_the_executable(self):
+        result = self.run_runner("run", "TBDApp", "--jobs", "99")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "run --jobs 2 TBDApp --jobs 99")
+
+    def test_run_honors_swiftpm_jobs_but_ignores_app_jobs(self):
+        result = self.run_runner("run", "-c", "release", "-j", "1", "TBDApp", "-j12")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "run -c release -j 1 TBDApp -j12")
+
     def test_existing_safe_job_count_is_preserved(self):
         result = self.run_runner("build", "-j", "1")
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -72,10 +82,37 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("must be a positive integer", result.stderr)
 
-    def test_package_command_is_locked_without_inventing_jobs_flag(self):
+    def test_non_compiling_package_commands_do_not_enter_the_governor(self):
         result = self.run_runner("package", "resolve")
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "package resolve")
+        self.assertEqual(result.returncode, 64)
+        self.assertIn("usage:", result.stderr)
+
+    def test_execed_swift_keeps_the_lock(self):
+        self.fake_swift.write_text(
+            "#!/bin/sh\nprintf 'ready\\n'\nsleep 30\n",
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env.update({"TBD_HOME": str(self.tbd_home), "TBD_SWIFT_BIN": str(self.fake_swift)})
+        first = subprocess.Popen(
+            [str(RUNNER), "build"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+        )
+        try:
+            self.assertEqual(first.stdout.readline().strip(), "ready")
+            result = self.run_runner(
+                "test", TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.05"
+            )
+            self.assertEqual(result.returncode, 75)
+            self.assertIn("timed out", result.stderr)
+        finally:
+            first.terminate()
+            first.wait(timeout=5)
+            first.stdout.close()
+            first.stderr.close()
 
     def test_contended_lock_times_out_without_spawning_swift(self):
         lock_path = self.tbd_home / "runtime" / "swift-build.lock"

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -1,0 +1,94 @@
+"""Black-box tests for scripts/swift-safe (stdlib only)."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNNER = REPO_ROOT / "scripts" / "swift-safe"
+
+
+class SwiftSafeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        root = Path(self.temp.name)
+        self.tbd_home = root / "tbd"
+        self.fake_swift = root / "swift"
+        self.fake_swift.write_text(
+            textwrap.dedent(
+                """\
+                #!/bin/sh
+                printf '%s\\n' "$*"
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.fake_swift.chmod(0o755)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def run_runner(self, *arguments, **extra_env):
+        env = os.environ.copy()
+        env.update(
+            {
+                "TBD_HOME": str(self.tbd_home),
+                "TBD_SWIFT_BIN": str(self.fake_swift),
+                **extra_env,
+            }
+        )
+        return subprocess.run(
+            [str(RUNNER), *arguments],
+            text=True,
+            capture_output=True,
+            env=env,
+            check=False,
+        )
+
+    def test_compile_commands_default_to_two_jobs(self):
+        result = self.run_runner("test", "--filter", "Foo")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "test --filter Foo --jobs 2")
+
+    def test_existing_safe_job_count_is_preserved(self):
+        result = self.run_runner("build", "-j", "1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "build -j 1")
+
+    def test_excessive_job_count_is_rejected(self):
+        result = self.run_runner("test", "-j12")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("exceeds TBD_SWIFT_JOBS=2", result.stderr)
+
+    def test_fractional_default_job_count_is_rejected(self):
+        result = self.run_runner("build", TBD_SWIFT_JOBS="2.5")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be a positive integer", result.stderr)
+
+    def test_package_command_is_locked_without_inventing_jobs_flag(self):
+        result = self.run_runner("package", "resolve")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "package resolve")
+
+    def test_contended_lock_times_out_without_spawning_swift(self):
+        lock_path = self.tbd_home / "runtime" / "swift-build.lock"
+        lock_path.parent.mkdir(parents=True)
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            result = self.run_runner(
+                "build", TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.05"
+            )
+        self.assertEqual(result.returncode, 75)
+        self.assertIn("timed out", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a machine-global SwiftPM admission lock shared by all TBD worktrees
- default compile commands to two jobs and reject unsafe job counts
- block raw agent-issued SwiftPM build/test/run commands
- route restart, mock, and nightly stress builds through the governor
- document the resource controls and update agent/contributor guidance

## Root cause

Multiple independent TBD workers launched raw SwiftPM commands simultaneously. Each defaulted to `-j12`; surviving `swift-build` and `swift-test` parents kept spawning replacement `swift-frontend` children after individual frontends were killed. One worker also ran a sequential build loop, so stopping a child advanced it to the next target. Four concurrent build roots drove load above 150 and swap to roughly 15 GB.

## Validation

- `python3 .claude/hooks/guardrails/dispatch.py --self-test` (40 passed)
- `python3 scripts/test-swift-safe.py` (6 passed)
- `bash scripts/reclaim-build.test.sh` (all passed)
- `scripts/swift-safe build --target TBDShared` (passed, 56.93s)
- `git diff --check`

The real build ran alone through the new admission path. After legacy build roots were interrupted, Swift compiler process counts remained at zero outside that controlled validation.