### PR TITLE
Feat: Let the hibernate idle threshold reach 24 hours instead of capping at 4

### DIFF
--- a/Sources/TBDApp/AppState+Hibernation.swift
+++ b/Sources/TBDApp/AppState+Hibernation.swift
@@ -32,7 +32,7 @@ extension AppState {
     /// Persist the auto-hibernate master switch + idle timeout, updating local
     /// published state optimistically.
     func setAutoHibernate(enabled: Bool, idleMinutes: Int) async {
-        let minutes = max(1, idleMinutes)
+        let minutes = min(max(Config.minHibernateIdleMinutes, idleMinutes), Config.maxHibernateIdleMinutes)
         do {
             try await daemonClient.setAutoHibernate(enabled: enabled, idleMinutes: minutes)
             autoHibernateEnabled = enabled

--- a/Sources/TBDApp/Settings/HibernateIdleDuration.swift
+++ b/Sources/TBDApp/Settings/HibernateIdleDuration.swift
@@ -109,3 +109,57 @@ struct HibernateIdleDuration: Equatable {
         return min(parsed, targetUnit.maxAmount)
     }
 }
+
+/// The outcome of reconciling the Settings field with a freshly read
+/// `appState.hibernateIdleMinutes` — see
+/// `HibernateIdleDuration.syncing(current:persistedMinutes:isFocused:force:)`.
+struct HibernateIdleSyncResult: Equatable {
+    var duration: HibernateIdleDuration
+    var amountText: String
+}
+
+extension HibernateIdleDuration {
+    /// Pure decision behind `SettingsView.syncHibernateIdleFromAppState`:
+    /// whether, and how, to reconcile the field with the daemon's
+    /// persisted value. Free of SwiftUI so it unit-tests without a view
+    /// host; the view owns only the SwiftUI plumbing (`.onAppear`,
+    /// `.onChange`, `@FocusState`) that calls this and applies the result.
+    ///
+    /// `isFocused` guards against an *external* delta stomping an
+    /// in-progress edit; it is skipped when `force` is true, which marks
+    /// this view reconciling its own settled commit RPC rather than an
+    /// external change (success or failure — see
+    /// `SettingsView.applyHibernateIdleDuration`). Returns `nil` — no
+    /// change — only when that guard blocks the sync outright.
+    ///
+    /// When the guard passes, `duration` re-derives amount+unit from
+    /// `persistedMinutes` ONLY when the totals actually differ — a
+    /// genuine external delta. Re-deriving unconditionally would undo the
+    /// user's deliberately chosen unit: committing "120" with unit
+    /// Minutes would otherwise silently renormalize to "2 Hours" the
+    /// moment the round-trip lands and this fires again with an unchanged
+    /// total.
+    ///
+    /// `amountText`, however, is always recomputed from the (possibly
+    /// unchanged) `duration.amount` whenever the guard passes — it does
+    /// NOT share the totals-differ condition above. That distinction is
+    /// what keeps the field populated the first time this fires: on
+    /// `.onAppear`, `current` (the view's `@State` default) and
+    /// `persistedMinutes` (loaded from the daemon) both routinely equal
+    /// the shipped 30-minute default, so totals agree and `duration`
+    /// stays as-is — but the text field still needs its initial value
+    /// written, or it renders blank for the session (the regression this
+    /// type exists to make testable).
+    static func syncing(
+        current: HibernateIdleDuration,
+        persistedMinutes: Int,
+        isFocused: Bool,
+        force: Bool
+    ) -> HibernateIdleSyncResult? {
+        guard force || !isFocused else { return nil }
+        let duration = current.totalMinutes != persistedMinutes
+            ? HibernateIdleDuration(totalMinutes: persistedMinutes)
+            : current
+        return HibernateIdleSyncResult(duration: duration, amountText: String(duration.amount))
+    }
+}

--- a/Sources/TBDApp/Settings/HibernateIdleDuration.swift
+++ b/Sources/TBDApp/Settings/HibernateIdleDuration.swift
@@ -1,0 +1,111 @@
+import Foundation
+import TBDShared
+
+/// Field+unit split for editing `Config.hibernateIdleMinutes` in the Settings
+/// UI. Replaces a `Stepper` capped at 240 minutes (48 clicks to reach a day,
+/// impossible past 4 hours) with a numeric amount plus a unit picker spanning
+/// `Config.minHibernateIdleMinutes...Config.maxHibernateIdleMinutes` (1 minute
+/// to 99 days).
+///
+/// Deliberately free of SwiftUI so it unit-tests without a view host — the
+/// view owns the `TextField`/`Picker` and the commit-on-blur/submit timing;
+/// this type just knows how to pick a sensible unit for a total and convert
+/// back.
+struct HibernateIdleDuration: Equatable {
+    enum Unit: String, CaseIterable, Identifiable {
+        case minutes
+        case hours
+        case days
+
+        var id: String { rawValue }
+
+        var minutesPerUnit: Int {
+            switch self {
+            case .minutes: return 1
+            case .hours: return 60
+            case .days: return 60 * 24
+            }
+        }
+
+        /// Singular/plural-aware display name, e.g. "1 hour" vs "2 hours".
+        func displayName(count: Int) -> String {
+            let plural = count != 1
+            switch self {
+            case .minutes: return plural ? "minutes" : "minute"
+            case .hours: return plural ? "hours" : "hour"
+            case .days: return plural ? "days" : "day"
+            }
+        }
+
+        /// The largest whole amount of this unit that stays within
+        /// `Config.maxHibernateIdleMinutes` — bounds the amount field so it
+        /// can never express an out-of-range total.
+        var maxAmount: Int {
+            Config.maxHibernateIdleMinutes / minutesPerUnit
+        }
+    }
+
+    /// The accepted total-minutes range, mirroring `Config`'s bounds.
+    static let range = Config.minHibernateIdleMinutes...Config.maxHibernateIdleMinutes
+
+    var amount: Int
+    var unit: Unit
+
+    /// Picks the **largest unit that divides `totalMinutes` evenly** and
+    /// whose amount is a whole number >= 1, so a round total displays round
+    /// (1440 -> 1 day, 120 -> 2 hours, 90 -> 90 minutes, 30 -> 30 minutes).
+    /// Falls back to minutes when no larger unit divides evenly. Input is
+    /// clamped to `Self.range` first.
+    init(totalMinutes: Int) {
+        let clamped = Self.clamp(totalMinutes)
+        for candidate in [Unit.days, .hours] {
+            let perUnit = candidate.minutesPerUnit
+            if clamped % perUnit == 0, clamped / perUnit >= 1 {
+                self.amount = clamped / perUnit
+                self.unit = candidate
+                return
+            }
+        }
+        self.amount = clamped
+        self.unit = .minutes
+    }
+
+    /// Direct constructor for a field+unit pair the view already validated
+    /// (e.g. a freshly parsed amount paired with the picker's current unit).
+    init(amount: Int, unit: Unit) {
+        self.amount = amount
+        self.unit = unit
+    }
+
+    /// The total in minutes, clamped to `Self.range`. Overflow-safe: an
+    /// out-of-range `amount` (a caller skipping the view's validation, or a
+    /// pathological test input) saturates to `Int.max` before clamping
+    /// rather than trapping on the multiply.
+    var totalMinutes: Int {
+        let product = amount.multipliedReportingOverflow(by: unit.minutesPerUnit)
+        let raw = product.overflow ? Int.max : product.partialValue
+        return Self.clamp(raw)
+    }
+
+    private static func clamp(_ minutes: Int) -> Int {
+        min(max(minutes, Self.range.lowerBound), Self.range.upperBound)
+    }
+
+    /// Resolve the amount to apply for `targetUnit` from user-typed text,
+    /// treating `self` as the last committed duration to fall back to.
+    /// Shared by the Settings amount field's commit and the unit picker's
+    /// reinterpret-on-change commit — one rule for both: text that fails to
+    /// parse, is empty, or is zero/negative reverts to `self.amount` (the
+    /// last committed value); text that parses to a positive number but
+    /// exceeds what `targetUnit` can express clamps to `targetUnit.maxAmount`
+    /// instead of reverting the whole edit. Pure and view-independent so it
+    /// unit-tests without a view host; the caller re-derives its displayed
+    /// text from the duration it applies with the result.
+    func resolveAmount(fromText text: String, targetUnit: Unit) -> Int {
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        guard let parsed = Int(trimmed), parsed >= 1 else {
+            return min(amount, targetUnit.maxAmount)
+        }
+        return min(parsed, targetUnit.maxAmount)
+    }
+}

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -47,6 +47,14 @@ struct GeneralSettingsTab: View {
     @AppStorage("errorNotificationSoundName") private var errorSoundName: String = "Sosumi"
     @AppStorage("errorNotificationSoundCustomPath") private var errorCustomPath: String = ""
 
+    /// In-progress amount text for the hibernate-idle-threshold field. Kept
+    /// separate from the committed `hibernateIdleDuration` so a keystroke
+    /// never fires an RPC — only `.onSubmit` / focus-loss / a unit-picker
+    /// change commits (see `hibernateIdleThresholdRow`).
+    @State private var hibernateIdleAmountText: String = ""
+    @State private var hibernateIdleDuration = HibernateIdleDuration(totalMinutes: Config.defaultHibernateIdleMinutes)
+    @FocusState private var hibernateIdleFieldFocused: Bool
+
     private var systemSounds: [String] { NotificationSoundPlayer.systemSoundNames() }
     private let soundPlayer = NotificationSoundPlayer()
 
@@ -191,19 +199,7 @@ struct GeneralSettingsTab: View {
                 .help("Kill the claude process of a session idle at rest, keeping its tab alive. It respawns automatically on focus. The prompt cache has already expired by then, so resume is cheap. Never touches a running turn, a permission prompt, or a keep-warm session.")
 
                 if appState.autoHibernateEnabled {
-                    Stepper(
-                        "Idle before hibernating: \(appState.hibernateIdleMinutes) min",
-                        value: Binding(
-                            get: { appState.hibernateIdleMinutes },
-                            set: { newValue in
-                                Task { await appState.setAutoHibernate(
-                                    enabled: appState.autoHibernateEnabled, idleMinutes: newValue) }
-                            }
-                        ),
-                        in: 5...240,
-                        step: 5
-                    )
-                    .help("How long a Claude session must sit idle before it's hibernated.")
+                    hibernateIdleThresholdRow
                 }
             }
 
@@ -317,6 +313,111 @@ struct GeneralSettingsTab: View {
             set: { newValue in Task { await appState.setAutoTrustWorktrees(newValue) } }
         ))
         .help("Answer Claude's \u{201C}do you trust the files in this folder?\u{201D} prompt ahead of time for worktrees TBD created and for the checkout of each repo you added. You registered the repo and TBD made the worktree, so the answer is already known \u{2014} and the prompt blocks before any Claude hook fires, so a session waiting on it looks idle to TBD instead of stuck. Worktrees checked out from a pull request head are never pre-trusted, on or off: their files may come from someone else's fork, which is exactly what the prompt is for. On by default. Turning it off stops any further pre-trusting, including for worktrees that already exist; nothing already trusted is undone, and TBD's own scratch spaces are always trusted.")
+    }
+
+    /// Amount + unit control for `Config.hibernateIdleMinutes`, replacing a
+    /// `Stepper` that was capped at 240 minutes / 5-minute steps (48 clicks
+    /// for a day, impossible past 4 hours). Never fires an RPC per keystroke:
+    /// the amount commits on `.onSubmit` or focus loss, the unit commits
+    /// immediately on picker change. `HibernateIdleDuration` (its own file)
+    /// holds the pure amount/unit math; this view owns only the SwiftUI
+    /// commit timing.
+    @ViewBuilder
+    private var hibernateIdleThresholdRow: some View {
+        HStack {
+            Text("Idle before hibernating:")
+            TextField("", text: $hibernateIdleAmountText)
+                .frame(width: 56)
+                .multilineTextAlignment(.trailing)
+                .focused($hibernateIdleFieldFocused)
+                .onSubmit { commitHibernateIdleAmount() }
+            Picker("", selection: hibernateIdleUnitBinding) {
+                ForEach(HibernateIdleDuration.Unit.allCases) { unit in
+                    Text(unit.displayName(count: hibernateIdleDisplayAmount).capitalized)
+                        .tag(unit)
+                }
+            }
+            .labelsHidden()
+            .frame(width: 100)
+        }
+        .help("How long a Claude session must sit idle before it's hibernated. Accepts 1 minute to 99 days. Below about 5 minutes, the prompt cache may not have expired yet, so resume can cost more.")
+        .onAppear { syncHibernateIdleFromAppState() }
+        .onChange(of: appState.hibernateIdleMinutes) { _, _ in syncHibernateIdleFromAppState() }
+        .onChange(of: hibernateIdleFieldFocused) { _, focused in
+            if !focused { commitHibernateIdleAmount() }
+        }
+    }
+
+    /// The amount used to pluralize the unit-picker labels: the in-progress
+    /// typed value when it parses, otherwise the last committed amount — so
+    /// "1" -> "Minute" updates live as the user types, without waiting for
+    /// commit.
+    private var hibernateIdleDisplayAmount: Int {
+        Int(hibernateIdleAmountText.trimmingCharacters(in: .whitespaces)) ?? hibernateIdleDuration.amount
+    }
+
+    /// Unit-picker binding. Changing the unit commits immediately (unlike the
+    /// amount field), reinterpreting the currently-typed amount in the new
+    /// unit — 2 + hours -> Days means 2 days, not an equivalent-total
+    /// conversion. Uses the same resolve rule as `commitHibernateIdleAmount`
+    /// (see `HibernateIdleDuration.resolveAmount(fromText:targetUnit:)`).
+    private var hibernateIdleUnitBinding: Binding<HibernateIdleDuration.Unit> {
+        Binding(
+            get: { hibernateIdleDuration.unit },
+            set: { newUnit in
+                let amount = hibernateIdleDuration.resolveAmount(fromText: hibernateIdleAmountText, targetUnit: newUnit)
+                applyHibernateIdleDuration(HibernateIdleDuration(amount: amount, unit: newUnit))
+            }
+        )
+    }
+
+    /// Re-sync the field from the daemon's current value. Called on appear,
+    /// after this view's own commit RPC settles (`applyHibernateIdleDuration`
+    /// — success or failure), and whenever `appState.hibernateIdleMinutes`
+    /// changes externally (a config delta from another window/session) — but
+    /// never while the field is focused, so it can't stomp on an in-progress
+    /// edit.
+    ///
+    /// Returns early when the local duration's total already agrees with
+    /// `appState.hibernateIdleMinutes`: there is nothing to sync, and
+    /// re-deriving amount+unit from the total would undo the user's
+    /// deliberately chosen unit even though nothing actually changed —
+    /// typing "120" with unit Minutes and clicking away would otherwise
+    /// silently renormalize to "2 Hours" the moment the commit round-trips
+    /// and this fires from `.onChange(of: appState.hibernateIdleMinutes)`.
+    /// Only a genuine external delta — a different total — re-derives the
+    /// unit.
+    private func syncHibernateIdleFromAppState() {
+        guard !hibernateIdleFieldFocused else { return }
+        guard hibernateIdleDuration.totalMinutes != appState.hibernateIdleMinutes else { return }
+        hibernateIdleDuration = HibernateIdleDuration(totalMinutes: appState.hibernateIdleMinutes)
+        hibernateIdleAmountText = String(hibernateIdleDuration.amount)
+    }
+
+    /// Commit the typed amount for the current unit. See
+    /// `HibernateIdleDuration.resolveAmount(fromText:targetUnit:)` for the
+    /// revert-vs-clamp rule, shared with `hibernateIdleUnitBinding`.
+    private func commitHibernateIdleAmount() {
+        let amount = hibernateIdleDuration.resolveAmount(fromText: hibernateIdleAmountText, targetUnit: hibernateIdleDuration.unit)
+        applyHibernateIdleDuration(HibernateIdleDuration(amount: amount, unit: hibernateIdleDuration.unit))
+    }
+
+    /// Commit a validated duration: update local state immediately (so the
+    /// field/picker reflect it without waiting on the RPC round-trip),
+    /// persist via the same `setAutoHibernate` path the master-switch toggle
+    /// uses, and then re-sync from `appState` once the RPC settles. On
+    /// success this is a no-op (the persisted total now matches, so
+    /// `syncHibernateIdleFromAppState` returns early and the chosen unit
+    /// survives); on failure `appState.hibernateIdleMinutes` never moved, so
+    /// the re-sync reverts the field to what is actually persisted instead
+    /// of stranding an unsaved value that silently looks committed.
+    private func applyHibernateIdleDuration(_ duration: HibernateIdleDuration) {
+        hibernateIdleDuration = duration
+        hibernateIdleAmountText = String(duration.amount)
+        Task {
+            await appState.setAutoHibernate(enabled: appState.autoHibernateEnabled, idleMinutes: duration.totalMinutes)
+            syncHibernateIdleFromAppState()
+        }
     }
 
     /// Remote agent sessions master switch. Reads the persisted flag from

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -54,6 +54,10 @@ struct GeneralSettingsTab: View {
     @State private var hibernateIdleAmountText: String = ""
     @State private var hibernateIdleDuration = HibernateIdleDuration(totalMinutes: Config.defaultHibernateIdleMinutes)
     @FocusState private var hibernateIdleFieldFocused: Bool
+    /// Bumped on every `applyHibernateIdleDuration` call so a commit's
+    /// post-await re-sync can detect a newer commit landed while it was in
+    /// flight and skip applying its now-stale response.
+    @State private var hibernateIdleCommitGeneration = 0
 
     private var systemSounds: [String] { NotificationSoundPlayer.systemSoundNames() }
     private let soundPlayer = NotificationSoundPlayer()
@@ -372,23 +376,32 @@ struct GeneralSettingsTab: View {
     }
 
     /// Re-sync the field from the daemon's current value. Called on appear,
-    /// after this view's own commit RPC settles (`applyHibernateIdleDuration`
-    /// — success or failure), and whenever `appState.hibernateIdleMinutes`
-    /// changes externally (a config delta from another window/session) — but
-    /// never while the field is focused, so it can't stomp on an in-progress
-    /// edit.
+    /// whenever `appState.hibernateIdleMinutes` changes externally (a config
+    /// delta from another window/session), and — with `force: true` — after
+    /// this view's own commit RPC settles (`applyHibernateIdleDuration` —
+    /// success or failure).
     ///
-    /// Returns early when the local duration's total already agrees with
-    /// `appState.hibernateIdleMinutes`: there is nothing to sync, and
-    /// re-deriving amount+unit from the total would undo the user's
-    /// deliberately chosen unit even though nothing actually changed —
-    /// typing "120" with unit Minutes and clicking away would otherwise
+    /// The focus guard exists only to stop an *external* delta from stomping
+    /// an in-progress edit; it is skipped when `force` is true. That
+    /// distinction matters because `.onSubmit` does not resign first
+    /// responder on macOS: pressing Return leaves the field focused while
+    /// its own commit RPC is in flight, so a non-forced sync would silently
+    /// swallow the revert-on-failure this view relies on, leaving an
+    /// unpersisted value on screen until the user happens to click away.
+    /// This view reconciling its own settled write is not an external
+    /// delta, so it always applies regardless of focus.
+    ///
+    /// Returns early — force or not — when the local duration's total
+    /// already agrees with `appState.hibernateIdleMinutes`: there is nothing
+    /// to sync, and re-deriving amount+unit from the total would undo the
+    /// user's deliberately chosen unit even though nothing actually changed
+    /// — typing "120" with unit Minutes and clicking away would otherwise
     /// silently renormalize to "2 Hours" the moment the commit round-trips
     /// and this fires from `.onChange(of: appState.hibernateIdleMinutes)`.
     /// Only a genuine external delta — a different total — re-derives the
     /// unit.
-    private func syncHibernateIdleFromAppState() {
-        guard !hibernateIdleFieldFocused else { return }
+    private func syncHibernateIdleFromAppState(force: Bool = false) {
+        guard force || !hibernateIdleFieldFocused else { return }
         guard hibernateIdleDuration.totalMinutes != appState.hibernateIdleMinutes else { return }
         hibernateIdleDuration = HibernateIdleDuration(totalMinutes: appState.hibernateIdleMinutes)
         hibernateIdleAmountText = String(hibernateIdleDuration.amount)
@@ -405,18 +418,31 @@ struct GeneralSettingsTab: View {
     /// Commit a validated duration: update local state immediately (so the
     /// field/picker reflect it without waiting on the RPC round-trip),
     /// persist via the same `setAutoHibernate` path the master-switch toggle
-    /// uses, and then re-sync from `appState` once the RPC settles. On
-    /// success this is a no-op (the persisted total now matches, so
-    /// `syncHibernateIdleFromAppState` returns early and the chosen unit
-    /// survives); on failure `appState.hibernateIdleMinutes` never moved, so
-    /// the re-sync reverts the field to what is actually persisted instead
-    /// of stranding an unsaved value that silently looks committed.
+    /// uses, and then force a re-sync from `appState` once the RPC settles —
+    /// `force: true` because this is the view reconciling its own settled
+    /// write, not an external delta, so the focus guard in
+    /// `syncHibernateIdleFromAppState` must not apply here (see that
+    /// method's doc comment). On success the force-sync is still a no-op
+    /// (the persisted total now matches, so the totals-agree early return
+    /// fires and the chosen unit survives); on failure
+    /// `appState.hibernateIdleMinutes` never moved, so the re-sync reverts
+    /// the field to what is actually persisted instead of stranding an
+    /// unsaved value that silently looks committed.
+    ///
+    /// The amount commit and the unit-picker commit can each land in this
+    /// method while the other's RPC is still in flight. `hibernateIdleCommitGeneration`
+    /// tags each call so a response that settles after a newer commit was
+    /// already issued skips its re-sync instead of clobbering the newer
+    /// commit's local state with a stale round-trip.
     private func applyHibernateIdleDuration(_ duration: HibernateIdleDuration) {
         hibernateIdleDuration = duration
         hibernateIdleAmountText = String(duration.amount)
+        hibernateIdleCommitGeneration += 1
+        let generation = hibernateIdleCommitGeneration
         Task {
             await appState.setAutoHibernate(enabled: appState.autoHibernateEnabled, idleMinutes: duration.totalMinutes)
-            syncHibernateIdleFromAppState()
+            guard generation == hibernateIdleCommitGeneration else { return }
+            syncHibernateIdleFromAppState(force: true)
         }
     }
 

--- a/Sources/TBDApp/Settings/SettingsView.swift
+++ b/Sources/TBDApp/Settings/SettingsView.swift
@@ -391,20 +391,27 @@ struct GeneralSettingsTab: View {
     /// This view reconciling its own settled write is not an external
     /// delta, so it always applies regardless of focus.
     ///
-    /// Returns early — force or not — when the local duration's total
-    /// already agrees with `appState.hibernateIdleMinutes`: there is nothing
-    /// to sync, and re-deriving amount+unit from the total would undo the
-    /// user's deliberately chosen unit even though nothing actually changed
-    /// — typing "120" with unit Minutes and clicking away would otherwise
-    /// silently renormalize to "2 Hours" the moment the commit round-trips
-    /// and this fires from `.onChange(of: appState.hibernateIdleMinutes)`.
-    /// Only a genuine external delta — a different total — re-derives the
-    /// unit.
+    /// The decision itself lives in the pure, view-free
+    /// `HibernateIdleDuration.syncing(current:persistedMinutes:isFocused:force:)`
+    /// (unit-tested in `HibernateIdleDurationTests`): amount+unit re-derive
+    /// from the persisted total only on a genuine external delta (so a
+    /// same-total round-trip does not renormalize "120 Minutes" to
+    /// "2 Hours"), but the displayed text always refreshes from the
+    /// resulting amount whenever the focus guard allows a sync at all —
+    /// including when the total didn't change, which is what keeps the
+    /// field populated on first appearance instead of rendering blank for
+    /// the whole view lifetime when the persisted value already equals this
+    /// view's `@State` default (the shipped 30-minute default, for most
+    /// users).
     private func syncHibernateIdleFromAppState(force: Bool = false) {
-        guard force || !hibernateIdleFieldFocused else { return }
-        guard hibernateIdleDuration.totalMinutes != appState.hibernateIdleMinutes else { return }
-        hibernateIdleDuration = HibernateIdleDuration(totalMinutes: appState.hibernateIdleMinutes)
-        hibernateIdleAmountText = String(hibernateIdleDuration.amount)
+        guard let result = HibernateIdleDuration.syncing(
+            current: hibernateIdleDuration,
+            persistedMinutes: appState.hibernateIdleMinutes,
+            isFocused: hibernateIdleFieldFocused,
+            force: force
+        ) else { return }
+        hibernateIdleDuration = result.duration
+        hibernateIdleAmountText = result.amountText
     }
 
     /// Commit the typed amount for the current unit. See
@@ -422,9 +429,11 @@ struct GeneralSettingsTab: View {
     /// `force: true` because this is the view reconciling its own settled
     /// write, not an external delta, so the focus guard in
     /// `syncHibernateIdleFromAppState` must not apply here (see that
-    /// method's doc comment). On success the force-sync is still a no-op
-    /// (the persisted total now matches, so the totals-agree early return
-    /// fires and the chosen unit survives); on failure
+    /// method's doc comment). On success the force-sync re-applies the same
+    /// amount/text this method already set locally — the persisted total
+    /// now matches, so `HibernateIdleDuration.syncing` skips re-deriving
+    /// amount+unit and the chosen unit survives, while the text it writes
+    /// is identical to what is already on screen; on failure
     /// `appState.hibernateIdleMinutes` never moved, so the re-sync reverts
     /// the field to what is actually persisted instead of stranding an
     /// unsaved value that silently looks committed.

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -58,7 +58,17 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             nightwatchMode: nightwatch_mode
                 .flatMap(NightwatchMode.init(rawValue:)) ?? .off,
             autoHibernateEnabled: auto_hibernate_enabled ?? false,
-            hibernateIdleMinutes: hibernate_idle_minutes ?? Config.defaultHibernateIdleMinutes,
+            // Clamped on read (not just on write) so every consumer sees a
+            // bounded value regardless of what's actually in the row — a
+            // hand-edited DB, a value written by an older/newer daemon
+            // build, or any other row that bypassed `setAutoHibernate`.
+            hibernateIdleMinutes: min(
+                max(
+                    hibernate_idle_minutes ?? Config.defaultHibernateIdleMinutes,
+                    Config.minHibernateIdleMinutes
+                ),
+                Config.maxHibernateIdleMinutes
+            ),
             controlModeEnabled: control_mode_enabled ?? false,
             autoResumeOnApiError: auto_resume_on_api_error ?? false,
             hibernateInputVetoEnabled: hibernate_input_veto_enabled ?? false,
@@ -241,9 +251,13 @@ public struct ConfigStore: Sendable {
 
     /// Persist the auto-hibernate master switch + idle-timeout (minutes). The
     /// minutes value is floored at 1 so a zero/negative can't make the idle
-    /// timer hibernate everything on the next sweep.
+    /// timer hibernate everything on the next sweep, and ceilinged at 99 days
+    /// so a stale or hand-edited value can't produce an absurd timeout.
+    /// `ConfigRecord.toModel()` applies the same clamp on every read, so a
+    /// row that bypassed this method — hand-edited SQL, a value written by a
+    /// different daemon build — still comes back bounded.
     public func setAutoHibernate(enabled: Bool, idleMinutes: Int) async throws {
-        let minutes = max(1, idleMinutes)
+        let minutes = min(max(Config.minHibernateIdleMinutes, idleMinutes), Config.maxHibernateIdleMinutes)
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET auto_hibernate_enabled = ?, hibernate_idle_minutes = ? WHERE id = ?",

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -898,6 +898,14 @@ public struct Config: Codable, Sendable, Equatable {
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
+    /// Floor for `hibernateIdleMinutes` — a zero/negative value would make the
+    /// idle sweep hibernate everything on its next tick.
+    public static let minHibernateIdleMinutes = 1
+    /// Ceiling for `hibernateIdleMinutes` — 99 days. Enforced at every layer:
+    /// the Settings amount+unit control clamps input to it, `ConfigStore`
+    /// clamps on both write and read, and `HibernationCoordinator.sweep()`
+    /// floors the value it reads for the idle timer.
+    public static let maxHibernateIdleMinutes = 99 * 24 * 60
     /// Default grace period before the orphan-GC sweep reaps a directory.
     public static let defaultGCGraceSeconds = 3600
     /// Default retention window for reap snapshots.

--- a/Tests/TBDAppTests/HibernateIdleDurationTests.swift
+++ b/Tests/TBDAppTests/HibernateIdleDurationTests.swift
@@ -184,4 +184,87 @@ struct HibernateIdleDurationTests {
         let last = HibernateIdleDuration(amount: 30, unit: .minutes)
         #expect(last.resolveAmount(fromText: "30", targetUnit: .minutes) == 30)
     }
+
+    // MARK: - syncing: the pure decision behind
+    // SettingsView.syncHibernateIdleFromAppState. Regression coverage for
+    // the shipped-default-blank-field bug: the totals-agree guard must stop
+    // amount+unit from being re-derived, but must NOT also suppress writing
+    // the display text.
+
+    @Test func syncingWithMatchingDefaultPopulatesText() {
+        // The exact regression: current is the view's @State default (30
+        // min, the shipped default) and the daemon's persisted value is
+        // also 30 — the common case for most users on first appearance.
+        // The old totals-agree early return skipped everything, including
+        // the text write, leaving the field blank for the view's lifetime.
+        let current = HibernateIdleDuration(totalMinutes: 30)
+        let result = HibernateIdleDuration.syncing(
+            current: current,
+            persistedMinutes: 30,
+            isFocused: false,
+            force: false
+        )
+        #expect(result?.amountText == "30")
+        #expect(result?.duration == current)
+    }
+
+    @Test func syncingCommittedMinutesRoundTripKeepsUnit() {
+        // Committing "120 Minutes" leaves the totals equal on the next
+        // sync (e.g. the settle-sync after commit, or a later .onAppear).
+        // Re-deriving from the total would renormalize to "2 Hours" even
+        // though nothing external changed — the unit must survive.
+        let committed = HibernateIdleDuration(amount: 120, unit: .minutes)
+        let result = HibernateIdleDuration.syncing(
+            current: committed,
+            persistedMinutes: 120,
+            isFocused: false,
+            force: false
+        )
+        #expect(result?.duration.unit == .minutes)
+        #expect(result?.duration.amount == 120)
+        #expect(result?.amountText == "120")
+    }
+
+    @Test func syncingGenuineExternalDeltaRederivesAmountAndUnit() {
+        // A different total (another window/session changed the config)
+        // must re-derive amount+unit from the new total, not just refresh
+        // the text of the stale duration.
+        let current = HibernateIdleDuration(amount: 30, unit: .minutes)
+        let result = HibernateIdleDuration.syncing(
+            current: current,
+            persistedMinutes: 120,
+            isFocused: false,
+            force: false
+        )
+        #expect(result?.duration.unit == .hours)
+        #expect(result?.duration.amount == 2)
+        #expect(result?.amountText == "2")
+    }
+
+    @Test func syncingFocusedNotForcedMakesNoChange() {
+        // An external delta must not stomp an in-progress edit.
+        let current = HibernateIdleDuration(amount: 30, unit: .minutes)
+        let result = HibernateIdleDuration.syncing(
+            current: current,
+            persistedMinutes: 120,
+            isFocused: true,
+            force: false
+        )
+        #expect(result == nil)
+    }
+
+    @Test func syncingFocusedForcedStillApplies() {
+        // The view's own settled commit RPC must apply even if the field
+        // is still focused (`.onSubmit` doesn't resign first responder).
+        let current = HibernateIdleDuration(amount: 30, unit: .minutes)
+        let result = HibernateIdleDuration.syncing(
+            current: current,
+            persistedMinutes: 120,
+            isFocused: true,
+            force: true
+        )
+        #expect(result?.duration.unit == .hours)
+        #expect(result?.duration.amount == 2)
+        #expect(result?.amountText == "2")
+    }
 }

--- a/Tests/TBDAppTests/HibernateIdleDurationTests.swift
+++ b/Tests/TBDAppTests/HibernateIdleDurationTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Tests for `HibernateIdleDuration`, the pure amount/unit value type behind
+/// the Settings "Idle before hibernating" field. Tier 1: deterministic, no
+/// SwiftUI, no daemon.
+@Suite("HibernateIdleDuration")
+struct HibernateIdleDurationTests {
+
+    // MARK: - Unit selection: largest unit that divides evenly
+
+    @Test func oneMinuteStaysMinutes() {
+        let d = HibernateIdleDuration(totalMinutes: 1)
+        #expect(d.unit == .minutes)
+        #expect(d.amount == 1)
+    }
+
+    @Test func thirtyMinutesStaysMinutes() {
+        let d = HibernateIdleDuration(totalMinutes: 30)
+        #expect(d.unit == .minutes)
+        #expect(d.amount == 30)
+    }
+
+    @Test func sixtyMinutesBecomesOneHour() {
+        let d = HibernateIdleDuration(totalMinutes: 60)
+        #expect(d.unit == .hours)
+        #expect(d.amount == 1)
+    }
+
+    @Test func ninetyMinutesStaysMinutes() {
+        // 90 doesn't divide evenly into hours (90/60 = 1.5), so it stays in
+        // the smallest unit rather than losing precision.
+        let d = HibernateIdleDuration(totalMinutes: 90)
+        #expect(d.unit == .minutes)
+        #expect(d.amount == 90)
+    }
+
+    @Test func oneHundredTwentyMinutesBecomesTwoHours() {
+        let d = HibernateIdleDuration(totalMinutes: 120)
+        #expect(d.unit == .hours)
+        #expect(d.amount == 2)
+    }
+
+    @Test func fourteenFortyMinutesBecomesOneDay() {
+        let d = HibernateIdleDuration(totalMinutes: 1440)
+        #expect(d.unit == .days)
+        #expect(d.amount == 1)
+    }
+
+    @Test func twentyEightEightyMinutesBecomesTwoDays() {
+        let d = HibernateIdleDuration(totalMinutes: 2880)
+        #expect(d.unit == .days)
+        #expect(d.amount == 2)
+    }
+
+    @Test func maxMinutesBecomesNinetyNineDays() {
+        let d = HibernateIdleDuration(totalMinutes: 142_560)
+        #expect(d.unit == .days)
+        #expect(d.amount == 99)
+        #expect(d.totalMinutes == Config.maxHibernateIdleMinutes)
+    }
+
+    // MARK: - Clamping
+
+    @Test func zeroClampsToOneMinute() {
+        let d = HibernateIdleDuration(totalMinutes: 0)
+        #expect(d.totalMinutes == 1)
+        #expect(d.unit == .minutes)
+        #expect(d.amount == 1)
+    }
+
+    @Test func negativeClampsToOneMinute() {
+        let d = HibernateIdleDuration(totalMinutes: -100)
+        #expect(d.totalMinutes == 1)
+    }
+
+    @Test func aboveMaxClampsToNinetyNineDays() {
+        let d = HibernateIdleDuration(totalMinutes: 200_000)
+        #expect(d.totalMinutes == Config.maxHibernateIdleMinutes)
+        #expect(d.unit == .days)
+        #expect(d.amount == 99)
+    }
+
+    @Test func amountUnitConstructorClampsTotalMinutes() {
+        // 999 days worth of minutes, far past the 99-day ceiling.
+        let d = HibernateIdleDuration(amount: 999, unit: .days)
+        #expect(d.totalMinutes == Config.maxHibernateIdleMinutes)
+    }
+
+    @Test func overflowingAmountDoesNotTrap() {
+        let d = HibernateIdleDuration(amount: Int.max, unit: .days)
+        #expect(d.totalMinutes == Config.maxHibernateIdleMinutes)
+    }
+
+    // MARK: - Per-unit max amounts
+
+    @Test func perUnitMaxAmounts() {
+        #expect(HibernateIdleDuration.Unit.minutes.maxAmount == Config.maxHibernateIdleMinutes)
+        #expect(HibernateIdleDuration.Unit.hours.maxAmount == 2_376)
+        #expect(HibernateIdleDuration.Unit.days.maxAmount == 99)
+    }
+
+    // MARK: - Round-tripping
+
+    @Test func roundTripsThroughTotalMinutes() {
+        for minutes in [1, 5, 30, 60, 90, 120, 1440, 2880, 142_560] {
+            let first = HibernateIdleDuration(totalMinutes: minutes)
+            let second = HibernateIdleDuration(totalMinutes: first.totalMinutes)
+            #expect(second.totalMinutes == first.totalMinutes)
+            #expect(second.unit == first.unit)
+            #expect(second.amount == first.amount)
+        }
+    }
+
+    @Test func amountUnitRoundTripsWhenNormalized() {
+        // 2 hours normalizes to itself (2 doesn't divide the days boundary).
+        let original = HibernateIdleDuration(amount: 2, unit: .hours)
+        let normalized = HibernateIdleDuration(totalMinutes: original.totalMinutes)
+        #expect(normalized == original)
+    }
+
+    // MARK: - Singular/plural naming
+
+    @Test func singularNamesForCountOne() {
+        #expect(HibernateIdleDuration.Unit.minutes.displayName(count: 1) == "minute")
+        #expect(HibernateIdleDuration.Unit.hours.displayName(count: 1) == "hour")
+        #expect(HibernateIdleDuration.Unit.days.displayName(count: 1) == "day")
+    }
+
+    @Test func pluralNamesForCountOtherThanOne() {
+        #expect(HibernateIdleDuration.Unit.minutes.displayName(count: 2) == "minutes")
+        #expect(HibernateIdleDuration.Unit.hours.displayName(count: 0) == "hours")
+        #expect(HibernateIdleDuration.Unit.days.displayName(count: 99) == "days")
+    }
+
+    // MARK: - resolveAmount: shared revert-vs-clamp rule for the Settings
+    // amount field's commit and the unit picker's reinterpret-on-change
+    // commit (SettingsView.commitHibernateIdleAmount / hibernateIdleUnitBinding).
+
+    @Test func resolveAmountKeepsAValidInRangeParse() {
+        let last = HibernateIdleDuration(amount: 10, unit: .minutes)
+        #expect(last.resolveAmount(fromText: "45", targetUnit: .minutes) == 45)
+    }
+
+    @Test func resolveAmountRevertsUnparseableText() {
+        let last = HibernateIdleDuration(amount: 10, unit: .minutes)
+        #expect(last.resolveAmount(fromText: "abc", targetUnit: .minutes) == 10)
+    }
+
+    @Test func resolveAmountRevertsEmptyText() {
+        let last = HibernateIdleDuration(amount: 10, unit: .minutes)
+        #expect(last.resolveAmount(fromText: "  ", targetUnit: .minutes) == 10)
+    }
+
+    @Test func resolveAmountRevertsZero() {
+        let last = HibernateIdleDuration(amount: 10, unit: .minutes)
+        #expect(last.resolveAmount(fromText: "0", targetUnit: .minutes) == 10)
+    }
+
+    @Test func resolveAmountRevertsNegative() {
+        let last = HibernateIdleDuration(amount: 10, unit: .minutes)
+        #expect(last.resolveAmount(fromText: "-5", targetUnit: .minutes) == 10)
+    }
+
+    @Test func resolveAmountClampsInsteadOfRevertingWhenOverUnitMax() {
+        // 5000 is a valid positive parse, but exceeds what Days can express
+        // (99) — must clamp to the max, not revert to the unrelated last
+        // committed amount.
+        let last = HibernateIdleDuration(amount: 10, unit: .minutes)
+        #expect(last.resolveAmount(fromText: "5000", targetUnit: .days) == HibernateIdleDuration.Unit.days.maxAmount)
+    }
+
+    @Test func resolveAmountClampsRevertFallbackToNewUnitMax() {
+        // The fallback (last committed amount) must also be clamped to the
+        // target unit's max — reverting while reinterpreting into Days must
+        // not carry over an amount only valid in Minutes.
+        let last = HibernateIdleDuration(amount: 5_000, unit: .minutes)
+        #expect(last.resolveAmount(fromText: "", targetUnit: .days) == HibernateIdleDuration.Unit.days.maxAmount)
+    }
+
+    @Test func resolveAmountSameUnitRoundTrips() {
+        let last = HibernateIdleDuration(amount: 30, unit: .minutes)
+        #expect(last.resolveAmount(fromText: "30", targetUnit: .minutes) == 30)
+    }
+}

--- a/Tests/TBDDaemonTests/AutoHibernateStoreTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateStoreTests.swift
@@ -34,4 +34,52 @@ import TBDShared
         let updated = try await db.config.get()
         #expect(updated.autoHibernateOnMergeDefault == true)
     }
+
+    @Test func setAutoHibernateAcceptsTwentyFourHours() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1440)
+        let config = try await db.config.get()
+        #expect(config.autoHibernateEnabled == true)
+        #expect(config.hibernateIdleMinutes == 1440)
+    }
+
+    @Test func setAutoHibernateCeilingsAboveNinetyNineDays() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 200_000)
+        let config = try await db.config.get()
+        #expect(config.hibernateIdleMinutes == Config.maxHibernateIdleMinutes)
+    }
+
+    @Test func setAutoHibernateFloorsBelowOneMinute() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 0)
+        let config = try await db.config.get()
+        #expect(config.hibernateIdleMinutes == Config.minHibernateIdleMinutes)
+    }
+
+    /// `setAutoHibernate` clamps on write, but a row can also end up
+    /// out-of-range some other way — hand-edited SQL, a value written by a
+    /// different daemon build. `ConfigRecord.toModel()` must clamp on READ
+    /// too, so every consumer sees a bounded value regardless of what's
+    /// actually stored in the row.
+    @Test func readClampsOutOfRangeStoredValue() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: "UPDATE config SET hibernate_idle_minutes = ? WHERE id = ?",
+                arguments: [Config.maxHibernateIdleMinutes + 1_000, ConfigStore.singletonID]
+            )
+        }
+        let aboveCeiling = try await db.config.get()
+        #expect(aboveCeiling.hibernateIdleMinutes == Config.maxHibernateIdleMinutes)
+
+        try await db.writerForTests.write { conn in
+            try conn.execute(
+                sql: "UPDATE config SET hibernate_idle_minutes = ? WHERE id = ?",
+                arguments: [0, ConfigStore.singletonID]
+            )
+        }
+        let belowFloor = try await db.config.get()
+        #expect(belowFloor.hibernateIdleMinutes == Config.minHibernateIdleMinutes)
+    }
 }


