### PR TITLE
feat: append-only actuation log — every act the daemon performs gets a row nobody can self-report

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -254,3 +254,62 @@ custom_rules:
       - string
     message: "capture-pane text may only be passed through verbatim (display/transport/snapshot) from allowlisted files — never parsed for agent state. See CLAUDE.md 'No TUI screen-scraping'."
     severity: error
+
+  actuation_primitive_allowlist:
+    name: "Actuation primitive called outside the audited set"
+    # included/excluded HERE take REGEX (not glob), matched against file path.
+    # Only the daemon actuates sessions; the app and the CLI reach it by RPC.
+    included:
+      - "Sources/TBDDaemon/.*\\.swift"
+    excluded:
+      # THE ALLOWLIST: every file the actuation-log audit traced to a covering
+      # row. It exists because the wired set was found incomplete nine times
+      # across five review passes — each miss was a new call site nobody thought
+      # to check. Adding a file here means asserting that its acts are already
+      # recorded, and draws the same review scrutiny as capture_pane_allowlist.
+      #
+      # Granularity, stated plainly: this is FILE-level, like the rule above. A
+      # new call inside an already-allowlisted file is not caught — a reviewer
+      # still has to read those files. What it does catch is the shape the
+      # misses actually took: a primitive called from a file that had never
+      # actuated before.
+      - "Sources/TBDDaemon/Tmux/TmuxManager\\.swift"                          # defines the primitives; the implementation, not a caller
+      - "Sources/TBDDaemon/Server/RPCRouter\\+TerminalHandlers\\.swift"       # the terminal.* handlers; each writes its own row before acting
+      - "Sources/TBDDaemon/Server/RPCRouter\\+ScratchHandlers\\.swift"        # scratch.create/delete/archive; one scratch-named row per call
+      - "Sources/TBDDaemon/Server/RPCRouter\\+ContinueInCodexHandlers\\.swift" # terminal.continueInCodex; spawn row + rollback kill
+      - "Sources/TBDDaemon/Lifecycle/HibernationCoordinator\\.swift"          # park/wake engine: RPC rows plus the auto-hibernate rail's entry point
+      # The shared lifecycle internals and phases. They stay deliberately
+      # silent — `worktree.archive` and the reconcile sweep both reach them, and
+      # a row down here would double-count every teardown — so their acts are
+      # covered by the handler or rail row written one layer up.
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\.swift"               # killWindowAndReap / captureThenKillWindow themselves
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+Archive\\.swift"     # archive teardown; covered by worktree.archive / auto-archive-on-merge
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+Forget\\.swift"      # forget teardown; covered by worktree.forget
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+Create\\.swift"      # primary-terminal spawn; covered by worktree.create / scratch.create / revive
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+PreSession\\.swift"  # hook-terminal spawn and close; covered by worktree.rerunPreSession / create
+      - "Sources/TBDDaemon/Lifecycle/WorktreeLifecycle\\+Reconcile\\.swift"   # the reconcile rail; one row per act at its own entry point
+      - "Sources/TBDDaemon/Nightwatch/DeskSessionManager\\.swift"             # the nightwatch-desk rail: its pastes, spawn and close
+      - "Sources/TBDDaemon/Claude/LimitResumeActuator\\.swift"                # the limit-resume rail: Escape / continue / Enter
+    # Call sites only, which decides both odd-looking pieces of this regex:
+    #
+    #   - `(?<!func )` skips DECLARATIONS. TmuxManager's `public func
+    #     killWindow`, TerminalStore's `setHibernated`, and the protocol
+    #     witnesses LimitResumeActuator declares are the primitives being
+    #     defined, not acts being performed — and skipping them keeps
+    #     TerminalStore.swift (a DB layer that must never actuate) fully
+    #     covered instead of allowlisted for a declaration.
+    #   - `sendCommand` requires a `server:` label ahead of it, via a zero-width
+    #     lookahead so the label stays outside the matched range. Control mode's
+    #     `TmuxControlConnection.sendCommand(_ command: String)` is an unrelated
+    #     method that happens to share the name: it writes a line to the tmux
+    #     control socket. Matching on the label distinguishes the two by shape
+    #     rather than allowlisting the control-mode plumbing, which would blind
+    #     the rule to a real actuation added there later.
+    regex: '(?<!func )\b(?:killWindowAndReap|captureThenKillWindow|killWindow|killServer|respawnWindow|createWindow|pasteText|sendKeys|sendKey|setHibernated)\s*\(|(?<!func )\bsendCommand\s*\((?=\s*server:)'
+    # Code only. Several doc comments name these primitives while explaining the
+    # boundary (`ClaudeSpawnCommandBuilder` points at `createWindow(sensitiveEnv:)`),
+    # and firing on the prose that documents the rule is how a rule gets disabled.
+    match_kinds:
+      - identifier
+    message: "Acts that touch a session's process, pty or lifecycle must be recorded by exactly one actuation row — written by the RPC handler the request came through, or by the entry point of the rail that started it — so calling one of these primitives from a file outside the audited set means the act would go unrecorded. Read Sources/TBDDaemon/Actuation/ActuationSurface.swift for the boundary rule and the wiring pattern, wire the row, then add the file to this allowlist in the same commit."
+    severity: error

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -305,6 +305,12 @@ custom_rules:
     #     control socket. Matching on the label distinguishes the two by shape
     #     rather than allowlisting the control-mode plumbing, which would blind
     #     the rule to a real actuation added there later.
+    #
+    # Raw `kill(` is deliberately NOT in this list: no regex can separate a
+    # signal sent to a session's process from ordinary subprocess reaping, and a
+    # rule that fired on both would be one people disable. The two
+    # session-relevant sites (HibernationCoordinator, RPCRouter+TerminalHandlers)
+    # already sit in allowlisted files above and are covered by the manual audit.
     regex: '(?<!func )\b(?:killWindowAndReap|captureThenKillWindow|killWindow|killServer|respawnWindow|createWindow|pasteText|sendKeys|sendKey|setHibernated)\s*\(|(?<!func )\bsendCommand\s*\((?=\s*server:)'
     # Code only. Several doc comments name these primitives while explaining the
     # boundary (`ClaudeSpawnCommandBuilder` points at `createWindow(sensitiveEnv:)`),

--- a/Package.swift
+++ b/Package.swift
@@ -78,7 +78,7 @@ let package = Package(
                 "TBDDaemonLib",
             ],
             path: "Sources/TBDDaemon",
-            exclude: ["Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Keychain", "Claude", "Codex", "ModelProfile", "AskUserQuestion", "Diagnostics", "Process", "Mock", "Daemon.swift", "PIDFile.swift"],
+            exclude: ["Actuation", "Database", "Git", "Hooks", "Tmux", "Lifecycle", "Server", "SSH", "PR", "Keychain", "Claude", "Codex", "ModelProfile", "AskUserQuestion", "Diagnostics", "Process", "Mock", "Daemon.swift", "PIDFile.swift"],
             sources: ["main.swift"]
         ),
         .executableTarget(

--- a/Sources/TBDApp/DaemonClient.swift
+++ b/Sources/TBDApp/DaemonClient.swift
@@ -246,7 +246,11 @@ actor DaemonClient {
     /// FileManager, etc.) are freed immediately — prevents accumulation across
     /// the 2-second polling cycle.
     private nonisolated func sendRaw(_ request: RPCRequest) throws -> RPCResponse {
-        try autoreleasepool {
+        // The app is the operator's hand: every request it makes is declared
+        // `{"kind":"app"}` at this one encode chokepoint rather than at each
+        // of the ~200 call sites.
+        let request = request.stamping(actor: .app)
+        return try autoreleasepool {
             let fd = try makeConnectedSocket()
             defer { close(fd) }
 

--- a/Sources/TBDCLI/SocketClient.swift
+++ b/Sources/TBDCLI/SocketClient.swift
@@ -46,11 +46,20 @@ struct SocketClient: Sendable {
         FileManager.default.fileExists(atPath: socketPath)
     }
 
+    /// Identity this CLI process declares on every request: the ambient
+    /// `TBD_WORKTREE_ID` / `TBD_TERMINAL_ID` the daemon itself planted when it
+    /// spawned this session, so a session cannot mistype what it never types.
+    /// `nil` outside a TBD terminal — the field is then omitted and the daemon
+    /// records the call as anonymous, which is honest rather than wrong.
+    static let callerActor: ActuationActor? = ActuationActor.sessionFromEnvironment(
+        ProcessInfo.processInfo.environment)
+
     /// Send an RPC request to the daemon and return the response.
     func send(_ request: RPCRequest) throws -> RPCResponse {
         guard isDaemonRunning else {
             throw SocketClientError.daemonNotRunning
         }
+        let request = request.stamping(actor: Self.callerActor)
 
         // Create socket
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)

--- a/Sources/TBDDaemon/Actuation/ActuationLog.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationLog.swift
@@ -76,6 +76,18 @@ public actor ActuationLog {
     /// determined yet"; an empty or absent file needs no rotation.
     private var segmentDay: String?
 
+    /// Set when the tail read that learns `segmentDay` finds the file ending
+    /// mid-line, and consumed by that same append: the row goes out behind a
+    /// newline so the dangling bytes terminate as their own junk line instead
+    /// of fusing with it.
+    ///
+    /// Within one call the write loop's own recovery handles a fragment it
+    /// created itself; this covers the fragment nobody is left to recover —
+    /// a crash between `write` and `fsync`, a double failure, a hand-edit.
+    /// Both failure paths reset `segmentDay`, so a retried append re-reads the
+    /// tail and re-arms this rather than losing it.
+    private var fragmentPendingIsolation = false
+
     public init(path: String, now: @Sendable @escaping () -> Date = { Date() }) {
         self.init(path: path, now: now, syscalls: .system)
     }
@@ -171,9 +183,11 @@ public actor ActuationLog {
         /// Nothing reached the file (encode, rotate, open, or a `write` that
         /// failed on its first byte). A plain re-append is safe.
         case nothingWritten(any Error)
-        /// A prefix of the line reached the file. The retry prepends a newline
-        /// so the fragment terminates as its own isolated junk line.
-        case partiallyWritten(any Error)
+        /// A prefix of the line reached the file. The retry finishes the line
+        /// where it stopped rather than rewriting it, so it carries the exact
+        /// bytes it was writing, how many of them the kernel took, and the file
+        /// they went into (`nil` only if even `fstat` failed).
+        case partiallyWritten(any Error, line: Data, offset: Int, identity: FileIdentity?)
         /// The whole line reached the file but `fsync` failed. The bytes are
         /// there; only the flush is owed. `identity` is the file they went
         /// into, so the retry can tell "still the same file" from "replaced
@@ -189,14 +203,16 @@ public actor ActuationLog {
 
     /// Append with exactly one recovery attempt, shaped by how far the first
     /// attempt got (see `AppendFailure`): a plain retry when nothing was
-    /// written, a newline-prefixed retry that isolates a fragment when part of
-    /// the line was, and — when only the flush failed — a reopen-and-`fsync`
-    /// that never rewrites the row.
+    /// written, a resume-from-offset that finishes a half-written line where it
+    /// stopped, and — when only the flush failed — a reopen-and-`fsync` that
+    /// never rewrites the row.
     ///
-    /// Either way the row lands **at most once**. On a second failure the
-    /// caller's contract takes over: request rows throw (fail-closed, so the
-    /// actuation does not proceed), outcome rows are `.fault`-logged and
-    /// swallowed.
+    /// Every branch is decided by bytes already on disk rather than by
+    /// guessing, so the row lands **at most once**: nothing was written and it
+    /// is written; part was written and only the rest is; all of it was written
+    /// and only the flush is retried. On a second failure the caller's contract
+    /// takes over: request rows throw (fail-closed, so the actuation does not
+    /// proceed), outcome rows are `.fault`-logged and swallowed.
     private func appendWithOneRetry(_ row: ActuationRow, failClosed: Bool) throws {
         let firstFailure: AppendFailure
         do {
@@ -218,8 +234,8 @@ public actor ActuationLog {
             switch firstFailure {
             case .nothingWritten:
                 try appendOnce(row)
-            case .partiallyWritten:
-                try appendOnce(row, isolatingFragment: true)
+            case .partiallyWritten(_, let line, let offset, let identity):
+                try resumePartialWrite(row, line: line, offset: offset, identity: identity)
             case .unflushed(_, let identity):
                 try flushAlreadyWrittenRow(row, identity: identity)
             }
@@ -250,6 +266,56 @@ public actor ActuationLog {
         guard syscalls.fsync(descriptor) == 0 else { throw Self.posixError("fsync") }
     }
 
+    /// Recovery for a line the kernel accepted only part of: reopen and write
+    /// the remaining bytes, finishing the row where it stopped.
+    ///
+    /// `offset` is exactly what the file took — a failed `write(2)` returns -1
+    /// having written nothing — and this actor serializes its appends onto an
+    /// `O_APPEND` handle, so while the reopened path is the same file the
+    /// fragment is still its last bytes and the remainder completes it. The row
+    /// then lands once, whole, with no junk line at all. Rewriting it instead
+    /// would duplicate it in the boundary case: a short write that persisted
+    /// everything but the trailing newline leaves a "fragment" that is already
+    /// a complete, parseable row.
+    ///
+    /// A different inode means the fragment went into a file nobody will read —
+    /// re-append the whole row, which cannot duplicate on a fresh file. An
+    /// unknown identity proves neither, so it takes the newline-isolating
+    /// re-append: the fragment survives as its own junk line and the row still
+    /// parses on a line of its own.
+    private func resumePartialWrite(
+        _ row: ActuationRow, line: Data, offset: Int, identity: FileIdentity?
+    ) throws {
+        let descriptor = try openHandle()
+        guard let identity, let reopened = fileIdentity(of: descriptor) else {
+            try appendOnce(row, isolatingFragment: true)
+            return
+        }
+        guard reopened == identity else {
+            try appendOnce(row)
+            return
+        }
+        var written = 0
+        try writeAll(Data(line.dropFirst(offset)), to: descriptor, written: &written)
+        guard syscalls.fsync(descriptor) == 0 else { throw Self.posixError("fsync") }
+    }
+
+    /// Write every byte of `data`, returning only when all of it landed.
+    /// `written` reports how many bytes the file accepted, and stays accurate
+    /// when this throws — the failing `write` call itself wrote nothing.
+    private func writeAll(_ data: Data, to descriptor: Int32, written: inout Int) throws {
+        var offset = written
+        defer { written = offset }
+        try data.withUnsafeBytes { buffer in
+            while offset < buffer.count {
+                let count = syscalls.write(
+                    descriptor, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
+                guard count > 0 else { throw Self.posixError("write") }
+                offset += count
+            }
+        }
+    }
+
     private func appendOnce(_ row: ActuationRow, isolatingFragment: Bool = false) throws {
         var row = row
         let stampedAt = now()
@@ -270,28 +336,25 @@ public actor ActuationLog {
         let descriptor = try openHandle()
 
         var line = Data()
-        // A previous attempt left a fragment of a line in the file. Open this
-        // one with a newline so the fragment terminates as its own isolated
-        // junk line and this row still parses on a line of its own: a
+        // The file ends mid-line — a fragment this call's own recovery cannot
+        // account for, so it was left by a crash or a double failure. Open this
+        // row with a newline so those bytes terminate as their own isolated
+        // junk line and the row still parses on a line of its own: a
         // line-oriented reader skips the junk and sees the row exactly once.
-        if isolatingFragment { line.append(0x0A) }
+        if isolatingFragment || fragmentPendingIsolation { line.append(0x0A) }
+        fragmentPendingIsolation = false
         line.append(try encoder.encode(row))
         line.append(0x0A)
 
         var offset = 0
         do {
-            try line.withUnsafeBytes { buffer in
-                while offset < buffer.count {
-                    let written = syscalls.write(
-                        descriptor, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
-                    guard written > 0 else { throw Self.posixError("write") }
-                    offset += written
-                }
-            }
+            try writeAll(line, to: descriptor, written: &offset)
         } catch {
             throw offset == 0
                 ? AppendFailure.nothingWritten(error)
-                : AppendFailure.partiallyWritten(error)
+                : AppendFailure.partiallyWritten(
+                    error, line: line, offset: offset,
+                    identity: fileIdentity(of: descriptor))
         }
         // fsync per row is affordable at actuation rates (human/agent scale,
         // not packet scale). `F_FULLFSYNC` is deliberately declined: the
@@ -358,6 +421,9 @@ public actor ActuationLog {
         let destination = try rotationDestination(day: day)
         try FileManager.default.moveItem(atPath: path, toPath: destination)
         segmentDay = nil
+        // Any dangling fragment left the active file with the segment it
+        // belongs to; the fresh file starts clean and needs no isolation.
+        fragmentPendingIsolation = false
     }
 
     /// A name collision can only come from a crash-window edge (two segments
@@ -383,6 +449,11 @@ public actor ActuationLog {
     /// that restarts mid-day rotates against the record rather than against its
     /// own uptime. Reads only the file's tail — a segment can be large.
     /// Returns `nil` when there is nothing to rotate.
+    ///
+    /// The same tail read is where a fragment left by a *previous* process (or
+    /// by an append that failed twice) is noticed: a file whose last byte is
+    /// not a newline ends mid-line, and `fragmentPendingIsolation` makes the
+    /// append now in flight open with one so the two never fuse.
     private func determineSegmentDay() throws -> String? {
         let fileManager = FileManager.default
         guard fileManager.fileExists(atPath: path) else { return nil }
@@ -394,6 +465,7 @@ public actor ActuationLog {
         let window: UInt64 = 64 * 1024
         try handle.seek(toOffset: size > window ? size - window : 0)
         let tail = (try? handle.readToEnd()) ?? Data()
+        if let lastByte = tail.last, lastByte != 0x0A { fragmentPendingIsolation = true }
         let lines = tail.split(separator: 0x0A, omittingEmptySubsequences: true)
         guard let last = lines.last,
               let parsed = try? JSONDecoder().decode(TimestampProbe.self, from: Data(last)),

--- a/Sources/TBDDaemon/Actuation/ActuationLog.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationLog.swift
@@ -24,6 +24,21 @@ struct ActuationLogUnwritable: LocalizedError, CustomStringConvertible, Equatabl
     var errorDescription: String? { description }
 }
 
+/// The `write`/`fsync` pair the log appends through.
+///
+/// A seam, not a configuration knob: no filesystem state can make a `write`
+/// return short or an `fsync` fail on demand, so the three recovery phases in
+/// `appendWithOneRetry` are otherwise untestable. Production always uses
+/// `.system`.
+struct ActuationLogSyscalls: Sendable {
+    var write: @Sendable (Int32, UnsafeRawPointer, Int) -> Int
+    var fsync: @Sendable (Int32) -> Int32
+
+    static let system = ActuationLogSyscalls(
+        write: { descriptor, buffer, count in Foundation.write(descriptor, buffer, count) },
+        fsync: { descriptor in Foundation.fsync(descriptor) })
+}
+
 /// The daemon's append-only record of every state-changing actuation it
 /// performs on a session: one JSON object per line, request row first, then the
 /// synchronous outcome row that confirms it.
@@ -33,6 +48,12 @@ struct ActuationLogUnwritable: LocalizedError, CustomStringConvertible, Equatabl
 /// one append runs at a time, whole-line, so interleaved partial lines are
 /// impossible by construction.
 ///
+/// That claim is scoped to *this process*. The file is an `O_APPEND` handle,
+/// not a lock: a second daemon — a stale build from another worktree, say —
+/// pointed at the same path can still interleave its own appends, and TBD's
+/// pid-liveness check is not a lock either. One daemon per `TBD_HOME` is the
+/// assumption the record inherits from every other file under it.
+///
 /// Timestamps come through the `now` date seam, never a `Clock`: they are
 /// persisted data, not behavior. The same seam decides the UTC day boundary, so
 /// rotation is testable without wall time.
@@ -41,6 +62,7 @@ public actor ActuationLog {
     public let path: String
 
     private let now: @Sendable () -> Date
+    private let syscalls: ActuationLogSyscalls
     private let encoder: JSONEncoder
     private let timestampFormatter: ISO8601DateFormatter
     private let dayFormatter: DateFormatter
@@ -55,8 +77,17 @@ public actor ActuationLog {
     private var segmentDay: String?
 
     public init(path: String, now: @Sendable @escaping () -> Date = { Date() }) {
+        self.init(path: path, now: now, syscalls: .system)
+    }
+
+    init(
+        path: String,
+        now: @Sendable @escaping () -> Date = { Date() },
+        syscalls: ActuationLogSyscalls
+    ) {
         self.path = path
         self.now = now
+        self.syscalls = syscalls
 
         let encoder = JSONEncoder()
         // Sorted keys so a line is stable and diffable; no pretty-printing so
@@ -131,18 +162,67 @@ public actor ActuationLog {
         try? appendWithOneRetry(row, failClosed: false)
     }
 
+    /// How far an append got before it failed — which is what decides what the
+    /// single recovery attempt is allowed to do. Re-appending a row whose bytes
+    /// already reached the file would duplicate it; re-appending after a
+    /// half-written line would glue the retry onto the fragment and make one
+    /// unparseable line out of two rows.
+    private enum AppendFailure: Error {
+        /// Nothing reached the file (encode, rotate, open, or a `write` that
+        /// failed on its first byte). A plain re-append is safe.
+        case nothingWritten(any Error)
+        /// A prefix of the line reached the file. The retry prepends a newline
+        /// so the fragment terminates as its own isolated junk line.
+        case partiallyWritten(any Error)
+        /// The whole line reached the file but `fsync` failed. The bytes are
+        /// there; only the flush is owed. `identity` is the file they went
+        /// into, so the retry can tell "still the same file" from "replaced
+        /// under us" — `nil` only if even `fstat` on the open descriptor failed.
+        case unflushed(any Error, identity: FileIdentity?)
+    }
+
+    /// The `(device, inode)` pair naming one file on disk.
+    private struct FileIdentity: Equatable {
+        let device: dev_t
+        let inode: ino_t
+    }
+
+    /// Append with exactly one recovery attempt, shaped by how far the first
+    /// attempt got (see `AppendFailure`): a plain retry when nothing was
+    /// written, a newline-prefixed retry that isolates a fragment when part of
+    /// the line was, and — when only the flush failed — a reopen-and-`fsync`
+    /// that never rewrites the row.
+    ///
+    /// Either way the row lands **at most once**. On a second failure the
+    /// caller's contract takes over: request rows throw (fail-closed, so the
+    /// actuation does not proceed), outcome rows are `.fault`-logged and
+    /// swallowed.
     private func appendWithOneRetry(_ row: ActuationRow, failClosed: Bool) throws {
+        let firstFailure: AppendFailure
         do {
             try appendOnce(row)
             return
+        } catch let failure as AppendFailure {
+            firstFailure = failure
         } catch {
-            // A transient or single-bad-file condition self-heals: drop the
-            // handle, reopen (recreating the file if it vanished), retry once.
-            closeHandle()
-            segmentDay = nil
+            // Everything outside the write/fsync pair fails before any byte
+            // leaves this process: encoding, rotation, opening the file.
+            firstFailure = .nothingWritten(error)
         }
+
+        // A transient or single-bad-file condition self-heals: drop the handle,
+        // reopen (recreating the file if it vanished), recover once.
+        closeHandle()
+        segmentDay = nil
         do {
-            try appendOnce(row)
+            switch firstFailure {
+            case .nothingWritten:
+                try appendOnce(row)
+            case .partiallyWritten:
+                try appendOnce(row, isolatingFragment: true)
+            case .unflushed(_, let identity):
+                try flushAlreadyWrittenRow(row, identity: identity)
+            }
         } catch {
             let failure = ActuationLogUnwritable(
                 path: path, reason: (error as NSError).localizedDescription)
@@ -151,7 +231,26 @@ public actor ActuationLog {
         }
     }
 
-    private func appendOnce(_ row: ActuationRow) throws {
+    /// Recovery for a row whose bytes are already in the file but unflushed:
+    /// reopen the path and `fsync` again. `fsync` flushes the file's dirty
+    /// pages regardless of which descriptor wrote them, so this needs no
+    /// rewrite — and a rewrite is exactly what would duplicate the row.
+    ///
+    /// Unless the file at `path` is no longer the one those bytes went into:
+    /// replaced or deleted under us, the persisted-bytes assumption is void and
+    /// the row exists nowhere a reader will look. Then a full re-append is the
+    /// only way it survives, and it cannot duplicate — it lands on a different
+    /// inode. An unknown identity takes the no-duplication branch.
+    private func flushAlreadyWrittenRow(_ row: ActuationRow, identity: FileIdentity?) throws {
+        let descriptor = try openHandle()
+        if let identity, let reopened = fileIdentity(of: descriptor), reopened != identity {
+            try appendOnce(row)
+            return
+        }
+        guard syscalls.fsync(descriptor) == 0 else { throw Self.posixError("fsync") }
+    }
+
+    private func appendOnce(_ row: ActuationRow, isolatingFragment: Bool = false) throws {
         var row = row
         let stampedAt = now()
         row.ts = timestampFormatter.string(from: stampedAt)
@@ -170,23 +269,38 @@ public actor ActuationLog {
         try rotateIfNeeded(today: today)
         let descriptor = try openHandle()
 
-        var line = try encoder.encode(row)
+        var line = Data()
+        // A previous attempt left a fragment of a line in the file. Open this
+        // one with a newline so the fragment terminates as its own isolated
+        // junk line and this row still parses on a line of its own: a
+        // line-oriented reader skips the junk and sees the row exactly once.
+        if isolatingFragment { line.append(0x0A) }
+        line.append(try encoder.encode(row))
         line.append(0x0A)
 
-        try line.withUnsafeBytes { buffer in
-            var offset = 0
-            while offset < buffer.count {
-                let written = write(
-                    descriptor, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
-                guard written > 0 else { throw Self.posixError("write") }
-                offset += written
+        var offset = 0
+        do {
+            try line.withUnsafeBytes { buffer in
+                while offset < buffer.count {
+                    let written = syscalls.write(
+                        descriptor, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
+                    guard written > 0 else { throw Self.posixError("write") }
+                    offset += written
+                }
             }
+        } catch {
+            throw offset == 0
+                ? AppendFailure.nothingWritten(error)
+                : AppendFailure.partiallyWritten(error)
         }
         // fsync per row is affordable at actuation rates (human/agent scale,
         // not packet scale). `F_FULLFSYNC` is deliberately declined: the
         // residual power-loss window it would close also loses the actuation
         // itself, so the record stays truthful without it.
-        guard fsync(descriptor) == 0 else { throw Self.posixError("fsync") }
+        guard syscalls.fsync(descriptor) == 0 else {
+            throw AppendFailure.unflushed(
+                Self.posixError("fsync"), identity: fileIdentity(of: descriptor))
+        }
         segmentDay = today
     }
 
@@ -209,10 +323,18 @@ public actor ActuationLog {
     /// Cheap (two stats) and paid once per actuation, which is human/agent
     /// scale — not packet scale.
     private func handleStillPointsAtPath() -> Bool {
-        var openFile = stat()
         var pathFile = stat()
-        guard fstat(fd, &openFile) == 0, stat(path, &pathFile) == 0 else { return false }
-        return openFile.st_dev == pathFile.st_dev && openFile.st_ino == pathFile.st_ino
+        guard let openFile = fileIdentity(of: fd), stat(path, &pathFile) == 0 else { return false }
+        return openFile == FileIdentity(device: pathFile.st_dev, inode: pathFile.st_ino)
+    }
+
+    /// Which file an open descriptor names. `nil` when even `fstat` fails,
+    /// which on a live descriptor means the caller cannot prove identity either
+    /// way and must take whichever branch is safe without it.
+    private func fileIdentity(of descriptor: Int32) -> FileIdentity? {
+        var info = stat()
+        guard fstat(descriptor, &info) == 0 else { return nil }
+        return FileIdentity(device: info.st_dev, inode: info.st_ino)
     }
 
     private func closeHandle() {
@@ -250,7 +372,11 @@ public actor ActuationLog {
             let candidate = (directory as NSString).appendingPathComponent(name)
             if !fileManager.fileExists(atPath: candidate) { return candidate }
         }
-        throw Self.posixError("rotate")
+        // Not a syscall failure: `fileExists` succeeded 1000 times, so `errno`
+        // holds whatever some unrelated call left there. Say what happened.
+        throw Self.logError(
+            "could not find a free name for the rotated segment \(base).jsonl in \(directory) "
+                + "— 1000 candidates are already taken")
     }
 
     /// The UTC day of the newest row already in the active file, so a daemon
@@ -284,6 +410,13 @@ public actor ActuationLog {
 
     /// Just enough of a row to read its day back.
     private struct TimestampProbe: Decodable { let ts: String }
+
+    /// A failure of the log's own making, with no meaningful `errno` behind it.
+    private static func logError(_ reason: String) -> NSError {
+        NSError(
+            domain: "com.tbd.daemon.actuation-log", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: reason])
+    }
 
     private static func pathError(_ reason: String) -> NSError {
         NSError(

--- a/Sources/TBDDaemon/Actuation/ActuationLog.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationLog.swift
@@ -1,0 +1,300 @@
+import Foundation
+import os
+import TBDShared
+
+private let actuationLogger = Logger(subsystem: "com.tbd.daemon", category: "actuation-log")
+
+/// A request-row append that failed twice — once outright, once after closing
+/// and reopening the file. The actuation it was about to record does not
+/// proceed, so this message is what the caller sees: it names the full path and
+/// the recovery, not just an errno.
+///
+/// `CustomStringConvertible` as well as `LocalizedError` because the RPC router
+/// surfaces failures with `"\(error)"`, which would otherwise print the struct.
+struct ActuationLogUnwritable: LocalizedError, CustomStringConvertible, Equatable {
+    let path: String
+    let reason: String
+
+    var description: String {
+        "TBD could not record this action in its actuation log at \(path) (\(reason)). "
+            + "Actions are refused until the log is writable again — check the file's "
+            + "owner and mode, or move it aside; TBD will recreate it."
+    }
+
+    var errorDescription: String? { description }
+}
+
+/// The daemon's append-only record of every state-changing actuation it
+/// performs on a session: one JSON object per line, request row first, then the
+/// synchronous outcome row that confirms it.
+///
+/// The daemon is the only writer, and it writes at the moment it acts — nobody
+/// is the reporter of their own acts. Actor isolation *is* the serialization:
+/// one append runs at a time, whole-line, so interleaved partial lines are
+/// impossible by construction.
+///
+/// Timestamps come through the `now` date seam, never a `Clock`: they are
+/// persisted data, not behavior. The same seam decides the UTC day boundary, so
+/// rotation is testable without wall time.
+public actor ActuationLog {
+    /// The active file. Rotated day segments land beside it.
+    public let path: String
+
+    private let now: @Sendable () -> Date
+    private let encoder: JSONEncoder
+    private let timestampFormatter: ISO8601DateFormatter
+    private let dayFormatter: DateFormatter
+
+    /// Open `O_APPEND` descriptor, or -1 when closed. Reopened on demand, and
+    /// deliberately dropped on any write failure so the retry gets a fresh one.
+    private var fd: Int32 = -1
+
+    /// UTC day (`YYYY-MM-DD`) of the newest row in the active file, learned
+    /// lazily on the first append and maintained from there. `nil` means "not
+    /// determined yet"; an empty or absent file needs no rotation.
+    private var segmentDay: String?
+
+    public init(path: String, now: @Sendable @escaping () -> Date = { Date() }) {
+        self.path = path
+        self.now = now
+
+        let encoder = JSONEncoder()
+        // Sorted keys so a line is stable and diffable; no pretty-printing so
+        // one row is one line. Encoding details are implementation, not contract.
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        self.encoder = encoder
+
+        let timestampFormatter = ISO8601DateFormatter()
+        timestampFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        timestampFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        self.timestampFormatter = timestampFormatter
+
+        let dayFormatter = DateFormatter()
+        dayFormatter.calendar = Calendar(identifier: .gregorian)
+        dayFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dayFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dayFormatter.dateFormat = "yyyy-MM-dd"
+        self.dayFormatter = dayFormatter
+    }
+
+    deinit {
+        if fd >= 0 { close(fd) }
+    }
+
+    // MARK: - IDs
+
+    /// A 12-character lowercase `[a-z0-9]` identifier from the system CSPRNG
+    /// (`SystemRandomNumberGenerator`, which is `arc4random` on Darwin).
+    ///
+    /// One namespace, join-safe: ~2^62 of space, so a dispatch, its transcript
+    /// envelope and its outcome can join on this string alone for the record's
+    /// lifetime. Shell- and paste-safe too: no metacharacters and no hyphens,
+    /// so a double-click selects the whole token.
+    static func mintID() -> String {
+        let alphabet = Array("abcdefghijklmnopqrstuvwxyz0123456789")
+        var generator = SystemRandomNumberGenerator()
+        return String((0..<12).map { _ in
+            alphabet[Int.random(in: 0..<alphabet.count, using: &generator)]
+        })
+    }
+
+    // MARK: - Appending
+
+    /// Append a request row **before** the act it describes, and return its
+    /// minted id so the outcome row can confirm it.
+    ///
+    /// Fail-closed: on failure the writer closes, reopens (recreating the file
+    /// if it is missing) and retries exactly once. If that also fails it
+    /// throws, and the caller must not proceed with the actuation — the whole
+    /// reason the record exists is that no real act lacks a row.
+    @discardableResult
+    func appendRequest(_ row: ActuationRow) throws -> String {
+        var row = row
+        let id = Self.mintID()
+        row.id = id
+        try appendWithOneRetry(row, failClosed: true)
+        return id
+    }
+
+    /// Append the synchronous outcome of an act that already ran.
+    ///
+    /// Best-effort-loud, never fail-closed: retroactively refusing a completed
+    /// act is impossible, so a second failure is `.fault`-logged and swallowed.
+    /// The record then shows a request with no outcome, which reads as
+    /// unconfirmed — honest by construction.
+    func appendOutcome(confirms: String, result: ActuationResult, error: String? = nil) {
+        var row = ActuationRow(actor: .daemon(), kind: .outcome)
+        row.id = Self.mintID()
+        row.confirms = confirms
+        row.result = result
+        row.error = error
+        try? appendWithOneRetry(row, failClosed: false)
+    }
+
+    private func appendWithOneRetry(_ row: ActuationRow, failClosed: Bool) throws {
+        do {
+            try appendOnce(row)
+            return
+        } catch {
+            // A transient or single-bad-file condition self-heals: drop the
+            // handle, reopen (recreating the file if it vanished), retry once.
+            closeHandle()
+            segmentDay = nil
+        }
+        do {
+            try appendOnce(row)
+        } catch {
+            let failure = ActuationLogUnwritable(
+                path: path, reason: (error as NSError).localizedDescription)
+            actuationLogger.fault("\(failure.description, privacy: .public)")
+            if failClosed { throw failure }
+        }
+    }
+
+    private func appendOnce(_ row: ActuationRow) throws {
+        var row = row
+        let stampedAt = now()
+        row.ts = timestampFormatter.string(from: stampedAt)
+
+        // The row must land in the file that is at `path` NOW. An open
+        // descriptor whose inode was unlinked or replaced under us — a cleanup
+        // script, an external rotation, a `~/tbd` restored from backup — still
+        // accepts writes, into a file nobody will ever read. That is exactly
+        // the silent gap this record exists to forbid, so treat it as a failed
+        // append and let the single reopen-retry recreate the file.
+        if fd >= 0, !handleStillPointsAtPath() {
+            throw Self.pathError("the log file was moved or removed")
+        }
+
+        let today = dayFormatter.string(from: stampedAt)
+        try rotateIfNeeded(today: today)
+        let descriptor = try openHandle()
+
+        var line = try encoder.encode(row)
+        line.append(0x0A)
+
+        try line.withUnsafeBytes { buffer in
+            var offset = 0
+            while offset < buffer.count {
+                let written = write(
+                    descriptor, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
+                guard written > 0 else { throw Self.posixError("write") }
+                offset += written
+            }
+        }
+        // fsync per row is affordable at actuation rates (human/agent scale,
+        // not packet scale). `F_FULLFSYNC` is deliberately declined: the
+        // residual power-loss window it would close also loses the actuation
+        // itself, so the record stays truthful without it.
+        guard fsync(descriptor) == 0 else { throw Self.posixError("fsync") }
+        segmentDay = today
+    }
+
+    // MARK: - Handle and rotation
+
+    private func openHandle() throws -> Int32 {
+        if fd >= 0 { return fd }
+        let directory = (path as NSString).deletingLastPathComponent
+        if !directory.isEmpty {
+            try FileManager.default.createDirectory(
+                atPath: directory, withIntermediateDirectories: true)
+        }
+        let descriptor = open(path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+        guard descriptor >= 0 else { throw Self.posixError("open") }
+        fd = descriptor
+        return descriptor
+    }
+
+    /// Whether the open descriptor and `path` still name the same file.
+    /// Cheap (two stats) and paid once per actuation, which is human/agent
+    /// scale — not packet scale.
+    private func handleStillPointsAtPath() -> Bool {
+        var openFile = stat()
+        var pathFile = stat()
+        guard fstat(fd, &openFile) == 0, stat(path, &pathFile) == 0 else { return false }
+        return openFile.st_dev == pathFile.st_dev && openFile.st_ino == pathFile.st_ino
+    }
+
+    private func closeHandle() {
+        if fd >= 0 {
+            close(fd)
+            fd = -1
+        }
+    }
+
+    /// Lazily, at the first append of a new UTC day, move the active file aside
+    /// to `actuations-<YYYY-MM-DD>.jsonl` — stamped with the UTC date of the
+    /// segment's **last** row, not today's — and start a fresh active file.
+    ///
+    /// No header, footer, or marker row is ever written: rotation is mechanical
+    /// and implies no shift, session, or closed period. Readers reconstruct the
+    /// record by concatenating segments in name order plus the active file.
+    private func rotateIfNeeded(today: String) throws {
+        if segmentDay == nil { segmentDay = try determineSegmentDay() }
+        guard let day = segmentDay, day != today else { return }
+        closeHandle()
+        let destination = try rotationDestination(day: day)
+        try FileManager.default.moveItem(atPath: path, toPath: destination)
+        segmentDay = nil
+    }
+
+    /// A name collision can only come from a crash-window edge (two segments
+    /// dated the same day). Take a numeric suffix rather than concatenating —
+    /// concatenation would silently reorder somebody's record.
+    private func rotationDestination(day: String) throws -> String {
+        let directory = (path as NSString).deletingLastPathComponent
+        let base = "actuations-\(day)"
+        let fileManager = FileManager.default
+        for attempt in 0..<1000 {
+            let name = attempt == 0 ? "\(base).jsonl" : "\(base)-\(attempt).jsonl"
+            let candidate = (directory as NSString).appendingPathComponent(name)
+            if !fileManager.fileExists(atPath: candidate) { return candidate }
+        }
+        throw Self.posixError("rotate")
+    }
+
+    /// The UTC day of the newest row already in the active file, so a daemon
+    /// that restarts mid-day rotates against the record rather than against its
+    /// own uptime. Reads only the file's tail — a segment can be large.
+    /// Returns `nil` when there is nothing to rotate.
+    private func determineSegmentDay() throws -> String? {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: path) else { return nil }
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        let size = (try? handle.seekToEnd()) ?? 0
+        guard size > 0 else { return nil }
+
+        let window: UInt64 = 64 * 1024
+        try handle.seek(toOffset: size > window ? size - window : 0)
+        let tail = (try? handle.readToEnd()) ?? Data()
+        let lines = tail.split(separator: 0x0A, omittingEmptySubsequences: true)
+        guard let last = lines.last,
+              let parsed = try? JSONDecoder().decode(TimestampProbe.self, from: Data(last)),
+              parsed.ts.count >= 10
+        else {
+            // An unparseable tail (partial line from a crash, hand-editing)
+            // must not wedge rotation. Fall back to the file's own mtime.
+            let attributes = try? fileManager.attributesOfItem(atPath: path)
+            guard let modified = attributes?[.modificationDate] as? Date else { return nil }
+            return dayFormatter.string(from: modified)
+        }
+        return String(parsed.ts.prefix(10))
+    }
+
+    /// Just enough of a row to read its day back.
+    private struct TimestampProbe: Decodable { let ts: String }
+
+    private static func pathError(_ reason: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain, code: Int(ENOENT),
+            userInfo: [NSLocalizedDescriptionKey: reason])
+    }
+
+    private static func posixError(_ operation: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain, code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey:
+                "\(operation) failed: \(String(cString: strerror(errno)))"])
+    }
+}

--- a/Sources/TBDDaemon/Actuation/ActuationLog.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationLog.swift
@@ -165,11 +165,16 @@ public actor ActuationLog {
     /// act is impossible, so a second failure is `.fault`-logged and swallowed.
     /// The record then shows a request with no outcome, which reads as
     /// unconfirmed — honest by construction.
-    func appendOutcome(confirms: String, result: ActuationResult, error: String? = nil) {
+    ///
+    /// `result` and `reason` both come off the one `ActuationOutcome`, so a row
+    /// carries a reason exactly when it says `refused` — the caller cannot
+    /// forget one or attach the other.
+    func appendOutcome(confirms: String, result: ActuationOutcome, error: String? = nil) {
         var row = ActuationRow(actor: .daemon(), kind: .outcome)
         row.id = Self.mintID()
         row.confirms = confirms
-        row.result = result
+        row.result = result.result
+        row.reason = result.reason
         row.error = error
         try? appendWithOneRetry(row, failClosed: false)
     }

--- a/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
@@ -5,15 +5,19 @@ import Foundation
 /// modern RPCs, their two legacy shims, the two worktree fan-outs and the idle
 /// sweep — reads them the same way.
 ///
-/// `refused` covers the idempotent no-ops (already parked, not parked, a wake
-/// already in flight) as well as the outright declines. The RPC contract keeps
-/// returning success for those, but the record must not claim an act happened
-/// when the daemon never touched the transport.
-extension ActuationResult {
-    static func classify(_ result: HibernateResult) -> ActuationResult {
+/// `refused` covers the idempotent no-ops (already parked, not parked) as well
+/// as the outright declines, so each one names its `RefusedReason`: a reader
+/// asking which acts the daemon's controls stopped must not have to tell those
+/// apart by their detail strings. The RPC contract keeps returning success for
+/// the no-ops, but the record must not claim an act happened when the daemon
+/// never touched the transport.
+extension ActuationOutcome {
+    static func classify(_ result: HibernateResult) -> ActuationOutcome {
         switch result {
         case .ok: return .dispatched
-        case .alreadyHibernated, .notEligible, .notFound: return .refused
+        case .alreadyHibernated: return .refused(.noop)
+        case .notEligible: return .refused(.notEligible)
+        case .notFound: return .refused(.notFound)
         }
     }
 
@@ -26,15 +30,21 @@ extension ActuationResult {
         }
     }
 
-    static func classify(_ result: WakeResult) -> ActuationResult {
+    static func classify(_ result: WakeResult) -> ActuationOutcome {
         switch result {
         case .ok: return .dispatched
         // The respawn reached tmux and tmux failed — the one wake path that is
         // a transport failure rather than a decline.
         case .respawnFailed: return .transportFailed
-        case .notHibernated, .inFlight, .notFound, .noSessionID,
-             .worktreeMissing, .profileMissing:
-            return .refused
+        // Waking something that was never parked is the wake's idempotent
+        // no-op, not a decline.
+        case .notHibernated: return .refused(.noop)
+        case .inFlight: return .refused(.inFlight)
+        // The terminal row is gone, or the directory its worktree named is.
+        case .notFound, .worktreeMissing: return .refused(.notFound)
+        // The row is there but cannot be woken as asked: nothing to resume, or
+        // the profile it was pinned to no longer exists.
+        case .noSessionID, .profileMissing: return .refused(.notEligible)
         }
     }
 

--- a/Sources/TBDDaemon/Actuation/ActuationResult+Park.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationResult+Park.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Classification of the park/wake coordinator's results into the outcome
+/// vocabulary, spelled once so every hibernate and wake surface — the two
+/// modern RPCs, their two legacy shims, the two worktree fan-outs and the idle
+/// sweep — reads them the same way.
+///
+/// `refused` covers the idempotent no-ops (already parked, not parked, a wake
+/// already in flight) as well as the outright declines. The RPC contract keeps
+/// returning success for those, but the record must not claim an act happened
+/// when the daemon never touched the transport.
+extension ActuationResult {
+    static func classify(_ result: HibernateResult) -> ActuationResult {
+        switch result {
+        case .ok: return .dispatched
+        case .alreadyHibernated, .notEligible, .notFound: return .refused
+        }
+    }
+
+    static func detail(_ result: HibernateResult) -> String? {
+        switch result {
+        case .ok: return nil
+        case .alreadyHibernated: return "already parked"
+        case .notEligible(let reason): return reason
+        case .notFound: return "Terminal not found"
+        }
+    }
+
+    static func classify(_ result: WakeResult) -> ActuationResult {
+        switch result {
+        case .ok: return .dispatched
+        // The respawn reached tmux and tmux failed — the one wake path that is
+        // a transport failure rather than a decline.
+        case .respawnFailed: return .transportFailed
+        case .notHibernated, .inFlight, .notFound, .noSessionID,
+             .worktreeMissing, .profileMissing:
+            return .refused
+        }
+    }
+
+    static func detail(_ result: WakeResult) -> String? {
+        switch result {
+        case .ok: return nil
+        case .notHibernated: return "not parked"
+        case .inFlight: return "a wake is already in flight"
+        case .notFound: return "Terminal not found"
+        case .noSessionID: return "No session ID to resume"
+        case .respawnFailed(let reason): return reason
+        case .worktreeMissing(let path): return "Worktree directory missing on disk: \(path)"
+        case .profileMissing(let profileID):
+            return "Profile no longer exists: \(profileID.uuidString)"
+        }
+    }
+}

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -89,6 +89,15 @@ struct ActuationTarget: Codable, Sendable, Equatable {
     var terminal: String?
     var provider: String?
     var session: String?
+    /// The tmux server an act reached, for the reconcile sweep's two
+    /// server-scoped disposals. A dead server is killed precisely because no
+    /// live row references it any more, and an orphaned window is swept
+    /// precisely because no terminal row claims it — so neither has a worktree
+    /// or terminal to name, and the coordinates that DO identify them are the
+    /// server name, the window id, and the repo whose sweep found them.
+    var server: String?
+    var window: String?
+    var repo: String?
 
     static func local(worktree: UUID, terminal: UUID?) -> ActuationTarget {
         ActuationTarget(worktree: worktree.uuidString, terminal: terminal?.uuidString)
@@ -96,6 +105,12 @@ struct ActuationTarget: Codable, Sendable, Equatable {
 
     static func remote(provider: String, session: String? = nil) -> ActuationTarget {
         ActuationTarget(provider: provider, session: session)
+    }
+
+    /// A whole tmux server, or one untracked window on it, found by the
+    /// reconcile sweep of `repo`.
+    static func tmux(server: String, window: String? = nil, repo: UUID) -> ActuationTarget {
+        ActuationTarget(server: server, window: window, repo: repo.uuidString)
     }
 }
 

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -25,6 +25,62 @@ enum ActuationResult: String, Codable, Sendable {
     case transportFailed = "transport-failed"
 }
 
+/// Why a refusal refused, as a closed vocabulary beside the free-text detail.
+///
+/// `refused` alone covers two opposite facts: a genuine decline ("this may not
+/// happen") and an idempotent no-op ("this was already true"). Telling them
+/// apart is a question the record has to answer — *which acts did my controls
+/// stop?* — and answering it by matching the human-facing detail string would
+/// make every reworded message a silent break. The detail stays; this is what
+/// a query reads.
+///
+/// New raw values are additive: the field is just a string in JSON, so a reader
+/// that meets an unfamiliar reason on a newer daemon's file learns a name it
+/// did not know rather than failing to parse the row.
+enum RefusedReason: String, Codable, Sendable, CaseIterable {
+    /// The act was already true — parked when asked to park, not parked when
+    /// asked to wake. Nothing was declined and nothing was wrong.
+    case noop
+    /// The named target does not exist: the terminal, worktree, or repo row is
+    /// gone, or the directory it named is missing on disk.
+    case notFound = "not-found"
+    /// The target exists but is not in a state this act may touch — a safety
+    /// rail, a session-kind mismatch, a profile the session needs and lacks.
+    case notEligible = "not-eligible"
+    /// The same act is already running on this target.
+    case inFlight = "in-flight"
+}
+
+/// The synchronous outcome of one act, as the daemon classifies it just before
+/// it writes the row.
+///
+/// The reason rides as `refused`'s associated value rather than a sibling
+/// parameter, which is what makes "present on every refusal, absent on every
+/// other result" a property of the type instead of a comment: there is no way
+/// to spell a refusal without naming why, and no way to attach a reason to a
+/// dispatch. `ActuationResult` stays the wire vocabulary; this is how callers
+/// speak it.
+enum ActuationOutcome: Sendable, Equatable {
+    case dispatched
+    case refused(RefusedReason)
+    case transportFailed
+
+    var result: ActuationResult {
+        switch self {
+        case .dispatched: return .dispatched
+        case .refused: return .refused
+        case .transportFailed: return .transportFailed
+        }
+    }
+
+    var reason: RefusedReason? {
+        switch self {
+        case .refused(let reason): return reason
+        case .dispatched, .transportFailed: return nil
+        }
+    }
+}
+
 /// The thing an actuation acted on. Local sessions carry `worktree`/`terminal`
 /// (full uppercase UUID strings, matching the DB); remote sessions carry
 /// `provider` and, once known, `session`.
@@ -71,5 +127,8 @@ struct ActuationRow: Codable, Sendable, Equatable {
     /// The `id` of the request row this outcome confirms.
     var confirms: String?
     var result: ActuationResult?
+    /// Set on — and only on — a `refused` outcome, by `appendOutcome` from the
+    /// same `ActuationOutcome` that decided `result`.
+    var reason: RefusedReason?
     var error: String?
 }

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -1,0 +1,75 @@
+import Foundation
+import TBDShared
+
+/// The closed vocabulary of act names. Everything else about a row may grow;
+/// this set is contract. `outcome` is the synchronous confirmation rung — it
+/// says only what the daemon observed as it returned, and never that anything
+/// *landed*.
+enum ActuationKind: String, Codable, Sendable {
+    case send
+    case wake
+    case hibernate
+    case spawn
+    case dispose
+    case outcome
+}
+
+/// What the daemon observed synchronously, immediately after the act returned.
+enum ActuationResult: String, Codable, Sendable {
+    /// The act reached the transport and the transport reported no failure.
+    case dispatched
+    /// The daemon declined before touching the transport — target missing,
+    /// busy, profile missing, feature disabled.
+    case refused
+    /// The tmux/provider command itself failed.
+    case transportFailed = "transport-failed"
+}
+
+/// The thing an actuation acted on. Local sessions carry `worktree`/`terminal`
+/// (full uppercase UUID strings, matching the DB); remote sessions carry
+/// `provider` and, once known, `session`.
+struct ActuationTarget: Codable, Sendable, Equatable {
+    var worktree: String?
+    var terminal: String?
+    var provider: String?
+    var session: String?
+
+    static func local(worktree: UUID, terminal: UUID?) -> ActuationTarget {
+        ActuationTarget(worktree: worktree.uuidString, terminal: terminal?.uuidString)
+    }
+
+    static func remote(provider: String, session: String? = nil) -> ActuationTarget {
+        ActuationTarget(provider: provider, session: session)
+    }
+}
+
+/// One line of the record. The envelope (`id`, `ts`, `actor`, `kind`) is
+/// shared by every row; the rest is per-kind body, absent when it does not
+/// apply. `ActuationLog` mints `id` and stamps `ts` — callers leave both empty.
+///
+/// Decodable as well as Encodable so tests (and later readers) can parse the
+/// file back without a second model.
+struct ActuationRow: Codable, Sendable, Equatable {
+    var id: String = ""
+    var ts: String = ""
+    var actor: ActuationActor
+    var kind: ActuationKind
+
+    /// The exact public surface that carried the request. Present on every
+    /// RPC-initiated row, absent on daemon-internal actuations — which is what
+    /// lets the kind vocabulary stay small while the surface list grows.
+    var method: String?
+    var target: ActuationTarget?
+    /// Payload verbatim, never filtered: a stale premise has to stay visible.
+    var message: String?
+    var submit: Bool?
+    var prompt: String?
+    var agent: String?
+    var profile: String?
+
+    // Outcome-row body.
+    /// The `id` of the request row this outcome confirms.
+    var confirms: String?
+    var result: ActuationResult?
+    var error: String?
+}

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -1,0 +1,100 @@
+import Foundation
+import TBDShared
+
+// MARK: - The actuation boundary
+//
+// A row exists for acts that touch a session's **process, pty, or lifecycle**.
+//
+//  - IN: spawning or disposing of a session, parking or waking one, and
+//    sending payload into one — local (tmux) or remote (provider).
+//  - OUT: DB-only settings *about* a session (`setKeepWarm`, `setPin`,
+//    renames, config writes, worktree/notes/repo mutations). Nothing there
+//    reaches a process, so nothing there is an actuation.
+//  - Sub-steps of one actuation are NOT separate rows. The polite `/exit`,
+//    the Escape/C-c and the SIGTERM inside a hibernate, the interrupt inside
+//    a profile swap, the paste-then-Enter inside a send — one row per
+//    actuation-level intent, at the moment the intent is acted on.
+//
+// The wired set lives here, in one file next to the writer, so a reviewer can
+// see it at a glance: `method` names the door a request came through and
+// `kind` names the act, and both are spelled once, per surface.
+
+/// The public RPC surfaces that actuate a session, and what each one is.
+///
+/// Two exhaustive switches rather than a dictionary: the compiler then proves
+/// every wired surface has both a method name and a kind, and a handler cannot
+/// silently drift onto the wrong one.
+enum ActuationSurface: CaseIterable, Sendable {
+    case terminalSend
+    case terminalCreate
+    case terminalDelete
+    case terminalHibernate
+    case terminalWake
+    /// Legacy shim, retained for old CLI/app builds; parks like `terminal.hibernate`.
+    case terminalSuspend
+    /// Legacy shim, retained for old CLI/app builds; wakes like `terminal.wake`.
+    case terminalResume
+    /// Fan-out shim: one row per terminal it parks, at that terminal's own act moment.
+    case worktreeSuspend
+    /// Fan-out shim: one row per terminal it wakes, at that terminal's own act moment.
+    case worktreeResume
+    case terminalRecreateWindow
+    case terminalSwapProfile
+    case terminalContinueInCodex
+    case terminalHistoryRevive
+    case worktreeRevive
+    case worktreeReviveConversationFresh
+    case remoteCreate
+    case remoteStop
+    case remoteSend
+
+    /// The exact public method name that carries this surface's requests.
+    var method: String {
+        switch self {
+        case .terminalSend: return RPCMethod.terminalSend
+        case .terminalCreate: return RPCMethod.terminalCreate
+        case .terminalDelete: return RPCMethod.terminalDelete
+        case .terminalHibernate: return RPCMethod.terminalHibernate
+        case .terminalWake: return RPCMethod.terminalWake
+        case .terminalSuspend: return RPCMethod.terminalSuspend
+        case .terminalResume: return RPCMethod.terminalResume
+        case .worktreeSuspend: return RPCMethod.worktreeSuspend
+        case .worktreeResume: return RPCMethod.worktreeResume
+        case .terminalRecreateWindow: return RPCMethod.terminalRecreateWindow
+        case .terminalSwapProfile: return RPCMethod.terminalSwapProfile
+        case .terminalContinueInCodex: return RPCMethod.terminalContinueInCodex
+        case .terminalHistoryRevive: return RPCMethod.terminalHistoryRevive
+        case .worktreeRevive: return RPCMethod.worktreeRevive
+        case .worktreeReviveConversationFresh: return RPCMethod.worktreeReviveConversationFresh
+        case .remoteCreate: return RPCMethod.remoteCreate
+        case .remoteStop: return RPCMethod.remoteStop
+        case .remoteSend: return RPCMethod.remoteSend
+        }
+    }
+
+    /// The act this surface performs. "Suspend" is not a kind — park and
+    /// hibernate were unified, so the legacy suspend/resume surfaces map onto
+    /// `hibernate`/`wake` while keeping their own `method`.
+    var kind: ActuationKind {
+        switch self {
+        case .terminalSend, .remoteSend: return .send
+        case .terminalCreate, .terminalRecreateWindow, .terminalSwapProfile,
+             .terminalContinueInCodex, .terminalHistoryRevive, .worktreeRevive,
+             .worktreeReviveConversationFresh, .remoteCreate: return .spawn
+        case .terminalDelete, .remoteStop: return .dispose
+        case .terminalHibernate, .terminalSuspend, .worktreeSuspend: return .hibernate
+        case .terminalWake, .terminalResume, .worktreeResume: return .wake
+        }
+    }
+}
+
+/// Daemon-internal actuation sites bypass the router entirely, so they carry
+/// no `method`; they name the rail that acted instead.
+enum ActuationRail {
+    /// `LimitResumeActuator` typing its Escape/continue/Enter sequence.
+    static let limitResume = "limit-resume"
+    /// The idle sweep's trigger into `HibernationCoordinator`.
+    static let autoHibernate = "auto-hibernate"
+    /// The Watch Desk's wrap-up and nudge pastes.
+    static let nightwatchDesk = "nightwatch-desk"
+}

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -14,6 +14,11 @@ import TBDShared
 //    the Escape/C-c and the SIGTERM inside a hibernate, the interrupt inside
 //    a profile swap, the paste-then-Enter inside a send — one row per
 //    actuation-level intent, at the moment the intent is acted on.
+//    The auto-`/login` pump a login spawn arms (`armLoginSession`) is a
+//    sub-step too, even though its `/login` paste lands seconds later: the
+//    operator asked for one thing — a session logged into this profile — and
+//    the typing is how the spawn finishes, not a second intent. When the
+//    observed rung lands it will confirm that spawn's row, not open a new one.
 //
 // The wired set lives here, in one file next to the writer, so a reviewer can
 // see it at a glance: `method` names the door a request came through and
@@ -42,6 +47,12 @@ enum ActuationSurface: CaseIterable, Sendable {
     case terminalSwapProfile
     case terminalContinueInCodex
     case terminalHistoryRevive
+    /// Creates a worktree and spawns its primary terminals. The row names the
+    /// worktree, not a terminal: those are minted inside the lifecycle phase.
+    case worktreeCreate
+    /// Creates a scratch space and spawns its primary terminal — same shape as
+    /// `worktreeCreate`, through the same lifecycle spawn.
+    case scratchCreate
     case worktreeRevive
     case worktreeReviveConversationFresh
     case remoteCreate
@@ -64,6 +75,8 @@ enum ActuationSurface: CaseIterable, Sendable {
         case .terminalSwapProfile: return RPCMethod.terminalSwapProfile
         case .terminalContinueInCodex: return RPCMethod.terminalContinueInCodex
         case .terminalHistoryRevive: return RPCMethod.terminalHistoryRevive
+        case .worktreeCreate: return RPCMethod.worktreeCreate
+        case .scratchCreate: return RPCMethod.scratchCreate
         case .worktreeRevive: return RPCMethod.worktreeRevive
         case .worktreeReviveConversationFresh: return RPCMethod.worktreeReviveConversationFresh
         case .remoteCreate: return RPCMethod.remoteCreate
@@ -79,8 +92,9 @@ enum ActuationSurface: CaseIterable, Sendable {
         switch self {
         case .terminalSend, .remoteSend: return .send
         case .terminalCreate, .terminalRecreateWindow, .terminalSwapProfile,
-             .terminalContinueInCodex, .terminalHistoryRevive, .worktreeRevive,
-             .worktreeReviveConversationFresh, .remoteCreate: return .spawn
+             .terminalContinueInCodex, .terminalHistoryRevive, .worktreeCreate,
+             .scratchCreate, .worktreeRevive, .worktreeReviveConversationFresh,
+             .remoteCreate: return .spawn
         case .terminalDelete, .remoteStop: return .dispose
         case .terminalHibernate, .terminalSuspend, .worktreeSuspend: return .hibernate
         case .terminalWake, .terminalResume, .worktreeResume: return .wake
@@ -95,6 +109,9 @@ enum ActuationRail {
     static let limitResume = "limit-resume"
     /// The idle sweep's trigger into `HibernationCoordinator`.
     static let autoHibernate = "auto-hibernate"
+    /// `AutoHibernateOnMergeCoordinator` parking a worktree's sessions once its
+    /// PR merged — a separate rail from the idle sweep, with its own switch.
+    static let autoHibernateOnMerge = "auto-hibernate-on-merge"
     /// The Watch Desk's wrap-up and nudge pastes.
     static let nightwatchDesk = "nightwatch-desk"
 }

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -42,6 +42,11 @@ import TBDShared
 // The wired set lives here, in one file next to the writer, so a reviewer can
 // see it at a glance: `method` names the door a request came through and
 // `kind` names the act, and both are spelled once, per surface.
+//
+// The mechanical guard is the SwiftLint custom rule `actuation_primitive_allowlist`
+// in `.swiftlint.yml`: calling a tmux/park primitive from a daemon file outside
+// the audited set fails the build, so a new actuation surface has to be wired
+// here before it can be written.
 
 /// The public RPC surfaces that actuate a session, and what each one is.
 ///

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -20,6 +20,22 @@ import TBDShared
 //    the typing is how the spawn finishes, not a second intent. When the
 //    observed rung lands it will confirm that spawn's row, not open a new one.
 //
+// Two layers write, and only two: the **RPC handler** for anything a caller
+// asked for, and a **rail's own entry point** for anything the daemon started
+// by itself. The shared lifecycle internals in between — `captureThenKillWindow`,
+// `killWindowAndReap`, `performHibernate`, `closeScratchTerminals` — stay
+// silent, because both `worktree.archive` and the boot-time reconcile sweep
+// reach them and a row down there would double-count every archive. Reconcile
+// is an entry point in its own right (boot is what invoked it), so its rows are
+// rail-level logging rather than shared-path logging.
+//
+// The two layers name different things, deliberately. A worktree-level RPC
+// (`worktree.archive`, `worktree.forget`, `scratch.delete`) writes ONE row
+// naming the worktree, with no terminal: the caller asked for one thing and the
+// per-terminal kills are how the lifecycle carries it out. Reconcile writes one
+// row PER act, because each kill or park it performs is an independent decision
+// it made about a terminal it has already resolved.
+//
 // The wired set lives here, in one file next to the writer, so a reviewer can
 // see it at a glance: `method` names the door a request came through and
 // `kind` names the act, and both are spelled once, per surface.
@@ -33,6 +49,19 @@ enum ActuationSurface: CaseIterable, Sendable {
     case terminalSend
     case terminalCreate
     case terminalDelete
+    /// Tears down the worktree's sessions (capture, kill, reap) before the
+    /// checkout goes away. One row per call naming the worktree — the
+    /// per-terminal kills happen inside `WorktreeLifecycle`'s phase.
+    case worktreeArchive
+    /// Same teardown as archive, minus the disk removal: one row, worktree-named.
+    case worktreeForget
+    /// Spawns a fresh hook terminal. The terminal is minted inside the
+    /// lifecycle, so the row names the worktree — as `worktree.revive` does.
+    case worktreeRerunPreSession
+    /// Kills the scratch space's windows, then trashes its folder.
+    case scratchDelete
+    /// The same teardown as `scratch.delete`, keeping the folder on disk.
+    case scratchArchive
     case terminalHibernate
     case terminalWake
     /// Legacy shim, retained for old CLI/app builds; parks like `terminal.hibernate`.
@@ -65,6 +94,11 @@ enum ActuationSurface: CaseIterable, Sendable {
         case .terminalSend: return RPCMethod.terminalSend
         case .terminalCreate: return RPCMethod.terminalCreate
         case .terminalDelete: return RPCMethod.terminalDelete
+        case .worktreeArchive: return RPCMethod.worktreeArchive
+        case .worktreeForget: return RPCMethod.worktreeForget
+        case .worktreeRerunPreSession: return RPCMethod.worktreeRerunPreSession
+        case .scratchDelete: return RPCMethod.scratchDelete
+        case .scratchArchive: return RPCMethod.scratchArchive
         case .terminalHibernate: return RPCMethod.terminalHibernate
         case .terminalWake: return RPCMethod.terminalWake
         case .terminalSuspend: return RPCMethod.terminalSuspend
@@ -94,8 +128,9 @@ enum ActuationSurface: CaseIterable, Sendable {
         case .terminalCreate, .terminalRecreateWindow, .terminalSwapProfile,
              .terminalContinueInCodex, .terminalHistoryRevive, .worktreeCreate,
              .scratchCreate, .worktreeRevive, .worktreeReviveConversationFresh,
-             .remoteCreate: return .spawn
-        case .terminalDelete, .remoteStop: return .dispose
+             .worktreeRerunPreSession, .remoteCreate: return .spawn
+        case .terminalDelete, .worktreeArchive, .worktreeForget, .scratchDelete,
+             .scratchArchive, .remoteStop: return .dispose
         case .terminalHibernate, .terminalSuspend, .worktreeSuspend: return .hibernate
         case .terminalWake, .terminalResume, .worktreeResume: return .wake
         }
@@ -112,6 +147,14 @@ enum ActuationRail {
     /// `AutoHibernateOnMergeCoordinator` parking a worktree's sessions once its
     /// PR merged — a separate rail from the idle sweep, with its own switch.
     static let autoHibernateOnMerge = "auto-hibernate-on-merge"
+    /// `AutoArchiveOnMergeCoordinator` archiving a whole worktree once its PR
+    /// merged, tearing down its sessions with it.
+    static let autoArchiveOnMerge = "auto-archive-on-merge"
     /// The Watch Desk's wrap-up and nudge pastes.
     static let nightwatchDesk = "nightwatch-desk"
+    /// The boot-time (and post-`cleanup`) reconcile sweep: it kills the windows
+    /// of worktrees that left disk, parks sessions whose window is gone, and
+    /// reaps orphaned windows and dead servers. One row per act — each is an
+    /// independent decision about a target the sweep has already resolved.
+    static let reconcile = "reconcile"
 }

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -87,6 +87,8 @@ enum ActuationSurface: CaseIterable, Sendable {
     case worktreeSuspend
     /// Fan-out shim: one row per terminal it wakes, at that terminal's own act moment.
     case worktreeResume
+    /// Respawns a terminal's window and process. Its dead-window re-park branch
+    /// acts too, and acts differently — see `ActuationBranch`.
     case terminalRecreateWindow
     case terminalSwapProfile
     case terminalContinueInCodex
@@ -149,6 +151,42 @@ enum ActuationSurface: CaseIterable, Sendable {
              .scratchDelete, .scratchArchive, .remoteStop: return .dispose
         case .terminalHibernate, .terminalSuspend, .worktreeSuspend: return .hibernate
         case .terminalWake, .terminalResume, .worktreeResume: return .wake
+        }
+    }
+}
+
+/// A branch of a wired surface whose act is not the one its surface names.
+///
+/// `terminal.recreateWindow` is the only such door today. It normally respawns
+/// a window and its process — a `spawn` — but when the terminal is a resumable
+/// Claude whose window is gone it kills that window and parks the session
+/// instead, which is the recovery park `reconcile` performs and therefore a
+/// `hibernate`. One surface still names one door, so the second act is spelled
+/// here rather than as a second `ActuationSurface` case claiming the same
+/// method.
+///
+/// A closed enum rather than a `kind:` argument at the call site, for the
+/// reason the two switches above exist: a handler may select a sanctioned
+/// branch but cannot invent a kind, the compiler still proves each branch has
+/// both a door and an act, and the whole wired set — surfaces and their
+/// alternate acts — stays readable in this one file.
+enum ActuationBranch: CaseIterable, Sendable {
+    /// The dead-window re-park: `terminal.recreateWindow` kills the window it
+    /// read as already gone — a read that can be stale — and parks the session,
+    /// preserving the identity `wake()` resumes from.
+    case recreateWindowRepark
+
+    /// The door this branch still came through.
+    var surface: ActuationSurface {
+        switch self {
+        case .recreateWindowRepark: return .terminalRecreateWindow
+        }
+    }
+
+    /// The act this branch performs, in place of its surface's.
+    var kind: ActuationKind {
+        switch self {
+        case .recreateWindowRepark: return .hibernate
         }
     }
 }

--- a/Sources/TBDDaemon/Actuation/ActuationSurface.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationSurface.swift
@@ -34,7 +34,10 @@ import TBDShared
 // naming the worktree, with no terminal: the caller asked for one thing and the
 // per-terminal kills are how the lifecycle carries it out. Reconcile writes one
 // row PER act, because each kill or park it performs is an independent decision
-// it made about a terminal it has already resolved.
+// it made about a terminal it has already resolved. `repo.remove`'s cascade sits
+// between the two and follows reconcile: the handler resolves a LIST of
+// worktrees and archives each one through a separate lifecycle call, so each is
+// its own teardown and gets its own worktree-named row.
 //
 // The wired set lives here, in one file next to the writer, so a reviewer can
 // see it at a glance: `method` names the door a request came through and
@@ -55,6 +58,13 @@ enum ActuationSurface: CaseIterable, Sendable {
     case worktreeArchive
     /// Same teardown as archive, minus the disk removal: one row, worktree-named.
     case worktreeForget
+    /// A forced repo removal cascade-archives every active worktree the repo
+    /// owns, killing their live windows. One row per worktree torn down, each
+    /// naming that worktree — the handler resolves them itself and archives each
+    /// through its own lifecycle call, so they are separate teardowns rather
+    /// than sub-steps of one. An unforced removal with live worktrees is
+    /// declined before any row exists.
+    case repoRemove
     /// Spawns a fresh hook terminal. The terminal is minted inside the
     /// lifecycle, so the row names the worktree — as `worktree.revive` does.
     case worktreeRerunPreSession
@@ -96,6 +106,7 @@ enum ActuationSurface: CaseIterable, Sendable {
         case .terminalDelete: return RPCMethod.terminalDelete
         case .worktreeArchive: return RPCMethod.worktreeArchive
         case .worktreeForget: return RPCMethod.worktreeForget
+        case .repoRemove: return RPCMethod.repoRemove
         case .worktreeRerunPreSession: return RPCMethod.worktreeRerunPreSession
         case .scratchDelete: return RPCMethod.scratchDelete
         case .scratchArchive: return RPCMethod.scratchArchive
@@ -129,8 +140,8 @@ enum ActuationSurface: CaseIterable, Sendable {
              .terminalContinueInCodex, .terminalHistoryRevive, .worktreeCreate,
              .scratchCreate, .worktreeRevive, .worktreeReviveConversationFresh,
              .worktreeRerunPreSession, .remoteCreate: return .spawn
-        case .terminalDelete, .worktreeArchive, .worktreeForget, .scratchDelete,
-             .scratchArchive, .remoteStop: return .dispose
+        case .terminalDelete, .worktreeArchive, .worktreeForget, .repoRemove,
+             .scratchDelete, .scratchArchive, .remoteStop: return .dispose
         case .terminalHibernate, .terminalSuspend, .worktreeSuspend: return .hibernate
         case .terminalWake, .terminalResume, .worktreeResume: return .wake
         }
@@ -150,7 +161,9 @@ enum ActuationRail {
     /// `AutoArchiveOnMergeCoordinator` archiving a whole worktree once its PR
     /// merged, tearing down its sessions with it.
     static let autoArchiveOnMerge = "auto-archive-on-merge"
-    /// The Watch Desk's wrap-up and nudge pastes.
+    /// The Watch Desk's wrap-up and nudge pastes, the spawn that opens its
+    /// judge session, and the close that kills that session's windows — all
+    /// acts the desk performs on its own, with no RPC behind them.
     static let nightwatchDesk = "nightwatch-desk"
     /// The boot-time (and post-`cleanup`) reconcile sweep: it kills the windows
     /// of worktrees that left disk, parks sessions whose window is gone, and

--- a/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
+++ b/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
@@ -1,0 +1,70 @@
+import Foundation
+import TBDShared
+
+extension RPCRouter {
+
+    /// Append the request row for an RPC-initiated actuation.
+    ///
+    /// Call this in the handler **after params decode and after the target is
+    /// resolved, but before the first mutating step** — never from a blanket
+    /// `handle(_:)` wrapper. Three reasons: the row must carry the resolved
+    /// target and the verbatim payload, which exist only after decode; a
+    /// wrapper would also row malformed requests that were never about to be
+    /// dispatched; and the daemon-internal rails bypass the router anyway, so a
+    /// wrapper buys no completeness.
+    ///
+    /// Throws when the record is unwritable even after one reopen-retry. The
+    /// actuation must then NOT proceed — let the error propagate so the caller
+    /// sees the self-explaining message.
+    func beginActuation(
+        _ surface: ActuationSurface,
+        actor: ActuationActor?,
+        target: ActuationTarget,
+        message: String? = nil,
+        submit: Bool? = nil,
+        prompt: String? = nil,
+        agent: String? = nil,
+        profile: String? = nil
+    ) async throws -> String {
+        var row = ActuationRow(actor: actor ?? .anonymous, kind: surface.kind)
+        row.method = surface.method
+        row.target = target
+        row.message = message
+        row.submit = submit
+        row.prompt = prompt
+        row.agent = agent
+        row.profile = profile
+        return try await actuationLog.appendRequest(row)
+    }
+
+    /// Target for a surface whose params name only the terminal. Resolves the
+    /// owning worktree so the row carries full coordinates; a terminal whose
+    /// row has already vanished still gets a row naming what was asked for,
+    /// with `worktree` absent.
+    func resolvedTerminalTarget(_ terminalID: UUID) async -> ActuationTarget {
+        let terminal = (try? await db.terminals.get(id: terminalID)) ?? nil
+        return ActuationTarget(
+            worktree: terminal?.worktreeID.uuidString, terminal: terminalID.uuidString)
+    }
+
+    /// Append the synchronous outcome row for a request. Never fails the call:
+    /// the act already ran, so a lost outcome row leaves the request
+    /// unconfirmed rather than retroactively refused.
+    func finishActuation(
+        _ id: String, _ result: ActuationResult, error: String? = nil
+    ) async {
+        await actuationLog.appendOutcome(confirms: id, result: result, error: error)
+    }
+
+    /// Convenience for handlers whose only post-row failure mode is the daemon
+    /// declining before it touches the transport. A successful response is
+    /// `dispatched`; anything else is `refused`. Handlers that CAN fail inside
+    /// the transport classify explicitly instead.
+    func finishActuation(_ id: String, response: RPCResponse) async {
+        if response.success {
+            await finishActuation(id, .dispatched)
+        } else {
+            await finishActuation(id, .refused, error: response.error)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
+++ b/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
@@ -47,6 +47,23 @@ extension RPCRouter {
             worktree: terminal?.worktreeID.uuidString, terminal: terminalID.uuidString)
     }
 
+    /// Run one acting step of a wired handler, recording a throw as
+    /// `transport-failed` before it propagates.
+    ///
+    /// The error is rethrown **unchanged**: the RPC's error surface must stay
+    /// byte-identical, and the router's blanket catch keeps formatting it. What
+    /// this adds is the outcome row that catch cannot write — without it a
+    /// throw leaves the request row unconfirmed, and the record cannot tell
+    /// "the act failed" from "the outcome was lost".
+    func actuating<T>(_ id: String, _ step: () async throws -> T) async throws -> T {
+        do {
+            return try await step()
+        } catch {
+            await finishActuation(id, .transportFailed, error: "\(error)")
+            throw error
+        }
+    }
+
     /// Append the synchronous outcome row for a request. Never fails the call:
     /// the act already ran, so a lost outcome row leaves the request
     /// unconfirmed rather than retroactively refused.

--- a/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
+++ b/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
@@ -68,20 +68,24 @@ extension RPCRouter {
     /// the act already ran, so a lost outcome row leaves the request
     /// unconfirmed rather than retroactively refused.
     func finishActuation(
-        _ id: String, _ result: ActuationResult, error: String? = nil
+        _ id: String, _ result: ActuationOutcome, error: String? = nil
     ) async {
         await actuationLog.appendOutcome(confirms: id, result: result, error: error)
     }
 
     /// Convenience for handlers whose only post-row failure mode is the daemon
     /// declining before it touches the transport. A successful response is
-    /// `dispatched`; anything else is `refused`. Handlers that CAN fail inside
-    /// the transport classify explicitly instead.
-    func finishActuation(_ id: String, response: RPCResponse) async {
+    /// `dispatched`; anything else is a refusal for the reason the caller names
+    /// here — the handler knows what its own failure response means, and the
+    /// record must not have to read it back out of the error text. Handlers
+    /// that CAN fail inside the transport classify explicitly instead.
+    func finishActuation(
+        _ id: String, response: RPCResponse, refusedAs reason: RefusedReason
+    ) async {
         if response.success {
             await finishActuation(id, .dispatched)
         } else {
-            await finishActuation(id, .refused, error: response.error)
+            await finishActuation(id, .refused(reason), error: response.error)
         }
     }
 }

--- a/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
+++ b/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
@@ -37,6 +37,20 @@ extension RPCRouter {
         return try await actuationLog.appendRequest(row)
     }
 
+    /// Append the request row for a surface's alternate branch — the same door,
+    /// a different act (see `ActuationBranch`). Same placement and the same
+    /// fail-closed contract as the surface overload above.
+    func beginActuation(
+        _ branch: ActuationBranch,
+        actor: ActuationActor?,
+        target: ActuationTarget
+    ) async throws -> String {
+        var row = ActuationRow(actor: actor ?? .anonymous, kind: branch.kind)
+        row.method = branch.surface.method
+        row.target = target
+        return try await actuationLog.appendRequest(row)
+    }
+
     /// Target for a surface whose params name only the terminal. Resolves the
     /// owning worktree so the row carries full coordinates; a terminal whose
     /// row has already vanished still gets a row naming what was asked for,

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -61,6 +61,8 @@ public struct LimitResumeActuator: LimitResumeActuating {
     // MARK: - Timing constants (spec §Actuation 5-6)
 
     static let interKeyPause: Duration = .milliseconds(150)
+    /// The literal typed into the pane, recorded verbatim in the rail's row.
+    static let continueMessage = "continue"
     static let verifyPollInterval: Duration = .seconds(1)
     static let verifyPolls = 20   // ~20s window
 
@@ -73,6 +75,9 @@ public struct LimitResumeActuator: LimitResumeActuating {
     private let transcriptModifiedAt: @Sendable (String) -> Date?
     /// Injectable sleep so unit tests run instantly.
     private let waiter: @Sendable (Duration) async -> Void
+    /// The daemon's actuation record. This rail bypasses the RPC router, so it
+    /// writes its own row — with no `method`, and an actor naming the rail.
+    private let actuationLog: ActuationLog
 
     public init(
         db: TBDDatabase,
@@ -80,7 +85,8 @@ public struct LimitResumeActuator: LimitResumeActuating {
         inspector: any PaneProcessInspecting,
         readTranscript: @escaping @Sendable (String) -> Data?,
         transcriptModifiedAt: @escaping @Sendable (String) -> Date?,
-        waiter: @escaping @Sendable (Duration) async -> Void
+        waiter: @escaping @Sendable (Duration) async -> Void,
+        actuationLog: ActuationLog? = nil
     ) {
         self.db = db
         self.tmux = tmux
@@ -88,6 +94,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
         self.readTranscript = readTranscript
         self.transcriptModifiedAt = transcriptModifiedAt
         self.waiter = waiter
+        self.actuationLog = actuationLog ?? ActuationLog(path: TBDConstants.actuationLogPath)
     }
 
     /// Early-cancel probe (see `LimitResumeActuating.userAlreadyContinued`).
@@ -162,10 +169,26 @@ public struct LimitResumeActuator: LimitResumeActuating {
                 }
             }
 
+            // The rail's own request row, immediately before the keys go out.
+            // The Escape, the literal "continue" and the Enter are sub-steps of
+            // one send, so they share one row. Fail-closed: an unrecordable
+            // send is not sent.
+            var row = ActuationRow(
+                actor: .daemon(rail: ActuationRail.limitResume), kind: .send)
+            row.target = .local(worktree: context.worktreeID, terminal: context.terminalID)
+            row.message = Self.continueMessage
+            row.submit = true
+            guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                return .failed("could not record the resume in the actuation log")
+            }
+
             do {
                 try await Self.sendContinueSequence(
                     tmux: tmux, server: context.server, paneID: context.paneID, waiter: waiter)
+                await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
             } catch {
+                await actuationLog.appendOutcome(
+                    confirms: actuationID, result: .transportFailed, error: "\(error)")
                 // Treat a thrown send like a failed verification: retry
                 // (with a fresh eligibility re-check) rather than failing
                 // instantly — only give up after attempt 2 also fails.
@@ -194,6 +217,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
         let server: String
         let paneID: String
         let terminalID: UUID
+        let worktreeID: UUID
         let transcriptPath: String?
         /// Transcript bytes read during THIS eligibility pass's
         /// user-already-continued check (step 2) — reused as the growth
@@ -283,6 +307,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
 
         return .eligible(EligibilityContext(
             server: server, paneID: terminal.tmuxPaneID, terminalID: terminal.id,
+            worktreeID: terminal.worktreeID,
             transcriptPath: terminal.transcriptPath, preSendTranscriptData: preSendTranscriptData))
     }
 
@@ -302,7 +327,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
     ) async throws {
         try await tmux.sendKey(server: server, paneID: paneID, key: "Escape")
         await waiter(interKeyPause)
-        try await tmux.sendKeys(server: server, paneID: paneID, text: "continue")
+        try await tmux.sendKeys(server: server, paneID: paneID, text: continueMessage)
         await waiter(interKeyPause)
         try await tmux.sendKey(server: server, paneID: paneID, key: "Enter")
     }

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -86,7 +86,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
         readTranscript: @escaping @Sendable (String) -> Data?,
         transcriptModifiedAt: @escaping @Sendable (String) -> Date?,
         waiter: @escaping @Sendable (Duration) async -> Void,
-        actuationLog: ActuationLog? = nil
+        actuationLog: ActuationLog
     ) {
         self.db = db
         self.tmux = tmux
@@ -94,7 +94,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
         self.readTranscript = readTranscript
         self.transcriptModifiedAt = transcriptModifiedAt
         self.waiter = waiter
-        self.actuationLog = actuationLog ?? ActuationLog(path: TBDConstants.actuationLogPath)
+        self.actuationLog = actuationLog
     }
 
     /// Early-cancel probe (see `LimitResumeActuating.userAlreadyContinued`).

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -434,7 +434,13 @@ public final class Daemon: Sendable {
             try? await database.worktrees.setPRStatus(id: worktreeID, status: status)
         }
 
-        // 8. Initialize RPC router
+        // 8. Initialize RPC router.
+        //
+        // One `ActuationLog` for the whole daemon: the router hands it to the
+        // hibernation coordinator, and it is passed to every daemon-internal
+        // rail below, so all of them append to the same file through the same
+        // actor (which is what serializes the appends).
+        let actuationLog = ActuationLog(path: TBDConstants.actuationLogPath)
         let rpcRouter = RPCRouter(
             db: database,
             lifecycle: lifecycle,
@@ -445,7 +451,8 @@ public final class Daemon: Sendable {
             prManager: prManager,
             modelProfileResolver: modelProfileResolver,
             pendingQuestions: pendingQuestions,
-            remoteManager: remoteManager
+            remoteManager: remoteManager,
+            actuationLog: actuationLog
         )
         // Wire the shared input activity tracker to the coordinator
         await rpcRouter.hibernationCoordinator.setInputActivity(inputActivity)
@@ -701,7 +708,8 @@ public final class Daemon: Sendable {
                     (try? FileManager.default.attributesOfItem(atPath: path))?[.modificationDate] as? Date
                 },
                 // swiftlint:disable:next no_raw_task_sleep - already seamed: this closure IS the production value of `LimitResumeActuator`'s non-defaulted `waiter:` parameter (the seam itself), exercised by Tests/TBDDaemonTests/LimitResumeActuatorTests.swift which injects `waiter: { _ in }` at 5 construction sites; see docs/specs/2026-07-24-test-hardening-design.md
-                waiter: { duration in _ = try? await Task.sleep(for: duration) }
+                waiter: { duration in _ = try? await Task.sleep(for: duration) },
+                actuationLog: actuationLog
             )
             let resumeScheduler = LimitResumeScheduler(
                 store: database.scheduledResumes,
@@ -750,7 +758,8 @@ public final class Daemon: Sendable {
                 lifecycle: lifecycle,
                 tmux: tmux,
                 skillDir: skillDir,
-                subscriptions: subs
+                subscriptions: subs,
+                actuationLog: actuationLog
             )
 
             let runner = DaywatchRunner(

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -185,7 +185,8 @@ public final class Daemon: Sendable {
     /// the socket/HTTP servers or background tasks. In mock mode this is a
     /// no-op so hand-seeded fixtures render exactly as authored.
     func performStartupReconciliation(
-        mockMode: MockMode?, database: TBDDatabase, git: GitManager, lifecycle: WorktreeLifecycle
+        mockMode: MockMode?, database: TBDDatabase, git: GitManager,
+        lifecycle: WorktreeLifecycle, actuationLog: ActuationLog
     ) async {
         guard mockMode == nil else {
             daemonLogger.info("Mock mode: skipping startup reconciliation")
@@ -210,7 +211,7 @@ public final class Daemon: Sendable {
             let repos = try await database.repos.list()
             for repo in repos {
                 do {
-                    try await lifecycle.reconcile(repoID: repo.id)
+                    try await lifecycle.reconcile(repoID: repo.id, actuationLog: actuationLog)
                 } catch {
                     reconcileLogger.warning("Failed to reconcile repo \(repo.displayName, privacy: .public): \(error.localizedDescription, privacy: .public)")
                 }
@@ -479,7 +480,7 @@ public final class Daemon: Sendable {
         // handlers — and the socket server that serves those doesn't start until
         // step 9 below. So no merge can be observed between construction and here.
         let autoArchiveCoordinator = AutoArchiveOnMergeCoordinator(
-            db: database, lifecycle: lifecycle, subscriptions: subs)
+            db: database, lifecycle: lifecycle, subscriptions: subs, actuationLog: actuationLog)
         let autoHibernateCoordinator = AutoHibernateOnMergeCoordinator(
             db: database, hibernation: rpcRouter.hibernationCoordinator, subscriptions: subs)
         let mergedTransitionDispatcher = MergedTransitionDispatcher(
@@ -562,7 +563,9 @@ public final class Daemon: Sendable {
         }
 
         // 11. Perform DB-mutating reconciliation (skipped in mock mode so fixtures render as authored)
-        await performStartupReconciliation(mockMode: mockMode, database: database, git: git, lifecycle: lifecycle)
+        await performStartupReconciliation(
+            mockMode: mockMode, database: database, git: git, lifecycle: lifecycle,
+            actuationLog: actuationLog)
 
         if mockMode == nil {
             // 11a-reaper. Reap orphaned/wedged agent processes: sweep now, then periodically.

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -143,11 +143,11 @@ public actor HibernationCoordinator {
     /// "escalate after exactly N attempts" boundary is exact.
     private let clock: any Clock<Duration>
 
-    /// The daemon's actuation record. The idle sweep is a daemon-internal
-    /// actuation site — it bypasses the router, so the rail logs its own row.
-    /// Deliberately NOT logged inside `performHibernate`: the RPC handlers call
-    /// that same method after writing their own row, and a row there would
-    /// double-count every manual park.
+    /// The daemon's actuation record. The idle sweep and the merge-park rail
+    /// are daemon-internal actuation sites — they bypass the router, so each
+    /// logs its own row. Deliberately NOT logged inside `performHibernate`: the
+    /// RPC handlers call that same method after writing their own row, and a
+    /// row there would double-count every manual park.
     private let actuationLog: ActuationLog
 
     private var defaultShell: String {
@@ -164,7 +164,7 @@ public actor HibernationCoordinator {
         exitPollAttempts: Int = 15,
         exitPollInterval: Duration = .milliseconds(200),
         clock: any Clock<Duration> = ContinuousClock(),
-        actuationLog: ActuationLog? = nil
+        actuationLog: ActuationLog
     ) {
         self.db = db
         self.tmux = tmux
@@ -177,7 +177,7 @@ public actor HibernationCoordinator {
         self.exitPollAttempts = exitPollAttempts
         self.exitPollInterval = exitPollInterval
         self.clock = clock
-        self.actuationLog = actuationLog ?? ActuationLog(path: TBDConstants.actuationLogPath)
+        self.actuationLog = actuationLog
     }
 
     /// Projects root for a wake spawn's resolved profile config dir path,
@@ -255,6 +255,12 @@ public actor HibernationCoordinator {
     /// Park a session because its worktree's PR merged. Honors every safety rail
     /// (including keep-warm, unlike `manualHibernate`) but NOT the idle window or
     /// the idle-sweep master switch — see `HibernationGate.decideForMerge`.
+    ///
+    /// A daemon-internal rail: no RPC carried this, so it writes its own row
+    /// with no `method` and the rail-named actor. `AutoHibernateOnMergeCoordinator`
+    /// fans out over every terminal in the worktree and most are refused by the
+    /// rails above, so — like the idle sweep — the row goes after the gate, at
+    /// the moment this rail is actually about to act on a session.
     public func hibernateForMerge(terminalID: UUID) async -> HibernateResult {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
@@ -263,7 +269,27 @@ public actor HibernationCoordinator {
         if let blocked = HibernationGate.blockingRail(terminal: terminal) {
             return .notEligible(reason: Self.mergeBlockReason(blocked))
         }
-        return await performHibernate(terminal: terminal, reason: .merged)
+
+        // Fail-closed, as everywhere else: an unrecordable park does not
+        // happen. The writer already logged the failure at `.fault`; carrying
+        // its self-explaining text out as the refusal reason puts it in the
+        // caller's log too.
+        var row = ActuationRow(
+            actor: .daemon(rail: ActuationRail.autoHibernateOnMerge), kind: .hibernate)
+        row.target = .local(worktree: terminal.worktreeID, terminal: terminal.id)
+        let actuationID: String
+        do {
+            actuationID = try await actuationLog.appendRequest(row)
+        } catch {
+            return .notEligible(reason: "\(error)")
+        }
+
+        let result = await performHibernate(terminal: terminal, reason: .merged)
+        await actuationLog.appendOutcome(
+            confirms: actuationID,
+            result: ActuationResult.classify(result),
+            error: ActuationResult.detail(result))
+        return result
     }
 
     /// The reason a merge-park was refused, for logging/telemetry. Mirrors

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -287,8 +287,8 @@ public actor HibernationCoordinator {
         let result = await performHibernate(terminal: terminal, reason: .merged)
         await actuationLog.appendOutcome(
             confirms: actuationID,
-            result: ActuationResult.classify(result),
-            error: ActuationResult.detail(result))
+            result: ActuationOutcome.classify(result),
+            error: ActuationOutcome.detail(result))
         return result
     }
 
@@ -878,8 +878,8 @@ public actor HibernationCoordinator {
                         let result = await performHibernate(terminal: terminal, reason: .auto)
                         await actuationLog.appendOutcome(
                             confirms: actuationID,
-                            result: ActuationResult.classify(result),
-                            error: ActuationResult.detail(result))
+                            result: ActuationOutcome.classify(result),
+                            error: ActuationOutcome.detail(result))
                     }
                 } else {
                     pendingKillSince[terminal.id] = reference

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -143,6 +143,13 @@ public actor HibernationCoordinator {
     /// "escalate after exactly N attempts" boundary is exact.
     private let clock: any Clock<Duration>
 
+    /// The daemon's actuation record. The idle sweep is a daemon-internal
+    /// actuation site — it bypasses the router, so the rail logs its own row.
+    /// Deliberately NOT logged inside `performHibernate`: the RPC handlers call
+    /// that same method after writing their own row, and a row there would
+    /// double-count every manual park.
+    private let actuationLog: ActuationLog
+
     private var defaultShell: String {
         ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
     }
@@ -156,7 +163,8 @@ public actor HibernationCoordinator {
         now: @escaping @Sendable () -> Date = { Date() },
         exitPollAttempts: Int = 15,
         exitPollInterval: Duration = .milliseconds(200),
-        clock: any Clock<Duration> = ContinuousClock()
+        clock: any Clock<Duration> = ContinuousClock(),
+        actuationLog: ActuationLog? = nil
     ) {
         self.db = db
         self.tmux = tmux
@@ -169,6 +177,7 @@ public actor HibernationCoordinator {
         self.exitPollAttempts = exitPollAttempts
         self.exitPollInterval = exitPollInterval
         self.clock = clock
+        self.actuationLog = actuationLog ?? ActuationLog(path: TBDConstants.actuationLogPath)
     }
 
     /// Projects root for a wake spawn's resolved profile config dir path,
@@ -830,7 +839,21 @@ public actor HibernationCoordinator {
                 }
                 if let pending = pendingKillSince[terminal.id] {
                     if reference.timeIntervalSince(pending) >= Self.killDebounce {
-                        _ = await performHibernate(terminal: terminal, reason: .auto)
+                        // The rail's own row, written at its act moment. A
+                        // request row that cannot be persisted refuses the act
+                        // (fail-closed) — an unrecorded auto-park is exactly the
+                        // silent gap the record exists to forbid.
+                        var row = ActuationRow(
+                            actor: .daemon(rail: ActuationRail.autoHibernate), kind: .hibernate)
+                        row.target = .local(worktree: terminal.worktreeID, terminal: terminal.id)
+                        guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                            continue
+                        }
+                        let result = await performHibernate(terminal: terminal, reason: .auto)
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID,
+                            result: ActuationResult.classify(result),
+                            error: ActuationResult.detail(result))
                     }
                 } else {
                     pendingKillSince[terminal.id] = reference

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -107,7 +107,22 @@ extension WorktreeLifecycle {
     ///
     /// - Worktrees in db but missing from git: marked as archived
     /// - Worktrees in git but missing from db: added with default names
-    public func reconcile(repoID: UUID) async throws {
+    ///
+    /// This sweep is a daemon-internal actuation rail in its own right: boot
+    /// (and `cleanup`) invoke it, and it kills windows, parks sessions and kills
+    /// whole tmux servers on its own judgement. So it takes the record and
+    /// writes one row **per act** — each kill or park is an independent decision
+    /// about a target it has already resolved, unlike an RPC archive where the
+    /// caller asked for one worktree-level thing. The shared helpers it calls
+    /// (`captureThenKillWindow`, `killWindowAndReap`) stay silent so the RPC
+    /// paths that also reach them are not double-counted.
+    ///
+    /// `actuationLog` is a required parameter rather than a defaulted one: a
+    /// default would point every caller at one real file under `$TBD_HOME`,
+    /// which is exactly the "helper ignores its caller's injected seam" shape.
+    /// Fail-closed here means skipping the individual act — the daemon still
+    /// boots, and the orphan waits for a writable log and the next sweep.
+    public func reconcile(repoID: UUID, actuationLog: ActuationLog) async throws {
         // Null out parent pointers whose target is missing OR archived. Either
         // case would leave the child unreachable in the sidebar — missing rows
         // can't render, and archived parents are filtered out of the subtree
@@ -174,8 +189,25 @@ extension WorktreeLifecycle {
         // row and its history rows survive, so the output stays readable.
         for wt in dbWorktrees where !gitPaths.contains(wt.path) {
             let terminals = try await db.terminals.list(worktreeID: wt.id)
+            var recordedEveryKill = true
             for terminal in terminals {
+                var row = ActuationRow(
+                    actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
+                row.target = .local(worktree: wt.id, terminal: terminal.id)
+                guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                    recordedEveryKill = false
+                    continue
+                }
                 await captureThenKillWindow(terminal: terminal, server: wt.tmuxServer)
+                await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
+            }
+            // A kill that could not be recorded did not happen, so the rows that
+            // still point at those windows must not be torn down either — that
+            // would archive the worktree and leave its live windows unreachable.
+            // Leave the whole worktree for the next sweep instead.
+            guard recordedEveryKill else {
+                logger.warning("reconcile: leaving \(wt.id, privacy: .public) for the next sweep — the actuation record is unwritable, so its windows were not killed")
+                continue
             }
             try await db.terminals.deleteForWorktree(worktreeID: wt.id)
             try await db.tabs.deleteForWorktree(worktreeID: wt.id)
@@ -285,7 +317,26 @@ extension WorktreeLifecycle {
                     // Deleting here would orphan the transcript and the session
                     // would vanish from TBD. Write the authoritative `hibernatedAt`
                     // column so `wake()` (which un-parks any parked row) can resume it.
-                    try? await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID, reason: .recovery)
+                    //
+                    // This park bypasses `HibernationCoordinator` entirely, so it
+                    // is this sweep's own act and carries this sweep's own row.
+                    // Fail-closed: an unrecordable park is skipped and the row
+                    // stays as it is for the next sweep.
+                    var row = ActuationRow(
+                        actor: .daemon(rail: ActuationRail.reconcile), kind: .hibernate)
+                    row.target = .local(worktree: wt.id, terminal: terminal.id)
+                    guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                        logger.warning("reconcile: skipped parking terminal \(terminal.id, privacy: .public) — the actuation record is unwritable")
+                        continue
+                    }
+                    do {
+                        try await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID, reason: .recovery)
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID, result: .dispatched)
+                    } catch {
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID, result: .transportFailed, error: "\(error)")
+                    }
                     logger.info("reconcile: parked terminal \(terminal.id, privacy: .public) — window \(terminal.tmuxWindowID, privacy: .public) gone, session \(sessionID, privacy: .public) preserved, wakeable via the unified resume path")
                 } else {
                     // Plain shell / Codex: nothing resumable to preserve, delete.
@@ -353,10 +404,24 @@ extension WorktreeLifecycle {
                 // rows keep pointing here forever, so this is the steady
                 // state on every later reconcile).
                 guard await tmux.serverExists(server: server) else { continue }
+                // Nothing left names this server — that is why it is being
+                // killed — so the row is identified by what IS known: the
+                // server, and the repo whose sweep found it. The child reap is
+                // part of this one disposal, not a second act.
+                var row = ActuationRow(
+                    actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
+                row.target = .tmux(server: server, repo: repoID)
+                guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                    logger.warning("reconcile: skipped killing tmux server \(server, privacy: .public) — the actuation record is unwritable")
+                    continue
+                }
                 await reaper.reapServerChildren(server: server)
                 do {
                     try await tmux.killServer(server: server)
+                    await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
                 } catch {
+                    await actuationLog.appendOutcome(
+                        confirms: actuationID, result: .transportFailed, error: "\(error)")
                     logger.warning("reconcile: failed to kill tmux server \(server, privacy: .public): \(error, privacy: .public)")
                 }
             } else {
@@ -373,11 +438,24 @@ extension WorktreeLifecycle {
                 do {
                     let tmuxWindows = try await tmux.listWindows(server: server, session: "main")
                     for window in tmuxWindows where !trackedWindowIDs.contains(window.windowID) {
+                        // No terminal row claims this window — that is what
+                        // makes it an orphan — so the row names the server, the
+                        // window and the sweeping repo.
+                        var row = ActuationRow(
+                            actor: .daemon(rail: ActuationRail.reconcile), kind: .dispose)
+                        row.target = .tmux(
+                            server: server, window: window.windowID, repo: repoID)
+                        guard let actuationID = try? await actuationLog.appendRequest(row) else {
+                            logger.warning("reconcile: skipped sweeping orphan window \(window.windowID, privacy: .public) on \(server, privacy: .public) — the actuation record is unwritable")
+                            continue
+                        }
                         await killWindowAndReap(
                             server: server,
                             windowID: window.windowID,
                             paneID: window.paneID
                         )
+                        await actuationLog.appendOutcome(
+                            confirms: actuationID, result: .dispatched)
                     }
                 } catch {
                     logger.warning("reconcile: failed to list tmux windows for server \(server, privacy: .public): \(error, privacy: .public)")

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -670,11 +670,32 @@ public actor DeskSessionManager: DeskSessionManaging {
                 return
             }
 
-            // Kill tmux windows
             let terminals = try await db.terminals.list(worktreeID: wt.id)
+
+            // This rail kills the desk's windows itself rather than through a
+            // lifecycle an RPC handler already rowed, so it writes its own —
+            // one dispose naming the desk worktree, the shape `worktree.archive`
+            // uses, because the per-terminal kills below are how this one intent
+            // is carried out. Fail-closed like the wrap-up and the nudge: an
+            // unrecordable close does not happen, and `deskWorktreeID` is left
+            // set (this returns before the reset at the end) so the next close
+            // still knows which desk to tear down.
+            var row = ActuationRow(
+                actor: .daemon(rail: ActuationRail.nightwatchDesk), kind: .dispose)
+            row.target = ActuationTarget(worktree: wt.id.uuidString)
+            let actuationID: String
+            do {
+                actuationID = try await actuationLog.appendRequest(row)
+            } catch {
+                logger.warning("Skipping Watch Desk close: \(error, privacy: .public)")
+                return
+            }
+
+            // Kill tmux windows
             for t in terminals {
                 try? await tmux.killWindow(server: wt.tmuxServer, windowID: t.tmuxWindowID)
             }
+            await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
 
             // Delete terminal rows
             try await db.terminals.deleteForWorktree(worktreeID: wt.id)
@@ -806,14 +827,34 @@ public actor DeskSessionManager: DeskSessionManaging {
             logger.debug("Wrote judge instructions to \(path, privacy: .public)")
         }
 
+        // The rail spawns an agent session here with nobody having asked, so it
+        // writes its own row — one naming the desk worktree and no terminal, the
+        // shape `worktree.revive` uses, because the terminals are minted inside
+        // `spawnPrimaryTerminals`. This is the one chokepoint all three spawn
+        // paths pass through (fresh create, recovery, pre-nudge respawn), so a
+        // row here counts each spawn exactly once. Fail-closed: the throw
+        // reaches the same callers that already treat a failed spawn as
+        // best-effort, so an unrecordable spawn simply does not happen.
+        var row = ActuationRow(
+            actor: .daemon(rail: ActuationRail.nightwatchDesk), kind: .spawn)
+        row.target = ActuationTarget(worktree: worktree.id.uuidString)
+        let actuationID = try await actuationLog.appendRequest(row)
+
         // Use production spawn path which handles trust, overlay, and all lifecycle concerns
-        _ = try await lifecycle.spawnPrimaryTerminals(
-            worktree: worktree,
-            repo: nil,
-            skipClaude: false,
-            initialPrompt: initialPrompt,
-            preSessionTerminalID: nil
-        )
+        do {
+            _ = try await lifecycle.spawnPrimaryTerminals(
+                worktree: worktree,
+                repo: nil,
+                skipClaude: false,
+                initialPrompt: initialPrompt,
+                preSessionTerminalID: nil
+            )
+        } catch {
+            await actuationLog.appendOutcome(
+                confirms: actuationID, result: .transportFailed, error: "\(error)")
+            throw error
+        }
+        await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
         // Model follows the profile spawnPrimaryTerminals resolves internally —
         // resolving here too would just double the keychain-backed lookup.
         logger.info("Spawned desk terminal in \(worktree.id, privacy: .public)")

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -107,7 +107,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         skillDir: String,
         subscriptions: StateSubscriptionManager? = nil,
         now: @escaping @Sendable () -> Date = { Date() },
-        actuationLog: ActuationLog? = nil
+        actuationLog: ActuationLog
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -115,7 +115,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         self.subscriptions = subscriptions
         self.skillDir = skillDir
         self.now = now
-        self.actuationLog = actuationLog ?? ActuationLog(path: TBDConstants.actuationLogPath)
+        self.actuationLog = actuationLog
         self.deskWorktreeID = nil
     }
 

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -38,6 +38,9 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// Without it the 10-minute window is unreachable in a test, which is why the
     /// guard went so long with no observable beyond "doesn't throw".
     private let now: @Sendable () -> Date
+    /// The daemon's actuation record. The desk's pastes bypass the RPC router,
+    /// so this rail writes its own rows.
+    private let actuationLog: ActuationLog
 
     // MARK: - State
 
@@ -103,7 +106,8 @@ public actor DeskSessionManager: DeskSessionManaging {
         tmux: TmuxManager,
         skillDir: String,
         subscriptions: StateSubscriptionManager? = nil,
-        now: @escaping @Sendable () -> Date = { Date() }
+        now: @escaping @Sendable () -> Date = { Date() },
+        actuationLog: ActuationLog? = nil
     ) {
         self.db = db
         self.lifecycle = lifecycle
@@ -111,6 +115,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         self.subscriptions = subscriptions
         self.skillDir = skillDir
         self.now = now
+        self.actuationLog = actuationLog ?? ActuationLog(path: TBDConstants.actuationLogPath)
         self.deskWorktreeID = nil
     }
 
@@ -448,19 +453,34 @@ public actor DeskSessionManager: DeskSessionManaging {
                 return
             }
 
-            // Paste the wrap-up prompt text
-            try await tmux.pasteText(
-                server: worktree.tmuxServer,
-                paneID: agentTerminal.tmuxPaneID,
-                bytes: Data(NightwatchDeskPrompts.wrapUpPrompt.utf8)
-            )
+            // Request row before the paste; the paste and the Enter are one
+            // send. Fail-closed: an unrecordable wrap-up is not posted.
+            guard let actuationID = try? await recordDeskSend(
+                worktreeID: worktreeID,
+                terminalID: agentTerminal.id,
+                message: NightwatchDeskPrompts.wrapUpPrompt)
+            else { return }
 
-            // Send Enter to submit
-            try await tmux.sendKey(
-                server: worktree.tmuxServer,
-                paneID: agentTerminal.tmuxPaneID,
-                key: "Enter"
-            )
+            do {
+                // Paste the wrap-up prompt text
+                try await tmux.pasteText(
+                    server: worktree.tmuxServer,
+                    paneID: agentTerminal.tmuxPaneID,
+                    bytes: Data(NightwatchDeskPrompts.wrapUpPrompt.utf8)
+                )
+
+                // Send Enter to submit
+                try await tmux.sendKey(
+                    server: worktree.tmuxServer,
+                    paneID: agentTerminal.tmuxPaneID,
+                    key: "Enter"
+                )
+            } catch {
+                await actuationLog.appendOutcome(
+                    confirms: actuationID, result: .transportFailed, error: "\(error)")
+                throw error
+            }
+            await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
 
             // Fire a completion notification
             _ = try await db.notifications.create(
@@ -564,19 +584,35 @@ public actor DeskSessionManager: DeskSessionManaging {
                 prompt = NightwatchDeskPrompts.judgePrompt(mode: mode, skillDir: skillDir)
             }
 
-            // Paste the prompt text (matches handleTerminalSend pattern for reliability)
-            try await tmux.pasteText(
-                server: worktree.tmuxServer,
-                paneID: agentTerminal.tmuxPaneID,
-                bytes: Data(prompt.utf8)
-            )
+            // Request row before the paste; the paste and the Enter are one
+            // send. Fail-closed: an unrecordable nudge is not sent, and
+            // `lastNudgeTime` below is left alone so the next tick retries.
+            guard let actuationID = try? await recordDeskSend(
+                worktreeID: worktreeID,
+                terminalID: agentTerminal.id,
+                message: prompt)
+            else { return }
 
-            // Send Enter to submit
-            try await tmux.sendKey(
-                server: worktree.tmuxServer,
-                paneID: agentTerminal.tmuxPaneID,
-                key: "Enter"
-            )
+            do {
+                // Paste the prompt text (matches handleTerminalSend pattern for reliability)
+                try await tmux.pasteText(
+                    server: worktree.tmuxServer,
+                    paneID: agentTerminal.tmuxPaneID,
+                    bytes: Data(prompt.utf8)
+                )
+
+                // Send Enter to submit
+                try await tmux.sendKey(
+                    server: worktree.tmuxServer,
+                    paneID: agentTerminal.tmuxPaneID,
+                    key: "Enter"
+                )
+            } catch {
+                await actuationLog.appendOutcome(
+                    confirms: actuationID, result: .transportFailed, error: "\(error)")
+                throw error
+            }
+            await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
 
             // Record nudge time for overlap guard. `lastNudgedMode` is set only
             // here, after the paste actually went out — a nudge that failed to
@@ -589,6 +625,20 @@ public actor DeskSessionManager: DeskSessionManaging {
         } catch {
             logger.error("Failed to nudge desk session: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    /// One request row for a desk paste, carrying the payload verbatim.
+    /// Returns the minted id; throws when the record is unwritable even after
+    /// the writer's reopen-retry, in which case the caller must not paste.
+    private func recordDeskSend(
+        worktreeID: UUID, terminalID: UUID, message: String
+    ) async throws -> String {
+        var row = ActuationRow(
+            actor: .daemon(rail: ActuationRail.nightwatchDesk), kind: .send)
+        row.target = .local(worktree: worktreeID, terminal: terminalID)
+        row.message = message
+        row.submit = true
+        return try await actuationLog.appendRequest(row)
     }
 
     /// Gracefully close the desk session (archive it).

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -454,12 +454,18 @@ public actor DeskSessionManager: DeskSessionManaging {
             }
 
             // Request row before the paste; the paste and the Enter are one
-            // send. Fail-closed: an unrecordable wrap-up is not posted.
-            guard let actuationID = try? await recordDeskSend(
-                worktreeID: worktreeID,
-                terminalID: agentTerminal.id,
-                message: NightwatchDeskPrompts.wrapUpPrompt)
-            else { return }
+            // send. Fail-closed: an unrecordable wrap-up is not posted — and
+            // says so, like every other refusal on this path.
+            let actuationID: String
+            do {
+                actuationID = try await recordDeskSend(
+                    worktreeID: worktreeID,
+                    terminalID: agentTerminal.id,
+                    message: NightwatchDeskPrompts.wrapUpPrompt)
+            } catch {
+                logger.warning("Skipping Watch Desk wrap-up prompt: \(error, privacy: .public)")
+                return
+            }
 
             do {
                 // Paste the wrap-up prompt text
@@ -587,11 +593,16 @@ public actor DeskSessionManager: DeskSessionManaging {
             // Request row before the paste; the paste and the Enter are one
             // send. Fail-closed: an unrecordable nudge is not sent, and
             // `lastNudgeTime` below is left alone so the next tick retries.
-            guard let actuationID = try? await recordDeskSend(
-                worktreeID: worktreeID,
-                terminalID: agentTerminal.id,
-                message: prompt)
-            else { return }
+            let actuationID: String
+            do {
+                actuationID = try await recordDeskSend(
+                    worktreeID: worktreeID,
+                    terminalID: agentTerminal.id,
+                    message: prompt)
+            } catch {
+                logger.warning("Skipping Watch Desk nudge: \(error, privacy: .public)")
+                return
+            }
 
             do {
                 // Paste the prompt text (matches handleTerminalSend pattern for reliability)

--- a/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
+++ b/Sources/TBDDaemon/PR/AutoArchiveOnMergeCoordinator.swift
@@ -10,11 +10,23 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
     let db: TBDDatabase
     let lifecycle: WorktreeLifecycle
     let subscriptions: StateSubscriptionManager
+    /// The daemon's actuation record. This is a daemon-internal rail — no RPC
+    /// carried it — so it writes its own row, with no `method` and the
+    /// rail-named actor. Deliberately NOT logged inside `beginArchiveWorktree`:
+    /// the `worktree.archive` handler calls that same method after writing its
+    /// own row, and a row there would double-count every manual archive.
+    let actuationLog: ActuationLog
 
-    public init(db: TBDDatabase, lifecycle: WorktreeLifecycle, subscriptions: StateSubscriptionManager) {
+    public init(
+        db: TBDDatabase,
+        lifecycle: WorktreeLifecycle,
+        subscriptions: StateSubscriptionManager,
+        actuationLog: ActuationLog
+    ) {
         self.db = db
         self.lifecycle = lifecycle
         self.subscriptions = subscriptions
+        self.actuationLog = actuationLog
     }
 
     /// Returns `true` ONLY when it actually began archiving the worktree (i.e.
@@ -41,7 +53,33 @@ public struct AutoArchiveOnMergeCoordinator: Sendable {
                 return false
             }
 
-            let (worktree, repo) = try await lifecycle.beginArchiveWorktree(worktreeID: worktreeID)
+            // The rail's own row, written at its act moment — after the gates
+            // above, at the point this rail is actually about to tear a
+            // worktree's sessions down. Fail-closed, as everywhere else: an
+            // unrecordable archive does not happen, and the worktree survives
+            // for the next merged-transition to retry. The writer already
+            // logged the failure at `.fault`.
+            var row = ActuationRow(
+                actor: .daemon(rail: ActuationRail.autoArchiveOnMerge), kind: .dispose)
+            row.target = ActuationTarget(worktree: worktreeID.uuidString)
+            let actuationID: String
+            do {
+                actuationID = try await actuationLog.appendRequest(row)
+            } catch {
+                logger.warning("auto-archive skipped (record unwritable): \(worktreeID, privacy: .public): \(error, privacy: .public)")
+                return false
+            }
+
+            let worktree: Worktree
+            let repo: Repo
+            do {
+                (worktree, repo) = try await lifecycle.beginArchiveWorktree(worktreeID: worktreeID)
+            } catch {
+                await actuationLog.appendOutcome(
+                    confirms: actuationID, result: .transportFailed, error: "\(error)")
+                throw error
+            }
+            await actuationLog.appendOutcome(confirms: actuationID, result: .dispatched)
             subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(worktreeID: worktreeID)))
 
             // Surface it: persist + broadcast a notification (non-activating).

--- a/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
@@ -16,8 +16,9 @@ private enum ContinueInCodexHandlerError: LocalizedError {
 }
 
 extension RPCRouter {
-    func handleTerminalContinueInCodex(_ paramsData: Data) async throws
-        -> RPCResponse {
+    func handleTerminalContinueInCodex(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(
             TerminalContinueInCodexParams.self, from: paramsData)
 
@@ -109,22 +110,35 @@ extension RPCRouter {
             executablePath: preparation.executablePath,
             profileFlag: profileFlag)
 
-        _ = try await tmux.ensureServer(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            cols: TmuxManager.defaultCols,
-            rows: TmuxManager.defaultRows)
-        await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
-        let window = try await tmux.createWindow(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            shellCommand: command,
-            env: codexEnv,
-            sensitiveEnv: sensitiveEnv,
-            cols: TmuxManager.defaultCols,
-            rows: TmuxManager.defaultRows)
+        // The import above created Codex state but touched no session; the
+        // tmux calls below are the actuation, so the row goes here.
+        let actuationID = try await beginActuation(
+            .terminalContinueInCodex, actor: actor,
+            target: .local(worktree: worktree.id, terminal: plannedTerminalID),
+            agent: TerminalKind.codex.rawValue)
+
+        let window: (windowID: String, paneID: String)
+        do {
+            _ = try await tmux.ensureServer(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                cols: TmuxManager.defaultCols,
+                rows: TmuxManager.defaultRows)
+            await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
+            window = try await tmux.createWindow(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                shellCommand: command,
+                env: codexEnv,
+                sensitiveEnv: sensitiveEnv,
+                cols: TmuxManager.defaultCols,
+                rows: TmuxManager.defaultRows)
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
 
         let terminal: Terminal
         do {
@@ -139,6 +153,7 @@ extension RPCRouter {
             try? await tmux.killWindow(
                 server: worktree.tmuxServer,
                 windowID: window.windowID)
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
             throw error
         }
 
@@ -148,6 +163,7 @@ extension RPCRouter {
             label: terminal.label)))
         continueInCodexLogger.info(
             "Continued Claude terminal \(source.id, privacy: .public) in Codex terminal \(terminal.id, privacy: .public)")
+        await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: TerminalContinueInCodexResult(
             terminalID: terminal.id,
             threadID: threadID))

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -5,9 +5,17 @@ extension RPCRouter {
 
     /// `terminal.hibernate` — manually hibernate one Claude terminal (kill its
     /// process, keep the tmux window). Honors the running/permission rails.
-    func handleTerminalHibernate(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalHibernate(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalHibernateParams.self, from: paramsData)
+        let actuationID = try await beginActuation(
+            .terminalHibernate, actor: actor,
+            target: await resolvedTerminalTarget(params.terminalID))
         let result = await hibernationCoordinator.manualHibernate(terminalID: params.terminalID)
+        await finishActuation(
+            actuationID, ActuationResult.classify(result),
+            error: ActuationResult.detail(result))
         switch result {
         case .ok:
             // Hibernating cancels any pending auto-resume inside the
@@ -26,13 +34,22 @@ extension RPCRouter {
 
     /// `terminal.wake` — respawn `claude --resume <id>` in the hibernated
     /// terminal's kept-alive window. Idempotent.
-    func handleTerminalWake(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalWake(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalWakeParams.self, from: paramsData)
+        let actuationID = try await beginActuation(
+            .terminalWake, actor: actor,
+            target: await resolvedTerminalTarget(params.terminalID),
+            prompt: params.prompt)
         let result = await hibernationCoordinator.wake(
             terminalID: params.terminalID, cols: params.cols, rows: params.rows,
             allowDefaultProfileFallback: params.fallbackToDefaultProfile ?? false,
             initialPrompt: params.prompt
         )
+        await finishActuation(
+            actuationID, ActuationResult.classify(result),
+            error: ActuationResult.detail(result))
         switch result {
         case .ok:
             return try RPCResponse(result: TerminalWakeResult(woken: true))

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -14,8 +14,8 @@ extension RPCRouter {
             target: await resolvedTerminalTarget(params.terminalID))
         let result = await hibernationCoordinator.manualHibernate(terminalID: params.terminalID)
         await finishActuation(
-            actuationID, ActuationResult.classify(result),
-            error: ActuationResult.detail(result))
+            actuationID, ActuationOutcome.classify(result),
+            error: ActuationOutcome.detail(result))
         switch result {
         case .ok:
             // Hibernating cancels any pending auto-resume inside the
@@ -48,8 +48,8 @@ extension RPCRouter {
             initialPrompt: params.prompt
         )
         await finishActuation(
-            actuationID, ActuationResult.classify(result),
-            error: ActuationResult.detail(result))
+            actuationID, ActuationOutcome.classify(result),
+            error: ActuationOutcome.detail(result))
         switch result {
         case .ok:
             return try RPCResponse(result: TerminalWakeResult(woken: true))

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -14,8 +14,13 @@ import TBDShared
 ///   - `worktree.resume`   → wake every parked Claude terminal
 extension RPCRouter {
 
-    func handleTerminalSuspend(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalSuspend(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSuspendParams.self, from: paramsData)
+        let actuationID = try await beginActuation(
+            .terminalSuspend, actor: actor,
+            target: await resolvedTerminalTarget(params.terminalID))
         // Parking (formerly suspend) routes to the unified HibernationCoordinator.
         // Cancel any pending auto-resume up-front and unconditionally (spec
         // §Cancellation, preserving #341's shim behavior): the intent to park
@@ -27,6 +32,9 @@ extension RPCRouter {
             await limitResumeScheduler?.wake()
         }
         let result = await hibernationCoordinator.manualHibernate(terminalID: params.terminalID)
+        await finishActuation(
+            actuationID, ActuationResult.classify(result),
+            error: ActuationResult.detail(result))
         switch result {
         case .ok, .alreadyHibernated:
             return .ok()
@@ -37,9 +45,17 @@ extension RPCRouter {
         }
     }
 
-    func handleTerminalResume(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalResume(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalResumeParams.self, from: paramsData)
+        let actuationID = try await beginActuation(
+            .terminalResume, actor: actor,
+            target: await resolvedTerminalTarget(params.terminalID))
         let result = await hibernationCoordinator.wake(terminalID: params.terminalID)
+        await finishActuation(
+            actuationID, ActuationResult.classify(result),
+            error: ActuationResult.detail(result))
         switch result {
         case .ok, .notHibernated, .inFlight:
             // notHibernated / inFlight are benign no-ops for an idempotent wake.
@@ -61,7 +77,9 @@ extension RPCRouter {
         }
     }
 
-    func handleWorktreeSuspend(_ paramsData: Data) async throws -> RPCResponse {
+    func handleWorktreeSuspend(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeSuspendParams.self, from: paramsData)
         guard let terminals = try? await db.terminals.list(worktreeID: params.worktreeID) else {
             return RPCResponse(error: "Worktree not found")
@@ -80,16 +98,33 @@ extension RPCRouter {
 
         // Fire in background — RPC returns immediately so the app can show
         // the parking overlay while the daemon does its work.
-        Task { [hibernationCoordinator] in
+        //
+        // One row per terminal, written at THAT terminal's own act moment
+        // rather than one row for the fan-out: the record's unit is an
+        // actuation on a session. A terminal whose request row cannot be
+        // persisted is skipped (fail-closed) — the RPC already returned, so
+        // there is nothing left to refuse but the act itself.
+        let worktreeID = params.worktreeID
+        Task { [hibernationCoordinator, actuationLog] in
             for terminal in eligible {
-                _ = await hibernationCoordinator.manualHibernate(terminalID: terminal.id)
+                var row = ActuationRow(actor: actor ?? .anonymous, kind: ActuationSurface.worktreeSuspend.kind)
+                row.method = ActuationSurface.worktreeSuspend.method
+                row.target = .local(worktree: worktreeID, terminal: terminal.id)
+                guard let actuationID = try? await actuationLog.appendRequest(row) else { continue }
+                let result = await hibernationCoordinator.manualHibernate(terminalID: terminal.id)
+                await actuationLog.appendOutcome(
+                    confirms: actuationID,
+                    result: ActuationResult.classify(result),
+                    error: ActuationResult.detail(result))
             }
         }
 
         return .ok()
     }
 
-    func handleWorktreeResume(_ paramsData: Data) async throws -> RPCResponse {
+    func handleWorktreeResume(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeResumeParams.self, from: paramsData)
         guard let terminals = try? await db.terminals.list(worktreeID: params.worktreeID) else {
             return RPCResponse(error: "Worktree not found")
@@ -97,9 +132,18 @@ extension RPCRouter {
 
         // Wake every parked terminal (authoritative or legacy). The coordinator
         // is an actor so calls serialize anyway.
+        // One row per terminal, at each terminal's own act moment (see the
+        // note in `handleWorktreeSuspend`). This fan-out runs inline, so an
+        // unwritable record refuses the whole call before the first wake.
         let parked = terminals.filter { $0.isParked && $0.isClaudeResumable }
         for terminal in parked {
-            _ = await hibernationCoordinator.wake(terminalID: terminal.id)
+            let actuationID = try await beginActuation(
+                .worktreeResume, actor: actor,
+                target: .local(worktree: params.worktreeID, terminal: terminal.id))
+            let result = await hibernationCoordinator.wake(terminalID: terminal.id)
+            await finishActuation(
+                actuationID, ActuationResult.classify(result),
+                error: ActuationResult.detail(result))
         }
 
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -33,8 +33,8 @@ extension RPCRouter {
         }
         let result = await hibernationCoordinator.manualHibernate(terminalID: params.terminalID)
         await finishActuation(
-            actuationID, ActuationResult.classify(result),
-            error: ActuationResult.detail(result))
+            actuationID, ActuationOutcome.classify(result),
+            error: ActuationOutcome.detail(result))
         switch result {
         case .ok, .alreadyHibernated:
             return .ok()
@@ -54,8 +54,8 @@ extension RPCRouter {
             target: await resolvedTerminalTarget(params.terminalID))
         let result = await hibernationCoordinator.wake(terminalID: params.terminalID)
         await finishActuation(
-            actuationID, ActuationResult.classify(result),
-            error: ActuationResult.detail(result))
+            actuationID, ActuationOutcome.classify(result),
+            error: ActuationOutcome.detail(result))
         switch result {
         case .ok, .notHibernated, .inFlight:
             // notHibernated / inFlight are benign no-ops for an idempotent wake.
@@ -114,8 +114,8 @@ extension RPCRouter {
                 let result = await hibernationCoordinator.manualHibernate(terminalID: terminal.id)
                 await actuationLog.appendOutcome(
                     confirms: actuationID,
-                    result: ActuationResult.classify(result),
-                    error: ActuationResult.detail(result))
+                    result: ActuationOutcome.classify(result),
+                    error: ActuationOutcome.detail(result))
             }
         }
 
@@ -145,8 +145,8 @@ extension RPCRouter {
                 target: .local(worktree: params.worktreeID, terminal: terminal.id))
             let result = await hibernationCoordinator.wake(terminalID: terminal.id)
             await finishActuation(
-                actuationID, ActuationResult.classify(result),
-                error: ActuationResult.detail(result))
+                actuationID, ActuationOutcome.classify(result),
+                error: ActuationOutcome.detail(result))
         }
 
         return .ok()

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -134,7 +134,10 @@ extension RPCRouter {
         // is an actor so calls serialize anyway.
         // One row per terminal, at each terminal's own act moment (see the
         // note in `handleWorktreeSuspend`). This fan-out runs inline, so an
-        // unwritable record refuses the whole call before the first wake.
+        // unwritable record fails the RPC — but only the terminals whose rows
+        // had not been written yet are spared: the wakes already performed
+        // stand, each with its own request and outcome row, and the error the
+        // caller sees names a fan-out that stopped partway.
         let parked = terminals.filter { $0.isParked && $0.isClaudeResumable }
         for terminal in parked {
             let actuationID = try await beginActuation(

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -135,7 +135,14 @@ extension RPCRouter {
             await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
-        let session = try result.decoded(RemoteSessionPayload.self)
+        // A provider that exits 0 and returns garbage has lied at the transport
+        // level, so its decode failure is an outcome like any other: without
+        // this the throw would leave the request row unconfirmed forever, and
+        // the record could not tell "the create failed" from "the outcome was
+        // lost". The error propagates unchanged.
+        let session = try await actuating(actuationID) {
+            try result.decoded(RemoteSessionPayload.self)
+        }
         // Adopt immediately so the sidebar shows `starting` before the next poll.
         await manager.applyUpsert(session, provider: params.provider)
         await finishActuation(actuationID, .dispatched)

--- a/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RemoteHandlers.swift
@@ -83,7 +83,9 @@ extension RPCRouter {
         return try RPCResponse(result: RemoteSessionsResult(sessions: sessions))
     }
 
-    func handleRemoteCreate(_ paramsData: Data) async throws -> RPCResponse {
+    func handleRemoteCreate(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
         }
@@ -94,6 +96,12 @@ extension RPCRouter {
         guard let paramsJSON = Self.normalizedParamsJSON(params.paramsJSON) else {
             return RPCResponse(error: "remote.create paramsJSON must be a JSON object; got: \(params.paramsJSON)")
         }
+        // The session ID is the provider's return value, so the request row
+        // carries the provider alone; the resolved ID lands with the observed
+        // rung, not here.
+        let actuationID = try await beginActuation(
+            .remoteCreate, actor: actor,
+            target: .remote(provider: params.provider))
         // ponytail: the idempotency key is handler-scoped (retry-once on
         // timeout), not persisted — the provider dedupes on it for the
         // lifetime of a single create call, and a create that outlives even
@@ -115,22 +123,28 @@ extension RPCRouter {
             } catch let error as ProviderRunError {
                 remoteHandlerLogger.error(
                     "remote.create provider=\(params.provider, privacy: .public) timed out on both the initial call and the retry")
-                return RPCResponse(error: Self.friendlyMessage(for: error, provider: params.provider))
+                let message = Self.friendlyMessage(for: error, provider: params.provider)
+                await finishActuation(actuationID, .transportFailed, error: message)
+                return RPCResponse(error: message)
             }
         }
         if result.failureClass != nil {
             let message = result.decodedError?.message ?? "create failed (exit \(result.exitCode))"
             remoteHandlerLogger.error(
                 "remote.create provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
         let session = try result.decoded(RemoteSessionPayload.self)
         // Adopt immediately so the sidebar shows `starting` before the next poll.
         await manager.applyUpsert(session, provider: params.provider)
+        await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: session)
     }
 
-    func handleRemoteStop(_ paramsData: Data) async throws -> RPCResponse {
+    func handleRemoteStop(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
         }
@@ -138,27 +152,36 @@ extension RPCRouter {
         if await manager.hasStaleSnapshot(provider: params.provider) {
             return Self.staleSnapshotMutationResponse(provider: params.provider)
         }
+        let actuationID = try await beginActuation(
+            .remoteStop, actor: actor,
+            target: .remote(provider: params.provider, session: params.sessionID))
         let result: ProviderResult
         do {
             result = try await manager.invoke(
                 providerName: params.provider, verb: ["stop", params.sessionID], stdin: nil, timeout: 30)
         } catch let error as ProviderRunError {
             remoteHandlerLogger.error("remote.stop provider=\(params.provider, privacy: .public) timed out")
-            return RPCResponse(error: Self.friendlyMessage(for: error, provider: params.provider))
+            let message = Self.friendlyMessage(for: error, provider: params.provider)
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
         }
         if result.failureClass != nil {
             let message = result.decodedError?.message ?? "stop failed (exit \(result.exitCode))"
             remoteHandlerLogger.error(
                 "remote.stop provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
         if let session = try? result.decoded(RemoteSessionPayload.self) {
             await manager.applyUpsert(session, provider: params.provider)
         }
+        await finishActuation(actuationID, .dispatched)
         return .ok()
     }
 
-    func handleRemoteSend(_ paramsData: Data) async throws -> RPCResponse {
+    func handleRemoteSend(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         guard let manager = try await remoteGate() else {
             return Self.remoteBackendsDisabledResponse
         }
@@ -166,6 +189,10 @@ extension RPCRouter {
         if await manager.hasStaleSnapshot(provider: params.provider) {
             return Self.staleSnapshotMutationResponse(provider: params.provider)
         }
+        let actuationID = try await beginActuation(
+            .remoteSend, actor: actor,
+            target: .remote(provider: params.provider, session: params.sessionID),
+            message: params.text, submit: true)
         let result: ProviderResult
         do {
             result = try await manager.invoke(
@@ -173,14 +200,18 @@ extension RPCRouter {
                 stdin: Data(params.text.utf8), timeout: 30)
         } catch let error as ProviderRunError {
             remoteHandlerLogger.error("remote.send provider=\(params.provider, privacy: .public) timed out")
-            return RPCResponse(error: Self.friendlyMessage(for: error, provider: params.provider))
+            let message = Self.friendlyMessage(for: error, provider: params.provider)
+            await finishActuation(actuationID, .transportFailed, error: message)
+            return RPCResponse(error: message)
         }
         if result.failureClass != nil {
             let message = result.decodedError?.message ?? "send failed (exit \(result.exitCode))"
             remoteHandlerLogger.error(
                 "remote.send provider=\(params.provider, privacy: .public) failed: \(message, privacy: .public)")
+            await finishActuation(actuationID, .transportFailed, error: message)
             return RPCResponse(error: message)
         }
+        await finishActuation(actuationID, .dispatched)
         return .ok()
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -57,7 +57,7 @@ extension RPCRouter {
         let tmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
         _ = try await db.worktrees.createMain(repoID: repo.id, name: defaultBranch,
                                               branch: defaultBranch, path: path, tmuxServer: tmuxServer)
-        try? await lifecycle.reconcile(repoID: repo.id)
+        try? await lifecycle.reconcile(repoID: repo.id, actuationLog: actuationLog)
         subscriptions.broadcast(delta: .repoAdded(RepoDelta(
             repoID: repo.id, path: repo.path, displayName: repo.displayName)))
         return repo

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -91,6 +91,14 @@ extension RPCRouter {
                 // repo half-dismantled; rowing the whole set first makes the
                 // refusal all-or-nothing, with the repo and every session it
                 // owns still standing.
+                // The edge that leaves: if an append throws partway through
+                // this loop, the rows already written stay unconfirmed and
+                // render that way — while nothing at all was torn down. That is
+                // the honest shape rather than a gap to repair. No refusal
+                // reason means "the record itself failed", and minting one here
+                // would grow the outcome contract for a case where the appends
+                // that carried it would very likely fail too — the log was
+                // unwritable one row ago.
                 var actuationIDs: [String] = []
                 for wt in activeWorktrees {
                     actuationIDs.append(try await beginActuation(

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -63,7 +63,9 @@ extension RPCRouter {
         return repo
     }
 
-    func handleRepoRemove(_ paramsData: Data) async throws -> RPCResponse {
+    func handleRepoRemove(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(RepoRemoveParams.self, from: paramsData)
 
         guard let repo = try await db.repos.get(id: params.repoID) else {
@@ -75,9 +77,43 @@ extension RPCRouter {
 
         if !activeWorktrees.isEmpty {
             if params.force {
-                // Cascade-archive all active worktrees
+                // A forced removal tears down every active worktree's sessions,
+                // killing live windows the operator can see. One row per
+                // worktree, each naming that worktree with no terminal: the
+                // handler resolves the list itself and archives each through its
+                // own `archiveWorktree` call, so these are separate teardowns —
+                // the same reasoning that gives reconcile a row per act, and the
+                // same worktree-named shape `worktree.archive` uses for one.
+                //
+                // Every row is written BEFORE the first teardown, not
+                // interleaved. Fail-closed means an unrecordable act does not
+                // happen, and a cascade that stopped halfway would leave the
+                // repo half-dismantled; rowing the whole set first makes the
+                // refusal all-or-nothing, with the repo and every session it
+                // owns still standing.
+                var actuationIDs: [String] = []
                 for wt in activeWorktrees {
-                    try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+                    actuationIDs.append(try await beginActuation(
+                        .repoRemove, actor: actor,
+                        target: ActuationTarget(worktree: wt.id.uuidString)))
+                }
+
+                // Cascade-archive all active worktrees
+                for (index, wt) in activeWorktrees.enumerated() {
+                    do {
+                        try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+                    } catch {
+                        // The throw ends the cascade, so this row and every row
+                        // behind it names a teardown that did not happen. They
+                        // are confirmed as transport-failed together rather than
+                        // left unconfirmed, which the record would otherwise
+                        // read as an outcome that was merely lost.
+                        for pending in actuationIDs[index...] {
+                            await finishActuation(pending, .transportFailed, error: "\(error)")
+                        }
+                        throw error
+                    }
+                    await finishActuation(actuationIDs[index], .dispatched)
                 }
             } else {
                 return RPCResponse(

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -94,6 +94,10 @@ extension RPCRouter {
     /// forgetWorktree). Shared by `scratch.delete` and `scratch.archive` — both
     /// tear down the terminal/tab state identically before mutating the row
     /// itself (delete removes it, archive flips its status).
+    ///
+    /// Deliberately writes no row: both callers record one worktree-named row of
+    /// their own before calling this, and a row here would double-count every
+    /// teardown (the same reason `captureThenKillWindow` stays silent).
     private func closeScratchTerminals(_ wt: Worktree) async throws {
         let terminals = try await db.terminals.list(worktreeID: wt.id)
         for t in terminals {
@@ -107,7 +111,9 @@ extension RPCRouter {
         }
     }
 
-    func handleScratchDelete(_ paramsData: Data) async throws -> RPCResponse {
+    func handleScratchDelete(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchDeleteParams.self, from: paramsData)
         guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
             return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
@@ -116,7 +122,16 @@ extension RPCRouter {
             return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
         }
 
-        try await closeScratchTerminals(wt)
+        // One row per call naming the scratch space, ahead of the first kill —
+        // the same shape `worktree.archive` uses, and for the same reason: the
+        // per-terminal kills inside the teardown are sub-steps of one intent.
+        // The trashing and the row deletion below touch no process and confirm
+        // nothing, so the outcome lands as soon as the teardown returns.
+        let actuationID = try await beginActuation(
+            .scratchDelete, actor: actor,
+            target: ActuationTarget(worktree: wt.id.uuidString))
+        try await actuating(actuationID) { try await closeScratchTerminals(wt) }
+        await finishActuation(actuationID, .dispatched)
 
         // Move the folder to Trash — never rm -rf. Promoted rows already had
         // their folder moved by promotion (handleScratchPromote sets
@@ -158,7 +173,9 @@ extension RPCRouter {
     /// Archive a scratch space: close its terminals (same teardown as delete)
     /// and flip its status to `.archived`, but leave the folder on disk —
     /// unlike delete, nothing is moved to Trash.
-    func handleScratchArchive(_ paramsData: Data) async throws -> RPCResponse {
+    func handleScratchArchive(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchArchiveParams.self, from: paramsData)
         guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
             return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
@@ -167,7 +184,13 @@ extension RPCRouter {
             return RPCResponse(error: "Not a scratch space: \(params.worktreeID)")
         }
 
-        try await closeScratchTerminals(wt)
+        // Same teardown as `scratch.delete`, so the same row: one per call,
+        // worktree-named, written before the first kill.
+        let actuationID = try await beginActuation(
+            .scratchArchive, actor: actor,
+            target: ActuationTarget(worktree: wt.id.uuidString))
+        try await actuating(actuationID) { try await closeScratchTerminals(wt) }
+        await finishActuation(actuationID, .dispatched)
         try await db.worktrees.archive(id: wt.id)
 
         // Same delta `scratch.delete` broadcasts — deliberate: from the

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -6,7 +6,9 @@ private let scratchLogger = Logger(subsystem: "com.tbd.daemon", category: "scrat
 
 extension RPCRouter {
 
-    func handleScratchCreate(_ paramsData: Data) async throws -> RPCResponse {
+    func handleScratchCreate(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchCreateParams.self, from: paramsData)
         let fm = FileManager.default
         let base = TBDConstants.scratchDir
@@ -48,6 +50,18 @@ extension RPCRouter {
             throw error
         }
 
+        // The same lifecycle spawn `worktree.create` and `worktree.revive`
+        // reach, so it gets the same row: one per call, naming the scratch
+        // space, with no terminal (those are minted inside the spawn). The
+        // folder and the DB row above are not actuations — nothing there
+        // reaches a process — so the row still precedes the first acting step.
+        // An unwritable record refuses the spawn and fails the call; the scratch
+        // space itself stays on disk and usable, which is the same state a
+        // failed spawn already leaves (add a terminal by hand).
+        let actuationID = try await beginActuation(
+            .scratchCreate, actor: actor,
+            target: ActuationTarget(worktree: wt.id.uuidString))
+
         // Spawn the default primary agent terminal (Claude/Codex/shell per the
         // global primary-agent preference), mirroring what repo worktrees get on
         // creation. Best-effort: a spawn failure must not fail scratch creation —
@@ -56,8 +70,13 @@ extension RPCRouter {
         do {
             createdTerminals = try await lifecycle.spawnPrimaryTerminals(
                 worktree: wt, repo: nil, skipClaude: false, preSessionTerminalID: nil)
+            await finishActuation(actuationID, .dispatched)
         } catch {
             scratchLogger.warning("scratch.create: primary terminal spawn failed for \(wt.id, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            // The RPC still succeeds (pre-existing contract — the row and the
+            // folder exist and the user can add a terminal by hand), but the
+            // record must not claim a spawn that failed inside tmux.
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
         }
 
         subscriptions.broadcast(delta: .worktreeCreated(WorktreeDelta(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -146,7 +146,7 @@ extension RPCRouter {
         // Look up repo once for system prompt env vars and Claude session setup
         let repo: Repo?
         if let rid = worktree.repoID {
-            repo = try await db.repos.get(id: rid)
+            repo = try await actuating(actuationID) { try await db.repos.get(id: rid) }
         } else {
             repo = nil
         }
@@ -213,29 +213,31 @@ extension RPCRouter {
                 repo: repo?.envOverrides,
                 profile: nil
             ).merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
-            let window = try await tmux.createWindow(
-                server: worktree.tmuxServer,
-                session: "main",
-                cwd: worktree.path,
-                shellCommand: CodexSpawnCommandBuilder.build(
-                    initialPrompt: params.prompt,
-                    executablePath: codexPreparation.executablePath),
-                env: codexEnv,
-                sensitiveEnv: codexEnvOverrides,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
+            let terminal = try await actuating(actuationID) {
+                let window = try await tmux.createWindow(
+                    server: worktree.tmuxServer,
+                    session: "main",
+                    cwd: worktree.path,
+                    shellCommand: CodexSpawnCommandBuilder.build(
+                        initialPrompt: params.prompt,
+                        executablePath: codexPreparation.executablePath),
+                    env: codexEnv,
+                    sensitiveEnv: codexEnvOverrides,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
 
-            let terminal = try await db.terminals.create(
-                id: plannedTerminalID,
-                worktreeID: params.worktreeID,
-                tmuxWindowID: window.windowID,
-                tmuxPaneID: window.paneID,
-                label: TerminalLabel.codex,
-                claudeSessionID: nil,
-                profileID: nil,
-                kind: .codex
-            )
+                return try await db.terminals.create(
+                    id: plannedTerminalID,
+                    worktreeID: params.worktreeID,
+                    tmuxWindowID: window.windowID,
+                    tmuxPaneID: window.paneID,
+                    label: TerminalLabel.codex,
+                    claudeSessionID: nil,
+                    profileID: nil,
+                    kind: .codex
+                )
+            }
 
             subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
                 terminalID: terminal.id, worktreeID: terminal.worktreeID, label: terminal.label
@@ -402,28 +404,31 @@ extension RPCRouter {
         } else {
             primarySensitiveEnv = spawn.sensitiveEnv
         }
-        let window = try await tmux.createWindow(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            shellCommand: spawn.command,
-            env: env,
-            sensitiveEnv: primarySensitiveEnv,
-            cols: resolvedCols,
-            rows: resolvedRows
-        )
-
         let terminalKind: TerminalKind? = isClaudeType ? .claude : .shell
-        let terminal = try await db.terminals.create(
-            id: plannedTerminalID,
-            worktreeID: params.worktreeID,
-            tmuxWindowID: window.windowID,
-            tmuxPaneID: window.paneID,
-            label: label,
-            claudeSessionID: claudeSessionID,
-            profileID: resolvedProfile?.profileID,
-            kind: terminalKind
-        )
+        let (window, terminal) = try await actuating(actuationID) {
+            let window = try await tmux.createWindow(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                shellCommand: spawn.command,
+                env: env,
+                sensitiveEnv: primarySensitiveEnv,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+
+            let terminal = try await db.terminals.create(
+                id: plannedTerminalID,
+                worktreeID: params.worktreeID,
+                tmuxWindowID: window.windowID,
+                tmuxPaneID: window.paneID,
+                label: label,
+                claudeSessionID: claudeSessionID,
+                profileID: resolvedProfile?.profileID,
+                kind: terminalKind
+            )
+            return (window, terminal)
+        }
 
         subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
             terminalID: terminal.id, worktreeID: terminal.worktreeID, label: terminal.label
@@ -525,20 +530,29 @@ extension RPCRouter {
         // this command's primary cleanup use case. A dead-window row cannot be
         // mid-turn, so it stays closeable without --force.
         if params.respectActivityRails == true,
-           terminal.activityState == .working || terminal.activityState == .waitingForUser,
-           let worktree = try await db.worktrees.get(id: terminal.worktreeID),
-           await tmux.windowExists(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID) {
-            let what = terminal.activityState == .working
-                ? "mid-turn"
-                : "waiting on a permission prompt"
-            let message = "Terminal \(params.terminalID) is \(what) "
-                + "(activityState=\(terminal.activityState.rawValue)). "
-                + "Closing now would kill in-flight work. Pass --force to close anyway."
-            await finishActuation(actuationID, .refused, error: message)
-            return RPCResponse(
-                error: message,
-                code: RPCErrorCode.terminalBusy.rawValue
-            )
+           terminal.activityState == .working || terminal.activityState == .waitingForUser {
+            // Resolved inside the rails branch, not in the condition list, so
+            // the lookup keeps its short-circuit (only reached when the rails
+            // are on and the row looks busy) while a DB failure still confirms
+            // the request row before it propagates.
+            let railWorktree = try await actuating(actuationID) {
+                try await db.worktrees.get(id: terminal.worktreeID)
+            }
+            if let railWorktree,
+               await tmux.windowExists(
+                server: railWorktree.tmuxServer, windowID: terminal.tmuxWindowID) {
+                let what = terminal.activityState == .working
+                    ? "mid-turn"
+                    : "waiting on a permission prompt"
+                let message = "Terminal \(params.terminalID) is \(what) "
+                    + "(activityState=\(terminal.activityState.rawValue)). "
+                    + "Closing now would kill in-flight work. Pass --force to close anyway."
+                await finishActuation(actuationID, .refused, error: message)
+                return RPCResponse(
+                    error: message,
+                    code: RPCErrorCode.terminalBusy.rawValue
+                )
+            }
         }
 
         // Terminal close cancels any pending auto-resume (spec §Cancellation).
@@ -550,7 +564,10 @@ extension RPCRouter {
         // user can view it read-only later (Session History → Closed
         // Terminals). Strictly best-effort: any failure logs inside
         // captureOnClose and the close proceeds unchanged.
-        if let worktree = try await db.worktrees.get(id: terminal.worktreeID) {
+        let worktree = try await actuating(actuationID) {
+            try await db.worktrees.get(id: terminal.worktreeID)
+        }
+        if let worktree {
             await db.terminalHistory.captureOnClose(terminal: terminal) {
                 try await tmux.capturePaneScrollback(
                     server: worktree.tmuxServer, paneID: terminal.tmuxPaneID)
@@ -560,8 +577,10 @@ extension RPCRouter {
         }
 
         // Delete from DB
-        try await db.terminals.delete(id: params.terminalID)
-        try await db.tabs.delete(tabID: params.terminalID)
+        try await actuating(actuationID) {
+            try await db.terminals.delete(id: params.terminalID)
+            try await db.tabs.delete(tabID: params.terminalID)
+        }
         await pendingQuestions.clear(terminalID: params.terminalID)
         await loginSessions.cancelPendingAutoLogin(terminalID: params.terminalID)
 
@@ -643,7 +662,7 @@ extension RPCRouter {
         if entry.kind == .claude, let sessionID = entry.claudeSessionID {
             let repo: Repo?
             if let rid = worktree.repoID {
-                repo = try await db.repos.get(id: rid)
+                repo = try await actuating(actuationID) { try await db.repos.get(id: rid) }
             } else {
                 repo = nil
             }
@@ -703,19 +722,21 @@ extension RPCRouter {
                 repo: repo?.envOverrides,
                 profile: resolvedProfile?.envOverrides
             )
-            let terminal = try await spawnRevivedTerminal(
-                worktree: worktree,
-                plannedTerminalID: plannedTerminalID,
-                spawnCommand: spawn.command,
-                env: env,
-                sensitiveEnv: mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder },
-                label: TerminalLabel.claudeCode,
-                kind: .claude,
-                claudeSessionID: sessionID,
-                profileID: resolvedProfile?.profileID,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
+            let terminal = try await actuating(actuationID) {
+                try await spawnRevivedTerminal(
+                    worktree: worktree,
+                    plannedTerminalID: plannedTerminalID,
+                    spawnCommand: spawn.command,
+                    env: env,
+                    sensitiveEnv: mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder },
+                    label: TerminalLabel.claudeCode,
+                    kind: .claude,
+                    claudeSessionID: sessionID,
+                    profileID: resolvedProfile?.profileID,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
+            }
             logger.info("revive: resumed claude session \(sessionID, privacy: .public) as terminal \(terminal.id, privacy: .public) in worktree \(worktree.id, privacy: .public)")
             await finishActuation(actuationID, .dispatched)
             return try RPCResponse(result: terminal)
@@ -736,19 +757,21 @@ extension RPCRouter {
             "TBD_WORKTREE_ID": worktree.id.uuidString,
             "TBD_TERMINAL_ID": plannedTerminalID.uuidString,
         ]
-        let terminal = try await spawnRevivedTerminal(
-            worktree: worktree,
-            plannedTerminalID: plannedTerminalID,
-            spawnCommand: command,
-            env: env,
-            sensitiveEnv: [:],
-            label: nil,
-            kind: .shell,
-            claudeSessionID: nil,
-            profileID: nil,
-            cols: resolvedCols,
-            rows: resolvedRows
-        )
+        let terminal = try await actuating(actuationID) {
+            try await spawnRevivedTerminal(
+                worktree: worktree,
+                plannedTerminalID: plannedTerminalID,
+                spawnCommand: command,
+                env: env,
+                sensitiveEnv: [:],
+                label: nil,
+                kind: .shell,
+                claudeSessionID: nil,
+                profileID: nil,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+        }
         logger.info("revive: opened shell terminal \(terminal.id, privacy: .public) from history entry \(entry.id, privacy: .public) (capture present: \(haveCapture, privacy: .public))")
         await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: terminal)
@@ -914,13 +937,15 @@ extension RPCRouter {
         let resolvedRows = params.rows ?? TmuxManager.defaultRows
 
         // Ensure tmux server exists
-        _ = try await tmux.ensureServer(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            cols: resolvedCols,
-            rows: resolvedRows
-        )
+        try await actuating(actuationID) {
+            _ = try await tmux.ensureServer(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+        }
         await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
 
         // Branch on terminal kind: codex stays codex; shell/claude become shell
@@ -957,28 +982,32 @@ extension RPCRouter {
                 repo: recreateRepo?.envOverrides,
                 profile: nil
             ).merging(["DISABLE_AUTO_UPDATE": "true"]) { _, forced in forced }
-            let window = try await tmux.createWindow(
-                server: worktree.tmuxServer,
-                session: "main",
-                cwd: worktree.path,
-                shellCommand: CodexSpawnCommandBuilder.command(
-                    executablePath: codexPreparation.executablePath),
-                env: codexEnv,
-                sensitiveEnv: codexEnvOverrides,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
+            let updatedTerminal = try await actuating(actuationID) {
+                let window = try await tmux.createWindow(
+                    server: worktree.tmuxServer,
+                    session: "main",
+                    cwd: worktree.path,
+                    shellCommand: CodexSpawnCommandBuilder.command(
+                        executablePath: codexPreparation.executablePath),
+                    env: codexEnv,
+                    sensitiveEnv: codexEnvOverrides,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
 
-            // Update tmux IDs but DO NOT call clearRecreated — that nukes the label and kind
-            try await db.terminals.updateTmuxIDs(
-                id: params.terminalID,
-                windowID: window.windowID,
-                paneID: window.paneID
-            )
-            try await db.terminals.setActivityState(id: params.terminalID, activityState: .unknown)
+                // Update tmux IDs but DO NOT call clearRecreated — that nukes the label and kind
+                try await db.terminals.updateTmuxIDs(
+                    id: params.terminalID,
+                    windowID: window.windowID,
+                    paneID: window.paneID
+                )
+                try await db.terminals.setActivityState(
+                    id: params.terminalID, activityState: .unknown)
+                return try await db.terminals.get(id: params.terminalID)
+            }
 
             // Return updated terminal
-            guard let updated = try await db.terminals.get(id: params.terminalID) else {
+            guard let updated = updatedTerminal else {
                 await finishActuation(actuationID, .refused, error: "Terminal not found after update")
                 return RPCResponse(error: "Terminal not found after update")
             }
@@ -995,27 +1024,30 @@ extension RPCRouter {
             // identity into this one.
             let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
             let env: [String: String] = ["TBD_WORKTREE_ID": worktree.id.uuidString]
-            let window = try await tmux.createWindow(
-                server: worktree.tmuxServer,
-                session: "main",
-                cwd: worktree.path,
-                shellCommand: shell,
-                env: env,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
+            let updatedTerminal = try await actuating(actuationID) {
+                let window = try await tmux.createWindow(
+                    server: worktree.tmuxServer,
+                    session: "main",
+                    cwd: worktree.path,
+                    shellCommand: shell,
+                    env: env,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
 
-            // Update the terminal record with new window/pane IDs and clear stale
-            // Claude metadata — the recreated window runs a plain shell, not Claude.
-            try await db.terminals.updateTmuxIDs(
-                id: params.terminalID,
-                windowID: window.windowID,
-                paneID: window.paneID
-            )
-            try await db.terminals.clearRecreated(id: params.terminalID)
+                // Update the terminal record with new window/pane IDs and clear stale
+                // Claude metadata — the recreated window runs a plain shell, not Claude.
+                try await db.terminals.updateTmuxIDs(
+                    id: params.terminalID,
+                    windowID: window.windowID,
+                    paneID: window.paneID
+                )
+                try await db.terminals.clearRecreated(id: params.terminalID)
+                return try await db.terminals.get(id: params.terminalID)
+            }
 
             // Return updated terminal
-            guard let updated = try await db.terminals.get(id: params.terminalID) else {
+            guard let updated = updatedTerminal else {
                 await finishActuation(actuationID, .refused, error: "Terminal not found after update")
                 return RPCResponse(error: "Terminal not found after update")
             }
@@ -1538,6 +1570,12 @@ extension RPCRouter {
             profile: resolved?.profileID.uuidString)
 
         let response: RPCResponse
+        // Set when the in-place respawn's tmux call failed. That failure is
+        // deliberately swallowed downstream — the RPC still returns the updated
+        // row (pre-existing contract) — so it is invisible in the response and
+        // has to be carried out separately, or the record would call a failed
+        // respawn `dispatched`.
+        var respawnFailure: String?
         do {
             switch mode {
             case .fork:
@@ -1555,7 +1593,7 @@ extension RPCRouter {
                 )
 
             case .inPlace:
-                response = try await inPlaceSwapRespawn(
+                let outcome = try await inPlaceSwapRespawn(
                     oldTerminal: oldTerminal,
                     worktree: worktree,
                     spawnCommand: spawn.command,
@@ -1567,12 +1605,18 @@ extension RPCRouter {
                     cols: resolvedCols,
                     rows: resolvedRows
                 )
+                response = outcome.response
+                respawnFailure = outcome.respawnError
             }
         } catch {
             await finishActuation(actuationID, .transportFailed, error: "\(error)")
             throw error
         }
-        await finishActuation(actuationID, response: response)
+        if let respawnFailure {
+            await finishActuation(actuationID, .transportFailed, error: respawnFailure)
+        } else {
+            await finishActuation(actuationID, response: response)
+        }
         return response
     }
 
@@ -1639,6 +1683,11 @@ extension RPCRouter {
     /// respawn so a respawn failure still leaves the row on the new account
     /// (the pane shows the error; the user can retry). The transcript was
     /// already carried into the destination config dir upstream.
+    ///
+    /// A failed respawn is therefore invisible in the returned response — by
+    /// design, and unchanged here. `respawnError` reports it out of band so the
+    /// caller's actuation row can say `transport-failed` instead of inheriting
+    /// the response's success.
     private func inPlaceSwapRespawn(
         oldTerminal: Terminal,
         worktree: Worktree,
@@ -1650,10 +1699,11 @@ extension RPCRouter {
         scheduleRecapture: Bool,
         cols: Int,
         rows: Int
-    ) async throws -> RPCResponse {
+    ) async throws -> (response: RPCResponse, respawnError: String?) {
         let server = worktree.tmuxServer
         let paneID = oldTerminal.tmuxPaneID
         let windowID = oldTerminal.tmuxWindowID
+        var respawnError: String?
 
         // 1. Gracefully interrupt the pane's current Claude before respawn.
         //    `respawn-window -k` will forcibly replace it regardless, but a
@@ -1682,8 +1732,10 @@ extension RPCRouter {
         } catch {
             // Failure path: the row keeps the new profile id (respawn can be
             // retried); the pane surfaces the error. Log clearly and still
-            // return the updated row so the app reflects the new account.
+            // return the updated row so the app reflects the new account — but
+            // hand the failure back so the record classifies it truthfully.
             logger.warning("inPlace swap: respawn failed for terminal \(oldTerminal.id, privacy: .public) window \(windowID, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            respawnError = "\(error)"
         }
 
         subscriptions.broadcast(delta: .terminalSessionUpdated(TerminalSessionDelta(
@@ -1706,10 +1758,10 @@ extension RPCRouter {
         }
 
         guard let updated = try await db.terminals.get(id: oldTerminal.id) else {
-            return RPCResponse(error: "Terminal vanished after swap")
+            return (RPCResponse(error: "Terminal vanished after swap"), respawnError)
         }
         logger.info("inPlace swap: terminal \(oldTerminal.id, privacy: .public) switched to profile \(newProfileID?.uuidString ?? "ambient", privacy: .public) in window \(windowID, privacy: .public)")
-        return try RPCResponse(result: updated)
+        return (try RPCResponse(result: updated), respawnError)
     }
 
     /// Best-effort graceful interrupt of a pane's foreground program before an

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -904,16 +904,33 @@ extension RPCRouter {
                 logger.info("recreateWindow: window \(terminal.tmuxWindowID, privacy: .public) for claude terminal \(terminal.id, privacy: .public) is alive — ignoring stale recreate request")
                 return try RPCResponse(result: terminal)
             }
+            // This branch actuates too, and differently: it kills a window the
+            // check above read as gone — a read that can be stale — and parks
+            // the session. That is the same act reconcile's recovery park
+            // performs, so it carries kind `hibernate` through this surface's
+            // own door (`ActuationBranch.recreateWindowRepark`). The row goes in
+            // ahead of the kill, fail-closed: an unrecordable park refuses the
+            // RPC with the window and the row untouched.
+            let reparkID = try await beginActuation(
+                .recreateWindowRepark, actor: actor,
+                target: .local(worktree: worktree.id, terminal: terminal.id))
+
             // Clean up any lingering (almost always already-dead) window to avoid orphans.
             try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
-            // Authoritative `hibernatedAt` column so the unified `wake()` can resume it.
-            try await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID)
-            // Drop any stale pending-question entry — the window the question
-            // belonged to is gone. Mirrors reconcile()/handleTerminalDelete.
-            await pendingQuestions.clear(terminalID: terminal.id)
-            guard let updated = try await db.terminals.get(id: params.terminalID) else {
+            let parked = try await actuating(reparkID) { () -> Terminal? in
+                // Authoritative `hibernatedAt` column so the unified `wake()` can resume it.
+                try await db.terminals.setHibernated(id: terminal.id, sessionID: sessionID)
+                // Drop any stale pending-question entry — the window the question
+                // belonged to is gone. Mirrors reconcile()/handleTerminalDelete.
+                await pendingQuestions.clear(terminalID: terminal.id)
+                return try await db.terminals.get(id: params.terminalID)
+            }
+            guard let updated = parked else {
+                await finishActuation(
+                    reparkID, .refused(.notFound), error: "Terminal not found after suspend")
                 return RPCResponse(error: "Terminal not found after suspend")
             }
+            await finishActuation(reparkID, .dispatched)
             logger.info("recreateWindow: parked claude terminal \(terminal.id, privacy: .public) as suspended — window \(terminal.tmuxWindowID, privacy: .public) gone, session \(sessionID, privacy: .public) preserved")
             return try RPCResponse(result: updated)
         }
@@ -936,9 +953,9 @@ extension RPCRouter {
             codexPreparation = nil
         }
 
-        // Only the respawning branch is an actuation: the re-park branch above
-        // returned already, and it touches nothing but the DB and a window that
-        // was already dead. The row goes here, ahead of the first kill.
+        // The respawning branch's own row, ahead of its first kill. The re-park
+        // branch above wrote its own before returning — it is an actuation in
+        // its own right, not a DB-only edit.
         let actuationID = try await beginActuation(
             .terminalRecreateWindow, actor: actor,
             target: .local(worktree: worktree.id, terminal: terminal.id),

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -181,7 +181,7 @@ extension RPCRouter {
         if params.type == .codex {
             guard let codexPreparation else {
                 await finishActuation(
-                    actuationID, .refused,
+                    actuationID, .refused(.notEligible),
                     error: "Codex launch preparation unexpectedly returned no result.")
                 return RPCResponse(
                     error: "Codex launch preparation unexpectedly returned no result.")
@@ -278,17 +278,17 @@ extension RPCRouter {
         if isLoginSession {
             guard isClaudeType else {
                 let message = "Login sessions must be Claude terminals (type: claude)"
-                await finishActuation(actuationID, .refused, error: message)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
             guard params.overrideProfileID != nil else {
                 let message = "Login sessions require a profile (overrideProfileID)"
-                await finishActuation(actuationID, .refused, error: message)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
             guard resolvedProfile != nil else {
                 let message = "Profile not found or unreadable — cannot open a login session for it"
-                await finishActuation(actuationID, .refused, error: message)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
         }
@@ -547,7 +547,7 @@ extension RPCRouter {
                 let message = "Terminal \(params.terminalID) is \(what) "
                     + "(activityState=\(terminal.activityState.rawValue)). "
                     + "Closing now would kill in-flight work. Pass --force to close anyway."
-                await finishActuation(actuationID, .refused, error: message)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(
                     error: message,
                     code: RPCErrorCode.terminalBusy.rawValue
@@ -953,7 +953,7 @@ extension RPCRouter {
             // Recreate as codex — preserve identity
             guard let codexPreparation else {
                 let message = "Codex launch preparation was unavailable"
-                await finishActuation(actuationID, .refused, error: message)
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
             var codexEnv: [String: String] = [:]
@@ -1008,7 +1008,8 @@ extension RPCRouter {
 
             // Return updated terminal
             guard let updated = updatedTerminal else {
-                await finishActuation(actuationID, .refused, error: "Terminal not found after update")
+                await finishActuation(
+                    actuationID, .refused(.notFound), error: "Terminal not found after update")
                 return RPCResponse(error: "Terminal not found after update")
             }
 
@@ -1048,7 +1049,8 @@ extension RPCRouter {
 
             // Return updated terminal
             guard let updated = updatedTerminal else {
-                await finishActuation(actuationID, .refused, error: "Terminal not found after update")
+                await finishActuation(
+                    actuationID, .refused(.notFound), error: "Terminal not found after update")
                 return RPCResponse(error: "Terminal not found after update")
             }
 
@@ -1615,7 +1617,9 @@ extension RPCRouter {
         if let respawnFailure {
             await finishActuation(actuationID, .transportFailed, error: respawnFailure)
         } else {
-            await finishActuation(actuationID, response: response)
+            // The only unsuccessful response either swap branch returns is
+            // "Terminal vanished after swap" — the row it respawned is gone.
+            await finishActuation(actuationID, response: response, refusedAs: .notFound)
         }
         return response
     }

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -64,7 +64,9 @@ extension RPCRouter {
 
     // MARK: - Terminal Handlers
 
-    func handleTerminalCreate(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalCreate(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalCreateParams.self, from: paramsData)
 
         // Look up the worktree to get tmux server and path
@@ -108,14 +110,37 @@ extension RPCRouter {
         let resolvedCols = params.cols ?? TmuxManager.defaultCols
         let resolvedRows = params.rows ?? TmuxManager.defaultRows
 
+        // Pre-mint the terminal ID so we can inject it into the spawned env
+        // as TBD_TERMINAL_ID. Claude's SessionStart hook (registered via the
+        // TBD overlay file) reads this env var to route session events back
+        // to the right terminal record. Minted here, ahead of any tmux call,
+        // so the actuation row below can name the terminal it is about to
+        // spawn.
+        let plannedTerminalID = UUID()
+
+        // Request row before the first mutating step. `profile` is deliberately
+        // absent: it is resolved further down, after the tmux server exists, and
+        // reordering that resolution would move which failures happen before the
+        // server is created.
+        let actuationID = try await beginActuation(
+            .terminalCreate, actor: actor,
+            target: .local(worktree: params.worktreeID, terminal: plannedTerminalID),
+            prompt: params.prompt,
+            agent: (params.type ?? .shell).rawValue)
+
         // Ensure tmux server exists before creating window
-        _ = try await tmux.ensureServer(
-            server: worktree.tmuxServer,
-            session: "main",
-            cwd: worktree.path,
-            cols: resolvedCols,
-            rows: resolvedRows
-        )
+        do {
+            _ = try await tmux.ensureServer(
+                server: worktree.tmuxServer,
+                session: "main",
+                cwd: worktree.path,
+                cols: resolvedCols,
+                rows: resolvedRows
+            )
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
         await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
 
         // Look up repo once for system prompt env vars and Claude session setup
@@ -130,12 +155,6 @@ extension RPCRouter {
         // free-form env overrides (global < repo < profile). The profile scope
         // is folded in per-branch once the profile is resolved.
         let createConfig = try? await db.config.get()
-
-        // Pre-mint the terminal ID so we can inject it into the spawned env
-        // as TBD_TERMINAL_ID. Claude's SessionStart hook (registered via the
-        // TBD overlay file) reads this env var to route session events back
-        // to the right terminal record.
-        let plannedTerminalID = UUID()
 
         // Build env vars available in all TBD terminals
         var env = SystemPromptBuilder.promptLayers(
@@ -161,6 +180,9 @@ extension RPCRouter {
         // Codex pane.
         if params.type == .codex {
             guard let codexPreparation else {
+                await finishActuation(
+                    actuationID, .refused,
+                    error: "Codex launch preparation unexpectedly returned no result.")
                 return RPCResponse(
                     error: "Codex launch preparation unexpectedly returned no result.")
             }
@@ -219,6 +241,7 @@ extension RPCRouter {
                 terminalID: terminal.id, worktreeID: terminal.worktreeID, label: terminal.label
             )))
 
+            await finishActuation(actuationID, .dispatched)
             return try RPCResponse(result: terminal)
         }
 
@@ -252,13 +275,19 @@ extension RPCRouter {
         // surface the error instead of leaving a ghost tab.
         if isLoginSession {
             guard isClaudeType else {
-                return RPCResponse(error: "Login sessions must be Claude terminals (type: claude)")
+                let message = "Login sessions must be Claude terminals (type: claude)"
+                await finishActuation(actuationID, .refused, error: message)
+                return RPCResponse(error: message)
             }
             guard params.overrideProfileID != nil else {
-                return RPCResponse(error: "Login sessions require a profile (overrideProfileID)")
+                let message = "Login sessions require a profile (overrideProfileID)"
+                await finishActuation(actuationID, .refused, error: message)
+                return RPCResponse(error: message)
             }
             guard resolvedProfile != nil else {
-                return RPCResponse(error: "Profile not found or unreadable — cannot open a login session for it")
+                let message = "Profile not found or unreadable — cannot open a login session for it"
+                await finishActuation(actuationID, .refused, error: message)
+                return RPCResponse(error: message)
             }
         }
 
@@ -409,6 +438,7 @@ extension RPCRouter {
             )
         }
 
+        await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: terminal)
     }
 
@@ -462,7 +492,9 @@ extension RPCRouter {
     }
 
 
-    func handleTerminalDelete(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalDelete(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalDeleteParams.self, from: paramsData)
 
         // Closing an already-closed terminal is a no-op SUCCESS, not an error —
@@ -472,6 +504,14 @@ extension RPCRouter {
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
             return try RPCResponse(result: TerminalDeleteResult(closed: false, alreadyGone: true))
         }
+
+        // Request row before the rails check, not after: the rails only read
+        // state, and a refusal to close a busy session is itself something the
+        // record should show. A close of an already-gone terminal returns above
+        // without a row — nothing was acted on.
+        let actuationID = try await beginActuation(
+            .terminalDelete, actor: actor,
+            target: .local(worktree: terminal.worktreeID, terminal: terminal.id))
 
         // Optional rails (CLI sets them; --force drops them; the app never
         // does). Refuse to kill an in-flight turn or a raised permission hand,
@@ -491,10 +531,12 @@ extension RPCRouter {
             let what = terminal.activityState == .working
                 ? "mid-turn"
                 : "waiting on a permission prompt"
+            let message = "Terminal \(params.terminalID) is \(what) "
+                + "(activityState=\(terminal.activityState.rawValue)). "
+                + "Closing now would kill in-flight work. Pass --force to close anyway."
+            await finishActuation(actuationID, .refused, error: message)
             return RPCResponse(
-                error: "Terminal \(params.terminalID) is \(what) "
-                    + "(activityState=\(terminal.activityState.rawValue)). "
-                    + "Closing now would kill in-flight work. Pass --force to close anyway.",
+                error: message,
                 code: RPCErrorCode.terminalBusy.rawValue
             )
         }
@@ -531,6 +573,7 @@ extension RPCRouter {
             terminalID: terminal.id
         )))
 
+        await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: TerminalDeleteResult(
             closed: true,
             alreadyGone: false,
@@ -552,7 +595,9 @@ extension RPCRouter {
     /// Claude session (no scrollback replay — Claude repaints its transcript);
     /// every other kind opens a fresh shell with the raw capture (colors
     /// intact) printed above the prompt. The history row is kept.
-    func handleTerminalHistoryRevive(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalHistoryRevive(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalHistoryReviveParams.self, from: paramsData)
 
         guard let worktree = try await db.worktrees.get(id: params.worktreeID) else {
@@ -576,9 +621,21 @@ extension RPCRouter {
         let plannedTerminalID = UUID()
         let defaultShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
 
-        _ = try await tmux.ensureServer(
-            server: worktree.tmuxServer, session: "main", cwd: worktree.path,
-            cols: resolvedCols, rows: resolvedRows)
+        // Request row after the terminal ID is minted and before the first
+        // tmux act, so it names the session it is about to bring back.
+        let actuationID = try await beginActuation(
+            .terminalHistoryRevive, actor: actor,
+            target: .local(worktree: worktree.id, terminal: plannedTerminalID),
+            agent: (entry.kind ?? .shell).rawValue)
+
+        do {
+            _ = try await tmux.ensureServer(
+                server: worktree.tmuxServer, session: "main", cwd: worktree.path,
+                cols: resolvedCols, rows: resolvedRows)
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
         await controlMode?.enableIfGated(serverName: worktree.tmuxServer)
 
         // Claude-kind with a live session id → resume it. Mirrors the
@@ -660,6 +717,7 @@ extension RPCRouter {
                 rows: resolvedRows
             )
             logger.info("revive: resumed claude session \(sessionID, privacy: .public) as terminal \(terminal.id, privacy: .public) in worktree \(worktree.id, privacy: .public)")
+            await finishActuation(actuationID, .dispatched)
             return try RPCResponse(result: terminal)
         }
 
@@ -692,6 +750,7 @@ extension RPCRouter {
             rows: resolvedRows
         )
         logger.info("revive: opened shell terminal \(terminal.id, privacy: .public) from history entry \(entry.id, privacy: .public) (capture present: \(haveCapture, privacy: .public))")
+        await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: terminal)
     }
 
@@ -776,7 +835,9 @@ extension RPCRouter {
         return .ok()
     }
 
-    func handleTerminalRecreateWindow(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalRecreateWindow(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalRecreateWindowParams.self, from: paramsData)
 
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
@@ -838,6 +899,14 @@ extension RPCRouter {
             codexPreparation = nil
         }
 
+        // Only the respawning branch is an actuation: the re-park branch above
+        // returned already, and it touches nothing but the DB and a window that
+        // was already dead. The row goes here, ahead of the first kill.
+        let actuationID = try await beginActuation(
+            .terminalRecreateWindow, actor: actor,
+            target: .local(worktree: worktree.id, terminal: terminal.id),
+            agent: (terminal.kind ?? .shell).rawValue)
+
         // Kill the old window if it still exists (avoids orphans)
         try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
 
@@ -858,7 +927,9 @@ extension RPCRouter {
         if terminal.kind == .codex || terminal.label == TerminalLabel.codex {
             // Recreate as codex — preserve identity
             guard let codexPreparation else {
-                return RPCResponse(error: "Codex launch preparation was unavailable")
+                let message = "Codex launch preparation was unavailable"
+                await finishActuation(actuationID, .refused, error: message)
+                return RPCResponse(error: message)
             }
             var codexEnv: [String: String] = [:]
             codexEnv["TBD_WORKTREE_ID"] = worktree.id.uuidString
@@ -908,9 +979,11 @@ extension RPCRouter {
 
             // Return updated terminal
             guard let updated = try await db.terminals.get(id: params.terminalID) else {
+                await finishActuation(actuationID, .refused, error: "Terminal not found after update")
                 return RPCResponse(error: "Terminal not found after update")
             }
 
+            await finishActuation(actuationID, .dispatched)
             return try RPCResponse(result: updated)
         } else {
             // Recreate as shell (claude or shell terminal becomes a plain shell)
@@ -943,9 +1016,11 @@ extension RPCRouter {
 
             // Return updated terminal
             guard let updated = try await db.terminals.get(id: params.terminalID) else {
+                await finishActuation(actuationID, .refused, error: "Terminal not found after update")
                 return RPCResponse(error: "Terminal not found after update")
             }
 
+            await finishActuation(actuationID, .dispatched)
             return try RPCResponse(result: updated)
         }
     }
@@ -1179,7 +1254,9 @@ extension RPCRouter {
         return fm.fileExists(atPath: candidate.path) ? candidate : nil
     }
 
-    func handleTerminalSwapProfile(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalSwapProfile(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSwapProfileParams.self, from: paramsData)
 
         guard let oldTerminal = try await db.terminals.get(id: params.terminalID) else {
@@ -1446,35 +1523,57 @@ extension RPCRouter {
         let resolvedRows = params.rows ?? TmuxManager.defaultRows
         let sensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
 
-        switch mode {
-        case .fork:
-            return try await forkSwapNewTab(
-                worktree: worktree,
-                plannedTerminalID: plannedTerminalID,
-                spawnCommand: spawn.command,
-                env: env,
-                sensitiveEnv: sensitiveEnv,
-                storedSessionID: storedSessionID,
-                profileID: resolved?.profileID,
-                scheduleRecapture: scheduleRecapture,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
+        // One row for the whole swap, on the two branches that actually
+        // reshape a live session. The interrupt the in-place branch sends
+        // first is a sub-step of this one actuation, not a send of its own —
+        // and the cold (parked) swap returned above without a row, because
+        // re-homing a parked row touches no process. `.fork` names the new
+        // terminal it is about to spawn; `.inPlace` names the one it respawns.
+        let actuationID = try await beginActuation(
+            .terminalSwapProfile, actor: actor,
+            target: .local(
+                worktree: worktree.id,
+                terminal: mode == .fork ? plannedTerminalID : oldTerminal.id),
+            agent: TerminalKind.claude.rawValue,
+            profile: resolved?.profileID.uuidString)
 
-        case .inPlace:
-            return try await inPlaceSwapRespawn(
-                oldTerminal: oldTerminal,
-                worktree: worktree,
-                spawnCommand: spawn.command,
-                env: env,
-                sensitiveEnv: sensitiveEnv,
-                storedSessionID: storedSessionID,
-                newProfileID: resolved?.profileID,
-                scheduleRecapture: scheduleRecapture,
-                cols: resolvedCols,
-                rows: resolvedRows
-            )
+        let response: RPCResponse
+        do {
+            switch mode {
+            case .fork:
+                response = try await forkSwapNewTab(
+                    worktree: worktree,
+                    plannedTerminalID: plannedTerminalID,
+                    spawnCommand: spawn.command,
+                    env: env,
+                    sensitiveEnv: sensitiveEnv,
+                    storedSessionID: storedSessionID,
+                    profileID: resolved?.profileID,
+                    scheduleRecapture: scheduleRecapture,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
+
+            case .inPlace:
+                response = try await inPlaceSwapRespawn(
+                    oldTerminal: oldTerminal,
+                    worktree: worktree,
+                    spawnCommand: spawn.command,
+                    env: env,
+                    sensitiveEnv: sensitiveEnv,
+                    storedSessionID: storedSessionID,
+                    newProfileID: resolved?.profileID,
+                    scheduleRecapture: scheduleRecapture,
+                    cols: resolvedCols,
+                    rows: resolvedRows
+                )
+            }
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
         }
+        await finishActuation(actuationID, response: response)
+        return response
     }
 
     /// `.fork` swap: spawn a NEW window + terminal row in the same worktree,
@@ -1649,7 +1748,9 @@ extension RPCRouter {
         )
     }
 
-    func handleTerminalSend(_ paramsData: Data) async throws -> RPCResponse {
+    func handleTerminalSend(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSendParams.self, from: paramsData)
 
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
@@ -1660,6 +1761,14 @@ extension RPCRouter {
         guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
+
+        // Request row first: the target is resolved and the payload is known,
+        // and nothing has touched the pane yet. The paste and the Enter are
+        // sub-steps of one send, so they share this one row.
+        let actuationID = try await beginActuation(
+            .terminalSend, actor: actor,
+            target: .local(worktree: terminal.worktreeID, terminal: terminal.id),
+            message: params.text, submit: params.submit == true)
 
         // Deliver the body as an EXPLICIT bracketed paste (load-buffer +
         // paste-buffer -d -p) rather than raw `send-keys -l`. For payloads
@@ -1672,22 +1781,28 @@ extension RPCRouter {
         // both enable it at the prompt; cooked-mode consumers get bare bytes and
         // behave as before. Skip an empty body entirely (don't paste an empty
         // buffer) but still press Enter below if requested.
-        if !params.text.isEmpty {
-            try await tmux.pasteText(
-                server: worktree.tmuxServer,
-                paneID: terminal.tmuxPaneID,
-                bytes: Data(params.text.utf8)
-            )
+        do {
+            if !params.text.isEmpty {
+                try await tmux.pasteText(
+                    server: worktree.tmuxServer,
+                    paneID: terminal.tmuxPaneID,
+                    bytes: Data(params.text.utf8)
+                )
+            }
+
+            if params.submit == true {
+                try await tmux.sendKey(
+                    server: worktree.tmuxServer,
+                    paneID: terminal.tmuxPaneID,
+                    key: "Enter"
+                )
+            }
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
         }
 
-        if params.submit == true {
-            try await tmux.sendKey(
-                server: worktree.tmuxServer,
-                paneID: terminal.tmuxPaneID,
-                key: "Enter"
-            )
-        }
-
+        await finishActuation(actuationID, .dispatched)
         return .ok()
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -567,13 +567,23 @@ extension RPCRouter {
         let worktree = try await actuating(actuationID) {
             try await db.worktrees.get(id: terminal.worktreeID)
         }
+        // Set when the kill itself failed. The deletion proceeds regardless
+        // (pre-existing contract — the row goes and the response is the same),
+        // so the failure is invisible in the response and has to be carried out
+        // separately, or the record would call a failed kill `dispatched`.
+        var killWindowFailure: String?
         if let worktree {
             await db.terminalHistory.captureOnClose(terminal: terminal) {
                 try await tmux.capturePaneScrollback(
                     server: worktree.tmuxServer, paneID: terminal.tmuxPaneID)
             }
             // Kill the tmux window
-            try? await tmux.killWindow(server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
+            do {
+                try await tmux.killWindow(
+                    server: worktree.tmuxServer, windowID: terminal.tmuxWindowID)
+            } catch {
+                killWindowFailure = "\(error)"
+            }
         }
 
         // Delete from DB
@@ -592,7 +602,11 @@ extension RPCRouter {
             terminalID: terminal.id
         )))
 
-        await finishActuation(actuationID, .dispatched)
+        if let killWindowFailure {
+            await finishActuation(actuationID, .transportFailed, error: killWindowFailure)
+        } else {
+            await finishActuation(actuationID, .dispatched)
+        }
         return try RPCResponse(result: TerminalDeleteResult(
             closed: true,
             alreadyGone: false,
@@ -1421,6 +1435,23 @@ extension RPCRouter {
         )
         let plan = Self.planTerminalSwap(oldSessionID: sessionID, isBlank: blank)
 
+        // One row for the whole swap, on the two branches that actually reshape
+        // a live session. It sits here, as soon as the plan names what will be
+        // acted on, because the very next step already mutates state outside the
+        // daemon: the resume path copies the session transcript into the
+        // destination profile's config dir. The interrupt the in-place branch
+        // sends later is a sub-step of this one actuation, not a send of its
+        // own — and the cold (parked) swap returned above without a row, because
+        // re-homing a parked row touches no process. `.fork` names the new
+        // terminal it is about to spawn; `.inPlace` names the one it respawns.
+        let actuationID = try await beginActuation(
+            .terminalSwapProfile, actor: actor,
+            target: .local(
+                worktree: worktree.id,
+                terminal: mode == .fork ? plannedTerminalID : oldTerminal.id),
+            agent: TerminalKind.claude.rawValue,
+            profile: resolved?.profileID.uuidString)
+
         // Carry the session transcript into the DESTINATION config dir so the
         // forked `claude --resume <id>` finds the conversation. Only matters on
         // the resume path — a fresh spawn has no prior transcript to carry.
@@ -1556,20 +1587,6 @@ extension RPCRouter {
         let resolvedCols = params.cols ?? TmuxManager.defaultCols
         let resolvedRows = params.rows ?? TmuxManager.defaultRows
         let sensitiveEnv = mergedEnvOverrides.merging(spawn.sensitiveEnv) { _, builder in builder }
-
-        // One row for the whole swap, on the two branches that actually
-        // reshape a live session. The interrupt the in-place branch sends
-        // first is a sub-step of this one actuation, not a send of its own —
-        // and the cold (parked) swap returned above without a row, because
-        // re-homing a parked row touches no process. `.fork` names the new
-        // terminal it is about to spawn; `.inPlace` names the one it respawns.
-        let actuationID = try await beginActuation(
-            .terminalSwapProfile, actor: actor,
-            target: .local(
-                worktree: worktree.id,
-                terminal: mode == .fork ? plannedTerminalID : oldTerminal.id),
-            agent: TerminalKind.claude.rawValue,
-            profile: resolved?.profileID.uuidString)
 
         let response: RPCResponse
         // Set when the in-place respawn's tmux call failed. That failure is
@@ -1984,7 +2001,7 @@ extension RPCRouter {
             // Reconcile DB against actual git worktree list
             do {
                 let beforeCount = try await db.worktrees.list(repoID: repo.id, status: .active).count
-                try await lifecycle.reconcile(repoID: repo.id)
+                try await lifecycle.reconcile(repoID: repo.id, actuationLog: actuationLog)
                 let afterCount = try await db.worktrees.list(repoID: repo.id, status: .active).count
                 let delta = abs(beforeCount - afterCount)
                 worktreesReconciled += delta

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -223,20 +223,35 @@ extension RPCRouter {
         ))
     }
 
-    func handleWorktreeRevive(_ paramsData: Data) async throws -> RPCResponse {
+    func handleWorktreeRevive(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeReviveParams.self, from: paramsData)
+        // The row names the worktree, not a terminal: revive spawns its
+        // primary terminals inside the lifecycle's own (possibly detached,
+        // pre-session-gated) phase, so no terminal ID exists to name yet.
+        let actuationID = try await beginActuation(
+            .worktreeRevive, actor: actor,
+            target: ActuationTarget(worktree: params.worktreeID.uuidString))
         // Non-blocking: when a preSession hook gates the primary terminals,
         // this returns promptly with the row in `.creating` (which is what
         // the app gates its pre-session UI on — beginReviveWorktree flips it
         // before returning) and the detached phase-3 task finishes the revive
         // in the background. Blocking here for up to the hook timeout (600s)
         // would starve the RPC connection.
-        let completion = try await lifecycle.beginReviveWorktree(
-            worktreeID: params.worktreeID,
-            cols: params.cols,
-            rows: params.rows,
-            preferredSessionID: params.preferredSessionID
-        )
+        let completion: WorktreeReviveCompletion
+        do {
+            completion = try await lifecycle.beginReviveWorktree(
+                worktreeID: params.worktreeID,
+                cols: params.cols,
+                rows: params.rows,
+                preferredSessionID: params.preferredSessionID
+            )
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
+        await finishActuation(actuationID, .dispatched)
         let worktree = completion.worktree
 
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
@@ -248,7 +263,7 @@ extension RPCRouter {
     }
 
     func handleWorktreeReviveConversationFresh(
-        _ paramsData: Data
+        _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
         let params = try decoder.decode(
             WorktreeReviveConversationFreshParams.self,
@@ -266,28 +281,42 @@ extension RPCRouter {
             )
         }
 
+        // As in `handleWorktreeRevive`: the new worktree and its terminals are
+        // minted inside the lifecycle, so the row names the source worktree
+        // whose conversation is being brought back.
+        let actuationID = try await beginActuation(
+            .worktreeReviveConversationFresh, actor: actor,
+            target: ActuationTarget(worktree: params.archivedWorktreeID.uuidString))
+
         let lifecycle = self.lifecycle
         let outcome: (
             completion: WorktreeCreateCompletion,
             result: WorktreeReviveConversationFreshResult
-        ) = try await withCheckedThrowingContinuation { continuation in
-            Task {
-                await repoSerializer.submit(repoID: repoID) {
-                    do {
-                        let outcome = try await lifecycle
-                            .reviveConversationOnFreshBranch(
-                                archivedWorktreeID: params.archivedWorktreeID,
-                                sessionID: params.sessionID,
-                                cols: params.cols,
-                                rows: params.rows
-                            )
-                        continuation.resume(returning: outcome)
-                    } catch {
-                        continuation.resume(throwing: error)
+        )
+        do {
+            outcome = try await withCheckedThrowingContinuation { continuation in
+                Task {
+                    await repoSerializer.submit(repoID: repoID) {
+                        do {
+                            let outcome = try await lifecycle
+                                .reviveConversationOnFreshBranch(
+                                    archivedWorktreeID: params.archivedWorktreeID,
+                                    sessionID: params.sessionID,
+                                    cols: params.cols,
+                                    rows: params.rows
+                                )
+                            continuation.resume(returning: outcome)
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
                     }
                 }
             }
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
         }
+        await finishActuation(actuationID, .dispatched)
 
         let created = outcome.result.worktree
         switch outcome.completion {

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -28,6 +28,17 @@ extension RPCRouter {
             prNumber: params.prNumber
         )
 
+        // Reads precede the row; the row precedes the acts. This lookup is a
+        // plain DB read, so a missing repo is pre-row validation — the create is
+        // refused before anything claims it was about to be dispatched, exactly
+        // as the worktree-not-found guards on the sibling handlers do.
+        guard let repo = try await db.repos.get(id: params.repoID) else {
+            // Mirror completeCreateWorktree's guard: clean up the .creating row
+            // inserted by beginCreateWorktree so it can't be orphaned forever.
+            try? await db.worktrees.delete(id: pending.id)
+            throw WorktreeLifecycleError.repoNotFound(params.repoID)
+        }
+
         // Creation ends in a spawn — the lifecycle's phase 2/3 opens this
         // worktree's primary terminals, the same call `worktree.revive` reaches
         // — so it gets the same shape of row: one per call, naming the worktree,
@@ -40,24 +51,10 @@ extension RPCRouter {
                 .worktreeCreate, actor: actor,
                 target: ActuationTarget(worktree: pending.id.uuidString))
         } catch {
-            // Same cleanup the repo guard below does: an unrecordable spawn is
+            // Same cleanup the repo guard above does: an unrecordable spawn is
             // refused, so don't leave the `.creating` row orphaned forever.
             try? await db.worktrees.delete(id: pending.id)
             throw error
-        }
-
-        // Phase 1.5: Fetch from origin (coalesced, with tight timeout)
-        // Fire off as a background task so it doesn't block the RPC response.
-        // Phase 2 will re-await before git worktree add; FetchCache's singleflight
-        // means the second await joins the in-flight fetch or is a no-op if cached.
-        let repoRow = try await actuating(actuationID) { try await db.repos.get(id: params.repoID) }
-        guard let repo = repoRow else {
-            // Mirror completeCreateWorktree's guard: clean up the .creating row
-            // inserted by beginCreateWorktree so it can't be orphaned forever.
-            try? await db.worktrees.delete(id: pending.id)
-            await finishActuation(
-                actuationID, .refused(.notFound), error: "Repo not found: \(params.repoID)")
-            throw WorktreeLifecycleError.repoNotFound(params.repoID)
         }
 
         // Arm the per-worktree auto-archive-on-merge override when the spawn
@@ -70,6 +67,10 @@ extension RPCRouter {
             }
         }
 
+        // Phase 1.5: Fetch from origin (coalesced, with tight timeout)
+        // Fire off as a background task so it doesn't block the RPC response.
+        // Phase 2 will re-await before git worktree add; FetchCache's singleflight
+        // means the second await joins the in-flight fetch or is a no-op if cached.
         let repoPath = repo.path
         let defaultBranch = repo.defaultBranch
         let fetchCache = self.fetchCache
@@ -192,11 +193,31 @@ extension RPCRouter {
         return try RPCResponse(result: worktrees)
     }
 
-    func handleWorktreeArchive(_ paramsData: Data) async throws -> RPCResponse {
+    func handleWorktreeArchive(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeArchiveParams.self, from: paramsData)
 
+        // One row per call, naming the worktree and no terminal: the caller
+        // asked to archive a worktree, and the per-terminal captures and kills
+        // are how `WorktreeLifecycle`'s phase 1 carries that out — sub-steps of
+        // one intent, not separate actuations. Same shape as `worktree.create`,
+        // for the same reason.
+        let actuationID = try await beginActuation(
+            .worktreeArchive, actor: actor,
+            target: ActuationTarget(worktree: params.worktreeID.uuidString))
+
         // Phase 1: Fast — update DB, kill tmux, return immediately
-        let (worktree, repo) = try await lifecycle.beginArchiveWorktree(worktreeID: params.worktreeID)
+        let worktree: Worktree
+        let repo: Repo
+        do {
+            (worktree, repo) = try await lifecycle.beginArchiveWorktree(
+                worktreeID: params.worktreeID)
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
+        await finishActuation(actuationID, .dispatched)
 
         subscriptions.broadcast(delta: .worktreeArchived(WorktreeIDDelta(
             worktreeID: params.worktreeID
@@ -218,24 +239,66 @@ extension RPCRouter {
     /// Rejections (`no hook`, `already running`, `still creating`) come back as
     /// RPC errors and surface as an app alert — the menu hides the item when no
     /// hook resolves, but the app's view can be a keystroke stale.
-    func handleWorktreeRerunPreSession(_ paramsData: Data) async throws -> RPCResponse {
+    func handleWorktreeRerunPreSession(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeRerunPreSessionParams.self, from: paramsData)
+        // The hook's terminal is minted inside the lifecycle, so — as with
+        // `worktree.revive` — the row names the worktree and no terminal. Every
+        // rejection below happens after the row and confirms it as refused: the
+        // lifecycle owns those checks, and duplicating them here to get ahead of
+        // the row would be two implementations of one rule.
+        let actuationID = try await beginActuation(
+            .worktreeRerunPreSession, actor: actor,
+            target: ActuationTarget(worktree: params.worktreeID.uuidString))
         do {
             try await lifecycle.rerunPreSessionHook(worktreeID: params.worktreeID, cols: params.cols, rows: params.rows)
+            await finishActuation(actuationID, .dispatched)
             return .ok()
         } catch let error as RerunPreSessionError {
+            await finishActuation(
+                actuationID, .refused(Self.refusedReason(error)), error: error.description)
             return RPCResponse(error: error.description)
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
         }
     }
 
-    func handleWorktreeForget(_ paramsData: Data) async throws -> RPCResponse {
+    /// Why a pre-session re-run was declined, in the record's closed vocabulary
+    /// — so "which acts did my controls stop?" is a query over the envelope
+    /// rather than a match on a message that may be reworded.
+    private static func refusedReason(_ error: RerunPreSessionError) -> RefusedReason {
+        switch error {
+        case .worktreeNotFound: return .notFound
+        case .noHookConfigured: return .notEligible
+        // Both mean the same thing to a reader: this worktree's hook is already
+        // running, under a manual re-run or under the create/revive phase 3.
+        case .alreadyRunning, .worktreeBusy: return .inFlight
+        }
+    }
+
+    func handleWorktreeForget(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeForgetParams.self, from: paramsData)
 
         // Capture the path before the row is deleted so the result can report
         // the directory we deliberately left on disk.
         let path = try await db.worktrees.get(id: params.worktreeID)?.path
 
-        try await lifecycle.forgetWorktree(worktreeID: params.worktreeID)
+        // Forget kills the same windows archive does, so it records the same
+        // shape: one worktree-named row per call, ahead of the first kill.
+        let actuationID = try await beginActuation(
+            .worktreeForget, actor: actor,
+            target: ActuationTarget(worktree: params.worktreeID.uuidString))
+        do {
+            try await lifecycle.forgetWorktree(worktreeID: params.worktreeID)
+        } catch {
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
+        await finishActuation(actuationID, .dispatched)
 
         // Reuse the archive delta — from the client's perspective the row has
         // left the active list, which is exactly what `.worktreeArchived`

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -8,7 +8,9 @@ extension RPCRouter {
 
     // MARK: - Worktree Handlers
 
-    func handleWorktreeCreate(_ paramsData: Data) async throws -> RPCResponse {
+    func handleWorktreeCreate(
+        _ paramsData: Data, actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
         let params = try decoder.decode(WorktreeCreateParams.self, from: paramsData)
         let useExistingBranch = params.useExistingBranch ?? false
 
@@ -26,14 +28,35 @@ extension RPCRouter {
             prNumber: params.prNumber
         )
 
+        // Creation ends in a spawn — the lifecycle's phase 2/3 opens this
+        // worktree's primary terminals, the same call `worktree.revive` reaches
+        // — so it gets the same shape of row: one per call, naming the worktree,
+        // with no terminal (those are minted inside the lifecycle phase). Phase
+        // 1 above is DB-only and touches no process, which is why the row can
+        // sit after it and still precede every acting step.
+        let actuationID: String
+        do {
+            actuationID = try await beginActuation(
+                .worktreeCreate, actor: actor,
+                target: ActuationTarget(worktree: pending.id.uuidString))
+        } catch {
+            // Same cleanup the repo guard below does: an unrecordable spawn is
+            // refused, so don't leave the `.creating` row orphaned forever.
+            try? await db.worktrees.delete(id: pending.id)
+            throw error
+        }
+
         // Phase 1.5: Fetch from origin (coalesced, with tight timeout)
         // Fire off as a background task so it doesn't block the RPC response.
         // Phase 2 will re-await before git worktree add; FetchCache's singleflight
         // means the second await joins the in-flight fetch or is a no-op if cached.
-        guard let repo = try await db.repos.get(id: params.repoID) else {
+        let repoRow = try await actuating(actuationID) { try await db.repos.get(id: params.repoID) }
+        guard let repo = repoRow else {
             // Mirror completeCreateWorktree's guard: clean up the .creating row
             // inserted by beginCreateWorktree so it can't be orphaned forever.
             try? await db.worktrees.delete(id: pending.id)
+            await finishActuation(
+                actuationID, .refused, error: "Repo not found: \(params.repoID)")
             throw WorktreeLifecycleError.repoNotFound(params.repoID)
         }
 
@@ -122,6 +145,11 @@ extension RPCRouter {
             }
         }
 
+        // Dispatched once the synchronous phase returned, exactly as
+        // `worktree.revive` records it: the spawn itself runs in the lifecycle's
+        // own background phase, and what this rung can honestly claim is that
+        // the daemon handed it off.
+        await finishActuation(actuationID, .dispatched)
         return try RPCResponse(result: pending)
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -56,7 +56,7 @@ extension RPCRouter {
             // inserted by beginCreateWorktree so it can't be orphaned forever.
             try? await db.worktrees.delete(id: pending.id)
             await finishActuation(
-                actuationID, .refused, error: "Repo not found: \(params.repoID)")
+                actuationID, .refused(.notFound), error: "Repo not found: \(params.repoID)")
             throw WorktreeLifecycleError.repoNotFound(params.repoID)
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -205,11 +205,11 @@ public final class RPCRouter: Sendable {
             case RPCMethod.scratchCreate:
                 return try await handleScratchCreate(request.paramsData, actor: request.actor)
             case RPCMethod.scratchDelete:
-                return try await handleScratchDelete(request.paramsData)
+                return try await handleScratchDelete(request.paramsData, actor: request.actor)
             case RPCMethod.scratchPromote:
                 return try await handleScratchPromote(request.paramsData)
             case RPCMethod.scratchArchive:
-                return try await handleScratchArchive(request.paramsData)
+                return try await handleScratchArchive(request.paramsData, actor: request.actor)
             case RPCMethod.scratchRevive:
                 return try await handleScratchRevive(request.paramsData)
             case RPCMethod.repoUpdateInstructions:
@@ -231,9 +231,9 @@ public final class RPCRouter: Sendable {
             case RPCMethod.worktreeList:
                 return try await handleWorktreeList(request.paramsData)
             case RPCMethod.worktreeArchive:
-                return try await handleWorktreeArchive(request.paramsData)
+                return try await handleWorktreeArchive(request.paramsData, actor: request.actor)
             case RPCMethod.worktreeRerunPreSession:
-                return try await handleWorktreeRerunPreSession(request.paramsData)
+                return try await handleWorktreeRerunPreSession(request.paramsData, actor: request.actor)
             case RPCMethod.worktreeRevive:
                 return try await handleWorktreeRevive(request.paramsData, actor: request.actor)
             case RPCMethod.worktreeReviveConversationFresh:
@@ -247,7 +247,7 @@ public final class RPCRouter: Sendable {
             case RPCMethod.worktreeMove:
                 return try await handleWorktreeMove(request.paramsData)
             case RPCMethod.worktreeForget:
-                return try await handleWorktreeForget(request.paramsData)
+                return try await handleWorktreeForget(request.paramsData, actor: request.actor)
             case RPCMethod.terminalCreate:
                 return try await handleTerminalCreate(request.paramsData, actor: request.actor)
             case RPCMethod.terminalContinueInCodex:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -15,6 +15,12 @@ public final class RPCRouter: Sendable {
     public let subscriptions: StateSubscriptionManager
     public let prManager: PRStatusManager
     public let hibernationCoordinator: HibernationCoordinator
+    /// Append-only record of every state-changing actuation this router
+    /// performs. Shared with the daemon-internal rails (see `Daemon.swift`) so
+    /// the whole daemon writes one file. Handlers append a request row before
+    /// their first mutating step and an outcome row after the act returns —
+    /// see `RPCRouter+Actuation.swift`.
+    public let actuationLog: ActuationLog
     public let usageFetcher: ClaudeUsageFetcher
     public let modelProfileResolver: ModelProfileResolver
     public nonisolated(unsafe) var daywatchRunner: DaywatchRunner?
@@ -131,8 +137,12 @@ public final class RPCRouter: Sendable {
         loginSessions: LoginSessionCoordinator = LoginSessionCoordinator(),
         remoteManager: RemoteProviderManager? = nil,
         codexExecutableResolver: (@Sendable () throws -> String)? = nil,
-        codexHomeEnsurer: (@Sendable () throws -> URL)? = nil
+        codexHomeEnsurer: (@Sendable () throws -> URL)? = nil,
+        actuationLog: ActuationLog? = nil
     ) {
+        let resolvedActuationLog = actuationLog
+            ?? ActuationLog(path: TBDConstants.actuationLogPath)
+        self.actuationLog = resolvedActuationLog
         self.db = db
         self.lifecycle = lifecycle
         self.tmux = tmux
@@ -148,7 +158,8 @@ public final class RPCRouter: Sendable {
         self.modelProfileResolver = resolvedModelProfileResolver
         self.hibernationCoordinator = HibernationCoordinator(
             db: db, tmux: tmux, modelProfileResolver: resolvedModelProfileResolver,
-            subscriptions: subscriptions, configDirManager: configDirManager
+            subscriptions: subscriptions, configDirManager: configDirManager,
+            actuationLog: resolvedActuationLog
         )
         self.usageFetcher = usageFetcher
         self.pendingQuestions = pendingQuestions
@@ -226,9 +237,9 @@ public final class RPCRouter: Sendable {
             case RPCMethod.worktreeRerunPreSession:
                 return try await handleWorktreeRerunPreSession(request.paramsData)
             case RPCMethod.worktreeRevive:
-                return try await handleWorktreeRevive(request.paramsData)
+                return try await handleWorktreeRevive(request.paramsData, actor: request.actor)
             case RPCMethod.worktreeReviveConversationFresh:
-                return try await handleWorktreeReviveConversationFresh(request.paramsData)
+                return try await handleWorktreeReviveConversationFresh(request.paramsData, actor: request.actor)
             case RPCMethod.worktreeAdopt:
                 return try await handleWorktreeAdopt(request.paramsData)
             case RPCMethod.worktreeRename:
@@ -240,19 +251,19 @@ public final class RPCRouter: Sendable {
             case RPCMethod.worktreeForget:
                 return try await handleWorktreeForget(request.paramsData)
             case RPCMethod.terminalCreate:
-                return try await handleTerminalCreate(request.paramsData)
+                return try await handleTerminalCreate(request.paramsData, actor: request.actor)
             case RPCMethod.terminalContinueInCodex:
-                return try await handleTerminalContinueInCodex(request.paramsData)
+                return try await handleTerminalContinueInCodex(request.paramsData, actor: request.actor)
             case RPCMethod.terminalList:
                 return try await handleTerminalList(request.paramsData)
             case RPCMethod.terminalSend:
-                return try await handleTerminalSend(request.paramsData)
+                return try await handleTerminalSend(request.paramsData, actor: request.actor)
             case RPCMethod.terminalDelete:
-                return try await handleTerminalDelete(request.paramsData)
+                return try await handleTerminalDelete(request.paramsData, actor: request.actor)
             case RPCMethod.terminalSetPin:
                 return try await handleTerminalSetPin(request.paramsData)
             case RPCMethod.terminalSwapProfile:
-                return try await handleTerminalSwapProfile(request.paramsData)
+                return try await handleTerminalSwapProfile(request.paramsData, actor: request.actor)
             case RPCMethod.terminalSessionEvent:
                 return try await handleTerminalSessionEvent(request.paramsData)
             case RPCMethod.terminalActivityEvent:
@@ -294,15 +305,15 @@ public final class RPCRouter: Sendable {
             case RPCMethod.daemonCapabilities:
                 return try await handleDaemonCapabilities()
             case RPCMethod.terminalSuspend:
-                return try await handleTerminalSuspend(request.paramsData)
+                return try await handleTerminalSuspend(request.paramsData, actor: request.actor)
             case RPCMethod.terminalResume:
-                return try await handleTerminalResume(request.paramsData)
+                return try await handleTerminalResume(request.paramsData, actor: request.actor)
             case RPCMethod.worktreeSuspend:
-                return try await handleWorktreeSuspend(request.paramsData)
+                return try await handleWorktreeSuspend(request.paramsData, actor: request.actor)
             case RPCMethod.worktreeResume:
-                return try await handleWorktreeResume(request.paramsData)
+                return try await handleWorktreeResume(request.paramsData, actor: request.actor)
             case RPCMethod.terminalRecreateWindow:
-                return try await handleTerminalRecreateWindow(request.paramsData)
+                return try await handleTerminalRecreateWindow(request.paramsData, actor: request.actor)
             case RPCMethod.noteCreate:
                 return try await handleNoteCreate(request.paramsData)
             case RPCMethod.noteGet:
@@ -316,7 +327,7 @@ public final class RPCRouter: Sendable {
             case RPCMethod.terminalHistoryList:
                 return try await handleTerminalHistoryList(request.paramsData)
             case RPCMethod.terminalHistoryRevive:
-                return try await handleTerminalHistoryRevive(request.paramsData)
+                return try await handleTerminalHistoryRevive(request.paramsData, actor: request.actor)
             case RPCMethod.terminalOutput:
                 return try await handleTerminalOutput(request.paramsData)
             case RPCMethod.terminalConversation:
@@ -431,9 +442,9 @@ public final class RPCRouter: Sendable {
             case RPCMethod.nightwatchLeaseRelease:
                 return try await handleNightwatchLeaseRelease(request.paramsData)
             case RPCMethod.terminalHibernate:
-                return try await handleTerminalHibernate(request.paramsData)
+                return try await handleTerminalHibernate(request.paramsData, actor: request.actor)
             case RPCMethod.terminalWake:
-                return try await handleTerminalWake(request.paramsData)
+                return try await handleTerminalWake(request.paramsData, actor: request.actor)
             case RPCMethod.terminalSetKeepWarm:
                 return try await handleTerminalSetKeepWarm(request.paramsData)
             case RPCMethod.configSetAutoHibernate:
@@ -453,11 +464,11 @@ public final class RPCRouter: Sendable {
             case RPCMethod.remoteSessions:
                 return try await handleRemoteSessions()
             case RPCMethod.remoteCreate:
-                return try await handleRemoteCreate(request.paramsData)
+                return try await handleRemoteCreate(request.paramsData, actor: request.actor)
             case RPCMethod.remoteStop:
-                return try await handleRemoteStop(request.paramsData)
+                return try await handleRemoteStop(request.paramsData, actor: request.actor)
             case RPCMethod.remoteSend:
-                return try await handleRemoteSend(request.paramsData)
+                return try await handleRemoteSend(request.paramsData, actor: request.actor)
             case RPCMethod.remoteLog:
                 return try await handleRemoteLog(request.paramsData)
             case RPCMethod.remoteRename:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -199,7 +199,7 @@ public final class RPCRouter: Sendable {
             case RPCMethod.repoAdd:
                 return try await handleRepoAdd(request.paramsData)
             case RPCMethod.repoRemove:
-                return try await handleRepoRemove(request.paramsData)
+                return try await handleRepoRemove(request.paramsData, actor: request.actor)
             case RPCMethod.repoList:
                 return try await handleRepoList()
             case RPCMethod.scratchCreate:

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -138,11 +138,9 @@ public final class RPCRouter: Sendable {
         remoteManager: RemoteProviderManager? = nil,
         codexExecutableResolver: (@Sendable () throws -> String)? = nil,
         codexHomeEnsurer: (@Sendable () throws -> URL)? = nil,
-        actuationLog: ActuationLog? = nil
+        actuationLog: ActuationLog
     ) {
-        let resolvedActuationLog = actuationLog
-            ?? ActuationLog(path: TBDConstants.actuationLogPath)
-        self.actuationLog = resolvedActuationLog
+        self.actuationLog = actuationLog
         self.db = db
         self.lifecycle = lifecycle
         self.tmux = tmux
@@ -159,7 +157,7 @@ public final class RPCRouter: Sendable {
         self.hibernationCoordinator = HibernationCoordinator(
             db: db, tmux: tmux, modelProfileResolver: resolvedModelProfileResolver,
             subscriptions: subscriptions, configDirManager: configDirManager,
-            actuationLog: resolvedActuationLog
+            actuationLog: actuationLog
         )
         self.usageFetcher = usageFetcher
         self.pendingQuestions = pendingQuestions
@@ -205,7 +203,7 @@ public final class RPCRouter: Sendable {
             case RPCMethod.repoList:
                 return try await handleRepoList()
             case RPCMethod.scratchCreate:
-                return try await handleScratchCreate(request.paramsData)
+                return try await handleScratchCreate(request.paramsData, actor: request.actor)
             case RPCMethod.scratchDelete:
                 return try await handleScratchDelete(request.paramsData)
             case RPCMethod.scratchPromote:
@@ -229,7 +227,7 @@ public final class RPCRouter: Sendable {
             case RPCMethod.repoListOpenPRs:
                 return try await handleRepoListOpenPRs(request.paramsData)
             case RPCMethod.worktreeCreate:
-                return try await handleWorktreeCreate(request.paramsData)
+                return try await handleWorktreeCreate(request.paramsData, actor: request.actor)
             case RPCMethod.worktreeList:
                 return try await handleWorktreeList(request.paramsData)
             case RPCMethod.worktreeArchive:

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -58,6 +58,13 @@ public struct TmuxManager: Sendable {
     /// it, dryRun respawnWindow always succeeds, which makes the wake path's
     /// respawn-failure branch (`WakeResult.respawnFailed`) untestable.
     public let dryRunRespawnWindowError: (@Sendable (String) -> Error?)?
+    /// Optional test hook consulted by `killWindow` in dryRun mode: return a
+    /// non-nil error for a `(server, windowID)` pair to simulate the kill
+    /// failing (server wedged, window already reaped by someone else, …).
+    /// Without it, dryRun killWindow always succeeds, which makes the close
+    /// paths' transport-failure branch — the one the actuation record
+    /// classifies as `transport-failed` rather than `dispatched` — untestable.
+    public let dryRunKillWindowError: (@Sendable (String, String) -> Error?)?
     /// Optional test hook for real (non-dryRun) mode: override the result of
     /// `windowExists(server:windowID:)`. Allows tests to force a window as dead
     /// while still having a live process running in the pane (for testing the
@@ -89,7 +96,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -100,6 +107,7 @@ public struct TmuxManager: Sendable {
         self.dryRunPaneCurrentCommand = dryRunPaneCurrentCommand
         self.dryRunCreateWindowError = dryRunCreateWindowError
         self.dryRunRespawnWindowError = dryRunRespawnWindowError
+        self.dryRunKillWindowError = dryRunKillWindowError
         self.realModeWindowExistsOverride = realModeWindowExistsOverride
         self.realModePaneCurrentCommandOverride = realModePaneCurrentCommandOverride
     }
@@ -517,6 +525,7 @@ public struct TmuxManager: Sendable {
         let args = Self.killWindowCommand(server: server, windowID: windowID)
         if dryRun {
             dryRunRecorder?(args)
+            if let error = dryRunKillWindowError?(server, windowID) { throw error }
             return
         }
         try await runTmux(args)

--- a/Sources/TBDShared/ActuationActor.swift
+++ b/Sources/TBDShared/ActuationActor.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Who declared an actuation.
+///
+/// Identity here is **ambient declaration, never authentication** — any
+/// process talking to the daemon socket can claim anything, and TBD
+/// deliberately builds nothing stronger. The value of the declaration is that
+/// the daemon writes it down at the moment it acts, so the record says plainly
+/// which door an act came through, including "nobody said".
+///
+/// **Always a JSON object, never a bare string.** Several kinds inherently
+/// carry fields (an identified session carries its coordinates; a supervisor
+/// carries its project), so the object form is required anyway; keeping it
+/// uniform means every consumer query reads `.actor.kind` and growing a kind
+/// later never changes its JSON type.
+///
+/// `kind` is a `String` rather than an enum on purpose: kinds reserved for
+/// later work (`supervisor`) must decode on a daemon that predates them
+/// instead of failing the whole row. Use the static constructors and the
+/// `Kind` namespace below rather than spelling literals at call sites.
+public struct ActuationActor: Codable, Sendable, Equatable {
+    /// Known kind names. Not an enum — see the type's doc comment.
+    public enum Kind {
+        public static let daemon = "daemon"
+        public static let app = "app"
+        public static let session = "session"
+        public static let anonymous = "anonymous"
+        /// Reserved for fleet supervisors; nothing writes it yet.
+        public static let supervisor = "supervisor"
+    }
+
+    public var kind: String
+    /// Names the daemon-internal subsystem for `kind == "daemon"` acts that a
+    /// rail performed on its own schedule (`limit-resume`, `auto-hibernate`,
+    /// `nightwatch-desk`). Absent for daemon acts with no rail.
+    public var rail: String?
+    /// Uppercase worktree UUID string, for `kind == "session"`.
+    public var worktree: String?
+    /// Uppercase terminal UUID string, for `kind == "session"`.
+    public var terminal: String?
+    /// Reserved for `kind == "supervisor"`; nothing writes it yet.
+    public var project: String?
+
+    public init(
+        kind: String,
+        rail: String? = nil,
+        worktree: String? = nil,
+        terminal: String? = nil,
+        project: String? = nil
+    ) {
+        self.kind = kind
+        self.rail = rail
+        self.worktree = worktree
+        self.terminal = terminal
+        self.project = project
+    }
+
+    /// The daemon acting on its own behalf, optionally naming the internal rail.
+    public static func daemon(rail: String? = nil) -> ActuationActor {
+        ActuationActor(kind: Kind.daemon, rail: rail)
+    }
+
+    /// The macOS app's RPC client — the operator's hand.
+    public static let app = ActuationActor(kind: Kind.app)
+
+    /// No identity was declared. Explicit rather than an absent field: the
+    /// record must say plainly that the caller was anonymous.
+    public static let anonymous = ActuationActor(kind: Kind.anonymous)
+
+    /// An identified caller echoing the coordinates the daemon itself planted
+    /// in its environment at spawn time. A partial declaration (only one
+    /// variable set) carries just the declared field; declaring neither is
+    /// anonymity, not a session, so this returns `nil` and the caller omits
+    /// the field entirely.
+    public static func session(worktree: String?, terminal: String?) -> ActuationActor? {
+        let worktree = worktree.flatMap { $0.isEmpty ? nil : $0 }
+        let terminal = terminal.flatMap { $0.isEmpty ? nil : $0 }
+        if worktree == nil && terminal == nil { return nil }
+        return ActuationActor(kind: Kind.session, worktree: worktree, terminal: terminal)
+    }
+
+    /// Reads a session declaration out of the ambient TBD environment.
+    /// Returns `nil` when neither variable is set.
+    public static func sessionFromEnvironment(_ environment: [String: String]) -> ActuationActor? {
+        session(
+            worktree: environment["TBD_WORKTREE_ID"],
+            terminal: environment["TBD_TERMINAL_ID"])
+    }
+}

--- a/Sources/TBDShared/ActuationActor.swift
+++ b/Sources/TBDShared/ActuationActor.swift
@@ -32,7 +32,8 @@ public struct ActuationActor: Codable, Sendable, Equatable {
     public var kind: String
     /// Names the daemon-internal subsystem for `kind == "daemon"` acts that a
     /// rail performed on its own schedule (`limit-resume`, `auto-hibernate`,
-    /// `nightwatch-desk`). Absent for daemon acts with no rail.
+    /// `auto-hibernate-on-merge`, `nightwatch-desk`). Absent for daemon acts
+    /// with no rail.
     public var rail: String?
     /// Uppercase worktree UUID string, for `kind == "session"`.
     public var worktree: String?

--- a/Sources/TBDShared/Constants.swift
+++ b/Sources/TBDShared/Constants.swift
@@ -229,4 +229,16 @@ public enum TBDConstants {
     public static var agentProvidersPath: String {
         agentProvidersPath(environment: ProcessInfo.processInfo.environment)
     }
+
+    /// Path to the append-only actuation record: `~/tbd/actuations.jsonl`.
+    /// The daemon is its only writer; rotated day segments
+    /// (`actuations-<YYYY-MM-DD>.jsonl`) sit beside it in the same directory.
+    /// Honors `TBD_HOME` like every other derived path — never hand-build it
+    /// from `$HOME`.
+    public static func actuationLogPath(environment: [String: String]) -> String {
+        configDir(environment: environment).appendingPathComponent("actuations.jsonl").path
+    }
+    public static var actuationLogPath: String {
+        actuationLogPath(environment: ProcessInfo.processInfo.environment)
+    }
 }

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -8,17 +8,33 @@ import Foundation
 public struct RPCRequest: Codable, Sendable {
     public let method: String
     public let params: String
+    /// Optional caller identity declaration, deliberately a TOP-LEVEL field
+    /// beside `method`/`params` rather than a member of any per-method params
+    /// struct — so no verb's parameter shape changes. An absent field means
+    /// the caller declared nothing and the daemon records `anonymous`; old
+    /// clients simply omit it, and daemons that predate it ignore the key.
+    public let actor: ActuationActor?
 
-    public init(method: String, params: String = "{}") {
+    public init(method: String, params: String = "{}", actor: ActuationActor? = nil) {
         self.method = method
         self.params = params
+        self.actor = actor
     }
 
     /// Convenience: encode a Codable param struct into an RPCRequest.
-    public init<P: Encodable>(method: String, params: P) throws {
+    public init<P: Encodable>(method: String, params: P, actor: ActuationActor? = nil) throws {
         self.method = method
         let data = try JSONEncoder().encode(params)
         self.params = String(data: data, encoding: .utf8) ?? "{}"
+        self.actor = actor
+    }
+
+    /// Returns a copy carrying `actor`, leaving an already-declared identity
+    /// alone. Clients stamp their own identity at their single encode
+    /// chokepoint rather than at every call site.
+    public func stamping(actor: ActuationActor?) -> RPCRequest {
+        guard self.actor == nil, let actor else { return self }
+        return RPCRequest(method: method, params: params, actor: actor)
     }
 
     /// Decode the params JSON string into Data for JSONDecoder consumption.

--- a/Tests/TBDDaemonLiveTests/WorktreeLifecycleLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/WorktreeLifecycleLiveTests.swift
@@ -72,7 +72,7 @@ import Testing
     #expect(!aliveAfterKill, "precondition: server must be gone to model a reboot")
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
     } catch {
         try? await realTmux.killServer(server: serverName)
         throw error
@@ -137,7 +137,7 @@ import Testing
     )
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
     } catch {
         try? await realTmux.killServer(server: serverName)
         throw error
@@ -180,7 +180,7 @@ import Testing
     )
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
     } catch {
         try? await realTmux.killServer(server: serverName)
         throw error
@@ -219,7 +219,7 @@ import Testing
     )
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
     } catch {
         try? await realTmux.killServer(server: serverName)
         throw error
@@ -282,7 +282,7 @@ func testReconcileDeadWindowLiveClaudeNotParked() async throws {
     )
 
     do {
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
     } catch {
         try? await tmux.killServer(server: serverName)
         throw error

--- a/Tests/TBDDaemonTests/ActuationLogDeskCloseWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogDeskCloseWiringTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+extension TBDHomeSerialized {
+
+    /// Tier 2 — dry-run tmux, a real (temp-directory) actuation log, and a real
+    /// `TBD_HOME` because a desk session is a scratch worktree.
+    ///
+    /// The Watch Desk rail acts on sessions with nobody having asked, and two of
+    /// those acts reach no logged lifecycle of their own: `spawnDeskTerminal`
+    /// opens the judge session, and `closeDeskSession` kills its tmux windows
+    /// directly. Both write their own worktree-named row on the
+    /// `nightwatch-desk` rail with no `method`, and both skip their act when the
+    /// record is unwritable.
+    @Suite("Actuation log desk spawn/close wiring")
+    struct ActuationLogDeskCloseWiringTests {
+
+        // MARK: - Fixture
+
+        private func makeLogPath() throws -> String {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "tbd-actuation-desk-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true)
+            return directory.appendingPathComponent("actuations.jsonl").path
+        }
+
+        /// A path that can never be opened: its parent is a regular file.
+        private func makeUnwritablePath() throws -> String {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent(
+                    "tbd-actuation-blocked-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true)
+            let blocker = directory.appendingPathComponent("blocker")
+            try Data("not a directory".utf8).write(to: blocker)
+            return blocker.appendingPathComponent("actuations.jsonl").path
+        }
+
+        private func rows(at path: String) throws -> [[String: Any]] {
+            guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+                return []
+            }
+            return try contents
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map { line in
+                    try #require(
+                        try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+                }
+        }
+
+        /// Temp `TBD_HOME` + in-memory DB + a desk manager writing to `logPath`.
+        /// Caller owns cleanup of `home` and restoring `priorTBDHome`.
+        private func makeFixture(logPath: String) throws -> (
+            db: TBDDatabase, manager: DeskSessionManager, home: URL, priorTBDHome: String?
+        ) {
+            let home = FileManager.default.temporaryDirectory
+                .appendingPathComponent("tbd-desk-close-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+            let priorTBDHome = setTBDHome(home.path)
+
+            let db = try TBDDatabase(inMemory: true)
+            let manager = DeskSessionManager(
+                db: db,
+                lifecycle: WorktreeLifecycle(
+                    db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
+                    hooks: HookResolver()),
+                tmux: TmuxManager(dryRun: true),
+                skillDir: home.appendingPathComponent("skills/nightwatch").path,
+                actuationLog: ActuationLog(path: logPath))
+            return (db, manager, home, priorTBDHome)
+        }
+
+        // MARK: - The rail's own spawn row
+
+        @Test("opening the desk session writes one spawn row on the nightwatch-desk rail")
+        func spawnWritesSpawnRow() async throws {
+            let logPath = try makeLogPath()
+            let fixture = try makeFixture(logPath: logPath)
+            defer {
+                restoreTBDHome(fixture.priorTBDHome)
+                try? FileManager.default.removeItem(at: fixture.home)
+            }
+
+            let desk = try await fixture.manager.ensureDeskSession(mode: .daywatch)
+
+            let written = try rows(at: logPath)
+            let spawns = written.filter { $0["kind"] as? String == "spawn" }
+            #expect(spawns.count == 1)
+            let request = try #require(spawns.first)
+            #expect(request["method"] == nil)
+            let actor = try #require(request["actor"] as? [String: Any])
+            #expect(actor["kind"] as? String == "daemon")
+            #expect(actor["rail"] as? String == "nightwatch-desk")
+            let target = try #require(request["target"] as? [String: Any])
+            #expect(target["worktree"] as? String == desk.id.uuidString)
+            // The terminals mint inside `spawnPrimaryTerminals`, so there is
+            // none to name at request time — as with `worktree.revive`.
+            #expect(target["terminal"] == nil)
+
+            let outcome = try #require(written.first {
+                $0["confirms"] as? String == request["id"] as? String
+            })
+            #expect(outcome["result"] as? String == "dispatched")
+            #expect(try await fixture.db.terminals.list(worktreeID: desk.id).isEmpty == false)
+        }
+
+        @Test("an unwritable record skips the desk spawn — the desk opens with no session")
+        func unwritableRecordSkipsDeskSpawn() async throws {
+            let fixture = try makeFixture(logPath: try makeUnwritablePath())
+            defer {
+                restoreTBDHome(fixture.priorTBDHome)
+                try? FileManager.default.removeItem(at: fixture.home)
+            }
+
+            // The worktree still gets created — a failed desk spawn has always
+            // been best-effort — but nothing was spawned into it.
+            let desk = try await fixture.manager.ensureDeskSession(mode: .daywatch)
+            #expect(try await fixture.db.terminals.list(worktreeID: desk.id).isEmpty)
+        }
+
+        // MARK: - The rail's own dispose row
+
+        @Test("closing the desk writes one dispose row on the nightwatch-desk rail")
+        func closeWritesDisposeRow() async throws {
+            let logPath = try makeLogPath()
+            let fixture = try makeFixture(logPath: logPath)
+            defer {
+                restoreTBDHome(fixture.priorTBDHome)
+                try? FileManager.default.removeItem(at: fixture.home)
+            }
+
+            let desk = try await fixture.manager.ensureDeskSession(mode: .daywatch)
+            await fixture.manager.closeDeskSession()
+
+            let written = try rows(at: logPath)
+            let disposes = written.filter { $0["kind"] as? String == "dispose" }
+            #expect(disposes.count == 1)
+            let request = try #require(disposes.first)
+            // Daemon-internal: no RPC carried this, so no method.
+            #expect(request["method"] == nil)
+            let actor = try #require(request["actor"] as? [String: Any])
+            #expect(actor["kind"] as? String == "daemon")
+            #expect(actor["rail"] as? String == "nightwatch-desk")
+            let target = try #require(request["target"] as? [String: Any])
+            #expect(target["worktree"] as? String == desk.id.uuidString)
+            // One row for the whole desk, as `worktree.archive` records it — the
+            // per-terminal kills are how the close carries that out.
+            #expect(target["terminal"] == nil)
+
+            let outcome = try #require(written.first {
+                $0["confirms"] as? String == request["id"] as? String
+            })
+            #expect(outcome["result"] as? String == "dispatched")
+            #expect(try await fixture.db.worktrees.get(id: desk.id)?.status == .archived)
+        }
+
+        @Test("an unwritable record skips the close — the desk stays live")
+        func unwritableRecordSkipsClose() async throws {
+            let fixture = try makeFixture(logPath: try makeUnwritablePath())
+            defer {
+                restoreTBDHome(fixture.priorTBDHome)
+                try? FileManager.default.removeItem(at: fixture.home)
+            }
+
+            let desk = try await fixture.manager.ensureDeskSession(mode: .daywatch)
+            // The same unwritable record already refused the spawn, so seed the
+            // terminal row the close would otherwise tear down.
+            _ = try await fixture.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+            await fixture.manager.closeDeskSession()
+
+            // Nothing was torn down: the worktree is still active and still owns
+            // its terminal rows.
+            #expect(try await fixture.db.worktrees.get(id: desk.id)?.status == .active)
+            #expect(try await fixture.db.terminals.list(worktreeID: desk.id).count == 1)
+        }
+
+        /// A close that had gone through would archive the desk, and the recovery
+        /// path deliberately excludes archived desks — so the next `ensure` would
+        /// mint a second one. Getting the same id back is how the refusal shows.
+        @Test("a skipped close leaves the same desk addressable")
+        func skippedCloseKeepsDeskIdentity() async throws {
+            let fixture = try makeFixture(logPath: try makeUnwritablePath())
+            defer {
+                restoreTBDHome(fixture.priorTBDHome)
+                try? FileManager.default.removeItem(at: fixture.home)
+            }
+
+            let desk = try await fixture.manager.ensureDeskSession(mode: .daywatch)
+            await fixture.manager.closeDeskSession()
+
+            let again = try await fixture.manager.ensureDeskSession(mode: .daywatch)
+            #expect(again.id == desk.id)
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationLogRetryTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogRetryTests.swift
@@ -144,8 +144,44 @@ struct ActuationLogRetryTests {
 
     // MARK: - write failed
 
-    @Test("a half-written line is isolated, and the retried row parses on its own line")
-    func partialWriteIsolatesTheFragment() async throws {
+    /// The write stops with everything but the trailing newline persisted, so
+    /// the "fragment" left behind is a complete, parseable row. Rewriting the
+    /// row here would put the same actuation in the file twice — the one
+    /// corruption a reader cannot recover from, because both copies parse.
+    @Test("a write that stops exactly at the newline boundary still records the act once")
+    func partialWriteAtTheNewlineBoundaryDoesNotDuplicate() async throws {
+        let path = try makePath()
+        let counter = CallCounter()
+        let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
+            write: { descriptor, buffer, count in
+                switch counter.next() {
+                case 1:
+                    // Everything except the row's own terminating newline.
+                    return Foundation.write(descriptor, buffer, count - 1)
+                case 2:
+                    errno = EIO
+                    return -1
+                default:
+                    return Foundation.write(descriptor, buffer, count)
+                }
+            },
+            fsync: { descriptor in Foundation.fsync(descriptor) }))
+
+        let id = try await log.appendRequest(sendRow())
+
+        let lines = contents(at: path).split(separator: "\n", omittingEmptySubsequences: true)
+        #expect(lines.count == 1, "the resumed write must finish the line, not start another")
+        let rows = parsedRows(at: path)
+        #expect(rows.count == 1)
+        #expect(rows.first?["id"] as? String == id, "the row must round-trip as JSON, once")
+        #expect(rows.first?["message"] as? String == "please rebase onto main")
+    }
+
+    /// The general case of the same recovery: a short write anywhere inside the
+    /// line is finished from its own offset, so the file holds one whole row
+    /// and no junk at all.
+    @Test("a write that stops mid-line is resumed from its offset, leaving no junk line")
+    func partialWriteOffBoundaryResumesFromOffset() async throws {
         let path = try makePath()
         let counter = CallCounter()
         let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
@@ -168,13 +204,61 @@ struct ActuationLogRetryTests {
         let id = try await log.appendRequest(sendRow())
 
         let lines = contents(at: path).split(separator: "\n", omittingEmptySubsequences: true)
-        #expect(lines.count == 2, "the fragment must terminate as a line of its own")
-        // The fragment is junk a reader skips; the row is intact and appears once.
-        #expect(
-            (try? JSONSerialization.jsonObject(with: Data(lines[0].utf8))) == nil,
-            "the fragment must not be fused with the retried row")
+        #expect(lines.count == 1)
         let rows = parsedRows(at: path)
         #expect(rows.count == 1)
+        #expect(rows.first?["id"] as? String == id)
+        #expect(rows.first?["message"] as? String == "please rebase onto main")
+    }
+
+    /// Resume-from-offset is only sound while the fragment is still the file's
+    /// last bytes. A file replaced under us voids that, and the row exists
+    /// nowhere a reader will look — so the whole row is re-appended, which
+    /// cannot duplicate on a fresh inode.
+    @Test("a half-written line whose file was replaced is re-appended whole, once")
+    func partialWriteOntoAReplacedFileReAppends() async throws {
+        let path = try makePath()
+        let counter = CallCounter()
+        let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
+            write: { descriptor, buffer, count in
+                switch counter.next() {
+                case 1:
+                    return Foundation.write(descriptor, buffer, count / 2)
+                case 2:
+                    // A cleanup script took the file the fragment went into.
+                    try? FileManager.default.removeItem(atPath: path)
+                    errno = EIO
+                    return -1
+                default:
+                    return Foundation.write(descriptor, buffer, count)
+                }
+            },
+            fsync: { descriptor in Foundation.fsync(descriptor) }))
+
+        let id = try await log.appendRequest(sendRow())
+
+        let rows = parsedRows(at: path)
+        #expect(rows.count == 1)
+        #expect(rows.first?["id"] as? String == id)
+    }
+
+    /// A fragment nobody is left to recover — a crash between `write` and
+    /// `fsync`, or an append that failed twice — is still in the file when a
+    /// later daemon opens it. The next append must not weld itself onto it.
+    @Test("a dangling fragment from an earlier process is isolated, not fused")
+    func danglingFragmentFromAnEarlierProcessIsIsolated() async throws {
+        let path = try makePath()
+        let fragment = #"{"actor":{"kind":"app"},"id":"aaaaaaaaaaaa","kind":"se"#
+        try Data(fragment.utf8).write(to: URL(fileURLWithPath: path))
+
+        let log = ActuationLog(path: path)
+        let id = try await log.appendRequest(sendRow())
+
+        let lines = contents(at: path).split(separator: "\n", omittingEmptySubsequences: true)
+        #expect(lines.count == 2, "the fragment must terminate as a line of its own")
+        #expect(lines.first == fragment[...], "the fragment must survive verbatim")
+        let rows = parsedRows(at: path)
+        #expect(rows.count == 1, "only the new row parses; the fragment stays junk a reader skips")
         #expect(rows.first?["id"] as? String == id)
     }
 

--- a/Tests/TBDDaemonTests/ActuationLogRetryTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogRetryTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — real filesystem, plus the writer's `write`/`fsync` seam.
+///
+/// One property, and it is the one a reader cannot recover from if it breaks:
+/// after a recovered append the row is in the file **exactly once**, and it
+/// parses. A retry that rewrites a line whose bytes already landed duplicates
+/// an actuation that happened once; a retry that appends after a half-written
+/// line fuses two rows into one unparseable one. Neither state can be
+/// provoked by filesystem setup — no `chmod` makes `fsync` fail or a `write`
+/// return short — so the failures are injected through the seam.
+@Suite("Actuation log recovery")
+struct ActuationLogRetryTests {
+
+    // MARK: - Fixture
+
+    /// Counts seam calls and decides which of them fails. A class with a lock
+    /// rather than an actor: the seam is a synchronous closure.
+    private final class CallCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = 0
+
+        func next() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            value += 1
+            return value
+        }
+
+        var count: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+    }
+
+    private func makePath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-retry-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    private func contents(at path: String) -> String {
+        (try? String(contentsOfFile: path, encoding: .utf8)) ?? ""
+    }
+
+    /// Every line that parses as a JSON object, in order. Lines that do not
+    /// parse — the isolated fragment a partial write leaves — are skipped,
+    /// exactly as a line-oriented reader would skip them.
+    private func parsedRows(at path: String) -> [[String: Any]] {
+        contents(at: path)
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .compactMap { line in
+                (try? JSONSerialization.jsonObject(with: Data(line.utf8))) as? [String: Any]
+            }
+    }
+
+    private func sendRow() -> ActuationRow {
+        var row = ActuationRow(actor: .app, kind: .send)
+        row.method = ActuationSurface.terminalSend.method
+        row.target = ActuationTarget(
+            worktree: "1B7E2C90-88AA-4F60-B1D0-9E8F7A6B5C4D",
+            terminal: "6D40F3A1-2B14-4E14-9C4A-0F1D2E3A4B5C")
+        row.message = "please rebase onto main"
+        row.submit = true
+        return row
+    }
+
+    // MARK: - fsync failed after a complete write
+
+    @Test("a failed flush is re-flushed, never rewritten — the row lands once")
+    func failedFsyncFlushesRatherThanDuplicating() async throws {
+        let path = try makePath()
+        let counter = CallCounter()
+        let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
+            write: { descriptor, buffer, count in
+                Foundation.write(descriptor, buffer, count)
+            },
+            fsync: { descriptor in
+                if counter.next() == 1 {
+                    errno = EIO
+                    return -1
+                }
+                return Foundation.fsync(descriptor)
+            }))
+
+        let id = try await log.appendRequest(sendRow())
+
+        let rows = parsedRows(at: path)
+        #expect(rows.count == 1, "the recovery must flush the existing bytes, not append them again")
+        #expect(rows.first?["id"] as? String == id)
+        // Exactly two flushes: the one that failed, and the recovery's.
+        #expect(counter.count == 2)
+    }
+
+    @Test("a flush that fails onto a file replaced under us re-appends, still exactly once")
+    func failedFsyncOnAReplacedFileReAppends() async throws {
+        let path = try makePath()
+        let counter = CallCounter()
+        let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
+            write: { descriptor, buffer, count in
+                Foundation.write(descriptor, buffer, count)
+            },
+            fsync: { descriptor in
+                if counter.next() == 1 {
+                    // A cleanup script / external rotation took the file the
+                    // bytes went into. The persisted-bytes assumption is void:
+                    // the row now exists nowhere a reader will look.
+                    try? FileManager.default.removeItem(atPath: path)
+                    errno = EIO
+                    return -1
+                }
+                return Foundation.fsync(descriptor)
+            }))
+
+        let id = try await log.appendRequest(sendRow())
+
+        let rows = parsedRows(at: path)
+        #expect(rows.count == 1, "a fresh inode cannot duplicate — the row must be re-appended")
+        #expect(rows.first?["id"] as? String == id)
+    }
+
+    @Test("a flush that never succeeds still fails closed")
+    func permanentlyFailingFsyncRefusesTheAct() async throws {
+        let path = try makePath()
+        let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
+            write: { descriptor, buffer, count in
+                Foundation.write(descriptor, buffer, count)
+            },
+            fsync: { _ in
+                errno = EIO
+                return -1
+            }))
+
+        await #expect(throws: ActuationLogUnwritable.self) {
+            _ = try await log.appendRequest(self.sendRow())
+        }
+    }
+
+    // MARK: - write failed
+
+    @Test("a half-written line is isolated, and the retried row parses on its own line")
+    func partialWriteIsolatesTheFragment() async throws {
+        let path = try makePath()
+        let counter = CallCounter()
+        let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
+            write: { descriptor, buffer, count in
+                switch counter.next() {
+                case 1:
+                    // Half the line reaches the file...
+                    return Foundation.write(descriptor, buffer, count / 2)
+                case 2:
+                    // ...and the loop's continuation fails, so the line is
+                    // left half-written on disk.
+                    errno = EIO
+                    return -1
+                default:
+                    return Foundation.write(descriptor, buffer, count)
+                }
+            },
+            fsync: { descriptor in Foundation.fsync(descriptor) }))
+
+        let id = try await log.appendRequest(sendRow())
+
+        let lines = contents(at: path).split(separator: "\n", omittingEmptySubsequences: true)
+        #expect(lines.count == 2, "the fragment must terminate as a line of its own")
+        // The fragment is junk a reader skips; the row is intact and appears once.
+        #expect(
+            (try? JSONSerialization.jsonObject(with: Data(lines[0].utf8))) == nil,
+            "the fragment must not be fused with the retried row")
+        let rows = parsedRows(at: path)
+        #expect(rows.count == 1)
+        #expect(rows.first?["id"] as? String == id)
+    }
+
+    @Test("a write that failed on its first byte retries plainly, with no stray blank line")
+    func writeThatWroteNothingRetriesPlainly() async throws {
+        let path = try makePath()
+        let counter = CallCounter()
+        let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
+            write: { descriptor, buffer, count in
+                if counter.next() == 1 {
+                    errno = EIO
+                    return -1
+                }
+                return Foundation.write(descriptor, buffer, count)
+            },
+            fsync: { descriptor in Foundation.fsync(descriptor) }))
+
+        let id = try await log.appendRequest(sendRow())
+
+        let raw = contents(at: path)
+        #expect(!raw.hasPrefix("\n"), "nothing was written, so nothing needs isolating")
+        let rows = parsedRows(at: path)
+        #expect(rows.count == 1)
+        #expect(rows.first?["id"] as? String == id)
+    }
+
+    // MARK: - Outcome rows take the same recovery
+
+    @Test("a recovered outcome row is also written exactly once")
+    func outcomeRowRecoversWithoutDuplicating() async throws {
+        let path = try makePath()
+        let counter = CallCounter()
+        let log = ActuationLog(path: path, syscalls: ActuationLogSyscalls(
+            write: { descriptor, buffer, count in
+                Foundation.write(descriptor, buffer, count)
+            },
+            fsync: { descriptor in
+                // Let the request row through; fail the outcome row's flush.
+                if counter.next() == 2 {
+                    errno = EIO
+                    return -1
+                }
+                return Foundation.fsync(descriptor)
+            }))
+
+        let requestID = try await log.appendRequest(sendRow())
+        await log.appendOutcome(confirms: requestID, result: .dispatched)
+
+        let rows = parsedRows(at: path)
+        #expect(rows.count == 2)
+        let outcomes = rows.filter { $0["kind"] as? String == "outcome" }
+        #expect(outcomes.count == 1)
+        #expect(outcomes.first?["confirms"] as? String == requestID)
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
@@ -1,0 +1,283 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// Nested under TBDHomeSerialized: `scratch.create` writes under
+// `TBDConstants.scratchDir` and `worktree.create` resolves hooks under
+// TBD_HOME, so these redirect it to a temp dir (see TBDHomeSerializedSuites).
+extension TBDHomeSerialized {
+/// Tier 2 — dry-run tmux, a real (temp-directory) actuation log, real git for
+/// the `worktree.create` fixture.
+///
+/// The three surfaces that end in the lifecycle's own terminal spawn:
+/// `worktree.create`, `scratch.create` and the merge-park rail. Each writes a
+/// row naming what it is about to act on, before it acts — and refuses the act
+/// when the record is unwritable.
+@Suite("Actuation log spawn wiring")
+struct ActuationLogSpawnWiringTests {
+
+    // MARK: - Fixture
+
+    private func isolateTBDHome() -> (home: URL, cleanup: () -> Void) {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-spawn-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        let priorTBDHome = setTBDHome(home.path)
+        return (home, {
+            restoreTBDHome(priorTBDHome)
+            try? FileManager.default.removeItem(at: home)
+        })
+    }
+
+    private func makeLogPath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-spawn-log-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    /// A path that can never be opened: its parent is a regular file.
+    private func makeUnwritablePath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-blocked-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let blocker = directory.appendingPathComponent("blocker")
+        try Data("not a directory".utf8).write(to: blocker)
+        return blocker.appendingPathComponent("actuations.jsonl").path
+    }
+
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    private func makeRouter(db: TBDDatabase, logPath: String) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: ActuationLog(path: logPath)
+        )
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 10,
+        _ condition: @Sendable () async throws -> Bool
+    ) async throws -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if try await condition() { return true }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return try await condition()
+    }
+
+    // MARK: - scratch.create
+
+    @Test("scratch.create writes one spawn row naming the scratch space")
+    func scratchCreateWritesSpawnRow() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate,
+            params: ScratchCreateParams(name: nil),
+            actor: .app))
+        #expect(response.success)
+        let scratch = try response.decodeResult(Worktree.self)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "spawn")
+        #expect(request["method"] as? String == "scratch.create")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == scratch.id.uuidString)
+        // The terminals are minted inside the lifecycle spawn, so the row names
+        // the worktree and nothing else.
+        #expect(target["terminal"] == nil)
+        #expect((request["actor"] as? [String: Any])?["kind"] as? String == "app")
+        #expect(written.last?["result"] as? String == "dispatched")
+    }
+
+    @Test("an unwritable record refuses the scratch spawn — no terminal is created")
+    func unwritableRecordRefusesScratchSpawn() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: try makeUnwritablePath())
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("actuation log"))
+        // The scratch row itself is not an actuation and survives; the spawn
+        // did not happen.
+        let scratches = try await db.worktrees.listScratch()
+        let created = try #require(scratches.first)
+        #expect(try await db.terminals.list(worktreeID: created.id).isEmpty)
+    }
+
+    // MARK: - worktree.create
+
+    @Test("worktree.create writes one spawn row naming the worktree it just minted")
+    func worktreeCreateWritesSpawnRow() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeCreate,
+            params: WorktreeCreateParams(repoID: repo.id),
+            actor: .app))
+        #expect(response.success)
+        let pending = try response.decodeResult(Worktree.self)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "spawn")
+        #expect(request["method"] as? String == "worktree.create")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == pending.id.uuidString)
+        #expect(target["terminal"] == nil)
+        #expect(written.last?["result"] as? String == "dispatched")
+
+        // Let the background phase finish before the fixture repo goes away.
+        _ = try await waitUntil {
+            try await db.worktrees.get(id: pending.id)?.status != .creating
+        }
+    }
+
+    @Test("an unwritable record refuses the create and leaves no half-created row")
+    func unwritableRecordRefusesWorktreeCreate() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: try makeUnwritablePath())
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeCreate,
+            params: WorktreeCreateParams(repoID: repo.id)))
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("actuation log"))
+        // The `.creating` row phase 1 inserted is swept back out, so nothing is
+        // left spinning in the sidebar forever.
+        let rowsForRepo = try await db.worktrees.list(repoID: repo.id, status: .creating)
+        #expect(rowsForRepo.isEmpty)
+    }
+
+    // MARK: - The merge-park rail
+
+    /// In-memory DB + repo + worktree + one idle Claude terminal.
+    private func makeParkable(
+        keepWarm: Bool = false
+    ) async throws -> (db: TBDDatabase, worktreeID: UUID, terminalID: UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-merge-park-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let repo = try await db.repos.create(
+            path: directory.path, displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: directory.path, tmuxServer: "tbd-acme")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-1", kind: .claude)
+        try await db.terminals.setActivityState(id: terminal.id, activityState: .idle)
+        if keepWarm {
+            try await db.terminals.setKeepWarm(id: terminal.id, keepWarm: true)
+        }
+        return (db, worktree.id, terminal.id)
+    }
+
+    private func makeCoordinator(
+        db: TBDDatabase, logPath: String
+    ) -> HibernationCoordinator {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-merge-park-claude-\(UUID().uuidString)", isDirectory: true)
+        return HibernationCoordinator(
+            db: db,
+            tmux: TmuxManager(dryRun: true),
+            configDirManager: ClaudeProfileConfigDirManager(
+                baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
+                hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)),
+            actuationLog: ActuationLog(path: logPath))
+    }
+
+    @Test("merge-park writes its own rail row, with no method and a rail-named actor")
+    func mergeParkWritesRailRow() async throws {
+        let fixture = try await makeParkable()
+        let logPath = try makeLogPath()
+        let coordinator = makeCoordinator(db: fixture.db, logPath: logPath)
+
+        let result = await coordinator.hibernateForMerge(terminalID: fixture.terminalID)
+        #expect(result == .ok)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "hibernate")
+        // Daemon-internal: no RPC carried this, so no method.
+        #expect(request["method"] == nil)
+        let actor = try #require(request["actor"] as? [String: Any])
+        #expect(actor["kind"] as? String == "daemon")
+        #expect(actor["rail"] as? String == "auto-hibernate-on-merge")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == fixture.worktreeID.uuidString)
+        #expect(target["terminal"] as? String == fixture.terminalID.uuidString)
+        #expect(written.last?["result"] as? String == "dispatched")
+    }
+
+    @Test("a terminal the rails refuse is never acted on, so it writes no row")
+    func mergeParkRefusedByRailWritesNothing() async throws {
+        let fixture = try await makeParkable(keepWarm: true)
+        let logPath = try makeLogPath()
+        let coordinator = makeCoordinator(db: fixture.db, logPath: logPath)
+
+        let result = await coordinator.hibernateForMerge(terminalID: fixture.terminalID)
+        #expect(result == .notEligible(reason: "Terminal is pinned keep-warm"))
+        #expect(try rows(at: logPath).isEmpty)
+    }
+
+    @Test("an unwritable record skips the merge park — the session stays live")
+    func unwritableRecordSkipsMergePark() async throws {
+        let fixture = try await makeParkable()
+        let coordinator = makeCoordinator(db: fixture.db, logPath: try makeUnwritablePath())
+
+        let result = await coordinator.hibernateForMerge(terminalID: fixture.terminalID)
+        guard case .notEligible(let reason) = result else {
+            Issue.record("expected the park to be skipped, got \(result)")
+            return
+        }
+        #expect(reason.contains("actuation log"))
+        let after = try await fixture.db.terminals.get(id: fixture.terminalID)
+        #expect(after?.hibernatedAt == nil)
+    }
+}
+}

--- a/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
@@ -170,6 +170,26 @@ struct ActuationLogSpawnWiringTests {
         }
     }
 
+    /// The repo lookup is a plain DB read, not an act — so it happens ahead of
+    /// the row, and a missing repo is declined before anything claims a spawn
+    /// was about to be dispatched. Same shape as every other handler's
+    /// pre-row validation.
+    @Test("a create naming a repo that does not exist writes no row at all")
+    func worktreeCreateWithUnknownRepoWritesNoRow() async throws {
+        let iso = isolateTBDHome(); defer { iso.cleanup() }
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeCreate,
+            params: WorktreeCreateParams(repoID: UUID()),
+            actor: .app))
+
+        #expect(!response.success)
+        #expect(try rows(at: logPath).isEmpty)
+    }
+
     @Test("an unwritable record refuses the create and leaves no half-created row")
     func unwritableRecordRefusesWorktreeCreate() async throws {
         let iso = isolateTBDHome(); defer { iso.cleanup() }

--- a/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSpawnWiringTests.swift
@@ -161,6 +161,7 @@ struct ActuationLogSpawnWiringTests {
         let target = try #require(request["target"] as? [String: Any])
         #expect(target["worktree"] as? String == pending.id.uuidString)
         #expect(target["terminal"] == nil)
+        #expect((request["actor"] as? [String: Any])?["kind"] as? String == "app")
         #expect(written.last?["result"] as? String == "dispatched")
 
         // Let the background phase finish before the fixture repo goes away.

--- a/Tests/TBDDaemonTests/ActuationLogSweepWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogSweepWiringTests.swift
@@ -1,0 +1,351 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — dry-run tmux, a real (temp-directory) actuation log, and a real git
+/// repo for the reconcile fixture.
+///
+/// The two daemon-internal rails this covers act with nobody having asked: the
+/// boot-time reconcile sweep (kills the windows of worktrees that left disk,
+/// parks sessions whose window is gone, reaps orphaned windows and dead
+/// servers) and the auto-archive-on-merge rail. Both carry `{"kind":"daemon",
+/// "rail":…}` and no `method`, and both skip their act rather than perform it
+/// unrecorded.
+@Suite("Actuation log sweep wiring")
+struct ActuationLogSweepWiringTests {
+
+    // MARK: - Fixture
+
+    private func makeLogPath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-sweep-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    /// A path that can never be opened: its parent is a regular file.
+    private func makeUnwritablePath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-blocked-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let blocker = directory.appendingPathComponent("blocker")
+        try Data("not a directory".utf8).write(to: blocker)
+        return blocker.appendingPathComponent("actuations.jsonl").path
+    }
+
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    private func requests(at path: String) throws -> [[String: Any]] {
+        try rows(at: path).filter { $0["kind"] as? String != "outcome" }
+    }
+
+    private func outcomes(at path: String) throws -> [[String: Any]] {
+        try rows(at: path).filter { $0["kind"] as? String == "outcome" }
+    }
+
+    private func makeLifecycle(db: TBDDatabase, tmux: TmuxManager) -> WorktreeLifecycle {
+        WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver())
+    }
+
+    // MARK: - reconcile: a worktree that left disk
+
+    @Test("reconcile writes one dispose row per window it kills, with the reconcile rail")
+    func reconcileKillsWriteDisposeRows() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, tmux: TmuxManager(dryRun: true))
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        // A worktree row whose path is not a live git worktree → reconcile
+        // archives it, killing its windows on the way.
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "gone", branch: "gone-branch",
+            path: tempDir.appendingPathComponent("vanished").path, tmuxServer: "tbd-acme")
+        var terminalIDs: Set<String> = []
+        for index in 0..<2 {
+            let terminal = try await db.terminals.create(
+                worktreeID: worktree.id, tmuxWindowID: "@\(index)", tmuxPaneID: "%\(index)")
+            terminalIDs.insert(terminal.id.uuidString)
+        }
+
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath))
+
+        // The same sweep also reaps the servers those rows leave behind; this is
+        // about the per-terminal kills.
+        let written = try requests(at: logPath).filter {
+            ($0["target"] as? [String: Any])?["terminal"] != nil
+        }
+        #expect(written.count == 2)
+        #expect(written.allSatisfy { $0["kind"] as? String == "dispose" })
+        // Daemon-internal: no RPC carried this, so no method.
+        #expect(written.allSatisfy { $0["method"] == nil })
+        #expect(written.allSatisfy {
+            ($0["actor"] as? [String: Any])?["rail"] as? String == "reconcile"
+        })
+        #expect(written.allSatisfy {
+            ($0["actor"] as? [String: Any])?["kind"] as? String == "daemon"
+        })
+        // One row per kill: each names the terminal it was about to kill.
+        let named = Set(written.compactMap { ($0["target"] as? [String: Any])?["terminal"] as? String })
+        #expect(named == terminalIDs)
+        #expect(try outcomes(at: logPath).allSatisfy { $0["result"] as? String == "dispatched" })
+        #expect(try await db.worktrees.get(id: worktree.id)?.status == .archived)
+    }
+
+    @Test("an unwritable record leaves the worktree and its windows for the next sweep")
+    func unwritableRecordSkipsReconcileKills() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, tmux: TmuxManager(dryRun: true))
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "gone", branch: "gone-branch",
+            path: tempDir.appendingPathComponent("vanished").path, tmuxServer: "tbd-acme")
+        _ = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@0", tmuxPaneID: "%0")
+
+        // The sweep still completes — the daemon boots either way.
+        try await lifecycle.reconcile(
+            repoID: repo.id, actuationLog: ActuationLog(path: try makeUnwritablePath()))
+
+        // But the act did not happen: the row is still active and still owns its
+        // terminal, so the next sweep (with a writable log) retries it.
+        #expect(try await db.worktrees.get(id: worktree.id)?.status == .active)
+        #expect(try await db.terminals.list(worktreeID: worktree.id).count == 1)
+    }
+
+    // MARK: - reconcile: the recovery park
+
+    @Test("reconcile writes a hibernate row for the recovery park it performs itself")
+    func reconcileRecoveryParkWritesHibernateRow() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        // Every window reports dead, so the live main worktree's Claude session
+        // takes the park-on-recovery branch.
+        let lifecycle = makeLifecycle(
+            db: db, tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }))
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        let main = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoDir.path,
+            tmuxServer: TmuxManager.serverName(forRepoPath: repoDir.path))
+        let terminal = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-1", kind: .claude)
+
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath))
+
+        let parks = try requests(at: logPath).filter { $0["kind"] as? String == "hibernate" }
+        #expect(parks.count == 1)
+        let request = try #require(parks.first)
+        #expect(request["method"] == nil)
+        #expect((request["actor"] as? [String: Any])?["rail"] as? String == "reconcile")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == main.id.uuidString)
+        #expect(target["terminal"] as? String == terminal.id.uuidString)
+
+        let outcome = try #require(
+            try outcomes(at: logPath).first { $0["confirms"] as? String == request["id"] as? String })
+        #expect(outcome["result"] as? String == "dispatched")
+        let parked = try await db.terminals.get(id: terminal.id)
+        #expect(parked?.hibernatedAt != nil)
+        #expect(parked?.hibernateReason == .recovery)
+    }
+
+    @Test("an unwritable record skips the recovery park — the row stays unparked")
+    func unwritableRecordSkipsRecoveryPark() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(
+            db: db, tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }))
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        let main = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoDir.path,
+            tmuxServer: TmuxManager.serverName(forRepoPath: repoDir.path))
+        let terminal = try await db.terminals.create(
+            worktreeID: main.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, claudeSessionID: "sess-1", kind: .claude)
+
+        try await lifecycle.reconcile(
+            repoID: repo.id, actuationLog: ActuationLog(path: try makeUnwritablePath()))
+
+        #expect(try await db.terminals.get(id: terminal.id)?.hibernatedAt == nil)
+    }
+
+    // MARK: - reconcile: servers and orphaned windows
+
+    @Test("killing a server nobody references writes a dispose row naming the server")
+    func reconcileKillServerWritesDisposeRow() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db, tmux: TmuxManager(dryRun: true))
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        // An archived row is the last pointer at this server — no live row
+        // references it, so the sweep kills the server itself.
+        let retired = try await db.worktrees.create(
+            repoID: repo.id, name: "retired", branch: "retired-branch",
+            path: tempDir.appendingPathComponent("retired").path, tmuxServer: "tbd-orphan-server")
+        try await db.worktrees.archive(id: retired.id)
+
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath))
+
+        let serverRows = try requests(at: logPath).filter {
+            ($0["target"] as? [String: Any])?["server"] as? String == "tbd-orphan-server"
+        }
+        #expect(serverRows.count == 1)
+        let request = try #require(serverRows.first)
+        #expect(request["kind"] as? String == "dispose")
+        #expect(request["method"] == nil)
+        #expect((request["actor"] as? [String: Any])?["rail"] as? String == "reconcile")
+        let target = try #require(request["target"] as? [String: Any])
+        // Nothing names this server any more, so the row carries what does
+        // identify it: the server, and the repo whose sweep found it.
+        #expect(target["repo"] as? String == repo.id.uuidString)
+        #expect(target["window"] == nil)
+        #expect(target["terminal"] == nil)
+        #expect(try outcomes(at: logPath).contains {
+            $0["confirms"] as? String == request["id"] as? String
+                && $0["result"] as? String == "dispatched"
+        })
+    }
+
+    @Test("sweeping an orphaned window writes a dispose row naming server and window")
+    func reconcileOrphanWindowWritesDisposeRow() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let server = TmuxManager.serverName(forRepoPath: repoDir.path)
+        // One live window on the repo's own server that no terminal row claims.
+        let lifecycle = makeLifecycle(
+            db: db,
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunListWindows: { probed, _ in
+                    probed == server ? [(windowID: "@99", paneID: "%99")] : []
+                }))
+        let repo = try await db.repos.create(
+            path: repoDir.path, displayName: "acme", defaultBranch: "main")
+        _ = try await db.worktrees.createMain(
+            repoID: repo.id, name: "main", branch: "main", path: repoDir.path,
+            tmuxServer: server)
+
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: ActuationLog(path: logPath))
+
+        let orphanRows = try requests(at: logPath).filter {
+            ($0["target"] as? [String: Any])?["window"] as? String == "@99"
+        }
+        #expect(orphanRows.count == 1)
+        let request = try #require(orphanRows.first)
+        #expect(request["kind"] as? String == "dispose")
+        #expect((request["actor"] as? [String: Any])?["rail"] as? String == "reconcile")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["server"] as? String == server)
+        #expect(target["repo"] as? String == repo.id.uuidString)
+        #expect(try outcomes(at: logPath).contains {
+            $0["confirms"] as? String == request["id"] as? String
+                && $0["result"] as? String == "dispatched"
+        })
+    }
+
+    // MARK: - The auto-archive-on-merge rail
+
+    private func makeMergeFixture(
+        logPath: String
+    ) async throws -> (coordinator: AutoArchiveOnMergeCoordinator, db: TBDDatabase, worktreeID: UUID) {
+        let db = try TBDDatabase(inMemory: true)
+        let subscriptions = StateSubscriptionManager()
+        let lifecycle = makeLifecycle(db: db, tmux: TmuxManager(dryRun: true))
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "acme-branch",
+            path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
+        try await db.worktrees.setAutoArchiveOnMerge(id: worktree.id, value: true)
+        _ = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@0", tmuxPaneID: "%0")
+        let coordinator = AutoArchiveOnMergeCoordinator(
+            db: db, lifecycle: lifecycle, subscriptions: subscriptions,
+            actuationLog: ActuationLog(path: logPath))
+        return (coordinator, db, worktree.id)
+    }
+
+    @Test("auto-archive-on-merge writes its own rail row, with no method")
+    func autoArchiveRailWritesRow() async throws {
+        let logPath = try makeLogPath()
+        let fixture = try await makeMergeFixture(logPath: logPath)
+
+        let archived = await fixture.coordinator.handleMergedTransition(
+            worktreeID: fixture.worktreeID, prNumber: 7)
+        #expect(archived)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "dispose")
+        #expect(request["method"] == nil)
+        let actor = try #require(request["actor"] as? [String: Any])
+        #expect(actor["kind"] as? String == "daemon")
+        #expect(actor["rail"] as? String == "auto-archive-on-merge")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == fixture.worktreeID.uuidString)
+        // One row for the whole worktree, as the RPC archive records it.
+        #expect(target["terminal"] == nil)
+        let outcome = try #require(written.last)
+        #expect(outcome["confirms"] as? String == request["id"] as? String)
+        #expect(outcome["result"] as? String == "dispatched")
+    }
+
+    @Test("a worktree the rail is not armed for is never acted on, so it writes no row")
+    func autoArchiveDisarmedWritesNothing() async throws {
+        let logPath = try makeLogPath()
+        let fixture = try await makeMergeFixture(logPath: logPath)
+        try await fixture.db.worktrees.setAutoArchiveOnMerge(id: fixture.worktreeID, value: false)
+
+        let archived = await fixture.coordinator.handleMergedTransition(
+            worktreeID: fixture.worktreeID, prNumber: 7)
+        #expect(!archived)
+        #expect(try rows(at: logPath).isEmpty)
+    }
+
+    @Test("an unwritable record skips the auto-archive — the worktree survives")
+    func unwritableRecordSkipsAutoArchive() async throws {
+        let fixture = try await makeMergeFixture(logPath: try makeUnwritablePath())
+
+        let archived = await fixture.coordinator.handleMergedTransition(
+            worktreeID: fixture.worktreeID, prNumber: 7)
+
+        // Reported as not-archived, so the merge-park rail behind it still gets
+        // its turn — and the worktree and its session are untouched.
+        #expect(!archived)
+        #expect(try await fixture.db.worktrees.get(id: fixture.worktreeID)?.status == .active)
+        #expect(try await fixture.db.terminals.list(worktreeID: fixture.worktreeID).count == 1)
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationLogTeardownWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTeardownWiringTests.swift
@@ -1,0 +1,436 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — dry-run tmux plus a real (temp-directory) actuation log.
+///
+/// The teardown surfaces: `worktree.archive`, `worktree.forget`,
+/// `scratch.delete` and `scratch.archive` all kill a worktree's windows, and
+/// `worktree.rerunPreSession` spawns one. Each writes ONE row naming the
+/// worktree — the per-terminal kills inside the lifecycle are sub-steps of the
+/// one thing the caller asked for — and each refuses its act when the record is
+/// unwritable.
+///
+/// Also here, because they are about *when* a row is written rather than which:
+/// `terminal.delete`'s failed kill reads as transport-failed rather than
+/// dispatched, and `terminal.swapProfile`'s row precedes the transcript copy it
+/// makes on the resume path.
+@Suite("Actuation log teardown wiring")
+struct ActuationLogTeardownWiringTests {
+
+    // MARK: - Fixture
+
+    private func makeLogPath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-teardown-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    /// A path that can never be opened: its parent is a regular file.
+    private func makeUnwritablePath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-blocked-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let blocker = directory.appendingPathComponent("blocker")
+        try Data("not a directory".utf8).write(to: blocker)
+        return blocker.appendingPathComponent("actuations.jsonl").path
+    }
+
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    private func makeRouter(
+        db: TBDDatabase, logPath: String, tmux: TmuxManager = TmuxManager(dryRun: true)
+    ) -> RPCRouter {
+        RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: ActuationLog(path: logPath))
+    }
+
+    /// A repo-backed worktree with `count` live terminals on it.
+    private func makeWorktree(
+        in db: TBDDatabase, terminals count: Int = 2
+    ) async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "acme-branch",
+            path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
+        for index in 0..<count {
+            _ = try await db.terminals.create(
+                worktreeID: worktree.id, tmuxWindowID: "@\(index)", tmuxPaneID: "%\(index)")
+        }
+        return worktree
+    }
+
+    private func makeScratch(
+        in db: TBDDatabase, terminals count: Int = 2
+    ) async throws -> Worktree {
+        let name = "acme-scratch-\(UUID().uuidString)"
+        let scratch = try await db.worktrees.createScratch(
+            name: name, displayName: name, path: "/tmp/\(name)", tmuxServer: "tbd-scratch")
+        for index in 0..<count {
+            _ = try await db.terminals.create(
+                worktreeID: scratch.id, tmuxWindowID: "@\(index)", tmuxPaneID: "%\(index)")
+        }
+        return scratch
+    }
+
+    // MARK: - worktree.archive
+
+    @Test("worktree.archive writes one dispose row naming the worktree, not its terminals")
+    func archiveWritesOneWorktreeNamedRow() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let worktree = try await makeWorktree(in: db)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: worktree.id),
+            actor: .app))
+        #expect(response.success)
+
+        let written = try rows(at: logPath)
+        // Two terminals died, but the caller asked for one thing — so one row.
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "dispose")
+        #expect(request["method"] as? String == "worktree.archive")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == worktree.id.uuidString)
+        #expect(target["terminal"] == nil)
+        #expect((request["actor"] as? [String: Any])?["kind"] as? String == "app")
+
+        let outcome = try #require(written.last)
+        #expect(outcome["confirms"] as? String == request["id"] as? String)
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(try await db.terminals.list(worktreeID: worktree.id).isEmpty)
+    }
+
+    @Test("an unwritable record refuses the archive — the sessions stay live")
+    func unwritableRecordRefusesArchive() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: try makeUnwritablePath())
+        let worktree = try await makeWorktree(in: db)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeArchive,
+            params: WorktreeArchiveParams(worktreeID: worktree.id)))
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("actuation log"))
+        #expect(try await db.worktrees.get(id: worktree.id)?.status == .active)
+        #expect(try await db.terminals.list(worktreeID: worktree.id).count == 2)
+    }
+
+    // MARK: - worktree.forget
+
+    @Test("worktree.forget writes one dispose row under its own method")
+    func forgetWritesOneWorktreeNamedRow() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let worktree = try await makeWorktree(in: db)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeForget,
+            params: WorktreeForgetParams(worktreeID: worktree.id),
+            actor: .app))
+        #expect(response.success)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "dispose")
+        #expect(request["method"] as? String == "worktree.forget")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == worktree.id.uuidString)
+        #expect(target["terminal"] == nil)
+        #expect(written.last?["result"] as? String == "dispatched")
+        #expect(try await db.worktrees.get(id: worktree.id) == nil)
+    }
+
+    @Test("an unwritable record refuses the forget — the row and its sessions survive")
+    func unwritableRecordRefusesForget() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: try makeUnwritablePath())
+        let worktree = try await makeWorktree(in: db)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeForget,
+            params: WorktreeForgetParams(worktreeID: worktree.id)))
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("actuation log"))
+        #expect(try await db.worktrees.get(id: worktree.id) != nil)
+        #expect(try await db.terminals.list(worktreeID: worktree.id).count == 2)
+    }
+
+    // MARK: - worktree.rerunPreSession
+
+    @Test("a pre-session re-run with no hook writes a spawn row confirmed as refused")
+    func rerunPreSessionRefusalIsRecorded() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let worktree = try await makeWorktree(in: db, terminals: 0)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRerunPreSession,
+            params: WorktreeRerunPreSessionParams(worktreeID: worktree.id),
+            actor: .app))
+        #expect(!response.success)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "spawn")
+        #expect(request["method"] as? String == "worktree.rerunPreSession")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == worktree.id.uuidString)
+        // The hook's terminal is minted inside the lifecycle, so there is none
+        // to name at request time.
+        #expect(target["terminal"] == nil)
+
+        let outcome = try #require(written.last)
+        #expect(outcome["confirms"] as? String == request["id"] as? String)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-eligible")
+        #expect(outcome["error"] as? String == response.error)
+    }
+
+    @Test("a pre-session re-run on a vanished worktree is refused as not-found")
+    func rerunPreSessionMissingWorktreeIsNotFound() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.worktreeRerunPreSession,
+            params: WorktreeRerunPreSessionParams(worktreeID: UUID())))
+        #expect(!response.success)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        #expect(written.last?["result"] as? String == "refused")
+        #expect(written.last?["reason"] as? String == "not-found")
+    }
+
+    // MARK: - scratch.delete / scratch.archive
+
+    @Test("scratch.delete writes one dispose row naming the scratch space")
+    func scratchDeleteWritesOneRow() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let scratch = try await makeScratch(in: db)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchDelete,
+            params: ScratchDeleteParams(worktreeID: scratch.id),
+            actor: .app))
+        #expect(response.success)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "dispose")
+        #expect(request["method"] as? String == "scratch.delete")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == scratch.id.uuidString)
+        #expect(target["terminal"] == nil)
+        #expect(written.last?["result"] as? String == "dispatched")
+        #expect(try await db.worktrees.get(id: scratch.id) == nil)
+    }
+
+    @Test("scratch.archive writes the same dispose row under its own method")
+    func scratchArchiveWritesOneRow() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let scratch = try await makeScratch(in: db)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchArchive,
+            params: ScratchArchiveParams(worktreeID: scratch.id),
+            actor: .app))
+        #expect(response.success)
+
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        #expect(written.first?["kind"] as? String == "dispose")
+        #expect(written.first?["method"] as? String == "scratch.archive")
+        #expect(written.last?["result"] as? String == "dispatched")
+        #expect(try await db.worktrees.get(id: scratch.id)?.status == .archived)
+    }
+
+    @Test("a scratch space that does not exist is declined before any row exists")
+    func scratchDeleteOfAbsentRowWritesNothing() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: UUID())))
+        #expect(!response.success)
+        #expect(try rows(at: logPath).isEmpty)
+    }
+
+    @Test("an unwritable record refuses the scratch teardown — the sessions stay live")
+    func unwritableRecordRefusesScratchTeardown() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: try makeUnwritablePath())
+        let scratch = try await makeScratch(in: db)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.scratchDelete,
+            params: ScratchDeleteParams(worktreeID: scratch.id)))
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("actuation log"))
+        #expect(try await db.worktrees.get(id: scratch.id) != nil)
+        #expect(try await db.terminals.list(worktreeID: scratch.id).count == 2)
+    }
+
+    // MARK: - terminal.delete: a kill that failed is not a dispatch
+
+    @Test("terminal.delete records a failed kill as transport-failed, and still closes")
+    func deleteRecordsFailedKillAsTransportFailed() async throws {
+        struct TmuxWentAway: Error, CustomStringConvertible {
+            var description: String { "no server running on tbd-acme" }
+        }
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(
+            db: db, logPath: logPath,
+            tmux: TmuxManager(dryRun: true, dryRunKillWindowError: { _, _ in TmuxWentAway() }))
+        let worktree = try await makeWorktree(in: db, terminals: 0)
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        // The UX is unchanged: the deletion proceeds and the response is the
+        // same one a clean kill returns.
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: terminal.id),
+            actor: .app))
+        #expect(response.success)
+        #expect(try response.decodeResult(TerminalDeleteResult.self).closed)
+        #expect(try await db.terminals.get(id: terminal.id) == nil)
+
+        // Only the record knows the kill failed — which is the point.
+        let written = try rows(at: logPath)
+        #expect(written.count == 2)
+        #expect(written.first?["kind"] as? String == "dispose")
+        let outcome = try #require(written.last)
+        #expect(outcome["result"] as? String == "transport-failed")
+        #expect(outcome["error"] as? String == "\(TmuxWentAway())")
+        #expect(outcome["reason"] == nil)
+    }
+
+    @Test("a clean kill still reads as dispatched")
+    func deleteWithLiveTmuxStaysDispatched() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let worktree = try await makeWorktree(in: db, terminals: 0)
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        _ = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: terminal.id)))
+
+        #expect(try rows(at: logPath).last?["result"] as? String == "dispatched")
+    }
+
+    // MARK: - terminal.swapProfile: the row precedes the transcript copy
+
+    /// The resume branch copies the session transcript into the DESTINATION
+    /// profile's config dir before it respawns anything — a real mutation
+    /// outside the daemon. So the row has to come first, and the way to prove it
+    /// is to make the record unwritable: the copy must not have happened either.
+    @Test("an unwritable record refuses the swap before it copies the transcript")
+    func unwritableRecordRefusesSwapBeforeTranscriptCarry() async throws {
+        let baseDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-swap-row-base-\(UUID().uuidString)", isDirectory: true)
+        let hostDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-swap-row-host-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: baseDir)
+            try? FileManager.default.removeItem(at: hostDir)
+        }
+        let manager = ClaudeProfileConfigDirManager(
+            baseDirectory: baseDir, hostBaseDirectory: hostDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let tmux = TmuxManager(dryRun: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            usageFetcher: StubClaudeUsageFetcher(),
+            configDirManager: manager,
+            actuationLog: ActuationLog(path: try makeUnwritablePath()))
+
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
+        let destination = try await db.modelProfiles.create(name: "Dest", kind: .oauth)
+        defer { try? ModelProfileKeychain.delete(id: destination.id.uuidString) }
+
+        // An ambient Claude session with a non-blank transcript under the host
+        // (ambient) config dir — the shape whose swap carries a transcript.
+        let sessionID = UUID().uuidString
+        let slug = "-acme-slug"
+        let projectDir = hostDir
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(slug, isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        let transcript = projectDir.appendingPathComponent("\(sessionID).jsonl")
+        try #"{"type":"user","message":{"role":"user","content":"hello there"}}"#
+            .write(to: transcript, atomically: true, encoding: .utf8)
+
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: TerminalLabel.claudeCode, claudeSessionID: sessionID, kind: .claude)
+        try await db.terminals.updateSession(
+            id: terminal.id, sessionID: sessionID, transcriptPath: transcript.path)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.terminalSwapProfile,
+            params: TerminalSwapProfileParams(
+                terminalID: terminal.id, newProfileID: destination.id)))
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("actuation log"))
+        // Nothing was carried into the destination profile: the refusal landed
+        // ahead of the copy, which is what the row's placement buys.
+        let carried = manager.configDirectory(forProfileID: destination.id)
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(slug, isDirectory: true)
+            .appendingPathComponent("\(sessionID).jsonl")
+        #expect(!FileManager.default.fileExists(atPath: carried.path))
+        // And the session was left exactly as it was.
+        #expect(try await db.terminals.get(id: terminal.id)?.profileID == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationLogTeardownWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTeardownWiringTests.swift
@@ -307,6 +307,118 @@ struct ActuationLogTeardownWiringTests {
         #expect(try await db.terminals.list(worktreeID: scratch.id).count == 2)
     }
 
+    // MARK: - repo.remove: the cascade that archives a repo's worktrees
+
+    @Test("a forced repo.remove writes one dispose row per worktree it tears down")
+    func repoRemoveWritesRowPerCascadedWorktree() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        var worktreeIDs: Set<String> = []
+        for index in 0..<2 {
+            let worktree = try await db.worktrees.create(
+                repoID: repo.id, name: "acme-wt-\(index)", branch: "acme-branch-\(index)",
+                path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
+            _ = try await db.terminals.create(
+                worktreeID: worktree.id, tmuxWindowID: "@\(index)", tmuxPaneID: "%\(index)")
+            worktreeIDs.insert(worktree.id.uuidString)
+        }
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: repo.id, force: true),
+            actor: .app))
+        #expect(response.success)
+
+        let written = try rows(at: logPath)
+        let requests = written.filter { $0["kind"] as? String != "outcome" }
+        // Two worktrees torn down through two separate lifecycle calls — so two
+        // rows, each naming its own worktree and no terminal.
+        #expect(requests.count == 2)
+        #expect(requests.allSatisfy { $0["kind"] as? String == "dispose" })
+        #expect(requests.allSatisfy { $0["method"] as? String == "repo.remove" })
+        #expect(requests.allSatisfy {
+            ($0["actor"] as? [String: Any])?["kind"] as? String == "app"
+        })
+        let named = Set(requests.compactMap {
+            ($0["target"] as? [String: Any])?["worktree"] as? String
+        })
+        #expect(named == worktreeIDs)
+        #expect(requests.allSatisfy { ($0["target"] as? [String: Any])?["terminal"] == nil })
+
+        let outcomes = written.filter { $0["kind"] as? String == "outcome" }
+        #expect(outcomes.count == 2)
+        #expect(outcomes.allSatisfy { $0["result"] as? String == "dispatched" })
+        let confirmed = Set(outcomes.compactMap { $0["confirms"] as? String })
+        #expect(confirmed == Set(requests.compactMap { $0["id"] as? String }))
+    }
+
+    @Test("a repo with nothing active to tear down writes no row")
+    func repoRemoveWithoutWorktreesWritesNothing() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: repo.id, force: true)))
+        #expect(response.success)
+        #expect(try rows(at: logPath).isEmpty)
+    }
+
+    @Test("a repo that does not exist is declined before any row exists")
+    func repoRemoveOfAbsentRepoWritesNothing() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: UUID(), force: true)))
+        #expect(!response.success)
+        #expect(try rows(at: logPath).isEmpty)
+    }
+
+    /// The unforced refusal is pre-row validation too: nothing is torn down, so
+    /// nothing claims it was about to be.
+    @Test("an unforced removal that finds live worktrees writes no row")
+    func repoRemoveWithoutForceWritesNothing() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let worktree = try await makeWorktree(in: db)
+        let repoID = try #require(try await db.worktrees.get(id: worktree.id)?.repoID)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: repoID, force: false)))
+        #expect(!response.success)
+        #expect(try rows(at: logPath).isEmpty)
+        #expect(try await db.terminals.list(worktreeID: worktree.id).count == 2)
+    }
+
+    @Test("an unwritable record refuses the whole cascade — the repo survives intact")
+    func unwritableRecordRefusesRepoRemove() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: try makeUnwritablePath())
+        let worktree = try await makeWorktree(in: db)
+        let repoID = try #require(try await db.worktrees.get(id: worktree.id)?.repoID)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: repoID, force: true)))
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("actuation log"))
+        #expect(try await db.repos.get(id: repoID) != nil)
+        #expect(try await db.worktrees.get(id: worktree.id)?.status == .active)
+        #expect(try await db.terminals.list(worktreeID: worktree.id).count == 2)
+    }
+
     // MARK: - terminal.delete: a kill that failed is not a dispatch
 
     @Test("terminal.delete records a failed kill as transport-failed, and still closes")

--- a/Tests/TBDDaemonTests/ActuationLogTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTests.swift
@@ -138,11 +138,78 @@ struct ActuationLogTests {
         let path = directory.appendingPathComponent("actuations.jsonl").path
         let log = ActuationLog(path: path)
         let requestID = try await log.appendRequest(sendRow())
-        for result in [ActuationResult.dispatched, .refused, .transportFailed] {
+        for result in [ActuationOutcome.dispatched, .refused(.noop), .transportFailed] {
             await log.appendOutcome(confirms: requestID, result: result)
         }
         let results = try rows(at: path).compactMap { $0["result"] as? String }
         #expect(Set(results) == ["dispatched", "refused", "transport-failed"])
+    }
+
+    // MARK: - Why a refusal refused
+
+    @Test("a refused outcome names a closed reason beside the human-facing detail")
+    func refusedOutcomeCarriesItsReason() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        let requestID = try await log.appendRequest(sendRow())
+        await log.appendOutcome(
+            confirms: requestID, result: .refused(.notEligible), error: "Not hibernatable")
+
+        let outcome = try #require(try rows(at: path).last)
+        // Whitelist: exactly the keys a refused outcome is allowed to carry.
+        #expect(Set(outcome.keys)
+            == ["actor", "confirms", "error", "id", "kind", "reason", "result", "ts"])
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-eligible")
+        // The detail stays exactly as the daemon phrased it for a human.
+        #expect(outcome["error"] as? String == "Not hibernatable")
+    }
+
+    @Test("only refusals carry a reason — a dispatch and a transport failure carry none")
+    func onlyRefusalsCarryAReason() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        let requestID = try await log.appendRequest(sendRow())
+        await log.appendOutcome(confirms: requestID, result: .dispatched)
+        await log.appendOutcome(confirms: requestID, result: .transportFailed, error: "tmux exited 1")
+        await log.appendOutcome(confirms: requestID, result: .refused(.inFlight))
+
+        let outcomes = try rows(at: path).filter { $0["kind"] as? String == "outcome" }
+        #expect(outcomes.count == 3)
+        let reasoned = outcomes.filter { $0["reason"] != nil }
+        #expect(reasoned.count == 1)
+        #expect(reasoned.first?["result"] as? String == "refused")
+        #expect(reasoned.first?["reason"] as? String == "in-flight")
+    }
+
+    @Test("the refusal vocabulary is closed, and every name is query-shaped")
+    func refusedReasonVocabulary() {
+        #expect(Set(RefusedReason.allCases.map(\.rawValue))
+            == ["noop", "not-found", "not-eligible", "in-flight"])
+    }
+
+    @Test("park and wake results classify onto the vocabulary, no-ops apart from declines")
+    func parkAndWakeClassification() {
+        #expect(ActuationOutcome.classify(HibernateResult.ok) == .dispatched)
+        #expect(ActuationOutcome.classify(HibernateResult.alreadyHibernated) == .refused(.noop))
+        #expect(ActuationOutcome.classify(HibernateResult.notEligible(reason: "running"))
+            == .refused(.notEligible))
+        #expect(ActuationOutcome.classify(HibernateResult.notFound) == .refused(.notFound))
+
+        #expect(ActuationOutcome.classify(WakeResult.ok) == .dispatched)
+        #expect(ActuationOutcome.classify(WakeResult.respawnFailed(reason: "tmux")) == .transportFailed)
+        #expect(ActuationOutcome.classify(WakeResult.notHibernated) == .refused(.noop))
+        #expect(ActuationOutcome.classify(WakeResult.inFlight) == .refused(.inFlight))
+        #expect(ActuationOutcome.classify(WakeResult.notFound) == .refused(.notFound))
+        #expect(ActuationOutcome.classify(WakeResult.worktreeMissing(path: "/tmp/acme"))
+            == .refused(.notFound))
+        #expect(ActuationOutcome.classify(WakeResult.noSessionID) == .refused(.notEligible))
+        #expect(ActuationOutcome.classify(WakeResult.profileMissing(profileID: UUID()))
+            == .refused(.notEligible))
     }
 
     // MARK: - Rotation

--- a/Tests/TBDDaemonTests/ActuationLogTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTests.swift
@@ -1,0 +1,312 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — real filesystem, no clocks, no subprocesses.
+///
+/// Every test injects its own log path into `ActuationLog(path:)` rather than
+/// touching `TBD_HOME`: the seam exists precisely so this suite never needs the
+/// process-global env, which only `TBDHomeSerialized` may mutate.
+@Suite("Actuation log writer")
+struct ActuationLogTests {
+
+    // MARK: - Fixture
+
+    private static func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    /// Every JSON object in a file, in order.
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                let object = try JSONSerialization.jsonObject(with: Data(line.utf8))
+                return try #require(object as? [String: Any])
+            }
+    }
+
+    private func date(_ iso: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.formatOptions = [.withInternetDateTime]
+        return try #require(formatter.date(from: iso))
+    }
+
+    private func sendRow(message: String = "please rebase onto main") -> ActuationRow {
+        var row = ActuationRow(actor: .app, kind: .send)
+        row.method = ActuationSurface.terminalSend.method
+        row.target = ActuationTarget(
+            worktree: "1B7E2C90-88AA-4F60-B1D0-9E8F7A6B5C4D",
+            terminal: "6D40F3A1-2B14-4E14-9C4A-0F1D2E3A4B5C")
+        row.message = message
+        row.submit = true
+        return row
+    }
+
+    // MARK: - IDs
+
+    @Test("ids are 12 lowercase base36 characters and do not repeat")
+    func idFormatAndUniqueness() {
+        var seen = Set<String>()
+        for _ in 0..<500 {
+            let id = ActuationLog.mintID()
+            #expect(id.count == 12)
+            #expect(id.allSatisfy { $0.isASCII && ($0.isLowercase || $0.isNumber) })
+            #expect(id.allSatisfy { "abcdefghijklmnopqrstuvwxyz0123456789".contains($0) })
+            seen.insert(id)
+        }
+        #expect(seen.count == 500)
+    }
+
+    // MARK: - Envelope
+
+    @Test("a request row is one line carrying the envelope plus its body, and nothing else")
+    func requestRowShape() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path, now: { Date(timeIntervalSince1970: 1_770_300_131.482) })
+
+        let id = try await log.appendRequest(sendRow())
+
+        let written = try rows(at: path)
+        #expect(written.count == 1)
+        let row = try #require(written.first)
+        // Whitelist: exactly the keys this shape is allowed to carry.
+        #expect(Set(row.keys) == ["actor", "id", "kind", "message", "method", "submit", "target", "ts"])
+        #expect(row["id"] as? String == id)
+        #expect(row["kind"] as? String == "send")
+        #expect(row["method"] as? String == "terminal.send")
+        #expect(row["message"] as? String == "please rebase onto main")
+        #expect(row["submit"] as? Bool == true)
+        let actor = try #require(row["actor"] as? [String: Any])
+        #expect(Set(actor.keys) == ["kind"])
+        #expect(actor["kind"] as? String == "app")
+        let target = try #require(row["target"] as? [String: Any])
+        #expect(Set(target.keys) == ["terminal", "worktree"])
+        // ISO8601 UTC with millisecond precision — a log needs sub-second ordering.
+        let ts = try #require(row["ts"] as? String)
+        #expect(ts.hasSuffix("Z"))
+        #expect(ts.contains("."))
+        #expect(ts.count == "2026-08-05T14:02:11.482Z".count)
+    }
+
+    @Test("an outcome row confirms its request and is written by the daemon")
+    func outcomeRowShape() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        let requestID = try await log.appendRequest(sendRow())
+        await log.appendOutcome(confirms: requestID, result: .dispatched)
+
+        let written = try rows(at: path)
+        #expect(written.count == 2)
+        let outcome = try #require(written.last)
+        #expect(Set(outcome.keys) == ["actor", "confirms", "id", "kind", "result", "ts"])
+        #expect(outcome["kind"] as? String == "outcome")
+        #expect(outcome["confirms"] as? String == requestID)
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(outcome["id"] as? String != requestID)
+        let actor = try #require(outcome["actor"] as? [String: Any])
+        #expect(actor["kind"] as? String == "daemon")
+    }
+
+    @Test("a failed outcome carries its result and the error text")
+    func outcomeCarriesFailureDetail() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        let requestID = try await log.appendRequest(sendRow())
+        await log.appendOutcome(confirms: requestID, result: .transportFailed, error: "tmux exited 1")
+
+        let outcome = try #require(try rows(at: path).last)
+        #expect(outcome["result"] as? String == "transport-failed")
+        #expect(outcome["error"] as? String == "tmux exited 1")
+    }
+
+    @Test("no row ever claims the message landed")
+    func neverClaimsLanded() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+        let requestID = try await log.appendRequest(sendRow())
+        for result in [ActuationResult.dispatched, .refused, .transportFailed] {
+            await log.appendOutcome(confirms: requestID, result: result)
+        }
+        let results = try rows(at: path).compactMap { $0["result"] as? String }
+        #expect(Set(results) == ["dispatched", "refused", "transport-failed"])
+    }
+
+    // MARK: - Rotation
+
+    @Test("the first append of a new UTC day moves the previous segment aside")
+    func rotatesAcrossMidnight() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let dates = TestDateSource(try date("2026-08-05T23:59:59Z"))
+        let log = ActuationLog(path: path, now: dates.provider)
+
+        _ = try await log.appendRequest(sendRow(message: "before midnight"))
+        dates.now = try date("2026-08-06T00:00:01Z")
+        _ = try await log.appendRequest(sendRow(message: "after midnight"))
+
+        // The active file holds only the new day's row…
+        let active = try rows(at: path)
+        #expect(active.count == 1)
+        #expect(active.first?["message"] as? String == "after midnight")
+
+        // …and the segment is stamped with the UTC date of its LAST row.
+        let segment = directory.appendingPathComponent("actuations-2026-08-05.jsonl").path
+        let rotated = try rows(at: segment)
+        #expect(rotated.count == 1)
+        #expect(rotated.first?["message"] as? String == "before midnight")
+
+        // No header, footer, or marker row is ever written.
+        #expect(rotated.allSatisfy { $0["kind"] as? String == "send" })
+    }
+
+    @Test("appends within one UTC day never rotate")
+    func doesNotRotateWithinADay() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let dates = TestDateSource(try date("2026-08-05T00:00:01Z"))
+        let log = ActuationLog(path: path, now: dates.provider)
+
+        _ = try await log.appendRequest(sendRow(message: "early"))
+        dates.now = try date("2026-08-05T23:59:58Z")
+        _ = try await log.appendRequest(sendRow(message: "late"))
+
+        #expect(try rows(at: path).count == 2)
+        let siblings = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+        #expect(siblings == ["actuations.jsonl"])
+    }
+
+    @Test("a fresh writer learns the segment's day from the rows already on disk")
+    func segmentDayReadBackFromExistingFile() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let firstDay = try date("2026-08-05T12:00:00Z")
+        let first = ActuationLog(path: path, now: { firstDay })
+        _ = try await first.appendRequest(sendRow(message: "yesterday"))
+
+        // A daemon restart: a brand-new writer over the same file, next day.
+        let secondDay = try date("2026-08-06T09:00:00Z")
+        let second = ActuationLog(path: path, now: { secondDay })
+        _ = try await second.appendRequest(sendRow(message: "today"))
+
+        #expect(try rows(at: path).count == 1)
+        let rotated = try rows(
+            at: directory.appendingPathComponent("actuations-2026-08-05.jsonl").path)
+        #expect(rotated.first?["message"] as? String == "yesterday")
+    }
+
+    @Test("a name collision takes a numeric suffix rather than concatenating")
+    func rotationCollisionTakesNumericSuffix() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let collision = directory.appendingPathComponent("actuations-2026-08-05.jsonl")
+        try Data("{}\n".utf8).write(to: collision)
+
+        let dates = TestDateSource(try date("2026-08-05T10:00:00Z"))
+        let log = ActuationLog(path: path, now: dates.provider)
+        _ = try await log.appendRequest(sendRow(message: "day one"))
+        dates.now = try date("2026-08-06T10:00:00Z")
+        _ = try await log.appendRequest(sendRow(message: "day two"))
+
+        // The pre-existing segment is untouched…
+        #expect(try String(contentsOf: collision, encoding: .utf8) == "{}\n")
+        // …and the new one landed beside it under a suffixed name.
+        let suffixed = try rows(
+            at: directory.appendingPathComponent("actuations-2026-08-05-1.jsonl").path)
+        #expect(suffixed.first?["message"] as? String == "day one")
+    }
+
+    // MARK: - Fail-closed
+
+    @Test("an unwritable log throws a self-explaining error naming the path and the recovery")
+    func unwritablePathThrowsSelfExplainingError() async throws {
+        let directory = try Self.makeDirectory()
+        // A path whose parent is a FILE: neither the mkdir nor the open can work.
+        let blocker = directory.appendingPathComponent("blocker")
+        try Data("not a directory".utf8).write(to: blocker)
+        let path = blocker.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        await #expect(throws: ActuationLogUnwritable.self) {
+            _ = try await log.appendRequest(sendRow())
+        }
+
+        do {
+            _ = try await log.appendRequest(sendRow())
+            Issue.record("expected the append to refuse")
+        } catch let failure as ActuationLogUnwritable {
+            #expect(failure.path == path)
+            // Self-explaining: the full path, and what to do about it.
+            #expect(failure.description.contains(path))
+            #expect(failure.description.contains("actuation log"))
+            #expect(failure.description.contains("refused"))
+            #expect(failure.description.contains("TBD will recreate it"))
+            // The RPC router surfaces errors with "\(error)" — the message has
+            // to survive that, not just `localizedDescription`.
+            #expect("\(failure)" == failure.description)
+        }
+    }
+
+    @Test("an outcome append never throws, even when the log is unwritable")
+    func outcomeAppendNeverFailsClosed() async throws {
+        let directory = try Self.makeDirectory()
+        let blocker = directory.appendingPathComponent("blocker")
+        try Data("not a directory".utf8).write(to: blocker)
+        let log = ActuationLog(path: blocker.appendingPathComponent("actuations.jsonl").path)
+
+        // The act already ran; refusing retroactively is impossible.
+        await log.appendOutcome(confirms: "k7m2q9w4x1p8", result: .dispatched)
+    }
+
+    @Test("a file removed between appends is noticed and recreated by the reopen-retry")
+    func reopenRetryRecoversAfterFileRemoval() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        _ = try await log.appendRequest(sendRow(message: "first"))
+        // Someone moved the whole directory aside. The still-open descriptor
+        // would happily accept writes into the unlinked inode — the retry has
+        // to notice and recreate the file at the path instead.
+        try FileManager.default.removeItem(at: directory)
+
+        _ = try await log.appendRequest(sendRow(message: "second"))
+
+        let written = try rows(at: path)
+        #expect(written.count == 1)
+        #expect(written.first?["message"] as? String == "second")
+    }
+
+    @Test("a file replaced by a different file between appends is followed, not written past")
+    func replacedFileIsFollowed() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        _ = try await log.appendRequest(sendRow(message: "first"))
+        // An external rotation: the segment is moved aside and a fresh file
+        // takes its place at the same path.
+        try FileManager.default.moveItem(
+            atPath: path, toPath: directory.appendingPathComponent("archived.jsonl").path)
+        FileManager.default.createFile(atPath: path, contents: Data())
+
+        _ = try await log.appendRequest(sendRow(message: "second"))
+
+        #expect(try rows(at: path).map { $0["message"] as? String } == ["second"])
+        let archived = try rows(at: directory.appendingPathComponent("archived.jsonl").path)
+        #expect(archived.map { $0["message"] as? String } == ["first"])
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
@@ -105,6 +105,8 @@ struct ActuationLogWiringTests {
         #expect(outcome["kind"] as? String == "outcome")
         #expect(outcome["confirms"] as? String == request["id"] as? String)
         #expect(outcome["result"] as? String == "dispatched")
+        // Only a refusal has a reason to name.
+        #expect(outcome["reason"] == nil)
     }
 
     @Test("a request declaring no identity is recorded as anonymous, explicitly")
@@ -202,6 +204,9 @@ struct ActuationLogWiringTests {
         #expect(written.first?["method"] as? String == "terminal.create")
         let outcome = try #require(written.last)
         #expect(outcome["result"] as? String == "refused")
+        // A decline, not an idempotent no-op — and the record says which
+        // without anyone having to read the detail string.
+        #expect(outcome["reason"] as? String == "not-eligible")
         #expect(outcome["error"] as? String == response.error)
         // Refused means refused: no terminal row came out of it.
         #expect(try await fixture.db.terminals.list(worktreeID: worktree.id).isEmpty)
@@ -258,6 +263,7 @@ struct ActuationLogWiringTests {
         #expect(written.first?["kind"] as? String == "hibernate")
         #expect(written.first?["method"] as? String == "terminal.hibernate")
         #expect(written.last?["result"] as? String == "refused")
+        #expect(written.last?["reason"] as? String == "not-eligible")
         #expect(written.last?["error"] as? String != nil)
     }
 
@@ -293,8 +299,11 @@ struct ActuationLogWiringTests {
         #expect(request["kind"] as? String == "wake")
         #expect(request["method"] as? String == "terminal.wake")
         #expect(request["prompt"] as? String == "carry on")
-        // Nothing was parked, so the daemon declined without touching tmux.
+        // Nothing was parked, so the daemon declined without touching tmux —
+        // and waking something that was never parked is the idempotent no-op,
+        // not a decline the operator's controls made.
         #expect(written.last?["result"] as? String == "refused")
+        #expect(written.last?["reason"] as? String == "noop")
     }
 
     @Test("worktree.resume fans out one row per parked terminal")

--- a/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
@@ -1,0 +1,366 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — dry-run tmux plus a real (temp-directory) actuation log.
+///
+/// These prove the wiring rather than the writer: that each surface appends
+/// exactly one request row naming the right kind, method and actor, that the
+/// outcome row confirms it, and that an unwritable record refuses the act
+/// instead of performing it silently.
+@Suite("Actuation log wiring")
+struct ActuationLogWiringTests {
+
+    // MARK: - Fixture
+
+    private struct Fixture {
+        let router: RPCRouter
+        let db: TBDDatabase
+        let logPath: String
+    }
+
+    private func makeFixture(logPath: String? = nil) throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-wiring-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let path = logPath ?? directory.appendingPathComponent("actuations.jsonl").path
+
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db,
+                git: GitManager(),
+                tmux: TmuxManager(dryRun: true),
+                hooks: HookResolver()
+            ),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: ActuationLog(path: path)
+        )
+        return Fixture(router: router, db: db, logPath: path)
+    }
+
+    /// A path that can never be opened: its parent is a regular file.
+    private func makeUnwritablePath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-blocked-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let blocker = directory.appendingPathComponent("blocker")
+        try Data("not a directory".utf8).write(to: blocker)
+        return blocker.appendingPathComponent("actuations.jsonl").path
+    }
+
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    private func makeWorktree(in db: TBDDatabase) async throws -> Worktree {
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        return try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+    }
+
+    // MARK: - terminal.send
+
+    @Test("terminal.send writes one send request and one dispatched outcome")
+    func sendWritesRequestAndOutcome() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminal.id, text: "rebase onto main", submit: true),
+            actor: ActuationActor.session(
+                worktree: worktree.id.uuidString, terminal: terminal.id.uuidString)))
+        #expect(response.success)
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "send")
+        #expect(request["method"] as? String == "terminal.send")
+        // Payload verbatim: a stale premise stays visible, never filtered.
+        #expect(request["message"] as? String == "rebase onto main")
+        #expect(request["submit"] as? Bool == true)
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == worktree.id.uuidString)
+        #expect(target["terminal"] as? String == terminal.id.uuidString)
+        let actor = try #require(request["actor"] as? [String: Any])
+        #expect(actor["kind"] as? String == "session")
+        #expect(actor["terminal"] as? String == terminal.id.uuidString)
+
+        let outcome = try #require(written.last)
+        #expect(outcome["kind"] as? String == "outcome")
+        #expect(outcome["confirms"] as? String == request["id"] as? String)
+        #expect(outcome["result"] as? String == "dispatched")
+    }
+
+    @Test("a request declaring no identity is recorded as anonymous, explicitly")
+    func undeclaredCallerIsAnonymous() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        _ = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminal.id, text: "hello", submit: false)))
+
+        let request = try #require(try rows(at: fixture.logPath).first)
+        let actor = try #require(request["actor"] as? [String: Any])
+        #expect(Set(actor.keys) == ["kind"])
+        #expect(actor["kind"] as? String == "anonymous")
+    }
+
+    @Test("the app's declaration rides through the router untouched")
+    func appActorRecorded() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        _ = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminal.id, text: "hi", submit: false),
+            actor: .app))
+
+        let request = try #require(try rows(at: fixture.logPath).first)
+        #expect((request["actor"] as? [String: Any])?["kind"] as? String == "app")
+    }
+
+    @Test("a send to a terminal that does not exist acts on nothing and records nothing")
+    func missingTargetWritesNoRow() async throws {
+        let fixture = try makeFixture()
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: UUID(), text: "hi", submit: false)))
+        #expect(!response.success)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    // MARK: - spawn / dispose
+
+    @Test("terminal.create writes a spawn row naming the terminal it is about to mint")
+    func createWritesSpawnRow() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: worktree.id, cmd: "ls", type: .shell),
+            actor: .app))
+        #expect(response.success)
+        let created = try response.decodeResult(Terminal.self)
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "spawn")
+        #expect(request["method"] as? String == "terminal.create")
+        #expect(request["agent"] as? String == "shell")
+        let target = try #require(request["target"] as? [String: Any])
+        // The row was written BEFORE the spawn, and still names the row that
+        // came out of it — that is what pre-minting the id buys.
+        #expect(target["terminal"] as? String == created.id.uuidString)
+        #expect(written.last?["result"] as? String == "dispatched")
+    }
+
+    @Test("terminal.delete writes a dispose row")
+    func deleteWritesDisposeRow() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: terminal.id),
+            actor: .app))
+        #expect(response.success)
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        #expect(written.first?["kind"] as? String == "dispose")
+        #expect(written.first?["method"] as? String == "terminal.delete")
+        #expect(written.last?["result"] as? String == "dispatched")
+    }
+
+    @Test("closing an already-gone terminal acts on nothing and records nothing")
+    func deleteOfAbsentTerminalWritesNoRow() async throws {
+        let fixture = try makeFixture()
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalDelete,
+            params: TerminalDeleteParams(terminalID: UUID())))
+        #expect(response.success)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    // MARK: - park / wake, including the legacy shims
+
+    @Test("terminal.hibernate writes a hibernate row, and a decline reads as refused")
+    func hibernateWritesRefusedOutcomeForIneligibleTarget() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        // A plain shell terminal is not manually hibernatable — the daemon
+        // declines before it touches the transport.
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        _ = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalHibernate,
+            params: TerminalHibernateParams(terminalID: terminal.id),
+            actor: .app))
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        #expect(written.first?["kind"] as? String == "hibernate")
+        #expect(written.first?["method"] as? String == "terminal.hibernate")
+        #expect(written.last?["result"] as? String == "refused")
+        #expect(written.last?["error"] as? String != nil)
+    }
+
+    @Test("the legacy terminal.suspend shim records kind hibernate under its own method")
+    func legacySuspendKeepsItsMethod() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        _ = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSuspend,
+            params: TerminalSuspendParams(terminalID: terminal.id)))
+
+        let request = try #require(try rows(at: fixture.logPath).first)
+        #expect(request["kind"] as? String == "hibernate")
+        #expect(request["method"] as? String == "terminal.suspend")
+    }
+
+    @Test("terminal.wake writes a wake row carrying the prompt it would type")
+    func wakeCarriesPrompt() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        _ = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id, prompt: "carry on")))
+
+        let written = try rows(at: fixture.logPath)
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "wake")
+        #expect(request["method"] as? String == "terminal.wake")
+        #expect(request["prompt"] as? String == "carry on")
+        // Nothing was parked, so the daemon declined without touching tmux.
+        #expect(written.last?["result"] as? String == "refused")
+    }
+
+    @Test("worktree.resume fans out one row per parked terminal")
+    func worktreeResumeFansOutPerTerminal() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        for index in 1...2 {
+            let terminal = try await fixture.db.terminals.create(
+                worktreeID: worktree.id, tmuxWindowID: "@\(index)", tmuxPaneID: "%\(index)",
+                label: TerminalLabel.claudeCode, claudeSessionID: "session-\(index)", kind: .claude)
+            try await fixture.db.terminals.setHibernated(
+                id: terminal.id, sessionID: "session-\(index)")
+        }
+
+        _ = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.worktreeResume,
+            params: WorktreeResumeParams(worktreeID: worktree.id)))
+
+        let requests = try rows(at: fixture.logPath).filter { $0["kind"] as? String == "wake" }
+        #expect(requests.count == 2)
+        #expect(requests.allSatisfy { $0["method"] as? String == "worktree.resume" })
+        let terminals = Set(requests.compactMap { ($0["target"] as? [String: Any])?["terminal"] as? String })
+        #expect(terminals.count == 2)
+    }
+
+    // MARK: - Fail-closed
+
+    @Test("an unwritable record refuses the send with the self-explaining error")
+    func unwritableRecordRefusesSend() async throws {
+        let fixture = try makeFixture(logPath: try makeUnwritablePath())
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminal.id, text: "hi", submit: true)))
+
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains(fixture.logPath))
+        #expect(error.contains("actuation log"))
+        #expect(error.contains("TBD will recreate it"))
+    }
+
+    @Test("an unwritable record refuses the spawn — the terminal is never created")
+    func unwritableRecordRefusesSpawn() async throws {
+        let fixture = try makeFixture(logPath: try makeUnwritablePath())
+        let worktree = try await makeWorktree(in: fixture.db)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(worktreeID: worktree.id, cmd: "ls", type: .shell)))
+
+        #expect(!response.success)
+        #expect(try #require(response.error).contains("actuation log"))
+        // The act did not proceed: no terminal row exists.
+        #expect(try await fixture.db.terminals.list(worktreeID: worktree.id).isEmpty)
+    }
+
+    @Test("recovery: once the record is writable again, the next act goes through")
+    func recoversOnceRecordIsWritableAgain() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        func send() async -> RPCResponse {
+            await fixture.router.handle(try! RPCRequest(
+                method: RPCMethod.terminalSend,
+                params: TerminalSendParams(terminalID: terminal.id, text: "hi", submit: false)))
+        }
+
+        #expect(await send().success)
+        // Someone moved the whole directory aside between acts.
+        try FileManager.default.removeItem(
+            atPath: (fixture.logPath as NSString).deletingLastPathComponent)
+        #expect(await send().success)
+        #expect(try rows(at: fixture.logPath).count == 2)
+    }
+
+    // MARK: - The wired set
+
+    @Test("every wired surface names a real RPC method and a kind in the vocabulary")
+    func surfaceMapIsWellFormed() {
+        let kinds: Set<ActuationKind> = [.send, .wake, .hibernate, .spawn, .dispose]
+        var methods = Set<String>()
+        for surface in ActuationSurface.allCases {
+            #expect(!surface.method.isEmpty)
+            #expect(surface.method.contains("."))
+            #expect(kinds.contains(surface.kind))
+            methods.insert(surface.method)
+        }
+        // One surface per method — no two enum cases claim the same door.
+        #expect(methods.count == ActuationSurface.allCases.count)
+        // `outcome` is the daemon's own confirmation rung; no surface produces it.
+        #expect(!ActuationSurface.allCases.contains { $0.kind == .outcome })
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
@@ -177,6 +177,36 @@ struct ActuationLogWiringTests {
         #expect(written.last?["result"] as? String == "dispatched")
     }
 
+    /// A spawn the daemon declines *after* the row is written — the request row
+    /// still stands, and its outcome says refused rather than being left
+    /// unconfirmed. (The worktree-not-found and archived-worktree checks sit
+    /// ahead of the row and write nothing at all; this is the first refusal
+    /// downstream of it.)
+    @Test("a spawn the daemon declines after the row is written reads as refused")
+    func createRefusalIsConfirmedAsRefused() async throws {
+        let fixture = try makeFixture()
+        let worktree = try await makeWorktree(in: fixture.db)
+
+        // A login session with no profile to log into: the daemon refuses
+        // before it touches the transport.
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalCreate,
+            params: TerminalCreateParams(
+                worktreeID: worktree.id, type: .claude, loginSession: true),
+            actor: .app))
+        #expect(!response.success)
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        #expect(written.first?["kind"] as? String == "spawn")
+        #expect(written.first?["method"] as? String == "terminal.create")
+        let outcome = try #require(written.last)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["error"] as? String == response.error)
+        // Refused means refused: no terminal row came out of it.
+        #expect(try await fixture.db.terminals.list(worktreeID: worktree.id).isEmpty)
+    }
+
     @Test("terminal.delete writes a dispose row")
     func deleteWritesDisposeRow() async throws {
         let fixture = try makeFixture()

--- a/Tests/TBDDaemonTests/ActuationThrowClassificationTests.swift
+++ b/Tests/TBDDaemonTests/ActuationThrowClassificationTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 1 — no tmux, no subprocesses, one temp file.
+///
+/// The wired handlers call tmux and the DB with plain `try await` after their
+/// request row. Without `actuating`, such a throw falls through to the router's
+/// blanket catch, which writes no outcome — and the record then cannot tell
+/// "the act failed" from "the outcome was lost". This is that seam's own test:
+/// the outcome is recorded, and the error still propagates untouched so the RPC
+/// error surface stays byte-identical.
+@Suite("Actuation throw classification")
+struct ActuationThrowClassificationTests {
+
+    private struct TmuxWentAway: Error, CustomStringConvertible {
+        var description: String { "tmux server 'tbd-acme' is not running" }
+    }
+
+    private func makeFixture() throws -> (router: RPCRouter, logPath: String) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-throw-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            actuationLog: ActuationLog(path: path))
+        return (router, path)
+    }
+
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    @Test("a throw in the acting section is recorded as transport-failed and rethrown unchanged")
+    func throwIsRecordedAndRethrown() async throws {
+        let fixture = try makeFixture()
+        let requestID = try await fixture.router.beginActuation(
+            .terminalCreate, actor: .app,
+            target: .local(worktree: UUID(), terminal: UUID()))
+
+        await #expect(throws: TmuxWentAway.self) {
+            try await fixture.router.actuating(requestID) { throw TmuxWentAway() }
+        }
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        let outcome = try #require(written.last)
+        #expect(outcome["confirms"] as? String == requestID)
+        #expect(outcome["result"] as? String == "transport-failed")
+        // The error text the caller would have seen, verbatim.
+        #expect(outcome["error"] as? String == "\(TmuxWentAway())")
+    }
+
+    @Test("an acting section that returns writes no outcome of its own")
+    func successfulStepLeavesTheOutcomeToTheHandler() async throws {
+        let fixture = try makeFixture()
+        let requestID = try await fixture.router.beginActuation(
+            .terminalCreate, actor: .app,
+            target: .local(worktree: UUID(), terminal: UUID()))
+
+        let value = try await fixture.router.actuating(requestID) { 42 }
+        #expect(value == 42)
+        // Only the request row: the handler decides what a success is called,
+        // and one act must never confirm twice.
+        #expect(try rows(at: fixture.logPath).count == 1)
+    }
+}

--- a/Tests/TBDDaemonTests/AttachRPCTests.swift
+++ b/Tests/TBDDaemonTests/AttachRPCTests.swift
@@ -19,7 +19,8 @@ private func makeRouterAndDB() throws -> (RPCRouter, TBDDatabase) {
             hooks: HookResolver()
         ),
         tmux: TmuxManager(dryRun: true),
-        startTime: Date()
+        startTime: Date(),
+        actuationLog: makeTestActuationLog()
     )
     return (router, db)
 }

--- a/Tests/TBDDaemonTests/AutoArchiveRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveRPCTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite struct AutoArchiveRPCTests {
 
@@ -16,7 +17,8 @@ import Foundation
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
         return (router, db)
     }

--- a/Tests/TBDDaemonTests/AutoArchiveRuleTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveRuleTests.swift
@@ -80,7 +80,8 @@ import TestSupport
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
 
         let repo = try await db.repos.create(
@@ -120,7 +121,8 @@ import TestSupport
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
 
         let repo = try await db.repos.create(

--- a/Tests/TBDDaemonTests/AutoArchiveTriggerTests.swift
+++ b/Tests/TBDDaemonTests/AutoArchiveTriggerTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import TestSupport
 @testable import TBDDaemonLib
 @testable import TBDShared
 
@@ -45,7 +46,9 @@ actor FiredBox {
             hooks: HookResolver(),
             subscriptions: subs
         )
-        let coord = AutoArchiveOnMergeCoordinator(db: db, lifecycle: lifecycle, subscriptions: subs)
+        let coord = AutoArchiveOnMergeCoordinator(
+            db: db, lifecycle: lifecycle, subscriptions: subs,
+            actuationLog: makeTestActuationLog())
         return (coord, db)
     }
 

--- a/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// A `ClaudeProfileConfigDirManager` pointed at fresh temp dirs so nothing
 /// touches the developer's real `~/.claude` (mirrors HibernationCoordinatorTests).
@@ -30,7 +31,7 @@ struct AutoHibernateOnMergeCoordinatorTests {
         let subs = StateSubscriptionManager()
         let hibernation = HibernationCoordinator(
             db: db, tmux: TmuxManager(dryRun: true),
-            subscriptions: subs, configDirManager: isolatedConfigDirManager())
+            subscriptions: subs, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
         let coord = AutoHibernateOnMergeCoordinator(
             db: db, hibernation: hibernation, subscriptions: subs)
 

--- a/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateOnMergeCoordinatorTests.swift
@@ -25,13 +25,15 @@ struct AutoHibernateOnMergeCoordinatorTests {
         keepWarm: Bool = false,
         sessionID: String? = "sess-1",
         kind: TerminalKind? = .claude,
-        status: WorktreeStatus = .active
+        status: WorktreeStatus = .active,
+        logPath: String? = nil
     ) async throws -> (AutoHibernateOnMergeCoordinator, TBDDatabase, wtID: UUID, terminalID: UUID) {
         let db = try TBDDatabase(inMemory: true)
         let subs = StateSubscriptionManager()
         let hibernation = HibernationCoordinator(
             db: db, tmux: TmuxManager(dryRun: true),
-            subscriptions: subs, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
+            subscriptions: subs, configDirManager: isolatedConfigDirManager(),
+            actuationLog: logPath.map { ActuationLog(path: $0) } ?? makeTestActuationLog())
         let coord = AutoHibernateOnMergeCoordinator(
             db: db, hibernation: hibernation, subscriptions: subs)
 
@@ -203,5 +205,55 @@ struct AutoHibernateOnMergeCoordinatorTests {
         #expect(notifications.first?.type == .taskComplete)
         #expect(notifications.first?.message?.contains("2 sessions") == true)
         #expect(notifications.first?.message?.contains("#11") == true)
+    }
+
+    // MARK: - The rail's own actuation record
+
+    /// The fan-out is where a per-terminal record can go wrong in both
+    /// directions: one row for the whole merge would under-count the sessions
+    /// actually acted on, and a row written before the rails would count the
+    /// ones that were never touched. So: one request row per PARKED terminal,
+    /// each confirmed by exactly one outcome, and none for the refused one.
+    @Test func mergeParkWritesOneRequestAndOutcomePerParkedTerminal() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-authib-actuation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let logPath = directory.appendingPathComponent("actuations.jsonl").path
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let (coord, db, wtID, parkedID) = try await makeDeps(logPath: logPath)
+        try await db.worktrees.setAutoHibernateOnMerge(id: wtID, value: true)
+
+        // A second, keep-warm terminal: armed, but the rails refuse it.
+        let keptWarm = try await db.terminals.create(
+            worktreeID: wtID, tmuxWindowID: "@1", tmuxPaneID: "%1",
+            label: "claude2", claudeSessionID: "sess-2", kind: .claude)
+        try await db.terminals.setActivityState(id: keptWarm.id, activityState: .idle)
+        try await db.terminals.setKeepWarm(id: keptWarm.id, keepWarm: true)
+
+        await coord.handleMergedTransition(worktreeID: wtID, prNumber: 12)
+        #expect(try await db.terminals.get(id: parkedID)?.hibernatedAt != nil)
+        #expect(try await db.terminals.get(id: keptWarm.id)?.hibernatedAt == nil)
+
+        let written = try String(contentsOfFile: logPath, encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+        let requests = written.filter { $0["kind"] as? String == "hibernate" }
+        #expect(requests.count == 1, "only the terminal the rail actually parked gets a row")
+        let request = try #require(requests.first)
+        #expect(request["method"] == nil)
+        let actor = try #require(request["actor"] as? [String: Any])
+        #expect(actor["rail"] as? String == "auto-hibernate-on-merge")
+        #expect((request["target"] as? [String: Any])?["terminal"] as? String
+            == parkedID.uuidString)
+
+        let outcomes = written.filter { $0["kind"] as? String == "outcome" }
+        #expect(outcomes.count == 1)
+        #expect(outcomes.first?["confirms"] as? String == request["id"] as? String)
+        #expect(outcomes.first?["result"] as? String == "dispatched")
+        #expect(written.count == 2, "nothing else is written for a merge fan-out")
     }
 }

--- a/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite struct AutoHibernateRPCTests {
 
@@ -16,7 +17,8 @@ import Foundation
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
         return (router, db)
     }

--- a/Tests/TBDDaemonTests/AutoResumeConfigRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoResumeConfigRPCTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite struct AutoResumeConfigRPCTests {
     let db: TBDDatabase
@@ -16,7 +17,7 @@ import Testing
                 db: db, git: GitManager(),
                 tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date())
+            startTime: Date(), actuationLog: makeTestActuationLog())
     }
 
     @Test func enablePersistsFlag() async throws {

--- a/Tests/TBDDaemonTests/AutoTrustWorktreesRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoTrustWorktreesRPCTests.swift
@@ -3,6 +3,7 @@ import GRDB
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Worktree auto-trust RPC tests. Covers the `config.setAutoTrustWorktrees`
 /// RPC, the `daemon.capabilities` field carrying the flag, and the Codable
@@ -26,7 +27,8 @@ struct AutoTrustWorktreesRPCTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
         return (router, db)
     }

--- a/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
+++ b/Tests/TBDDaemonTests/CodexActivityReconciliationTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite("codex activity reconciliation")
 struct CodexActivityReconciliationTests {
@@ -20,7 +21,8 @@ struct CodexActivityReconciliationTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/ContinueInCodexRPCTests.swift
+++ b/Tests/TBDDaemonTests/ContinueInCodexRPCTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite("terminal.continueInCodex RPC")
 struct ContinueInCodexRPCTests {
@@ -65,7 +66,7 @@ struct ContinueInCodexRPCTests {
                 git: GitManager(),
                 tmux: tmux,
                 hooks: HookResolver()),
-            tmux: tmux)
+            tmux: tmux, actuationLog: makeTestActuationLog())
         router.codexExecutableResolver = {
             recorder.event("resolve")
             return "/opt/test/bin/codex"

--- a/Tests/TBDDaemonTests/ControlModeSettingsRPCTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeSettingsRPCTests.swift
@@ -25,7 +25,8 @@ struct ControlModeSettingsRPCTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
         return (router, db)
     }

--- a/Tests/TBDDaemonTests/DaemonMockGateTests.swift
+++ b/Tests/TBDDaemonTests/DaemonMockGateTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import TestSupport
 @testable import TBDDaemonLib
 @testable import TBDShared
 
@@ -36,7 +37,8 @@ struct DaemonMockGateTests {
 
         // Run with mockMode == nil (live mode) — RepoHealthValidator should flip it
         await Daemon().performStartupReconciliation(
-            mockMode: nil, database: db, git: git, lifecycle: lifecycle)
+            mockMode: nil, database: db, git: git, lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
 
         let after = try await db.repos.list()
         #expect(after.first?.status == .missing)
@@ -74,7 +76,8 @@ struct DaemonMockGateTests {
         // Run with mockMode == .enabled — reconciliation should be skipped
         await Daemon().performStartupReconciliation(
             mockMode: .enabled(fixturePath: "/tmp/x.json"),
-            database: db, git: git, lifecycle: lifecycle)
+            database: db, git: git, lifecycle: lifecycle,
+            actuationLog: makeTestActuationLog())
 
         // Repo should still be .ok (RepoHealthValidator never ran)
         let repos = try await db.repos.list()

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -117,7 +117,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             // First call creates
@@ -159,7 +160,8 @@ extension TBDHomeSerialized {
                     db: db,
                     lifecycle: lifecycle,
                         tmux: TmuxManager(dryRun: true),
-                    skillDir: skillDir
+                    skillDir: skillDir,
+                    actuationLog: makeTestActuationLog()
                 )
 
                 let desk = try await manager.ensureDeskSession(mode: .daywatch)
@@ -190,7 +192,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             // Nudge with non-existent ID should not throw
@@ -220,7 +223,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             let desk = try await manager.ensureDeskSession(mode: .daywatch)
@@ -258,7 +262,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             let dayDesk = try await manager.ensureDeskSession(mode: .daywatch)
@@ -294,7 +299,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             // Ensure creates desk with terminal
@@ -344,7 +350,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             // Create a desk with a Claude terminal so nudges don't fail on missing terminal
@@ -389,7 +396,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             let desk = try await manager.ensureDeskSession(mode: .nightwatch)
@@ -449,7 +457,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             let desk = try await manager.ensureDeskSession(mode: .daywatch)
@@ -504,7 +513,8 @@ extension TBDHomeSerialized {
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
                 skillDir: skillDir,
-                now: clock.provider
+                now: clock.provider,
+                actuationLog: makeTestActuationLog()
             )
 
             let desk = try await manager.ensureDeskSession(mode: .daywatch)
@@ -564,7 +574,8 @@ extension TBDHomeSerialized {
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
                 skillDir: skillDir,
-                now: clock.provider
+                now: clock.provider,
+                actuationLog: makeTestActuationLog()
             )
 
             let desk = try await manager.ensureDeskSession(mode: .daywatch)
@@ -612,7 +623,8 @@ extension TBDHomeSerialized {
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
                 skillDir: skillDir,
-                now: clock.provider
+                now: clock.provider,
+                actuationLog: makeTestActuationLog()
             )
 
             let desk = try await manager.ensureDeskSession(mode: .nightwatch)
@@ -657,7 +669,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: "/tmp/skill"
+                skillDir: "/tmp/skill",
+                actuationLog: makeTestActuationLog()
             )
 
             // Fire two ensures concurrently: without the FIFO gate both pass the
@@ -694,7 +707,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             // Create initial desk (caches ID internally)
@@ -740,7 +754,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             // Create a desk
@@ -794,7 +809,8 @@ extension TBDHomeSerialized {
                 db: db,
                 lifecycle: lifecycle,
                 tmux: TmuxManager(dryRun: true),
-                skillDir: skillDir
+                skillDir: skillDir,
+                actuationLog: makeTestActuationLog()
             )
 
             // Create initial desk (caches ID internally)
@@ -864,7 +880,8 @@ extension TBDHomeSerialized {
                     dryRunWindowIsDead: { dead.isDead($0) },
                     dryRunPaneCurrentCommand: { _, paneID in commands.command(for: paneID) }
                 ),
-                skillDir: home.appendingPathComponent("skills/nightwatch").path
+                skillDir: home.appendingPathComponent("skills/nightwatch").path,
+                actuationLog: makeTestActuationLog()
             )
             return (db, manager, recorder, dead, commands, spawnFailures, home, priorTBDHome)
         }
@@ -1103,7 +1120,7 @@ extension TBDHomeSerialized {
                     dryRunRecorder: { f.recorder.record($0) },
                     dryRunWindowIsDead: { f.dead.isDead($0) },
                     dryRunPaneCurrentCommand: { _, pane in f.commands.command(for: pane) }),
-                skillDir: f.home.appendingPathComponent("skills/nightwatch").path)
+                skillDir: f.home.appendingPathComponent("skills/nightwatch").path, actuationLog: makeTestActuationLog())
             _ = try await laterManager.ensureDeskSession(mode: .nightwatch)
             let before = f.recorder.pastedPanes.count
             await laterManager.nudgeDeskSession(worktreeID: desk.id, act: true)
@@ -1141,7 +1158,7 @@ extension TBDHomeSerialized {
                     dryRunRecorder: { f.recorder.record($0) },
                     dryRunWindowIsDead: { f.dead.isDead($0) },
                     dryRunPaneCurrentCommand: { _, pane in f.commands.command(for: pane) }),
-                skillDir: f.home.appendingPathComponent("skills/nightwatch").path)
+                skillDir: f.home.appendingPathComponent("skills/nightwatch").path, actuationLog: makeTestActuationLog())
             _ = try await laterManager.ensureDeskSession(mode: .nightwatch)
             await laterManager.nudgeDeskSession(worktreeID: desk.id, act: true)
 

--- a/Tests/TBDDaemonTests/GCHandlersTests.swift
+++ b/Tests/TBDDaemonTests/GCHandlersTests.swift
@@ -42,7 +42,8 @@ struct GCHandlersTests {
             ),
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
-            subscriptions: subscriptions
+            subscriptions: subscriptions,
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/HibernateInputVetoRPCTests.swift
+++ b/Tests/TBDDaemonTests/HibernateInputVetoRPCTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Pending-input veto for auto-hibernate RPC tests. Covers the
 /// `config.setHibernateInputVeto` RPC and the extended `daemon.capabilities`
@@ -20,7 +21,8 @@ struct HibernateInputVetoRPCTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
         return (router, db)
     }

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -63,7 +63,7 @@ struct HibernationCoordinatorTests {
     private func coordinator(_ db: TBDDatabase) -> HibernationCoordinator {
         HibernationCoordinator(
             db: db, tmux: TmuxManager(dryRun: true),
-            configDirManager: isolatedConfigDirManager())
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
     }
 
     // MARK: - Manual hibernate
@@ -154,7 +154,7 @@ struct HibernationCoordinatorTests {
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
         let clock = TestClock<Duration>()
         let coord = HibernationCoordinator(
-            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), clock: clock)
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), clock: clock, actuationLog: makeTestActuationLog())
 
         let park = Task { await coord.manualHibernate(terminalID: terminalID) }
         // Unblocks the single verify-exit poll attempt.
@@ -198,7 +198,7 @@ struct HibernationCoordinatorTests {
         let pollInterval: Duration = .milliseconds(200)
         let coord = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
-            exitPollAttempts: 3, exitPollInterval: pollInterval, clock: clock)
+            exitPollAttempts: 3, exitPollInterval: pollInterval, clock: clock, actuationLog: makeTestActuationLog())
 
         let park = Task { await coord.manualHibernate(terminalID: terminalID) }
         // Exhaust the whole poll window: one advance per attempt.
@@ -242,7 +242,7 @@ struct HibernationCoordinatorTests {
         let attempts = 3
         let coord = HibernationCoordinator(
             db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
-            exitPollAttempts: attempts, exitPollInterval: pollInterval, clock: clock)
+            exitPollAttempts: attempts, exitPollInterval: pollInterval, clock: clock, actuationLog: makeTestActuationLog())
         func interruptSent() -> Bool {
             recorded.snapshot()
                 .map { $0.joined(separator: " ") }
@@ -290,7 +290,7 @@ struct HibernationCoordinatorTests {
         // same hook in dryRun) and must persist it into `suspendedSnapshot`.
         let tmux = TmuxManager(dryRun: true, dryRunCapturePane: { _, _ in "FROZEN PANE" })
         let coord = HibernationCoordinator(
-            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let result = await coord.manualHibernate(terminalID: terminalID)
         #expect(result == .ok)
@@ -353,7 +353,7 @@ struct HibernationCoordinatorTests {
         let (db, _, terminalID) = try await setup()
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         _ = await coord.manualHibernate(terminalID: terminalID)
         #expect(try await db.terminals.get(id: terminalID)?.isHibernated == true)
@@ -372,7 +372,7 @@ struct HibernationCoordinatorTests {
         let (db, _, terminalID) = try await setup()
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
         let result = await coord.wake(terminalID: terminalID)
         #expect(result == .notHibernated)
         #expect(recorded.snapshot().isEmpty,
@@ -416,7 +416,7 @@ struct HibernationCoordinatorTests {
         let (db, _, terminalID) = try await setup()
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         // Legacy park: only suspendedAt set, hibernatedAt nil.
         try await db.terminals.setSuspended(id: terminalID, sessionID: "sess-1")
@@ -451,7 +451,7 @@ struct HibernationCoordinatorTests {
         let recorded = RecordedTmuxCommands()
         let serverHookCalls = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
         await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
 
         let wake = await coord.wake(terminalID: terminalID)
@@ -485,7 +485,7 @@ struct HibernationCoordinatorTests {
             dryRunRecorder: { recorded.append($0) },
             dryRunWindowIsDead: { $0 == "@0" }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
         await coord.setOnServerCreated { server in serverHookCalls.append([server]) }
 
         let wake = await coord.wake(terminalID: terminalID)
@@ -531,7 +531,7 @@ struct HibernationCoordinatorTests {
         let recorded = RecordedTmuxCommands()
         // No dryRunWindowIsDead: the window EXISTS — ownership must win.
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let wake = await coord.wake(terminalID: terminalID)
         #expect(wake == .ok)
@@ -560,7 +560,7 @@ struct HibernationCoordinatorTests {
         )
         let recorded = RecordedTmuxCommands()
         let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) })
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let wake = await coord.wake(terminalID: terminalID)
         #expect(wake == .ok)
@@ -600,7 +600,7 @@ struct HibernationCoordinatorTests {
             dryRunRecorder: { recorded.append($0) },
             dryRunWindowIsDead: { _ in true }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         async let wakeA = coord.wake(terminalID: terminalA)
         async let wakeB = coord.wake(terminalID: terminalB.id)
@@ -660,7 +660,7 @@ struct HibernationCoordinatorTests {
             dryRunRecorder: { recorded.append($0) },
             dryRunWindowIsDead: { _ in true }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         async let wakeA = coord.wake(terminalID: terminalA.id)
         async let wakeB = coord.wake(terminalID: terminalB.id)
@@ -733,7 +733,7 @@ struct HibernationCoordinatorTests {
             dryRunWindowIsDead: { $0 == "@0" },
             dryRunCreateWindowError: { _ in TmuxError.unexpectedOutput("no server running") }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let wake = await coord.wake(terminalID: terminalID)
         guard case .respawnFailed(let reason) = wake else {
@@ -756,7 +756,7 @@ struct HibernationCoordinatorTests {
             dryRun: true,
             dryRunRespawnWindowError: { $0 == "@0" ? TmuxError.unexpectedOutput("pane died") : nil }
         )
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let wake = await coord.wake(terminalID: terminalID)
         guard case .respawnFailed(let reason) = wake else {
@@ -793,7 +793,8 @@ struct HibernationCoordinatorTests {
             configDirManager: ClaudeProfileConfigDirManager(
                 baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
                 hostBaseDirectory: host
-            )
+            ),
+            actuationLog: makeTestActuationLog()
         )
         let wake = await coord.wake(terminalID: terminalID)
         #expect(wake == .ok)
@@ -821,7 +822,7 @@ struct HibernationCoordinatorTests {
             modelProfileResolver: ModelProfileResolver(
                 profiles: db.modelProfiles, repos: db.repos, config: db.config,
                 keychain: { _ in nil }),
-            configDirManager: isolatedConfigDirManager())
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
     }
 
     /// Wake refuses when the pinned profile ID no longer exists, returning
@@ -907,7 +908,7 @@ struct HibernationCoordinatorTests {
         // Pane still runs claude (reported as its version string) → the parked
         // state is stale and must be cleared.
         let tmux = TmuxManager(dryRun: true, dryRunPaneCurrentCommand: { _, _ in "1.2.3" })
-        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager())
+        let coord = HibernationCoordinator(db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
         await coord.reconcileOnStartup()
 
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil,
@@ -955,7 +956,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(
             db: db, tmux: tmux,
             subscriptions: recorder.subscriptions(),
-            configDirManager: isolatedConfigDirManager())
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let result = await coord.manualHibernate(terminalID: terminalID)
         #expect(result == .ok)
@@ -977,7 +978,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(
             db: db, tmux: tmux,
             subscriptions: recorder.subscriptions(),
-            configDirManager: isolatedConfigDirManager())
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         _ = await coord.manualHibernate(terminalID: terminalID)
         let wake = await coord.wake(terminalID: terminalID)
@@ -1001,7 +1002,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(
             db: db, tmux: TmuxManager(dryRun: true),
             subscriptions: recorder.subscriptions(),
-            configDirManager: isolatedConfigDirManager())
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let ok = await coord.setKeepWarm(terminalID: terminalID, keepWarm: true)
         #expect(ok)
@@ -1023,7 +1024,7 @@ struct HibernationCoordinatorTests {
         let coord = HibernationCoordinator(
             db: db, tmux: TmuxManager(dryRun: true),
             subscriptions: recorder.subscriptions(),
-            configDirManager: isolatedConfigDirManager())
+            configDirManager: isolatedConfigDirManager(), actuationLog: makeTestActuationLog())
 
         let ok = await coord.setKeepWarm(terminalID: terminalID, keepWarm: true)
         #expect(ok)
@@ -1089,7 +1090,8 @@ struct RPCRouterWakeErrorMappingTests {
                 db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
                 configDirManager: isolatedConfigDirManager()),
             tmux: tmux,
-            configDirManager: isolatedConfigDirManager()
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog()
         )
         let repo = try await db.repos.create(path: "/tmp/hib-repo", displayName: "test", defaultBranch: "main")
         let wt = try await db.worktrees.create(
@@ -1131,7 +1133,8 @@ struct RPCRouterWakePromptDeliveryTests {
                 db: db, git: GitManager(), tmux: tmux, hooks: HookResolver(),
                 configDirManager: isolatedConfigDirManager()),
             tmux: tmux,
-            configDirManager: isolatedConfigDirManager()
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1065,6 +1065,107 @@ struct HibernationCoordinatorTests {
         #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil,
                 "a keep-warm session must never be auto-hibernated")
     }
+
+    // MARK: - Idle sweep: the rail's own actuation record
+
+    /// A log at a fresh temp path, plus a coordinator wired to it whose date
+    /// seam the test drives. The verify-exit poll is paced down to virtual-ish
+    /// speed (`exitPollInterval`) because this test is about the record, not
+    /// about how long a polite `/exit` waits.
+    private func sweepCoordinator(
+        _ db: TBDDatabase, logPath: String, dates: TestDateSource
+    ) -> HibernationCoordinator {
+        HibernationCoordinator(
+            db: db, tmux: TmuxManager(dryRun: true),
+            configDirManager: isolatedConfigDirManager(),
+            now: dates.provider,
+            exitPollAttempts: 1, exitPollInterval: .milliseconds(1),
+            actuationLog: ActuationLog(path: logPath))
+    }
+
+    private func sweepLogPath() throws -> String {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-sweep-actuation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("actuations.jsonl").path
+    }
+
+    private func logRows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    /// Walk one terminal all the way through the sweep's poll/decide sequence:
+    /// seed the idle marker, cross the idle window to arm the debounce, then
+    /// let the settle window elapse so the rail actually parks it. The date
+    /// seam does the waiting, so no wall time is spent.
+    private func sweepUntilParked(
+        _ coord: HibernationCoordinator, dates: TestDateSource, idleMinutes: Int = 1
+    ) async {
+        await coord.sweep()                                        // seed idleSince
+        dates.advance(by: TimeInterval(idleMinutes) * 60 + 1)
+        await coord.sweep()                                        // arm the debounce
+        dates.advance(by: HibernationCoordinator.killDebounce + 1)
+        await coord.sweep()                                        // act
+    }
+
+    /// The idle rail's success path. Everything else about the sweep is gating;
+    /// this is the one branch that actuates, and it must leave the same
+    /// request-then-outcome pair as any RPC surface — under its own rail name,
+    /// with no `method`, because no RPC carried it.
+    @Test func sweepParkWritesItsOwnRailRowAndOutcome() async throws {
+        let (db, worktreeID, terminalID) = try await setup(activityState: .idle)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        let logPath = try sweepLogPath()
+        let dates = TestDateSource()
+        let coord = sweepCoordinator(db, logPath: logPath, dates: dates)
+
+        await sweepUntilParked(coord, dates: dates)
+
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt != nil)
+        let written = try logRows(at: logPath)
+        #expect(written.count == 2, "exactly one request row and its outcome")
+        let request = try #require(written.first)
+        #expect(request["kind"] as? String == "hibernate")
+        #expect(request["method"] == nil)
+        let actor = try #require(request["actor"] as? [String: Any])
+        #expect(actor["kind"] as? String == "daemon")
+        #expect(actor["rail"] as? String == "auto-hibernate")
+        let target = try #require(request["target"] as? [String: Any])
+        #expect(target["worktree"] as? String == worktreeID.uuidString)
+        #expect(target["terminal"] as? String == terminalID.uuidString)
+        let outcome = try #require(written.last)
+        #expect(outcome["kind"] as? String == "outcome")
+        #expect(outcome["confirms"] as? String == request["id"] as? String)
+        #expect(outcome["result"] as? String == "dispatched")
+    }
+
+    /// Fail-closed on a daemon-internal rail: an unrecordable park does not
+    /// happen. The sweep has no caller to return an error to, so the property
+    /// is the park itself — skipped, silently to the user, loudly in the log.
+    @Test func sweepSkipsTheParkWhenTheRecordIsUnwritable() async throws {
+        let (db, _, terminalID) = try await setup(activityState: .idle)
+        try await db.config.setAutoHibernate(enabled: true, idleMinutes: 1)
+        // A path that can never be opened: its parent is a regular file.
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-sweep-blocked-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let blocker = directory.appendingPathComponent("blocker")
+        try Data("not a directory".utf8).write(to: blocker)
+        let dates = TestDateSource()
+        let coord = sweepCoordinator(
+            db, logPath: blocker.appendingPathComponent("actuations.jsonl").path, dates: dates)
+
+        await sweepUntilParked(coord, dates: dates)
+
+        #expect(try await db.terminals.get(id: terminalID)?.hibernatedAt == nil,
+                "an unrecordable park must not happen")
+    }
 }
 
 /// `terminal.wake` RPC error mapping. The shared `RPCRouterTests` harness pins

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1143,6 +1143,8 @@ struct HibernationCoordinatorTests {
         #expect(outcome["kind"] as? String == "outcome")
         #expect(outcome["confirms"] as? String == request["id"] as? String)
         #expect(outcome["result"] as? String == "dispatched")
+        // The rail acted; there is no refusal, so there is no reason.
+        #expect(outcome["reason"] == nil)
     }
 
     /// Fail-closed on a daemon-internal rail: an unrecordable park does not

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -3,6 +3,7 @@ import os
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 struct FakeTmuxSendError: Error {}
 
@@ -96,7 +97,7 @@ struct FakeInspector: PaneProcessInspecting {
             db: db, tmux: tmux, inspector: inspector,
             readTranscript: { _ in transcript },
             transcriptModifiedAt: { _ in transcriptMtime },
-            waiter: { _ in })   // no real sleeping in unit tests
+            waiter: { _ in }, actuationLog: makeTestActuationLog())   // no real sleeping in unit tests
     }
 
     @Test func missingTerminalIsTerminalGone() async throws {
@@ -185,7 +186,7 @@ struct FakeInspector: PaneProcessInspecting {
         let actuator = LimitResumeActuator(
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
             readTranscript: growing,
-            transcriptModifiedAt: { _ in nil }, waiter: { _ in })
+            transcriptModifiedAt: { _ in nil }, waiter: { _ in }, actuationLog: makeTestActuationLog())
         let outcome = await actuator.actuate(row)
         #expect(outcome == .sent)
     }
@@ -226,7 +227,7 @@ struct FakeInspector: PaneProcessInspecting {
         let actuator = LimitResumeActuator(
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
             readTranscript: flipping,
-            transcriptModifiedAt: { _ in nil }, waiter: { _ in })
+            transcriptModifiedAt: { _ in nil }, waiter: { _ in }, actuationLog: makeTestActuationLog())
         let outcome = await actuator.actuate(row)
         #expect(outcome == .userAlreadyContinued)
         #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
@@ -253,7 +254,7 @@ struct FakeInspector: PaneProcessInspecting {
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
             readTranscript: { _ in Data("{}\n".utf8) },
             transcriptModifiedAt: { _ in nil },
-            waiter: flippingWaiter)
+            waiter: flippingWaiter, actuationLog: makeTestActuationLog())
         let outcome = await actuator.actuate(row)
         #expect(outcome == .cancelledExternally)
         // Only attempt 1's 3 sends — attempt 2 never fires.
@@ -337,7 +338,7 @@ struct FakeInspector: PaneProcessInspecting {
             db: db, tmux: tmux, inspector: FakeInspector(claudePID: 4242),
             readTranscript: { _ in Data("{}\n".utf8) },
             transcriptModifiedAt: { _ in nil },
-            waiter: cancellingWaiter)
+            waiter: cancellingWaiter, actuationLog: makeTestActuationLog())
         let outcome = await actuator.actuate(row)
         #expect(outcome == .cancelledExternally)
         // Only attempt 1's 3 sends — attempt 2 never fires.
@@ -395,7 +396,7 @@ struct FakeInspector: PaneProcessInspecting {
                 reads.withLock { $0 += 1 }
                 return newerRecord
             },
-            transcriptModifiedAt: { _ in staleMtime }, waiter: { _ in })
+            transcriptModifiedAt: { _ in staleMtime }, waiter: { _ in }, actuationLog: makeTestActuationLog())
         let continued = await actuator.userAlreadyContinued(row)
         #expect(continued == false)
         #expect(reads.withLock { $0 } == 0)
@@ -412,7 +413,7 @@ struct FakeInspector: PaneProcessInspecting {
                 reads.withLock { $0 += 1 }
                 return newerRecord
             },
-            transcriptModifiedAt: { _ in freshMtime }, waiter: { _ in })
+            transcriptModifiedAt: { _ in freshMtime }, waiter: { _ in }, actuationLog: makeTestActuationLog())
         let continued = await actuator.userAlreadyContinued(row)
         #expect(continued)
         #expect(reads.withLock { $0 } == 1)

--- a/Tests/TBDDaemonTests/MergedTransitionPrecedenceTests.swift
+++ b/Tests/TBDDaemonTests/MergedTransitionPrecedenceTests.swift
@@ -26,7 +26,9 @@ struct MergedTransitionPrecedenceTests {
             hooks: HookResolver(),
             subscriptions: subs
         )
-        let archive = AutoArchiveOnMergeCoordinator(db: db, lifecycle: lifecycle, subscriptions: subs)
+        let archive = AutoArchiveOnMergeCoordinator(
+            db: db, lifecycle: lifecycle, subscriptions: subs,
+            actuationLog: makeTestActuationLog())
         let hibernation = HibernationCoordinator(
             db: db, tmux: TmuxManager(dryRun: true),
             subscriptions: subs, configDirManager: mergeIsolatedConfigDirManager(), actuationLog: makeTestActuationLog())

--- a/Tests/TBDDaemonTests/MergedTransitionPrecedenceTests.swift
+++ b/Tests/TBDDaemonTests/MergedTransitionPrecedenceTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// The precedence rule when a PR merges: archive supersedes hibernate, but only
 /// when archive ACTUALLY began. The important asymmetry — an armed-but-blocked
@@ -28,7 +29,7 @@ struct MergedTransitionPrecedenceTests {
         let archive = AutoArchiveOnMergeCoordinator(db: db, lifecycle: lifecycle, subscriptions: subs)
         let hibernation = HibernationCoordinator(
             db: db, tmux: TmuxManager(dryRun: true),
-            subscriptions: subs, configDirManager: mergeIsolatedConfigDirManager())
+            subscriptions: subs, configDirManager: mergeIsolatedConfigDirManager(), actuationLog: makeTestActuationLog())
         let hibernate = AutoHibernateOnMergeCoordinator(db: db, hibernation: hibernation, subscriptions: subs)
         let dispatcher = MergedTransitionDispatcher(archive: archive, hibernate: hibernate)
         return Deps(dispatcher: dispatcher, archive: archive, db: db)

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Stub fetcher with a queued response list.
 final class StubClaudeUsageFetcher: ClaudeUsageFetcher, @unchecked Sendable {
@@ -54,7 +55,8 @@ struct ModelProfileRPCTests {
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
             usageFetcher: stub,
-            configDirManager: configDirManager
+            configDirManager: configDirManager,
+            actuationLog: makeTestActuationLog()
         )
         return (router, db, stub)
     }

--- a/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileRPCTests.swift
@@ -28,6 +28,22 @@ final class StubClaudeUsageFetcher: ClaudeUsageFetcher, @unchecked Sendable {
     }
 }
 
+// Nested under TBDHomeSerialized: this suite does not *mutate* `TBD_HOME`, it
+// depends on the value staying put. `ModelProfileKeychain` is a file store
+// under `$TBD_HOME/claude-tokens` and resolves that directory from the
+// process-global environment on every call, so a test that seeds a token and
+// then drives a handler which reads it back straddles two independent
+// resolutions. Run concurrently with a suite that points `TBD_HOME` at its own
+// temp directory, the seed and the read land in different homes and the
+// handler answers "Secret missing from keychain" — the observed failure. The
+// gap is seconds wide in the fast parallel pass, where a test spends most of
+// its wall time suspended between awaits.
+//
+// See `TBDHomeSerializedSuites.swift`: the serialized domain is the only
+// mutual exclusion available here, because the handlers reach
+// `ModelProfileKeychain` through static members with no injection seam.
+extension TBDHomeSerialized {
+
 @Suite("ModelProfile RPC Handlers")
 struct ModelProfileRPCTests {
 
@@ -1045,4 +1061,6 @@ struct ModelProfileRPCTests {
         #expect(!resp.success)
         #expect(resp.error == "Profile not found")
     }
+}
+
 }

--- a/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
+++ b/Tests/TBDDaemonTests/ModelProfileSpawnTests.swift
@@ -60,7 +60,8 @@ struct ModelProfileSpawnTests {
             tmux: tmux,
             startTime: Date(),
             usageFetcher: StubClaudeUsageFetcher(),
-            configDirManager: isolatedConfigDirManager()
+            configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog()
         )
         return (router, db, recorder)
     }
@@ -1107,7 +1108,8 @@ struct ModelProfileSpawnTests {
                 pumpTimeout: .seconds(5),
                 identityPollInterval: .milliseconds(5),
                 identityPollTimeout: .milliseconds(50)
-            ))
+            )),
+            actuationLog: makeTestActuationLog()
         )
         return (router, db, recorder, pane)
     }

--- a/Tests/TBDDaemonTests/PanelImportHandlerTests.swift
+++ b/Tests/TBDDaemonTests/PanelImportHandlerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Task 11: `panel.importLegacy` handler tests. Router-level — exercises the
 /// full gating → convert → commitImport → broadcast pipeline. The pure
@@ -35,7 +36,8 @@ struct PanelImportHandlerTests {
             ),
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
-            subscriptions: subs
+            subscriptions: subs,
+            actuationLog: makeTestActuationLog()
         )
         return (router, db, deltas)
     }

--- a/Tests/TBDDaemonTests/PanelRPCTests.swift
+++ b/Tests/TBDDaemonTests/PanelRPCTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Router-level tests for `panel.get` / `panel.apply` / `panel.importLegacy`
 /// (Task 10, spec C §10). Exercises ROUTING only — `PanelCoordinator`'s
@@ -24,7 +25,8 @@ struct PanelRPCTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
         return (router, db)
     }

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -1124,7 +1124,7 @@ struct PreSessionHookTests {
             label: "pre-session", kind: .shell
         )
 
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
         let kills = recorder.snapshot().filter { $0.contains("kill-window") }
         #expect(!kills.contains { $0.contains("@mock-pre") },
@@ -1166,7 +1166,7 @@ struct PreSessionHookTests {
             label: "pre-session", kind: .shell
         )
 
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
         #expect(!recorder.snapshot().contains { $0.contains("kill-server") },
                 "a repo whose only live worktree is .creating must keep its tmux server")
@@ -1206,7 +1206,7 @@ struct PreSessionHookTests {
         // exactly what Daemon.start() runs.
         let resumed = await lifecycle.recoverCreatingWorktrees()
         #expect(resumed.count == 1)
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
         #expect(!recorder.snapshot().contains { $0.contains("kill-window") && $0.contains("@mock-pre") },
                 "the just-resumed pre-session window must survive the startup reconcile")

--- a/Tests/TBDDaemonTests/PreSessionRerunTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionRerunTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 // Nested under TBDHomeSerialized: these tests mutate the process-global
 // `TBD_HOME` env var via isolateTBDHome() (shared with PreSessionHookTests,
@@ -113,7 +114,7 @@ struct PreSessionRerunTests {
 
         let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder, timeout: 2)
-        let router = RPCRouter(db: db, lifecycle: lifecycle, tmux: TmuxManager(dryRun: true))
+        let router = RPCRouter(db: db, lifecycle: lifecycle, tmux: TmuxManager(dryRun: true), actuationLog: makeTestActuationLog())
         let params = try JSONEncoder().encode(
             WorktreeRerunPreSessionParams(worktreeID: worktree.id, cols: 180, rows: 45)
         )
@@ -149,7 +150,7 @@ struct PreSessionRerunTests {
         try await installPreSessionHook(repoDir: repoDir, script: "#!/bin/sh\nexit 0\n")
 
         let lifecycle = makeLifecycle(db: db, timeout: 2)
-        let router = RPCRouter(db: db, lifecycle: lifecycle, tmux: TmuxManager(dryRun: true))
+        let router = RPCRouter(db: db, lifecycle: lifecycle, tmux: TmuxManager(dryRun: true), actuationLog: makeTestActuationLog())
         let params = try JSONEncoder().encode(
             WorktreeRerunPreSessionParams(worktreeID: worktree.id)
         )

--- a/Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift
@@ -42,7 +42,7 @@ struct RPCRouterNightwatchLeaseTests {
             lifecycle: WorktreeLifecycle(
                 db: db, git: GitManager(), tmux: TmuxManager(dryRun: true),
                 hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         let desk = try await db.worktrees.createScratch(
             name: "watch-desk", displayName: "Watch Desk",
             path: "/tmp/watch-desk-\(UUID())", tmuxServer: "test")

--- a/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
@@ -352,6 +352,45 @@ struct RPCRouterRemoteTests: ~Copyable {
         #expect(response.error?.contains("branch required") == true)
     }
 
+    /// A provider that exits 0 and hands back a truncated payload has failed at
+    /// the transport, however healthy its exit code looks. The decode throw
+    /// must confirm the request row as `transport-failed` — an unconfirmed row
+    /// is indistinguishable from a lost outcome — and still surface unchanged
+    /// to the caller.
+    @Test func createRecordsTransportFailureWhenTheProviderPayloadDoesNotDecode() async throws {
+        try await db.config.setRemoteBackendsEnabled(true)
+        let logPath = dir.appendingPathComponent("create-decode-actuations.jsonl").path
+        let manager = RemoteProviderManager(
+            db: db, subscriptions: subs,
+            runner: FakeProviderInvoker(script: [providerOK(#"{"id": "new-1", "sta"#)]),
+            registryURL: registryURL)
+        let r = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
+            tmux: TmuxManager(dryRun: true),
+            startTime: Date(),
+            subscriptions: subs,
+            remoteManager: manager, actuationLog: ActuationLog(path: logPath))
+
+        let response = await call(r, "remote.create", #"{"provider": "fake", "paramsJSON": "{}"}"#)
+        #expect(response.success == false)
+
+        let written = try String(contentsOfFile: logPath, encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+        #expect(written.count == 2)
+        #expect(written.first?["kind"] as? String == "spawn")
+        #expect(written.first?["method"] as? String == "remote.create")
+        let outcome = try #require(written.last)
+        #expect(outcome["kind"] as? String == "outcome")
+        #expect(outcome["confirms"] as? String == written.first?["id"] as? String)
+        #expect(outcome["result"] as? String == "transport-failed")
+    }
+
     @Test func logDecodesRawBytes() async throws {
         try await db.config.setRemoteBackendsEnabled(true)
         let invoker = FakeProviderInvoker(script: [

--- a/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRemoteTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Thread-safe collector for broadcast StateDeltas. Mirrors the pattern in
 /// `RemoteProviderManagerTests`'s private `BroadcastDeltas` (not reusable
@@ -64,7 +65,7 @@ struct RPCRouterRemoteTests: ~Copyable {
             tmux: TmuxManager(dryRun: true),
             startTime: Date(),
             subscriptions: subs,
-            remoteManager: manager)
+            remoteManager: manager, actuationLog: makeTestActuationLog())
     }
 
     private func router(invoker: FakeProviderInvoker) -> RPCRouter {

--- a/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
@@ -120,7 +120,7 @@ extension RPCRouterTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         router.orphanGC = OrphanGC(
             db: db, git: GitManager(), broadcast: { _ in }, lsofProvider: { [] }, scratchpadBase: base)
 
@@ -161,7 +161,7 @@ extension RPCRouterTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         router.orphanGC = OrphanGC(
             db: db, git: GitManager(), broadcast: { _ in }, lsofProvider: { [] }, scratchpadBase: base)
 

--- a/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTerminalTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 // Terminal-scoped RPC methods: terminal.create (shell + claude), terminal.list,
 // terminal.send, terminal.output.
@@ -77,7 +78,8 @@ extension RPCRouterTests {
             lifecycle: WorktreeLifecycle(
                 db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
             tmux: tmux,
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
         let repo = try await db.repos.create(
             path: "/tmp/test-repo-\(UUID().uuidString)",

--- a/Tests/TBDDaemonTests/RPCRouterTestHelpers.swift
+++ b/Tests/TBDDaemonTests/RPCRouterTestHelpers.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Shared test fixture for all RPCRouter-* test files.
 ///
@@ -25,7 +26,8 @@ struct RPCRouterTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 }

--- a/Tests/TBDDaemonTests/RPCRouterWorktreeCreateBroadcastTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterWorktreeCreateBroadcastTests.swift
@@ -49,7 +49,8 @@ struct RPCRouterWorktreeCreateBroadcastTests {
             db: db,
             lifecycle: lifecycle,
             tmux: TmuxManager(dryRun: true),
-            subscriptions: subs
+            subscriptions: subs,
+            actuationLog: makeTestActuationLog()
         )
         return (router, deltas)
     }

--- a/Tests/TBDDaemonTests/RateLimitDetectedRPCTests.swift
+++ b/Tests/TBDDaemonTests/RateLimitDetectedRPCTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite struct RateLimitDetectedRPCTests {
     let db: TBDDatabase
@@ -19,7 +20,7 @@ import Testing
                 db: db, git: GitManager(),
                 tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date())
+            startTime: Date(), actuationLog: makeTestActuationLog())
         let repo = try await db.repos.create(
             path: "/tmp/rld-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
         let wt = try await db.worktrees.create(

--- a/Tests/TBDDaemonTests/RepoAddScratchGuardTests.swift
+++ b/Tests/TBDDaemonTests/RepoAddScratchGuardTests.swift
@@ -17,7 +17,7 @@ struct RepoAddScratchGuardTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         let scratchChild = TBDConstants.scratchDir.appendingPathComponent("some-project").path
         try FileManager.default.createDirectory(atPath: scratchChild, withIntermediateDirectories: true)
@@ -37,7 +37,7 @@ struct RepoAddScratchGuardTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         // Create a temporary git repo outside the scratch directory
         let repoPath = FileManager.default.temporaryDirectory.appendingPathComponent("normal-repo-\(UUID().uuidString)")
@@ -97,7 +97,7 @@ struct RepoAddScratchGuardTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         // Create a scratch child directory
         let scratchChild = TBDConstants.scratchDir.appendingPathComponent("symlink-test-project")

--- a/Tests/TBDDaemonTests/RepoRelocateTests.swift
+++ b/Tests/TBDDaemonTests/RepoRelocateTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite struct RepoRelocateTests {
 
@@ -28,7 +29,8 @@ import Foundation
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/ScheduledResumeCancellationTests.swift
+++ b/Tests/TBDDaemonTests/ScheduledResumeCancellationTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite struct ScheduledResumeCancellationTests {
     let db: TBDDatabase
@@ -18,7 +19,7 @@ import Testing
                 db: db, git: GitManager(),
                 tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date())
+            startTime: Date(), actuationLog: makeTestActuationLog())
         try await db.config.setAutoResumeOnLimitReset(true)
         let repo = try await db.repos.create(
             path: "/tmp/can-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -29,7 +29,7 @@ struct ScratchArchiveReviveRPCTests {
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
-            subscriptions: subs)
+            subscriptions: subs, actuationLog: makeTestActuationLog())
         return (router, deltas)
     }
 

--- a/Tests/TBDDaemonTests/ScratchCreateRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchCreateRPCTests.swift
@@ -21,7 +21,7 @@ struct ScratchCreateRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         let request = try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil))
         let response = await router.handle(request)
@@ -46,7 +46,7 @@ struct ScratchCreateRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         let response = await router.handle(
             try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
@@ -87,7 +87,7 @@ struct ScratchCreateRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         let response = await router.handle(
             try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
@@ -107,7 +107,7 @@ struct ScratchCreateRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         let r1 = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "notes")))
         let w1 = try r1.decodeResult(Worktree.self)

--- a/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
@@ -20,7 +20,7 @@ struct ScratchDeleteRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "gone")))
         let wt = try created.decodeResult(Worktree.self)
         #expect(FileManager.default.fileExists(atPath: wt.path))
@@ -37,7 +37,7 @@ struct ScratchDeleteRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-terminal")))
         let wt = try created.decodeResult(Worktree.self)
         // The scratch.create RPC now auto-spawns a default primary agent terminal;
@@ -71,7 +71,7 @@ struct ScratchDeleteRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "undeletable")))
         let wt = try created.decodeResult(Worktree.self)
 
@@ -95,7 +95,7 @@ struct ScratchDeleteRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         let scratchpadBase = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-scratchdel-claudebase-\(UUID().uuidString)")
@@ -132,7 +132,7 @@ struct ScratchDeleteRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
 
         let scratchpadBase = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-scratchdel-claudebase-\(UUID().uuidString)")
@@ -163,7 +163,7 @@ struct ScratchDeleteRPCTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         let repo = try await db.repos.create(path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
         let wt = try await db.worktrees.create(repoID: repo.id, name: "w", branch: "b",
                                                path: "/tmp/w-\(UUID().uuidString)", tmuxServer: "tbd-x")

--- a/Tests/TBDDaemonTests/ScratchExclusionTests.swift
+++ b/Tests/TBDDaemonTests/ScratchExclusionTests.swift
@@ -57,7 +57,7 @@ struct ScratchExclusionTests {
         // Reconcile is entered per repo and scopes its worktree lookups to
         // that repoID — a scratch row (repoID == nil) can never be in scope,
         // even when the repo itself is real and reconcile runs to completion.
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
         let after = try await db.worktrees.get(id: scratch.id)
         #expect(after != nil)               // untouched
         #expect(after?.status == .active)   // not archived

--- a/Tests/TBDDaemonTests/ScratchExclusionTests.swift
+++ b/Tests/TBDDaemonTests/ScratchExclusionTests.swift
@@ -33,7 +33,7 @@ struct ScratchExclusionTests {
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-            tmux: TmuxManager(dryRun: true), startTime: Date())
+            tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         let scratch = try await db.worktrees.createScratch(
             name: "s", displayName: "s", path: "/tmp/scr-\(UUID().uuidString)", tmuxServer: "tbd-scratch")
 

--- a/Tests/TBDDaemonTests/ScratchPromoteAtomicityTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteAtomicityTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// `WorktreeStore.promoteScratchMigration` — the single-transaction row
 /// migration behind `scratch.promote`. Pure in-memory-DB tests: no TBD_HOME,
@@ -90,7 +91,8 @@ struct TerminalCreateArchivedWorktreeGuardTests {
             lifecycle: WorktreeLifecycle(
                 db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
@@ -40,7 +40,8 @@ struct ScratchPromoteMigrationTests {
             configDirManager: ClaudeProfileConfigDirManager(
                 baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
                 hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
-            )
+            ),
+            actuationLog: makeTestActuationLog()
         )
     }
 
@@ -215,7 +216,8 @@ struct WakePathGuardTests {
             lifecycle: WorktreeLifecycle(
                 db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 
@@ -307,7 +309,8 @@ struct TerminalCreateResumeSyncWiringTests {
             configDirManager: ClaudeProfileConfigDirManager(
                 baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
                 hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
-            )
+            ),
+            actuationLog: makeTestActuationLog()
         )
 
         let wtDir = home.appendingPathComponent("wt", isDirectory: true)

--- a/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
@@ -17,7 +17,7 @@ struct ScratchPromoteRPCTests {
     private func makeRouter(_ db: TBDDatabase) -> RPCRouter {
         RPCRouter(db: db,
                   lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
-                  tmux: TmuxManager(dryRun: true), startTime: Date())
+                  tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
     }
 
     private func gitInitCommit(at path: String) throws {

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -41,7 +41,8 @@ struct ScratchPromoteReconcileTests {
             configDirManager: ClaudeProfileConfigDirManager(
                 baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
                 hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
-            )
+            ),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -101,7 +101,7 @@ struct ScratchPromoteReconcileTests {
         // the live-session case reconcile must leave alone.
         let lifecycle = WorktreeLifecycle(
             db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID)
+        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
 
         // The inherited tmux server survives reconcile.
         let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
@@ -158,7 +158,7 @@ struct ScratchPromoteReconcileTests {
             db: db, git: GitManager(),
             tmux: TmuxManager(dryRun: true, dryRunRecorder: { recorder.append($0) }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: survivor.id)
+        try await lifecycle.reconcile(repoID: survivor.id, actuationLog: makeTestActuationLog())
 
         let serverKills = recorder.snapshot().filter { $0.contains("kill-server") }
         #expect(serverKills.contains { $0.contains(promoted.scratch.tmuxServer) },
@@ -216,7 +216,7 @@ struct ScratchPromoteReconcileTests {
                         : []
                 }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: survivor.id)
+        try await lifecycle.reconcile(repoID: survivor.id, actuationLog: makeTestActuationLog())
 
         let cmds = recorder.snapshot()
         #expect(!cmds.contains { $0.contains("kill-server") && $0.contains(scratchServer) },
@@ -244,7 +244,7 @@ struct ScratchPromoteReconcileTests {
             db: db, git: GitManager(),
             tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID)
+        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
 
         let canonical = TmuxManager.serverName(forRepoPath: promoted.dest)
         let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))

--- a/Tests/TBDDaemonTests/SocketServerConnectedClientsTests.swift
+++ b/Tests/TBDDaemonTests/SocketServerConnectedClientsTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 // BUG 2: SocketServer must increment its connected-client count when a client
 // connects and decrement it when the client disconnects. The daemon.status
@@ -23,7 +24,8 @@ struct SocketServerConnectedClientsTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/StopHookTranscriptSyncTests.swift
+++ b/Tests/TBDDaemonTests/StopHookTranscriptSyncTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Stop-hook (activity → idle) lazy transcript sync: when a terminal's stored
 /// transcriptPath lies outside the project dir derived from the worktree's
@@ -30,7 +31,8 @@ struct StopHookTranscriptSyncTests {
             configDirManager: ClaudeProfileConfigDirManager(
                 baseDirectory: home.appendingPathComponent("profiles", isDirectory: true),
                 hostBaseDirectory: home.appendingPathComponent("claude-host", isDirectory: true)
-            )
+            ),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/SwapTranscriptCarryTests.swift
+++ b/Tests/TBDDaemonTests/SwapTranscriptCarryTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 /// Covers the account-swap transcript carry: when "Switch account" forks a new
 /// `claude --resume <id>` under a DIFFERENT config dir, the session transcript
@@ -217,7 +218,8 @@ struct SwapTranscriptCarryTests {
             tmux: tmux,
             startTime: Date(),
             usageFetcher: StubClaudeUsageFetcher(),
-            configDirManager: manager
+            configDirManager: manager,
+            actuationLog: makeTestActuationLog()
         )
 
         // Seed repo + worktree.

--- a/Tests/TBDDaemonTests/TBDHomeSerializedSuites.swift
+++ b/Tests/TBDDaemonTests/TBDHomeSerializedSuites.swift
@@ -15,6 +15,15 @@ import Testing
 /// `extension TBDHomeSerialized { ... }` so it becomes a nested (and therefore
 /// serialized) child of this suite.
 ///
+/// **Readers belong here too when they cannot use a seam.** A suite that only
+/// *depends on* `TBD_HOME` holding still is exposed to exactly the same race:
+/// production code that resolves the variable per call will answer differently
+/// on either side of a mutator's window, and in the fast parallel pass a test
+/// spends most of its wall time suspended, so that window is seconds wide.
+/// Prefer an injection seam; nest here when the code under test reaches the
+/// environment through static members that have none (`ModelProfileRPCTests`
+/// and `ModelProfileKeychain` are the standing example).
+///
 /// **Important — this domain only serializes suites WITHIN TBDDaemonTests.**
 /// All test targets (TBDSharedTests, TBDDaemonTests, TBDAppTests, …) compile
 /// into ONE process and Swift Testing runs suites across all targets in

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -138,7 +138,8 @@ func testHandleTerminalRecreateWindowSetsWorktreeID() async throws {
             tmux: tmux,
             hooks: HookResolver()
         ),
-        tmux: tmux
+        tmux: tmux,
+        actuationLog: makeTestActuationLog()
     )
 
     let repo = try await db.repos.create(
@@ -195,7 +196,8 @@ func testHandleTerminalRecreateWindowParksClaudeAsSuspended() async throws {
             tmux: tmux,
             hooks: HookResolver()
         ),
-        tmux: tmux
+        tmux: tmux,
+        actuationLog: makeTestActuationLog()
     )
 
     let repo = try await db.repos.create(
@@ -255,7 +257,8 @@ func testHandleTerminalRecreateWindowIgnoresStaleRequestWhenWindowAlive() async 
             tmux: tmux,
             hooks: HookResolver()
         ),
-        tmux: tmux
+        tmux: tmux,
+        actuationLog: makeTestActuationLog()
     )
 
     let repo = try await db.repos.create(
@@ -313,7 +316,8 @@ func testHandleTerminalRecreateWindowRebuildsShellAsShell() async throws {
             tmux: tmux,
             hooks: HookResolver()
         ),
-        tmux: tmux
+        tmux: tmux,
+        actuationLog: makeTestActuationLog()
     )
 
     let repo = try await db.repos.create(
@@ -442,7 +446,8 @@ func testHandleTerminalCreateRegressionWorktreeID() async throws {
             tmux: tmux,
             hooks: HookResolver()
         ),
-        tmux: tmux
+        tmux: tmux,
+        actuationLog: makeTestActuationLog()
     )
 
     let repo = try await db.repos.create(
@@ -500,7 +505,8 @@ struct CodexLaunchCommandTests {
                 tmux: tmux,
                 hooks: HookResolver()
             ),
-            tmux: tmux
+            tmux: tmux,
+            actuationLog: makeTestActuationLog()
         )
 
         let repo = try await db.repos.create(
@@ -554,7 +560,8 @@ struct CodexLaunchCommandTests {
                 tmux: tmux,
                 hooks: HookResolver()
             ),
-            tmux: tmux
+            tmux: tmux,
+            actuationLog: makeTestActuationLog()
         )
 
         let repo = try await db.repos.create(
@@ -618,7 +625,8 @@ struct CodexLaunchCommandTests {
                 tmux: tmux,
                 hooks: HookResolver()
             ),
-            tmux: tmux
+            tmux: tmux,
+            actuationLog: makeTestActuationLog()
         )
 
         let repo = try await db.repos.create(

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -238,6 +238,152 @@ func testHandleTerminalRecreateWindowParksClaudeAsSuspended() async throws {
     #expect(updated.isClaudeResumable, "parked terminal must remain Claude-resumable")
 }
 
+// MARK: - The re-park branch is an actuation, and carries its own row
+
+/// A readable actuation-log path for the two tests below, plus the rows in it.
+/// `makeTestActuationLog()` is deliberately opaque about its path; these tests
+/// assert on the record, so they build their own under `$TMPDIR`.
+private func makeReadableActuationLog() throws -> (log: ActuationLog, path: String) {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-actuation-repark-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let path = directory.appendingPathComponent("actuations.jsonl").path
+    return (ActuationLog(path: path), path)
+}
+
+/// A path that can never be opened: its parent is a regular file.
+private func makeUnwritableActuationLogPath() throws -> String {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-actuation-blocked-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let blocker = directory.appendingPathComponent("blocker")
+    try Data("not a directory".utf8).write(to: blocker)
+    return blocker.appendingPathComponent("actuations.jsonl").path
+}
+
+private func actuationRows(at path: String) throws -> [[String: Any]] {
+    guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+    return try contents
+        .split(separator: "\n", omittingEmptySubsequences: true)
+        .map { line in
+            try #require(try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+        }
+}
+
+/// The re-park branch kills a window it read as dead and parks the session. It
+/// is an actuation, not a DB-only edit — the `windowExists` read one line
+/// earlier can be stale — so it writes its own `hibernate` row through
+/// `terminal.recreateWindow`'s door, the same act reconcile's recovery park
+/// records.
+@Test("the recreateWindow re-park writes one hibernate request and one dispatched outcome")
+func testRecreateWindowReparkWritesHibernateRow() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    // The window is genuinely DEAD: the premise of the re-park branch.
+    let tmux = TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true })
+    let (log, logPath) = try makeReadableActuationLog()
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+        tmux: tmux,
+        actuationLog: log
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-repark-row", displayName: "test", defaultBranch: "main")
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-repark-row",
+        branch: "tbd/wt-repark-row",
+        path: "/tmp/fake-repo-repark-row/wt-repark-row",
+        tmuxServer: "tbd-4e9a4c01"
+    )
+    let sessionID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@dead-claude",
+        tmuxPaneID: "%dead-claude",
+        label: "claude",
+        claudeSessionID: sessionID,
+        kind: .claude
+    )
+
+    let response = await router.handle(try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id),
+        actor: ActuationActor.app))
+    #expect(response.success, "expected success; error: \(response.error ?? "nil")")
+
+    let written = try actuationRows(at: logPath)
+    #expect(written.count == 2, "exactly one request and one outcome; got \(written)")
+    let request = try #require(written.first)
+    // A park, recorded as one — not as the surface's usual spawn.
+    #expect(request["kind"] as? String == "hibernate")
+    #expect(request["method"] as? String == "terminal.recreateWindow")
+    let target = try #require(request["target"] as? [String: Any])
+    #expect(target["worktree"] as? String == wt.id.uuidString)
+    #expect(target["terminal"] as? String == terminal.id.uuidString)
+    let actor = try #require(request["actor"] as? [String: Any])
+    #expect(actor["kind"] as? String == "app")
+
+    let outcome = try #require(written.last)
+    #expect(outcome["kind"] as? String == "outcome")
+    #expect(outcome["confirms"] as? String == request["id"] as? String)
+    #expect(outcome["result"] as? String == "dispatched")
+
+    let updated = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(updated.isParked, "the park itself must still happen")
+}
+
+/// Fail-closed: an unwritable record refuses the re-park before the kill. The
+/// window is not killed and the row is not parked, and the caller gets the
+/// self-explaining log error rather than a silent, unrecorded teardown.
+@Test("an unwritable record refuses the recreateWindow re-park before the kill")
+func testRecreateWindowReparkRefusedWhenRecordUnwritable() async throws {
+    let db = try TBDDatabase(inMemory: true)
+    let recorded = RecordedCommands()
+    let tmux = TmuxManager(
+        dryRun: true, dryRunRecorder: { recorded.append($0) }, dryRunWindowIsDead: { _ in true })
+    let router = RPCRouter(
+        db: db,
+        lifecycle: WorktreeLifecycle(db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+        tmux: tmux,
+        actuationLog: ActuationLog(path: try makeUnwritableActuationLogPath())
+    )
+
+    let repo = try await db.repos.create(
+        path: "/tmp/fake-repo-repark-refused", displayName: "test", defaultBranch: "main")
+    let wt = try await db.worktrees.create(
+        repoID: repo.id,
+        name: "wt-repark-refused",
+        branch: "tbd/wt-repark-refused",
+        path: "/tmp/fake-repo-repark-refused/wt-repark-refused",
+        tmuxServer: "tbd-4e9a4c02"
+    )
+    let sessionID = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+    let terminal = try await db.terminals.create(
+        worktreeID: wt.id,
+        tmuxWindowID: "@dead-claude-refused",
+        tmuxPaneID: "%dead-claude-refused",
+        label: "claude",
+        claudeSessionID: sessionID,
+        kind: .claude
+    )
+
+    let response = await router.handle(try RPCRequest(
+        method: RPCMethod.terminalRecreateWindow,
+        params: TerminalRecreateWindowParams(terminalID: terminal.id)))
+    #expect(!response.success, "an unrecordable park must not be performed")
+    #expect(response.error?.contains("actuation log") == true,
+            "the caller must see the self-explaining log error; got: \(response.error ?? "nil")")
+
+    let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+    #expect(!joined.contains { $0.contains("kill-window") },
+            "the kill must not run ahead of an unwritable record; got: \(joined)")
+
+    let updated = try #require(try await db.terminals.get(id: terminal.id))
+    #expect(!updated.isParked, "the refused act must leave the row unparked")
+}
+
 /// Stale-caller gate: when the claude terminal's CURRENT window is actually
 /// ALIVE (the app's dead-window path raced a wake that just recreated the
 /// window and updated the row's ids), `handleTerminalRecreateWindow` must NOT

--- a/Tests/TBDDaemonTests/TabRPCHandlersTests.swift
+++ b/Tests/TBDDaemonTests/TabRPCHandlersTests.swift
@@ -2,6 +2,7 @@ import Testing
 import Foundation
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite struct TabRPCHandlersTests {
 
@@ -15,7 +16,8 @@ import Foundation
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalActivityEventHandlerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite("terminal.activityEvent handler")
 struct TerminalActivityEventHandlerTests {
@@ -20,7 +21,8 @@ struct TerminalActivityEventHandlerTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
+++ b/Tests/TBDDaemonTests/TerminalCloseRailsTests.swift
@@ -47,7 +47,7 @@ struct TerminalCloseRailsTests {
             lifecycle: WorktreeLifecycle(
                 db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
             tmux: tmux,
-            startTime: Date())
+            startTime: Date(), actuationLog: makeTestActuationLog())
     }
 
     private func close(

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -52,7 +52,7 @@ import Testing
             lifecycle: WorktreeLifecycle(
                 db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
             tmux: tmux,
-            startTime: Date())
+            startTime: Date(), actuationLog: makeTestActuationLog())
     }
 
     // MARK: - Capture on terminal.delete

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -209,7 +209,7 @@ import Testing
             worktreeID: wt.id, tmuxWindowID: "@1", tmuxPaneID: "%0",
             label: "Claude Code", claudeSessionID: UUID().uuidString, kind: .claude)
 
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
         // Worktree archived, terminal torn down, scrollback captured.
         #expect(try await db.worktrees.get(id: wt.id)?.status == .archived)

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite("terminal.sessionEvent handler")
 struct TerminalSessionEventHandlerTests {
@@ -20,7 +21,8 @@ struct TerminalSessionEventHandlerTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/TerminalTranscriptHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalTranscriptHandlerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite("terminal.transcript handler")
 struct TerminalTranscriptHandlerTests {
@@ -20,7 +21,8 @@ struct TerminalTranscriptHandlerTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/TerminalTranscriptItemFullBodyHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalTranscriptItemFullBodyHandlerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 // Nested because this suite READS the process-global `TBD_CLAUDE_HOST_HOME` —
 // once via `resolveHostBaseDirectory()` when planting fixtures, and again when
@@ -29,7 +30,8 @@ struct TerminalTranscriptItemFullBodyHandlerTests {
                 hooks: HookResolver()
             ),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date()
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDDaemonTests/TransientApiErrorRPCTests.swift
+++ b/Tests/TBDDaemonTests/TransientApiErrorRPCTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import TBDDaemonLib
 @testable import TBDShared
+import TestSupport
 
 @Suite struct TransientApiErrorRPCTests {
     let db: TBDDatabase
@@ -19,7 +20,7 @@ import Testing
                 db: db, git: GitManager(),
                 tmux: TmuxManager(dryRun: true), hooks: HookResolver()),
             tmux: TmuxManager(dryRun: true),
-            startTime: Date())
+            startTime: Date(), actuationLog: makeTestActuationLog())
         let repo = try await db.repos.create(
             path: "/tmp/tae-repo-\(UUID().uuidString)", displayName: "R", defaultBranch: "main")
         let wt = try await db.worktrees.create(

--- a/Tests/TBDDaemonTests/WorktreeForgetTombstoneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeForgetTombstoneTests.swift
@@ -49,7 +49,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
 
     // The directory is still on disk AND still registered with git — exactly
     // the situation that used to make reconcile resurrect the row.
-    try await lifecycle.reconcile(repoID: repo.id)
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
     #expect(!active.contains { $0.path == wt.path },
@@ -77,7 +77,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     let wtPath = (base as NSString).appendingPathComponent("stray")
     try await shell("git worktree add -b stray-branch '\(wtPath)'", at: repoDir)
 
-    try await lifecycle.reconcile(repoID: repo.id)
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
     #expect(active.contains { $0.path == wtPath },
@@ -108,7 +108,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     // after its row disappears (proves the skip was tombstone-driven, not
     // some other latent state).
     try await db.worktrees.delete(id: outcome.worktree.id)
-    try await lifecycle.reconcile(repoID: repo.id)
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
     #expect(active.contains { $0.path == wt.path },
             "after the tombstone is cleared, reconcile behavior is back to normal")

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -746,7 +746,7 @@ import Testing
 
     let windowIDsBefore = Set(terminalsBefore.map { $0.tmuxWindowID })
 
-    try await lifecycle.reconcile(repoID: repo.id)
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
     let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
     #expect(terminalsAfter.count == 2, "Alive terminals must not be deleted during reconcile")
@@ -791,7 +791,7 @@ import Testing
     let suspendedBefore = try await db.terminals.get(id: suspended.id)
     #expect(suspendedBefore?.suspendedAt != nil, "Terminal should have suspendedAt set")
 
-    try await lifecycle.reconcile(repoID: repo.id)
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
     // All terminals must still exist after reconcile.
     terminals = try await db.terminals.list(worktreeID: wt.id)
@@ -846,7 +846,7 @@ import Testing
     )
     try await db.terminals.setHibernated(id: codex.id, sessionID: "sess-codex")
 
-    try await lifecycle.reconcile(repoID: repo.id)
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
     let claudeAfter = try await db.terminals.get(id: claude.id)
     #expect(claudeAfter != nil, "hibernated claude terminal must survive reconcile")
@@ -890,7 +890,7 @@ import Testing
     // In dryRun mode, serverExists → true (not the reboot path).
     // windowExists → true for any ID, so the stale window is treated as alive.
     // Result: the terminal record must NOT be deleted (no dead-window deletion).
-    try await lifecycle.reconcile(repoID: repo.id)
+    try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
     let terminalsAfter = try await db.terminals.list(worktreeID: wt.id)
     #expect(terminalsAfter.count == 2, "Terminal with stale window ID must survive when server is alive (dryRun)")

--- a/Tests/TBDDaemonTests/WorktreeReconcileOverlayCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReconcileOverlayCleanupTests.swift
@@ -67,7 +67,7 @@ struct WorktreeReconcileOverlayCleanupTests {
         #expect(overlayPath != ClaudeHookOverlay.overlayPath)
         #expect(FileManager.default.fileExists(atPath: overlayPath))
 
-        try await lifecycle.reconcile(repoID: repo.id)
+        try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
         // Worktree archived AND its per-session overlay reclaimed.
         let reloaded = try await db.worktrees.get(id: wt.id)

--- a/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
@@ -843,7 +843,8 @@ struct WorktreeReviveFreshTests {
             db: db,
             lifecycle: lifecycle,
             tmux: lifecycle.tmux,
-            subscriptions: subscriptions
+            subscriptions: subscriptions,
+            actuationLog: makeTestActuationLog()
         )
     }
 

--- a/Tests/TBDSharedTests/ActuationActorTests.swift
+++ b/Tests/TBDSharedTests/ActuationActorTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import TBDShared
+
+/// Tier 1. The caller-identity declaration and its transport on `RPCRequest`.
+///
+/// Assertions whitelist the keys a shape is allowed to carry rather than
+/// blacklisting ones it must not: a blacklist passes for a row that grew an
+/// unexpected key nobody named.
+@Suite("Actuation actor")
+struct ActuationActorTests {
+
+    private func encodedObject(_ actor: ActuationActor) throws -> [String: Any] {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(actor)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try #require(object as? [String: Any])
+    }
+
+    @Test("daemon actor is an object carrying only its kind")
+    func daemonIsObjectWithKindOnly() throws {
+        let object = try encodedObject(.daemon())
+        #expect(Set(object.keys) == ["kind"])
+        #expect(object["kind"] as? String == "daemon")
+    }
+
+    @Test("a daemon rail names the internal subsystem")
+    func daemonRail() throws {
+        let object = try encodedObject(.daemon(rail: "limit-resume"))
+        #expect(Set(object.keys) == ["kind", "rail"])
+        #expect(object["rail"] as? String == "limit-resume")
+    }
+
+    @Test("app actor is an object, never a bare string")
+    func appIsObject() throws {
+        let object = try encodedObject(.app)
+        #expect(Set(object.keys) == ["kind"])
+        #expect(object["kind"] as? String == "app")
+    }
+
+    @Test("a session declaring both coordinates carries both")
+    func sessionCarriesBothCoordinates() throws {
+        let actor = try #require(
+            ActuationActor.session(worktree: "WT-UUID", terminal: "TERM-UUID"))
+        let object = try encodedObject(actor)
+        #expect(Set(object.keys) == ["kind", "terminal", "worktree"])
+        #expect(object["kind"] as? String == "session")
+        #expect(object["worktree"] as? String == "WT-UUID")
+        #expect(object["terminal"] as? String == "TERM-UUID")
+    }
+
+    @Test("a partial declaration carries just the declared field")
+    func sessionPartialDeclaration() throws {
+        let actor = try #require(ActuationActor.session(worktree: "WT-UUID", terminal: nil))
+        let object = try encodedObject(actor)
+        #expect(Set(object.keys) == ["kind", "worktree"])
+    }
+
+    @Test("declaring neither coordinate is not a session")
+    func sessionWithNothingDeclaredIsNil() {
+        #expect(ActuationActor.session(worktree: nil, terminal: nil) == nil)
+        #expect(ActuationActor.session(worktree: "", terminal: "") == nil)
+    }
+
+    @Test("a session is read out of the ambient TBD environment")
+    func sessionFromEnvironment() throws {
+        let actor = try #require(ActuationActor.sessionFromEnvironment([
+            "TBD_WORKTREE_ID": "WT", "TBD_TERMINAL_ID": "TERM", "PATH": "/usr/bin",
+        ]))
+        #expect(actor.kind == "session")
+        #expect(actor.worktree == "WT")
+        #expect(actor.terminal == "TERM")
+        #expect(ActuationActor.sessionFromEnvironment(["PATH": "/usr/bin"]) == nil)
+    }
+
+    @Test("a kind reserved for later work still decodes")
+    func reservedKindDecodes() throws {
+        let json = #"{"kind":"supervisor","project":"acme-web"}"#
+        let actor = try JSONDecoder().decode(ActuationActor.self, from: Data(json.utf8))
+        #expect(actor.kind == "supervisor")
+        #expect(actor.project == "acme-web")
+    }
+
+    @Test("an unknown key on a known kind is ignored rather than failing the decode")
+    func unknownKeyIgnored() throws {
+        let json = #"{"kind":"daemon","somethingNewer":"x"}"#
+        let actor = try JSONDecoder().decode(ActuationActor.self, from: Data(json.utf8))
+        #expect(actor.kind == "daemon")
+    }
+}
+
+@Suite("RPCRequest actor field")
+struct RPCRequestActorTests {
+
+    @Test("an absent actor decodes as nil — the daemon records anonymous")
+    func absentActorDecodesNil() throws {
+        let json = #"{"method":"terminal.send","params":"{}"}"#
+        let request = try JSONDecoder().decode(RPCRequest.self, from: Data(json.utf8))
+        #expect(request.method == "terminal.send")
+        #expect(request.actor == nil)
+    }
+
+    @Test("a declared actor rides beside method and params, not inside them")
+    func actorIsTopLevel() throws {
+        let request = RPCRequest(
+            method: "terminal.send", params: "{}", actor: .app)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: encoder.encode(request)) as? [String: Any])
+        #expect(Set(object.keys) == ["actor", "method", "params"])
+        let actor = try #require(object["actor"] as? [String: Any])
+        #expect(actor["kind"] as? String == "app")
+        // The params blob is untouched — no verb's parameter shape changes.
+        #expect(object["params"] as? String == "{}")
+    }
+
+    @Test("a request with no identity omits the key entirely, so old daemons see no change")
+    func undeclaredActorOmitsKey() throws {
+        let request = RPCRequest(method: "terminal.send", params: "{}")
+        let object = try #require(
+            try JSONSerialization.jsonObject(
+                with: JSONEncoder().encode(request)) as? [String: Any])
+        #expect(Set(object.keys) == ["method", "params"])
+    }
+
+    @Test("stamping fills an undeclared identity and leaves a declared one alone")
+    func stampingIsNonDestructive() {
+        let bare = RPCRequest(method: "terminal.send")
+        #expect(bare.stamping(actor: .app).actor == .app)
+
+        let declared = RPCRequest(method: "terminal.send", actor: .daemon())
+        #expect(declared.stamping(actor: .app).actor == .daemon())
+
+        #expect(bare.stamping(actor: nil).actor == nil)
+    }
+}

--- a/Tests/TBDSharedTests/ConstantsTests.swift
+++ b/Tests/TBDSharedTests/ConstantsTests.swift
@@ -53,6 +53,13 @@ import Foundation
         #expect(TBDConstants.portFilePath(environment: env) == "/tmp/tbd-derived/port")
         #expect(TBDConstants.reposDir(environment: env).path == "/tmp/tbd-derived/repos")
         #expect(TBDConstants.socketPath(environment: env) == "/tmp/tbd-derived/sock")
+        #expect(TBDConstants.actuationLogPath(environment: env) == "/tmp/tbd-derived/actuations.jsonl")
+    }
+
+    @Test func actuationLogPathFallsBackToHomeTbdWhenKeyAbsent() {
+        let path = TBDConstants.actuationLogPath(environment: [:])
+        #expect(path.hasSuffix("/tbd/actuations.jsonl"))
+        #expect(path.hasPrefix(FileManager.default.homeDirectoryForCurrentUser.path))
     }
 
     @Test func socketPathOverrideWinsOverTBDHome() {

--- a/Tests/TestSupport/ActuationLogTestSupport.swift
+++ b/Tests/TestSupport/ActuationLogTestSupport.swift
@@ -1,0 +1,19 @@
+import Foundation
+@testable import TBDDaemonLib
+
+/// An `ActuationLog` writing to a unique temp path, for the many tests that
+/// construct a daemon type requiring one but assert nothing about the record.
+///
+/// The writer creates its directory and file lazily, at the first append, so a
+/// test that never actuates touches no disk at all.
+///
+/// This exists because the production types must NOT default the parameter to
+/// `ActuationLog(path: TBDConstants.actuationLogPath)`. That default is the
+/// "helper ignores its caller's injected seam" shape: ~45 construction sites
+/// would silently share one real file under `$TBD_HOME`, appending to each
+/// other's record and to the live daemon's whenever the fence was not in force.
+public func makeTestActuationLog(tag: String = "test") -> ActuationLog {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("tbd-actuation-\(tag)-\(UUID().uuidString)", isDirectory: true)
+    return ActuationLog(path: directory.appendingPathComponent("actuations.jsonl").path)
+}

--- a/Tests/TestSupport/ActuationLogTestSupport.swift
+++ b/Tests/TestSupport/ActuationLogTestSupport.swift
@@ -7,6 +7,13 @@ import Foundation
 /// The writer creates its directory and file lazily, at the first append, so a
 /// test that never actuates touches no disk at all.
 ///
+/// No teardown, deliberately: the directory lives under `$TMPDIR` (per-user on
+/// darwin, and the run's own scratch home under `scripts/test.sh`), which the
+/// OS reaps, and the only tests that write through it are the ones asserting on
+/// the record — those build their own path and clean it up. Returning a cleanup
+/// closure instead would put a `defer` at ~45 call sites that never touch the
+/// file. `makeIsolatedConfigDirManager` is the same shape for the same reason.
+///
 /// This exists because the production types must NOT default the parameter to
 /// `ActuationLog(path: TBDConstants.actuationLogPath)`. That default is the
 /// "helper ignores its caller's injected seam" shape: ~45 construction sites


### PR DESCRIPTION
## Summary

First slice (1a) of the fleet-supervision rebuild: the daemon now writes an append-only JSONL record at `~/tbd/actuations.jsonl` of every state-changing actuation it executes on a session — send, wake, hibernate, spawn, dispose — for every caller, whether supervision exists or not. **No verb changes behavior on the happy path; nothing reads the file yet.**

The property this creates (requirements P1-7): **nobody is the reporter of their own acts.** The old action log was the supervising agent's own notes file, so it could claim anything. Here only daemon code appends, and the request row lands durably *before* the act runs, so no crash window can produce a real act with no record.

**Spec:** this implements `docs/specs/2026-07-26-fleet-supervision-design.md` §3/§6/§7/§12 (and requirements P1-7) — the committed, reviewed spec set for the supervision rebuild. The per-slice envelope decisions (actor shape, kind set, ID scheme, fail-closed semantics, refused-reason vocabulary) were written up and review-approved on the `supervision-migration` agent channel per the migration workflow; the scratch note itself stays uncommitted per the `docs/plans/` policy.

## The record's shape

- Envelope `{id, ts, actor, kind}`; body carries target, verbatim payload, and (for `outcome` rows) result. `actor` is always an object — `daemon` (with an optional `rail`), `app`, `session` (echoing the `TBD_WORKTREE_ID`/`TBD_TERMINAL_ID` the daemon itself planted at spawn), or an explicit `anonymous`. Identity is ambient declaration, never authentication.
- Kinds are a small closed set; a `method` field names the RPC surface, so the surface list can grow without touching contract.
- Ordering per actuation: request row (fail-closed) → act → synchronous outcome row (`dispatched`/`refused`/`transport-failed`, best-effort-loud — the act already ran). Outcomes never claim *landed*; that rung is a later slice (observed via transcript envelope + re-check).
- Every `refused` outcome also carries a closed `reason` — `noop` / `not-found` / `not-eligible` / `in-flight` (slice 5 adds `precondition`) — beside the human-facing detail, so "which acts did my controls stop" is a query over the envelope, never a string match. Enforced by construction: the outcome type cannot spell a refusal without a reason, and no other result can carry one.
- IDs: 12-char lowercase base36, one namespace that dispatch/receipt/outcome will join on.
- Rotation: at the first append of a new UTC day the active file moves to `actuations-<date>.jsonl`. No header/footer/marker rows — rotation is housekeeping, never a record boundary.
- Identity transport: one optional top-level `actor` field on `RPCRequest` beside `method`/`params` — no verb's parameter shape changes, old CLIs omit it (recorded as anonymous), old daemons ignore it.

## Failure semantics (the one deliberate new behavior)

If the request row cannot be appended, the writer closes/reopens and retries exactly once; if that also fails, **the actuation is refused** with a self-explaining error naming the full log path and the recovery, plus a `.fault` log line. Fail-open would make the record a liar by omission on exactly the night it gets read. Recovery is phase-aware so the row lands at most once: a half-written line is finished from the byte the kernel accepted, a written-but-unflushed line is only re-`fsync`ed, and a dangling fragment from a crash is isolated on its own junk line at the next open.

**Nightwatch:** on the happy path its `tbd terminal send` calls behave identically (one fsync-scale append ahead of each act). If the log is unwritable its daemon-side desk pastes, spawns, and closes refuse — degrading it to inert, never crashed. Accepted cost.

**No feature flag.** The log acts on no session, deletes nothing, and replaces no path; its only behavioral surface is the refuse-when-unwritable mode above, which triggers only when `~/tbd` is already broken. Flagging it would mean the unflagged path is the unrecorded one — backwards for a record.

## Wired surfaces

All session-actuating RPC surfaces: `terminal.send/create/delete/hibernate/wake`, the legacy suspend/resume shims and worktree fan-outs, `recreateWindow`, `swapProfile`, `continueInCodex`, the revive family, `worktree.create`/`scratch.create` primary-terminal spawns, the teardown family (`worktree.archive`/`forget`/`rerunPreSession`, `scratch.delete`/`archive`, `repo.remove`'s per-worktree cascade), and `remote.create/stop/send`.

Six daemon-internal rails that bypass RPC: `limit-resume` (auto-continue), `auto-hibernate` (idle sweep), `auto-hibernate-on-merge`, `auto-archive-on-merge`, `reconcile` (the boot sweep's kills and recovery parks, one row per act), and `nightwatch-desk` (the desk's spawns, closes, and pastes).

An audit of every actuation primitive call site in the daemon (`killWindow`, `killServer`, `respawnWindow`, `setHibernated`, `pasteText`, `sendKey`, `createWindow`, raw `kill`) confirms each traces to a covering row at an entry point or a documented exception; shared lifecycle helpers stay silent so every act is counted exactly once.

That audit is now **enforced mechanically**: a SwiftLint custom rule (`actuation_primitive_allowlist`, same shape and severity as the existing `capture_pane_allowlist`) fails the build when an actuation primitive is called from a file outside the audited set, with a message stating the boundary rule and pointing at `ActuationSurface.swift`. The wired set was found incomplete nine times across five attentive review passes — completeness-by-vigilance demonstrably does not hold for this property, so it is no longer guarded by vigilance. The rule is mutation-checked (a probe call in a clean file reds the build; declarations and control-mode's unrelated same-named method do not).

## Known limitations, stated deliberately

- `refused` is unreachable on `terminal.send` and the two worktree-revive surfaces (dispatched-or-transport-failed only); `transport-failed` is unreachable for hibernate (`HibernateResult` has no tmux-failure case). Idempotent no-ops record `refused` (`reason: noop`) with a detail string while the RPC still returns success.
- `worktree.archive`/`forget` classify any throw as `transport-failed`, matching the revive precedent — a genuine decline (main-branch worktree, active children) is currently not separated into `refused`; refining all four siblings together is a named follow-up.
- `worktree.create` records `dispatched` when the spawn is enqueued (its spawn phase is async); `scratch.create` awaits its spawn inline — the asymmetry resolves at the observed rung in a later slice.
- `worktree.suspend`'s fan-out skips a terminal's park on an unpersistable row after the RPC already returned ok; a mid-loop failure on `worktree.resume` leaves a partial fan-out completed with an error returned. `repo.remove` rows its whole cascade up front, so an unwritable record refuses it all-or-nothing.
- One branch deliberately carries no row (verified DB/file-only, commented in code): `swapProfile`'s parked cold-swap. `recreateWindow`'s re-park — earlier described here as DB-only — was found by review to call `killWindow` and is now wired as a `hibernate` row of its own. The spawn-time auto-`/login` pump is a sub-step of the spawn row, not a separate row.
- `terminal.continueInCodex` runs its transcript import (a subprocess that mints persisted Codex thread state) before the request row — DB/state-only per the documented boundary, so a crash in that window leaves the import unrecorded rather than unconfirmed. Reasoned in code; listed here for completeness.
- The writer's serialization claim is process-scoped; a stale daemon from another worktree writing the same path is out of scope (pid-liveness is not a lock, noted in the doc comment).

## Test plan

- [x] ~100 new tests across writer, wiring, actor/protocol, retry phases, rotation, rails, and teardown suites — including mutation-checked retry-recovery tests, fail-closed refusal asserting the side effect never ran, per-rail request/outcome pairs read back from the file, forward-compat actor decoding, and the refused-reason classification matrix
- [x] Full suite via `scripts/test.sh`: 5044 tests / 554 suites pass; no pre-existing test assertion modified (only construction-site injection of the now-required `ActuationLog`, so tier-1 suites stay off the shared path)
- [x] `scripts/swift-safe build` clean; `swiftlint --strict` 0 violations, including the new `actuation_primitive_allowlist` guard (verified by a one-time mutation probe: a primitive call added to a clean file reds the build; declarations and same-named non-primitives do not — matching the `capture_pane_allowlist` precedent, which likewise has no persisted mutation test)
- [x] Multiple review rounds (multi-agent code review + adversarial verification + the PR review bot's interception-completeness pass) — all High/Medium findings fixed and re-verified

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7C2ECC06-6835-44A0-B712-3468D9EDD6DD)


