### PR TITLE
Compound: Teach agents that a nested run loop drains nothing a @MainActor test is waiting for

### DIFF
--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -422,12 +422,14 @@ that queue runs — including the deferred work the body is trying to observe.
 
 **Never spin a nested run loop to wait for something.** A nested
 `RunLoop.current.run(until:)` cannot re-enter the main queue, so it drains none
-of it. Three things were measured here, and all three hold both bare and after
-`NSApplication.shared` exists: a block enqueued with `DispatchQueue.main.async`
-immediately before a 0.3 s nested run loop had **still not run** when the loop
-returned; a suspended `@MainActor` task was **not** resumed by it; and neither
-was a task parked on a continuation resumed from a background queue — the shape
-a test awaiting a bounded-poll helper has.
+of it. Three things were measured here — each against a loop kept alive by an
+attached timer, so it genuinely spun for its full duration rather than returning
+early — and all three hold both bare and after `NSApplication.shared` exists: a
+block enqueued with `DispatchQueue.main.async` immediately before a 0.3 s nested
+run loop had **still not run** when the loop returned; a suspended `@MainActor`
+task was **not** resumed by it; and neither was a task parked on a continuation
+resumed from a background queue — the shape a test awaiting a bounded-poll
+helper has.
 
 **Suspending is the only thing that returns the queue.** `await Task.yield()`
 hands the main actor back, the queued block runs, and only then does the
@@ -457,9 +459,13 @@ input source or timer is attached to the loop — measured 0.000 s bare against
 0.321 s once a timer was added. A pump that appears to be doing something may be
 doing nothing at all, at either end of the range.
 
-The compiler already closes the worst half: `RunLoop.current` and `run(until:)`
-are `NS_SWIFT_UNAVAILABLE_FROM_ASYNC`, so a nested loop can only appear in a
-synchronous body or helper — exactly the context that can never suspend.
+The compiler already closes the worst half. `NSRunLoop.h` annotates every
+spinning method — `run`, `run(until:)`, `run(_:before:)`,
+`acceptInput(for:before:)` — plus the `current` property itself with
+`NS_SWIFT_UNAVAILABLE_FROM_ASYNC`; `main` is deliberately not annotated, so the
+methods are the enforcement point and `RunLoop.main.run(until:)` is refused
+just the same. A nested loop can therefore only appear in a synchronous body or
+helper — exactly the context that can never suspend.
 **Reaching for one from an `async` test and finding it won't compile is the
 signal to yield, not to hoist the spin into a sync helper.**
 

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -413,6 +413,60 @@ Four rules. Each traces to a real flake — provenance kept so the rule sticks.
 
 Full rationale: `docs/specs/2026-07-24-test-hardening-design.md` §6.
 
