### PR TITLE
fix: v2 review state moves to a workflow-authored marker comment; document the shadow pipeline

### DIFF
--- a/.github/workflows/claude-code-review-v2.yml
+++ b/.github/workflows/claude-code-review-v2.yml
@@ -341,7 +341,7 @@ jobs:
               printf '%s\n' "<!-- claude-review-v2 -->"
               printf '%s\n' "<!-- last-reviewed-patch-id: $HEAD_PATCH_ID -->"
               printf '%s\n' "<!-- last-verdict: $VERDICT -->"
-              printf '%s\n' "_Review state marker for the [claude-review-v2 shadow check](https://github.com/$REPO/blob/$BASE_REF/.github/workflows/claude-code-review-v2.yml) — machine-read; see the review comment above._"
+              printf '%s\n' "_Review state marker for the [claude-review-v2 shadow check](https://github.com/$REPO/blob/$BASE_REF/.github/workflows/claude-code-review-v2.yml) — machine-read; see the latest review comment on this PR._"
               printf '\n%s\n' "> ⏭️ Review skipped — diff unchanged since the last review (patch-id match). Re-asserting the recorded verdict: $VERDICT. (The prior marker comment could not be found to update.)"
             } > "$note_file"
             gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@"$note_file" > /dev/null \
@@ -575,7 +575,7 @@ jobs:
             printf '%s\n' "<!-- claude-review-v2 -->"
             printf '%s\n' "<!-- last-reviewed-patch-id: $HEAD_PATCH_ID -->"
             printf '%s\n' "<!-- last-verdict: $verdict -->"
-            printf '%s\n' "_Review state marker for the [claude-review-v2 shadow check](https://github.com/$REPO/blob/$BASE_REF/.github/workflows/claude-code-review-v2.yml) — machine-read; see the review comment above._"
+            printf '%s\n' "_Review state marker for the [claude-review-v2 shadow check](https://github.com/$REPO/blob/$BASE_REF/.github/workflows/claude-code-review-v2.yml) — machine-read; see the latest review comment on this PR._"
           } > "$marker_file"
           if gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate > "$tmp/all-comments.json"; then
             # The startswith matcher is exact here: this workflow authors the

--- a/.github/workflows/claude-code-review-v2.yml
+++ b/.github/workflows/claude-code-review-v2.yml
@@ -140,9 +140,9 @@ jobs:
         # so the only files downstream steps can read are ones THIS run's scripts
         # and review session wrote. Without this a PR could commit e.g.
         # verdict.txt=APPROVE or a forged skip-decision.json and, if the session
-        # were killed or a step skipped, sail through the gate. (The prior-sticky
-        # body is written to $RUNNER_TEMP, outside the PR-controlled tree, for the
-        # same reason — see the fetch step below.)
+        # were killed or a step skipped, sail through the gate. (The prior
+        # marker-comment body is written to $RUNNER_TEMP, outside the
+        # PR-controlled tree, for the same reason — see the fetch step below.)
         run: |
           rm -f "$GITHUB_WORKSPACE/review-result.json" \
                 "$GITHUB_WORKSPACE/verdict.txt" \
@@ -214,7 +214,7 @@ jobs:
         id: app-token
         if: steps.trust.outputs.trusted == 'true'
         # A dedicated GitHub App whose slug contains "claude" (e.g. tbd-claude-reviewer)
-        # so comments post under a stable bot identity the fetch/patch steps below can
+        # so comments post under a stable bot identity the fetch/upsert steps below can
         # match on (and, in v1, so the action's sticky-comment matcher recognizes its
         # own prior comment). See docs/pr-review-gate.md. The OIDC-fallback exchange
         # 401s under pull_request_target (anthropics/claude-code-action#1017), and a
@@ -225,12 +225,15 @@ jobs:
           app-id: ${{ secrets.CLAUDE_REVIEWER_APP_ID }}
           private-key: ${{ secrets.CLAUDE_REVIEWER_APP_PRIVATE_KEY }}
 
-      - name: Fetch prior v2 sticky comment
+      - name: Fetch prior v2 marker comment
         if: steps.trust.outputs.trusted == 'true'
         # Finds the most recent comment on the PR that (a) was posted by the