### PR DESCRIPTION
## Summary

- **What was tedious.** "Idle before hibernating" was a `Stepper` with `in: 5...240, step: 5`. Reaching a day meant 48 clicks, and anything past four hours was simply unreachable. Both bounds were UI artifacts: `ConfigStore.setAutoHibernate` and `HibernationCoordinator.sweep()` have only ever enforced a `max(1, ...)` floor, never a ceiling or a step.
- **What replaces it.** A numeric field plus a Minutes/Hours/Days picker spanning 1 minute to 99 days. The amount commits on submit or focus loss rather than per keystroke, so typing a number no longer fires an RPC per digit; the unit commits immediately.
- **No migration.** The column already stores plain minutes, so 1440 fits the existing schema unchanged. `Config` gains `min`/`maxHibernateIdleMinutes`, and `ConfigStore` now clamps on read as well as write so a row written outside `setAutoHibernate` still comes back bounded.

`HibernateIdleDuration` carries the amount/unit math as a pure value type so it unit-tests without a view host: it picks the largest unit that divides a total evenly (1440 → 1 day), bounds the amount per unit, and resolves typed text under one rule — unparseable, empty, or non-positive text reverts to the last committed value, while a valid but oversized amount clamps to the unit's max.

### Three commit-timing hazards, all found in review