+## `@MainActor` tests: suspend to drain, never pump
+
+A `@MainActor` test body **is** a block executing on the serial main queue, and in
+this test process that queue is drained by libdispatch's own main-thread drain,
+not by CFRunLoop. So for as long as the body runs synchronously, nothing else on
+that queue runs — including the deferred work the body is trying to observe.
+
+**Never spin a nested run loop to wait for something.** A nested
+`RunLoop.current.run(until:)` cannot re-enter the main queue, so it drains none
+of it. Measured here: a block enqueued with `DispatchQueue.main.async`
+immediately before a 0.3 s nested run loop had **still not run** when the loop
+returned, and a suspended `@MainActor` task was **not** resumed by it either.
+The same three assertions hold after `NSApplication.shared` exists.
+
+**Suspending is the only thing that returns the queue.** `await Task.yield()`
+hands the main actor back, the queued block runs, and only then does the
+continuation resume — so the test observes the effect it came to assert. Bound
+the wait (assertion-hygiene rule 3 above): poll with `Task.sleep` against an
+iteration cap so work that never arrives fails an assertion instead of hanging.
+`TableTranscriptHarness.drainMainQueue()` is the minimal shape and
+`TranscriptImageAttachmentTests.pump(_:until:)` the bounded-poll one.
+
+**The failure shape is why this rule is written down.** The deferred work does
+not vanish; it runs once the body ends, inside whatever test is running by then.
+So the offending test **passes in isolation** and reds a *sibling* — the reported
+failure names innocent code. Shared process-wide state makes it concrete: a
+block that repopulates `TranscriptImageService.shared` after another test called
+`clearCaches()` corrupts that test, not its own. **`.serialized` does not help**,
+because it orders test *bodies* and this work escaped one.
+
+**What a nested run loop legitimately does** is run-loop-scheduled work only:
+`NSTimer`, `CFRunLoopSource`, AppKit display and layout. Driving those from a
+synchronous body is its one honest use, and the two `pump()` helpers in
+`Tests/TBDAppTests` exist for it. It is never a synchronization primitive for
+`DispatchQueue.main.async` or Swift concurrency — if a helper's docstring claims
+to "drain" either, the claim is false.
+
+**And it can be a silent no-op.** `run(until:)` returns immediately when no
+input source or timer is attached to the loop — measured 0.000 s bare against
+0.321 s once a timer was added. A pump that appears to be doing something may be
+doing nothing at all, at either end of the range.
+
+The compiler already closes the worst half: `RunLoop.current` and `run(until:)`
+are `NS_SWIFT_UNAVAILABLE_FROM_ASYNC`, so a nested loop can only appear in a
+synchronous body or helper — exactly the context that can never suspend.
+**Reaching for one from an `async` test and finding it won't compile is the
+signal to yield, not to hoist the spin into a sync helper.**
+
+There is no lint rule for this, deliberately, and for the same reason rule 4
+above has none: nothing mechanical can tell "drive AppKit layout" from "wait for
+a callback" at a `RunLoop.run` call site. A rule banning the syntax would fire
+on both, would start life fully suppressed against the legitimate sites, and
+would be one people disable.
+
 ## Clock and date seams
 
 Governing rule: **`Duration` is behavior, `Date` is data.** The two seams are

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -433,11 +433,19 @@ helper has.
 
 **Suspending is the only thing that returns the queue.** `await Task.yield()`
 hands the main actor back, the queued block runs, and only then does the
-continuation resume — so the test observes the effect it came to assert. Bound
-the wait (assertion-hygiene rule 3 above): poll with `Task.sleep` against an
-iteration cap so work that never arrives fails an assertion instead of hanging.
-`TableTranscriptHarness.drainMainQueue()` is the minimal shape and
-`TranscriptImageAttachmentTests.pump(_:until:)` the bounded-poll one.
+continuation resume — so the test observes the effect it came to assert.
+
+Two shapes, and they are not interchangeable.
+`TableTranscriptHarness.drainMainQueue()` is the minimal one — a few bare
+`Task.yield()`s, no condition and no sleep. That is enough when the work is
+already on the queue and handing it back is all that was missing, but it checks
+nothing and so **carries no failure signal**: if the work needs longer than the
+yields it gets, the test proceeds as though it arrived. Use it only where the
+work is certainly enqueued. When you are waiting on something that may never
+arrive — a decode, a file read — poll instead (assertion-hygiene rule 3 above):
+`Task.sleep` between checks of a done condition, against an iteration cap, so a
+no-show fails an assertion rather than passing quietly.
+`TranscriptImageAttachmentTests.pump(_:until:)` is that shape.
 
 This does not contradict the warning under "Clock and date seams" below that
 spinning `Task.yield()` **does not converge**. The two describe opposite

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -422,10 +422,12 @@ that queue runs — including the deferred work the body is trying to observe.
 
 **Never spin a nested run loop to wait for something.** A nested
 `RunLoop.current.run(until:)` cannot re-enter the main queue, so it drains none
-of it. Measured here: a block enqueued with `DispatchQueue.main.async`
+of it. Three things were measured here, and all three hold both bare and after
+`NSApplication.shared` exists: a block enqueued with `DispatchQueue.main.async`
 immediately before a 0.3 s nested run loop had **still not run** when the loop
