### PR TITLE
Feat: Show which worktree you're actually looking at in the status bar

### DIFF
--- a/Sources/TBDApp/Components/GitBranchIcon.swift
+++ b/Sources/TBDApp/Components/GitBranchIcon.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// The git-branch glyph: two hollow nodes on a trunk, with a third node
+/// branching off it. This is the icon VS Code and GitHub put beside a branch
+/// name in their own status bars, so it reads as "branch" without a label —
+/// which SF Symbols' generic `arrow.triangle.branch` does not.
+///
+/// Traced from Octicons `git-branch-16` (MIT, © GitHub, Inc.) as a native
+/// `Shape` rather than a vendored asset: TBDApp is a bare SPM executable with
+/// no Xcode asset catalog, and SVG needs one to render. Drawing it also lets
+/// the stroke weight track the surrounding text instead of being baked into a
+/// bitmap at one size.
+struct GitBranchIcon: Shape {
+    /// Octicons' design grid. Geometry below is authored in this space and
+    /// scaled to whatever frame the caller gives us.
+    private static let grid: CGFloat = 16
+    /// Node ring: outer edge 2.25, inner hole 0.75 — a 1.5-wide stroke on a
+    /// 1.5 radius, which is also the trunk's width.
+    private static let strokeWidth: CGFloat = 1.5
+    private static let nodeRadius: CGFloat = 1.5
+
+    func path(in rect: CGRect) -> Path {
+        let scale = min(rect.width, rect.height) / Self.grid
+        var path = Path()
+
+        // Nodes, drawn as circles and stroked below into rings.
+        for center in [CGPoint(x: 4.25, y: 3.25),
+                       CGPoint(x: 11.75, y: 3.25),
+                       CGPoint(x: 4.25, y: 12.75)] {
+            path.addEllipse(in: CGRect(
+                x: center.x - Self.nodeRadius,
+                y: center.y - Self.nodeRadius,
+                width: Self.nodeRadius * 2,
+                height: Self.nodeRadius * 2
+            ))
+        }
+
+        // Trunk, stopping at the rings' edges so their holes stay open.
+        path.move(to: CGPoint(x: 4.25, y: 4.75))
+        path.addLine(to: CGPoint(x: 4.25, y: 11.25))
+
+        // The branch: down out of the right node, a rounded turn to the left,
+        // then a rounded turn back down to merge into the trunk. Each control
+        // point sits where the two tangents meet, which is what makes the
+        // corners read as arcs.
+        path.move(to: CGPoint(x: 11.75, y: 4.75))
+        path.addLine(to: CGPoint(x: 11.75, y: 6))
+        path.addQuadCurve(to: CGPoint(x: 10, y: 7.75), control: CGPoint(x: 11.75, y: 7.75))
+        path.addLine(to: CGPoint(x: 6, y: 7.75))
+        path.addQuadCurve(to: CGPoint(x: 4.25, y: 9.5), control: CGPoint(x: 4.25, y: 7.75))
+
+        let stroked = path.strokedPath(StrokeStyle(
+            lineWidth: Self.strokeWidth,
+            lineCap: .round,
+            lineJoin: .round
+        ))
+        return stroked
+            .applying(CGAffineTransform(scaleX: scale, y: scale))
+            .applying(CGAffineTransform(
+                translationX: rect.minX + (rect.width - Self.grid * scale) / 2,
+                y: rect.minY + (rect.height - Self.grid * scale) / 2
+            ))
+    }
+}