- A **successful** write mutates `appState.hibernateIdleMinutes`, which fires the external-delta sync and re-derives the unit from the total — silently rewriting "120 Minutes" to "2 Hours" with no user gesture. The `guard !hibernateIdleFieldFocused` did not cover it, because on the click-away path the field is already unfocused when the RPC lands. The sync now returns early when the totals already agree, so only a genuine external change re-derives the unit.
- A **failed** write left the field showing a value that was never persisted — a regression against the `Stepper`, whose binding read app state directly and could not diverge. The commit now re-syncs once the RPC settles: a no-op on success, a revert on failure.
- The amount field and the unit picker resolved out-of-range input two different ways (revert vs. clamp), so typing `5000` minutes and then switching to Days persisted 99 days. Both now share `resolveAmount(fromText:targetUnit:)`.

### Notes

- **No spec.** Per CLAUDE.md this is a minor UI change — one Settings control swapped, no feature flag, no migration, no new subsystem, none of the autonomous/destructive triggers that would force a flag.
- **The 1-minute floor is newly reachable through the UI** (it was always reachable via RPC/CLI). Below roughly 5 minutes the prompt cache has not expired yet, so the "resume is cheap" premise weakens; the field's help text now says so. The default stays 30 minutes.

## Test plan

- [x] `scripts/swift-safe build` — clean
- [x] `scripts/test.sh` full suite — 4972 tests in 545 suites pass (plus the documented `FlakyQuarantineSelfTests` self-test anchor)
- [x] `scripts/test.sh --filter HibernateIdleDurationTests --filter AutoHibernateStoreTests` — 32 tests in 2 suites pass, covering unit selection, clamping at both bounds, overflow safety, the revert-vs-clamp rule, and a hand-written out-of-range DB row reading back clamped
- [x] `swiftlint --strict` — 0 violations across 658 files
- [ ] **Needs a human's eyes:** the row's live layout. The Settings window is fixed-size and would not scroll or resize under GUI automation, and the control only renders when "Auto-hibernate idle Claude sessions" is on (default off), so I could not get it on screen without flipping that setting on the live fleet. Enable the toggle and confirm the field + picker sit correctly in the row.