-returned, and a suspended `@MainActor` task was **not** resumed by it either.
-The same three assertions hold after `NSApplication.shared` exists.
+returned; a suspended `@MainActor` task was **not** resumed by it; and neither
+was a task parked on a continuation resumed from a background queue — the shape
+a test awaiting a bounded-poll helper has.
 
 **Suspending is the only thing that returns the queue.** `await Task.yield()`
 hands the main actor back, the queued block runs, and only then does the

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -439,6 +439,16 @@ iteration cap so work that never arrives fails an assertion instead of hanging.
 `TableTranscriptHarness.drainMainQueue()` is the minimal shape and
 `TranscriptImageAttachmentTests.pump(_:until:)` the bounded-poll one.
 
+This does not contradict the warning under "Clock and date seams" below that
+spinning `Task.yield()` **does not converge**. The two describe opposite
+situations. There, the waiter needs *scheduling progress somewhere else* before
+it can proceed, and yielding re-queues it ahead of the very work it is waiting
+on, so more yields make it worse. Here the work is already enqueued on the
+queue this body is holding, and letting go of it is the entire remedy — one
+handoff suffices, and the loop exists only to bound how long you wait for a
+decode that may never arrive. **Yield to release something you hold; never to
+hurry something you don't.**
+
 **The failure shape is why this rule is written down.** The deferred work does
 not vanish; it runs once the body ends, inside whatever test is running by then.
 So the offending test **passes in isolation** and reds a *sibling* — the reported

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -442,12 +442,12 @@ iteration cap so work that never arrives fails an assertion instead of hanging.
 This does not contradict the warning under "Clock and date seams" below that
 spinning `Task.yield()` **does not converge**. The two describe opposite
 situations. There, the waiter needs *scheduling progress somewhere else* before
-it can proceed, and yielding re-queues it ahead of the very work it is waiting
-on, so more yields make it worse. Here the work is already enqueued on the
-queue this body is holding, and letting go of it is the entire remedy — one
-handoff suffices, and the loop exists only to bound how long you wait for a
-decode that may never arrive. **Yield to release something you hold; never to
-hurry something you don't.**
+it can proceed, and yielding does not produce it — that section owns the
+queueing mechanics and the measurement behind them. Here the work is already
+enqueued on the queue this body is holding, so releasing that queue is the
+entire remedy, and the surrounding loop exists only to bound how long you wait
+for a decode that may never arrive. **Yield to release something you hold;
+never to hurry something you don't.**
 
 **The failure shape is why this rule is written down.** The deferred work does
 not vanish; it runs once the body ends, inside whatever test is running by then.