-        # reviewer App and (b) starts with the v2 marker, and writes its body to
+        # reviewer App and (b) starts with the v2 marker. That is the dedicated
+        # MARKER comment — a small state-only comment written exclusively by this
+        # workflow's deterministic steps (the record/skip steps below), never by
+        # the review session, whose comment is pure prose. Its body is written to
         # $RUNNER_TEMP — deliberately OUTSIDE the PR-controlled workspace, so a PR
-        # cannot pre-commit a forged sticky body carrying its own patch-id +
+        # cannot pre-commit a forged marker body carrying its own patch-id +
         # APPROVE markers and skip its own review.
         #
         # Failure direction (prepare.py contract): if the API call FAILS, the file
@@ -259,7 +262,7 @@ jobs:
             | map(select(.user.login == $login and (.body | startswith("<!-- claude-review-v2 -->"))))
             | (last | .body) // ""
           ' "$all_comments" > "$RUNNER_TEMP/claude-review-v2/sticky-body.txt"
-          echo "Wrote prior sticky body ($(wc -c < "$RUNNER_TEMP/claude-review-v2/sticky-body.txt") bytes) for $APP_LOGIN."
+          echo "Wrote prior marker-comment body ($(wc -c < "$RUNNER_TEMP/claude-review-v2/sticky-body.txt") bytes) for $APP_LOGIN."
 
       - name: Prepare (skip decision + discussion context)
         id: prepare
@@ -289,34 +292,38 @@ jobs:
           echo "Skip decision: $(jq -c . skip-decision.json)"
 
       # ----------------------------------------------------------------------
-      # SKIP PATH (spec §3.5): the diff's patch-id matches the prior sticky's
-      # marker and its verdict marker parsed cleanly, so re-assert the recorded
-      # verdict without spending a review. The review-session, validate, and
+      # SKIP PATH (spec §3.5): the diff's patch-id matches the prior marker
+      # comment's patch-id and its verdict marker parsed cleanly, so re-assert
+      # the recorded verdict without spending a review. The review-session, validate, and
       # enforce steps below are all conditioned off; the two steps here are the
       # entire remainder of the job on this path.
       # ----------------------------------------------------------------------
 
-      - name: Update sticky comment (review skipped)
+      - name: Update marker comment (review skipped)
         if: steps.trust.outputs.trusted == 'true' && steps.prepare.outputs.skip == 'true'
-        # Refresh the existing sticky with a "review skipped" note while KEEPING
-        # its body — the prior findings and both markers must survive so (a) a
-        # REJECT re-assertion still shows the author what to fix and (b) the next
-        # identical push skips again. Any previous skip note is stripped first so
-        # repeated rebases don't accumulate them. Best-effort: a comment-update
-        # failure is warned, not fatal — the check outcome (next step) is the
-        # gate, and the unmodified prior sticky still carries correct markers.
+        # Refresh the marker comment with a visible "review skipped" note while
+        # KEEPING its marker lines — they must survive so the next identical push
+        # skips again. The session's review comment (the prose findings) is not
+        # touched on this path: it is still on the PR, so a REJECT re-assertion
+        # still shows the author what to fix. Any previous skip note is stripped
+        # first so repeated rebases don't accumulate them. Best-effort: a
+        # comment-update failure is warned, not fatal — the check outcome (next
+        # step) is the gate, and the unmodified marker comment still carries
+        # correct markers.
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           APP_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
           VERDICT: ${{ steps.prepare.outputs.verdict }}