### Follow-up commits

Review found three further defects, all in the SwiftUI commit timing rather than the range math:

- `5b6a3144` — the revert-on-failed-write never fired on the Return path. `.onSubmit` does not resign first responder on macOS, so the field was still focused when a failed RPC returned and the focus guard swallowed the revert. The guard now applies only to *external* deltas, not to this view reconciling its own settled write. Same commit adds a generation counter so two overlapping in-flight commits cannot apply out of order.
- `b3060d4f` — **the amount field rendered blank for anyone on the shipped 30-minute default.** The totals-agree guard added to stop unit renormalization was doing two jobs, and also suppressed the initial text population; `loadHibernationConfig` only assigns on a difference, so `.onChange` never corrected it. The sync decision is now a pure function, `HibernateIdleDuration.syncing(current:persistedMinutes:isFocused:force:)`, with the blank-field case as an explicit regression test.

That extraction matters more than the fix. Every commit-timing claim here had been verified by code reading alone, which is how a blank field survived a green 4972-test suite — the pure value type was well covered and the view was not covered at all. The sync decision is now testable without a view host. The remaining wiring (`.onAppear`, focus transitions) still is not.

### On the two bounds

- **Why 99 days.** It is the input bound requested for this change, and its job is to bound the control — it gives each unit a whole-number maximum so the amount field cannot express an out-of-range total. It is not a supervision policy, and nothing has named a use case beyond it. Fair to call it an unexplained constant otherwise, so: that is the reason.
- **Why a 1-minute floor is safe despite the v50 incident.** CLAUDE.md flags this subsystem because `auto_hibernate_enabled` shipped default-ON in v39 and had to be force-disabled in v50 over the eat-typed-input risk, so lowering the floor deserves an explicit answer. `HibernationCoordinator.performHibernate` runs `HibernationSafetyChecks.hasPendingInput` unconditionally before any park — independent of `hibernate_input_veto_enabled` and independent of the idle-minutes value — so that rail holds however low the threshold goes. Auto-hibernate itself still defaults off. The field's help text warns about the prompt-cache cost below ~5 minutes, which is the real reason to think twice, not safety.


[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=F84D734A-1E5E-4B50-9D5C-FF20FAF5014B)