--- a/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
@@ -598,9 +598,9 @@ struct TranscriptImageAttachmentTests {
     ///
     /// It YIELDS rather than spinning a nested `RunLoop.run`: the decode's
     /// completion arrives via `DispatchQueue.main.async`, and suspending is what
-    /// lets the main queue deliver it. A nested run loop would deliver it too, but
-    /// it would also resume every other suspended `@MainActor` test in this
-    /// 200-suite process inside this test's body.
+    /// lets the main queue deliver it. A nested run loop could not — this body is
+    /// itself a block on that serial queue, so the completion would sit there
+    /// until the body ended and then land inside some other test.
     ///
     /// Bounded on purpose: a decode that never arrives must fail the assertion
     /// below rather than hang the suite.


### PR DESCRIPTION
## Summary

A `@MainActor` test body **is** a block on the serial main queue, and in this test process that queue is drained by libdispatch, not CFRunLoop. So a nested `RunLoop.current.run(until:)` inside a test body cannot re-enter the queue and drains none of it. The deferred work does not vanish — it runs once the body ends, inside whatever test is running by then. The offending test **passes in isolation** and reds a *sibling*, so the reported failure names innocent code, and `.serialized` does not help because it orders test bodies, not queue work that escaped one.

This documents the rule in `Tests/CLAUDE.md` (alongside the clock/date seams and `TBD_HOME` fencing rules) and corrects a comment in `TranscriptImageAttachmentTests` that stated the opposite mechanism.

**Measured, not assumed.** A temporary probe suite run in the real test process established:

- A block enqueued with `DispatchQueue.main.async` immediately before a 0.3 s nested run loop had **still not run** when the loop returned. Suspending (`Task.sleep`) delivered it.
- A suspended `@MainActor` task was **not** resumed by a 0.4 s nested run loop — identical to a busy-wait control. Same for a task parked on a continuation resumed from a background queue.
- Both hold after `NSApplication.shared` exists.
- The escape is directly observable: inside the body the log read `["probeF body end"]`; a later test saw `["probeF body end", "deferred block"]`.
- `run(until:)` returns immediately when no source is attached — 0.000 s bare vs 0.321 s once a timer was added — so a `pump()` helper can be a silent no-op.

`TableTranscriptHarness.drainMainQueue()` already carried the correct explanation; the comment in `TranscriptImageAttachmentTests` claimed a nested loop *would* deliver the work and would resume every other suspended `@MainActor` test. Both halves are false, and that is the version a reader was most likely to trust, so it is rewritten.

## No lint rule, deliberately

Nothing mechanical can distinguish "drive AppKit layout" (correct) from "wait for a callback" (broken) at a `RunLoop.run` call site. A syntactic ban would fire on both existing `pump()` helpers in `Tests/TBDAppTests`, which use a nested loop for its one honest purpose — run-loop-scheduled work — so the rule would ship fully suppressed and get disabled. Same reasoning the repo already applies to assertion-hygiene rule 4. The rationale is recorded in the doc so it is not re-proposed.

The compiler already enforces the half that can be enforced: `RunLoop.current` and `run(until:)` are `NS_SWIFT_UNAVAILABLE_FROM_ASYNC`, so a nested loop can only appear in a synchronous body or helper.

## Survey

Two `RunLoop.current.run` sites in test code, both `pump()` helpers driving AppKit layout — `TableTranscriptHarness.swift:1707` and `WorkbenchSnapshotTests.swift:260`. Neither changed; both are the permitted use. No `CFRunLoopRun` anywhere. Hits in `Sources/` are `RunLoop.main.add(timer:)`, which is scheduling, not pumping.

**One residual for a human, not fixed here.** `settle()`'s docstring claims to drain "deferred async height corrections," and `TableTranscriptView` has five `DispatchQueue.main.async` sites. `pump()` provably cannot drain those. The harness has `drainMainQueue()` for exactly this, used at only 2 of ~25 settle/pump call sites. Worth auditing whether any assertion there passes against an effect that never fired — it needs someone who knows which of those five matter, and converting `settle()` to `async` ripples across every call site.

## Test plan

- [x] `swiftlint --strict` — 0 violations in 674 files
- [x] `scripts/test.sh --filter 'TranscriptImageAttachmentTests'` — 27 tests passed (count checked; a filter matching nothing exits green)
- [x] Probe suite removed; only the doc and the comment remain in the diff

No production code changed. Docs plus one test comment.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9E25064A-999B-4889-9B02-FEC413AF1730)

## On the spec convention

No `docs/specs/` entry, deliberately. The repo requires one for work that revises the system's theory, and asks that a larger change without one say so here — this is that statement.

This records a measured property of the existing test harness and the convention that follows from it. It revises no theory, adds no flag, no migration, no runtime behavior. `Tests/CLAUDE.md` is largely made of exactly this kind of hard-won convention — the kill hazards, the shared-box hazards, the `.flaky` quarantine rules — none of which carry a spec reference. The one section that does, "Assertion hygiene", cites `2026-07-24-test-hardening-design.md` because that section came out of the test-hardening program, not because every rule in the file needs a spec.

There is also a hard constraint: a human answers the brainstorming questions, and an agent may not answer its own. A spec authored unilaterally here would be the failure mode that rule exists to prevent.