+          HEAD_PATCH_ID: ${{ steps.prepare.outputs.head_patch_id }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -uo pipefail
           tmp="$RUNNER_TEMP/claude-review-v2"
           mkdir -p "$tmp"
           if ! gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate > "$tmp/all-comments.json"; then
-            echo "::warning::Could not fetch PR comments to add the skip note. The prior sticky already records this verdict; continuing."
+            echo "::warning::Could not fetch PR comments to add the skip note. The prior marker comment already records this verdict; continuing."
             exit 0
           fi
           comment_id="$(jq -s -r --arg login "$APP_LOGIN" '
@@ -325,21 +332,24 @@ jobs:
             | (last | .id) // ""
           ' "$tmp/all-comments.json")"
           if [ -z "$comment_id" ]; then
-            # Should be unreachable — the skip only fires off a fetched sticky —
-            # but if the comment vanished between fetch and now, re-post a
-            # minimal one re-asserting the verdict (markers first, so the next
-            # run's fetch matches it).
+            # Should be unreachable — the skip only fires off a fetched marker
+            # comment — but if it vanished between fetch and now, re-post one:
+            # the same body the record step writes (markers first, so the next
+            # run's fetch matches it), plus the skip note.
             note_file="$tmp/skip-note-body.txt"
             {
               printf '%s\n' "<!-- claude-review-v2 -->"
-              printf '%s\n' "<!-- last-reviewed-patch-id: ${{ steps.prepare.outputs.head_patch_id }} -->"
+              printf '%s\n' "<!-- last-reviewed-patch-id: $HEAD_PATCH_ID -->"
               printf '%s\n' "<!-- last-verdict: $VERDICT -->"
-              printf '\n%s\n' "> ⏭️ Review skipped — diff unchanged since the last review (patch-id match). Re-asserting the recorded verdict: $VERDICT. (The prior review comment could not be found to update.)"
+              printf '%s\n' "_Review state marker for the [claude-review-v2 shadow check](https://github.com/$REPO/blob/$BASE_REF/.github/workflows/claude-code-review-v2.yml) — machine-read; see the review comment above._"
+              printf '\n%s\n' "> ⏭️ Review skipped — diff unchanged since the last review (patch-id match). Re-asserting the recorded verdict: $VERDICT. (The prior marker comment could not be found to update.)"
             } > "$note_file"
             gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@"$note_file" > /dev/null \
-              || echo "::warning::Could not post the skip-note comment; continuing."
+              || echo "::warning::Could not re-post the marker comment with the skip note; continuing."
             exit 0
           fi
+          # Comment bodies fetched from the API are moved between files by jq
+          # only, never interpolated into the shell.
           jq -s -r --arg login "$APP_LOGIN" --arg verdict "$VERDICT" '
             add
             | map(select(.user.login == $login and (.body | startswith("<!-- claude-review-v2 -->"))))
@@ -349,8 +359,8 @@ jobs:
             | . + "\n\n> ⏭️ Review skipped — diff unchanged since the last review (patch-id match). Re-asserting the recorded verdict: " + $verdict + "."
           ' "$tmp/all-comments.json" > "$tmp/updated-body.txt"
           gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" -F body=@"$tmp/updated-body.txt" > /dev/null \
-            || echo "::warning::Could not update sticky comment $comment_id with the skip note; continuing."
-          echo "Sticky comment $comment_id updated with the skip note."
+            || echo "::warning::Could not update marker comment $comment_id with the skip note; continuing."
+          echo "Marker comment $comment_id updated with the skip note."
 
       - name: Enforce re-asserted verdict (review skipped)
         if: steps.trust.outputs.trusted == 'true' && steps.prepare.outputs.skip == 'true'
@@ -395,11 +405,15 @@ jobs:
           # No use_sticky_comment: v1 still owns the App's action-managed sticky
           # identity during the shadow soak, and the action's matcher keys on the
           # posting App, so opting in here could clobber v1's comment (spec §5).
-          # v2's "sticky" is instead the newest App comment starting with the
-          # <!-- claude-review-v2 --> marker: the session writes it via
+          # The session posts its prose review via
           # mcp__github_comment__update_claude_comment (updating the tracking
-          # comment track_progress creates for this run), and the fetch/patch
-          # steps select on the marker.
+          # comment track_progress creates for this run). That comment carries NO
+          # machine-read state: track_progress owns its body (it prepends its own
+          # "Claude finished ..." header — field-measured on the first real run),
+          # so marker lines written there do not survive. v2's machine-read state
+          # lives in a separate marker comment — the newest App comment starting
+          # with <!-- claude-review-v2 --> — that only the deterministic
+          # record/skip steps write and the fetch step selects on.
           track_progress: true
           # Installs a Stop hook that refuses to end the session until
           # review-result.json exists and parses as JSON. Unlike v1 it does NOT
@@ -459,11 +473,7 @@ jobs:
             - `disposition`: one entry for EVERY specialist finding id — action `kept`, `merged`, `downgraded`, or `dropped`, with `note` REQUIRED for downgraded/dropped (the validation script fails the job if any specialist id is unaccounted for).
             - `comment_body`: the review comment markdown, described next.
 
-            COMMENT BODY FORMAT (`comment_body`): it must BEGIN with these three lines exactly (the first line first — machine-matched by later runs):
-            <!-- claude-review-v2 -->
-            <!-- last-reviewed-patch-id: ${{ steps.prepare.outputs.head_patch_id }} -->
-            <!-- last-verdict: PENDING -->
-            Write `PENDING` literally: you do NOT know the final verdict — a script computes it after validation, and a workflow step replaces PENDING with the computed value (spec §3.5; the model never types the verdict). Then:
+            COMMENT BODY FORMAT (`comment_body`): prose only — include NO HTML comment markers and no other machine-read state (a separate comment written only by deterministic workflow steps records that; spec §3.5). You do NOT know the final verdict: a script computes it after validation — the model never types the verdict. The comment contains:
             - The verdict line at the very top of the visible text. The script's rule is: REJECT iff any HIGH or MEDIUM finding survives the merge, otherwise APPROVE. State REJECT-shaped language ("🧌 Changes requested") only if HIGH/MEDIUM findings survive; otherwise approval-shaped language ("✅ Looks good").
             - Each surviving HIGH/MEDIUM finding with file path and line numbers. Do not leave inline comments; do not use `mcp__github_inline_comment__create_inline_comment` — state file path and line numbers in this comment.
             - MINOR items tucked into an html <details><summary>..</summary> ... </details> section.
@@ -475,7 +485,7 @@ jobs:
               List any tool calls that failed or were denied (e.g. "Write to /tmp/ blocked", "gh api denied") — across the specialists too, if they reported any. If none failed, say so. This helps us tune the workflow permissions and allowedTools over time.
               </details>
 
-            STEP 3 — POST. Post the exact `comment_body` text as the review comment using `mcp__github_comment__update_claude_comment`. Do NOT use `gh pr comment` — it creates comments this pipeline cannot find or update later. Do NOT submit a formal GitHub review (no `gh pr review`). Do NOT write verdict.txt or claude-verdict.txt — the verdict is computed by the validation script from review-result.json. Your outputs are exactly: the two specialists' findings files (written by them), review-result.json, and the posted comment. A stop hook will refuse to let the session end until review-result.json exists and parses as JSON.
+            STEP 3 — POST. Post the exact `comment_body` text as the review comment using `mcp__github_comment__update_claude_comment`. Do NOT use `gh pr comment` — it creates a stray extra comment instead of updating this run's tracking comment. Do NOT submit a formal GitHub review (no `gh pr review`). Do NOT write verdict.txt or claude-verdict.txt — the verdict is computed by the validation script from review-result.json. Your outputs are exactly: the two specialists' findings files (written by them), review-result.json, and the posted comment. A stop hook will refuse to let the session end until review-result.json exists and parses as JSON.
           # 100 matches v1's budget rationale: 80 was set after a large review
           # (#364) exhausted its turns without writing its result (which fails
           # closed); the fan-out orchestration and the correctness specialist's
@@ -508,25 +518,29 @@ jobs:
             exit 1
           fi
 
-      - name: Patch verdict marker and enforce verdict
+      - name: Record verdict marker comment and enforce verdict
         if: steps.trust.outputs.trusted == 'true' && steps.prepare.outputs.skip != 'true'
         # Two duties, in this order:
-        # 1. Replace `<!-- last-verdict: PENDING -->` in the posted sticky with the
-        #    computed verdict. The session writes PENDING because the model never
-        #    knows (and must never type) the final verdict — validate.py computes
-        #    it (spec §3.5) — yet the NEXT run's skip decision reads the verdict
-        #    from the sticky's marker, so a deterministic step has to stamp it in.
-        #    Best-effort: if patching fails the marker stays PENDING, which
-        #    prepare.py treats as unrecognized and falls through to a full review
+        # 1. Upsert the dedicated marker comment recording this run's patch-id
+        #    and computed verdict — the state the NEXT run's skip decision reads.
+        #    The model never knows (and must never type) the verdict; validate.py
+        #    computes it (spec §3.5). It cannot live in the session's review
+        #    comment either: the posting action's track_progress mode owns that
+        #    comment's body and prepends its own header, so machine-read state
+        #    lives in a comment only this workflow's deterministic steps write.
+        #    Best-effort: if the upsert fails, no fresh marker comment records
+        #    this patch-id, so prepare.py falls through to a full review next run
         #    — failing toward a review, never toward a wrong skip.
         # 2. Enforce the verdict exactly like v1: whitespace-trimmed exact match,
         #    APPROVE passes, REJECT fails, anything else fails closed. Enforcement
-        #    comes AFTER the patch because a REJECT exits 1.
+        #    comes AFTER the upsert because a REJECT exits 1.
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           APP_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
+          HEAD_PATCH_ID: ${{ steps.prepare.outputs.head_patch_id }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -uo pipefail
           verdict_file="$GITHUB_WORKSPACE/verdict.txt"
@@ -548,49 +562,45 @@ jobs:
               exit 1 ;;
           esac
 
-          # --- 1. Stamp the verdict into the sticky's PENDING marker ---
+          # --- 1. Upsert the marker comment with this run's patch-id + verdict ---
+          # The body is built entirely from workflow-generated values: the verdict
+          # is validated APPROVE/REJECT above, and HEAD_PATCH_ID is
+          # script-generated hex (prepare.py) delivered via GITHUB_OUTPUT — safe
+          # to interpolate. Posted from a file (gh api -F body=@file) like every
+          # comment write in this workflow.
           tmp="$RUNNER_TEMP/claude-review-v2"
           mkdir -p "$tmp"
+          marker_file="$tmp/marker-body.txt"
+          {
+            printf '%s\n' "<!-- claude-review-v2 -->"
+            printf '%s\n' "<!-- last-reviewed-patch-id: $HEAD_PATCH_ID -->"
+            printf '%s\n' "<!-- last-verdict: $verdict -->"
+            printf '%s\n' "_Review state marker for the [claude-review-v2 shadow check](https://github.com/$REPO/blob/$BASE_REF/.github/workflows/claude-code-review-v2.yml) — machine-read; see the review comment above._"
+          } > "$marker_file"
           if gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate > "$tmp/all-comments.json"; then
+            # The startswith matcher is exact here: this workflow authors the
+            # marker comment itself, so its body genuinely BEGINS with the marker
+            # (no action-prepended header, unlike the session's review comment).
             comment_id="$(jq -s -r --arg login "$APP_LOGIN" '
               add
               | map(select(.user.login == $login and (.body | startswith("<!-- claude-review-v2 -->"))))
               | (last | .id) // ""
             ' "$tmp/all-comments.json")"
             if [ -n "$comment_id" ]; then
-              # Comment bodies are untrusted text: moved between files by jq only,
-              # never interpolated into the shell. jq `sub` replaces the first
-              # occurrence, which is the marker the session wrote at the top.
-              jq -s -r --arg login "$APP_LOGIN" '
-                add
-                | map(select(.user.login == $login and (.body | startswith("<!-- claude-review-v2 -->"))))
-                | last
-                | .body
-              ' "$tmp/all-comments.json" > "$tmp/original-body.txt"
-              jq -s -r --arg login "$APP_LOGIN" --arg verdict "$verdict" '
-                add
-                | map(select(.user.login == $login and (.body | startswith("<!-- claude-review-v2 -->"))))
-                | last
-                | .body
-                | sub("<!-- last-verdict: PENDING -->"; "<!-- last-verdict: " + $verdict + " -->")
-              ' "$tmp/all-comments.json" > "$tmp/patched-body.txt"
-              # Self-reporting check (same pattern as the merge-base step): jq sub
-              # returns its input UNCHANGED when the literal never matches, so an
-              # absent/mangled PENDING marker would otherwise "patch" silently.
-              # Fails safe either way (an unstamped marker means the next run does
-              # a full review, never a wrong skip) — but say so in the log.
-              if cmp -s "$tmp/original-body.txt" "$tmp/patched-body.txt"; then
-                echo "::warning::Sticky comment $comment_id contains no exact '<!-- last-verdict: PENDING -->' marker — verdict not stamped; the next run performs a full review instead of skipping."
-              elif gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" -F body=@"$tmp/patched-body.txt" > /dev/null; then
-                echo "Stamped verdict $verdict into sticky comment $comment_id."
+              if gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" -F body=@"$marker_file" > /dev/null; then
+                echo "Updated marker comment $comment_id (patch-id: ${HEAD_PATCH_ID:-<empty>}, verdict: $verdict)."
               else
-                echo "::warning::Could not update sticky comment $comment_id — its verdict marker stays PENDING, so the next run performs a full review instead of skipping."
+                echo "::warning::Could not update marker comment $comment_id — this run's verdict is not recorded, so the next run performs a full review instead of skipping."
               fi
             else
-              echo "::warning::No v2 sticky comment found to stamp the verdict into (the session may have failed to post) — the next run performs a full review instead of skipping."
+              if gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@"$marker_file" > /dev/null; then
+                echo "Posted new marker comment (patch-id: ${HEAD_PATCH_ID:-<empty>}, verdict: $verdict)."
+              else
+                echo "::warning::Could not post the marker comment — this run's verdict is not recorded, so the next run performs a full review instead of skipping."
+              fi
             fi
           else
-            echo "::warning::Could not fetch PR comments to stamp the verdict — the sticky's marker stays PENDING, so the next run performs a full review instead of skipping."
+            echo "::warning::Could not fetch PR comments to upsert the marker comment — this run's verdict is not recorded, so the next run performs a full review instead of skipping."
           fi
 
           # --- 2. Enforce ---

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -127,6 +127,23 @@ and gets no `claude-review` run — which leaves the required check unreported a
 the PR blocked. That is a one-time bootstrap gap: land such a PR with an admin
 merge, after which every subsequent PR is gated normally.
 
+## The v2 shadow pipeline
+
+A second review pipeline, `claude-review-v2`, runs alongside this gate as a
+**non-required** check, produced by
+[`.github/workflows/claude-code-review-v2.yml`](../.github/workflows/claude-code-review-v2.yml).
+It reviews with two specialist subagents and deterministic script bookends —
+schema-validated findings, a script-computed verdict, and a patch-id skip for
+unchanged diffs — and is designed to eventually replace this gate once its
+verdicts prove out against v1's on real PRs. Design and rollout plan:
+[`docs/specs/2026-08-03-pr-review-fanout-design.md`](specs/2026-08-03-pr-review-fanout-design.md).
+
+Both traps documented in this file apply to the v2 workflow identically: it runs
+on `pull_request_target` and must pass `github_token` explicitly, and changing
+its trigger event needs an admin merge. Graduation — swapping the required check
+from `claude-review` to `claude-review-v2` — is a branch-protection settings
+change, not a workflow change, so it springs neither trap.
+
 ## Operational notes
 
 - The gate is **fail-closed on infrastructure**: if the Anthropic API is down or

--- a/docs/specs/2026-08-03-pr-review-fanout-design.md
+++ b/docs/specs/2026-08-03-pr-review-fanout-design.md
@@ -40,8 +40,8 @@ The current merge gate (`.github/workflows/claude-code-review.yml`, check
   merge prompt requires a per-finding *disposition list* (§3.4) instead of a
   deterministic post-merge reconciliation check. Upgrade trigger recorded in §6.
 - **Skip-if-unchanged** — **patch-id skip only.** Skip the re-review when
-  `git patch-id` over the diff matches the marker in the prior sticky comment. No
-  discussion-content fingerprint in v1 (§6).
+  `git patch-id` over the diff matches the patch-id recorded in the prior run's
+  marker comment (§3.5). No discussion-content fingerprint in v1 (§6).
 - **PR discussion context** — **yes, trimmed.** Fetch human discussion once, render
   it into a sanitized, fenced, untrusted-data block the reviewer weighs but may not
   take instructions from (§3.6).
@@ -92,7 +92,7 @@ Initial specialist set (2, deliberately small):
 
 The orchestrator (same session, after specialists return) merges the findings lists:
 dedup (same file within a few lines = same finding), severity reconciliation, and the
-summary prose for the sticky comment. Output is one `review-result.json` holding the
+summary prose for the review comment. Output is one `review-result.json` holding the
 final findings array, the disposition list, and the comment body.
 
 ### 3.4 Disposition list (the prose accounting rule)
@@ -112,7 +112,7 @@ conventions-1: downgraded MEDIUM→MINOR — <reason>
 correctness-3: dropped — <reason>
 ```
 
-The disposition list is embedded in the posted sticky comment inside a collapsed
+The disposition list is embedded in the posted review comment inside a collapsed
 section, so a silent drop is at least *visible* to a human reading the review, and the
 validate script checks only its *presence* (an ID-coverage count), not its judgment.
 
@@ -127,18 +127,30 @@ validate script checks only its *presence* (an ID-coverage count), not its judgm
   enforces specialist-set completeness (`--expected-specialists`): if any named
   specialist never produced a findings file — e.g. the orchestrator merged before
   all background specialists completed — it fails closed with no verdict written.
-- **Sticky markers**: the sticky comment carries
-  `<!-- last-reviewed-patch-id: … -->` and `<!-- last-verdict: … -->` HTML comments.
+- **Marker comment**: the machine-read state — a `<!-- claude-review-v2 -->`
+  sentinel plus `<!-- last-reviewed-patch-id: … -->` and `<!-- last-verdict: … -->`
+  HTML comments — lives in a small dedicated PR comment that only deterministic
+  workflow steps create and update: after validation, a workflow step upserts it
+  (PATCH the App's newest sentinel-led comment, else POST one) with the run's
+  patch-id and computed verdict, plus one visible line pointing readers at the
+  review comment. The model session's review comment is pure prose and carries no
+  machine-read state: the posting action's progress-tracking mode owns that
+  comment's body (it prepends its own header), so machine-read state lives in a
+  comment only the workflow writes — which also keeps the markers out of the
+  model's hands entirely.
 - **Skip**: the prepare script computes `git patch-id --stable` over
-  `git diff base...HEAD`; if it equals the sticky's marker, the run short-circuits and
-  re-asserts the recorded verdict without spending a review. A new human comment does
-  **not** defeat the skip in v1 (accepted: a human can re-request review by pushing or
-  re-running the check).
-- **Skip fail-direction**: the skip fires only when the sticky fetch succeeded, both
-  markers parse, and the recorded verdict is exactly `APPROVE` or `REJECT`. Any other
-  state — fetch error, missing or malformed marker, unrecognized verdict — falls
-  through to a full review. The cheap direction to fail is toward spending a review,
-  never toward re-asserting a verdict we can't read.
+  `git diff base...HEAD`; if it equals the marker comment's recorded patch-id, the
+  run short-circuits and re-asserts the recorded verdict without spending a review,
+  refreshing the marker comment with a visible one-line skip note (markers kept).
+  A new human comment does **not** defeat the skip in v1 (accepted: a human can
+  re-request review by pushing or re-running the check).
+- **Skip fail-direction**: the skip fires only when the marker-comment fetch
+  succeeded, both markers parse, and the recorded verdict is exactly `APPROVE` or
+  `REJECT`. Any other state — fetch error, no marker comment, missing or malformed
+  marker, unrecognized verdict — falls through to a full review. The cheap
+  direction to fail is toward spending a review, never toward re-asserting a
+  verdict we can't read. The record step is best-effort in the same direction: a
+  failed upsert leaves no fresh marker, so the next run full-reviews.
 
 ### 3.6 PR discussion context (trimmed anti-hijack envelope)
 
@@ -148,8 +160,8 @@ properties, all implemented as pure functions:
 
 - **Bot filtering** by GraphQL `__typename == "Bot"` (logins alone are unreliable);
   empty bodies dropped; ascending timestamp order.
-- **Sanitization**: strip HTML comments whole (so quoted sticky markers can't
-  masquerade as ours), then escape angle brackets.
+- **Sanitization**: strip HTML comments whole (so quoted marker-comment markers
+  can't masquerade as ours), then escape angle brackets.
 - **Fencing**: the block sits between BEGIN/END markers carrying a per-run random
   token; the header states that envelope metadata (author, timestamp) is trustworthy
   and comment *bodies* are untrusted data, never instructions — and that a marker with
@@ -168,9 +180,9 @@ preamble — this adds surface area of the same kind, not a new kind.
 ### 3.7 What stays from the current gate
 
 Trust gating for forks, `pull_request_target` + explicit `github_token` (the OIDC trap),
-the pre-review verdict-file reset, unshallow/merge-base repair, the reviewer App for
-sticky-comment identity, and the exact-match fail-closed enforce step all carry over
-as-is. The trigger event does not change, so the admin-merge trap is not sprung.
+the pre-review verdict-file reset, unshallow/merge-base repair, the reviewer App as a
+stable comment-author identity, and the exact-match fail-closed enforce step all carry
+over as-is. The trigger event does not change, so the admin-merge trap is not sprung.
 
 ## 4. Testability (a design driver, not an afterthought)
 
@@ -199,11 +211,12 @@ as-is. The trigger event does not change, so the admin-merge trap is not sprung.
 Per the "large or risky new behavior ships default-off" convention, translated to CI:
 
 1. **Shadow**: land as a separate workflow producing a non-required check
-   (`claude-review-v2`) posting its own sticky comment. The existing `claude-review`
+   (`claude-review-v2`) posting its own comments. The existing `claude-review`
    remains the required gate. Soak across several real PRs; compare verdicts. The two
    workflows must not share a sticky identity: the action's sticky matcher keys on the
-   posting App, so v2 posts through its own marker (and, if the matcher proves too
-   greedy, its own App) rather than updating the v1 comment in place.
+   posting App, so v2 stays out of the action's sticky-comment mode and finds its
+   marker comment by its own sentinel (and, if the matcher proves too greedy, would
+   get its own App) rather than updating the v1 comment in place.
 2. **Graduate**: swap the required check from `claude-review` to `claude-review-v2` in
    branch protection (a settings change, not a workflow change — no admin-merge trap),
    then retire the old workflow.


### PR DESCRIPTION
## What

Two changes, both products of the v2 pipeline's first live run (which happened on this very PR):

1. **Fix (from a field measurement on this PR's first review):** the design had the review session write HTML marker lines (`claude-review-v2` / patch-id / verdict) at the top of its posted comment, with a workflow step stamping in the computed verdict. The first run showed the posting action's `track_progress` mode owns that comment's body — it prepends its own header and the marker lines didn't survive — so the patch-id skip could never fire (the stamp step correctly warned and failed toward a full review; no wrong-skip risk existed). Machine-read state now lives in a **dedicated small comment that only deterministic workflow steps create and update**; the session's review comment is pure prose. This brings the implementation fully in line with the spec's own principle that scripts own every machine-read decision. Spec §3.5 updated.

2. **Docs:** a short section in `docs/pr-review-gate.md` documenting that the `claude-review-v2` shadow check exists, that both `pull_request_target` traps apply to it identically, and that graduation is a branch-protection settings change.

## Verification

- 94 tests green (the marker mechanics live in workflow shell + the already-tested `parse_markers`/`decide_skip`, which are unchanged — they now parse a body that matches their expectations even better).
- YAML parses; zero `PENDING` references remain.
- Note: because `pull_request_target` runs the *base* branch's workflow, this fix takes effect on PRs opened after it merges — the first marker comment will appear on the next PR, and the patch-id skip becomes testable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUgeXxHP455HutsFvUZcxv