--- a/Sources/TBDApp/Components/ToastOverlay.swift
+++ b/Sources/TBDApp/Components/ToastOverlay.swift
@@ -48,6 +48,9 @@ private struct ToastCard: View {
         case .notice:
             Image(systemName: "archivebox")
                 .foregroundStyle(.secondary)
+        case .success:
+            Image(systemName: "checkmark.circle")
+                .foregroundStyle(.secondary)
         case .error:
             Image(systemName: "exclamationmark.triangle")
                 .foregroundStyle(.yellow)

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -13,6 +13,42 @@ struct StatusBarView: View {
         return (worktree.path, worktree.repoID)
     }
 
+    /// The bottom-left cluster: where the selected worktree lives on disk and
+    /// which branch it is on. `displayPath` is tilde-abbreviated for display
+    /// only — `path` is the full value that lands on the pasteboard.
+    struct LocationLabel: Equatable {
+        let path: String
+        let displayPath: String
+        /// nil when the worktree has no branch (scratch spaces).
+        let branch: String?
+    }
+
+    /// Pure helper so tests can exercise the formatting without a view.
+    /// `home` is injected for the same reason.
+    static func locationLabel(
+        _ worktree: Worktree?,
+        home: String = NSHomeDirectory()
+    ) -> LocationLabel? {
+        guard let worktree, !worktree.path.isEmpty else { return nil }
+        let branch = worktree.branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        return LocationLabel(
+            path: worktree.path,
+            displayPath: abbreviateWithTilde(worktree.path, home: home),
+            branch: branch.isEmpty ? nil : branch
+        )
+    }
+
+    /// Tilde-abbreviates `path` against `home`, matching only whole path
+    /// components so a sibling directory like `/Users/meadow` under a home of
+    /// `/Users/me` is left alone.
+    static func abbreviateWithTilde(_ path: String, home: String) -> String {
+        let home = home.hasSuffix("/") ? String(home.dropLast()) : home
+        guard !home.isEmpty else { return path }
+        if path == home { return "~" }
+        guard path.hasPrefix(home + "/") else { return path }
+        return "~" + path.dropFirst(home.count)
+    }
+
     /// Resolved once per process: the absolute path of the worktree that built
     /// this running TBDApp. Primary source is a sidecar file written into the
     /// bundle by `scripts/restart.sh`; falls back to parsing the exec path for
@@ -55,6 +91,32 @@ struct StatusBarView: View {
             : nil
         let selectedInfo = Self.selectedWorktreeInfo(selected)
         HStack {
+            if let location = Self.locationLabel(selected) {
+                HStack(spacing: 8) {
+                    CopyableStatusText(
+                        text: location.displayPath,
+                        copyValue: location.path,
+                        truncation: .head,
+                        tooltip: "Click to copy \(location.path)",
+                        confirmation: "Copied path"
+                    )
+                    if let branch = location.branch {
+                        // The branch glyph doubles as the separator from the
+                        // path, so no interpunct is needed between them.
+                        CopyableStatusText(
+                            icon: "arrow.triangle.branch",
+                            text: branch,
+                            copyValue: branch,
+                            truncation: .tail,
+                            tooltip: "Click to copy branch \(branch)",
+                            confirmation: "Copied branch"
+                        )
+                    }
+                }
+                // Yields to the version/display-name label on the right, which
+                // is short and must never truncate.
+                .layoutPriority(-1)
+            }
             Spacer()
             if let info = selectedInfo {
                 OpenInEditorButton(path: info.path, repoID: info.repoID)
@@ -73,5 +135,68 @@ struct StatusBarView: View {
         .padding(.horizontal)
         .padding(.vertical, 4)
         .background(.bar)
+    }
+}
+
+/// A deliberately chrome-less status-bar label that copies `copyValue` on
+/// click. It carries no button styling — the hover underline plus pointing-hand
+/// cursor are the whole affordance, and the toast is what confirms the copy
+/// landed (the label itself is too small to flash a "Copied" state legibly).
+private struct CopyableStatusText: View {
+    @EnvironmentObject var appState: AppState
+
+    /// Optional leading SF Symbol naming what the value is. Part of the same
+    /// click target and hover affordance as the text.
+    var icon: String?
+    let text: String
+    let copyValue: String
+    let truncation: Text.TruncationMode
+    let tooltip: String
+    let confirmation: String
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 3) {
+            if let icon {
+                Image(systemName: icon)
+                    .imageScale(.small)
+            }
+            Text(text)
+                .lineLimit(1)
+                .truncationMode(truncation)
+                .underline(isHovering)
+        }
+            .foregroundStyle(.secondary)
+            // Makes the icon and the gap beside it part of the click target,
+            // not just the glyphs.
+            .contentShape(Rectangle())
+            .help(tooltip)
+            .onHover { hovering in
+                guard hovering != isHovering else { return }
+                isHovering = hovering
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .onDisappear {
+                // Selection changes can tear the label down mid-hover, and an
+                // unmatched push leaves the pointing hand stuck app-wide.
+                if isHovering {
+                    isHovering = false
+                    NSCursor.pop()
+                }
+            }
+            .onTapGesture {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(copyValue, forType: .string)
+                appState.showTransientToast(confirmation, style: .success)
+            }
+            .accessibilityElement()
+            .accessibilityLabel(text)
+            .accessibilityHint(tooltip)
+            .accessibilityAddTraits(.isButton)
     }
 }

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -104,7 +104,7 @@ struct StatusBarView: View {
                         // The branch glyph doubles as the separator from the
                         // path, so no interpunct is needed between them.
                         CopyableStatusText(
-                            icon: "arrow.triangle.branch",
+                            icon: GitBranchIcon(),
                             text: branch,
                             copyValue: branch,
                             truncation: .tail,
@@ -145,9 +145,9 @@ struct StatusBarView: View {
 private struct CopyableStatusText: View {
     @EnvironmentObject var appState: AppState
 
-    /// Optional leading SF Symbol naming what the value is. Part of the same
-    /// click target and hover affordance as the text.
-    var icon: String?
+    /// Optional leading glyph naming what the value is. Part of the same click
+    /// target and hover affordance as the text.
+    var icon: GitBranchIcon?
     let text: String
     let copyValue: String
     let truncation: Text.TruncationMode
@@ -159,8 +159,9 @@ private struct CopyableStatusText: View {
     var body: some View {
         HStack(spacing: 3) {
             if let icon {
-                Image(systemName: icon)
-                    .imageScale(.small)
+                // Sized to the caption text this bar is set in; the glyph's
+                // own grid has generous padding, so it optically matches.
+                icon.frame(width: 11, height: 11)
             }
             Text(text)
                 .lineLimit(1)

--- a/Sources/TBDApp/Toast.swift
+++ b/Sources/TBDApp/Toast.swift
@@ -9,6 +9,8 @@ struct Toast: Equatable, Identifiable {
         case progress
         /// Informational notice (archivebox icon); auto-dismisses.
         case notice
+        /// A completed action the user just triggered (checkmark); auto-dismisses.
+        case success
         /// Failure notice; auto-dismisses.
         case error
     }

--- a/Tests/TBDAppTests/GitBranchIconTests.swift
+++ b/Tests/TBDAppTests/GitBranchIconTests.swift
@@ -1,0 +1,32 @@
+import Testing
+import SwiftUI
+@testable import TBDApp
+
+// Tier 1: the branch glyph is authored on a 16x16 grid and scaled to its
+// frame. These pin the scaling, since a regression there draws a glyph that
+// silently overflows or shrinks to a smudge rather than failing loudly.
+
+@Test func gitBranchIcon_staysInsideItsFrame() {
+    for side in [11.0, 16.0, 64.0] {
+        let rect = CGRect(x: 0, y: 0, width: side, height: side)
+        let bounds = GitBranchIcon().path(in: rect).boundingRect
+        #expect(rect.insetBy(dx: -0.01, dy: -0.01).contains(bounds),
+                "glyph \(bounds) escaped its \(side)pt frame")
+    }
+}
+
+@Test func gitBranchIcon_scalesToFillMostOfTheFrame() {
+    // The 16-unit grid carries ~1.75 units of padding on the tight axis, so
+    // the drawn glyph should cover most of the frame — a scale factor applied
+    // twice, or not at all, breaks this.
+    let bounds = GitBranchIcon().path(in: CGRect(x: 0, y: 0, width: 64, height: 64)).boundingRect
+    #expect(bounds.width > 40 && bounds.height > 50)
+}
+
+@Test func gitBranchIcon_centersInANonSquareFrame() {
+    let rect = CGRect(x: 0, y: 0, width: 100, height: 20)
+    let bounds = GitBranchIcon().path(in: rect).boundingRect
+    let leftGap = bounds.minX - rect.minX
+    let rightGap = rect.maxX - bounds.maxX
+    #expect(abs(leftGap - rightGap) < 0.01)
+}

--- a/Tests/TBDAppTests/StatusBarViewLocationLabelTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewLocationLabelTests.swift
@@ -1,0 +1,52 @@
+import Testing
+import Foundation
+import TBDShared
+@testable import TBDApp
+
+// Tier 1: pure formatting helpers for the bottom-left status-bar cluster.
+
+private func worktree(branch: String, path: String) -> Worktree {
+    Worktree(
+        id: UUID(),
+        repoID: UUID(),
+        name: "wt",
+        displayName: "WT",
+        branch: branch,
+        path: path,
+        status: .active,
+        tmuxServer: "test-server"
+    )
+}
+
+@Test func locationLabel_abbreviatesPathAndKeepsFullValueForCopying() {
+    let label = StatusBarView.locationLabel(
+        worktree(branch: "feature/x", path: "/Users/me/tbd/worktrees/acme/wt"),
+        home: "/Users/me"
+    )
+    #expect(label?.displayPath == "~/tbd/worktrees/acme/wt")
+    #expect(label?.path == "/Users/me/tbd/worktrees/acme/wt")
+    #expect(label?.branch == "feature/x")
+}
+
+@Test func locationLabel_nilWorktreeOrEmptyPath_returnsNil() {
+    #expect(StatusBarView.locationLabel(nil, home: "/Users/me") == nil)
+    #expect(StatusBarView.locationLabel(worktree(branch: "main", path: ""), home: "/Users/me") == nil)
+}
+
+@Test func locationLabel_blankBranch_dropsBranchSegment() {
+    let label = StatusBarView.locationLabel(
+        worktree(branch: "   ", path: "/Users/me/scratch"),
+        home: "/Users/me"
+    )
+    #expect(label?.branch == nil)
+    #expect(label?.displayPath == "~/scratch")
+}
+
+@Test func abbreviateWithTilde_onlyMatchesWholeComponents() {
+    // A sibling directory sharing the home prefix must not be abbreviated.
+    #expect(StatusBarView.abbreviateWithTilde("/Users/meadow/x", home: "/Users/me") == "/Users/meadow/x")
+    #expect(StatusBarView.abbreviateWithTilde("/Users/me", home: "/Users/me") == "~")
+    #expect(StatusBarView.abbreviateWithTilde("/Users/me/a", home: "/Users/me/") == "~/a")
+    #expect(StatusBarView.abbreviateWithTilde("/opt/other", home: "/Users/me") == "/opt/other")
+    #expect(StatusBarView.abbreviateWithTilde("/Users/me/a", home: "") == "/Users/me/a")
+}


### PR DESCRIPTION
## Summary

The bottom-left of the status bar was empty, so nothing in the window chrome told you where the selected worktree lives on disk or which branch it is on — you had to open the row's context menu to find out. It now carries both, in the same deminutive secondary caption style as the source-worktree name on the right:

`~/tbd/worktrees/acme/20260805-example  ⑂ fix/some-branch`

- **Click either segment to copy it.** The path lands on the pasteboard unabbreviated — the `~` is display-only.
- **The glyph is the real git-branch icon**, traced from Octicons `git-branch-16` (MIT, © GitHub, Inc.) as a native SwiftUI `Shape`. SF Symbols' `arrow.triangle.branch` is a generic branching arrow that doesn't read as "git branch" without a label; this is the glyph VS Code and GitHub put beside a branch name in their own status bars, so the meaning carries with no caption. A `Shape` rather than a vendored SVG because TBDApp is a bare SPM executable with no Xcode asset catalog and SVG needs one to render — drawing it also lets the stroke weight track the surrounding text instead of being baked into a bitmap at one size.
- **`Toast` gains a `.success` style** (checkmark), because the copy confirmation shouldn't be the archivebox that `.notice` uses.

### Notes for the reviewer

- **This region previously held a different label that #409 removed.** That one duplicated the toolbar's repo / display-name, and its copy actions live on in `RowActionMenuActions`. This is not that label: it shows the literal on-disk path and branch, which nothing else in the chrome surfaces, and it is glanceable rather than two clicks into a menu. The `RowActionMenu` entries stay as-is.
- **Chrome-less by design.** A hover underline plus the pointing-hand cursor are the whole affordance; the toast is what confirms the copy landed, since the label is too small to flash a "Copied" state legibly. `.onDisappear` pops the cursor, because deselecting tears the label down mid-hover and an unmatched `NSCursor.push()` leaves the pointing hand stuck app-wide.
- **`abbreviateWithTilde` is hand-rolled rather than Foundation's `abbreviatingWithTildeInPath`** so `home` can be injected for tests. It matches whole path components, so a sibling directory like `/Users/meadow` under a home of `/Users/me` is left alone.
- **No spec** — this is a small additive UI change with no flag, no migration, and no revision to the system's theory.

## Test plan

- [x] `scripts/test.sh --filter '^TBDAppTests\.'` — 1889 tests pass, including 7 new tier-1 tests covering the path/branch formatting and the glyph's scaling and centering
- [x] `swiftlint --strict` — 0 violations
- [x] Live in the running app: the cluster renders in the correct style, truncates from the head as the window narrows, and yields space to the right-hand label
- [ ] Reviewer: click the path and the branch, confirm the pasteboard holds the full unabbreviated path / the branch name and the checkmark toast appears
- [ ] Reviewer: select a scratch space (no branch) and confirm the branch segment and its glyph disappear cleanly; select nothing, or multi-select, and confirm the whole cluster does

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=85549EBE-3BFF-436B-A907-DB6A3D9401AA)