### PR TITLE
Feat: Quiet the transcript down to prose, and preview pasted images inline

### DIFF
--- a/Sources/TBDApp/Panes/HistoryPaneView.swift
+++ b/Sources/TBDApp/Panes/HistoryPaneView.swift
@@ -369,6 +369,10 @@ struct SessionTranscriptView: View {
     /// the last row (NSTableView renderer path).
     @State private var scrollToBottomToken: Int = 0
     @State private var activityGroupExpansion: [String: Bool] = [:]
+    /// Bumped alongside every write to `activityGroupExpansion`, so the table can
+    /// tell a user-driven disclosure toggle (anchor the clicked row) from a
+    /// streaming update (follow the tail).
+    @State private var activityToggleToken: Int = 0
 
     @State private var isFreshBranchReviveInFlight = false
 
@@ -462,6 +466,7 @@ struct SessionTranscriptView: View {
                         ),
                         atBottom: $atBottom,
                         scrollToBottomToken: scrollToBottomToken,
+                        activityToggleToken: activityToggleToken,
                         nodesProvider: { presentation.nodes }
                     )
                     .overlay(alignment: .bottomTrailing) {
@@ -525,6 +530,7 @@ struct SessionTranscriptView: View {
 
     private func setActivityGroup(_ id: String, expanded: Bool) {
         activityGroupExpansion[id] = expanded
+        activityToggleToken &+= 1
     }
 
     @ViewBuilder

--- a/Sources/TBDApp/Panes/Transcript/ActivityRowChrome.swift
+++ b/Sources/TBDApp/Panes/Transcript/ActivityRowChrome.swift
@@ -5,7 +5,11 @@ import TBDShared
 /// Provides the full-bleed row layout, header (icon + title + timestamp),
 /// and a header-only click-to-overlay interaction (see #129 spec).
 struct ActivityRowChrome<Header: View>: View {
-    let icon: String
+    /// Leading SF Symbol, or nil for a row that renders no icon at all. Nil
+    /// collapses the icon column entirely so the header sits at the row's
+    /// leading inset — it does NOT leave an empty gutter. Mirrors
+    /// `ActivityRowPresentation.iconSystemName` on the native path.
+    let icon: String?
     let timestamp: Date?
     let onOpen: () -> Void
     let headerContent: () -> Header
@@ -13,7 +17,7 @@ struct ActivityRowChrome<Header: View>: View {
     @State private var hovering = false
 
     init(
-        icon: String,
+        icon: String?,
         timestamp: Date?,
         onOpen: @escaping () -> Void,
         @ViewBuilder header: @escaping () -> Header
@@ -27,10 +31,12 @@ struct ActivityRowChrome<Header: View>: View {
     var body: some View {
         Button(action: onOpen) {
             HStack(spacing: 6) {
-                Image(systemName: icon)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .frame(width: 14)
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 14)
+                }
                 headerContent()
                     .font(.subheadline)
                     .foregroundStyle(.secondary)

--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -83,6 +83,8 @@ struct ChatBubbleView: View {
                         .transcriptSelectableText()
                 case .code(let lang, let body):
                     codeBlock(language: lang, content: body)
+                case .image(let attachment):
+                    TranscriptImageAttachmentView(attachment: attachment)
                 }
             }
         }

--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -24,43 +24,41 @@ struct ChatBubbleView: View {
 
     private var roleLabel: String { isUser ? "You" : "Claude" }
 
+    /// Speaker attribution for assistive technology only — never drawn. A
+    /// transcript is not a group chat, so the bubble shows no role/timestamp
+    /// header and relies on position and tint; VoiceOver has no position cue, so
+    /// the bubble carries the attribution as its accessibility label. Mirrors
+    /// `TranscriptBubbleGeometry.accessibilityAttribution(for:)`.
+    private var accessibilityAttribution: String {
+        guard let ts = item.timestamp?.absoluteShort else { return roleLabel }
+        return isUser ? "\(ts) · \(roleLabel)" : "\(roleLabel) · \(ts)"
+    }
+
     var body: some View {
         // Flattened row wrapper (issue #129 per-row layout-depth): the prior
         // `HStack { Spacer ; column.frame(maxWidth:.infinity) ; Spacer }` is
         // layout-equivalent to a single column that fills width and reserves the
         // 52pt opposite-side gutter via padding. Dropping the outer HStack +
         // Spacer removes a StackLayout node from every bubble row's measure pass.
-        VStack(alignment: isUser ? .trailing : .leading, spacing: 3) {
-            roleHeader
-            bubbleBody
-        }
-        .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
-        // Single EdgeInsets folds the 52pt opposite-side gutter into the 4/12
-        // chrome insets (12 + 52 = 64) — one _PaddingLayout instead of two,
-        // per bubble row. Nested uniform paddings compose additively, so this
-        // is layout-identical to the prior two-`.padding` chain.
-        .padding(EdgeInsets(
-            top: 4,
-            leading: isUser ? 64 : 16,
-            bottom: 4,
-            trailing: 12
-        ))
-    }
-
-    @ViewBuilder
-    private var roleHeader: some View {
-        HStack(spacing: 4) {
-            if isUser, let ts = item.timestamp {
-                Text(ts.absoluteShort).font(.caption2).foregroundStyle(.tertiary)
-                Text("·").foregroundStyle(.quaternary).font(.caption2)
-            }
-            Text(roleLabel).font(.caption2).foregroundStyle(.tertiary)
-            if !isUser, let ts = item.timestamp {
-                Text("·").foregroundStyle(.quaternary).font(.caption2)
-                Text(ts.absoluteShort).font(.caption2).foregroundStyle(.tertiary)
-            }
-        }
-        .padding(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 4))
+        // The role/timestamp header is gone too, which took the enclosing VStack
+        // with it — one fewer StackLayout node per bubble row.
+        bubbleBody
+            .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
+            // Single EdgeInsets folds the 52pt opposite-side gutter into the 8/12
+            // chrome insets (12 + 52 = 64) — one _PaddingLayout instead of two,
+            // per bubble row. Nested uniform paddings compose additively, so this
+            // is layout-identical to the prior two-`.padding` chain. The 8pt
+            // top/bottom matches `TranscriptBubbleGeometry.outerVertical`: with no
+            // header line between them it is the only thing separating one message
+            // from the next.
+            .padding(EdgeInsets(
+                top: 8,
+                leading: isUser ? 64 : 16,
+                bottom: 8,
+                trailing: 12
+            ))
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(accessibilityAttribution)
     }
 
     private var bubbleBody: some View {

--- a/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
+++ b/Sources/TBDApp/Panes/Transcript/ChatBubbleView.swift
@@ -45,16 +45,6 @@ struct ChatBubbleView: View {
             bottom: 4,
             trailing: 12
         ))
-        .overlay(alignment: .leading) {
-            if !isUser {
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(Color.secondary.opacity(0.28))
-                    .frame(width: 2)
-                    .padding(.vertical, 4)
-                    .offset(x: 4)
-                    .accessibilityHidden(true)
-            }
-        }
     }
 
     @ViewBuilder

--- a/Sources/TBDApp/Panes/Transcript/MarkdownSegments.swift
+++ b/Sources/TBDApp/Panes/Transcript/MarkdownSegments.swift
@@ -10,11 +10,27 @@ enum MarkdownSegments {
     enum Segment: Equatable {
         case prose(String)
         case code(language: String?, content: String)
+        case image(TranscriptImageAttachment)
     }
 
+    /// Splits at attached-image markers first (they are not markdown), then
+    /// splits each remaining text run at code fences. Mirrors the native path's
+    /// `MarkdownAttributedRenderer.renderBlocks`, which does the same two-stage
+    /// split — the two renderers must not diverge.
     static func split(_ text: String) -> [Segment] {
         let signpostState = TranscriptSignposts.signposter.beginInterval("transcript.markdown.segment")
         defer { TranscriptSignposts.signposter.endInterval("transcript.markdown.segment", signpostState) }
+        var segments: [Segment] = []
+        for segment in TranscriptImageMarker.split(text) {
+            switch segment {
+            case .image(let attachment): segments.append(.image(attachment))
+            case .text(let run): segments.append(contentsOf: splitFences(run))
+            }
+        }
+        return segments
+    }
+
+    private static func splitFences(_ text: String) -> [Segment] {
         var segments: [Segment] = []
         let lines = text.components(separatedBy: "\n")
 
@@ -80,6 +96,8 @@ extension MarkdownSegments.Segment: Identifiable {
             return "p:\(text.hashValue)"
         case .code(let language, let content):
             return "c:\(language ?? ""):\(content.hashValue)"
+        case .image(let attachment):
+            return "i:\(attachment.path)"
         }
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/Renderer/MarkdownAttributedRenderer.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/MarkdownAttributedRenderer.swift
@@ -54,7 +54,6 @@ enum MarkdownAttributedRenderer {
     /// own view. Code blocks, lists, blockquotes, paragraphs, and headings all
     /// stay inside prose with unchanged inline rendering. (#129)
     static func renderBlocks(_ markdown: String, theme: TranscriptTextTheme = .chatBubble) -> [MessageBlock] {
-        let document = Document(parsing: markdown, options: [])
         var visitor = AttributedStringVisitor(theme: theme)
         var blocks: [MessageBlock] = []
         var proseRun = NSMutableAttributedString()
@@ -65,13 +64,26 @@ enum MarkdownAttributedRenderer {
             proseRun = NSMutableAttributedString()
         }
 
-        for child in document.children {
-            if let table = child as? Markdown.Table {
+        // Attached-image markers are pulled out BEFORE markdown parsing: the
+        // marker is not markdown, and an image is its own laid-out block rather
+        // than a run of text. Everything between markers still goes through the
+        // same document walk, so prose, code and tables are unaffected.
+        for segment in TranscriptImageMarker.split(markdown) {
+            switch segment {
+            case .image(let attachment):
                 flushProse()
-                let data = MarkdownTable.data(table, theme: theme, render: { visitor.visit($0) })
-                if data.columnCount > 0 { blocks.append(.table(data)) }
-            } else {
-                proseRun.append(visitor.visit(child))
+                blocks.append(.image(attachment))
+            case .text(let run):
+                let document = Document(parsing: run, options: [])
+                for child in document.children {
+                    if let table = child as? Markdown.Table {
+                        flushProse()
+                        let data = MarkdownTable.data(table, theme: theme, render: { visitor.visit($0) })
+                        if data.columnCount > 0 { blocks.append(.table(data)) }
+                    } else {
+                        proseRun.append(visitor.visit(child))
+                    }
+                }
             }
         }
         flushProse()
@@ -99,13 +111,15 @@ enum MarkdownAttributedRenderer {
     }
 }
 
-/// One typed segment of a chat message: either a run of prose (rendered markdown
-/// as an `NSAttributedString`, laid out on TextKit 1) or a GFM table (its parsed
-/// cell data, rendered as a native grid view). A message is an ordered list of
+/// One typed segment of a chat message: a run of prose (rendered markdown as an
+/// `NSAttributedString`, laid out on TextKit 1), a GFM table (its parsed cell
+/// data, rendered as a native grid view), or an image the user attached (a
+/// thumbnail that reveals the file in Finder). A message is an ordered list of
 /// these, stacked vertically inside one bubble. (#129)
 enum MessageBlock {
     case prose(NSAttributedString)
     case table(TranscriptTableData)
+    case image(TranscriptImageAttachment)
 }
 
 /// Walks the swift-markdown AST and appends styled runs. Only ever instantiated

--- a/Sources/TBDApp/Panes/Transcript/Renderer/TranscriptImageService.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/TranscriptImageService.swift
@@ -1,0 +1,250 @@
+import AppKit
+import ImageIO
+import UniformTypeIdentifiers
+import os
+
+/// What we know about the file a `[Image: source: …]` marker names, WITHOUT
+/// decoding it. Produced by a header-only probe cheap enough to run inside
+/// synchronous row measurement.
+struct TranscriptImageMetadata: Equatable {
+    enum State: Equatable {
+        /// A decodable image whose pixel dimensions are known.
+        case ready(CGSize)
+        /// No file at the path (or it is not a regular file). The image cache is
+        /// disposable, so old transcripts hit this constantly.
+        case missing
+        /// The file exists but carries no image header: zero bytes, a truncated
+        /// download, or a marker naming something that was never an image.
+        case unreadable
+    }
+
+    let state: State
+
+    var pixelSize: CGSize? {
+        if case .ready(let size) = state { return size }
+        return nil
+    }
+}
+
+/// Loads attached-image thumbnails for the transcript: a synchronous header-only
+/// metadata probe used by row measurement, and an asynchronous downsampling
+/// decode used by the cells. Both are cached and bounded.
+///
+/// ## Why the decode is off-main
+///
+/// The transcript has a documented hard-freeze history from expensive work on the
+/// main thread (issue #129 — syntax highlighting inside a JavaScriptCore VM, fixed
+/// by moving it to `CodeHighlightService`'s background queue). Fully decoding a
+/// user's 12-megapixel screenshot is the same class of hazard, so this service
+/// never does it: `CGImageSourceCreateThumbnailAtIndex` with
+/// `kCGImageSourceThumbnailMaxPixelSize` downsamples during decode, on a
+/// background queue, and only the finished `NSImage` crosses back to main.
+///
+/// ## Why measurement can stay synchronous
+///
+/// `CGImageSourceCopyPropertiesAtIndex` reads the file's header — it does not
+/// decode pixels — so the true aspect ratio is available BEFORE the thumbnail
+/// exists. Row height is therefore exact from the first measurement and does not
+/// change when the image arrives. Measured on a 4000×3000 PNG: the cold probe
+/// runs in 0.12 ms median / 0.24 ms p95, against 26.4 ms to decode the same file
+/// in full — cheap enough to sit inside synchronous row measurement, and the
+/// cache below means a scrolled row pays it once.
+///
+/// `@unchecked Sendable` is justified by the state: `NSCache` is documented
+/// thread-safe, and every other stored property is a `let` of a Sendable type.
+final class TranscriptImageService: @unchecked Sendable {
+    static let shared = TranscriptImageService()
+
+    private let queue = DispatchQueue(
+        label: "com.tbd.transcript-image", qos: .userInitiated, attributes: .concurrent)
+    private let log = Logger(subsystem: "com.tbd.app", category: "transcript-image")
+
+    /// Header probes, keyed by path + mtime + byte size, so a rewritten file
+    /// re-probes rather than serving a stale aspect ratio.
+    private let metadataCache = NSCache<NSString, MetadataBox>()
+    /// Decoded thumbnails, keyed by the metadata key plus the requested max pixel
+    /// size. Bounded by count AND by approximate bitmap bytes so scrolling a long
+    /// transcript full of screenshots cannot grow without limit.
+    private let thumbnailCache = NSCache<NSString, NSImage>()
+
+    private final class MetadataBox {
+        let metadata: TranscriptImageMetadata
+        init(_ metadata: TranscriptImageMetadata) { self.metadata = metadata }
+    }
+
+    private init() {
+        metadataCache.countLimit = 512
+        thumbnailCache.countLimit = 64
+        thumbnailCache.totalCostLimit = 64 * 1024 * 1024
+    }
+
+    // MARK: - Synchronous metadata (measurement path)
+
+    /// Header-only probe of `path`. Safe to call from row measurement: it stats
+    /// the file, and on a cache miss reads only the image header.
+    func metadata(forPath path: String) -> TranscriptImageMetadata {
+        guard let stamp = Self.fileStamp(path) else { return TranscriptImageMetadata(state: .missing) }
+        let key = Self.cacheKey(path: path, stamp: stamp) as NSString
+        if let box = metadataCache.object(forKey: key) { return box.metadata }
+
+        let metadata = Self.probe(path: path, stamp: stamp)
+        metadataCache.setObject(MetadataBox(metadata), forKey: key)
+        return metadata
+    }
+
+    // MARK: - Asynchronous thumbnail (render path)
+
+    /// Delivers a downsampled thumbnail for `path` on the main thread, or `nil` if
+    /// the file vanished or does not decode. A cache hit calls back synchronously,
+    /// so a scroll-reused cell paints its image without a frame of blank.
+    ///
+    /// `maxPixelSize` is the longest edge in PIXELS — pass the display size scaled
+    /// by the backing-scale factor so the thumbnail is crisp on Retina without
+    /// decoding the original.
+    @MainActor
+    func thumbnail(
+        forPath path: String,
+        maxPixelSize: Int,
+        completion: @escaping @MainActor (NSImage?) -> Void
+    ) {
+        guard let stamp = Self.fileStamp(path) else {
+            completion(nil)
+            return
+        }
+        let key = "\(Self.cacheKey(path: path, stamp: stamp))|\(maxPixelSize)" as NSString
+        if let cached = thumbnailCache.object(forKey: key) {
+            completion(cached)
+            return
+        }
+
+        queue.async { [self] in
+            guard let image = Self.decodeThumbnail(path: path, maxPixelSize: maxPixelSize) else {
+                log.debug("transcript-image decode failed path=\(path, privacy: .public)")
+                DispatchQueue.main.async { MainActor.assumeIsolated { completion(nil) } }
+                return
+            }
+            let cost = Int(image.size.width * image.size.height * 4)
+            thumbnailCache.setObject(image, forKey: key, cost: max(cost, 1))
+            DispatchQueue.main.async { MainActor.assumeIsolated { completion(image) } }
+        }
+    }
+
+    /// Test seam: drops every probe and thumbnail so a test can observe a cold
+    /// path. Production never calls it — the caches are self-bounding.
+    func clearCaches() {
+        metadataCache.removeAllObjects()
+        thumbnailCache.removeAllObjects()
+    }
+
+    /// Test seam: true when a thumbnail for this exact (path, mtime, size,
+    /// maxPixelSize) is already resident, i.e. the next request is served without
+    /// a decode.
+    func hasCachedThumbnail(forPath path: String, maxPixelSize: Int) -> Bool {
+        guard let stamp = Self.fileStamp(path) else { return false }
+        let key = "\(Self.cacheKey(path: path, stamp: stamp))|\(maxPixelSize)" as NSString
+        return thumbnailCache.object(forKey: key) != nil
+    }
+
+    // MARK: - Primitives
+
+    private struct FileStamp {
+        let modified: TimeInterval
+        let size: Int64
+    }
+
+    /// mtime + size of a REGULAR file at `path`, or nil. The regular-file check
+    /// is not pedantry: a marker naming a fifo or a character device would hang
+    /// the reader forever, and `/dev/random` would never end.
+    private static func fileStamp(_ path: String) -> FileStamp? {
+        guard !path.isEmpty,
+              let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              (attrs[.type] as? FileAttributeType) == .typeRegular else { return nil }
+        let modified = (attrs[.modificationDate] as? Date)?.timeIntervalSince1970 ?? 0
+        let size = (attrs[.size] as? NSNumber)?.int64Value ?? 0
+        return FileStamp(modified: modified, size: size)
+    }
+
+    private static func cacheKey(path: String, stamp: FileStamp) -> String {
+        "\(path)|\(stamp.modified)|\(stamp.size)"
+    }
+
+    /// Header-only dimensions probe. Never decodes pixels.
+    private static func probe(path: String, stamp: FileStamp) -> TranscriptImageMetadata {
+        guard stamp.size > 0 else { return TranscriptImageMetadata(state: .unreadable) }
+        let url = URL(fileURLWithPath: path)
+        let sourceOptions: [CFString: Any] = [kCGImageSourceShouldCache: false]
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, sourceOptions as CFDictionary),
+              CGImageSourceGetCount(source) > 0,
+              let props = CGImageSourceCopyPropertiesAtIndex(
+                source, 0, sourceOptions as CFDictionary) as? [CFString: Any],
+              let width = (props[kCGImagePropertyPixelWidth] as? NSNumber)?.doubleValue,
+              let height = (props[kCGImagePropertyPixelHeight] as? NSNumber)?.doubleValue,
+              width > 0, height > 0 else {
+            return TranscriptImageMetadata(state: .unreadable)
+        }
+        // EXIF orientations 5–8 transpose the image; the thumbnail is created with
+        // `kCGImageSourceCreateThumbnailWithTransform`, so measurement must swap
+        // the axes to match what will actually be drawn.
+        let orientation = (props[kCGImagePropertyOrientation] as? NSNumber)?.intValue ?? 1
+        let transposed = orientation >= 5 && orientation <= 8
+        let size = transposed
+            ? CGSize(width: height, height: width)
+            : CGSize(width: width, height: height)
+        return TranscriptImageMetadata(state: .ready(size))
+    }
+
+    /// Downsampling decode. `kCGImageSourceThumbnailMaxPixelSize` bounds the
+    /// decoded bitmap, so a 12-megapixel screenshot never enters memory at full
+    /// size. Index 0 is the first frame, which is what makes an animated GIF
+    /// render as a still.
+    private static func decodeThumbnail(path: String, maxPixelSize: Int) -> NSImage? {
+        let url = URL(fileURLWithPath: path)
+        guard let source = CGImageSourceCreateWithURL(
+            url as CFURL, [kCGImageSourceShouldCache: false] as CFDictionary),
+            CGImageSourceGetCount(source) > 0 else { return nil }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: max(maxPixelSize, 1)
+        ]
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(
+            source, 0, options as CFDictionary) else { return nil }
+        return NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+    }
+}
+
+/// Deterministic on-screen size for an attached image, and the fallback chip's
+/// size when there is nothing to draw.
+///
+/// The scheme fits the image inside a fixed box while preserving its true aspect
+/// ratio, and NEVER upscales. That works for both shapes the transcript actually
+/// sees: a wide screenshot binds on width and lands well under the height cap; a
+/// tall portrait binds on height and stays narrow. Because the aspect ratio comes
+/// from the synchronous header probe, this size is known before the decode starts,
+/// so the row height measured at open equals the row height after the image lands.
+@MainActor
+enum TranscriptImageGeometry {
+    /// Longest the thumbnail may be vertically.
+    static let maxHeight: CGFloat = 200
+    /// Widest the thumbnail may be, before the body width clamps it further.
+    static let maxWidth: CGFloat = 420
+    /// Height of the one-line chip shown for a missing or undecodable file.
+    static let fallbackHeight: CGFloat = 20
+    /// Width of that chip (clamped to the body width).
+    static let fallbackWidth: CGFloat = 320
+
+    /// Laid-out size of the attachment at `bodyWidth`. Deterministic and
+    /// decode-independent: `metadata` comes from the header probe.
+    static func displaySize(metadata: TranscriptImageMetadata, bodyWidth: CGFloat) -> CGSize {
+        guard let pixelSize = metadata.pixelSize, pixelSize.width > 0, pixelSize.height > 0 else {
+            return CGSize(width: min(max(bodyWidth, 1), fallbackWidth), height: fallbackHeight)
+        }
+        let availableWidth = min(max(bodyWidth, 1), maxWidth)
+        let scale = min(availableWidth / pixelSize.width, maxHeight / pixelSize.height, 1)
+        return CGSize(
+            width: max((pixelSize.width * scale).rounded(.down), 1),
+            height: max((pixelSize.height * scale).rounded(.down), 1)
+        )
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/Renderer/TranscriptImageService.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/TranscriptImageService.swift
@@ -217,18 +217,19 @@ final class TranscriptImageService: @unchecked Sendable {
 /// Deterministic on-screen size for an attached image, and the fallback chip's
 /// size when there is nothing to draw.
 ///
-/// The scheme fits the image inside a fixed box while preserving its true aspect
-/// ratio, and NEVER upscales. That works for both shapes the transcript actually
-/// sees: a wide screenshot binds on width and lands well under the height cap; a
-/// tall portrait binds on height and stays narrow. Because the aspect ratio comes
-/// from the synchronous header probe, this size is known before the decode starts,
-/// so the row height measured at open equals the row height after the image lands.
+/// The scheme CONTAINS the image inside a `maxEdge` × `maxEdge` square while
+/// preserving its true aspect ratio, and NEVER upscales — the same fit a Finder
+/// icon grid uses. One cap on both axes is what keeps a thumbnail recognisably a
+/// thumbnail: a wide screenshot binds on width and comes out short, a tall
+/// portrait binds on height and comes out narrow, and neither shape can dominate
+/// the bubble. Because the aspect ratio comes from the synchronous header probe,
+/// this size is known before the decode starts, so the row height measured at
+/// open equals the row height after the image lands.
 @MainActor
 enum TranscriptImageGeometry {
-    /// Longest the thumbnail may be vertically.
-    static let maxHeight: CGFloat = 200
-    /// Widest the thumbnail may be, before the body width clamps it further.
-    static let maxWidth: CGFloat = 420
+    /// Longest the thumbnail may be on EITHER axis — the side of the square it
+    /// is contained in.
+    static let maxEdge: CGFloat = 200
     /// Height of the one-line chip shown for a missing or undecodable file.
     static let fallbackHeight: CGFloat = 20
     /// Width of that chip (clamped to the body width).
@@ -240,8 +241,10 @@ enum TranscriptImageGeometry {
         guard let pixelSize = metadata.pixelSize, pixelSize.width > 0, pixelSize.height > 0 else {
             return CGSize(width: min(max(bodyWidth, 1), fallbackWidth), height: fallbackHeight)
         }
-        let availableWidth = min(max(bodyWidth, 1), maxWidth)
-        let scale = min(availableWidth / pixelSize.width, maxHeight / pixelSize.height, 1)
+        // A bubble narrower than the box clamps the square further; nothing may
+        // overflow the body.
+        let availableWidth = min(max(bodyWidth, 1), maxEdge)
+        let scale = min(availableWidth / pixelSize.width, maxEdge / pixelSize.height, 1)
         return CGSize(
             width: max((pixelSize.width * scale).rounded(.down), 1),
             height: max((pixelSize.height * scale).rounded(.down), 1)

--- a/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/SystemReminderRow.swift
@@ -27,7 +27,48 @@ struct SystemReminderRow: View {
         }
     }
 
-    var body: some View {
+    @ViewBuilder var body: some View {
+        // Background-task notifications are not labelled reminders: they read as
+        // one gray sentence with no icon, no capsule and no timestamp. Same
+        // treatment, same shared phrasing as the native cell.
+        if kind == .taskNotification {
+            taskNotificationRow
+        } else {
+            reminderRow
+        }
+    }
+
+    private var taskNotificationRow: some View {
+        let phrasing = ActivityRowFormatter.taskNotificationPhrasing(text)
+        return ActivityRowChrome(
+            icon: nil,
+            timestamp: nil,
+            onOpen: { openTranscriptOverlay?(id) }
+        ) {
+            HStack(spacing: 6) {
+                // `ActivityRowChrome` already styles its header `.subheadline` /
+                // `.secondary` — the native cell's `.secondary` segment style.
+                Text(phrasing.phrase)
+                    .lineLimit(1)
+                // Only a failure still earns a capsule; every other outcome is
+                // already in the sentence.
+                if let failure = phrasing.failureStatus {
+                    Text(failure)
+                        .font(.caption2)
+                        .padding(.horizontal, 5).padding(.vertical, 1)
+                        .background(Color.red.opacity(0.2))
+                        .clipShape(Capsule())
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .accessibilityLabel(
+            ActivityRowFormatter.taskNotificationAccessibilityLabel(
+                text: text, timestamp: timestamp)
+        )
+    }
+
+    private var reminderRow: some View {
         ActivityRowChrome(
             icon: "info.circle",
             timestamp: timestamp,

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowCellView.swift
@@ -54,6 +54,10 @@ final class ActivityRowCellView: NSTableCellView {
     private var widthConstraint: NSLayoutConstraint!
     private var heightConstraint: NSLayoutConstraint!
     private var iconLeading: NSLayoutConstraint!
+    /// Both zeroed for an icon-less presentation, so the title lands exactly on
+    /// the row's leading inset instead of hanging off an empty icon column.
+    private var iconWidth: NSLayoutConstraint!
+    private var titleLeading: NSLayoutConstraint!
 
     // MARK: State
 
@@ -123,6 +127,9 @@ final class ActivityRowCellView: NSTableCellView {
 
         let m = Metrics.self
         iconLeading = iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: m.insetLeading)
+        iconWidth = iconView.widthAnchor.constraint(equalToConstant: m.iconWidth)
+        titleLeading = titleField.leadingAnchor.constraint(
+            equalTo: iconView.trailingAnchor, constant: m.hStackSpacing)
 
         NSLayoutConstraint.activate([
             widthConstraint,
@@ -135,9 +142,9 @@ final class ActivityRowCellView: NSTableCellView {
 
             iconLeading,
             iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            iconView.widthAnchor.constraint(equalToConstant: m.iconWidth),
+            iconWidth,
 
-            titleField.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: m.hStackSpacing),
+            titleLeading,
             titleField.centerYAnchor.constraint(equalTo: centerYAnchor),
 
             badgeStack.leadingAnchor.constraint(
@@ -181,7 +188,20 @@ final class ActivityRowCellView: NSTableCellView {
         if abs(widthConstraint.constant - w) > 0.5 { widthConstraint.constant = w }
         if abs(heightConstraint.constant - h) > 0.5 { heightConstraint.constant = h }
 
-        iconView.image = NSImage(systemSymbolName: presentation.iconSystemName, accessibilityDescription: nil)
+        if let icon = presentation.iconSystemName {
+            iconView.image = NSImage(systemSymbolName: icon, accessibilityDescription: nil)
+            iconView.isHidden = false
+            iconWidth.constant = Metrics.iconWidth
+            titleLeading.constant = Metrics.hStackSpacing
+        } else {
+            // Collapse the icon column rather than leaving a hole: an empty
+            // 14pt gutter next to sibling rows that fill theirs reads as a
+            // failed image, so the title takes the leading inset itself.
+            iconView.image = nil
+            iconView.isHidden = true
+            iconWidth.constant = 0
+            titleLeading.constant = 0
+        }
 
         titleField.attributedStringValue = Self.attributedTitle(
             presentation.titleSegments, truncation: presentation.titleTruncation)

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -138,10 +138,13 @@ enum ActivityRowFormatter {
     private static func activityGroup(_ summary: ActivityGroupSummary) -> ActivityRowPresentation {
         // The whole title is one sentence built by `ActivityGroupSummary`, so
         // this renderer and `ActivityGroupSummaryRow` cannot phrase it
-        // differently. One `.primary` run: `ActivityRowSegment.Style` has no
-        // bold, so the numerals Claude Code emboldens stay plain here rather
-        // than growing a styling mechanism for one row kind.
-        let segments = [ActivityRowSegment(text: summary.activityPhrase, style: .primary)]
+        // differently. One `.secondary` run: the summary is chrome describing
+        // work that already happened, so it recedes from the assistant prose it
+        // sits between rather than competing with it. `.secondary` (subheadline
+        // + `secondaryLabelColor`) is the right weight — `.tertiary` would also
+        // drop to caption2, shrinking the row's only text below a glanceable
+        // size and drifting from `ActivityGroupSummaryRow`'s subheadline.
+        let segments = [ActivityRowSegment(text: summary.activityPhrase, style: .secondary)]
         // Attention badges only. Successful groups say nothing (a "complete"
         // capsule was redundant chrome) and running groups say it in the title's
         // tense — "Running 2 shell commands…" — so no "active" capsule either.

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -494,8 +494,8 @@ enum ActivityRowFormatter {
         id: String, kind: SystemKind, text: String, timestamp: Date?,
         source: String?, truncatedTo: Int?
     ) -> ActivityRowPresentation {
-        // Background-task notifications get a richer presentation: a
-        // "Background · <summary>" title with the status surfaced as a badge.
+        // Background-task notifications read as one gray sentence instead of a
+        // labelled reminder — see `taskNotification` below.
         if kind == .taskNotification {
             return taskNotification(id: id, text: text, timestamp: timestamp)
         }
@@ -576,53 +576,99 @@ enum ActivityRowFormatter {
 
     // MARK: Task notification (background-task activity row)
 
-    /// Builds the activity-row presentation for a background-task notification.
-    /// Surfaces the `<summary>` as the row title and the `<status>` as a badge;
-    /// the full original text remains available via the click-to-open overlay.
+    /// The single-sentence phrasing of a `<task-notification>` envelope, plus the
+    /// one piece of status the sentence cannot be trusted to carry.
+    struct TaskNotificationPhrasing: Equatable {
+        /// One contiguous sentence, rendered as a single `.secondary` run.
+        let phrase: String
+        /// Non-nil ONLY when `<status>` reads as a failure — the sole surviving
+        /// badge. Completed, running and stopped states say so in `phrase`.
+        let failureStatus: String?
+    }
+
+    /// Builds the activity-row presentation for a background-task notification:
+    /// one gray sentence, no icon, no timestamp, and a badge only when the task
+    /// failed. The full original text remains available via click-to-open.
     private static func taskNotification(
         id: String, text: String, timestamp: Date?
     ) -> ActivityRowPresentation {
-        let (summary, status) = parseTaskNotification(text)
-        let titleSegments: [ActivityRowSegment] = [
-            ActivityRowSegment(text: "Background", style: .primary),
-            ActivityRowSegment(text: "·", style: .tertiary),
-            ActivityRowSegment(text: summary, style: .secondary)
-        ]
-        var badges: [ActivityRowBadge] = []
-        if !status.isEmpty {
-            let lower = status.lowercased()
-            let kind: ActivityRowBadge.Kind =
-                (lower.contains("fail") || lower.contains("error")) ? .error : .neutral
-            badges.append(ActivityRowBadge(text: status, kind: kind))
-        }
+        let phrasing = taskNotificationPhrasing(text)
+        let badges = phrasing.failureStatus.map {
+            [ActivityRowBadge(text: $0, kind: .error)]
+        } ?? []
         return ActivityRowPresentation(
-            iconSystemName: "clock.arrow.circlepath",
-            titleSegments: titleSegments,
-            timestamp: timestamp,
-            isError: false,
+            // No icon, no timestamp, one `.secondary` run — the treatment the
+            // activity-group summary already got. The envelope's own wording
+            // ("… finished", "… was stopped by user", "… completed (exit code
+            // 0)") IS the status report, so a clock glyph, a "completed" capsule
+            // and a date stamp were three restatements of a row nobody acts on.
+            iconSystemName: nil,
+            titleSegments: [ActivityRowSegment(text: phrasing.phrase, style: .secondary)],
+            timestamp: nil,
+            isError: phrasing.failureStatus != nil,
             badges: badges,
             openTargetID: id,
-            titleTruncation: .byTruncatingTail
+            titleTruncation: .byTruncatingTail,
+            // The timestamp left the visible row but not the record: VoiceOver
+            // still hears when the notification landed (bubble-header precedent).
+            accessibilityLabel: taskNotificationAccessibilityLabel(
+                text: text, timestamp: timestamp)
         )
     }
 
-    /// Extracts `(summary, status)` from a `<task-notification>` envelope using
-    /// plain string scanning (no regex). Returns the substrings between
-    /// `<summary>…</summary>` and `<status>…</status>`, trimmed. When `<summary>`
-    /// is absent, falls back to the status (or "Background task" if neither is
-    /// present). The status component is "" when absent.
-    static func parseTaskNotification(_ text: String) -> (summary: String, status: String) {
+    /// Phrases a `<task-notification>` envelope as one sentence, shared by the
+    /// native cell and `SystemReminderRow` so the two renderers cannot drift.
+    ///
+    /// Each `<summary>` already arrives as a self-describing sentence —
+    /// `Background command "…" completed (exit code 0)`, `Monitor "…" stream
+    /// ended`, `Stop hook …`, `Dynamic workflow "…" …`, `No completion record was
+    /// found for background agent …`. Only the agent shape opens with a bare
+    /// `Agent "…"`, so only that one absorbs the "Background" lead-in this row
+    /// used to wear as a separate bold token; prefixing the rest would stutter
+    /// ("Background Background command …"). Not every notification is an agent,
+    /// so nothing here may say "agent" unconditionally.
+    static func taskNotificationPhrasing(_ text: String) -> TaskNotificationPhrasing {
         let summary = extractTagBody(in: text, tag: "summary") ?? ""
         let status = extractTagBody(in: text, tag: "status") ?? ""
-        let resolvedSummary: String
-        if !summary.isEmpty {
-            resolvedSummary = summary
-        } else if !status.isEmpty {
-            resolvedSummary = status
+        let agentPrefix = "Agent "
+
+        let phrase: String
+        if summary.isEmpty {
+            // Status-only envelope — how a still-running task reports itself.
+            // Present participle plus "…", the activity-group summary's idiom
+            // for work still in flight.
+            if status.isEmpty {
+                phrase = "Background task"
+            } else if status.caseInsensitiveCompare("running") == .orderedSame {
+                phrase = "Background task running…"
+            } else {
+                phrase = "Background task \(status)"
+            }
+        } else if summary.hasPrefix(agentPrefix) {
+            phrase = "Background agent " + summary.dropFirst(agentPrefix.count)
         } else {
-            resolvedSummary = "Background task"
+            phrase = summary
         }
-        return (resolvedSummary, status)
+
+        let lower = status.lowercased()
+        let isFailure = lower.contains("fail") || lower.contains("error")
+        return TaskNotificationPhrasing(
+            phrase: phrase,
+            // A failure keeps its badge because the sentence is not guaranteed to
+            // name it: `<summary>` wording varies by task kind, and a long
+            // failure reason truncates. Completed/stopped/running badges are
+            // gone — those the sentence does carry.
+            failureStatus: isFailure ? status : nil
+        )
+    }
+
+    /// VoiceOver text for a background-task row: the sentence, the failure status
+    /// if any, and the timestamp the visible row no longer prints.
+    static func taskNotificationAccessibilityLabel(text: String, timestamp: Date?) -> String {
+        let phrasing = taskNotificationPhrasing(text)
+        return phrasing.phrase
+            + (phrasing.failureStatus.map { ", \($0)" } ?? "")
+            + (timestamp.map { ", \($0.absoluteShort)" } ?? "")
     }
 
     /// Returns the trimmed substring between `<tag>` and `</tag>`, or nil.

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -133,12 +133,11 @@ enum ActivityRowFormatter {
     }
 
     private static func activityGroup(_ summary: ActivityGroupSummary) -> ActivityRowPresentation {
+        // A summary node is only emitted for runs of two or more (a lone
+        // activity renders as its own row), so the count is always plural.
         var segments = [
             ActivityRowSegment(text: "Worked", style: .primary),
-            ActivityRowSegment(
-                text: "· \(summary.itemCount) \(summary.itemCount == 1 ? "action" : "actions")",
-                style: .secondary
-            )
+            ActivityRowSegment(text: "· \(summary.itemCount) actions", style: .secondary)
         ]
         if !summary.labels.isEmpty {
             segments.append(ActivityRowSegment(
@@ -146,15 +145,17 @@ enum ActivityRowFormatter {
                 style: .tertiary
             ))
         }
+        // No badge when everything in the group succeeded — `statusLabel` is nil
+        // exactly then, and a "complete" capsule was redundant chrome.
         var badges: [ActivityRowBadge] = []
-        if summary.requiresResponse {
-            badges.append(ActivityRowBadge(text: "needs response", kind: .error))
-        } else if summary.errorCount > 0 {
-            badges.append(ActivityRowBadge(text: summary.statusLabel.lowercased(), kind: .error))
-        } else if summary.pendingCount > 0 {
-            badges.append(ActivityRowBadge(text: "active", kind: .neutral))
-        } else {
-            badges.append(ActivityRowBadge(text: "complete", kind: .neutral))
+        if let status = summary.statusLabel {
+            if summary.requiresResponse {
+                badges.append(ActivityRowBadge(text: "needs response", kind: .error))
+            } else if summary.errorCount > 0 {
+                badges.append(ActivityRowBadge(text: status.lowercased(), kind: .error))
+            } else {
+                badges.append(ActivityRowBadge(text: "active", kind: .neutral))
+            }
         }
         return ActivityRowPresentation(
             iconSystemName: "point.3.connected.trianglepath.dotted",
@@ -166,7 +167,8 @@ enum ActivityRowFormatter {
             accessorySystemName: summary.isExpanded ? "chevron.down" : "chevron.right",
             accessoryAlwaysVisible: true,
             accessibilityLabel: "\(summary.isExpanded ? "Collapse" : "Expand") "
-                + "\(summary.itemCount) actions, \(summary.statusLabel)"
+                + "\(summary.itemCount) actions"
+                + (summary.statusLabel.map { ", \($0)" } ?? "")
         )
     }
 

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -51,7 +51,10 @@ struct ActivityRowPresentation: Equatable {
         case plainSummary
     }
 
-    let iconSystemName: String
+    /// Leading SF Symbol, or nil for a row that renders no icon at all. Nil
+    /// collapses the icon column entirely so the title sits at the row's leading
+    /// inset — it does NOT leave an empty gutter.
+    let iconSystemName: String?
     /// Ordered runs composing the one-line title.
     let titleSegments: [ActivityRowSegment]
     let timestamp: Date?
@@ -75,7 +78,7 @@ struct ActivityRowPresentation: Equatable {
     let accessibilityLabel: String?
 
     init(
-        iconSystemName: String,
+        iconSystemName: String?,
         titleSegments: [ActivityRowSegment],
         timestamp: Date?,
         isError: Bool,
@@ -158,7 +161,10 @@ enum ActivityRowFormatter {
             }
         }
         return ActivityRowPresentation(
-            iconSystemName: "point.3.connected.trianglepath.dotted",
+            // No icon: the group summary already announces itself with the
+            // persistent disclosure chevron, and a second glyph on the same row
+            // was redundant chrome. The title takes the row's leading inset.
+            iconSystemName: nil,
             titleSegments: segments,
             timestamp: nil,
             isError: summary.errorCount > 0 || summary.requiresResponse,

--- a/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/ActivityRowPresentation.swift
@@ -136,29 +136,21 @@ enum ActivityRowFormatter {
     }
 
     private static func activityGroup(_ summary: ActivityGroupSummary) -> ActivityRowPresentation {
-        // A summary node is only emitted for runs of two or more (a lone
-        // activity renders as its own row), so the count is always plural.
-        var segments = [
-            ActivityRowSegment(text: "Worked", style: .primary),
-            ActivityRowSegment(text: "· \(summary.itemCount) actions", style: .secondary)
-        ]
-        if !summary.labels.isEmpty {
-            segments.append(ActivityRowSegment(
-                text: "· \(summary.labels.joined(separator: " · "))",
-                style: .tertiary
-            ))
-        }
-        // No badge when everything in the group succeeded — `statusLabel` is nil
-        // exactly then, and a "complete" capsule was redundant chrome.
+        // The whole title is one sentence built by `ActivityGroupSummary`, so
+        // this renderer and `ActivityGroupSummaryRow` cannot phrase it
+        // differently. One `.primary` run: `ActivityRowSegment.Style` has no
+        // bold, so the numerals Claude Code emboldens stay plain here rather
+        // than growing a styling mechanism for one row kind.
+        let segments = [ActivityRowSegment(text: summary.activityPhrase, style: .primary)]
+        // Attention badges only. Successful groups say nothing (a "complete"
+        // capsule was redundant chrome) and running groups say it in the title's
+        // tense — "Running 2 shell commands…" — so no "active" capsule either.
         var badges: [ActivityRowBadge] = []
         if let status = summary.statusLabel {
-            if summary.requiresResponse {
-                badges.append(ActivityRowBadge(text: "needs response", kind: .error))
-            } else if summary.errorCount > 0 {
-                badges.append(ActivityRowBadge(text: status.lowercased(), kind: .error))
-            } else {
-                badges.append(ActivityRowBadge(text: "active", kind: .neutral))
-            }
+            badges.append(ActivityRowBadge(
+                text: summary.requiresResponse ? "needs response" : status.lowercased(),
+                kind: .error
+            ))
         }
         return ActivityRowPresentation(
             // No icon: the group summary already announces itself with the
@@ -173,7 +165,7 @@ enum ActivityRowFormatter {
             accessorySystemName: summary.isExpanded ? "chevron.down" : "chevron.right",
             accessoryAlwaysVisible: true,
             accessibilityLabel: "\(summary.isExpanded ? "Collapse" : "Expand") "
-                + "\(summary.itemCount) actions"
+                + summary.activityPhrase
                 + (summary.statusLabel.map { ", \($0)" } ?? "")
         )
     }

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptPaneView.swift
@@ -40,6 +40,10 @@ struct TableTranscriptPaneView: View {
     /// the last row.
     @State private var scrollToBottomToken: Int = 0
     @State private var activityGroupExpansion: [String: Bool] = [:]
+    /// Bumped alongside every write to `activityGroupExpansion`, so the table can
+    /// tell a user-driven disclosure toggle (anchor the clicked row) from a
+    /// streaming update (follow the tail).
+    @State private var activityToggleToken: Int = 0
 
     private static let log = Logger(subsystem: "com.tbd.app", category: "live-transcript")
 
@@ -190,6 +194,7 @@ struct TableTranscriptPaneView: View {
                 context: cardContext,
                 atBottom: $atBottom,
                 scrollToBottomToken: scrollToBottomToken,
+                activityToggleToken: activityToggleToken,
                 nodesProvider: { timedRenderNodes(presentation.nodes) }
             )
             // Compose the terminal with its current Claude session so a session
@@ -206,6 +211,7 @@ struct TableTranscriptPaneView: View {
 
     private func setActivityGroup(_ id: String, expanded: Bool) {
         activityGroupExpansion[id] = expanded
+        activityToggleToken &+= 1
     }
 
     // MARK: - Jump-to-Bottom

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
@@ -616,7 +616,7 @@ struct TableTranscriptView: NSViewRepresentable {
                 blockHeights: blockHeights,
                 sourceText: TranscriptBubbleGeometry.text(for: item),
                 role: role,
-                header: TranscriptBubbleGeometry.header(for: item),
+                accessibilityAttribution: TranscriptBubbleGeometry.accessibilityAttribution(for: item),
                 bodyWidth: TranscriptBubbleGeometry.bodyWidth(columnWidth: width, role: role),
                 columnWidth: width,
                 cachedHeight: height

--- a/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TableTranscriptView.swift
@@ -24,6 +24,11 @@ struct TableTranscriptView: NSViewRepresentable {
     /// Jump-to-bottom request token: incrementing it asks the coordinator to
     /// scroll to the last row.
     let scrollToBottomToken: Int
+    /// Bumped by the pane whenever the USER toggles an activity group open or
+    /// shut. The node array that arrives with a bumped token is the result of a
+    /// disclosure gesture, not of streaming, so the coordinator anchors the
+    /// clicked row instead of following the tail (see `update`).
+    let activityToggleToken: Int
     let nodesProvider: @MainActor () -> [TranscriptRenderNode]
 
     private static let log = Logger(subsystem: "com.tbd.app", category: "table-transcript")
@@ -86,6 +91,7 @@ struct TableTranscriptView: NSViewRepresentable {
         coordinator.tableView = tableView
         coordinator.scrollView = scrollView
         coordinator.lastScrollToken = scrollToBottomToken
+        coordinator.lastActivityToggleToken = activityToggleToken
         coordinator.atBottomBinding = $atBottom
         // Track the live scroll position so the jump-to-bottom button hides the
         // moment the viewport reaches the bottom — by the button OR a manual
@@ -151,7 +157,11 @@ struct TableTranscriptView: NSViewRepresentable {
             coordinator.lastScrollToken = scrollToBottomToken
             coordinator.scrollToEnd(animated: true)
         }
-        coordinator.update(nodes: nodesProvider(), atBottom: $atBottom)
+        coordinator.update(
+            nodes: nodesProvider(),
+            atBottom: $atBottom,
+            activityToggleToken: activityToggleToken
+        )
     }
 
     // MARK: - Coordinator
@@ -171,6 +181,11 @@ struct TableTranscriptView: NSViewRepresentable {
         var nodes: [TranscriptRenderNode] = []
         var previousNodes: [TranscriptRenderNode] = []
         var lastScrollToken = 0
+        /// Last activity-group toggle token seen by `update`. A token that has
+        /// MOVED means this node array came from the user opening or shutting a
+        /// group, which must keep the clicked row where it is rather than
+        /// re-pinning the tail.
+        var lastActivityToggleToken = 0
 
         /// Live binding driving the floating jump-to-bottom button. Held so the
         /// clip-bounds observer can keep it in sync with the ACTUAL scroll
@@ -186,8 +201,9 @@ struct TableTranscriptView: NSViewRepresentable {
         /// message text; caching the estimate turns those repeat scans into hash
         /// hits (~3× fewer `estimate(...)` computes per open). An entry here is
         /// SUPERSEDED by the exact height the moment a row is realized + measured
-        /// in `viewFor` (the exact cache is consulted first), and both caches are
-        /// cleared together on a width change / rebuild. (#129)
+        /// in `viewFor` (the exact cache is consulted first). Both caches are
+        /// cleared together on a width change and PRUNED (not cleared) to the live
+        /// rows on a rebuild — see `pruneCaches`. (#129)
         private var estimateCache: [HeightKey: CGFloat] = [:]
         /// The column width the cache was last computed against. When the table's
         /// width changes, the cache is cleared and the table reloaded.
@@ -209,8 +225,9 @@ struct TableTranscriptView: NSViewRepresentable {
         /// Composed `[MessageBlock]` for chat-bubble rows, keyed by
         /// `(node.id, contentVersion)`. The blocks `heightOfRow` measures are the
         /// SAME values `viewFor` installs into the cell, so render == measure by
-        /// construction. Invalidated for a node on `updateLast` (growing stream)
-        /// and cleared wholesale on a width-change reload.
+        /// construction. Invalidated for a node on `updateLast` (growing stream),
+        /// pruned to the live rows on a rebuild, and cleared wholesale on a
+        /// width-change reload.
         private var composedCache: [ComposedKey: [MessageBlock]] = [:]
 
         struct ComposedKey: Hashable {
@@ -225,8 +242,9 @@ struct TableTranscriptView: NSViewRepresentable {
         /// scroll-reused `TranscriptBubbleCellView` lays its blocks out from the
         /// cache instead of re-measuring — notably avoiding a fresh
         /// `NSHostingController.sizeThatFits` for every `.table` block on every
-        /// dequeue. Cleared alongside `heightCache`/`estimateCache` on a
-        /// width-change / rebuild, and per-node on `updateLast`. (#129)
+        /// dequeue. Cleared alongside `heightCache`/`estimateCache` on a width
+        /// change, pruned to the live rows on a rebuild, and dropped per-node on
+        /// `updateLast`. (#129)
         private var blockHeightCache: [BlockHeightKey: [CGFloat]] = [:]
 
         struct BlockHeightKey: Hashable {
@@ -754,7 +772,8 @@ struct TableTranscriptView: NSViewRepresentable {
         ///   (`ceil(textLength / charsPerLine)`, `charsPerLine ≈ bodyWidth /
         ///   avgCharWidth`) × line height, + the bubble's fixed chrome. If the
         ///   message contains a GFM table, the (cheap, regex-free) table row count
-        ///   contributes `rows × tableRowHeight + header`.
+        ///   contributes `rows × tableRowHeight + header`. An attached image
+        ///   contributes its TRUE laid-out height (see `chatBubbleEstimate`).
         /// * activity rows (systemReminder / skillBody / non-Ask toolCall /
         ///   subagentSummary): the row is ONE truncated line, so its height is the
         ///   EXACT fixed chrome height (`activityRowHeight`) — cheap and exact, no
@@ -786,7 +805,16 @@ struct TableTranscriptView: NSViewRepresentable {
         static let askUserQuestionEstimate: CGFloat = 180
 
         /// Arithmetic height estimate for a chat bubble: wrapped prose lines × line
-        /// height + any embedded GFM table + fixed bubble chrome. No layout.
+        /// height + any embedded GFM table + any attached image + fixed bubble
+        /// chrome. No text layout.
+        ///
+        /// The image term is not an approximation at all: an attached image is laid
+        /// out at `TranscriptImageGeometry.displaySize`, which derives from a
+        /// SYNCHRONOUS header-only probe (~0.1 ms, cached per file) rather than a
+        /// decode — so the estimate can read the same true size the exact
+        /// measurement will. Without it a screenshot row estimated ~1 line of prose
+        /// for the marker text and then corrected by up to ~200pt on realize,
+        /// dragging every row below it.
         private static func chatBubbleEstimate(
             _ item: TranscriptItem,
             badgeUsage: TokenUsage?,
@@ -797,26 +825,46 @@ struct TableTranscriptView: NSViewRepresentable {
             let charsPerLine = max(Int(bodyWidth / avgBubbleCharWidth), 12)
             let text = TranscriptBubbleGeometry.text(for: item)
 
-            // Prose lines: count explicit newlines (each forces a line break) plus
-            // the wrapped lines each non-empty paragraph contributes. A bubble that
-            // carries a usage badge adds one trailing line.
+            // Split on image markers exactly as `renderBlocks` does, so the marker
+            // text is not counted as prose and each image contributes its own block
+            // height. Marker-free text (the overwhelmingly common case) costs one
+            // substring search and yields a single text segment — the arithmetic
+            // below is then identical to the marker-free estimate.
             var proseLines = 0
-            for paragraph in text.split(separator: "\n", omittingEmptySubsequences: false) {
-                let len = paragraph.count
-                proseLines += max(1, (len + charsPerLine - 1) / charsPerLine)
+            var tableRows = 0
+            var imageCount = 0
+            var imagesHeight: CGFloat = 0
+            for segment in TranscriptImageMarker.split(text) {
+                switch segment {
+                case .text(let run):
+                    // Prose lines: count explicit newlines (each forces a line break)
+                    // plus the wrapped lines each non-empty paragraph contributes.
+                    for paragraph in run.split(separator: "\n", omittingEmptySubsequences: false) {
+                        let len = paragraph.count
+                        proseLines += max(1, (len + charsPerLine - 1) / charsPerLine)
+                    }
+                    // GFM table block: cheaply count pipe-prefixed-or-containing rows
+                    // in the source (header + separator + body) without rendering.
+                    // Each grid row is ~tableRowHeight tall.
+                    tableRows += estimatedTableRowCount(in: run)
+                case .image(let attachment):
+                    imageCount += 1
+                    imagesHeight += MessageBlockMeasurer.imageSize(
+                        attachment, bodyWidth: bodyWidth).height
+                }
             }
-            if proseLines == 0 { proseLines = 1 }
+            if proseLines == 0 && imageCount == 0 { proseLines = 1 }
+            // A bubble that carries a usage badge adds one trailing line.
             if badgeUsage != nil { proseLines += 1 }
 
             var blocksHeight = CGFloat(proseLines) * estimatedBubbleLineHeight
-
-            // GFM table block: cheaply count pipe-prefixed-or-containing rows in the
-            // source (header + separator + body) without rendering. Each grid row
-            // is ~tableRowHeight tall.
-            let tableRows = estimatedTableRowCount(in: text)
             if tableRows > 0 {
                 blocksHeight += CGFloat(tableRows) * estimatedTableRowHeight
                     + TranscriptBubbleGeometry.interBlockSpacing
+            }
+            if imageCount > 0 {
+                blocksHeight += imagesHeight
+                    + CGFloat(imageCount) * TranscriptBubbleGeometry.interBlockSpacing
             }
 
             return TranscriptBubbleGeometry.rowHeight(blocksHeight: max(blocksHeight, estimatedBubbleLineHeight))
@@ -844,10 +892,30 @@ struct TableTranscriptView: NSViewRepresentable {
         /// Apply a new poll result with a minimal table op derived from
         /// `TranscriptStreamPlan`. Captures at-bottom BEFORE the edit so a grown
         /// document doesn't misjudge whether to follow the tail.
-        func update(nodes newNodes: [TranscriptRenderNode], atBottom: Binding<Bool>) {
+        ///
+        /// `activityToggleToken` distinguishes the two reasons a node array can
+        /// change shape. Streaming grows the transcript at the tail, and a viewer
+        /// parked at the bottom expects to follow it. A disclosure toggle instead
+        /// splices rows in (or out) UNDER the row the user just clicked, and there
+        /// the only acceptable outcome is that the clicked row does not move: the
+        /// toggle also classifies as a `.rebuild` (indices shift and the summary
+        /// node's `contentVersion` folds in `isExpanded`), so without this signal
+        /// the tail-follow below would re-pin the bottom and translate everything
+        /// on screen upward by the height of the rows just revealed.
+        func update(
+            nodes newNodes: [TranscriptRenderNode],
+            atBottom: Binding<Bool>,
+            activityToggleToken: Int
+        ) {
             // Keep the observer's binding fresh (SwiftUI hands us a new binding
             // each update).
             atBottomBinding = atBottom
+            // Consume the toggle token unconditionally — BEFORE any early return —
+            // so a toggle that lands on a `.noop` (or on a torn-down view) cannot
+            // leave the signal armed and suppress the tail-follow of a later,
+            // genuine streaming append.
+            let isActivityToggle = activityToggleToken != lastActivityToggleToken
+            lastActivityToggleToken = activityToggleToken
             // `scrollView` must exist (downstream `scrollToEnd` / `isAtBottom`
             // read it via the stored property); bind it only to gate on presence.
             guard let tableView, scrollView != nil else { return }
@@ -886,21 +954,18 @@ struct TableTranscriptView: NSViewRepresentable {
             case .noop:
                 break
             case .rebuild:
-                // True rebuild: clear the cache, measure the bottom window exactly,
-                // reload (older rows lazily estimate + correct on realize).
-                heightCache.removeAll(keepingCapacity: true)
-                estimateCache.removeAll(keepingCapacity: true)
-                composedCache.removeAll(keepingCapacity: true)
-                blockHeightCache.removeAll(keepingCapacity: true)
+                // True rebuild: the row ORDER changed, but every cache here is
+                // content-addressed by `(id, contentVersion[, width])`, so a
+                // surviving entry still describes the row it was measured for.
+                // Prune to what the new list can reach, measure the bottom window
+                // exactly, reload (older rows lazily estimate + correct on realize).
+                pruneCaches(to: newNodes)
                 precomputeBottomWindow()
                 tableView.reloadData()
             case let .append(fromIndex):
                 let newCount = newNodes.count
                 guard newCount > fromIndex, fromIndex <= oldCount else {
-                    heightCache.removeAll(keepingCapacity: true)
-                    estimateCache.removeAll(keepingCapacity: true)
-                    composedCache.removeAll(keepingCapacity: true)
-                    blockHeightCache.removeAll(keepingCapacity: true)
+                    pruneCaches(to: newNodes)
                     precomputeBottomWindow()
                     tableView.reloadData()
                     break
@@ -939,7 +1004,12 @@ struct TableTranscriptView: NSViewRepresentable {
                 }
             }
 
-            if wasAtBottom {
+            // Follow the tail only for content the SESSION produced. A user-driven
+            // disclosure toggle keeps the viewport exactly where it is, so the row
+            // that was clicked stays under the pointer and only the content below
+            // it moves. (Everything above the clicked row keeps its cached exact
+            // height across the rebuild, so its rows do not re-lay either.)
+            if wasAtBottom && !isActivityToggle {
                 DispatchQueue.main.async { [weak self] in
                     self?.scrollToEnd(animated: false)
                     self?.recomputeAtBottom(atBottom)
@@ -947,6 +1017,51 @@ struct TableTranscriptView: NSViewRepresentable {
             } else {
                 recomputeAtBottom(atBottom)
             }
+        }
+
+        /// Drops every cache entry that the new node list can no longer reach,
+        /// keeping the rest.
+        ///
+        /// Every cache here is keyed by `(id, contentVersion[, width])`, so a
+        /// stale entry — one whose row changed content, or which is gone from the
+        /// list — is unreachable by construction: a lookup for the row's NEW
+        /// version simply misses. Clearing them on a rebuild was therefore pure
+        /// pessimism with a real cost: a row measured EXACTLY fell back to the
+        /// arithmetic estimate, got re-measured on realize, and was corrected via
+        /// `noteHeightOfRows` with no scroll compensation — so a visible row above
+        /// the user's focus that corrected by δ dragged everything below it by δ.
+        ///
+        /// Keeping them needs a growth story, which is what this prune is: after
+        /// it, the caches hold at most one entry per LIVE row per cache (plus
+        /// whatever the width-change path already clears wholesale). Between
+        /// prunes only live rows are ever measured — `.append` adds entries for
+        /// the rows it appended, and `.updateLast` invalidates the grown row's
+        /// entries by id before re-measuring — so a long streaming session cannot
+        /// accumulate one entry per superseded `contentVersion`.
+        private func pruneCaches(to newNodes: [TranscriptRenderNode]) {
+            var live = Set<ComposedKey>(minimumCapacity: newNodes.count)
+            for node in newNodes {
+                live.insert(ComposedKey(id: node.id, version: node.contentVersion))
+            }
+            heightCache = heightCache.filter { live.contains(ComposedKey(id: $0.key.id, version: $0.key.version)) }
+            estimateCache = estimateCache.filter { live.contains(ComposedKey(id: $0.key.id, version: $0.key.version)) }
+            composedCache = composedCache.filter { live.contains($0.key) }
+            blockHeightCache = blockHeightCache.filter {
+                live.contains(ComposedKey(id: $0.key.id, version: $0.key.version))
+            }
+        }
+
+        /// Test backstop: total entries held across every per-row cache. Bounds the
+        /// growth story in `pruneCaches` — after a rebuild this cannot exceed a
+        /// small multiple of the live row count.
+        var totalCachedEntryCount: Int {
+            heightCache.count + estimateCache.count + composedCache.count + blockHeightCache.count
+        }
+
+        /// Test backstop: the cached EXACT height for `node` at the current column
+        /// width, or nil when the row would be sized by the estimate instead.
+        func cachedExactHeight(for node: TranscriptRenderNode) -> CGFloat? {
+            heightCache[HeightKey(id: node.id, version: node.contentVersion, width: columnWidth)]
         }
 
         private func invalidateHeight(for node: TranscriptRenderNode) {

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
@@ -327,7 +327,6 @@ final class TranscriptBubbleTextView: NSTextView {}
 @MainActor
 final class TranscriptBubbleCellView: NSTableCellView {
     private let backgroundBox = RoundedBoxView()
-    private let signalSpine = RoundedBoxView()
     private let header = NSTextField(labelWithString: "")
     /// Vertical stack of block subviews inside the bubble.
     private let blockStack = NSStackView()
@@ -363,10 +362,6 @@ final class TranscriptBubbleCellView: NSTableCellView {
         backgroundBox.cornerRadius = TranscriptBubbleGeometry.cornerRadius
         backgroundBox.translatesAutoresizingMaskIntoConstraints = false
 
-        signalSpine.cornerRadius = 1
-        signalSpine.fillColor = NSColor.secondaryLabelColor.withAlphaComponent(0.28)
-        signalSpine.translatesAutoresizingMaskIntoConstraints = false
-
         header.font = TranscriptBubbleGeometry.headerFont
         header.textColor = .tertiaryLabelColor
         header.backgroundColor = .clear
@@ -385,7 +380,6 @@ final class TranscriptBubbleCellView: NSTableCellView {
         // so the stack's text views are topmost and take the mouse for selection
         // while the bubble paints behind them.
         addSubview(backgroundBox)
-        addSubview(signalSpine)
         addSubview(header)
         addSubview(blockStack, positioned: .above, relativeTo: backgroundBox)
 
@@ -405,10 +399,6 @@ final class TranscriptBubbleCellView: NSTableCellView {
         NSLayoutConstraint.activate([
             widthConstraint,
             heightConstraint,
-            signalSpine.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 4),
-            signalSpine.topAnchor.constraint(equalTo: topAnchor, constant: g.outerVertical),
-            signalSpine.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -g.outerVertical),
-            signalSpine.widthAnchor.constraint(equalToConstant: 2),
             header.topAnchor.constraint(equalTo: topAnchor, constant: g.outerVertical),
             backgroundBox.topAnchor.constraint(
                 equalTo: header.bottomAnchor, constant: g.headerBodyGap),
@@ -450,7 +440,6 @@ final class TranscriptBubbleCellView: NSTableCellView {
 
         header.stringValue = headerText
         backgroundBox.fillColor = g.backgroundColor(for: role)
-        signalSpine.isHidden = role == .user
 
         rebuildBlockStack(blocks: blocks, blockHeights: blockHeights, bodyWidth: bodyWidth)
 

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
@@ -202,7 +202,20 @@ final class MessageBlockMeasurer {
             return proseMeasurer.textHeight(of: string, width: bodyWidth)
         case .table(let data):
             return Self.tableHeight(data, bodyWidth: bodyWidth)
+        case .image(let attachment):
+            return Self.imageSize(attachment, bodyWidth: bodyWidth).height
         }
+    }
+
+    /// Laid-out size of an attached image. The aspect ratio comes from a
+    /// SYNCHRONOUS header-only probe (`CGImageSourceCopyPropertiesAtIndex` reads
+    /// the header, it does not decode), so the height is exact from the first
+    /// measurement and does not move when the downsampled thumbnail arrives on
+    /// the main thread later. A missing or undecodable file falls back to the
+    /// chip's fixed size — also deterministic.
+    static func imageSize(_ attachment: TranscriptImageAttachment, bodyWidth: CGFloat) -> CGSize {
+        let metadata = TranscriptImageService.shared.metadata(forPath: attachment.path)
+        return TranscriptImageGeometry.displaySize(metadata: metadata, bodyWidth: bodyWidth)
     }
 
     /// Per-block measured heights at `bodyWidth`, in block order. The summed-plus-
@@ -480,6 +493,8 @@ final class TranscriptBubbleCellView: NSTableCellView {
                 view = makeProseView(string, bodyWidth: width)
             case .table(let data):
                 view = makeTableView(data, bodyWidth: width)
+            case .image(let attachment):
+                view = makeImageView(attachment, bodyWidth: width)
             }
             view.translatesAutoresizingMaskIntoConstraints = false
             blockStack.addArrangedSubview(view)
@@ -550,6 +565,18 @@ final class TranscriptBubbleCellView: NSTableCellView {
         }
     }
 
+    /// An attached-image block: a leading-aligned thumbnail at exactly the size
+    /// the measurer reserved, decoded off-main and revealed in Finder on click.
+    private func makeImageView(_ attachment: TranscriptImageAttachment, bodyWidth: CGFloat) -> NSView {
+        let metadata = TranscriptImageService.shared.metadata(forPath: attachment.path)
+        let view = TranscriptImageBlockView()
+        view.configure(
+            attachment: attachment,
+            metadata: metadata,
+            displaySize: TranscriptImageGeometry.displaySize(metadata: metadata, bodyWidth: bodyWidth))
+        return view
+    }
+
     /// A table block hosted in an `NSHostingView` over the native grid.
     private func makeTableView(_ data: TranscriptTableData, bodyWidth: CGFloat) -> NSView {
         let view = TranscriptTableView(
@@ -570,6 +597,10 @@ final class TranscriptBubbleCellView: NSTableCellView {
             case .table:
                 // A table always wants the full body width.
                 widest = bodyWidth
+            case .image(let attachment):
+                // A thumbnail wants exactly its laid-out width, so a bubble that
+                // is just an image hugs the picture instead of spanning the column.
+                widest = max(widest, MessageBlockMeasurer.imageSize(attachment, bodyWidth: bodyWidth).width)
             }
         }
         return widest

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptBubbleCellView.swift
@@ -34,12 +34,15 @@ enum TranscriptBubbleGeometry {
     /// side additionally carries the 52pt gutter (12 + 52 = 64); an assistant bubble
     /// carries just the 12pt chrome inset on the opposite side (no gutter).
     static let outerNear: CGFloat = 12
-    /// Outer top/bottom padding.
-    static let outerVertical: CGFloat = 4
+    /// Outer top/bottom padding. Bubbles carry no role/timestamp header — position
+    /// alone says who spoke — so this inset is the ONLY thing separating one
+    /// message from the next, and it absorbs the vertical role the header line used
+    /// to play: 8pt per side gives a 16pt gutter between adjacent bubbles.
+    static let outerVertical: CGFloat = 8
     /// bubbleBody inner horizontal insets. User bubbles keep an 11pt inset on each
     /// side (visible chat-bubble padding). Assistant messages have no visible bubble,
     /// so they use ZERO horizontal inset — content sits flush at the box edge so it
-    /// aligns with the header and the 12pt tool-row inset.
+    /// aligns with the 12pt tool-row inset.
     static func bodyHorizontal(for role: Role) -> CGFloat {
         switch role {
         case .user: return 22
@@ -48,12 +51,8 @@ enum TranscriptBubbleGeometry {
     }
     /// bubbleBody inner vertical insets (8 top + 8 bottom).
     static let bodyVertical: CGFloat = 16
-    /// VStack header→body spacing.
-    static let headerBodyGap: CGFloat = 3
     /// Bubble corner radius.
     static let cornerRadius: CGFloat = 10
-    /// Header text horizontal inset (matches ChatBubbleView's roleHeader padding).
-    static let headerInset: CGFloat = 4
     /// Vertical gap BETWEEN stacked blocks inside one bubble (prose→table etc.).
     static let interBlockSpacing: CGFloat = 6
 
@@ -67,28 +66,22 @@ enum TranscriptBubbleGeometry {
     }
 
     /// Total row height: summed block heights + inter-block spacing + fixed chrome
-    /// (header line + header→body gap + body vertical insets + outer vertical
-    /// padding).
+    /// (body vertical insets + outer vertical padding). There is no header line to
+    /// account for — bubbles carry no visible role/timestamp attribution.
     static func rowHeight(blocksHeight: CGFloat) -> CGFloat {
-        blocksHeight + headerLineHeight + headerBodyGap + bodyVertical + outerVertical * 2
+        blocksHeight + bodyVertical + outerVertical * 2
     }
-
-    /// Measured single-line height of the caption2 header font.
-    static let headerLineHeight: CGFloat = {
-        let font = NSFont.preferredFont(forTextStyle: .caption2)
-        return ceil(font.ascender - font.descender + font.leading)
-    }()
-
-    static let headerFont: NSFont = .preferredFont(forTextStyle: .caption2)
 
     static func role(for item: TranscriptItem) -> Role {
         if case .userPrompt = item { return .user }
         return .assistant
     }
 
-    /// Header line, matching ChatBubbleView: user shows "ts · You",
-    /// assistant shows "Claude · ts".
-    static func header(for item: TranscriptItem) -> String {
+    /// Speaker attribution for ASSISTIVE technology only — it is deliberately not
+    /// drawn. The bubble shows no role/timestamp header (position says who spoke),
+    /// but VoiceOver has no position cue, so the cell carries this as its
+    /// accessibility label: user reads "ts · You", assistant "Claude · ts".
+    static func accessibilityAttribution(for item: TranscriptItem) -> String {
         let ts = item.timestamp?.absoluteShort
         switch role(for: item) {
         case .user:
@@ -318,7 +311,9 @@ private final class RoundedBoxView: NSView {
 final class TranscriptBubbleTextView: NSTextView {}
 
 /// `NSTableCellView` that renders a chat message as a vertical stack of typed
-/// block views inside ONE rounded bubble, with a caption2 header above. Prose
+/// block views inside ONE rounded bubble. There is no role/timestamp header —
+/// a transcript is not a group chat, and the bubble's side and tint already say
+/// who spoke; the attribution survives as the cell's accessibility label. Prose
 /// blocks render in selectable TextKit-1 `NSTextView`s; table blocks render in an
 /// `NSHostingView` over the native grid. The row height (from `heightOfRow`) is
 /// pinned via `columnWidth × cachedHeight`, and each block is laid out at the SAME
@@ -327,7 +322,6 @@ final class TranscriptBubbleTextView: NSTextView {}
 @MainActor
 final class TranscriptBubbleCellView: NSTableCellView {
     private let backgroundBox = RoundedBoxView()
-    private let header = NSTextField(labelWithString: "")
     /// Vertical stack of block subviews inside the bubble.
     private let blockStack = NSStackView()
     private let measurer = MessageBlockMeasurer()
@@ -344,8 +338,6 @@ final class TranscriptBubbleCellView: NSTableCellView {
     // Cell-box + role-dependent anchoring constraints (assigned post-super.init).
     private var widthConstraint: NSLayoutConstraint!
     private var heightConstraint: NSLayoutConstraint!
-    private var headerLeading: NSLayoutConstraint!
-    private var headerTrailing: NSLayoutConstraint!
     private var boxLeading: NSLayoutConstraint!
     private var boxTrailing: NSLayoutConstraint!
     private var boxWidth: NSLayoutConstraint!
@@ -362,14 +354,6 @@ final class TranscriptBubbleCellView: NSTableCellView {
         backgroundBox.cornerRadius = TranscriptBubbleGeometry.cornerRadius
         backgroundBox.translatesAutoresizingMaskIntoConstraints = false
 
-        header.font = TranscriptBubbleGeometry.headerFont
-        header.textColor = .tertiaryLabelColor
-        header.backgroundColor = .clear
-        header.isBezeled = false
-        header.isEditable = false
-        header.drawsBackground = false
-        header.translatesAutoresizingMaskIntoConstraints = false
-
         blockStack.orientation = .vertical
         blockStack.alignment = .leading
         blockStack.distribution = .fill
@@ -380,14 +364,9 @@ final class TranscriptBubbleCellView: NSTableCellView {
         // so the stack's text views are topmost and take the mouse for selection
         // while the bubble paints behind them.
         addSubview(backgroundBox)
-        addSubview(header)
         addSubview(blockStack, positioned: .above, relativeTo: backgroundBox)
 
         let g = TranscriptBubbleGeometry.self
-        headerLeading = header.leadingAnchor.constraint(
-            equalTo: leadingAnchor, constant: g.headerInset)
-        headerTrailing = header.trailingAnchor.constraint(
-            equalTo: trailingAnchor, constant: -g.headerInset)
         boxLeading = backgroundBox.leadingAnchor.constraint(equalTo: leadingAnchor)
         boxTrailing = backgroundBox.trailingAnchor.constraint(equalTo: trailingAnchor)
         boxWidth = backgroundBox.widthAnchor.constraint(equalToConstant: 1)
@@ -399,9 +378,10 @@ final class TranscriptBubbleCellView: NSTableCellView {
         NSLayoutConstraint.activate([
             widthConstraint,
             heightConstraint,
-            header.topAnchor.constraint(equalTo: topAnchor, constant: g.outerVertical),
-            backgroundBox.topAnchor.constraint(
-                equalTo: header.bottomAnchor, constant: g.headerBodyGap),
+            // With the attribution header gone the box hangs straight off the row
+            // top; `outerVertical` is the whole top chrome (and matches
+            // `rowHeight`'s `outerVertical * 2`).
+            backgroundBox.topAnchor.constraint(equalTo: topAnchor, constant: g.outerVertical),
             // The block stack fills the box minus the body insets. The box owns the
             // rounded-rect frame; the stack sits inside it with symmetric padding.
             blockStack.topAnchor.constraint(
@@ -424,7 +404,7 @@ final class TranscriptBubbleCellView: NSTableCellView {
         blockHeights: [CGFloat],
         sourceText: String,
         role: TranscriptBubbleGeometry.Role,
-        header headerText: String,
+        accessibilityAttribution: String,
         bodyWidth: CGFloat,
         columnWidth: CGFloat,
         cachedHeight: CGFloat
@@ -438,14 +418,18 @@ final class TranscriptBubbleCellView: NSTableCellView {
         if abs(widthConstraint.constant - w) > 0.5 { widthConstraint.constant = w }
         if abs(heightConstraint.constant - h) > 0.5 { heightConstraint.constant = h }
 
-        header.stringValue = headerText
+        // The speaker is conveyed visually by position and tint, which VoiceOver
+        // cannot perceive — so the attribution the header used to show is spoken
+        // as the cell's label instead.
+        setAccessibilityLabel(accessibilityAttribution)
+        setAccessibilityRole(.group)
         backgroundBox.fillColor = g.backgroundColor(for: role)
 
         rebuildBlockStack(blocks: blocks, blockHeights: blockHeights, bodyWidth: bodyWidth)
 
         // Box width: user bubbles shrink-to-fit (right-anchored), assistant fills.
         // Per-role block-stack inset: user keeps the 11pt-per-side bubble padding,
-        // assistant sits flush at the box edge (0) so content aligns with the header.
+        // assistant sits flush at the box edge (0), aligning with the tool rows.
         let bodyInset = g.bodyHorizontal(for: role) / 2
         blockLeading.constant = bodyInset
         blockTrailing.constant = -bodyInset
@@ -591,8 +575,7 @@ final class TranscriptBubbleCellView: NSTableCellView {
         return widest
     }
 
-    /// Right-anchor the box, fixed to the measured content width, with the
-    /// header right-aligned to match.
+    /// Right-anchor the box, fixed to the measured content width.
     private func applyUserAnchor(width: CGFloat) {
         let g = TranscriptBubbleGeometry.self
         boxLeading.isActive = false
@@ -600,11 +583,6 @@ final class TranscriptBubbleCellView: NSTableCellView {
         boxTrailing.constant = -g.outerNear  // trailing 12
         boxWidth.isActive = true
         boxWidth.constant = width
-
-        headerLeading.isActive = false
-        headerTrailing.isActive = true
-        headerTrailing.constant = -(g.outerNear + g.headerInset)
-        header.alignment = .right
     }
 
     /// Left-anchor the box filling the assistant bubble width.
@@ -614,14 +592,9 @@ final class TranscriptBubbleCellView: NSTableCellView {
         boxWidth.isActive = true
         boxWidth.constant = bubbleWidth
         boxLeading.isActive = true
+        // Flush at `outerNear` (12) — the same x as the assistant body (zero body
+        // inset) and the 12pt tool-row inset — forming one vertical line.
         boxLeading.constant = g.outerNear  // leading 12
-
-        headerTrailing.isActive = false
-        headerLeading.isActive = true
-        // Header sits flush at `outerNear` (12) — the same x as the assistant body
-        // (zero body inset) and the 12pt tool-row inset — forming one vertical line.
-        headerLeading.constant = g.outerNear
-        header.alignment = .left
     }
 
     // MARK: - Copy message

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptImageBlockView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptImageBlockView.swift
@@ -2,7 +2,8 @@ import AppKit
 import os
 
 /// The native (NSTableView) rendering of an attached image: a leading-aligned
-/// thumbnail that reveals the file in Finder when clicked.
+/// thumbnail that opens a Quick Look preview when clicked, with Finder and the
+/// pasteboard on its right-click menu.
 ///
 /// The view is width-pinned to the bubble's full body width by the block stack
 /// (like every other block), and draws its content at the leading edge in the
@@ -17,7 +18,12 @@ final class TranscriptImageBlockView: NSView {
     private let chipIcon = NSImageView()
 
     private var attachment: TranscriptImageAttachment?
-    private var isRevealable = false
+    /// A file that is there: clickable to preview, and worth a context menu.
+    /// False only for `.missing`, where there is nothing to show.
+    private var isPreviewable = false
+    /// True only for a decodable image, which is the one state where "Copy
+    /// Image" means anything.
+    private var isCopyable = false
 
     /// Bumped on every `configure`. An in-flight decode captures the value it was
     /// dispatched with and drops its result if the cell was recycled onto another
@@ -116,8 +122,9 @@ final class TranscriptImageBlockView: NSView {
 
         switch metadata.state {
         case .ready:
-            isRevealable = true
-            setAccessibilityHelp("Reveal in Finder")
+            isPreviewable = true
+            isCopyable = true
+            setAccessibilityHelp("Quick Look preview")
             chip.isHidden = true
             chipIcon.isHidden = true
             imageView.isHidden = false
@@ -143,19 +150,22 @@ final class TranscriptImageBlockView: NSView {
             }
 
         case .missing:
-            isRevealable = false
+            isPreviewable = false
+            isCopyable = false
             setAccessibilityHelp(nil)
             showChip(missing: true)
 
         case .unreadable:
-            // The file is there but is not a decodable image. Revealing it is
-            // still the useful gesture, so the chip stays clickable.
-            isRevealable = true
-            setAccessibilityHelp("Reveal in Finder")
+            // The file is there but is not a decodable image. Quick Look happily
+            // previews a text file or a PDF, so the chip stays clickable — only
+            // "Copy Image" drops off the menu.
+            isPreviewable = true
+            isCopyable = false
+            setAccessibilityHelp("Quick Look preview")
             showChip(missing: false)
         }
 
-        // A revealable/unrevealable switch changes whether we want the pointing
+        // A previewable/non-previewable switch changes whether we want the pointing
         // hand, and cursor rects are only rebuilt on request.
         window?.invalidateCursorRects(for: self)
     }
@@ -182,36 +192,77 @@ final class TranscriptImageBlockView: NSView {
         }
     }
 
-    // MARK: - Reveal affordance
+    // MARK: - Click and context menu
 
     override func resetCursorRects() {
         super.resetCursorRects()
-        guard isRevealable else { return }
-        addCursorRect(
-            NSRect(origin: .zero, size: NSSize(
-                width: contentWidth.constant, height: contentHeight.constant)),
-            cursor: .pointingHand)
+        guard isPreviewable else { return }
+        addCursorRect(contentRect, cursor: .pointingHand)
+    }
+
+    /// The drawn thumbnail (or chip) inside this width-pinned block — clicks in
+    /// the empty trailing space are not ours.
+    private var contentRect: NSRect {
+        NSRect(
+            origin: .zero,
+            size: NSSize(width: contentWidth.constant, height: contentHeight.constant))
     }
 
     override func mouseDown(with event: NSEvent) {
-        guard isRevealable, let attachment else {
+        guard isPreviewable, let attachment,
+              contentRect.contains(convert(event.locationInWindow, from: nil)) else {
             super.mouseDown(with: event)
             return
         }
-        let point = convert(event.locationInWindow, from: nil)
-        let content = NSRect(
-            origin: .zero,
-            size: NSSize(width: contentWidth.constant, height: contentHeight.constant))
-        guard content.contains(point) else {
-            super.mouseDown(with: event)
-            return
+        TranscriptImageActions.preview(path: attachment.path)
+    }
+
+    /// Right-click keeps Finder and the pasteboard reachable now that a plain
+    /// click previews. Returning nil outside the thumbnail (or for a missing
+    /// file) lets the enclosing bubble's "Copy message" menu answer instead.
+    override func menu(for event: NSEvent) -> NSMenu? {
+        guard contentRect.contains(convert(event.locationInWindow, from: nil)) else { return nil }
+        return makeContextMenu()
+    }
+
+    /// The menu for the current chip state, independent of where the click
+    /// landed. Also the seam the tests drive, since a synthesized `NSEvent`
+    /// cannot be located inside a view that has no window.
+    func makeContextMenu() -> NSMenu? {
+        guard isPreviewable, attachment != nil else { return nil }
+        let menu = NSMenu()
+        menu.addItem(item(title: "Quick Look", action: #selector(quickLook(_:))))
+        if isCopyable {
+            menu.addItem(item(title: "Copy Image", action: #selector(copyImage(_:))))
         }
-        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: attachment.path)])
+        menu.addItem(item(title: "Reveal in Finder", action: #selector(revealInFinder(_:))))
+        return menu
+    }
+
+    private func item(title: String, action: Selector) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        return item
+    }
+
+    @objc private func quickLook(_ sender: Any?) {
+        guard let attachment else { return }
+        TranscriptImageActions.preview(path: attachment.path)
+    }
+
+    @objc private func copyImage(_ sender: Any?) {
+        guard let attachment else { return }
+        TranscriptImageActions.copyImage(path: attachment.path)
+    }
+
+    @objc private func revealInFinder(_ sender: Any?) {
+        guard let attachment else { return }
+        TranscriptImageActions.revealInFinder(path: attachment.path)
     }
 
     override func accessibilityPerformPress() -> Bool {
-        guard isRevealable, let attachment else { return false }
-        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: attachment.path)])
+        guard isPreviewable, let attachment else { return false }
+        TranscriptImageActions.preview(path: attachment.path)
         return true
     }
 

--- a/Sources/TBDApp/Panes/Transcript/Table/TranscriptImageBlockView.swift
+++ b/Sources/TBDApp/Panes/Transcript/Table/TranscriptImageBlockView.swift
@@ -1,0 +1,223 @@
+import AppKit
+import os
+
+/// The native (NSTableView) rendering of an attached image: a leading-aligned
+/// thumbnail that reveals the file in Finder when clicked.
+///
+/// The view is width-pinned to the bubble's full body width by the block stack
+/// (like every other block), and draws its content at the leading edge in the
+/// exact `displaySize` the measurer used — so the drawn height equals the row
+/// height by construction, and the thumbnail arriving later never resizes
+/// anything.
+@MainActor
+final class TranscriptImageBlockView: NSView {
+    private let imageView = NSImageView()
+    private let placeholder = NSView()
+    private let chip = NSTextField(labelWithString: "")
+    private let chipIcon = NSImageView()
+
+    private var attachment: TranscriptImageAttachment?
+    private var isRevealable = false
+
+    /// Bumped on every `configure`. An in-flight decode captures the value it was
+    /// dispatched with and drops its result if the cell was recycled onto another
+    /// message meanwhile — the same staleness guard the async syntax highlighter
+    /// uses. (#129)
+    private var generation = 0
+
+    private var contentWidth: NSLayoutConstraint!
+    private var contentHeight: NSLayoutConstraint!
+    private var chipWidth: NSLayoutConstraint!
+
+    private static let log = Logger(subsystem: "com.tbd.app", category: "transcript-image")
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        placeholder.translatesAutoresizingMaskIntoConstraints = false
+        placeholder.wantsLayer = true
+        placeholder.layer?.cornerRadius = 6
+        placeholder.layer?.cornerCurve = .continuous
+        placeholder.layer?.backgroundColor = NSColor.quaternaryLabelColor.withAlphaComponent(0.25).cgColor
+
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.wantsLayer = true
+        imageView.layer?.cornerRadius = 6
+        imageView.layer?.cornerCurve = .continuous
+        imageView.layer?.masksToBounds = true
+
+        chipIcon.translatesAutoresizingMaskIntoConstraints = false
+        chipIcon.imageScaling = .scaleProportionallyDown
+        chipIcon.contentTintColor = .secondaryLabelColor
+
+        chip.translatesAutoresizingMaskIntoConstraints = false
+        chip.font = NSFont.systemFont(ofSize: 11)
+        chip.textColor = .secondaryLabelColor
+        chip.lineBreakMode = .byTruncatingMiddle
+        chip.cell?.truncatesLastVisibleLine = true
+
+        addSubview(placeholder)
+        addSubview(imageView)
+        addSubview(chipIcon)
+        addSubview(chip)
+
+        contentWidth = placeholder.widthAnchor.constraint(equalToConstant: 1)
+        contentHeight = placeholder.heightAnchor.constraint(equalToConstant: 1)
+        chipWidth = chip.widthAnchor.constraint(lessThanOrEqualToConstant: 1)
+
+        NSLayoutConstraint.activate([
+            placeholder.leadingAnchor.constraint(equalTo: leadingAnchor),
+            placeholder.topAnchor.constraint(equalTo: topAnchor),
+            contentWidth,
+            contentHeight,
+
+            imageView.leadingAnchor.constraint(equalTo: placeholder.leadingAnchor),
+            imageView.topAnchor.constraint(equalTo: placeholder.topAnchor),
+            imageView.widthAnchor.constraint(equalTo: placeholder.widthAnchor),
+            imageView.heightAnchor.constraint(equalTo: placeholder.heightAnchor),
+
+            chipIcon.leadingAnchor.constraint(equalTo: leadingAnchor),
+            chipIcon.centerYAnchor.constraint(equalTo: placeholder.centerYAnchor),
+            chipIcon.widthAnchor.constraint(equalToConstant: 12),
+            chipIcon.heightAnchor.constraint(equalToConstant: 12),
+
+            chip.leadingAnchor.constraint(equalTo: chipIcon.trailingAnchor, constant: 4),
+            chip.centerYAnchor.constraint(equalTo: chipIcon.centerYAnchor),
+            chipWidth
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Renders `attachment` at exactly `displaySize` — the size
+    /// `TranscriptImageGeometry` produced from the synchronous header probe, and
+    /// the size the row was measured at.
+    func configure(
+        attachment: TranscriptImageAttachment,
+        metadata: TranscriptImageMetadata,
+        displaySize: CGSize
+    ) {
+        generation &+= 1
+        let captured = generation
+        self.attachment = attachment
+
+        contentWidth.constant = max(displaySize.width, 1)
+        contentHeight.constant = max(displaySize.height, 1)
+        chipWidth.constant = max(displaySize.width - 16, 1)
+
+        toolTip = attachment.displayPath
+        setAccessibilityRole(.button)
+        setAccessibilityLabel(Self.accessibilityLabel(attachment: attachment, metadata: metadata))
+
+        switch metadata.state {
+        case .ready:
+            isRevealable = true
+            setAccessibilityHelp("Reveal in Finder")
+            chip.isHidden = true
+            chipIcon.isHidden = true
+            imageView.isHidden = false
+            placeholder.isHidden = false
+            imageView.image = nil
+            // Ask for pixels, not points, so the thumbnail stays crisp on Retina
+            // without the original ever being decoded at full size.
+            let scale = window?.backingScaleFactor ?? 2
+            let maxPixel = Int((max(displaySize.width, displaySize.height) * scale).rounded(.up))
+            TranscriptImageService.shared.thumbnail(
+                forPath: attachment.path, maxPixelSize: maxPixel
+            ) { [weak self] image in
+                guard let self, self.generation == captured else { return }
+                guard let image else {
+                    // The file decoded its header at measure time but not its
+                    // pixels now (truncated, deleted mid-scroll). Fall back to the
+                    // chip IN PLACE — the reserved height is unchanged.
+                    self.showChip(missing: true)
+                    return
+                }
+                self.imageView.image = image
+                self.placeholder.isHidden = true
+            }
+
+        case .missing:
+            isRevealable = false
+            setAccessibilityHelp(nil)
+            showChip(missing: true)
+
+        case .unreadable:
+            // The file is there but is not a decodable image. Revealing it is
+            // still the useful gesture, so the chip stays clickable.
+            isRevealable = true
+            setAccessibilityHelp("Reveal in Finder")
+            showChip(missing: false)
+        }
+
+        // A revealable/unrevealable switch changes whether we want the pointing
+        // hand, and cursor rects are only rebuilt on request.
+        window?.invalidateCursorRects(for: self)
+    }
+
+    private func showChip(missing: Bool) {
+        imageView.isHidden = true
+        placeholder.isHidden = true
+        chip.isHidden = false
+        chipIcon.isHidden = false
+        let symbol = missing ? "photo.badge.exclamationmark" : "doc"
+        chipIcon.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
+        let name = attachment?.fileName ?? "image"
+        chip.stringValue = missing ? "\(name) — unavailable" : name
+    }
+
+    static func accessibilityLabel(
+        attachment: TranscriptImageAttachment,
+        metadata: TranscriptImageMetadata
+    ) -> String {
+        switch metadata.state {
+        case .ready: return "Attached image, \(attachment.fileName)"
+        case .missing: return "Attached image, \(attachment.fileName), unavailable"
+        case .unreadable: return "Attached file, \(attachment.fileName), not a viewable image"
+        }
+    }
+
+    // MARK: - Reveal affordance
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        guard isRevealable else { return }
+        addCursorRect(
+            NSRect(origin: .zero, size: NSSize(
+                width: contentWidth.constant, height: contentHeight.constant)),
+            cursor: .pointingHand)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard isRevealable, let attachment else {
+            super.mouseDown(with: event)
+            return
+        }
+        let point = convert(event.locationInWindow, from: nil)
+        let content = NSRect(
+            origin: .zero,
+            size: NSSize(width: contentWidth.constant, height: contentHeight.constant))
+        guard content.contains(point) else {
+            super.mouseDown(with: event)
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: attachment.path)])
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        guard isRevealable, let attachment else { return false }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: attachment.path)])
+        return true
+    }
+
+    /// Test seam: the image currently drawn, if the async decode has landed.
+    var renderedImage: NSImage? { imageView.isHidden ? nil : imageView.image }
+
+    /// Test seam: the fallback chip's text, or nil when a thumbnail is showing.
+    var fallbackChipText: String? { chip.isHidden ? nil : chip.stringValue }
+}

--- a/Sources/TBDApp/Panes/Transcript/TranscriptImageActions.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptImageActions.swift
@@ -1,0 +1,148 @@
+import AppKit
+import QuickLookUI
+import os
+
+/// The gestures an attached-image thumbnail offers, shared by the native
+/// (`TranscriptImageBlockView`) and the SwiftUI (`TranscriptImageAttachmentView`)
+/// renderers so the two cannot drift: click previews, the context menu keeps
+/// Finder and the pasteboard reachable.
+@MainActor
+enum TranscriptImageActions {
+    private static let log = Logger(subsystem: "com.tbd.app", category: "transcript-image")
+
+    /// Primary click: the macOS Quick Look panel — what the space bar gives you
+    /// in Finder. Also the right gesture for a file that is NOT a decodable
+    /// image, which Quick Look previews perfectly well (a text file, a PDF).
+    static func preview(path: String) {
+        TranscriptQuickLook.shared.preview(url: URL(fileURLWithPath: path))
+    }
+
+    /// Where "Reveal in Finder" went when click became preview.
+    static func revealInFinder(path: String) {
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+    }
+
+    /// Copies the ORIGINAL file's pixels, not the downsampled thumbnail the
+    /// transcript drew. That is a full decode, so it runs off the main thread —
+    /// the same hazard class as #129, just triggered by a menu item instead of a
+    /// row. A file that does not decode falls back to copying its file URL, so
+    /// the menu item is never a no-op.
+    static func copyImage(path: String) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let image = NSImage(contentsOfFile: path)
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    if let image {
+                        pasteboard.writeObjects([image])
+                    } else {
+                        log.debug("transcript-image copy fell back to URL path=\(path, privacy: .public)")
+                        pasteboard.writeObjects([URL(fileURLWithPath: path) as NSURL])
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Drives the shared `QLPreviewPanel` for transcript attachments.
+///
+/// ## Why the app delegate owns the panel
+///
+/// `QLPreviewPanel` is a single app-wide panel that finds its controller by
+/// walking the responder chain of the key window — it shows an EMPTY window if
+/// nothing in that chain claims it. The chain ends at `NSApp` and then the
+/// application delegate, so implementing the three `QLPreviewPanelController`
+/// methods on `AppDelegate` (see the extension below) covers every caller
+/// without either renderer having to seize first-responder status from the
+/// transcript's text views — and it covers both renderers with one wiring.
+///
+/// Verified in this unbundled-SPM process rather than assumed: a probe binary
+/// with no `Info.plist` (`Bundle.main.bundleIdentifier == nil`) opened the panel
+/// through exactly this app-delegate chain, and it reported
+/// `isVisible == true`, a non-nil `currentController`, and the expected
+/// `currentPreviewItem` while rendering the picture. QuickLookUI reads nothing
+/// out of the bundle here, so no `bundleIdentifier` guard is warranted; the only
+/// fallback is for `sharedPreviewPanel` coming back nil, which opens the file in
+/// its default app instead of failing silently.
+@MainActor
+final class TranscriptQuickLook: NSObject, @MainActor QLPreviewPanelDataSource {
+    static let shared = TranscriptQuickLook()
+
+    private static let log = Logger(subsystem: "com.tbd.app", category: "transcript-image")
+
+    /// The file the panel shows while this object is its data source. Set before
+    /// the panel is asked to appear, because the responder-chain search calls
+    /// `acceptsPreviewPanelControl` synchronously inside that call.
+    private(set) var previewURL: URL?
+
+    /// Test seam: how the panel is actually put on screen. A test replaces this
+    /// so the click path can be exercised without a real Quick Look panel
+    /// appearing over the developer's screen mid-run. Production leaves it alone.
+    var showPanel: @MainActor () -> Void = { TranscriptQuickLook.showSharedPanel() }
+
+    /// Preview `url`, or open it in its default app if the panel is unavailable.
+    func preview(url: URL) {
+        previewURL = url
+        showPanel()
+    }
+
+    private static func showSharedPanel() {
+        guard let panel = QLPreviewPanel.shared() else {
+            // No panel to drive: opening in Preview.app is the honest fallback,
+            // rather than a click that does nothing.
+            if let url = shared.previewURL { NSWorkspace.shared.open(url) }
+            log.debug("transcript-image quick look unavailable, opened externally")
+            return
+        }
+        if panel.isVisible {
+            // Already up on another attachment — swap the item in place.
+            panel.reloadData()
+        } else {
+            panel.makeKeyAndOrderFront(nil)
+        }
+        // The key window did not necessarily change, so ask for the controller
+        // search explicitly.
+        panel.updateController()
+    }
+
+    // MARK: - QLPreviewPanelDataSource
+
+    func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int { previewURL == nil ? 0 : 1 }
+
+    func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> (any QLPreviewItem)! {
+        previewURL as NSURL?
+    }
+
+    // MARK: - Controller plumbing (called from the AppDelegate extension)
+
+    func accepts() -> Bool { previewURL != nil }
+
+    func beginControl(of panel: QLPreviewPanel?) { panel?.dataSource = self }
+
+    func endControl(of panel: QLPreviewPanel?) {
+        // Deliberately keeps `previewURL`: control ends whenever the key window
+        // changes, and dropping the item there would blank a panel the user is
+        // still looking at.
+        panel?.dataSource = nil
+    }
+}
+
+/// The responder-chain terminus that lets `QLPreviewPanel` find a controller.
+/// `QLPreviewPanelController` is an informal protocol on `NSObject`, so these are
+/// overrides of category methods and AppKit only ever calls them on the main
+/// thread.
+extension AppDelegate {
+    override func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool {
+        MainActor.assumeIsolated { TranscriptQuickLook.shared.accepts() }
+    }
+
+    override func beginPreviewPanelControl(_ panel: QLPreviewPanel!) {
+        MainActor.assumeIsolated { TranscriptQuickLook.shared.beginControl(of: panel) }
+    }
+
+    override func endPreviewPanelControl(_ panel: QLPreviewPanel!) {
+        MainActor.assumeIsolated { TranscriptQuickLook.shared.endControl(of: panel) }
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+
+/// SwiftUI rendering of an attached image, for the hosted-per-row transcript
+/// path. Deliberately the same geometry, the same off-main decode, the same
+/// caches and the same fallbacks as the native `TranscriptImageBlockView` — this
+/// repo's standing trap is the two renderers drifting apart.
+///
+/// The frame is fixed from the synchronous header probe BEFORE the decode
+/// starts, so the row does not resize when the thumbnail lands.
+struct TranscriptImageAttachmentView: View {
+    let attachment: TranscriptImageAttachment
+
+    @State private var image: NSImage?
+    @State private var hovering = false
+
+    /// Probed once per view identity. Cheap (header read, then cached by the
+    /// service), and it is what makes the frame deterministic.
+    private var metadata: TranscriptImageMetadata {
+        TranscriptImageService.shared.metadata(forPath: attachment.path)
+    }
+
+    private var displaySize: CGSize {
+        TranscriptImageGeometry.displaySize(
+            metadata: metadata, bodyWidth: TranscriptImageGeometry.maxWidth)
+    }
+
+    private var isRevealable: Bool { metadata.state != .missing }
+
+    var body: some View {
+        content
+            .frame(width: displaySize.width, height: displaySize.height, alignment: .leading)
+            .contentShape(Rectangle())
+            .onTapGesture { reveal() }
+            .onHover { inside in
+                hovering = inside
+                guard isRevealable else { return }
+                if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            }
+            .help(attachment.displayPath)
+            .accessibilityElement()
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(
+                TranscriptImageBlockView.accessibilityLabel(
+                    attachment: attachment, metadata: metadata))
+            .accessibilityHint(isRevealable ? "Reveal in Finder" : "")
+            .onAppear(perform: load)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch metadata.state {
+        case .ready:
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                    .opacity(hovering ? 0.85 : 1)
+            } else {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color(nsColor: .quaternaryLabelColor).opacity(0.25))
+            }
+        case .missing:
+            chip(symbol: "photo.badge.exclamationmark", text: "\(attachment.fileName) — unavailable")
+        case .unreadable:
+            chip(symbol: "doc", text: attachment.fileName)
+        }
+    }
+
+    private func chip(symbol: String, text: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: symbol)
+            Text(text).lineLimit(1).truncationMode(.middle)
+        }
+        .font(.system(size: 11))
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func load() {
+        guard case .ready = metadata.state, image == nil else { return }
+        let scale = NSScreen.main?.backingScaleFactor ?? 2
+        let maxPixel = Int((max(displaySize.width, displaySize.height) * scale).rounded(.up))
+        TranscriptImageService.shared.thumbnail(
+            forPath: attachment.path, maxPixelSize: maxPixel
+        ) { decoded in
+            image = decoded
+        }
+    }
+
+    private func reveal() {
+        guard isRevealable else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: attachment.path)])
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
@@ -15,6 +15,12 @@ struct TranscriptImageAttachmentView: View {
     @State private var image: NSImage?
     @State private var hovering = false
 
+    /// Bumped on every load. An in-flight decode captures the value it was
+    /// dispatched with and drops its result if this view was pointed at a
+    /// different attachment meanwhile — the same staleness guard
+    /// `TranscriptImageBlockView.generation` enforces on the native path.
+    @State private var generation = 0
+
     /// Probed once per view identity. Cheap (header read, then cached by the
     /// service), and it is what makes the frame deterministic.
     private var metadata: TranscriptImageMetadata {
@@ -66,6 +72,20 @@ struct TranscriptImageAttachmentView: View {
                 attachment: attachment, metadata: metadata))
         .accessibilityHint(isPreviewable ? "Quick Look preview" : "")
         .onAppear(perform: load)
+        // This view renders inside `TableTranscriptView`'s shared `NSHostingView`
+        // pool, where a recycled cell has its `rootView` REPLACED rather than being
+        // torn down. Today `MarkdownSegments.Segment.id` keys image segments by
+        // path, so SwiftUI rebuilds this view with fresh `@State` and the thumbnail
+        // cannot survive onto another message — but that is the CALL SITE's
+        // property, not this view's, and `load` alone would never notice: it bails
+        // once `image` is non-nil and `onAppear` does not fire a second time. Own
+        // the invariant here, where the failure (the wrong picture, silently) would
+        // land.
+        .onChange(of: attachment) { _, _ in
+            image = nil
+            hovering = false
+            load()
+        }
     }
 
     private var sized: some View {
@@ -107,11 +127,16 @@ struct TranscriptImageAttachmentView: View {
 
     private func load() {
         guard case .ready = metadata.state, image == nil else { return }
+        generation &+= 1
+        let captured = generation
         let scale = NSScreen.main?.backingScaleFactor ?? 2
         let maxPixel = Int((max(displaySize.width, displaySize.height) * scale).rounded(.up))
         TranscriptImageService.shared.thumbnail(
             forPath: attachment.path, maxPixelSize: maxPixel
         ) { decoded in
+            // A decode dispatched for the PREVIOUS attachment must not paint over
+            // the current one when it lands late.
+            guard captured == generation else { return }
             image = decoded
         }
     }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptImageAttachmentView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 /// SwiftUI rendering of an attached image, for the hosted-per-row transcript
 /// path. Deliberately the same geometry, the same off-main decode, the same
-/// caches and the same fallbacks as the native `TranscriptImageBlockView` — this
-/// repo's standing trap is the two renderers drifting apart.
+/// caches, the same click and menu actions and the same fallbacks as the native
+/// `TranscriptImageBlockView` — this repo's standing trap is the two renderers
+/// drifting apart.
 ///
 /// The frame is fixed from the synchronous header probe BEFORE the decode
 /// starts, so the row does not resize when the thumbnail lands.
@@ -22,29 +23,55 @@ struct TranscriptImageAttachmentView: View {
 
     private var displaySize: CGSize {
         TranscriptImageGeometry.displaySize(
-            metadata: metadata, bodyWidth: TranscriptImageGeometry.maxWidth)
+            metadata: metadata, bodyWidth: TranscriptImageGeometry.maxEdge)
     }
 
-    private var isRevealable: Bool { metadata.state != .missing }
+    /// A file that is there: clickable to preview, and worth a context menu.
+    private var isPreviewable: Bool { metadata.state != .missing }
+    /// Only a decodable image can meaningfully be copied as an image.
+    private var isCopyable: Bool { metadata.pixelSize != nil }
 
     var body: some View {
+        Group {
+            if isPreviewable {
+                // A Button rather than `.onTapGesture`: on macOS a tap gesture
+                // swallows the right-click that `.contextMenu` needs.
+                Button { TranscriptImageActions.preview(path: attachment.path) } label: {
+                    sized
+                }
+                .buttonStyle(.plain)
+                .contextMenu {
+                    Button("Quick Look") { TranscriptImageActions.preview(path: attachment.path) }
+                    if isCopyable {
+                        Button("Copy Image") { TranscriptImageActions.copyImage(path: attachment.path) }
+                    }
+                    Button("Reveal in Finder") {
+                        TranscriptImageActions.revealInFinder(path: attachment.path)
+                    }
+                }
+            } else {
+                sized
+            }
+        }
+        .onHover { inside in
+            hovering = inside
+            guard isPreviewable else { return }
+            if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+        .help(attachment.displayPath)
+        .accessibilityElement()
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(
+            TranscriptImageBlockView.accessibilityLabel(
+                attachment: attachment, metadata: metadata))
+        .accessibilityHint(isPreviewable ? "Quick Look preview" : "")
+        .onAppear(perform: load)
+    }
+
+    private var sized: some View {
         content
             .frame(width: displaySize.width, height: displaySize.height, alignment: .leading)
             .contentShape(Rectangle())
-            .onTapGesture { reveal() }
-            .onHover { inside in
-                hovering = inside
-                guard isRevealable else { return }
-                if inside { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-            }
-            .help(attachment.displayPath)
-            .accessibilityElement()
-            .accessibilityAddTraits(.isButton)
-            .accessibilityLabel(
-                TranscriptImageBlockView.accessibilityLabel(
-                    attachment: attachment, metadata: metadata))
-            .accessibilityHint(isRevealable ? "Reveal in Finder" : "")
-            .onAppear(perform: load)
     }
 
     @ViewBuilder
@@ -87,10 +114,5 @@ struct TranscriptImageAttachmentView: View {
         ) { decoded in
             image = decoded
         }
-    }
-
-    private func reveal() {
-        guard isRevealable else { return }
-        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: attachment.path)])
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptImageMarker.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptImageMarker.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// An image the user attached to a Claude Code prompt, named by a
+/// `[Image: source: /absolute/path.png]` marker in the transcript text.
+///
+/// The marker is the ONLY carrier of the on-disk path. Claude Code writes the
+/// pasted bitmap into the JSONL twice: once as a base64 `image` content block on
+/// the prompt line (structured, but megabytes wide and pathless), and once as
+/// this marker, in a follow-up `isMeta` user line that names the file it spooled
+/// into its image cache. Reveal-in-Finder needs the path, so the marker is what
+/// we read. See `docs`-free note in `TranscriptImageMarker` for the format.
+struct TranscriptImageAttachment: Equatable, Hashable {
+    /// Absolute path exactly as the marker spelled it.
+    let path: String
+
+    var fileName: String { (path as NSString).lastPathComponent }
+
+    /// Tilde-abbreviated path, for the hover tooltip. The path is deliberately
+    /// never DRAWN — replacing it with a thumbnail is the point of the feature —
+    /// but it stays one deliberate hover away.
+    var displayPath: String { (path as NSString).abbreviatingWithTildeInPath }
+}
+
+/// Splits transcript text at Claude Code's image-attachment markers.
+///
+/// ## The real format (measured against 113 markers in `~/.claude/projects`)
+///
+/// A prompt with pasted images produces TWO consecutive JSONL user lines:
+///
+/// 1. the prompt itself — content `[text, image, image…]`, where the text holds
+///    inline `[Image #N]` placeholders at the spot the user pasted, and each
+///    `image` block carries the bitmap as base64;
+/// 2. a follow-up line with `isMeta: true` and content `[text, text…]` — ONE
+///    text block per image, each holding exactly `[Image: source: <abs path>]`.
+///
+/// Empirically, in that corpus: every marker payload was an absolute path; every
+/// marker but one was the entire text block (the exception was a prompt quoting
+/// the marker syntax in prose, which is why this parser accepts mid-sentence
+/// markers); no text block ever held two markers, because multiple images become
+/// multiple text blocks; and `[Image #N]`'s N matched the marker's `N.png`
+/// basename, so the inline placeholders and the thumbnails stay in step.
+///
+/// `[Image #N]` is deliberately left alone. It sits where the user pasted, inside
+/// their own sentence, and with several images it is the only thing tying "this
+/// paragraph" to "that thumbnail". The `source:` marker — pure machine bookkeeping
+/// the user never typed — is what becomes a thumbnail.
+enum TranscriptImageMarker {
+    /// One piece of a message: literal text, or an image attachment that replaces
+    /// the marker at that position.
+    enum Segment: Equatable {
+        case text(String)
+        case image(TranscriptImageAttachment)
+    }
+
+    private static let openToken = "[Image: source: "
+    private static let closeToken = "]"
+
+    /// Splits `text` into ordered text / image segments.
+    ///
+    /// Markers inside fenced code blocks are left as literal text — a fenced
+    /// block is quoted source, not an attachment (this file's own doc comment
+    /// would otherwise render a thumbnail). Only ABSOLUTE paths become image
+    /// segments; anything else stays as text, since a path we cannot resolve is
+    /// nothing we could reveal in Finder either.
+    ///
+    /// Fast path: text with no marker at all returns a single `.text` segment
+    /// without any per-line work, so the overwhelmingly common message pays one
+    /// substring search.
+    static func split(_ text: String) -> [Segment] {
+        guard text.contains(openToken) else { return [.text(text)] }
+
+        var segments: [Segment] = []
+        var textBuffer = ""
+        var inFence = false
+
+        // Newlines that merely separated a marker from its neighbours are
+        // separators, not content: each text run is rendered as its own markdown
+        // document, so a run that is nothing but whitespace would become an empty
+        // prose block with real height. Trim the run's edges and drop it if
+        // nothing is left. Interior blank lines (paragraph breaks) survive.
+        func flushText() {
+            let trimmed = textBuffer.trimmingCharacters(in: .whitespacesAndNewlines)
+            textBuffer = ""
+            guard !trimmed.isEmpty else { return }
+            segments.append(.text(trimmed))
+        }
+
+        let lines = text.components(separatedBy: "\n")
+        for (index, line) in lines.enumerated() {
+            let isLast = index == lines.count - 1
+            if line.hasPrefix("```") {
+                inFence.toggle()
+                textBuffer += line
+                if !isLast { textBuffer += "\n" }
+                continue
+            }
+            if inFence {
+                textBuffer += line
+                if !isLast { textBuffer += "\n" }
+                continue
+            }
+
+            var rest = Substring(line)
+            while let open = rest.range(of: openToken) {
+                guard let close = rest[open.upperBound...].range(of: closeToken) else { break }
+                let payload = String(rest[open.upperBound..<close.lowerBound])
+                    .trimmingCharacters(in: .whitespaces)
+                guard payload.hasPrefix("/"), payload.count > 1 else {
+                    // Not an absolute path — keep the marker as literal text and
+                    // resume scanning after it.
+                    textBuffer += rest[rest.startIndex..<close.upperBound]
+                    rest = rest[close.upperBound...]
+                    continue
+                }
+                textBuffer += rest[rest.startIndex..<open.lowerBound]
+                flushText()
+                segments.append(.image(TranscriptImageAttachment(path: payload)))
+                rest = rest[close.upperBound...]
+            }
+            textBuffer += rest
+            if !isLast { textBuffer += "\n" }
+        }
+
+        flushText()
+        return segments
+    }
+}

--- a/Sources/TBDApp/Panes/Transcript/TranscriptPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptPresentation.swift
@@ -13,12 +13,17 @@ struct ActivityGroupSummary: Hashable {
     let requiresResponse: Bool
     let isExpanded: Bool
 
-    var statusLabel: String {
+    /// Trailing status text, or nil when every item in the group succeeded. A
+    /// fully-successful group says nothing: the row's own content already reads
+    /// as done, so a "complete" label was redundant chrome on the common case.
+    /// Non-nil exactly when `requiresResponse || errorCount > 0 ||
+    /// pendingCount > 0`.
+    var statusLabel: String? {
         if requiresResponse { return "Needs response" }
         if errorCount == 1 { return "1 failed" }
         if errorCount > 1 { return "\(errorCount) failed" }
         if pendingCount > 0 { return "In progress" }
-        return "Complete"
+        return nil
     }
 }
 
@@ -110,6 +115,16 @@ struct TranscriptPresentation {
 
         func flushActivity() {
             guard let first = pendingActivity.first else { return }
+            // A run of exactly one activity is not worth wrapping: a "Worked ·
+            // 1 action" summary repeats what the row underneath already says
+            // and offers a disclosure control with nothing behind it. Emit the
+            // row itself, as if it had never been grouped. Both renderers
+            // inherit this — neither can see a one-item summary node.
+            if pendingActivity.count == 1 {
+                projected.append(first)
+                pendingActivity.removeAll(keepingCapacity: true)
+                return
+            }
             let groupID = "\(first.id)#activity-group"
             let requiresResponse = pendingActivity.contains(where: isResponseRequired)
             let errorCount = pendingActivity.reduce(into: 0) { total, node in

--- a/Sources/TBDApp/Panes/Transcript/TranscriptPresentation.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptPresentation.swift
@@ -1,28 +1,157 @@
 import Foundation
 import TBDShared
 
+/// One vocabulary entry in a collapsed group's activity phrase. Each bucket
+/// with a nonzero count contributes exactly one clause, and `allCases`
+/// declaration order IS the clause order — fixed by this list, never
+/// chronological.
+///
+/// The first eight mirror Claude Code's own renderer verbatim (including
+/// `bash` genuinely coming last). The remaining four exist because TBD groups
+/// rows Claude Code's summary never sees — web tools, `AskUserQuestion`,
+/// injected context and skill bodies all reach a group here, and folding them
+/// into `other` would report an injected CLAUDE.md as "called 1 tool".
+enum ActivityBucket: String, CaseIterable, Hashable {
+    case edit
+    case search
+    case read
+    case list
+    case web
+    case mcp
+    case agent
+    case question
+    case context
+    case skill
+    case other
+    case bash
+
+    /// Present participle while the group is still running, simple past once
+    /// every item has landed.
+    var verbs: (running: String, done: String) {
+        switch self {
+        case .edit: return ("editing", "edited")
+        case .search: return ("searching for", "searched for")
+        case .read: return ("reading", "read")
+        case .list: return ("listing", "listed")
+        case .web: return ("fetching", "fetched")
+        case .mcp: return ("calling", "called")
+        case .agent: return ("running", "ran")
+        case .question: return ("asking", "asked")
+        case .context: return ("including", "included")
+        case .skill: return ("loading", "loaded")
+        case .other: return ("calling", "called")
+        case .bash: return ("running", "ran")
+        }
+    }
+
+    /// Per-clause singular/plural pair. `mcp` names servers instead of a noun,
+    /// so it never consults this.
+    func noun(count: Int) -> String {
+        switch self {
+        case .edit, .read: return count == 1 ? "file" : "files"
+        case .search: return count == 1 ? "pattern" : "patterns"
+        case .list: return count == 1 ? "directory" : "directories"
+        case .web: return count == 1 ? "URL" : "URLs"
+        case .agent: return count == 1 ? "agent" : "agents"
+        case .question: return count == 1 ? "question" : "questions"
+        case .context: return count == 1 ? "context injection" : "context injections"
+        case .skill: return count == 1 ? "skill" : "skills"
+        case .bash: return count == 1 ? "shell command" : "shell commands"
+        case .mcp, .other: return count == 1 ? "tool" : "tools"
+        }
+    }
+
+    /// `<verb> <count> <noun>`, always lowercase — the caller capitalizes only
+    /// the first clause of the joined phrase. Counts stay numerals.
+    ///
+    /// `mcp` is the one irregular form: it names the servers rather than
+    /// counting tools ("called github", "called github, sentry 3 times"),
+    /// falling back to the regular shape if no server name could be read.
+    func clause(count: Int, running: Bool, mcpServers: [String] = []) -> String {
+        let verb = running ? verbs.running : verbs.done
+        if self == .mcp, !mcpServers.isEmpty {
+            let names = mcpServers.joined(separator: ", ")
+            return count > 1 ? "\(verb) \(names) \(count) times" : "\(verb) \(names)"
+        }
+        return "\(verb) \(count) \(noun(count: count))"
+    }
+}
+
 /// A collapsed run of non-narrative transcript rows. The first child ID is the
 /// stable identity, so an append-only poll can extend the active group without
 /// losing the user's disclosure state.
 struct ActivityGroupSummary: Hashable {
     let id: String
+    /// Total grouped rows. Drives the ≥2 unwrap rule and nothing user-visible —
+    /// the row title reports per-bucket counts, not a raw action total.
     let itemCount: Int
-    let labels: [String]
+    /// Per-bucket tallies behind `activityPhrase`. `read` counts DISTINCT file
+    /// paths, so three reads of one file say "Read 1 file".
+    let bucketCounts: [ActivityBucket: Int]
+    /// Distinct MCP server names, in first-appearance order.
+    let mcpServers: [String]
     let errorCount: Int
     let pendingCount: Int
     let requiresResponse: Bool
     let isExpanded: Bool
 
-    /// Trailing status text, or nil when every item in the group succeeded. A
-    /// fully-successful group says nothing: the row's own content already reads
-    /// as done, so a "complete" label was redundant chrome on the common case.
-    /// Non-nil exactly when `requiresResponse || errorCount > 0 ||
-    /// pendingCount > 0`.
+    init(
+        id: String,
+        itemCount: Int,
+        bucketCounts: [ActivityBucket: Int],
+        mcpServers: [String] = [],
+        errorCount: Int = 0,
+        pendingCount: Int = 0,
+        requiresResponse: Bool = false,
+        isExpanded: Bool = false
+    ) {
+        self.id = id
+        self.itemCount = itemCount
+        self.bucketCounts = bucketCounts
+        self.mcpServers = mcpServers
+        self.errorCount = errorCount
+        self.pendingCount = pendingCount
+        self.requiresResponse = requiresResponse
+        self.isExpanded = isExpanded
+    }
+
+    /// The row's whole title, in Claude Code's phrasing: "Ran 2 shell
+    /// commands", "Read 3 files", "Ran 2 shell commands, read 1 file".
+    ///
+    /// One clause per nonzero bucket, joined with ", " — a flat comma list with
+    /// no "and", no "N more", no generic fallback. Only the FIRST clause is
+    /// capitalized; later clauses stay lowercase. While anything in the group is
+    /// still pending, every verb goes to its present participle and the phrase
+    /// gains a trailing "…", which is why the row carries no separate "active"
+    /// badge: the tense already says it.
+    ///
+    /// Both renderers read this one property. The previous per-renderer segment
+    /// assembly is what let the native and SwiftUI rows drift apart.
+    var activityPhrase: String {
+        let running = pendingCount > 0
+        let clauses = ActivityBucket.allCases.compactMap { bucket -> String? in
+            guard let count = bucketCounts[bucket], count > 0 else { return nil }
+            return bucket.clause(count: count, running: running, mcpServers: mcpServers)
+        }
+        // Unreachable: every render-node kind maps to a bucket, so a group with
+        // items always has at least one clause. Total function, not a fallback
+        // vocabulary — there is deliberately no generic "N actions" phrasing.
+        guard let first = clauses.first else { return "" }
+        let phrase = ([first.prefix(1).uppercased() + first.dropFirst()] + clauses.dropFirst())
+            .joined(separator: ", ")
+        return running ? phrase + "…" : phrase
+    }
+
+    /// Trailing status text, or nil when nothing in the group needs attention.
+    /// A fully-successful group says nothing: the row's own content already
+    /// reads as done, so a "complete" label was redundant chrome on the common
+    /// case. Pending work says nothing either — `activityPhrase` already renders
+    /// it as "Running 2 shell commands…". Non-nil exactly when
+    /// `requiresResponse || errorCount > 0`.
     var statusLabel: String? {
         if requiresResponse { return "Needs response" }
         if errorCount == 1 { return "1 failed" }
         if errorCount > 1 { return "\(errorCount) failed" }
-        if pendingCount > 0 { return "In progress" }
         return nil
     }
 }
@@ -115,11 +244,12 @@ struct TranscriptPresentation {
 
         func flushActivity() {
             guard let first = pendingActivity.first else { return }
-            // A run of exactly one activity is not worth wrapping: a "Worked ·
-            // 1 action" summary repeats what the row underneath already says
-            // and offers a disclosure control with nothing behind it. Emit the
-            // row itself, as if it had never been grouped. Both renderers
-            // inherit this — neither can see a one-item summary node.
+            // A run of exactly one activity is not worth wrapping: a "Read 1
+            // file" summary repeats what the row underneath already says and
+            // offers a disclosure control with nothing behind it. Emit the row
+            // itself, as if it had never been grouped. Both renderers inherit
+            // this — neither can see a one-item summary node. (Claude Code
+            // collapses only runs of two or more for the same reason.)
             if pendingActivity.count == 1 {
                 projected.append(first)
                 pendingActivity.removeAll(keepingCapacity: true)
@@ -135,10 +265,12 @@ struct TranscriptPresentation {
             }
             let defaultsExpanded = requiresResponse || errorCount > 0
             let isExpanded = expansionOverrides[groupID] ?? defaultsExpanded
+            let tally = activityTally(of: pendingActivity)
             let summary = ActivityGroupSummary(
                 id: groupID,
                 itemCount: pendingActivity.count,
-                labels: representativeLabels(from: pendingActivity),
+                bucketCounts: tally.counts,
+                mcpServers: tally.mcpServers,
                 errorCount: errorCount,
                 pendingCount: pendingCount,
                 requiresResponse: requiresResponse,
@@ -190,42 +322,96 @@ struct TranscriptPresentation {
         return false
     }
 
-    private nonisolated static func representativeLabels(
-        from nodes: [TranscriptRenderNode]
-    ) -> [String] {
-        var labels: [String] = []
+    /// Tallies a group's rows into the buckets `activityPhrase` reads.
+    ///
+    /// Counts here are monotonic across polls by construction: a group's member
+    /// list is append-only (a narrative bubble ends the run rather than
+    /// reordering it) and each row's bucket is a pure function of its tool name,
+    /// which never changes once written. So a streaming render can only ever see
+    /// a count hold or rise — no separate high-water-mark state is needed, and
+    /// `TranscriptPresentation.build` stays a pure function of its inputs.
+    nonisolated static func activityTally(
+        of nodes: [TranscriptRenderNode]
+    ) -> (counts: [ActivityBucket: Int], mcpServers: [String]) {
+        var counts: [ActivityBucket: Int] = [:]
+        var mcpServers: [String] = []
+        // Reads are counted by DISTINCT target, so re-reading one file three
+        // times (a very common shape) says "Read 1 file" rather than "3 files".
+        var readTargets: Set<String> = []
+
         for node in nodes {
-            let label: String
-            switch node.kind {
-            case .toolCall(_, let name, _, _, _, _):
-                label = toolLabel(name)
-            case .systemReminder:
-                label = "Context"
-            case .skillBody:
-                label = "Skill"
-            case .chatBubble, .activityGroupSummary, .subagentSummary:
-                continue
+            let bucket = activityBucket(for: node)
+            switch bucket {
+            case .read:
+                // A read whose path could not be parsed falls back to its own
+                // row identity, so it still counts once and never merges with
+                // an unrelated read.
+                let target = readFilePath(of: node) ?? node.id
+                guard readTargets.insert(target).inserted else { continue }
+            case .mcp:
+                if case .toolCall(_, let name, _, _, _, _) = node.kind,
+                   let server = mcpServerName(name),
+                   !mcpServers.contains(server) {
+                    mcpServers.append(server)
+                }
+            default:
+                break
             }
-            if !labels.contains(label) { labels.append(label) }
-            if labels.count == 3 { break }
+            counts[bucket, default: 0] += 1
         }
-        return labels
+        return (counts, mcpServers)
     }
 
-    private nonisolated static func toolLabel(_ name: String) -> String {
-        switch name {
-        case "Bash": return "Commands"
-        case "Read": return "Reads"
-        case "Write": return "Writes"
-        case "Edit", "MultiEdit": return "Edits"
-        case "Grep", "Glob": return "Search"
-        case "Task", "Agent": return "Delegation"
-        case "AskUserQuestion": return "Question"
-        case "WebFetch", "WebSearch": return "Web"
-        default:
-            if name.hasPrefix("mcp__") { return "Connected tools" }
-            return name
+    /// Total classification: every render-node kind lands in exactly one bucket,
+    /// which is what makes `activityPhrase` non-empty for any real group.
+    nonisolated static func activityBucket(for node: TranscriptRenderNode) -> ActivityBucket {
+        switch node.kind {
+        case .toolCall(_, let name, _, _, _, _):
+            return activityBucket(forToolNamed: name)
+        case .systemReminder:
+            return .context
+        case .skillBody:
+            return .skill
+        case .chatBubble, .activityGroupSummary, .subagentSummary:
+            // Unreachable in a group: bubbles flush the run, and the other two
+            // are never produced by `transcriptRenderNodes(from:)`.
+            return .other
         }
+    }
+
+    nonisolated static func activityBucket(forToolNamed name: String) -> ActivityBucket {
+        switch name {
+        case "Edit", "MultiEdit", "Write", "NotebookEdit": return .edit
+        case "Grep", "Glob": return .search
+        case "Read", "NotebookRead": return .read
+        case "LS": return .list
+        case "WebFetch", "WebSearch": return .web
+        case "Task", "Agent": return .agent
+        case "AskUserQuestion": return .question
+        case "Bash": return .bash
+        default:
+            return name.hasPrefix("mcp__") ? .mcp : .other
+        }
+    }
+
+    /// `mcp__github__list_prs` → `github`. Nil for anything that is not an MCP
+    /// tool name or carries no server segment.
+    nonisolated static func mcpServerName(_ toolName: String) -> String? {
+        guard toolName.hasPrefix("mcp__") else { return nil }
+        let server = toolName.dropFirst("mcp__".count)
+            .components(separatedBy: "__")
+            .first ?? ""
+        return server.isEmpty ? nil : server
+    }
+
+    private nonisolated static func readFilePath(of node: TranscriptRenderNode) -> String? {
+        guard case .toolCall(_, _, let inputJSON, _, _, _) = node.kind,
+              let data = inputJSON.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return stringValue("file_path", in: object)
+            ?? stringValue("notebook_path", in: object)
     }
 
     private struct EntryKey: Hashable {

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -133,23 +133,18 @@ struct ActivityGroupSummaryRow: View {
             toggleGroup?(summary.id, !summary.isExpanded)
         } label: {
             // No leading icon: the persistent disclosure chevron already marks
-            // this as a group, so "Worked" starts at the row's leading padding
+            // this as a group, so the phrase starts at the row's leading padding
             // (matching the native cell, which collapses its icon column).
             HStack(spacing: 7) {
-                Text("Worked")
+                // The single shared phrase — the native cell renders this exact
+                // string, so the two renderers cannot drift.
+                Text(summary.activityPhrase)
                     .font(.system(.subheadline, design: .rounded, weight: .medium))
-                // Always plural: a lone activity renders as its own row, so no
-                // one-item summary node ever reaches a renderer.
-                Text("· \(summary.itemCount) actions")
-                    .foregroundStyle(.secondary)
-                if !summary.labels.isEmpty {
-                    Text("· \(summary.labels.joined(separator: " · "))")
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
-                }
+                    .lineLimit(1)
                 Spacer(minLength: 8)
-                // Nil — and so nothing rendered — when every item succeeded,
-                // matching the native cell's badge logic.
+                // Nil — and so nothing rendered — unless the group failed or is
+                // waiting on the user; a running group says so in the phrase's
+                // tense. Matches the native cell's badge logic.
                 if let status = summary.statusLabel {
                     Text(status)
                         .font(.caption2)
@@ -166,7 +161,7 @@ struct ActivityGroupSummaryRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(
-            "\(summary.isExpanded ? "Collapse" : "Expand") \(summary.itemCount) actions"
+            "\(summary.isExpanded ? "Collapse" : "Expand") \(summary.activityPhrase)"
                 + (summary.statusLabel.map { ", \($0)" } ?? "")
         )
     }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -132,10 +132,10 @@ struct ActivityGroupSummaryRow: View {
         Button {
             toggleGroup?(summary.id, !summary.isExpanded)
         } label: {
+            // No leading icon: the persistent disclosure chevron already marks
+            // this as a group, so "Worked" starts at the row's leading padding
+            // (matching the native cell, which collapses its icon column).
             HStack(spacing: 7) {
-                Image(systemName: "point.3.connected.trianglepath.dotted")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
                 Text("Worked")
                     .font(.system(.subheadline, design: .rounded, weight: .medium))
                 // Always plural: a lone activity renders as its own row, so no

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -138,7 +138,9 @@ struct ActivityGroupSummaryRow: View {
                     .foregroundStyle(.secondary)
                 Text("Worked")
                     .font(.system(.subheadline, design: .rounded, weight: .medium))
-                Text("· \(summary.itemCount) \(summary.itemCount == 1 ? "action" : "actions")")
+                // Always plural: a lone activity renders as its own row, so no
+                // one-item summary node ever reaches a renderer.
+                Text("· \(summary.itemCount) actions")
                     .foregroundStyle(.secondary)
                 if !summary.labels.isEmpty {
                     Text("· \(summary.labels.joined(separator: " · "))")
@@ -146,9 +148,13 @@ struct ActivityGroupSummaryRow: View {
                         .lineLimit(1)
                 }
                 Spacer(minLength: 8)
-                Text(summary.statusLabel)
-                    .font(.caption2)
-                    .foregroundStyle(summary.errorCount > 0 ? Color.red : Color.secondary)
+                // Nil — and so nothing rendered — when every item succeeded,
+                // matching the native cell's badge logic.
+                if let status = summary.statusLabel {
+                    Text(status)
+                        .font(.caption2)
+                        .foregroundStyle(summary.errorCount > 0 ? Color.red : Color.secondary)
+                }
                 Image(systemName: summary.isExpanded ? "chevron.down" : "chevron.right")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.tertiary)
@@ -160,7 +166,8 @@ struct ActivityGroupSummaryRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(
-            "\(summary.isExpanded ? "Collapse" : "Expand") \(summary.itemCount) actions, \(summary.statusLabel)"
+            "\(summary.isExpanded ? "Collapse" : "Expand") \(summary.itemCount) actions"
+                + (summary.statusLabel.map { ", \($0)" } ?? "")
         )
     }
 }

--- a/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
+++ b/Sources/TBDApp/Panes/Transcript/TranscriptRow.swift
@@ -140,6 +140,10 @@ struct ActivityGroupSummaryRow: View {
                 // string, so the two renderers cannot drift.
                 Text(summary.activityPhrase)
                     .font(.system(.subheadline, design: .rounded, weight: .medium))
+                    // Matches the native cell's `.secondary` segment style
+                    // (`secondaryLabelColor`): the summary is chrome and must
+                    // recede from the assistant prose around it.
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
                 Spacer(minLength: 8)
                 // Nil — and so nothing rendered — unless the group failed or is

--- a/Sources/TBDDaemon/Claude/UserMessageClassifier.swift
+++ b/Sources/TBDDaemon/Claude/UserMessageClassifier.swift
@@ -67,10 +67,17 @@ enum UserMessageClassifier {
         }
 
         if let array = message["content"] as? [[String: Any]] {
-            return array
-                .first(where: { $0["type"] as? String == "text" })
-                .flatMap { $0["text"] as? String }
-                .flatMap { $0.isEmpty ? nil : $0 }
+            // EVERY text block, not just the first. Claude Code emits one text
+            // block PER attached image when it records where it spooled them
+            // (`[Image: source: …]`), so taking only the first silently dropped
+            // every image after the first in a multi-image paste. In the measured
+            // corpus that meta line is the only user message that ever carries
+            // more than one text block, so joining is a strict repair.
+            let texts = array
+                .filter { $0["type"] as? String == "text" }
+                .compactMap { $0["text"] as? String }
+                .filter { !$0.isEmpty }
+            return texts.isEmpty ? nil : texts.joined(separator: "\n")
         }
 
         return nil

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -197,28 +197,84 @@ struct ActivityRowFormatterTests {
         #expect(ActivityRowFormatter.injectedSize(text: "", truncatedTo: 1_000_000_000) == "1.0G chars")
     }
 
-    @Test("Task notification → clock icon, 'Background · <summary>' title, status badge")
+    /// Tier 1. Background-task rows read as one gray sentence: no icon, no
+    /// "completed" capsule, no trailing timestamp — the same quieting the
+    /// activity-group summary row got.
+    @Test("Task notification: no icon, one .secondary sentence, no badge, no timestamp")
     func taskNotification() throws {
         let node = TranscriptRenderNode.makeSystemReminder(
             id: "t1", kind: .taskNotification,
-            text: "<task-notification>\n<status>completed</status>\n<summary>Agent \"X\" came to rest</summary>\n</task-notification>")
+            text: "<task-notification>\n<status>completed</status>\n<summary>Agent \"X\" finished</summary>\n</task-notification>",
+            timestamp: Date(timeIntervalSinceReferenceDate: 800_000_000))
         let p = try #require(ActivityRowFormatter.presentation(for: node))
-        #expect(p.iconSystemName == "clock.arrow.circlepath")
-        #expect(titleText(p).contains("Background"))
-        #expect(titleText(p).contains("Agent \"X\" came to rest"))
-        #expect(p.badges == [ActivityRowBadge(text: "completed", kind: .neutral)])
+        #expect(p.iconSystemName == nil)
+        #expect(p.titleSegments == [
+            ActivityRowSegment(text: "Background agent \"X\" finished", style: .secondary)
+        ])
+        #expect(p.badges.isEmpty)
+        #expect(p.timestamp == nil)
+        #expect(p.isError == false)
         #expect(p.openTargetID == "t1")
         #expect(p.titleTruncation == .byTruncatingTail)
     }
 
-    @Test("Task notification with no <summary> → falls back to status text")
-    func taskNotificationFallbackToStatus() throws {
+    /// The timestamp left the visible row but not the record (bubble precedent).
+    @Test("Task notification keeps its timestamp in the accessibility label only")
+    func taskNotificationTimestampSurvivesInAccessibilityLabel() throws {
+        let ts = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "t1a", kind: .taskNotification,
+            text: "<task-notification>\n<status>completed</status>\n<summary>Agent \"X\" finished</summary>\n</task-notification>",
+            timestamp: ts)
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        let label = try #require(p.accessibilityLabel)
+        #expect(label.contains("Background agent \"X\" finished"))
+        #expect(label.contains(ts.absoluteShort))
+        // …and the visible title does NOT carry it.
+        #expect(titleText(p).contains(ts.absoluteShort) == false)
+    }
+
+    /// Only the `Agent "…"` shape takes the "Background" lead-in; every other
+    /// envelope already names itself and would stutter.
+    @Test("Task notification: self-describing summaries are used verbatim")
+    func taskNotificationNonAgentSummariesAreVerbatim() throws {
+        for summary in [
+            "Background command \"swift build\" completed (exit code 0)",
+            "Monitor \"PR checks\" stream ended",
+            "Stop hook fired",
+            "No completion record was found for background agent \"X\""
+        ] {
+            let node = TranscriptRenderNode.makeSystemReminder(
+                id: "t5", kind: .taskNotification,
+                text: "<task-notification>\n<status>completed</status>\n<summary>\(summary)</summary>\n</task-notification>")
+            let p = try #require(ActivityRowFormatter.presentation(for: node))
+            #expect(p.titleSegments == [ActivityRowSegment(text: summary, style: .secondary)])
+        }
+    }
+
+    /// A stopped/killed task says so in its own wording, so no badge is needed.
+    @Test("Task notification: a stopped task carries the outcome in the sentence")
+    func taskNotificationStopped() throws {
+        let node = TranscriptRenderNode.makeSystemReminder(
+            id: "t6", kind: .taskNotification,
+            text: "<task-notification>\n<status>killed</status>\n<summary>Agent \"X\" was stopped by user</summary>\n</task-notification>")
+        let p = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(titleText(p) == "Background agent \"X\" was stopped by user")
+        #expect(p.badges.isEmpty)
+    }
+
+    /// A still-running task reports status-only (no `<summary>`); the row reads
+    /// as running via present participle + "…", the activity-group idiom.
+    @Test("Task notification with no <summary> → 'Background task running…', no badge")
+    func taskNotificationRunning() throws {
         let node = TranscriptRenderNode.makeSystemReminder(
             id: "t2", kind: .taskNotification,
             text: "<task-notification>\n<status>running</status>\n</task-notification>")
         let p = try #require(ActivityRowFormatter.presentation(for: node))
-        #expect(titleText(p).contains("running"))
-        #expect(p.badges == [ActivityRowBadge(text: "running", kind: .neutral)])
+        #expect(p.titleSegments == [
+            ActivityRowSegment(text: "Background task running…", style: .secondary)
+        ])
+        #expect(p.badges.isEmpty)
     }
 
     @Test("Task notification with no summary or status → 'Background task', no badge")
@@ -227,17 +283,32 @@ struct ActivityRowFormatterTests {
             id: "t3", kind: .taskNotification,
             text: "<task-notification>\n<task-id>abc</task-id>\n</task-notification>")
         let p = try #require(ActivityRowFormatter.presentation(for: node))
-        #expect(titleText(p).contains("Background task"))
+        #expect(titleText(p) == "Background task")
         #expect(p.badges.isEmpty)
     }
 
-    @Test("Task notification with failing status → error badge kind")
+    /// Quieting the row must not delete the failure signal: a failed task keeps
+    /// its red capsule (summary wording varies by task kind and a long failure
+    /// reason truncates) AND marks the presentation as an error.
+    @Test("Task notification with failing status → error badge survives")
     func taskNotificationErrorBadge() throws {
         let node = TranscriptRenderNode.makeSystemReminder(
             id: "t4", kind: .taskNotification,
-            text: "<task-notification>\n<status>failed</status>\n<summary>boom</summary>\n</task-notification>")
+            text: "<task-notification>\n<status>failed</status>\n<summary>Agent \"X\" failed: boom</summary>\n</task-notification>")
         let p = try #require(ActivityRowFormatter.presentation(for: node))
         #expect(p.badges == [ActivityRowBadge(text: "failed", kind: .error)])
+        #expect(p.isError)
+        #expect(titleText(p) == "Background agent \"X\" failed: boom")
+        #expect(p.iconSystemName == nil)
+        #expect(p.timestamp == nil)
+
+        // Same when the envelope carries a status but no summary to phrase from.
+        let bare = TranscriptRenderNode.makeSystemReminder(
+            id: "t4b", kind: .taskNotification,
+            text: "<task-notification>\n<status>failed</status>\n</task-notification>")
+        let bareP = try #require(ActivityRowFormatter.presentation(for: bare))
+        #expect(titleText(bareP) == "Background task failed")
+        #expect(bareP.badges == [ActivityRowBadge(text: "failed", kind: .error)])
     }
 
     // MARK: Activity group summary badges

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -246,12 +246,13 @@ struct ActivityRowFormatterTests {
         errorCount: Int = 0,
         pendingCount: Int = 0,
         requiresResponse: Bool = false,
-        itemCount: Int = 3
+        itemCount: Int = 3,
+        bucketCounts: [ActivityBucket: Int] = [.read: 1, .bash: 2]
     ) -> TranscriptRenderNode {
         let summary = ActivityGroupSummary(
             id: "g1#activity-group",
             itemCount: itemCount,
-            labels: ["Reads", "Commands"],
+            bucketCounts: bucketCounts,
             errorCount: errorCount,
             pendingCount: pendingCount,
             requiresResponse: requiresResponse,
@@ -266,10 +267,10 @@ struct ActivityRowFormatterTests {
         #expect(p.badges.isEmpty)
         #expect(!p.isError)
         // …and the accessibility label drops the status clause entirely.
-        #expect(p.accessibilityLabel == "Expand 3 actions")
+        #expect(p.accessibilityLabel == "Expand Read 1 file, ran 2 shell commands")
     }
 
-    @Test("Activity group failures, questions and pending work still badge")
+    @Test("Activity group failures and questions still badge; running work does not")
     func activityGroupAttentionBadges() throws {
         let failed = try #require(ActivityRowFormatter.presentation(for: groupNode(errorCount: 2)))
         #expect(failed.badges == [ActivityRowBadge(text: "2 failed", kind: .error)])
@@ -279,16 +280,19 @@ struct ActivityRowFormatterTests {
             ActivityRowFormatter.presentation(for: groupNode(requiresResponse: true)))
         #expect(asking.badges == [ActivityRowBadge(text: "needs response", kind: .error)])
 
+        // The old "active" capsule is gone: the phrase's tense carries it.
         let pending = try #require(ActivityRowFormatter.presentation(for: groupNode(pendingCount: 1)))
-        #expect(pending.badges == [ActivityRowBadge(text: "active", kind: .neutral)])
+        #expect(pending.badges.isEmpty)
         #expect(!pending.isError)
-        #expect(pending.accessibilityLabel == "Expand 3 actions, In progress")
+        #expect(titleText(pending) == "Reading 1 file, running 2 shell commands…")
+        #expect(pending.accessibilityLabel == "Expand Reading 1 file, running 2 shell commands…")
     }
 
-    @Test("Activity group title is always plural (one-item runs are never wrapped)")
-    func activityGroupTitleIsPlural() throws {
-        let p = try #require(ActivityRowFormatter.presentation(for: groupNode(itemCount: 2)))
-        #expect(titleText(p).contains("· 2 actions"))
+    @Test("Activity group title is the whole phrase, in one primary run")
+    func activityGroupTitleIsThePhrase() throws {
+        let p = try #require(ActivityRowFormatter.presentation(
+            for: groupNode(itemCount: 2, bucketCounts: [.bash: 2])))
+        #expect(p.titleSegments == [ActivityRowSegment(text: "Ran 2 shell commands", style: .primary)])
     }
 
     @Test("Skill body → 'Skill' + skill-name segments")

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -240,6 +240,57 @@ struct ActivityRowFormatterTests {
         #expect(p.badges == [ActivityRowBadge(text: "failed", kind: .error)])
     }
 
+    // MARK: Activity group summary badges
+
+    private func groupNode(
+        errorCount: Int = 0,
+        pendingCount: Int = 0,
+        requiresResponse: Bool = false,
+        itemCount: Int = 3
+    ) -> TranscriptRenderNode {
+        let summary = ActivityGroupSummary(
+            id: "g1#activity-group",
+            itemCount: itemCount,
+            labels: ["Reads", "Commands"],
+            errorCount: errorCount,
+            pendingCount: pendingCount,
+            requiresResponse: requiresResponse,
+            isExpanded: false
+        )
+        return TranscriptRenderNode(id: summary.id, kind: .activityGroupSummary(summary), badgeUsage: nil)
+    }
+
+    @Test("Activity group where everything succeeded carries NO badge")
+    func activityGroupSucceededHasNoBadge() throws {
+        let p = try #require(ActivityRowFormatter.presentation(for: groupNode()))
+        #expect(p.badges.isEmpty)
+        #expect(!p.isError)
+        // …and the accessibility label drops the status clause entirely.
+        #expect(p.accessibilityLabel == "Expand 3 actions")
+    }
+
+    @Test("Activity group failures, questions and pending work still badge")
+    func activityGroupAttentionBadges() throws {
+        let failed = try #require(ActivityRowFormatter.presentation(for: groupNode(errorCount: 2)))
+        #expect(failed.badges == [ActivityRowBadge(text: "2 failed", kind: .error)])
+        #expect(failed.isError)
+
+        let asking = try #require(
+            ActivityRowFormatter.presentation(for: groupNode(requiresResponse: true)))
+        #expect(asking.badges == [ActivityRowBadge(text: "needs response", kind: .error)])
+
+        let pending = try #require(ActivityRowFormatter.presentation(for: groupNode(pendingCount: 1)))
+        #expect(pending.badges == [ActivityRowBadge(text: "active", kind: .neutral)])
+        #expect(!pending.isError)
+        #expect(pending.accessibilityLabel == "Expand 3 actions, In progress")
+    }
+
+    @Test("Activity group title is always plural (one-item runs are never wrapped)")
+    func activityGroupTitleIsPlural() throws {
+        let p = try #require(ActivityRowFormatter.presentation(for: groupNode(itemCount: 2)))
+        #expect(titleText(p).contains("· 2 actions"))
+    }
+
     @Test("Skill body → 'Skill' + skill-name segments")
     func skillBody() throws {
         let node = TranscriptRenderNode.makeSkillBody(

--- a/Tests/TBDAppTests/ActivityRowFormatterTests.swift
+++ b/Tests/TBDAppTests/ActivityRowFormatterTests.swift
@@ -288,11 +288,24 @@ struct ActivityRowFormatterTests {
         #expect(pending.accessibilityLabel == "Expand Reading 1 file, running 2 shell commands…")
     }
 
-    @Test("Activity group title is the whole phrase, in one primary run")
+    @Test("Activity group title is the whole phrase, in one secondary run")
     func activityGroupTitleIsThePhrase() throws {
         let p = try #require(ActivityRowFormatter.presentation(
             for: groupNode(itemCount: 2, bucketCounts: [.bash: 2])))
-        #expect(p.titleSegments == [ActivityRowSegment(text: "Ran 2 shell commands", style: .primary)])
+        #expect(p.titleSegments == [ActivityRowSegment(text: "Ran 2 shell commands", style: .secondary)])
+    }
+
+    @Test("Activity group summary is grayed down — never the primary label color")
+    func activityGroupSummaryRecedes() throws {
+        // The summary line is chrome between assistant prose; rendering it at
+        // `.primary` (labelColor) made it compete with the prose around it.
+        // `.secondary` keeps the subheadline size — it is greyed, not shrunk.
+        for node in [groupNode(), groupNode(errorCount: 2), groupNode(pendingCount: 1)] {
+            let p = try #require(ActivityRowFormatter.presentation(for: node))
+            #expect(p.titleSegments.count == 1)
+            #expect(p.titleSegments.allSatisfy { $0.style != .primary })
+            #expect(p.titleSegments.allSatisfy { $0.style == .secondary })
+        }
     }
 
     @Test("Skill body → 'Skill' + skill-name segments")

--- a/Tests/TBDAppTests/TableTranscriptHarness.swift
+++ b/Tests/TBDAppTests/TableTranscriptHarness.swift
@@ -1134,7 +1134,8 @@ struct TableTranscriptHarness {
         case .toolCall(_, let name, let inputJSON, _, let result, _):
             return "\(name)\n\(inputJSON)\n\(result?.text ?? "")"
         case .activityGroupSummary(let summary):
-            return "Worked \(summary.labels.joined(separator: " ")) \(summary.statusLabel)"
+            return (["Worked"] + summary.labels + [summary.statusLabel].compactMap { $0 })
+                .joined(separator: " ")
         case .subagentSummary(_, _, let agentType):
             return agentType ?? "subagent"
         }

--- a/Tests/TBDAppTests/TableTranscriptHarness.swift
+++ b/Tests/TBDAppTests/TableTranscriptHarness.swift
@@ -1134,7 +1134,7 @@ struct TableTranscriptHarness {
         case .toolCall(_, let name, let inputJSON, _, let result, _):
             return "\(name)\n\(inputJSON)\n\(result?.text ?? "")"
         case .activityGroupSummary(let summary):
-            return (["Worked"] + summary.labels + [summary.statusLabel].compactMap { $0 })
+            return ([summary.activityPhrase] + [summary.statusLabel].compactMap { $0 })
                 .joined(separator: " ")
         case .subagentSummary(_, _, let agentType):
             return agentType ?? "subagent"

--- a/Tests/TBDAppTests/TableTranscriptHarness.swift
+++ b/Tests/TBDAppTests/TableTranscriptHarness.swift
@@ -542,7 +542,16 @@ struct TableTranscriptHarness {
 
     /// Builds an offscreen 680x600 scroll view + table wired to an instrumented
     /// production Coordinator over `items`. Mirrors `makeNSView`'s setup.
-    private func makeScene(items: [TranscriptItem], appState: AppState, fixedSize: Bool) -> Scene {
+    ///
+    /// `nodes` overrides the render nodes the coordinator starts on — used by the
+    /// activity-group tests, whose lists come from `TranscriptPresentation.build`
+    /// (grouped/collapsed) rather than the raw per-item projection.
+    private func makeScene(
+        items: [TranscriptItem],
+        appState: AppState,
+        fixedSize: Bool,
+        nodes overrideNodes: [TranscriptRenderNode]? = nil
+    ) -> Scene {
         let context = TranscriptCardContext(
             terminalID: nil,
             openTranscriptOverlay: { _ in },
@@ -572,7 +581,7 @@ struct TableTranscriptHarness {
         coordinator.tableView = tableView
         coordinator.scrollView = scrollView
 
-        let nodes = transcriptRenderNodes(from: items)
+        let nodes = overrideNodes ?? transcriptRenderNodes(from: items)
         coordinator.nodes = nodes
         coordinator.previousNodes = nodes
 
@@ -969,6 +978,400 @@ struct TableTranscriptHarness {
                 "systemReminder row must dispatch to the native ActivityRowCellView")
         #expect(cell(forID: "k-ask") is TranscriptHostingCellView,
                 "AskUserQuestion row must stay SwiftUI-hosted (TranscriptHostingCellView)")
+    }
+
+    // MARK: - Activity-group disclosure (anchoring, caches, tail-follow)
+
+    /// Items shaped for the disclosure tests: `leadingBubbles` tall exchanges, then
+    /// a run of `groupSize` Read tool calls (which `TranscriptPresentation` folds
+    /// into ONE collapsible summary — the run needs ≥2 members to group at all),
+    /// then `trailingBubbles` exchanges to flush the run and give the list a tail.
+    private static func activityGroupFixture(
+        leadingBubbles: Int,
+        groupSize: Int,
+        trailingBubbles: Int
+    ) -> [TranscriptItem] {
+        func exchange(_ tag: String, _ index: Int) -> [TranscriptItem] {
+            [
+                .userPrompt(
+                    id: "\(tag)-u\(index)",
+                    text: "Question \(index): walk me through this part of the pipeline in "
+                        + "enough detail that the bubble wraps across several lines.",
+                    timestamp: nil
+                ),
+                .assistantText(
+                    id: "\(tag)-a\(index)",
+                    text: """
+                    Answer \(index): each upstream item becomes a render node cached by \
+                    `(id, contentVersion, width)`, so a re-poll never rebuilds an unchanged \
+                    row. This paragraph is deliberately long so the bubble has real height.
+
+                    A second paragraph adds vertical extent so scroll offsets can land in \
+                    the middle of a tall row.
+                    """,
+                    timestamp: nil,
+                    usage: nil
+                )
+            ]
+        }
+
+        var items: [TranscriptItem] = []
+        for i in 0..<leadingBubbles { items.append(contentsOf: exchange("lead", i)) }
+        for i in 0..<groupSize {
+            items.append(.toolCall(
+                id: "grp-t\(i)",
+                name: "Read",
+                inputJSON: #"{"file_path":"/x/Sources/Part\#(i).swift"}"#,
+                inputTruncatedTo: nil,
+                result: ToolResult(text: "1\timport AppKit\n", truncatedTo: nil, isError: false),
+                subagent: nil,
+                timestamp: nil
+            ))
+        }
+        for i in 0..<trailingBubbles { items.append(contentsOf: exchange("tail", i)) }
+        return items
+    }
+
+    /// The summary node id `TranscriptPresentation.build` mints for the fixture's
+    /// run of tool calls (first member's id + the group suffix).
+    private static let fixtureGroupID = "grp-t0#activity-group"
+
+    private static func groupNodes(_ items: [TranscriptItem], expanded: Bool) -> [TranscriptRenderNode] {
+        TranscriptPresentation.build(
+            items: items,
+            expansionOverrides: [fixtureGroupID: expanded]
+        ).nodes
+    }
+
+    /// Lets work the coordinator deferred with `DispatchQueue.main.async` — the
+    /// tail-follow `scrollToEnd` — actually run.
+    ///
+    /// `pump()` cannot do it: a Swift Testing `@MainActor` test body is ITSELF a
+    /// block executing on the serial main queue, so a nested run loop can never
+    /// re-enter that queue and the deferred block sits there until the test ends.
+    /// Suspending is what returns the queue, so the queued block runs and only
+    /// then does this continuation resume. Without this a test would "pass"
+    /// against a tail-follow that never fired.
+    private func drainMainQueue() async {
+        for _ in 0..<4 { await Task.yield() }
+    }
+
+    /// Vertical gap between the viewport's bottom edge and the document bottom.
+    private func gapToBottom(_ scene: Scene) -> CGFloat {
+        let clip = scene.scrollView.contentView
+        return scene.tableView.frame.height - (clip.bounds.origin.y + clip.bounds.height)
+    }
+
+    /// Screen-space offset of `row`'s top edge from the top of the viewport.
+    private func screenOffset(of row: Int, in scene: Scene) -> CGFloat {
+        scene.tableView.rect(ofRow: row).origin.y - scene.scrollView.contentView.bounds.origin.y
+    }
+
+    /// REGRESSION GUARD: expanding a collapsed work group must leave the clicked
+    /// summary row exactly where it was on screen — only the content BELOW it may
+    /// move. The reported bug scrolled the whole view up by the height of the
+    /// revealed rows, because the toggle classifies as a `.rebuild` and the
+    /// rebuild's tail-follow re-pinned the bottom.
+    ///
+    /// Run from the bottom of the transcript (the reported case, where tail-follow
+    /// fires) and from a scrolled-up viewport (where the cache wipe's realize-time
+    /// height corrections were the drift source).
+    @Test("expanding a work group keeps the summary row anchored", arguments: [true, false])
+    func expandingGroupKeepsSummaryAnchored(atBottom: Bool) async throws {
+        let suiteName = "table-harness-group-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let appState = AppState(userDefaults: defaults)
+
+        // Shape of the fixture, both arms: more leading rows than the bottom-window
+        // precompute measures, so the rows ABOVE the anchor are ones only the cache
+        // can keep exact (a wipe sends them back to the arithmetic estimate and the
+        // anchor moves with them). The tail is short when the viewport must sit AT
+        // the bottom with the summary still on screen, and deep when the viewport
+        // must be clear of the tail-follow threshold.
+        let items = Self.activityGroupFixture(
+            leadingBubbles: 25, groupSize: 5, trailingBubbles: atBottom ? 1 : 8)
+        let collapsed = Self.groupNodes(items, expanded: false)
+        let expanded = Self.groupNodes(items, expanded: true)
+        #expect(expanded.count == collapsed.count + 5, "expansion must reveal the group's 5 rows")
+
+        let scene = makeScene(items: items, appState: appState, fixedSize: true, nodes: collapsed)
+        defer { withExtendedLifetime(scene.coordinator) {} }
+
+        // Prime exactly as production does: the first `updateNSView` after
+        // `makeNSView` always takes the width-change branch (cachedColumnWidth
+        // starts at 0), which reloads and measures the bottom window.
+        scene.coordinator.update(nodes: collapsed, atBottom: .constant(true), activityToggleToken: 0)
+        settle(scene.tableView)
+
+        let summaryRow = try #require(collapsed.firstIndex { $0.id == Self.fixtureGroupID })
+        let clip = scene.scrollView.contentView
+
+        if atBottom {
+            scene.coordinator.scrollToEnd(animated: false)
+            settle(scene.tableView)
+            #expect(gapToBottom(scene) <= 120,
+                    Comment(rawValue: "arm precondition: viewport must be within the tail-follow "
+                        + "threshold (gap=\(gapToBottom(scene)))"))
+        } else {
+            // Park the summary row ~200pt below the viewport top, so real rows sit
+            // above it (any of which drifting would move the anchor).
+            let target = max(0, scene.tableView.rect(ofRow: summaryRow).minY - 200)
+            clip.scroll(to: NSPoint(x: 0, y: target))
+            scene.scrollView.reflectScrolledClipView(clip)
+            settle(scene.tableView)
+            #expect(gapToBottom(scene) > 120,
+                    Comment(rawValue: "arm precondition: viewport must be clear of the tail-follow "
+                        + "threshold (gap=\(gapToBottom(scene)))"))
+        }
+        let visible = clip.documentVisibleRect
+        let summaryRect = scene.tableView.rect(ofRow: summaryRow)
+        #expect(visible.intersects(summaryRect), "the summary row must be on screen before the click")
+
+        let offsetBefore = screenOffset(of: summaryRow, in: scene)
+        let rectsAboveBefore = (0..<summaryRow).map { scene.tableView.rect(ofRow: $0) }
+
+        // The click: a new node array carrying the expanded group, with the toggle
+        // token bumped exactly as `setActivityGroup` does.
+        scene.coordinator.update(nodes: expanded, atBottom: .constant(true), activityToggleToken: 1)
+        scene.tableView.layoutSubtreeIfNeeded()
+        // The FIRST frame after the click is what the user sees. Rows above the
+        // anchor must already be laid out at their unchanged heights here — if the
+        // rebuild dropped their cached exact heights they come back estimated, and
+        // the anchor jumps now even though later realize-time corrections settle it
+        // back.
+        let offsetFirstFrame = screenOffset(of: summaryRow, in: scene)
+        #expect(abs(offsetFirstFrame - offsetBefore) <= 1.0,
+                Comment(rawValue: "the clicked summary row moved in the first frame after the click: "
+                    + "before=\(offsetBefore) firstFrame=\(offsetFirstFrame)"))
+
+        // Give any deferred tail-follow its chance to run — without this the
+        // assertion would pass against a scroll that simply never fired.
+        await drainMainQueue()
+        settle(scene.tableView)
+
+        let offsetAfter = screenOffset(of: summaryRow, in: scene)
+        #expect(abs(offsetAfter - offsetBefore) <= 1.0,
+                Comment(rawValue: "the clicked summary row moved on screen: "
+                    + "before=\(offsetBefore) after=\(offsetAfter)"))
+
+        let rectsAboveAfter = (0..<summaryRow).map { scene.tableView.rect(ofRow: $0) }
+        var moved: [String] = []
+        for (row, (before, after)) in zip(rectsAboveBefore, rectsAboveAfter).enumerated()
+        where abs(before.origin.y - after.origin.y) > 0.5 || abs(before.height - after.height) > 0.5 {
+            moved.append("row \(row): \(before) → \(after)")
+        }
+        #expect(moved.isEmpty,
+                Comment(rawValue: "rows above the clicked row must keep identical rects: "
+                    + moved.joined(separator: "; ")))
+    }
+
+    /// FIX 2: the per-row caches are content-addressed by `(id, contentVersion,
+    /// width)`, so a rebuild may PRUNE them but must not wipe them. Rows the user
+    /// had already scrolled past stay EXACT across the rebuild rather than falling
+    /// back to the arithmetic estimate (whose realize-time correction is what
+    /// shifted rows underneath it).
+    @Test("a rebuild keeps exact heights for rows whose content did not change")
+    func rebuildKeepsContentAddressedHeights() throws {
+        let suiteName = "table-harness-cachekeep-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let appState = AppState(userDefaults: defaults)
+
+        // More rows than the bottom-window precompute measures, so a wipe cannot be
+        // masked by the post-rebuild `precomputeBottomWindow()`.
+        let items = Self.activityGroupFixture(leadingBubbles: 30, groupSize: 4, trailingBubbles: 2)
+        let collapsed = Self.groupNodes(items, expanded: false)
+        #expect(collapsed.count > TableTranscriptView.Coordinator.bottomEagerWindow,
+                "fixture must exceed the bottom-window precompute to be a real test")
+
+        let scene = makeScene(items: items, appState: appState, fixedSize: true, nodes: collapsed)
+        defer { withExtendedLifetime(scene.coordinator) {} }
+        scene.coordinator.update(nodes: collapsed, atBottom: .constant(true), activityToggleToken: 0)
+
+        // Realize every row once — as a user scrolling the whole transcript would —
+        // which measures each exactly and caches it.
+        for row in 0..<collapsed.count {
+            _ = scene.coordinator.tableView(scene.tableView, viewFor: nil, row: row)
+        }
+        let uncachedBefore = collapsed
+            .filter { scene.coordinator.cachedExactHeight(for: $0) == nil }
+            .map(\.id)
+        #expect(uncachedBefore.isEmpty,
+                Comment(rawValue: "every realized row should have an exact cached height; missing: "
+                    + uncachedBefore.prefix(5).joined(separator: ", ")))
+
+        let expanded = Self.groupNodes(items, expanded: true)
+        scene.coordinator.update(nodes: expanded, atBottom: .constant(true), activityToggleToken: 1)
+
+        // Every unchanged row keeps its exact height. The summary node itself is
+        // legitimately gone: `isExpanded` is part of its content, so the expanded
+        // summary is a different `contentVersion` and the old entry is unreachable.
+        let lost = collapsed
+            .filter { $0.id != Self.fixtureGroupID }
+            .filter { scene.coordinator.cachedExactHeight(for: $0) == nil }
+            .map(\.id)
+        #expect(lost.isEmpty,
+                Comment(rawValue: "rebuild dropped \(lost.count)/\(collapsed.count - 1) exact heights "
+                    + "for unchanged rows: \(lost.prefix(5).joined(separator: ", "))"))
+        #expect(scene.coordinator.cachedExactHeight(for: collapsed[
+            try #require(collapsed.firstIndex { $0.id == Self.fixtureGroupID })]) == nil,
+                "the superseded summary node's entry must be pruned")
+    }
+
+    /// FIX 2's growth story: keeping caches across rebuilds must not let them grow
+    /// without bound. Toggling a group open and shut repeatedly supersedes the
+    /// summary node's `contentVersion` every time and removes/reinstates its member
+    /// rows; the prune keeps the total pinned to the live row count.
+    @Test("cache growth stays bounded across repeated expand/collapse cycles")
+    func cacheGrowthIsBounded() throws {
+        let suiteName = "table-harness-cachebound-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let appState = AppState(userDefaults: defaults)
+
+        let items = Self.activityGroupFixture(leadingBubbles: 30, groupSize: 4, trailingBubbles: 2)
+        let collapsed = Self.groupNodes(items, expanded: false)
+        let expanded = Self.groupNodes(items, expanded: true)
+
+        let scene = makeScene(items: items, appState: appState, fixedSize: true, nodes: collapsed)
+        defer { withExtendedLifetime(scene.coordinator) {} }
+        scene.coordinator.update(nodes: collapsed, atBottom: .constant(true), activityToggleToken: 0)
+
+        // Four caches, at most one entry per live row each.
+        let ceiling = 4 * expanded.count
+        var token = 0
+        var peak = 0
+        for cycle in 0..<12 {
+            let nodes = cycle.isMultiple(of: 2) ? expanded : collapsed
+            token += 1
+            scene.coordinator.update(nodes: nodes, atBottom: .constant(true), activityToggleToken: token)
+            // Realize every row so the caches are filled to their maximum each cycle.
+            for row in 0..<nodes.count {
+                _ = scene.coordinator.tableView(scene.tableView, viewFor: nil, row: row)
+            }
+            peak = max(peak, scene.coordinator.totalCachedEntryCount)
+        }
+        #expect(peak <= ceiling,
+                Comment(rawValue: "cache entries grew past one per live row per cache "
+                    + "(peak=\(peak) ceiling=\(ceiling))"))
+    }
+
+    /// FIX 1 must not over-reach: a genuine streaming append with the viewport at
+    /// the bottom STILL follows the tail. Only a bumped toggle token suppresses it.
+    @Test("a streaming append still follows the tail from the bottom")
+    func streamingAppendStillFollowsTail() async throws {
+        let suiteName = "table-harness-tailfollow-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let appState = AppState(userDefaults: defaults)
+
+        let items = Self.activityGroupFixture(leadingBubbles: 8, groupSize: 5, trailingBubbles: 1)
+        let collapsed = Self.groupNodes(items, expanded: false)
+
+        let scene = makeScene(items: items, appState: appState, fixedSize: true, nodes: collapsed)
+        defer { withExtendedLifetime(scene.coordinator) {} }
+        scene.coordinator.update(nodes: collapsed, atBottom: .constant(true), activityToggleToken: 0)
+        settle(scene.tableView)
+        scene.coordinator.scrollToEnd(animated: false)
+        settle(scene.tableView)
+        #expect(gapToBottom(scene) <= 120, "precondition: the viewport starts at the bottom")
+
+        // A new assistant message lands, as it does mid-stream. The toggle token
+        // does NOT move — this is content the session produced.
+        var grown = items
+        grown.append(.assistantText(
+            id: "stream-new",
+            text: String(repeating: "A freshly streamed paragraph that wraps across the column. ", count: 12),
+            timestamp: nil,
+            usage: nil
+        ))
+        let appended = Self.groupNodes(grown, expanded: false)
+        #expect(appended.count == collapsed.count + 1)
+
+        scene.coordinator.update(nodes: appended, atBottom: .constant(true), activityToggleToken: 0)
+        // The tail-follow is deferred to the next run-loop turn, by which point a
+        // live app has laid the inserted row out; do that layout here so the
+        // queued `scrollToEnd` sees the grown document rather than the old bottom.
+        scene.tableView.layoutSubtreeIfNeeded()
+        await drainMainQueue()
+        settle(scene.tableView)
+
+        #expect(gapToBottom(scene) <= 2.0,
+                Comment(rawValue: "a streaming append at the bottom must scroll to the new tail "
+                    + "(gap=\(gapToBottom(scene)))"))
+    }
+
+    // MARK: - Image-attachment height estimate
+
+    /// FIX 3: the arithmetic estimate must include an image term. The exact path
+    /// lays an attachment out at up to 200pt from a synchronous header probe, so
+    /// an estimate that only counted the marker's characters undershot by ~180pt —
+    /// a correction that big, applied when the row realizes, drags every row below
+    /// it.
+    @Test("an image attachment is estimated close to its exact measured height")
+    func imageAttachmentEstimateMatchesExact() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-image-estimate-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let imagePath = dir.appendingPathComponent("shot.png").path
+        try Self.writePNG(width: 400, height: 300, to: imagePath)
+
+        let item = TranscriptItem.userPrompt(
+            id: "img-1",
+            text: "Here is the screenshot.\n\n[Image: source: \(imagePath)]",
+            timestamp: nil
+        )
+        let node = TranscriptRenderNode(id: "img-1", kind: .chatBubble(item), badgeUsage: nil)
+
+        let estimate = TableTranscriptView.Coordinator.estimate(for: node, width: Self.width)
+        let exact = oracleHeight(for: node)
+
+        // The image alone is 150pt tall here (a 400x300 source contained in the
+        // 200pt square), so a missing image term shows up as a ~150pt undershoot.
+        #expect(exact > 150, Comment(rawValue: "fixture must actually carry a laid-out image (exact=\(exact))"))
+        #expect(abs(estimate - exact) <= 20,
+                Comment(rawValue: "image row estimate is far from the exact height: "
+                    + "estimate=\(estimate) exact=\(exact)"))
+    }
+
+    /// A marker-free bubble's estimate is unchanged by the image term — the split
+    /// fast path returns one text segment and the arithmetic is as before.
+    @Test("a bubble with no attachment still estimates from its prose alone")
+    func plainBubbleEstimateUnaffected() {
+        let item = TranscriptItem.assistantText(
+            id: "plain-1",
+            text: "A plain paragraph with no attachment marker, long enough to wrap "
+                + "across more than one line of the column.",
+            timestamp: nil,
+            usage: nil
+        )
+        let node = TranscriptRenderNode(id: "plain-1", kind: .chatBubble(item), badgeUsage: nil)
+        let estimate = TableTranscriptView.Coordinator.estimate(for: node, width: Self.width)
+        let exact = oracleHeight(for: node)
+        #expect(abs(estimate - exact) <= 20,
+                Comment(rawValue: "plain bubble estimate drifted: estimate=\(estimate) exact=\(exact)"))
+    }
+
+    /// Writes a solid opaque PNG so `TranscriptImageService`'s header probe reads
+    /// real pixel dimensions.
+    private static func writePNG(width: Int, height: Int, to path: String) throws {
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ), let png = rep.representation(using: .png, properties: [:]) else {
+            throw HarnessError.couldNotMakePNG
+        }
+        try png.write(to: URL(fileURLWithPath: path))
     }
 
     // MARK: - Spot anchors (user-named clipping symptoms)

--- a/Tests/TBDAppTests/TableTranscriptHarness.swift
+++ b/Tests/TBDAppTests/TableTranscriptHarness.swift
@@ -574,6 +574,17 @@ struct TableTranscriptHarness {
         tableView.delegate = coordinator
 
         let scrollView = NSScrollView()
+        // PIN THE SCROLLER GEOMETRY. `NSScroller.preferredScrollerStyle` follows the
+        // host's "Show scroll bars" setting and whether a scroll-capable pointing
+        // device is attached, so an unpinned scroll view is 680pt wide on a developer
+        // box with overlay scrollers and 663pt on a runner with legacy ones — and
+        // every measured row height is keyed by that width. Pin the LEGACY,
+        // autohiding shape (the moving one: the scroller claims its 17pt only once
+        // the document outgrows the viewport, i.e. after the first `reloadData`) so
+        // every environment exercises the same geometry AND the same mid-setup width
+        // change. `primeScene` is what absorbs that change.
+        scrollView.scrollerStyle = .legacy
+        scrollView.autohidesScrollers = true
         scrollView.documentView = tableView
         scrollView.hasVerticalScroller = true
         scrollView.drawsBackground = false
@@ -1056,6 +1067,44 @@ struct TableTranscriptHarness {
         for _ in 0..<4 { await Task.yield() }
     }
 
+    /// Primes `scene` on `nodes` exactly as production's first `updateNSView` does,
+    /// then keeps updating until the table's COLUMN WIDTH stops moving.
+    ///
+    /// The first `update` after `makeNSView` always takes the width-change branch
+    /// (`cachedColumnWidth` starts at 0): it measures the bottom window and reloads.
+    /// That reload is also what first makes the document taller than the viewport,
+    /// so an autohiding legacy scroller claims its 17pt on the NEXT layout pass —
+    /// AFTER those heights were cached. Every cache here is keyed by `(id,
+    /// contentVersion, width)`, so the whole cache is then unreachable, and the next
+    /// `update` legitimately takes the width-change branch again (wipe + re-measure)
+    /// instead of the `.rebuild` branch a disclosure test means to exercise. Rows
+    /// above the click fall back to the arithmetic estimate — which is ~30-45pt off
+    /// a measured bubble by design — and the anchor jumps by hundreds of points.
+    ///
+    /// So: settle the width FIRST, and only then take a "before" snapshot. Returns
+    /// the settled column width; fails the test if it never settles.
+    @discardableResult
+    private func primeScene(_ scene: Scene, nodes: [TranscriptRenderNode]) -> CGFloat {
+        for _ in 0..<4 {
+            let widthAtUpdate = scene.tableView.bounds.width
+            scene.coordinator.update(nodes: nodes, atBottom: .constant(true), activityToggleToken: 0)
+            settle(scene.tableView)
+            if scene.tableView.bounds.width == widthAtUpdate { return widthAtUpdate }
+        }
+        Issue.record("the table's column width never settled: \(scene.tableView.bounds.width)")
+        return scene.tableView.bounds.width
+    }
+
+    /// Realizes every row once — as a user who scrolled the whole transcript would —
+    /// so each carries an EXACT measured height rather than the cheap arithmetic
+    /// estimate `heightOfRow` serves for unrealized rows.
+    private func realizeAllRows(_ scene: Scene, count: Int) {
+        for row in 0..<count {
+            _ = scene.coordinator.tableView(scene.tableView, viewFor: nil, row: row)
+        }
+        settle(scene.tableView)
+    }
+
     /// Vertical gap between the viewport's bottom edge and the document bottom.
     private func gapToBottom(_ scene: Scene) -> CGFloat {
         let clip = scene.scrollView.contentView
@@ -1084,11 +1133,11 @@ struct TableTranscriptHarness {
         let appState = AppState(userDefaults: defaults)
 
         // Shape of the fixture, both arms: more leading rows than the bottom-window
-        // precompute measures, so the rows ABOVE the anchor are ones only the cache
-        // can keep exact (a wipe sends them back to the arithmetic estimate and the
-        // anchor moves with them). The tail is short when the viewport must sit AT
-        // the bottom with the summary still on screen, and deep when the viewport
-        // must be clear of the tail-follow threshold.
+        // precompute measures, so the rows ABOVE the anchor are ones only the CACHE
+        // can keep exact across the rebuild (a wipe sends them back to the arithmetic
+        // estimate and the anchor moves with them). The tail is short when the
+        // viewport must sit AT the bottom with the summary still on screen, and deep
+        // when the viewport must be clear of the tail-follow threshold.
         let items = Self.activityGroupFixture(
             leadingBubbles: 25, groupSize: 5, trailingBubbles: atBottom ? 1 : 8)
         let collapsed = Self.groupNodes(items, expanded: false)
@@ -1098,14 +1147,29 @@ struct TableTranscriptHarness {
         let scene = makeScene(items: items, appState: appState, fixedSize: true, nodes: collapsed)
         defer { withExtendedLifetime(scene.coordinator) {} }
 
-        // Prime exactly as production does: the first `updateNSView` after
-        // `makeNSView` always takes the width-change branch (cachedColumnWidth
-        // starts at 0), which reloads and measures the bottom window.
-        scene.coordinator.update(nodes: collapsed, atBottom: .constant(true), activityToggleToken: 0)
-        settle(scene.tableView)
+        // Prime exactly as production does, then let the column width settle (see
+        // `primeScene`) — a width that moves mid-test sends the toggle down the
+        // width-change branch, which wipes the caches for a reason that has nothing
+        // to do with what this test guards.
+        let primedWidth = primeScene(scene, nodes: collapsed)
 
         let summaryRow = try #require(collapsed.firstIndex { $0.id == Self.fixtureGroupID })
         let clip = scene.scrollView.contentView
+
+        // Realize every row, so the "before" snapshot is entirely EXACT measurements.
+        // Without this the rows above the anchor carry the arithmetic estimate, which
+        // is deliberately cheap and can sit tens of points off the measurement — so a
+        // later estimate→exact transition (from anything at all: a re-measure, a
+        // width change, a different host font) would masquerade as anchor drift. The
+        // guard below then reads exactly as written: heights that were exact before
+        // the click must still be exact, and identical, after it.
+        realizeAllRows(scene, count: collapsed.count)
+        let unmeasuredAbove = (0..<summaryRow)
+            .filter { scene.coordinator.cachedExactHeight(for: collapsed[$0]) == nil }
+        #expect(unmeasuredAbove.isEmpty,
+                Comment(rawValue: "every row above the anchor must be exactly measured before the "
+                    + "click, else an estimate→exact transition can masquerade as drift; "
+                    + "unmeasured rows: \(unmeasuredAbove.prefix(5))"))
 
         if atBottom {
             scene.coordinator.scrollToEnd(animated: false)
@@ -1135,6 +1199,14 @@ struct TableTranscriptHarness {
         // token bumped exactly as `setActivityGroup` does.
         scene.coordinator.update(nodes: expanded, atBottom: .constant(true), activityToggleToken: 1)
         scene.tableView.layoutSubtreeIfNeeded()
+        // The toggle must have gone through the `.rebuild` branch. If the column
+        // width moved, `update` took the width-change branch instead — a legitimate
+        // cache wipe for an unrelated reason — and everything below would be
+        // measuring that, not the anchor.
+        #expect(scene.tableView.bounds.width == primedWidth,
+                Comment(rawValue: "the column width moved across the click "
+                    + "(\(primedWidth) → \(scene.tableView.bounds.width)), so the toggle took the "
+                    + "width-change branch rather than `.rebuild`"))
         // The FIRST frame after the click is what the user sees. Rows above the
         // anchor must already be laid out at their unchanged heights here — if the
         // rebuild dropped their cached exact heights they come back estimated, and
@@ -1187,13 +1259,11 @@ struct TableTranscriptHarness {
 
         let scene = makeScene(items: items, appState: appState, fixedSize: true, nodes: collapsed)
         defer { withExtendedLifetime(scene.coordinator) {} }
-        scene.coordinator.update(nodes: collapsed, atBottom: .constant(true), activityToggleToken: 0)
+        primeScene(scene, nodes: collapsed)
 
         // Realize every row once — as a user scrolling the whole transcript would —
         // which measures each exactly and caches it.
-        for row in 0..<collapsed.count {
-            _ = scene.coordinator.tableView(scene.tableView, viewFor: nil, row: row)
-        }
+        realizeAllRows(scene, count: collapsed.count)
         let uncachedBefore = collapsed
             .filter { scene.coordinator.cachedExactHeight(for: $0) == nil }
             .map(\.id)
@@ -1236,7 +1306,7 @@ struct TableTranscriptHarness {
 
         let scene = makeScene(items: items, appState: appState, fixedSize: true, nodes: collapsed)
         defer { withExtendedLifetime(scene.coordinator) {} }
-        scene.coordinator.update(nodes: collapsed, atBottom: .constant(true), activityToggleToken: 0)
+        primeScene(scene, nodes: collapsed)
 
         // Four caches, at most one entry per live row each.
         let ceiling = 4 * expanded.count
@@ -1271,8 +1341,7 @@ struct TableTranscriptHarness {
 
         let scene = makeScene(items: items, appState: appState, fixedSize: true, nodes: collapsed)
         defer { withExtendedLifetime(scene.coordinator) {} }
-        scene.coordinator.update(nodes: collapsed, atBottom: .constant(true), activityToggleToken: 0)
-        settle(scene.tableView)
+        primeScene(scene, nodes: collapsed)
         scene.coordinator.scrollToEnd(animated: false)
         settle(scene.tableView)
         #expect(gapToBottom(scene) <= 120, "precondition: the viewport starts at the bottom")

--- a/Tests/TBDAppTests/TranscriptBubbleGeometryTests.swift
+++ b/Tests/TBDAppTests/TranscriptBubbleGeometryTests.swift
@@ -1,10 +1,14 @@
+import AppKit
 import Foundation
+import SwiftUI
 import Testing
 @testable import TBDApp
+import TBDShared
 
 /// Locks in the role-dependent horizontal geometry of the table-based chat
 /// bubble: assistant messages drop the 52pt opposite-side gutter and span the
 /// full column, while user messages keep the gutter (right-anchored bubble).
+/// Also pins the VERTICAL chrome, which carries no role/timestamp header line.
 @MainActor
 struct TranscriptBubbleGeometryTests {
     private let columnWidth: CGFloat = 800
@@ -57,5 +61,100 @@ struct TranscriptBubbleGeometryTests {
         let g = TranscriptBubbleGeometry.self
         #expect(g.outerHorizontal(for: .user, columnWidth: 679) == 24)
         #expect(g.bodyWidth(columnWidth: 679, role: .user) == 633)
+    }
+
+    // MARK: - Vertical chrome carries no attribution header
+
+    /// A bubble shows no "Claude · 5:33 PM" header — position and tint say who
+    /// spoke — so the row's fixed chrome budgets NOTHING for a header line or a
+    /// header→body gap. If either crept back into `rowHeight`, every row would
+    /// reserve dead space above its prose and this goes red.
+    @Test func rowHeightChromeBudgetsNoHeaderLine() {
+        let g = TranscriptBubbleGeometry.self
+        #expect(g.rowHeight(blocksHeight: 0) == g.bodyVertical + g.outerVertical * 2)
+        #expect(g.rowHeight(blocksHeight: 100) == 132)
+        // With no header between them, `outerVertical` is the ONLY separation
+        // between adjacent bubbles — a 16pt gutter.
+        #expect(g.outerVertical == 8)
+        #expect(g.bodyVertical == 16)
+    }
+
+    /// The attribution string still exists, but only as spoken text: the native
+    /// cell draws none of it, and carries it as the cell's accessibility label so
+    /// VoiceOver users keep speaker identity.
+    @Test func nativeBubbleCellDrawsNoHeaderButSpeaksTheAttribution() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let item = TranscriptItem.assistantText(id: "a", text: "hello", timestamp: date, usage: nil)
+        let attribution = TranscriptBubbleGeometry.accessibilityAttribution(for: item)
+        #expect(attribution.hasPrefix("Claude · "))
+
+        let blocks = TranscriptBubbleGeometry.composedBlocks(for: item, badgeUsage: nil)
+        let bodyWidth = TranscriptBubbleGeometry.bodyWidth(columnWidth: columnWidth, role: .assistant)
+        let measurer = MessageBlockMeasurer()
+        let heights = measurer.blockHeights(blocks, bodyWidth: bodyWidth)
+        let rowHeight = TranscriptBubbleGeometry.rowHeight(
+            blocksHeight: measurer.blocksHeight(fromBlockHeights: heights))
+
+        let cell = TranscriptBubbleCellView()
+        cell.configure(
+            blocks: blocks, blockHeights: heights, sourceText: "hello",
+            role: .assistant, accessibilityAttribution: attribution,
+            bodyWidth: bodyWidth, columnWidth: columnWidth, cachedHeight: rowHeight)
+        cell.layoutSubtreeIfNeeded()
+
+        // Spoken, not drawn.
+        #expect(cell.accessibilityLabel() == attribution)
+        let drawn = Self.drawnStrings(in: cell)
+        #expect(drawn == ["hello"], "the bubble must draw its prose and nothing else, got \(drawn)")
+
+        // …and no dead space is left where the header used to be: the realized
+        // subtree is exactly the row height the table reserved.
+        #expect(abs(cell.realizedRowHeight - rowHeight) <= 1.0,
+                "realized=\(cell.realizedRowHeight) reserved=\(rowHeight)")
+    }
+
+    /// The SwiftUI bubble must not grow a header the native cell dropped (this
+    /// repo's standing two-renderer trap). Both paths lay the same one-line
+    /// message out, so their heights agree to well under one caption2 line — the
+    /// header the two used to share was a caption2 line plus a 3pt gap, so its
+    /// return on either side breaks this.
+    @Test func swiftUIBubbleMatchesTheNativeHeaderlessHeight() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let item = TranscriptItem.assistantText(id: "a", text: "hello", timestamp: date, usage: nil)
+
+        let controller = NSHostingController(rootView: ChatBubbleView(item: item))
+        controller.sizingOptions = [.preferredContentSize]
+        let swiftHeight = controller.sizeThatFits(
+            in: NSSize(width: columnWidth, height: .greatestFiniteMagnitude)).height
+        // DEFENSIVE SKIP: SwiftUI measurement collapses to 0 in a fully headless
+        // environment (same posture as TranscriptRowLayoutTests).
+        guard swiftHeight > 0 else { return }
+
+        let blocks = TranscriptBubbleGeometry.composedBlocks(for: item, badgeUsage: nil)
+        let bodyWidth = TranscriptBubbleGeometry.bodyWidth(columnWidth: columnWidth, role: .assistant)
+        let nativeHeight = TranscriptBubbleGeometry.rowHeight(
+            blocksHeight: MessageBlockMeasurer().blocksHeight(blocks, bodyWidth: bodyWidth))
+
+        let caption = NSFont.preferredFont(forTextStyle: .caption2)
+        let captionLine = ceil(caption.ascender - caption.descender + caption.leading)
+        #expect(abs(swiftHeight - nativeHeight) < captionLine,
+                Comment(rawValue: "SwiftUI bubble (\(swiftHeight)) and native row (\(nativeHeight)) "
+                    + "differ by at least a caption2 line (\(captionLine)) — one is drawing a header"))
+    }
+
+    /// Every string actually drawn by `view`'s subtree (label fields + prose text
+    /// views), trimmed, in tree order.
+    private static func drawnStrings(in view: NSView) -> [String] {
+        var found: [String] = []
+        func walk(_ v: NSView) {
+            if let field = v as? NSTextField {
+                found.append(field.stringValue)
+            } else if let text = v as? NSTextView {
+                found.append(text.string)
+            }
+            v.subviews.forEach(walk)
+        }
+        walk(view)
+        return found.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
     }
 }

--- a/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
@@ -152,7 +152,9 @@ struct TranscriptImageAttachmentTests {
 
     // MARK: - Sizing
 
-    @Test func wideImageBindsOnWidthAndTallImageBindsOnHeight() throws {
+    /// The thumbnail is CONTAINED in a `maxEdge` square: a wide image binds on
+    /// width, a tall one on height, and neither exceeds the box on either axis.
+    @Test func imagesAreContainedInTheSquareOnTheirLongEdge() throws {
         let scratch = Scratch()
         TranscriptImageService.shared.clearCaches()
         let wide = try writePNG(scratch, name: "wide.png", width: 1200, height: 800)
@@ -164,11 +166,25 @@ struct TranscriptImageAttachmentTests {
         let tallSize = TranscriptImageGeometry.displaySize(
             metadata: TranscriptImageService.shared.metadata(forPath: tall), bodyWidth: bodyWidth)
 
-        // Both fit the box, both keep their true aspect ratio.
-        #expect(wideSize == CGSize(width: 300, height: 200))
+        // 1200×800 binds on WIDTH now (3:2 → 200×133), 400×1600 on height.
+        #expect(wideSize == CGSize(width: 200, height: 133))
         #expect(tallSize == CGSize(width: 50, height: 200))
-        #expect(wideSize.width <= TranscriptImageGeometry.maxWidth)
-        #expect(tallSize.height <= TranscriptImageGeometry.maxHeight)
+        for size in [wideSize, tallSize] {
+            #expect(size.width <= TranscriptImageGeometry.maxEdge)
+            #expect(size.height <= TranscriptImageGeometry.maxEdge)
+        }
+    }
+
+    /// A square image fills the box exactly — the case that would expose a cap
+    /// applied to only one axis.
+    @Test func squareImageFillsTheBoxOnBothAxes() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let square = try writePNG(scratch, name: "square.png", width: 900, height: 900)
+        let size = TranscriptImageGeometry.displaySize(
+            metadata: TranscriptImageService.shared.metadata(forPath: square), bodyWidth: 702)
+        #expect(size == CGSize(
+            width: TranscriptImageGeometry.maxEdge, height: TranscriptImageGeometry.maxEdge))
     }
 
     /// A thumbnail is never blown up past its natural pixel size.
@@ -181,7 +197,7 @@ struct TranscriptImageAttachmentTests {
         #expect(size == CGSize(width: 32, height: 24))
     }
 
-    /// A narrow bubble clamps the thumbnail to the body width, not the 420pt cap.
+    /// A narrow bubble clamps the thumbnail to the body width, not the 200pt box.
     @Test func narrowBodyWidthClampsTheThumbnail() throws {
         let scratch = Scratch()
         TranscriptImageService.shared.clearCaches()
@@ -226,7 +242,7 @@ struct TranscriptImageAttachmentTests {
 
     /// A marker naming something that is not an image at all — including a file
     /// that merely LOOKS like one by extension.
-    @Test func nonImageFileRendersAChipAndStaysRevealable() throws {
+    @Test func nonImageFileRendersAChipAndStaysClickable() throws {
         let scratch = Scratch()
         TranscriptImageService.shared.clearCaches()
         let path = scratch.path("notreally.png")
@@ -252,6 +268,92 @@ struct TranscriptImageAttachmentTests {
         let scratch = Scratch()
         #expect(TranscriptImageService.shared.metadata(forPath: scratch.url.path).state == .missing)
         #expect(TranscriptImageService.shared.metadata(forPath: "").state == .missing)
+    }
+
+    // MARK: - Click and context menu
+
+    /// Counts how many times a click asked for the Quick Look panel. A class so
+    /// the stub presenter can mutate it after escaping.
+    private final class PanelShows { var count = 0 }
+
+    /// Runs `body` with the Quick Look panel presentation stubbed out — a real
+    /// panel would pop over the screen of whoever is running the suite, and needs
+    /// a key window this process does not have.
+    private func withStubbedPanel(_ body: (PanelShows) throws -> Void) rethrows {
+        let shows = PanelShows()
+        let previous = TranscriptQuickLook.shared.showPanel
+        TranscriptQuickLook.shared.showPanel = { shows.count += 1 }
+        defer { TranscriptQuickLook.shared.showPanel = previous }
+        try body(shows)
+    }
+
+    private func configuredView(path: String) -> TranscriptImageBlockView {
+        let metadata = TranscriptImageService.shared.metadata(forPath: path)
+        let view = TranscriptImageBlockView()
+        view.configure(
+            attachment: .init(path: path), metadata: metadata,
+            displaySize: TranscriptImageGeometry.displaySize(metadata: metadata, bodyWidth: 702))
+        return view
+    }
+
+    /// A click previews THAT file — the whole point of the gesture change. The
+    /// panel itself cannot be driven headlessly, so what is asserted is the
+    /// wiring: the presenter is asked exactly once, for exactly this URL.
+    @Test func clickingAThumbnailPreviewsThatExactFile() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = try writePNG(scratch, name: "shot.png", width: 800, height: 600)
+        let view = configuredView(path: path)
+
+        try withStubbedPanel { shows in
+            #expect(view.accessibilityPerformPress())
+            #expect(shows.count == 1)
+            #expect(TranscriptQuickLook.shared.previewURL?.path == path)
+        }
+        #expect(view.accessibilityHelp() == "Quick Look preview")
+    }
+
+    /// Reveal in Finder did not disappear when click stopped doing it — it moved
+    /// to the right-click menu, alongside Copy Image.
+    @Test func contextMenuKeepsRevealInFinderAndCopyReachable() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = try writePNG(scratch, name: "shot.png", width: 800, height: 600)
+        let menu = try #require(configuredView(path: path).makeContextMenu())
+        #expect(menu.items.map(\.title) == ["Quick Look", "Copy Image", "Reveal in Finder"])
+    }
+
+    /// An `.unreadable` file stays clickable — Quick Look previews a PDF or a
+    /// text file perfectly well — but there is no image to copy.
+    @Test func unreadableFileStaysPreviewableWithoutCopyImage() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = scratch.path("notreally.png")
+        try Data("this is plain text, not a PNG".utf8).write(to: URL(fileURLWithPath: path))
+        let view = configuredView(path: path)
+
+        let menu = try #require(view.makeContextMenu())
+        #expect(menu.items.map(\.title) == ["Quick Look", "Reveal in Finder"])
+
+        try withStubbedPanel { shows in
+            #expect(view.accessibilityPerformPress())
+            #expect(shows.count == 1)
+            #expect(TranscriptQuickLook.shared.previewURL?.path == path)
+        }
+    }
+
+    /// A `.missing` file is inert: no click, no menu. There is nothing on disk to
+    /// preview or reveal.
+    @Test func missingFileIsNotClickableAndHasNoMenu() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let view = configuredView(path: scratch.path("gone.png"))
+
+        #expect(view.makeContextMenu() == nil)
+        try withStubbedPanel { shows in
+            #expect(view.accessibilityPerformPress() == false)
+            #expect(shows.count == 0)
+        }
     }
 
     // MARK: - Decode and cache

--- a/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SwiftUI
 import Testing
 @testable import TBDApp
 import TBDShared
@@ -34,7 +35,10 @@ struct TranscriptImageAttachmentTests {
     }
 
     /// Writes a real PNG of the given pixel dimensions and returns its path.
-    private func writePNG(_ scratch: Scratch, name: String, width: Int, height: Int) throws -> String {
+    private func writePNG(
+        _ scratch: Scratch, name: String, width: Int, height: Int,
+        color: NSColor = .systemTeal
+    ) throws -> String {
         let rep = NSBitmapImageRep(
             bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
             bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
@@ -42,7 +46,7 @@ struct TranscriptImageAttachmentTests {
         let unwrapped = try #require(rep)
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: unwrapped)
-        NSColor.systemTeal.setFill()
+        color.setFill()
         NSRect(x: 0, y: 0, width: width, height: height).fill()
         NSGraphicsContext.restoreGraphicsState()
         let data = try #require(unwrapped.representation(using: .png, properties: [:]))
@@ -483,6 +487,90 @@ struct TranscriptImageAttachmentTests {
         // The bubble draws the picture, not the path.
         let drawn = Self.drawnStrings(in: cell)
         #expect(!drawn.contains { $0.contains(path) }, "the raw path must never be drawn, got \(drawn)")
+    }
+
+    // MARK: - Hosted (SwiftUI) reuse staleness
+
+    /// The SwiftUI image view renders inside `TableTranscriptView`'s shared
+    /// `NSHostingView` pool (reachable via `AskUserQuestionCard`'s embedded
+    /// `ChatBubbleView`), where a recycled cell has its `rootView` REPLACED rather
+    /// than being torn down. Its thumbnail lives in `@State` and `load()` bails
+    /// once that is non-nil, so a cell recycled onto a different message must be
+    /// made to fetch the NEW attachment — otherwise it keeps drawing the previous
+    /// message's picture.
+    ///
+    /// What is observable headlessly is the FETCH, not the pixels: SwiftUI content
+    /// is not captured by `cacheDisplay` or `CALayer.render` in this unbundled test
+    /// process, so the drawn image cannot be read back. The fetch is a sound proxy
+    /// — `load()` requests a thumbnail only when it holds no image, so a request
+    /// for the second attachment can only come from a view that dropped the first.
+    ///
+    /// Both fixtures are the same pixel size, so `maxPixelSize` is identical for
+    /// both and a cache hit cannot be confused for the wrong file.
+    @Test func recycledHostingViewFetchesTheNewAttachmentsThumbnail() async throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let first = try writePNG(scratch, name: "first.png", width: 160, height: 160, color: .red)
+        let second = try writePNG(scratch, name: "second.png", width: 160, height: 160, color: .blue)
+        let maxPixel = Self.hostedMaxPixelSize(forPath: first)
+
+        let host = NSHostingView(rootView: AnyView(Self.bubble(marker: marker(first))))
+        host.frame = NSRect(x: 0, y: 0, width: 420, height: 260)
+        let window = NSWindow(
+            contentRect: host.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = host
+
+        await pump(host) { TranscriptImageService.shared.hasCachedThumbnail(forPath: first, maxPixelSize: maxPixel) }
+        #expect(TranscriptImageService.shared.hasCachedThumbnail(forPath: first, maxPixelSize: maxPixel),
+                "precondition: the hosted view must fetch its own attachment at all")
+        #expect(!TranscriptImageService.shared.hasCachedThumbnail(forPath: second, maxPixelSize: maxPixel),
+                "precondition: nothing has asked for the second attachment yet")
+
+        // Recycle the cell onto a different message carrying a different image.
+        host.rootView = AnyView(Self.bubble(marker: marker(second)))
+        await pump(host) { TranscriptImageService.shared.hasCachedThumbnail(forPath: second, maxPixelSize: maxPixel) }
+        #expect(TranscriptImageService.shared.hasCachedThumbnail(forPath: second, maxPixelSize: maxPixel),
+                Comment(rawValue: "the recycled hosting view never fetched the new attachment, so "
+                    + "it is still drawing the previous message's thumbnail"))
+    }
+
+    /// The hosted shape the reuse pool actually renders: a chat bubble whose text
+    /// is one image marker.
+    @MainActor
+    private static func bubble(marker: String) -> some View {
+        ChatBubbleView(item: .userPrompt(id: "u1", text: marker, timestamp: nil))
+            .frame(width: 420, alignment: .leading)
+    }
+
+    /// The `maxPixelSize` `TranscriptImageAttachmentView.load` will ask for, derived
+    /// the same way it derives it — so the test reads the same cache slot the view
+    /// fills rather than a hardcoded one.
+    private static func hostedMaxPixelSize(forPath path: String) -> Int {
+        let display = TranscriptImageGeometry.displaySize(
+            metadata: TranscriptImageService.shared.metadata(forPath: path),
+            bodyWidth: TranscriptImageGeometry.maxEdge)
+        let scale = NSScreen.main?.backingScaleFactor ?? 2
+        return Int((max(display.width, display.height) * scale).rounded(.up))
+    }
+
+    /// Lays out, then yields the main actor until `done` or ~1s has passed.
+    ///
+    /// It YIELDS rather than spinning a nested `RunLoop.run`: the decode's
+    /// completion arrives via `DispatchQueue.main.async`, and suspending is what
+    /// lets the main queue deliver it. A nested run loop would deliver it too, but
+    /// it would also resume every other suspended `@MainActor` test in this
+    /// 200-suite process inside this test's body — including a sibling of this
+    /// `.serialized` suite parked on an `await`, whose `clearCaches()` then lands
+    /// mid-flight. Serialization does not cover that; not re-entering does.
+    ///
+    /// Bounded on purpose: a decode that never arrives must fail the assertion
+    /// below rather than hang the suite.
+    private func pump(_ view: NSView, until done: () -> Bool) async {
+        for _ in 0..<50 {
+            view.layoutSubtreeIfNeeded()
+            if done() { return }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
     }
 
     /// Every string actually drawn by `view`'s subtree.

--- a/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
@@ -1,0 +1,398 @@
+import AppKit
+import Foundation
+import Testing
+@testable import TBDApp
+import TBDShared
+
+/// Covers the inline rendering of Claude Code's `[Image: source: …]` attachment
+/// markers: how they are parsed out of transcript text, how the row is sized
+/// before the thumbnail exists, and how a missing / undecodable / hostile path
+/// degrades.
+///
+/// Every fixture is written into a per-test temp directory — no test reads the
+/// developer's real Claude image cache.
+/// `.serialized` because the tests share one process-wide `TranscriptImageService`
+/// and several of them call `clearCaches()`: run in parallel, one test's reset
+/// evicts another's just-decoded thumbnail and the cache assertions flake.
+@MainActor
+@Suite("Transcript image attachments", .serialized)
+struct TranscriptImageAttachmentTests {
+
+    // MARK: - Fixtures
+
+    /// A scratch directory that cleans itself up.
+    final class Scratch {
+        let url: URL
+        init() {
+            url = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("tbd-image-tests-\(UUID().uuidString)")
+            try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        }
+        deinit { try? FileManager.default.removeItem(at: url) }
+
+        func path(_ name: String) -> String { url.appendingPathComponent(name).path }
+    }
+
+    /// Writes a real PNG of the given pixel dimensions and returns its path.
+    private func writePNG(_ scratch: Scratch, name: String, width: Int, height: Int) throws -> String {
+        let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0)
+        let unwrapped = try #require(rep)
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: unwrapped)
+        NSColor.systemTeal.setFill()
+        NSRect(x: 0, y: 0, width: width, height: height).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        let data = try #require(unwrapped.representation(using: .png, properties: [:]))
+        let path = scratch.path(name)
+        try data.write(to: URL(fileURLWithPath: path))
+        return path
+    }
+
+    private func marker(_ path: String) -> String { "[Image: source: \(path)]" }
+
+    // MARK: - Marker parsing
+
+    /// The overwhelmingly common shape: an `isMeta` follow-up line whose entire
+    /// text is one marker. It becomes one image segment and NO text — the path
+    /// must not survive as prose anywhere.
+    @Test func soleMarkerBecomesOneImageSegmentAndNoText() {
+        let segments = TranscriptImageMarker.split(marker("/tmp/a/1.png"))
+        #expect(segments == [.image(TranscriptImageAttachment(path: "/tmp/a/1.png"))])
+    }
+
+    /// Several images in one paste arrive as several text blocks, which the
+    /// daemon joins with newlines. Order is preserved.
+    @Test func multipleMarkersProduceOrderedImageSegments() {
+        let text = [marker("/tmp/a/2.png"), marker("/tmp/a/3.png")].joined(separator: "\n")
+        let segments = TranscriptImageMarker.split(text)
+        #expect(segments == [
+            .image(TranscriptImageAttachment(path: "/tmp/a/2.png")),
+            .image(TranscriptImageAttachment(path: "/tmp/a/3.png"))
+        ])
+    }
+
+    /// A marker inside a sentence splits the prose around it and keeps both
+    /// halves. (Observed in the corpus when a prompt quotes the marker syntax.)
+    @Test func midSentenceMarkerKeepsSurroundingProse() {
+        let segments = TranscriptImageMarker.split("before \(marker("/tmp/a/1.png")) after")
+        #expect(segments == [
+            .text("before"),
+            .image(TranscriptImageAttachment(path: "/tmp/a/1.png")),
+            .text("after")
+        ])
+    }
+
+    /// The inline `[Image #N]` placeholder is the user's own text, marking where
+    /// they pasted; it lives in a DIFFERENT message from the `source:` marker and
+    /// is deliberately left untouched.
+    @Test func inlinePlaceholderIsNotTreatedAsAMarker() {
+        let segments = TranscriptImageMarker.split("looks good [Image #1] fix the badge")
+        #expect(segments == [.text("looks good [Image #1] fix the badge")])
+    }
+
+    /// A marker inside a fenced code block is quoted source, not an attachment.
+    @Test func markerInsideCodeFenceStaysLiteralText() {
+        let text = "docs:\n```\n\(marker("/tmp/a/1.png"))\n```\ndone"
+        let segments = TranscriptImageMarker.split(text)
+        #expect(segments.count == 1)
+        guard case .text(let body) = segments[0] else {
+            Issue.record("expected a single text segment, got \(segments)")
+            return
+        }
+        #expect(body.contains("[Image: source: /tmp/a/1.png]"))
+    }
+
+    /// A payload that is not an absolute path is nothing we could reveal, so the
+    /// marker stays as written rather than becoming an empty hole.
+    @Test func relativePathStaysLiteralText() {
+        let segments = TranscriptImageMarker.split("[Image: source: relative/1.png]")
+        #expect(segments == [.text("[Image: source: relative/1.png]")])
+    }
+
+    /// Text with no marker at all takes the fast path and is returned verbatim,
+    /// whitespace included — ordinary messages must not be reshaped.
+    @Test func textWithoutMarkersIsReturnedVerbatim() {
+        let text = "\n  hello **world**  \n\n"
+        #expect(TranscriptImageMarker.split(text) == [.text(text)])
+    }
+
+    // MARK: - Both renderers see the same blocks
+
+    @Test func renderBlocksEmitsImageBlocksBetweenProse() {
+        let blocks = MarkdownAttributedRenderer.renderBlocks(
+            "before \(marker("/tmp/a/1.png")) after")
+        #expect(blocks.count == 3)
+        guard case .prose(let lead) = blocks[0],
+              case .image(let attachment) = blocks[1],
+              case .prose(let trail) = blocks[2] else {
+            Issue.record("expected prose/image/prose, got \(blocks)")
+            return
+        }
+        #expect(lead.string.contains("before"))
+        #expect(attachment.path == "/tmp/a/1.png")
+        #expect(trail.string.contains("after"))
+        // The path must not leak into the rendered prose on either side.
+        #expect(!lead.string.contains("/tmp/a/1.png"))
+        #expect(!trail.string.contains("/tmp/a/1.png"))
+    }
+
+    /// The SwiftUI path splits identically — the standing two-renderer trap.
+    @Test func swiftUISegmentsMatchTheNativeBlocks() {
+        let text = "before \(marker("/tmp/a/1.png")) after"
+        let segments = MarkdownSegments.split(text)
+        #expect(segments == [
+            .prose("before"),
+            .image(TranscriptImageAttachment(path: "/tmp/a/1.png")),
+            .prose("after")
+        ])
+    }
+
+    // MARK: - Sizing
+
+    @Test func wideImageBindsOnWidthAndTallImageBindsOnHeight() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let wide = try writePNG(scratch, name: "wide.png", width: 1200, height: 800)
+        let tall = try writePNG(scratch, name: "tall.png", width: 400, height: 1600)
+        let bodyWidth: CGFloat = 702
+
+        let wideSize = TranscriptImageGeometry.displaySize(
+            metadata: TranscriptImageService.shared.metadata(forPath: wide), bodyWidth: bodyWidth)
+        let tallSize = TranscriptImageGeometry.displaySize(
+            metadata: TranscriptImageService.shared.metadata(forPath: tall), bodyWidth: bodyWidth)
+
+        // Both fit the box, both keep their true aspect ratio.
+        #expect(wideSize == CGSize(width: 300, height: 200))
+        #expect(tallSize == CGSize(width: 50, height: 200))
+        #expect(wideSize.width <= TranscriptImageGeometry.maxWidth)
+        #expect(tallSize.height <= TranscriptImageGeometry.maxHeight)
+    }
+
+    /// A thumbnail is never blown up past its natural pixel size.
+    @Test func smallImageIsNotUpscaled() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let icon = try writePNG(scratch, name: "icon.png", width: 32, height: 24)
+        let size = TranscriptImageGeometry.displaySize(
+            metadata: TranscriptImageService.shared.metadata(forPath: icon), bodyWidth: 702)
+        #expect(size == CGSize(width: 32, height: 24))
+    }
+
+    /// A narrow bubble clamps the thumbnail to the body width, not the 420pt cap.
+    @Test func narrowBodyWidthClampsTheThumbnail() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let wide = try writePNG(scratch, name: "wide.png", width: 1200, height: 800)
+        let size = TranscriptImageGeometry.displaySize(
+            metadata: TranscriptImageService.shared.metadata(forPath: wide), bodyWidth: 120)
+        #expect(size.width == 120)
+        #expect(size.height == 80)
+    }
+
+    // MARK: - Failure paths
+
+    @Test func missingFileDegradesToAFixedChipAndNeverPrintsThePath() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = scratch.path("gone.png")
+        let metadata = TranscriptImageService.shared.metadata(forPath: path)
+        #expect(metadata.state == .missing)
+
+        let size = TranscriptImageGeometry.displaySize(metadata: metadata, bodyWidth: 702)
+        #expect(size.height == TranscriptImageGeometry.fallbackHeight)
+
+        let view = TranscriptImageBlockView()
+        view.configure(attachment: .init(path: path), metadata: metadata, displaySize: size)
+        let chip = try #require(view.fallbackChipText)
+        #expect(chip.contains("gone.png"))
+        #expect(!chip.contains(path), "the raw path must never be drawn")
+        #expect(view.renderedImage == nil)
+        // Still legible to VoiceOver.
+        #expect(view.accessibilityLabel()?.contains("gone.png") == true)
+        // …and the tooltip is the one place the path stays reachable.
+        #expect(view.toolTip == (path as NSString).abbreviatingWithTildeInPath)
+    }
+
+    @Test func zeroByteFileIsUnreadableNotMissing() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = scratch.path("empty.png")
+        try Data().write(to: URL(fileURLWithPath: path))
+        #expect(TranscriptImageService.shared.metadata(forPath: path).state == .unreadable)
+    }
+
+    /// A marker naming something that is not an image at all — including a file
+    /// that merely LOOKS like one by extension.
+    @Test func nonImageFileRendersAChipAndStaysRevealable() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = scratch.path("notreally.png")
+        try Data("this is plain text, not a PNG".utf8).write(to: URL(fileURLWithPath: path))
+
+        let metadata = TranscriptImageService.shared.metadata(forPath: path)
+        #expect(metadata.state == .unreadable)
+        #expect(metadata.pixelSize == nil)
+
+        let view = TranscriptImageBlockView()
+        view.configure(
+            attachment: .init(path: path), metadata: metadata,
+            displaySize: TranscriptImageGeometry.displaySize(metadata: metadata, bodyWidth: 702))
+        #expect(view.fallbackChipText == "notreally.png")
+        #expect(view.accessibilityLabel()?.contains("not a viewable image") == true)
+    }
+
+    /// A directory (or anything that is not a regular file) must probe as missing
+    /// rather than being opened — the guard that also keeps a marker naming a
+    /// device node from blocking the reader forever.
+    @Test func nonRegularFileProbesAsMissing() {
+        TranscriptImageService.shared.clearCaches()
+        let scratch = Scratch()
+        #expect(TranscriptImageService.shared.metadata(forPath: scratch.url.path).state == .missing)
+        #expect(TranscriptImageService.shared.metadata(forPath: "").state == .missing)
+    }
+
+    // MARK: - Decode and cache
+
+    @Test func thumbnailDecodesOffMainAndIsThenServedFromCache() async throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = try writePNG(scratch, name: "big.png", width: 2400, height: 1600)
+        let maxPixel = 600
+
+        #expect(!TranscriptImageService.shared.hasCachedThumbnail(
+            forPath: path, maxPixelSize: maxPixel))
+
+        let image: NSImage? = await withCheckedContinuation { continuation in
+            TranscriptImageService.shared.thumbnail(forPath: path, maxPixelSize: maxPixel) {
+                continuation.resume(returning: $0)
+            }
+        }
+        let decoded = try #require(image)
+        // Downsampled, never decoded at full size.
+        #expect(max(decoded.size.width, decoded.size.height) <= CGFloat(maxPixel))
+        #expect(TranscriptImageService.shared.hasCachedThumbnail(
+            forPath: path, maxPixelSize: maxPixel))
+
+        // A cache hit calls back SYNCHRONOUSLY, so a scroll-reused row repaints
+        // without a blank frame and without re-decoding.
+        var synchronous = false
+        var second: NSImage?
+        TranscriptImageService.shared.thumbnail(forPath: path, maxPixelSize: maxPixel) {
+            synchronous = true
+            second = $0
+        }
+        #expect(synchronous, "a cached thumbnail must not round-trip through a queue")
+        #expect(second === decoded)
+    }
+
+    /// An animated GIF renders its FIRST frame as a still.
+    @Test func animatedGIFRendersAStill() async throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let png = try writePNG(scratch, name: "frame.png", width: 60, height: 40)
+        let source = try #require(NSImage(contentsOfFile: png))
+        // Two identical frames is enough to make it animated.
+        let gifPath = scratch.path("anim.gif")
+        let destination = try #require(CGImageDestinationCreateWithURL(
+            URL(fileURLWithPath: gifPath) as CFURL, "com.compuserve.gif" as CFString, 2, nil))
+        var rect = CGRect(x: 0, y: 0, width: 60, height: 40)
+        let cg = try #require(source.cgImage(forProposedRect: &rect, context: nil, hints: nil))
+        let frameProps = [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: 0.1]]
+        CGImageDestinationAddImage(destination, cg, frameProps as CFDictionary)
+        CGImageDestinationAddImage(destination, cg, frameProps as CFDictionary)
+        #expect(CGImageDestinationFinalize(destination))
+
+        #expect(TranscriptImageService.shared.metadata(forPath: gifPath).state == .ready(CGSize(width: 60, height: 40)))
+        let image: NSImage? = await withCheckedContinuation { continuation in
+            TranscriptImageService.shared.thumbnail(forPath: gifPath, maxPixelSize: 120) {
+                continuation.resume(returning: $0)
+            }
+        }
+        let decoded = try #require(image)
+        // One still frame, not an animated representation.
+        #expect(decoded.representations.count == 1)
+    }
+
+    // MARK: - Measurement is stable across the async decode
+
+    /// The whole point of probing the header synchronously: the row height the
+    /// table reserves BEFORE the thumbnail exists must equal the height after it
+    /// lands, or the transcript would jump while scrolling.
+    @Test func rowHeightIsIdenticalBeforeAndAfterTheImageArrives() async throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = try writePNG(scratch, name: "shot.png", width: 1600, height: 900)
+        let item = TranscriptItem.userPrompt(id: "u1", text: marker(path), timestamp: nil)
+        let columnWidth: CGFloat = 800
+        let bodyWidth = TranscriptBubbleGeometry.bodyWidth(columnWidth: columnWidth, role: .user)
+
+        let blocks = TranscriptBubbleGeometry.composedBlocks(for: item, badgeUsage: nil)
+        #expect(blocks.count == 1)
+        guard case .image = blocks[0] else {
+            Issue.record("expected a single image block, got \(blocks)")
+            return
+        }
+
+        let before = MessageBlockMeasurer().blockHeights(blocks, bodyWidth: bodyWidth)
+        let heightBefore = TranscriptBubbleGeometry.rowHeight(
+            blocksHeight: MessageBlockMeasurer().blocksHeight(fromBlockHeights: before))
+        #expect(!TranscriptImageService.shared.hasCachedThumbnail(forPath: path, maxPixelSize: 400))
+
+        _ = await withCheckedContinuation { continuation in
+            TranscriptImageService.shared.thumbnail(forPath: path, maxPixelSize: 400) {
+                continuation.resume(returning: $0)
+            }
+        }
+
+        let after = MessageBlockMeasurer().blockHeights(blocks, bodyWidth: bodyWidth)
+        let heightAfter = TranscriptBubbleGeometry.rowHeight(
+            blocksHeight: MessageBlockMeasurer().blocksHeight(fromBlockHeights: after))
+        #expect(before == after)
+        #expect(heightBefore == heightAfter)
+    }
+
+    /// …and the live cell realizes at exactly that reserved height, the row-height
+    /// oracle this transcript is held to everywhere else.
+    @Test func cellRealizesAtTheReservedRowHeight() throws {
+        let scratch = Scratch()
+        TranscriptImageService.shared.clearCaches()
+        let path = try writePNG(scratch, name: "shot.png", width: 1600, height: 900)
+        let item = TranscriptItem.userPrompt(id: "u1", text: marker(path), timestamp: nil)
+        let columnWidth: CGFloat = 800
+        let bodyWidth = TranscriptBubbleGeometry.bodyWidth(columnWidth: columnWidth, role: .user)
+
+        let blocks = TranscriptBubbleGeometry.composedBlocks(for: item, badgeUsage: nil)
+        let heights = MessageBlockMeasurer().blockHeights(blocks, bodyWidth: bodyWidth)
+        let rowHeight = TranscriptBubbleGeometry.rowHeight(
+            blocksHeight: MessageBlockMeasurer().blocksHeight(fromBlockHeights: heights))
+
+        let cell = TranscriptBubbleCellView()
+        cell.configure(
+            blocks: blocks, blockHeights: heights, sourceText: marker(path),
+            role: .user, accessibilityAttribution: "You",
+            bodyWidth: bodyWidth, columnWidth: columnWidth, cachedHeight: rowHeight)
+        cell.layoutSubtreeIfNeeded()
+        #expect(abs(cell.realizedRowHeight - rowHeight) <= 1.0,
+                "realized=\(cell.realizedRowHeight) reserved=\(rowHeight)")
+
+        // The bubble draws the picture, not the path.
+        let drawn = Self.drawnStrings(in: cell)
+        #expect(!drawn.contains { $0.contains(path) }, "the raw path must never be drawn, got \(drawn)")
+    }
+
+    /// Every string actually drawn by `view`'s subtree.
+    private static func drawnStrings(in view: NSView) -> [String] {
+        var out: [String] = []
+        if let field = view as? NSTextField, !field.isHidden, !field.stringValue.isEmpty {
+            out.append(field.stringValue)
+        }
+        if let textView = view as? NSTextView, !textView.isHidden, !textView.string.isEmpty {
+            out.append(textView.string)
+        }
+        for sub in view.subviews { out.append(contentsOf: drawnStrings(in: sub)) }
+        return out
+    }
+}

--- a/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
@@ -274,6 +274,47 @@ struct TranscriptImageAttachmentTests {
         #expect(TranscriptImageService.shared.metadata(forPath: "").state == .missing)
     }
 
+    /// Carries a probe's result back from a worker thread. A class so the escaping
+    /// closure can write it; the semaphore in the test is the ordering.
+    private final class ProbeResult: @unchecked Sendable {
+        var state: TranscriptImageMetadata.State?
+    }
+
+    /// The hazard `fileStamp`'s `.typeRegular` check is named for, exercised with a
+    /// real one: `open(2)` on a fifo with no writer never returns, so a probe that
+    /// opened the file would wedge the measurement thread forever. A directory —
+    /// what `nonRegularFileProbesAsMissing` covers — degrades for a different
+    /// reason (it opens fine and simply has no image header) and cannot catch this.
+    ///
+    /// The probe therefore runs OFF the main thread behind a deadline, so a
+    /// regression fails this test instead of hanging the suite; if it does block,
+    /// the test opens the write end to release the stuck opener before finishing.
+    @Test func fifoProbesAsMissingWithoutBlockingTheReader() throws {
+        TranscriptImageService.shared.clearCaches()
+        let scratch = Scratch()
+        let path = scratch.path("pipe.png")
+        try #require(mkfifo(path, 0o600) == 0,
+                     Comment(rawValue: "mkfifo failed: \(String(cString: strerror(errno)))"))
+        defer { unlink(path) }
+
+        let result = ProbeResult()
+        let finished = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            result.state = TranscriptImageService.shared.metadata(forPath: path).state
+            finished.signal()
+        }
+        let blocked = finished.wait(timeout: .now() + 5) == .timedOut
+        if blocked {
+            // Release the stuck `open(2)` so the worker thread is not leaked in a
+            // permanently blocking syscall, then report.
+            let writeEnd = open(path, O_WRONLY | O_NONBLOCK)
+            if writeEnd >= 0 { close(writeEnd) }
+            _ = finished.wait(timeout: .now() + 2)
+        }
+        #expect(!blocked, "the probe blocked opening a fifo — the .typeRegular guard is gone")
+        #expect(result.state == .missing)
+    }
+
     // MARK: - Click and context menu
 
     /// Counts how many times a click asked for the Quick Look panel. A class so
@@ -559,9 +600,7 @@ struct TranscriptImageAttachmentTests {
     /// completion arrives via `DispatchQueue.main.async`, and suspending is what
     /// lets the main queue deliver it. A nested run loop would deliver it too, but
     /// it would also resume every other suspended `@MainActor` test in this
-    /// 200-suite process inside this test's body — including a sibling of this
-    /// `.serialized` suite parked on an `await`, whose `clearCaches()` then lands
-    /// mid-flight. Serialization does not cover that; not re-entering does.
+    /// 200-suite process inside this test's body.
     ///
     /// Bounded on purpose: a decode that never arrives must fail the assertion
     /// below rather than hang the suite.

--- a/Tests/TBDAppTests/TranscriptPresentationTests.swift
+++ b/Tests/TBDAppTests/TranscriptPresentationTests.swift
@@ -42,14 +42,57 @@ struct TranscriptPresentationTests {
         #expect(presentation.nodes.map(\.id) == ["t1#activity-group", "t1", "t2"])
     }
 
-    @Test("append-only polls keep the active group identity stable")
-    func stableGroupIdentity() {
-        let first = TranscriptPresentation.build(
+    @Test("a lone activity renders as its own row, with no group wrapper")
+    func singleActivityIsNotWrapped() {
+        let presentation = TranscriptPresentation.build(
             items: [tool("t1", "Read", #"{"file_path":"A.swift"}"#)]
         )
+
+        #expect(presentation.nodes.map(\.id) == ["t1"])
+        #expect(presentation.nodes.allSatisfy { node in
+            if case .activityGroupSummary = node.kind { return false }
+            return true
+        })
+    }
+
+    @Test("a lone activity stays unwrapped between narrative turns and when expanded")
+    func singleActivityUnwrappedInEveryPosition() {
+        let betweenTurns = TranscriptPresentation.build(items: [
+            .assistantText(id: "a1", text: "Starting.", timestamp: nil),
+            tool("t1", "Read", #"{"file_path":"A.swift"}"#),
+            .assistantText(id: "a2", text: "Done.", timestamp: nil)
+        ])
+        #expect(betweenTurns.nodes.map(\.id) == ["a1", "t1", "a2"])
+
+        // An expansion override for a group that no longer exists must not
+        // resurrect the wrapper (stale overrides survive in the pane's state).
+        let withStaleOverride = TranscriptPresentation.build(
+            items: [tool("t1", "Read", #"{"file_path":"A.swift"}"#)],
+            expansionOverrides: ["t1#activity-group": true]
+        )
+        #expect(withStaleOverride.nodes.map(\.id) == ["t1"])
+    }
+
+    @Test("two consecutive activities still fold into a summary")
+    func twoActivitiesStillGroup() {
+        let presentation = TranscriptPresentation.build(items: [
+            tool("t1", "Read", #"{"file_path":"A.swift"}"#),
+            tool("t2", "Bash", #"{"command":"swift test"}"#)
+        ])
+
+        #expect(presentation.nodes.map(\.id) == ["t1#activity-group"])
+    }
+
+    @Test("append-only polls keep the active group identity stable")
+    func stableGroupIdentity() {
+        let first = TranscriptPresentation.build(items: [
+            tool("t1", "Read", #"{"file_path":"A.swift"}"#),
+            tool("t2", "Bash", #"{"command":"swift test"}"#)
+        ])
         let appended = TranscriptPresentation.build(items: [
             tool("t1", "Read", #"{"file_path":"A.swift"}"#),
             tool("t2", "Bash", #"{"command":"swift test"}"#),
+            tool("t3", "Grep", #"{"pattern":"foo"}"#),
         ])
 
         #expect(first.nodes.first?.id == "t1#activity-group")
@@ -65,9 +108,12 @@ struct TranscriptPresentationTests {
             subagent: nil, timestamp: nil
         )
         let question = tool("ask", "AskUserQuestion", #"{"questions":[]}"#)
+        // A second, succeeded item so the run still forms a group — a lone
+        // activity renders unwrapped and has no summary to expand.
+        let succeeded = succeededTool("ok", "Read", #"{"file_path":"A.swift"}"#)
 
-        let failed = TranscriptPresentation.build(items: [failure])
-        let awaiting = TranscriptPresentation.build(items: [question])
+        let failed = TranscriptPresentation.build(items: [failure, succeeded])
+        let awaiting = TranscriptPresentation.build(items: [question, succeeded])
 
         guard case .activityGroupSummary(let failedSummary) = failed.nodes[0].kind,
               case .activityGroupSummary(let questionSummary) = awaiting.nodes[0].kind else {
@@ -80,7 +126,7 @@ struct TranscriptPresentationTests {
         #expect(questionSummary.statusLabel == "Needs response")
 
         let collapsedFailure = TranscriptPresentation.build(
-            items: [failure],
+            items: [failure, succeeded],
             expansionOverrides: ["bad#activity-group": false]
         )
         guard case .activityGroupSummary(let collapsedSummary) = collapsedFailure.nodes[0].kind else {
@@ -92,15 +138,32 @@ struct TranscriptPresentationTests {
 
     @Test("unfinished tool calls are active rather than reported complete")
     func pendingGroupStatus() {
-        let presentation = TranscriptPresentation.build(
-            items: [tool("t1", "Bash", #"{"command":"swift test"}"#)]
-        )
+        let presentation = TranscriptPresentation.build(items: [
+            tool("t1", "Bash", #"{"command":"swift test"}"#),
+            succeededTool("t2", "Read", #"{"file_path":"A.swift"}"#)
+        ])
         guard case .activityGroupSummary(let summary) = presentation.nodes[0].kind else {
             Issue.record("expected activity summary")
             return
         }
         #expect(summary.pendingCount == 1)
         #expect(summary.statusLabel == "In progress")
+    }
+
+    @Test("an all-succeeded group carries no status label")
+    func succeededGroupHasNoStatusLabel() {
+        let presentation = TranscriptPresentation.build(items: [
+            succeededTool("t1", "Read", #"{"file_path":"A.swift"}"#),
+            succeededTool("t2", "Bash", #"{"command":"swift build"}"#)
+        ])
+        guard case .activityGroupSummary(let summary) = presentation.nodes[0].kind else {
+            Issue.record("expected activity summary")
+            return
+        }
+        #expect(summary.errorCount == 0)
+        #expect(summary.pendingCount == 0)
+        #expect(!summary.requiresResponse)
+        #expect(summary.statusLabel == nil)
     }
 
     @Test("index classifies, deduplicates, and retains latest click target")
@@ -144,9 +207,12 @@ struct TranscriptPresentationTests {
     func expandedGroupStaysExpandedWhenFailureArrives() {
         let pendingTool = tool("t1", "Bash", #"{"command":"sleep 10"}"#)
 
+        // A second, succeeded item so the run forms a group at all.
+        let companion = succeededTool("t2", "Read", #"{"file_path":"A.swift"}"#)
+
         // First build: pending tool (not expanded by default since no error/question)
         let firstPresentation = TranscriptPresentation.build(
-            items: [pendingTool],
+            items: [pendingTool, companion],
             expansionOverrides: ["t1#activity-group": true]
         )
 
@@ -166,7 +232,7 @@ struct TranscriptPresentationTests {
         )
 
         let secondPresentation = TranscriptPresentation.build(
-            items: [failedTool],
+            items: [failedTool, companion],
             expansionOverrides: ["t1#activity-group": true]
         )
 
@@ -189,9 +255,12 @@ struct TranscriptPresentationTests {
             subagent: nil, timestamp: nil
         )
 
+        // A second, succeeded item so the run forms a group at all.
+        let companion = succeededTool("t9", "Read", #"{"file_path":"A.swift"}"#)
+
         // First build: one failure (expanded by default), but we override to collapsed
         let firstPresentation = TranscriptPresentation.build(
-            items: [firstFailure],
+            items: [firstFailure, companion],
             expansionOverrides: ["t1#activity-group": false]
         )
 
@@ -211,7 +280,7 @@ struct TranscriptPresentationTests {
         )
 
         let secondPresentation = TranscriptPresentation.build(
-            items: [firstFailure, secondFailure],
+            items: [firstFailure, companion, secondFailure],
             expansionOverrides: ["t1#activity-group": false]
         )
 
@@ -229,7 +298,8 @@ struct TranscriptPresentationTests {
     func noOverrideFallsBackToDefault() {
         // Test with a plain group (no error, no question) - should collapse by default
         let plainItems = [
-            tool("t1", "Read", #"{"file_path":"A.swift"}"#)
+            tool("t1", "Read", #"{"file_path":"A.swift"}"#),
+            tool("t2", "Grep", #"{"pattern":"foo"}"#)
         ]
         let plainPresentation = TranscriptPresentation.build(
             items: plainItems,
@@ -249,7 +319,7 @@ struct TranscriptPresentationTests {
             subagent: nil, timestamp: nil
         )
         let failurePresentation = TranscriptPresentation.build(
-            items: [failure],
+            items: [failure, succeededTool("f2", "Read", #"{"file_path":"A.swift"}"#)],
             expansionOverrides: [:]
         )
         guard case .activityGroupSummary(let failureSummary) = failurePresentation.nodes[0].kind else {
@@ -259,10 +329,21 @@ struct TranscriptPresentationTests {
         #expect(failureSummary.isExpanded)
     }
 
+    /// A tool call with no result yet — counts as pending.
     private func tool(_ id: String, _ name: String, _ input: String) -> TranscriptItem {
         .toolCall(
             id: id, name: name, inputJSON: input, inputTruncatedTo: nil,
             result: nil, subagent: nil, timestamp: nil
+        )
+    }
+
+    /// A tool call that finished successfully: neither pending nor an error, so
+    /// it pads a run into a real group without changing the group's status.
+    private func succeededTool(_ id: String, _ name: String, _ input: String) -> TranscriptItem {
+        .toolCall(
+            id: id, name: name, inputJSON: input, inputTruncatedTo: nil,
+            result: ToolResult(text: "ok", truncatedTo: nil, isError: false),
+            subagent: nil, timestamp: nil
         )
     }
 }

--- a/Tests/TBDAppTests/TranscriptPresentationTests.swift
+++ b/Tests/TBDAppTests/TranscriptPresentationTests.swift
@@ -23,7 +23,7 @@ struct TranscriptPresentationTests {
         }
         #expect(summary.id == "t1#activity-group")
         #expect(summary.itemCount == 2)
-        #expect(summary.labels == ["Reads", "Commands"])
+        #expect(summary.bucketCounts == [.read: 1, .bash: 1])
         #expect(!summary.isExpanded)
     }
 
@@ -136,7 +136,7 @@ struct TranscriptPresentationTests {
         #expect(!collapsedSummary.isExpanded)
     }
 
-    @Test("unfinished tool calls are active rather than reported complete")
+    @Test("unfinished tool calls read as running in the phrase, not as a status label")
     func pendingGroupStatus() {
         let presentation = TranscriptPresentation.build(items: [
             tool("t1", "Bash", #"{"command":"swift test"}"#),
@@ -147,7 +147,10 @@ struct TranscriptPresentationTests {
             return
         }
         #expect(summary.pendingCount == 1)
-        #expect(summary.statusLabel == "In progress")
+        // The tense and the ellipsis ARE the running indicator, so there is no
+        // separate "In progress" label or "active" badge to drift from it.
+        #expect(summary.activityPhrase == "Reading 1 file, running 1 shell command…")
+        #expect(summary.statusLabel == nil)
     }
 
     @Test("an all-succeeded group carries no status label")
@@ -327,6 +330,123 @@ struct TranscriptPresentationTests {
             return
         }
         #expect(failureSummary.isExpanded)
+    }
+
+    // MARK: - Activity phrase
+    //
+    // Claude Code's own rule, reproduced: one `<verb> <count> <noun>` clause per
+    // nonzero bucket, joined with ", " (no "and", no "N more", no generic
+    // fallback), only the FIRST clause capitalized, numerals never spelled out,
+    // clause order fixed by `ActivityBucket.allCases` rather than by when the
+    // tools ran.
+
+    @Test("a single bucket pluralizes: 'Ran 2 shell commands'")
+    func phraseSingleBucketPlural() {
+        #expect(phrase(for: [
+            succeededTool("t1", "Bash", #"{"command":"swift build"}"#),
+            succeededTool("t2", "Bash", #"{"command":"swift test"}"#)
+        ]) == "Ran 2 shell commands")
+    }
+
+    @Test("a single bucket takes the singular noun: 'Read 1 file'")
+    func phraseSingleBucketSingular() {
+        // Three reads of ONE path: the read count is distinct file paths, not
+        // call count, so this is "1 file" and not "3 files".
+        #expect(phrase(for: [
+            succeededTool("t1", "Read", #"{"file_path":"A.swift"}"#),
+            succeededTool("t2", "Read", #"{"file_path":"A.swift"}"#),
+            succeededTool("t3", "Read", #"{"file_path":"A.swift","offset":40}"#)
+        ]) == "Read 1 file")
+    }
+
+    @Test("distinct read paths still count separately")
+    func phraseDistinctReadPaths() {
+        #expect(phrase(for: [
+            succeededTool("t1", "Read", #"{"file_path":"A.swift"}"#),
+            succeededTool("t2", "Read", #"{"file_path":"B.swift"}"#),
+            succeededTool("t3", "Read", #"{"file_path":"A.swift"}"#)
+        ]) == "Read 2 files")
+    }
+
+    @Test("mixed buckets join with a comma and only the first clause capitalizes")
+    func phraseMixedBucketsCapitalizeFirstOnly() {
+        let text = phrase(for: [
+            succeededTool("t1", "Bash", #"{"command":"swift build"}"#),
+            succeededTool("t2", "Bash", #"{"command":"swift test"}"#),
+            succeededTool("t3", "Read", #"{"file_path":"A.swift"}"#)
+        ])
+        // `read` precedes `bash` in the fixed clause order even though the Bash
+        // calls came first — order is by bucket, never chronological.
+        #expect(text == "Read 1 file, ran 2 shell commands")
+        // The subtle half: the SECOND clause must stay lowercase.
+        let second = text.components(separatedBy: ", ")[1]
+        #expect(second == second.lowercased())
+        #expect(!text.contains(" and "))
+    }
+
+    @Test("three or more buckets emit in the fixed clause order")
+    func phraseFixedClauseOrder() {
+        #expect(phrase(for: [
+            succeededTool("t1", "Bash", #"{"command":"swift test"}"#),
+            succeededTool("t2", "Read", #"{"file_path":"A.swift"}"#),
+            succeededTool("t3", "Grep", #"{"pattern":"foo"}"#),
+            succeededTool("t4", "Write", #"{"file_path":"B.swift","content":"x"}"#)
+        ]) == "Edited 1 file, searched for 1 pattern, read 1 file, ran 1 shell command")
+    }
+
+    @Test("a running group uses present participles and a trailing ellipsis")
+    func phraseRunningGroup() {
+        #expect(phrase(for: [
+            succeededTool("t1", "Grep", #"{"pattern":"foo"}"#),
+            tool("t2", "Bash", #"{"command":"swift test"}"#)
+        ]) == "Searching for 1 pattern, running 1 shell command…")
+    }
+
+    @Test("an unclassified tool falls into 'other': 'Called 1 tool'")
+    func phraseUnclassifiedTool() {
+        #expect(phrase(for: [
+            succeededTool("t1", "CustomScraper", #"{"url":"https://example.com"}"#),
+            succeededTool("t2", "Read", #"{"file_path":"A.swift"}"#)
+        ]) == "Read 1 file, called 1 tool")
+    }
+
+    @Test("MCP calls name their servers instead of counting tools")
+    func phraseMCPServers() {
+        #expect(phrase(for: [
+            succeededTool("t1", "mcp__github__list_prs", "{}"),
+            succeededTool("t2", "mcp__github__get_pr", "{}")
+        ]) == "Called github 2 times")
+
+        #expect(phrase(for: [
+            succeededTool("t1", "mcp__github__list_prs", "{}"),
+            succeededTool("t2", "mcp__sentry__issues", "{}"),
+            succeededTool("t3", "mcp__github__get_pr", "{}")
+        ]) == "Called github, sentry 3 times")
+    }
+
+    @MainActor
+    @Test("the phrase is built once and both renderers read that one string")
+    func phraseIsSharedByBothRenderers() throws {
+        let summary = ActivityGroupSummary(
+            id: "g#activity-group",
+            itemCount: 3,
+            bucketCounts: [.bash: 2, .read: 1]
+        )
+        let node = TranscriptRenderNode(
+            id: summary.id, kind: .activityGroupSummary(summary), badgeUsage: nil)
+        let native = try #require(ActivityRowFormatter.presentation(for: node))
+        #expect(native.titleSegments.map(\.text) == [summary.activityPhrase])
+        #expect(summary.activityPhrase == "Read 1 file, ran 2 shell commands")
+    }
+
+    /// The rendered phrase for a run of activity, via the real grouping path.
+    private func phrase(for items: [TranscriptItem]) -> String {
+        let presentation = TranscriptPresentation.build(items: items)
+        guard case .activityGroupSummary(let summary) = presentation.nodes.first?.kind else {
+            Issue.record("expected an activity group summary")
+            return ""
+        }
+        return summary.activityPhrase
     }
 
     /// A tool call with no result yet — counts as pending.

--- a/Tests/TBDDaemonTests/UserMessageClassifierTests.swift
+++ b/Tests/TBDDaemonTests/UserMessageClassifierTests.swift
@@ -24,6 +24,31 @@ struct UserMessageClassifierTests {
         #expect(UserMessageClassifier.extractText(l) == "Now add unit tests.")
     }
 
+    /// A multi-image paste records one text block PER image, so extraction must
+    /// keep them all. Taking only the first silently dropped every attachment
+    /// after the first, and the transcript could then never show them.
+    @Test("joins every text block, not just the first")
+    func joinsAllTextBlocks() {
+        let l = line("user", role: "user", content: [
+            ["type": "text", "text": "[Image: source: /tmp/cache/2.png]"],
+            ["type": "text", "text": "[Image: source: /tmp/cache/3.png]"]
+        ])
+        #expect(UserMessageClassifier.isRealUserMessage(l) == true)
+        #expect(UserMessageClassifier.extractText(l)
+            == "[Image: source: /tmp/cache/2.png]\n[Image: source: /tmp/cache/3.png]")
+    }
+
+    /// A typed prompt with a pasted image is `[text, image]` — the base64 block
+    /// carries no path, so only the text block contributes.
+    @Test("ignores non-text blocks when joining")
+    func ignoresNonTextBlocks() {
+        let l = line("user", role: "user", content: [
+            ["type": "text", "text": "looks good [Image #1]"],
+            ["type": "image", "source": ["type": "base64", "media_type": "image/png", "data": "iVBOR"]]
+        ])
+        #expect(UserMessageClassifier.extractText(l) == "looks good [Image #1]")
+    }
+
     @Test("filters system-reminder string")
     func filtersSystemReminder() {
         let l = line("user", role: "user", content: "<system-reminder>You are Claude.</system-reminder>")

--- a/docs/specs/2026-08-01-session-workbench-design.md
+++ b/docs/specs/2026-08-01-session-workbench-design.md
@@ -77,8 +77,11 @@ Reference light colors map to dynamic AppKit semantic colors in production:
 - **Fault:** the system error color.
 
 SF Pro Text carries prose. SF Pro Rounded appears only in small group labels and counts. SF Mono
-carries paths, commands, and other machine identifiers. The signature element is a quiet vertical
-**signal spine**. It encodes the alternation between narrative and work; it is not decorative.
+carries paths, commands, and other machine identifiers. The alternation between narrative and work
+is carried by the rhythm of the rows themselves — filled accent bubbles for prompts, unfilled prose
+for narrative, a single summary line for each run of work. Assistant prose takes no leading rule or
+border: a vertical bar down every message reads as a blockquote and turns the whole transcript into
+quoted matter.
 
 ### 5.2 Wide layout
 
@@ -90,7 +93,7 @@ At widths of 980 points or more, the session index occupies a 248-point trailing
 │  │                                        │  report.md          2× │
 │  ● Assistant narrative, full-width,       │ SOURCES                │
 │  │ unfilled, readable measure             │  TranscriptItem.swift  │
-│  ◇ Worked · 6 actions · all passed  [>]   │ WEB                    │
+│  Edited 2 files, ran 4 shell commands [>] │ WEB                    │
 │  │                                        │  SwiftUI documentation │
 │  ● Assistant narrative                    │ DELEGATES              │
 │                                           │  Design review       1 │
@@ -104,14 +107,14 @@ transcript and consistent with TBD's pane system.
 
 Below 980 points, the rail becomes a trailing inspector button with the number of indexed
 references. The button opens a popover that contains the same sections and actions. Below 680
-points, prompts and assistant prose both use 12-point horizontal insets; role, color, and the
-signal spine preserve their distinction.
+points, prompts and assistant prose both use 12-point horizontal insets; role and color preserve
+their distinction.
 
 ```text
 ┌ Transcript                                  [index 7] ┐
 │ You [prompt]                                          │
 │ ● Assistant narrative                                │
-│ ◇ Worked · 6 actions · all passed [>]                │
+│ Edited 2 files, ran 4 shell commands [>]              │
 └───────────────────────────────────────────────────────┘
 ```
 
@@ -120,13 +123,17 @@ signal spine preserve their distinction.
 ### 6.1 Narrative
 
 User prompts remain compact accent bubbles. Assistant prose becomes an unfilled, left-aligned
-reading block with a restrained line length and a marker on the signal spine. Markdown and code
-rendering retain their existing behavior.
+reading block with a restrained line length and no leading rule. Markdown and code rendering
+retain their existing behavior.
 
 ### 6.2 Work groups
 
-Consecutive non-narrative items between narrative items form one work group. Groups start
-collapsed. Their summaries show the number of actions, execution state, and representative verbs.
+Consecutive non-narrative items between narrative items form one work group. A run of two or more
+collapses; a lone item renders as its own row, since there is nothing to summarize. Groups start
+collapsed. A summary reads as one sentence naming what was done — a clause per kind of work, joined
+by commas, capitalized once: `Edited 2 files, ran 4 shell commands`. Verb tense carries execution
+state, present participle while the work runs and past tense once it finishes, so a running group
+needs no separate status badge.
 Expanding a group reveals the existing compact activity rows. Clicking a child row continues to
 open the existing item overlay.
 


### PR DESCRIPTION
## Summary

A session of transcript polish, driven by dogfooding. Each change removes something that was drawing the eye without earning it, or replaces stilted chrome with a sentence.

**Work groups read as prose.** A collapsed group said `Worked · 3 actions · Commands`. It now says `Edited 2 files, ran 4 shell commands` — one clause per kind of work, comma-joined, capitalized once. This vocabulary is not invented: it was read out of Claude Code 2.1.222's own bundle, so TBD matches the tool it wraps. Verb tense carries execution state (`running`/`ran`, `reading`/`read`, plus a trailing `…`), which made the status badge redundant. Failed and needs-response badges stay — tense doesn't encode those.

**Groups of one unwrap.** A single action renders as its own row rather than a `Worked · 1 action` wrapper around one thing. Claude Code does the same, and independently: it only collapses at two or more.

**Removed, as pure noise:** the gray `complete` capsule, the vertical rule down the left of every assistant message (it made the whole transcript read as quoted matter), the group icon, and the `Claude · 5:33 PM` / `7:49 PM · You` attribution header on every bubble — position already says who spoke. The attribution survives as the accessibility label, so VoiceOver keeps speaker identity and timestamp.

**Background-task rows got the same treatment.** A survey of every task-notification envelope under `~/.claude/projects` (10,733 background commands, 4,938 agents, 3,003 monitors, 2,689 stop hooks) showed Claude Code already writes each summary as a self-describing sentence carrying its outcome. So the `Background ·` lead-in is folded in only for the bare `Agent "…"` shape; prefixing the rest would have stuttered into `Background Background command …` or misnamed a monitor.

**Pasted images render as thumbnails.** They were showing as a raw absolute path. A paste lands as two JSONL user lines — the prompt, with inline `[Image #N]` placeholders and the bitmap as base64, and an `isMeta` follow-up carrying one `[Image: source: <path>]` marker per image. The marker is the only carrier of the on-disk path, so it becomes a thumbnail that fits in a 200pt square and opens Quick Look on click; right-click gets Reveal in Finder and Copy Image.

## Notable fixes found along the way

**Expanding a group scrolled the whole transcript.** A toggle rewrites the node array, which classifies as `.rebuild` and so reached the tail-follow block — a user disclosure gesture was indistinguishable from streamed-in content, and re-pinning to the new bottom slid everything on screen upward. Provenance: the expansion feature came in with 4ea9e1bc (#570, Session Workbench) and the tail-follow with 69ebdb7a (#300); neither is wrong alone, and the interaction went unnoticed because no test asserted on scroll anchoring. A toggle token now gates that one scroll, leaving the rebuild classification, the reload, and the tail-first open backfill alone so streaming appends still auto-scroll.

**`.rebuild` was wiping four caches whose keys already encode `(id, contentVersion, width)`.** Stale entries were unreachable by construction, so the wipe only forced exactly-measured rows back to estimates, which then re-corrected without compensation and drifted rows above the click. They now survive, pruned to the live node set.

**`UserMessageClassifier` took only the first text block**, so a multi-image paste lost every marker after the first before the app ever saw it. Across the whole corpus, every user message with multiple text blocks was an image-marker meta line, so joining them is a strict repair.

## Notes for review

- Every change lands in **both** rendering paths (native `NSTableView` cells and the hosted SwiftUI tree). Divergence between them is a standing trap here — a pre-existing one is fixed in passing: `SystemReminderRow` rendered a `[background]` capsule and no summary at all.
- **Image work is measured, not assumed.** Sizing reads true pixel dimensions from the image header, benchmarked at ~200× cheaper than a decode (0.12 ms vs 26.4 ms on a 4000×3000 PNG), so rows measure exactly and synchronously and never resize when the async thumbnail lands. Decode is `CGImageSourceCreateThumbnailAtIndex` on a background queue, bounded by max-pixel-size, behind two bounded caches — the on-main decode hazard is the same class as the #129 Highlightr freeze.
- **QuickLookUI was verified to work without a bundle identifier** via a throwaway no-`Info.plist` binary, so no unbundled-executable guard was added. The panel controller methods live on `AppDelegate` at the responder chain's terminus, so one wiring serves both renderers.
- **Any absolute path a marker names will render**, deliberately: the corpus shows two distinct cache roots and profile dirs are user-configurable, so an allowlist would break real transcripts. Guards added instead: a non-regular-file check (a marker naming `/dev/random` would otherwise hang the reader) and degrading non-images to a name-only chip. Missing files never dump the raw path.
- The workbench spec is updated: it named the removed signal spine as its signature element and mocked up the old summary line.

## Test plan

- [x] `scripts/swift-safe build` clean
- [x] `/opt/homebrew/bin/swiftlint --strict` — 0 violations across 662 files
- [x] `scripts/test.sh --filter '^TBDAppTests\.'` — 1939 tests pass (baseline 1892 at branch point; count checked, not just the exit code)
- [x] Daemon suites for the classifier change — 88 tests pass
- [x] The scroll-anchor guards were **mutation-checked**: each fix was deliberately reverted and the corresponding test confirmed red before restoring
- [ ] Live: expand a work group mid-transcript and confirm the clicked row stays put, both when pinned to the bottom and scrolled up
- [ ] Live: paste an image, click for Quick Look, right-click for Reveal in Finder
- [ ] Live: confirm streaming auto-scroll still follows the tail during an active turn

### Known coverage gap

The Quick Look panel presentation itself is not tested — a real panel needs a key window and would pop over the developer's screen — so the click tests drive the same action through `accessibilityPerformPress()` with the panel call behind an injectable seam. The SwiftUI path's click and context menu have no headless driver either.

### Follow-up, deliberately not in this PR

A real `splice(at:removed:inserted:)` step in `TranscriptStreamPlan` would make a toggle an insert/delete instead of a whole-table reload, so the scroll anchor would hold by construction rather than by convention. Larger change, and it doesn't fix the symptom on its own.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=01BF5ED0-FFFC-4505-BE99-617EEC285354)

https://claude.ai/code/session_018LEZrAYtVQiy1L5NwsFJPB