### PR TITLE
Fix: terminal.send stops reporting success into dead and misidentified panes

### DIFF
--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -257,12 +257,20 @@ extension AppState {
     }
 
     /// Send text to a terminal.
+    ///
+    /// The daemon now refuses a send whose pane is gone, dead, or has been
+    /// reused by a different session, so this can fail for a reason the user
+    /// can act on ("recreate the window"). `handleConnectionError` only flips
+    /// the connected flag for disconnects, which would leave such a refusal
+    /// invisible — so it is surfaced the way this file's sibling failures are,
+    /// as an error alert carrying the daemon's own message.
     func sendToTerminal(terminalID: UUID, text: String) async {
         do {
             try await daemonClient.sendToTerminal(terminalID: terminalID, text: text)
         } catch {
             logger.error("Failed to send to terminal: \(error)")
             handleConnectionError(error)
+            showAlert("Couldn't send to terminal: \(error.localizedDescription)", isError: true)
         }
     }
 

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -49,6 +49,16 @@ enum RefusedReason: String, Codable, Sendable, CaseIterable {
     case notEligible = "not-eligible"
     /// The same act is already running on this target.
     case inFlight = "in-flight"
+    /// The coordinate resolved to a *different* session than the one named:
+    /// the target answered with an identity that disagrees with the request's.
+    ///
+    /// Neither neighbour is honest about this. `notFound` would claim the named
+    /// target is gone, and it is not — its row is right there. `notEligible`
+    /// would claim the target is in the wrong state, and it is not — a
+    /// perfectly healthy *other* target answered. tmux reuses pane ids, so a
+    /// stale coordinate names a live stranger (issue #384); the record has to
+    /// be able to say that is what happened.
+    case targetMismatch = "target-mismatch"
 }
 
 /// The synchronous outcome of one act, as the daemon classifies it just before

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -6,11 +6,14 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "limitResume"
 
 /// The tmux surface the actuator needs. `TmuxManager` conforms; tests fake it.
 /// All sends go through the SAME methods `handleTerminalSend` uses — never
-/// raw tmux invocations (spec constraint).
+/// raw tmux invocations (spec constraint) — and, since this actuator types
+/// without a user gesture, behind the SAME target consultation
+/// (`paneSendTarget`) that `handleTerminalSend` runs before it types.
 public protocol ResumeSendingTmux: Sendable {
     func windowExists(server: String, windowID: String) async -> Bool
     func paneInMode(server: String, paneID: String) async throws -> Bool
     func panePID(server: String, paneID: String) async throws -> String
+    func paneSendTarget(server: String, paneID: String) async throws -> PaneSendTarget
     func sendKeys(server: String, paneID: String, text: String) async throws
     func sendKey(server: String, paneID: String, key: String) async throws
 }
@@ -263,6 +266,25 @@ public struct LimitResumeActuator: LimitResumeActuating {
             return .notEligible(.terminalGone)
         }
 
+        // 1a. Ask the pane who it is, before any key is typed into it.
+        //     `windowExists` above proves a window id resolves to SOME window;
+        //     it cannot prove the pane still belongs to THIS terminal. tmux
+        //     reuses pane ids, so a stale `tmuxPaneID` names a live stranger
+        //     that passes every remaining check — window alive, Claude
+        //     foreground, not in copy-mode — and then gets "continue" typed
+        //     into it. That is issue #384 as it was actually observed: this
+        //     actuator, not a human's `terminal.send`, was the thing typing.
+        //
+        //     Same rule as the send path: refusal requires POSITIVE
+        //     disagreement. A pane that answers with no identity is sent to
+        //     exactly as before, so panes predating the stamp do not regress.
+        switch await paneTargetVerdict(server: server, terminal: terminal) {
+        case .proceed:
+            break
+        case .notEligible(let outcome):
+            return .notEligible(outcome)
+        }
+
         // 1b. Explicit-cancel-mid-flight: the row itself can be cancelled
         //     (`cancelPending`/`cancelAllPending`) while a prior attempt's
         //     verify window is running — e.g. the user clicked "Cancel
@@ -309,6 +331,78 @@ public struct LimitResumeActuator: LimitResumeActuating {
             server: server, paneID: terminal.tmuxPaneID, terminalID: terminal.id,
             worktreeID: terminal.worktreeID,
             transcriptPath: terminal.transcriptPath, preSendTranscriptData: preSendTranscriptData))
+    }
+
+    /// What the pane consultation concluded for step 1a.
+    private enum PaneTargetVerdict {
+        case proceed
+        case notEligible(ResumeActuationOutcome)
+    }
+
+    /// Classify one `paneSendTarget` consultation into an eligibility verdict.
+    ///
+    /// The outcomes mirror how this actuator already treats the same facts:
+    /// a pane that is gone or whose process has exited is the `windowExists`
+    /// case one level finer, so it cancels silently as `.terminalGone`. A pane
+    /// that answers with a DIFFERENT terminal is not "gone" and not a
+    /// transient state to retry — the row's coordinate is stale and will stay
+    /// stale until something respawns the window, so retrying would only aim
+    /// at the same stranger again. It fails the row with a message naming both
+    /// ids, the way step 3's not-foreground check fails a row a retry cannot
+    /// help either.
+    private func paneTargetVerdict(
+        server: String, terminal: Terminal
+    ) async -> PaneTargetVerdict {
+        let target: PaneSendTarget
+        do {
+            target = try await tmux.paneSendTarget(server: server, paneID: terminal.tmuxPaneID)
+        } catch {
+            // The consultation could not be RUN (a wedged tmux tripping the
+            // subprocess timeout) — not an answer about the pane. Step 3's
+            // `panePID` treats the same wedged server as `.failed`, and typing
+            // into a pane we could not look at is exactly what this check
+            // exists to stop.
+            return .notEligible(.failed("could not verify the target pane: \(error)"))
+        }
+
+        switch target {
+        case .missing:
+            logger.info("""
+                actuate: pane \(terminal.tmuxPaneID, privacy: .public) for terminal \
+                \(terminal.id.uuidString, privacy: .public) no longer exists — cancelling
+                """)
+            return .notEligible(.terminalGone)
+        case .dead:
+            logger.info("""
+                actuate: pane \(terminal.tmuxPaneID, privacy: .public) for terminal \
+                \(terminal.id.uuidString, privacy: .public) is dead — cancelling
+                """)
+            return .notEligible(.terminalGone)
+        case .live(let paneTerminalID):
+            guard let paneTerminalID else {
+                // Absence is not disagreement: a pane spawned before TBD
+                // stamped identities carries none, and refusing on nothing
+                // would break auto-resume for every such session.
+                logger.debug("""
+                    actuate: pane \(terminal.tmuxPaneID, privacy: .public) claims no terminal \
+                    identity; proceeding without verifying it is terminal \
+                    \(terminal.id.uuidString, privacy: .public)
+                    """)
+                return .proceed
+            }
+            guard paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString) != .orderedSame
+            else { return .proceed }
+            logger.warning("""
+                actuate: pane \(terminal.tmuxPaneID, privacy: .public) belongs to terminal \
+                \(paneTerminalID, privacy: .public), not \
+                \(terminal.id.uuidString, privacy: .public) — typing nothing
+                """)
+            return .notEligible(.failed("""
+                tmux pane \(terminal.tmuxPaneID) now belongs to terminal \(paneTerminalID), \
+                not the scheduled terminal \(terminal.id.uuidString) — nothing was sent \
+                (tmux reuses pane ids, so this coordinate is stale)
+                """))
+        }
     }
 
     /// The exact production send sequence (spec §Actuation 5):

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -988,6 +988,12 @@ public actor HibernationCoordinator {
     /// Escape → settle → C-c C-c → settle → SIGTERM. Best-effort; the
     /// subsequent `respawn-window -k` guarantees termination. Copied from the
     /// swap path so hibernate and account-switch interrupt identically.
+    ///
+    /// **Acts on an unverified coordinate (issue #384)** — `paneID` comes from
+    /// the terminal row and tmux reuses pane ids, so a stale row points this
+    /// SIGTERM and the respawn that follows at a live stranger. See the swap
+    /// path's copy in `RPCRouter+TerminalHandlers` for why the fix is a spec
+    /// about refusal semantics rather than a consultation added here.
     private func gracefullyInterruptPane(server: String, paneID: String) async {
         try? await tmux.sendKey(server: server, paneID: paneID, key: "Escape")
         // swiftlint:disable:next no_raw_task_sleep - legacy sleep, see docs/specs/2026-07-24-test-hardening-design.md

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -266,6 +266,14 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// unrelated session*, which would then receive a pasted judge prompt plus Enter. That
     /// is issue #384, and picking the newest row alone would not prevent it.
     ///
+    /// Neither guard is sufficient on its own, and neither proves *ownership*.
+    /// `windowExists` proves a window id resolves to SOME window;
+    /// `paneCurrentCommand` proves an agent of the right kind is in the
+    /// foreground of SOME pane. A recycled pane id running a stranger's Claude
+    /// satisfies both. So each surviving candidate is asked who it is
+    /// (`paneSendTarget`) and dropped when it answers with a different terminal
+    /// — see `paneIdentityPermitsSend`.
+    ///
     /// Hibernated/suspended rows are excluded even if their tmux window still
     /// exists: their pane contains a shell, not an agent, and pasting a judge
     /// prompt there would execute it as shell input.
@@ -295,6 +303,7 @@ public actor DeskSessionManager: DeskSessionManaging {
                     """)
                 continue
             }
+            guard await paneIdentityPermitsSend(server: server, terminal: terminal) else { continue }
             if tmux.verifiesPaneCurrentCommand {
                 guard let command = try? await tmux.paneCurrentCommand(
                     server: server,
@@ -310,6 +319,83 @@ public actor DeskSessionManager: DeskSessionManaging {
             live.append(terminal)
         }
         return live
+    }
+
+    /// Ask a candidate's pane who it belongs to, before it can become the target
+    /// of a paste nobody asked for.
+    ///
+    /// The same read-only consultation `handleTerminalSend` and
+    /// `LimitResumeActuator` run, on the same rule, and the rule is the whole
+    /// point: **refusal requires POSITIVE disagreement, never absence.** A pane
+    /// that answers with no identity — spawned before TBD stamped one, or by
+    /// something outside TBD — is treated exactly as it was before this check
+    /// existed, so no pre-stamp desk regresses into a silent night. Only a pane
+    /// that names a *different* terminal is dropped.
+    ///
+    /// This rail needs it more than the send path does. Both consumers of the
+    /// candidate list paste on a timer with no user gesture behind them, and
+    /// what they paste is a judge prompt: a stranger agent on a recycled pane id
+    /// would not merely receive a stray keystroke, it would read and act on
+    /// instructions addressed to another session, with permissions bypassed.
+    ///
+    /// Excluding rather than throwing is what makes the outcome safe by
+    /// default. A dropped candidate is simply not live, so the callers'
+    /// existing "no uniquely owned live terminal … skipping" path handles it,
+    /// and `leasedJudgeTerminal` gets *more* correct: a stranger can no longer
+    /// masquerade as the lease owner, nor pad the candidate count into a
+    /// spurious fail-closed contention report.
+    ///
+    /// - Returns: `true` when this pane may be sent to.
+    private func paneIdentityPermitsSend(server: String, terminal: Terminal) async -> Bool {
+        let target: PaneSendTarget
+        do {
+            target = try await tmux.paneSendTarget(server: server, paneID: terminal.tmuxPaneID)
+        } catch {
+            // The consultation could not be RUN at all (a wedged tmux tripping
+            // the subprocess timeout) — no answer about the pane either way.
+            // Dropped, matching how the `paneCurrentCommand` check below already
+            // treats the same wedged server: `try?` there turns a failed query
+            // into a skipped candidate. Pasting a judge prompt into a pane we
+            // could not look at is exactly what this check exists to stop, and
+            // the cost of being wrong is only a skipped tick.
+            logger.notice("""
+                Skipping Watch Desk terminal \(terminal.id, privacy: .public): could not verify \
+                pane \(terminal.tmuxPaneID, privacy: .public) belongs to it: \
+                \(String(describing: error), privacy: .public)
+                """)
+            return false
+        }
+
+        switch target {
+        case .missing:
+            logger.notice("""
+                Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
+                pane \(terminal.tmuxPaneID, privacy: .public) no longer exists
+                """)
+            return false
+        case .dead:
+            logger.notice("""
+                Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
+                pane \(terminal.tmuxPaneID, privacy: .public) is dead
+                """)
+            return false
+        case .live(let paneTerminalID):
+            guard let paneTerminalID else { return true }
+            guard paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString) != .orderedSame
+            else { return true }
+            // Logged distinctly and loudly: to every caller this looks like an
+            // ordinary absence, and "no live terminal" is a sentence this rail
+            // prints for half a dozen benign reasons. A pane that has changed
+            // hands is not benign — it is the row's coordinate gone stale, and
+            // it stays stale until something respawns the window.
+            logger.warning("""
+                Skipping Watch Desk terminal \(terminal.id, privacy: .public): pane \
+                \(terminal.tmuxPaneID, privacy: .public) now belongs to terminal \
+                \(paneTerminalID, privacy: .public) — nothing will be pasted into it \
+                (tmux reuses pane ids, so this coordinate is stale)
+                """)
+            return false
+        }
     }
 
     private func liveAgentTerminal(

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1818,6 +1818,17 @@ extension RPCRouter {
     /// then C-c C-c, another settle, then a SIGTERM to the pane pid as a
     /// backstop. Every step is best-effort — failures are logged and ignored,
     /// since the subsequent `respawn-window -k` guarantees termination.
+    ///
+    /// **Acts on an unverified coordinate (issue #384).** `paneID` comes from
+    /// the terminal row, and tmux reuses pane ids, so a stale row aims this at
+    /// a live stranger — and unlike `terminal.send`, which now consults
+    /// `paneSendTarget` before typing and refuses on disagreement, what lands
+    /// here is a SIGTERM and then a forced respawn of that window. The
+    /// consultation is not the missing piece: what a *refusal* should do to a
+    /// user's account switch or hibernate is a product decision (fail it, mark
+    /// the row, or fall back to a coordinate-free path), and belongs in a spec
+    /// rather than being bolted on here. Same note on
+    /// `HibernationCoordinator`'s copy of this helper.
     private func gracefullyInterruptPane(server: String, paneID: String) async {
         // Escape: ask Claude to stop generating.
         try? await tmux.sendKey(server: server, paneID: paneID, key: "Escape")

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1054,8 +1054,19 @@ extension RPCRouter {
             // the env. Without this set, the pane would inherit whatever TBD_WORKTREE_ID
             // got baked into the tmux server's global env, leaking another worktree's
             // identity into this one.
+            //
+            // TBD_TERMINAL_ID is set for the same reason, plus one more: it is
+            // what `createWindow` stamps onto the new pane as
+            // `@tbd_terminal_id`, and an unstamped pane is one `terminal.send`
+            // can never verify (absence is not disagreement, so it proceeds
+            // unchecked). Omitting it here would leave this branch — the only
+            // spawn path that ever did — minting fresh panes that opt out of
+            // the stale-coordinate check for the rest of their life.
             let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
-            let env: [String: String] = ["TBD_WORKTREE_ID": worktree.id.uuidString]
+            let env: [String: String] = [
+                "TBD_WORKTREE_ID": worktree.id.uuidString,
+                "TBD_TERMINAL_ID": terminal.id.uuidString,
+            ]
             let updatedTerminal = try await actuating(actuationID) {
                 let window = try await tmux.createWindow(
                     server: worktree.tmuxServer,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1842,7 +1842,18 @@ extension RPCRouter {
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalSendParams.self, from: paramsData)
+        // Queue behind any send already mid-flight to this same terminal; sends
+        // to other terminals are unaffected. The whole handler runs inside the
+        // lane so the target check and the typing it authorizes cannot be
+        // separated by another caller's paste.
+        return try await terminalSendSerializer.run(terminalID: params.terminalID) {
+            try await self.performTerminalSend(params, actor: actor)
+        }
+    }
 
+    private func performTerminalSend(
+        _ params: TerminalSendParams, actor: ActuationActor?
+    ) async throws -> RPCResponse {
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
             return RPCResponse(error: "Terminal not found: \(params.terminalID)")
         }
@@ -1859,6 +1870,65 @@ extension RPCRouter {
             .terminalSend, actor: actor,
             target: .local(worktree: terminal.worktreeID, terminal: terminal.id),
             message: params.text, submit: params.submit == true)
+
+        // Ask the pane about itself before typing into it. tmux's own exit
+        // status cannot carry this: `send-keys` into a `remain-on-exit` dead
+        // pane exits 0, and keys sent to a reused pane id land in a live
+        // stranger's composer with no error anywhere (issue #384). Both answers
+        // arrive from ONE read-only `list-panes`, and both are read BEFORE any
+        // byte is written — so a decline here is a refusal, never a transport
+        // failure: the daemon declined without touching the transport.
+        let target: PaneSendTarget
+        do {
+            target = try await tmux.paneSendTarget(
+                server: worktree.tmuxServer, paneID: terminal.tmuxPaneID)
+        } catch {
+            // The consultation itself could not be run (a wedged tmux tripping
+            // the subprocess timeout). That is a tmux command failing, not an
+            // answer about the pane, and it is classified as such.
+            await finishActuation(actuationID, .transportFailed, error: "\(error)")
+            throw error
+        }
+
+        switch target {
+        case .missing:
+            let message = """
+                tmux pane \(terminal.tmuxPaneID) for terminal \(terminal.id.uuidString) \
+                no longer exists on server \(worktree.tmuxServer) — nothing was sent
+                """
+            await finishActuation(actuationID, .refused(.notFound), error: message)
+            return RPCResponse(error: message)
+        case .dead:
+            let message = """
+                tmux pane \(terminal.tmuxPaneID) for terminal \(terminal.id.uuidString) is \
+                dead (its process has exited) — nothing was sent; recreate the terminal's \
+                window first
+                """
+            await finishActuation(actuationID, .refused(.notEligible), error: message)
+            return RPCResponse(error: message)
+        case .live(let paneTerminalID):
+            guard let paneTerminalID else {
+                // Absence is not disagreement. A pane spawned before TBD stamped
+                // identities, or by something outside TBD, answers with nothing —
+                // and refusing on nothing would turn this fix into a regression
+                // for every such pane. Only a POSITIVE disagreement refuses.
+                logger.debug("""
+                    terminal.send: pane \(terminal.tmuxPaneID, privacy: .public) claims no \
+                    terminal identity; proceeding without verifying it is terminal \
+                    \(terminal.id.uuidString, privacy: .public)
+                    """)
+                break
+            }
+            if paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString) != .orderedSame {
+                let message = """
+                    tmux pane \(terminal.tmuxPaneID) now belongs to terminal \
+                    \(paneTerminalID), not the requested terminal \(terminal.id.uuidString) \
+                    — nothing was sent (tmux reuses pane ids, so this coordinate is stale)
+                    """
+                await finishActuation(actuationID, .refused(.targetMismatch), error: message)
+                return RPCResponse(error: message)
+            }
+        }
 
         // Deliver the body as an EXPLICIT bracketed paste (load-buffer +
         // paste-buffer -d -p) rather than raw `send-keys -l`. For payloads

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -109,6 +109,10 @@ public final class RPCRouter: Sendable {
     let upstreamBranchCache = UpstreamBranchCache()
     /// Coalesces fetch operations per repo using a TTL cache + singleflight.
     let fetchCache = FetchCache()
+    /// Queues concurrent `terminal.send` RPCs per terminal so two payloads
+    /// never interleave in one composer. Different terminals still send in
+    /// parallel — see `TerminalSendSerializer`.
+    let terminalSendSerializer = TerminalSendSerializer()
     /// Opt-in tmux control-mode wiring. `nil` when the daemon did not provide
     /// one (tests, older callers); when present, terminal handlers open a gated
     /// logging-only `tmux -CC` connection after each `ensureServer()`.

--- a/Sources/TBDDaemon/Server/TerminalSendSerializer.swift
+++ b/Sources/TBDDaemon/Server/TerminalSendSerializer.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Serializes `terminal.send` per terminal, so two payloads can never interleave
+/// in one composer.
+///
+/// A send is not one tmux command: it is a `load-buffer`, a `paste-buffer`, and
+/// often a separate `Enter`. Two of those sequences overlapping in one pane
+/// splices one caller's text into another's — a transport bug, since neither
+/// caller asked for the message that arrives. So a second send **queues behind**
+/// the first rather than being refused: the caller asked for delivery, and
+/// delivery a moment later is still delivery. (`RefusedReason.inFlight` names
+/// the opposite decision — an act declined because a twin is already running —
+/// and is deliberately not what happens here.)
+///
+/// Per terminal, not global: two different terminals are two different composers
+/// and must still send concurrently. Each terminal gets a chained `Task` lane
+/// that awaits its predecessor, the shape `RepoSerializer` already uses for
+/// per-repo git work; the difference is that this one hands the body's value and
+/// its errors back to the caller, because an RPC handler's response is the
+/// thing being serialized.
+///
+/// No timeout. Every step inside a send is already bounded by
+/// `TmuxManager.commandTimeout`, so a lane can be held for a bounded interval by
+/// a wedged tmux and no longer; a timeout here would only add a second, worse
+/// deadline that abandons a half-typed payload.
+actor TerminalSendSerializer {
+    private var lanes: [UUID: Task<Void, Never>] = [:]
+
+    /// Run `send` once every send already queued for `terminalID` has finished.
+    /// Returns what `send` returned and rethrows what it threw.
+    func run<T: Sendable>(
+        terminalID: UUID, _ send: @Sendable @escaping () async throws -> T
+    ) async throws -> T {
+        let predecessor = lanes[terminalID]
+        let task = Task<T, Error> { [predecessor] in
+            await predecessor?.value
+            return try await send()
+        }
+        // The lane's tail erases both the value and the failure: a send that
+        // threw still released the pane, so its successor must run, not inherit
+        // its error. Awaiting `.result` never rethrows and never cancels.
+        let tail = Task<Void, Never> { _ = await task.result }
+        lanes[terminalID] = tail
+        // Prune once this tail finishes, unless a later send has replaced it —
+        // otherwise `lanes` grows one entry per terminal ever sent to.
+        Task { [weak self] in
+            await tail.value
+            await self?.removeIfTail(terminalID: terminalID, task: tail)
+        }
+        return try await task.value
+    }
+
+    private func removeIfTail(terminalID: UUID, task: Task<Void, Never>) {
+        if lanes[terminalID] == task {
+            lanes[terminalID] = nil
+        }
+    }
+
+    /// Test-only inspection: number of terminals with a live lane.
+    var trackedTerminalCount: Int { lanes.count }
+}

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -3,6 +3,20 @@ import os
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "TmuxManager")
 
+/// What one read-only `list-panes` consultation says about a pane that a send
+/// is aimed at. Read before anything is typed; see `paneSendTargetQuery`.
+public enum PaneSendTarget: Sendable, Equatable {
+    /// tmux cannot find the pane — it, its window, or the whole server is gone.
+    case missing
+    /// The pane object exists (`remain-on-exit` kept it) but its process has
+    /// exited. `send-keys` into it still exits 0 and the keys go nowhere.
+    case dead
+    /// The pane is alive. `terminalID` is the TBD terminal UUID the pane itself
+    /// answered with, or `nil` when the pane carries no identity to compare —
+    /// a pane spawned before TBD stamped one, or by something outside TBD.
+    case live(terminalID: String?)
+}
+
 public struct TmuxManager: Sendable {
     /// Hard ceiling on any single tmux subprocess. tmux control operations
     /// (respawn-window, new-session, kill-window, capture-pane, …) normally
@@ -65,6 +79,12 @@ public struct TmuxManager: Sendable {
     /// paths' transport-failure branch — the one the actuation record
     /// classifies as `transport-failed` rather than `dispatched` — untestable.
     public let dryRunKillWindowError: (@Sendable (String, String) -> Error?)?
+    /// Optional test hook consulted by `paneSendTarget` in dryRun mode:
+    /// `(server, paneID)` → what the pane answers. Without it, dryRun reports
+    /// `.live(terminalID: nil)` — alive, carrying no identity — which is the
+    /// branch that proceeds, so a fixture that never spawned a real pane keeps
+    /// behaving exactly as it did before the send path started asking.
+    public let dryRunPaneSendTarget: (@Sendable (String, String) -> PaneSendTarget)?
     /// Optional test hook for real (non-dryRun) mode: override the result of
     /// `windowExists(server:windowID:)`. Allows tests to force a window as dead
     /// while still having a live process running in the pane (for testing the
@@ -96,7 +116,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) -> PaneSendTarget)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -108,6 +128,7 @@ public struct TmuxManager: Sendable {
         self.dryRunCreateWindowError = dryRunCreateWindowError
         self.dryRunRespawnWindowError = dryRunRespawnWindowError
         self.dryRunKillWindowError = dryRunKillWindowError
+        self.dryRunPaneSendTarget = dryRunPaneSendTarget
         self.realModeWindowExistsOverride = realModeWindowExistsOverride
         self.realModePaneCurrentCommandOverride = realModePaneCurrentCommandOverride
     }
@@ -356,6 +377,90 @@ public struct TmuxManager: Sendable {
         ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_current_command}"]
     }
 
+    /// The pane option TBD stamps with a terminal's UUID at spawn, so a later
+    /// send can ask the pane who it is. `@`-prefixed names are tmux's own
+    /// namespace for user options; the value is per-pane and freed with the
+    /// pane, which is what makes a *reused* pane id answer empty rather than
+    /// with its predecessor's identity.
+    public static let terminalIDPaneOption = "@tbd_terminal_id"
+
+    /// Stamp `terminalID` onto a pane so it can identify itself later.
+    ///
+    /// `target` may be a pane id or a window id — tmux resolves a window target
+    /// to that window's active pane, and every TBD window has exactly one pane.
+    public static func setPaneTerminalIDCommand(
+        server: String, target: String, terminalID: String
+    ) -> [String] {
+        ["-L", server, "set-option", "-p", "-t", target, terminalIDPaneOption, terminalID]
+    }
+
+    /// Separator between the three fields of `paneSendTargetQuery`.
+    ///
+    /// A tab: neither `0`/`1` nor a UUID can contain one, and the only field
+    /// that could — the start command — is last, so it takes the remainder of
+    /// the line rather than being split.
+    static let paneSendTargetSeparator: Character = "\t"
+
+    /// One read-only consultation answering everything a send needs to know
+    /// about its target: does the pane exist, is its process still alive, and
+    /// which TBD terminal does the pane itself say it belongs to.
+    ///
+    /// `list-panes` rather than `display-message`: it exits non-zero with
+    /// `can't find pane: %N` when the pane, its window, or the server is gone,
+    /// whereas `display-message -p` prints an empty line and exits 0 — which
+    /// would report a vanished pane as a healthy one. It is also the primitive
+    /// the sibling pane queries above already use.
+    public static func paneSendTargetQuery(server: String, paneID: String) -> [String] {
+        ["-L", server, "list-panes", "-t", paneID, "-F",
+         "#{pane_dead}\(paneSendTargetSeparator)"
+         + "#{\(terminalIDPaneOption)}\(paneSendTargetSeparator)"
+         + "#{pane_start_command}"]
+    }
+
+    /// Classify `paneSendTargetQuery`'s stdout. Pure, so the classification is
+    /// unit-testable without a tmux server.
+    static func parsePaneSendTarget(_ output: String) -> PaneSendTarget {
+        guard let line = output.split(separator: "\n").first else {
+            // rc 0 with nothing on stdout: no pane answered.
+            return .missing
+        }
+        let fields = line.split(
+            separator: paneSendTargetSeparator, maxSplits: 2, omittingEmptySubsequences: false)
+        guard fields.count == 3 else { return .missing }
+        if fields[0].trimmingCharacters(in: .whitespaces) == "1" { return .dead }
+        return .live(terminalID: resolvePaneTerminalID(
+            paneOption: String(fields[1]), startCommand: String(fields[2])))
+    }
+
+    /// Which TBD terminal a pane says it is, or nil when the pane carries no
+    /// answer at all.
+    ///
+    /// Two sources, in order. The `@tbd_terminal_id` pane option is stamped by
+    /// `createWindow`/`respawnWindow`. The fallback reads the same id back out
+    /// of `#{pane_start_command}`, because TBD plants `TBD_TERMINAL_ID` through
+    /// the `env` map and `newWindowCommand` inlines that map as an
+    /// `export KEY='value'; ` prefix on the command string — so every pane
+    /// spawned before the option existed still carries its own id. macOS forbids
+    /// reading another process's environment (SIP), so the start command, not
+    /// `ps eww`, is where the planted value remains legible.
+    static func resolvePaneTerminalID(paneOption: String, startCommand: String) -> String? {
+        let stamped = paneOption.trimmingCharacters(in: .whitespaces)
+        if !stamped.isEmpty { return stamped }
+
+        let marker = "TBD_TERMINAL_ID="
+        guard let markerRange = startCommand.range(of: marker) else { return nil }
+        let rest = startCommand[markerRange.upperBound...]
+        let value: Substring
+        if rest.first == "'" {
+            let afterQuote = rest.dropFirst()
+            guard let close = afterQuote.firstIndex(of: "'") else { return nil }
+            value = afterQuote[..<close]
+        } else {
+            value = rest.prefix { !$0.isWhitespace && $0 != ";" && $0 != "\"" }
+        }
+        return value.isEmpty ? nil : String(value)
+    }
+
     public static func panePIDQuery(server: String, paneID: String) -> [String] {
         ["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_pid}"]
     }
@@ -469,6 +574,11 @@ public struct TmuxManager: Sendable {
             result = (windowID: String(parts[0]), paneID: String(parts[1]))
         }
 
+        // Label the pane with the terminal it was spawned for, so a later send
+        // can ask the pane who it is instead of trusting a DB coordinate.
+        await stampTerminalID(
+            server: server, target: result.paneID, env: env, sensitiveEnv: sensitiveEnv)
+
         // tmux's `new-window` does NOT accept -x/-y, and a freshly-created
         // window inherits its size from the session's attached client. The TBD
         // `main` session has no attached clients (we only ever attach to
@@ -509,9 +619,17 @@ public struct TmuxManager: Sendable {
         if dryRun {
             dryRunRecorder?(args)
             if let error = dryRunRespawnWindowError?(windowID) { throw error }
+            await stampTerminalID(
+                server: server, target: windowID, env: env, sensitiveEnv: sensitiveEnv)
             return
         }
         try await runTmux(args)
+        // Re-stamp: the pane object survives `respawn-window -k` (and so does an
+        // earlier stamp), but a respawn is also how a window acquires a program
+        // it did not spawn with, so the label is refreshed from the env that
+        // actually launched it. A window target resolves to its single pane.
+        await stampTerminalID(
+            server: server, target: windowID, env: env, sensitiveEnv: sensitiveEnv)
         if let cols, let rows, cols >= Self.minCols, rows >= Self.minRows {
             do {
                 try await resizeWindow(server: server, windowID: windowID, cols: cols, rows: rows)
@@ -679,6 +797,63 @@ public struct TmuxManager: Sendable {
         }
         let args = Self.paneCurrentCommandQuery(server: server, paneID: paneID)
         return try await runTmux(args).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Ask a pane, before anything is typed into it, whether it exists, whether
+    /// its process is alive, and which TBD terminal it belongs to.
+    ///
+    /// Read-only — a query, not an actuation. Throws only when the query itself
+    /// could not be *run* (a wedged server tripping the subprocess timeout); a
+    /// tmux command failure means tmux answered "can't find pane", which is an
+    /// answer about the pane, not a failure of the consultation.
+    public func paneSendTarget(server: String, paneID: String) async throws -> PaneSendTarget {
+        if dryRun { return dryRunPaneSendTarget?(server, paneID) ?? .live(terminalID: nil) }
+        let args = Self.paneSendTargetQuery(server: server, paneID: paneID)
+        do {
+            return Self.parsePaneSendTarget(try await runTmux(args))
+        } catch TmuxError.commandFailed {
+            return .missing
+        }
+    }
+
+    /// Stamp `@tbd_terminal_id` onto a freshly created or respawned pane, when
+    /// the spawn's environment says which terminal it is.
+    ///
+    /// Called centrally from `createWindow` and `respawnWindow` so all ~12 spawn
+    /// call sites are covered without touching any of them. Best-effort: a
+    /// failed stamp is logged and swallowed, because `#{pane_start_command}`
+    /// carries the same id as a fallback (see `resolvePaneTerminalID`) and a
+    /// window that spawned fine must not be reported as failed over a label.
+    ///
+    /// Deliberately NOT backfilled onto existing panes from the DB at startup.
+    /// The DB's pane coordinate is exactly what goes stale when tmux reuses a
+    /// pane id, so backfilling would stamp the terminal's identity onto whatever
+    /// pane now holds that id — writing the wrong answer into the very check
+    /// that exists to catch it. Unstamped panes fall back to their start
+    /// command, and panes with neither are treated as unresolvable, never as
+    /// disagreeing.
+    private func stampTerminalID(
+        server: String, target: String, env: [String: String], sensitiveEnv: [String: String]
+    ) async {
+        guard let terminalID = env["TBD_TERMINAL_ID"] ?? sensitiveEnv["TBD_TERMINAL_ID"] else {
+            return
+        }
+        let args = Self.setPaneTerminalIDCommand(
+            server: server, target: target, terminalID: terminalID)
+        if dryRun {
+            dryRunRecorder?(args)
+            return
+        }
+        do {
+            try await runTmux(args)
+        } catch {
+            logger.warning("""
+                stamping \(Self.terminalIDPaneOption, privacy: .public) on \
+                \(target, privacy: .public) (server \(server, privacy: .public)) failed: \
+                \(String(describing: error), privacy: .public) — sends fall back to \
+                #{pane_start_command} for this pane's identity
+                """)
+        }
     }
 
     public func panePID(server: String, paneID: String) async throws -> String {

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -84,7 +84,12 @@ public struct TmuxManager: Sendable {
     /// `.live(terminalID: nil)` — alive, carrying no identity — which is the
     /// branch that proceeds, so a fixture that never spawned a real pane keeps
     /// behaving exactly as it did before the send path started asking.
-    public let dryRunPaneSendTarget: (@Sendable (String, String) -> PaneSendTarget)?
+    ///
+    /// Throwing, because "the consultation could not be run at all" is one of
+    /// the answers: it is the wedged-tmux path the send classifies as a
+    /// transport failure rather than a refusal, and a non-throwing hook would
+    /// leave that branch with no way to be exercised.
+    public let dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)?
     /// Optional test hook for real (non-dryRun) mode: override the result of
     /// `windowExists(server:windowID:)`. Allows tests to force a window as dead
     /// while still having a live process running in the pane (for testing the
@@ -116,7 +121,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) -> PaneSendTarget)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -387,18 +392,21 @@ public struct TmuxManager: Sendable {
     /// Stamp `terminalID` onto a pane so it can identify itself later.
     ///
     /// `target` may be a pane id or a window id — tmux resolves a window target
-    /// to that window's active pane, and every TBD window has exactly one pane.
+    /// to that window's active pane. The window form is only used right after a
+    /// `respawn-window -k`, which collapses the window to its original single
+    /// pane, so "active pane" is unambiguously the terminal's own pane even if
+    /// the user had split it by hand a moment earlier.
     public static func setPaneTerminalIDCommand(
         server: String, target: String, terminalID: String
     ) -> [String] {
         ["-L", server, "set-option", "-p", "-t", target, terminalIDPaneOption, terminalID]
     }
 
-    /// Separator between the three fields of `paneSendTargetQuery`.
+    /// Separator between the four fields of `paneSendTargetQuery`.
     ///
-    /// A tab: neither `0`/`1` nor a UUID can contain one, and the only field
-    /// that could — the start command — is last, so it takes the remainder of
-    /// the line rather than being split.
+    /// A tab: neither a pane id, nor `0`/`1`, nor a UUID can contain one, and
+    /// the only field that could — the start command — is last, so it takes the
+    /// remainder of the line rather than being split.
     static let paneSendTargetSeparator: Character = "\t"
 
     /// One read-only consultation answering everything a send needs to know
@@ -410,26 +418,42 @@ public struct TmuxManager: Sendable {
     /// whereas `display-message -p` prints an empty line and exits 0 — which
     /// would report a vanished pane as a healthy one. It is also the primitive
     /// the sibling pane queries above already use.
+    ///
+    /// `#{pane_id}` leads the format because `list-panes -t %N` does NOT list
+    /// only `%N`: it lists every pane in `%N`'s **window**, `%N` merely picking
+    /// the window. A TBD window normally holds one pane, but a user can split
+    /// one by hand at any time, and then the first line answers for a pane the
+    /// send never named — a stranger's `pane_dead` and a stranger's identity,
+    /// which is precisely a false refusal. So the line is selected by pane id
+    /// rather than by position; see `parsePaneSendTarget`.
     public static func paneSendTargetQuery(server: String, paneID: String) -> [String] {
         ["-L", server, "list-panes", "-t", paneID, "-F",
-         "#{pane_dead}\(paneSendTargetSeparator)"
+         "#{pane_id}\(paneSendTargetSeparator)"
+         + "#{pane_dead}\(paneSendTargetSeparator)"
          + "#{\(terminalIDPaneOption)}\(paneSendTargetSeparator)"
          + "#{pane_start_command}"]
     }
 
-    /// Classify `paneSendTargetQuery`'s stdout. Pure, so the classification is
-    /// unit-testable without a tmux server.
-    static func parsePaneSendTarget(_ output: String) -> PaneSendTarget {
-        guard let line = output.split(separator: "\n").first else {
-            // rc 0 with nothing on stdout: no pane answered.
-            return .missing
+    /// Classify `paneSendTargetQuery`'s stdout for the pane the send named.
+    /// Pure, so the classification is unit-testable without a tmux server.
+    ///
+    /// Only the line whose `#{pane_id}` is `paneID` counts — the query returns
+    /// one line per pane in the target's window. A run with no such line means
+    /// tmux answered about a window that no longer holds this pane, which is
+    /// the same fact as `can't find pane`: `.missing`.
+    static func parsePaneSendTarget(_ output: String, paneID: String) -> PaneSendTarget {
+        for line in output.split(separator: "\n") {
+            let fields = line.split(
+                separator: paneSendTargetSeparator, maxSplits: 3, omittingEmptySubsequences: false)
+            guard fields.count == 4 else { continue }
+            guard fields[0].trimmingCharacters(in: .whitespaces) == paneID else { continue }
+            if fields[1].trimmingCharacters(in: .whitespaces) == "1" { return .dead }
+            return .live(terminalID: resolvePaneTerminalID(
+                paneOption: String(fields[2]), startCommand: String(fields[3])))
         }
-        let fields = line.split(
-            separator: paneSendTargetSeparator, maxSplits: 2, omittingEmptySubsequences: false)
-        guard fields.count == 3 else { return .missing }
-        if fields[0].trimmingCharacters(in: .whitespaces) == "1" { return .dead }
-        return .live(terminalID: resolvePaneTerminalID(
-            paneOption: String(fields[1]), startCommand: String(fields[2])))
+        // rc 0 but no line for this pane (including no output at all): nothing
+        // answered for the coordinate the send named.
+        return .missing
     }
 
     /// Which TBD terminal a pane says it is, or nil when the pane carries no
@@ -803,14 +827,19 @@ public struct TmuxManager: Sendable {
     /// its process is alive, and which TBD terminal it belongs to.
     ///
     /// Read-only — a query, not an actuation. Throws only when the query itself
-    /// could not be *run* (a wedged server tripping the subprocess timeout); a
-    /// tmux command failure means tmux answered "can't find pane", which is an
-    /// answer about the pane, not a failure of the consultation.
+    /// could not be *run*: a wedged server tripping the subprocess timeout
+    /// (`TmuxError.timedOut`) or a tmux that would not spawn at all, neither of
+    /// which this catch matches. A non-zero *exit* is read as an answer instead,
+    /// because the only way this fixed argv can exit non-zero is tmux failing to
+    /// resolve the target — `can't find pane`, or no server on that socket, both
+    /// of which mean the same thing for a send. (`paneSendTargetQuery`'s exact
+    /// argv is pinned by a unit test, so it cannot drift into a usage error that
+    /// would arrive here wearing the same clothes.)
     public func paneSendTarget(server: String, paneID: String) async throws -> PaneSendTarget {
-        if dryRun { return dryRunPaneSendTarget?(server, paneID) ?? .live(terminalID: nil) }
+        if dryRun { return try dryRunPaneSendTarget?(server, paneID) ?? .live(terminalID: nil) }
         let args = Self.paneSendTargetQuery(server: server, paneID: paneID)
         do {
-            return Self.parsePaneSendTarget(try await runTmux(args))
+            return Self.parsePaneSendTarget(try await runTmux(args), paneID: paneID)
         } catch TmuxError.commandFailed {
             return .missing
         }
@@ -819,11 +848,14 @@ public struct TmuxManager: Sendable {
     /// Stamp `@tbd_terminal_id` onto a freshly created or respawned pane, when
     /// the spawn's environment says which terminal it is.
     ///
-    /// Called centrally from `createWindow` and `respawnWindow` so all ~12 spawn
-    /// call sites are covered without touching any of them. Best-effort: a
-    /// failed stamp is logged and swallowed, because `#{pane_start_command}`
-    /// carries the same id as a fallback (see `resolvePaneTerminalID`) and a
-    /// window that spawned fine must not be reported as failed over a label.
+    /// Called centrally from `createWindow` and `respawnWindow`, so every spawn
+    /// call site is covered by the one rule "whatever you plant as
+    /// `TBD_TERMINAL_ID` is what the pane will answer with" — a call site opts
+    /// out only by not planting the variable at all, which is a hole in the
+    /// send check rather than a local choice. Best-effort: a failed stamp is
+    /// logged and swallowed, because `#{pane_start_command}` carries the same
+    /// id as a fallback (see `resolvePaneTerminalID`) and a window that spawned
+    /// fine must not be reported as failed over a label.
     ///
     /// Deliberately NOT backfilled onto existing panes from the DB at startup.
     /// The DB's pane coordinate is exactly what goes stale when tmux reuses a

--- a/Tests/TBDDaemonLiveTests/TerminalSendTargetCheckLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/TerminalSendTargetCheckLiveTests.swift
@@ -1,0 +1,287 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 3 — a real tmux server, real panes, and the real `terminal.send`
+/// handler.
+///
+/// The dry-run suite proves the classification; this proves the facts the
+/// classification rests on, against the tmux actually installed here:
+///
+///  - `send-keys` into a `remain-on-exit` dead pane exits **0**, so tmux's own
+///    status can never be the signal — the send must consult the pane. This is
+///    asserted directly, so the day tmux changes that behavior the test says so.
+///  - `list-panes -t %missing` exits non-zero, which is how a vanished
+///    coordinate becomes an answer rather than a hang.
+///  - `createWindow` stamps `@tbd_terminal_id`, and `respawn-window -k` leaves a
+///    `#{pane_start_command}` that still carries the planted `TBD_TERMINAL_ID` —
+///    the fallback the unstamped panes of today depend on.
+@Suite("terminal.send target check (live tmux)", .serialized)
+struct TerminalSendTargetCheckLiveTests {
+
+    // MARK: - tmux helpers
+
+    @discardableResult
+    private func tmux(_ args: [String]) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tmux"] + args
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        } catch {
+            return -1
+        }
+    }
+
+    private func tmuxCapture(_ args: [String]) -> String? {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tmux"] + args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return nil }
+            return String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Bounded wait for a pane to report `pane_dead=1`.
+    private func awaitPaneDead(server: String, paneID: String) async throws {
+        let deadline = ContinuousClock.now + .seconds(15)
+        while ContinuousClock.now < deadline {
+            if tmuxCapture(["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_dead}"]) == "1" {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        struct NeverDied: Error, CustomStringConvertible {
+            let description: String
+        }
+        throw NeverDied(description: """
+            pane \(paneID) never reached pane_dead=1 within 15s — observed \
+            \(tmuxCapture(["-L", server, "list-panes", "-t", paneID, "-F", "#{pane_dead}"]) ?? "no answer")
+            """)
+    }
+
+    // MARK: - Router fixture
+
+    private struct Fixture {
+        let router: RPCRouter
+        let db: TBDDatabase
+        let logPath: String
+        let worktree: Worktree
+    }
+
+    private func makeFixture(server: String) async throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-send-live-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let logPath = directory.appendingPathComponent("actuations.jsonl").path
+
+        let db = try TBDDatabase(inMemory: true)
+        let tmux = TmuxManager()
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: ActuationLog(path: logPath))
+        let repo = try await db.repos.create(
+            path: directory.appendingPathComponent("repo").path,
+            displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: directory.path, tmuxServer: server)
+        return Fixture(router: router, db: db, logPath: logPath, worktree: worktree)
+    }
+
+    private func send(_ fixture: Fixture, terminalID: UUID) async throws -> RPCResponse {
+        await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: terminalID, text: "hello", submit: true)))
+    }
+
+    private func lastOutcome(at path: String) throws -> [String: Any] {
+        let contents = try String(contentsOfFile: path, encoding: .utf8)
+        let line = try #require(contents.split(separator: "\n").last)
+        return try #require(
+            try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+    }
+
+    // MARK: - Tests
+
+    @Test("a dead remain-on-exit pane errors, though raw send-keys into it exits 0")
+    func deadPaneErrors() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-dead-\(UUID().uuidString.prefix(8))"
+        defer { tmux(["-L", server, "kill-server"]) }
+
+        // rc-free bootstrap: the pane command IS the whole session.
+        #expect(tmux(["-L", server, "new-session", "-d", "-s", "main",
+                      "-x", "80", "-y", "24", "/bin/sh", "-c", "sleep 300"]) == 0)
+        #expect(tmux(["-L", server, "set-option", "-g", "remain-on-exit", "on"]) == 0)
+        let created = try #require(
+            tmuxCapture(["-L", server, "new-window", "-t", "main", "-PF", "#{pane_id}",
+                         "/bin/sh", "-c", "exit 0"]),
+            "could not create the short-lived window")
+        try await awaitPaneDead(server: server, paneID: created)
+
+        // The lie this whole slice exists to stop believing.
+        #expect(tmux(["-L", server, "send-keys", "-t", created, "typed", "Enter"]) == 0)
+
+        let fixture = try await makeFixture(server: server)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id, tmuxWindowID: "@1", tmuxPaneID: created)
+
+        let response = try await send(fixture, terminalID: terminal.id)
+        #expect(!response.success)
+        #expect(response.error?.contains("dead") == true)
+        let outcome = try lastOutcome(at: fixture.logPath)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-eligible")
+    }
+
+    @Test("a pane coordinate tmux cannot resolve is refused as not-found")
+    func missingPaneRefused() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-gone-\(UUID().uuidString.prefix(8))"
+        defer { tmux(["-L", server, "kill-server"]) }
+        #expect(tmux(["-L", server, "new-session", "-d", "-s", "main",
+                      "-x", "80", "-y", "24", "/bin/sh", "-c", "sleep 300"]) == 0)
+
+        // The property the classification rests on: list-panes FAILS here,
+        // where `display-message -p` would have printed an empty line and
+        // exited 0.
+        #expect(tmux(["-L", server, "list-panes", "-t", "%999", "-F", "#{pane_dead}"]) != 0)
+
+        let fixture = try await makeFixture(server: server)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id, tmuxWindowID: "@9", tmuxPaneID: "%999")
+
+        let response = try await send(fixture, terminalID: terminal.id)
+        #expect(!response.success)
+        let outcome = try lastOutcome(at: fixture.logPath)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-found")
+    }
+
+    @Test("a live pane belonging to another terminal is refused, naming both ids")
+    func mismatchedPaneRefused() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-mismatch-\(UUID().uuidString.prefix(8))"
+        defer { tmux(["-L", server, "kill-server"]) }
+        #expect(tmux(["-L", server, "new-session", "-d", "-s", "main",
+                      "-x", "80", "-y", "24", "/bin/sh", "-c", "sleep 300"]) == 0)
+
+        let stranger = UUID()
+        let created = try #require(
+            tmuxCapture(["-L", server, "new-window", "-t", "main", "-PF", "#{pane_id}",
+                         "/bin/sh", "-c", "sleep 300"]))
+        #expect(tmux(TmuxManager.setPaneTerminalIDCommand(
+            server: server, target: created, terminalID: stranger.uuidString)) == 0)
+
+        let fixture = try await makeFixture(server: server)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id, tmuxWindowID: "@1", tmuxPaneID: created)
+
+        let response = try await send(fixture, terminalID: terminal.id)
+        #expect(!response.success)
+        let error = try #require(response.error)
+        #expect(error.contains(stranger.uuidString))
+        #expect(error.contains(terminal.id.uuidString))
+        let outcome = try lastOutcome(at: fixture.logPath)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "target-mismatch")
+    }
+
+    @Test("a live pane carrying no identity still sends")
+    func unresolvablePaneSends() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-anon-\(UUID().uuidString.prefix(8))"
+        defer { tmux(["-L", server, "kill-server"]) }
+        #expect(tmux(["-L", server, "new-session", "-d", "-s", "main",
+                      "-x", "80", "-y", "24", "/bin/sh", "-c", "sleep 300"]) == 0)
+
+        // Spawned outside TBD: no pane option, no planted TBD_TERMINAL_ID.
+        let created = try #require(
+            tmuxCapture(["-L", server, "new-window", "-t", "main", "-PF", "#{pane_id}",
+                         "/bin/sh", "-c", "sleep 300"]))
+
+        let fixture = try await makeFixture(server: server)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: fixture.worktree.id, tmuxWindowID: "@1", tmuxPaneID: created)
+
+        let response = try await send(fixture, terminalID: terminal.id)
+        #expect(response.success)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
+    }
+
+    @Test("createWindow stamps the pane, and the stamped pane accepts its own sends")
+    func createWindowStampsAndSends() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-stamp-\(UUID().uuidString.prefix(8))"
+        defer { tmux(["-L", server, "kill-server"]) }
+
+        let manager = TmuxManager()
+        let cwd = FileManager.default.temporaryDirectory.path
+        try await manager.ensureServer(server: server, session: "main", cwd: cwd)
+        let terminalID = UUID()
+        let window = try await manager.createWindow(
+            server: server, session: "main", cwd: cwd, shellCommand: "sleep 300",
+            env: ["TBD_TERMINAL_ID": terminalID.uuidString])
+
+        #expect(tmuxCapture(["-L", server, "list-panes", "-t", window.paneID,
+                             "-F", "#{@tbd_terminal_id}"]) == terminalID.uuidString)
+
+        let target = try await manager.paneSendTarget(server: server, paneID: window.paneID)
+        #expect(target == .live(terminalID: terminalID.uuidString))
+    }
+
+    /// The fallback's coverage of the in-place profile swap depends on this:
+    /// `respawn-window -k` must leave a start command carrying the NEW env, or a
+    /// swapped pane would answer with a stale identity.
+    @Test("respawn-window leaves a start command carrying the planted terminal id")
+    func respawnRefreshesStartCommand() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-respawn-\(UUID().uuidString.prefix(8))"
+        defer { tmux(["-L", server, "kill-server"]) }
+
+        let manager = TmuxManager()
+        let cwd = FileManager.default.temporaryDirectory.path
+        try await manager.ensureServer(server: server, session: "main", cwd: cwd)
+        let window = try await manager.createWindow(
+            server: server, session: "main", cwd: cwd, shellCommand: "sleep 300")
+
+        // Nothing planted at spawn: the pane starts anonymous.
+        #expect(try await manager.paneSendTarget(server: server, paneID: window.paneID)
+            == .live(terminalID: nil))
+
+        let terminalID = UUID()
+        try await manager.respawnWindow(
+            server: server, windowID: window.windowID, cwd: cwd, shellCommand: "sleep 300",
+            env: ["TBD_TERMINAL_ID": terminalID.uuidString])
+
+        let startCommand = try #require(
+            tmuxCapture(["-L", server, "list-panes", "-t", window.paneID,
+                         "-F", "#{pane_start_command}"]))
+        #expect(startCommand.contains("TBD_TERMINAL_ID='\(terminalID.uuidString)'"))
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: startCommand)
+            == terminalID.uuidString)
+        // And the stamp is refreshed too, so both sources agree.
+        #expect(try await manager.paneSendTarget(server: server, paneID: window.paneID)
+            == .live(terminalID: terminalID.uuidString))
+    }
+}

--- a/Tests/TBDDaemonLiveTests/TerminalSendTargetCheckLiveTests.swift
+++ b/Tests/TBDDaemonLiveTests/TerminalSendTargetCheckLiveTests.swift
@@ -229,6 +229,50 @@ struct TerminalSendTargetCheckLiveTests {
         #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
     }
 
+    /// `list-panes -t %N` lists every pane in `%N`'s **window** — `%N` only
+    /// selects the window. So a user who splits a TBD window by hand makes the
+    /// consultation return two lines, and reading the first one would answer
+    /// with a stranger's identity and refuse a perfectly healthy send. This is
+    /// asserted against real tmux because the multi-line shape is tmux's
+    /// behavior, not TBD's, and a dry-run fixture cannot witness it.
+    @Test("a hand-split window does not make the send read the wrong pane")
+    func splitWindowDoesNotConfuseTheTarget() async throws {
+        guard await TmuxVersion.detect() != nil else { return }
+        let server = "tbd-test-send-split-\(UUID().uuidString.prefix(8))"
+        defer { tmux(["-L", server, "kill-server"]) }
+
+        let manager = TmuxManager()
+        let cwd = FileManager.default.temporaryDirectory.path
+        try await manager.ensureServer(server: server, session: "main", cwd: cwd)
+        let terminalID = UUID()
+        let window = try await manager.createWindow(
+            server: server, session: "main", cwd: cwd, shellCommand: "sleep 300",
+            env: ["TBD_TERMINAL_ID": terminalID.uuidString])
+
+        // The user splits the tab. The new pane is not TBD's and carries no id.
+        let sibling = try #require(
+            tmuxCapture(["-L", server, "split-window", "-t", window.windowID, "-d",
+                         "-P", "-F", "#{pane_id}", "/bin/sh", "-c", "sleep 300"]))
+        #expect(sibling != window.paneID)
+        // Both panes really are in the answer — otherwise this proves nothing.
+        let listed = try #require(
+            tmuxCapture(["-L", server, "list-panes", "-t", window.paneID, "-F", "#{pane_id}"]))
+        #expect(listed.split(separator: "\n").count == 2)
+
+        // TBD's pane still answers for itself, and the stranger answers for its.
+        #expect(try await manager.paneSendTarget(server: server, paneID: window.paneID)
+            == .live(terminalID: terminalID.uuidString))
+        #expect(try await manager.paneSendTarget(server: server, paneID: sibling)
+            == .live(terminalID: nil))
+
+        let fixture = try await makeFixture(server: server)
+        let terminal = try await fixture.db.terminals.create(
+            id: terminalID, worktreeID: fixture.worktree.id,
+            tmuxWindowID: window.windowID, tmuxPaneID: window.paneID)
+        #expect(try await send(fixture, terminalID: terminal.id).success)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
+    }
+
     @Test("createWindow stamps the pane, and the stamped pane accepts its own sends")
     func createWindowStampsAndSends() async throws {
         guard await TmuxVersion.detect() != nil else { return }

--- a/Tests/TBDDaemonTests/ActuationLogTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTests.swift
@@ -189,7 +189,7 @@ struct ActuationLogTests {
     @Test("the refusal vocabulary is closed, and every name is query-shaped")
     func refusedReasonVocabulary() {
         #expect(Set(RefusedReason.allCases.map(\.rawValue))
-            == ["noop", "not-found", "not-eligible", "in-flight"])
+            == ["noop", "not-found", "not-eligible", "in-flight", "target-mismatch"])
     }
 
     @Test("park and wake results classify onto the vocabulary, no-ops apart from declines")

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -70,6 +70,36 @@ private final class PaneCommands: @unchecked Sendable {
     }
 }
 
+/// What each pane answers when asked who it belongs to. Empty by default, so
+/// every pane reports `.live(terminalID: nil)` — alive, carrying no identity —
+/// which is the branch that proceeds, leaving fixtures that predate the
+/// consultation behaving exactly as they did.
+private final class PaneIdentities: @unchecked Sendable {
+    private let lock = NSLock()
+    private var answers: [String: PaneSendTarget] = [:]
+    private var unreachable: Set<String> = []
+
+    func set(_ target: PaneSendTarget, for paneID: String) {
+        lock.lock(); defer { lock.unlock() }
+        answers[paneID] = target
+    }
+
+    /// Make the consultation itself fail for a pane — a wedged tmux, not an
+    /// answer about the pane.
+    func markUnreachable(_ paneID: String) {
+        lock.lock(); defer { lock.unlock() }
+        unreachable.insert(paneID)
+    }
+
+    func answer(for paneID: String) throws -> PaneSendTarget {
+        lock.lock(); defer { lock.unlock() }
+        if unreachable.contains(paneID) {
+            throw TmuxError.timedOut(command: "list-panes", timeout: .seconds(15))
+        }
+        return answers[paneID] ?? .live(terminalID: nil)
+    }
+}
+
 private final class SpawnFailureSwitch: @unchecked Sendable {
     private let lock = NSLock()
     private var failing = false
@@ -850,7 +880,8 @@ extension TBDHomeSerialized {
         private func makeDeskFixture(tag: String) throws -> (
             db: TBDDatabase, manager: DeskSessionManager,
             recorder: DeskTmuxRecorder, dead: DeadWindows,
-            commands: PaneCommands, spawnFailures: SpawnFailureSwitch, home: URL,
+            commands: PaneCommands, identities: PaneIdentities,
+            spawnFailures: SpawnFailureSwitch, home: URL,
             priorTBDHome: String?
         ) {
             let home = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -862,6 +893,7 @@ extension TBDHomeSerialized {
             let recorder = DeskTmuxRecorder()
             let dead = DeadWindows()
             let commands = PaneCommands(defaultCommand: "1.2.3")
+            let identities = PaneIdentities()
             let spawnFailures = SpawnFailureSwitch()
             let manager = DeskSessionManager(
                 db: db,
@@ -878,12 +910,15 @@ extension TBDHomeSerialized {
                     dryRun: true,
                     dryRunRecorder: { recorder.record($0) },
                     dryRunWindowIsDead: { dead.isDead($0) },
-                    dryRunPaneCurrentCommand: { _, paneID in commands.command(for: paneID) }
+                    dryRunPaneCurrentCommand: { _, paneID in commands.command(for: paneID) },
+                    dryRunPaneSendTarget: { _, paneID in try identities.answer(for: paneID) }
                 ),
                 skillDir: home.appendingPathComponent("skills/nightwatch").path,
                 actuationLog: makeTestActuationLog()
             )
-            return (db, manager, recorder, dead, commands, spawnFailures, home, priorTBDHome)
+            return (
+                db, manager, recorder, dead, commands, identities, spawnFailures, home,
+                priorTBDHome)
         }
 
         /// The regression: `TerminalStore.list` orders createdAt ASC, so resolving the desk
@@ -1007,6 +1042,156 @@ extension TBDHomeSerialized {
             #expect(
                 notifications.contains(where: { $0.type == .taskComplete }),
                 "wrap-up should still fire its completion notification")
+        }
+
+        // MARK: - Pane ownership (#384 on the autonomous rails)
+
+        /// The hazard the window/command guards cannot see. A recycled pane id
+        /// resolves to a live window running a live Claude — both existing
+        /// checks pass — but the pane belongs to somebody else's session, and
+        /// what this rail pastes is a judge prompt an agent will read and act
+        /// on. Spawn recovery is switched off so "nothing was pasted" means the
+        /// stranger got nothing, not that a replacement absorbed the nudge.
+        @Test("a pane owned by another terminal is never nudged")
+        func testNudgeSkipsPaneOwnedByAnotherTerminal() async throws {
+            let f = try makeDeskFixture(tag: "nudge-stranger")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // Same pane id, different owner — tmux recycled it under the row.
+            f.identities.set(.live(terminalID: UUID().uuidString), for: claude.tmuxPaneID)
+            f.spawnFailures.setFailing(true)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            let targets = Array(f.recorder.pastedPanes.dropFirst(before))
+            #expect(targets.isEmpty, "a stranger's pane must receive nothing, got \(targets)")
+        }
+
+        /// The branch that matters most: absence is not disagreement. A pane
+        /// spawned before TBD stamped identities answers with none, and must be
+        /// treated exactly as it was before the consultation existed — refusing
+        /// on nothing would turn every pre-stamp desk into a silent night.
+        @Test("a pane that claims no identity is still nudged")
+        func testNudgeStillReachesPaneWithNoIdentity() async throws {
+            let f = try makeDeskFixture(tag: "nudge-unstamped")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            f.identities.set(.live(terminalID: nil), for: claude.tmuxPaneID)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            #expect(
+                Array(f.recorder.pastedPanes.dropFirst(before)) == [claude.tmuxPaneID],
+                "an unstamped pane must be nudged exactly as before")
+        }
+
+        @Test("a pane that names its own terminal is nudged")
+        func testNudgeReachesPaneThatNamesItsOwnTerminal() async throws {
+            let f = try makeDeskFixture(tag: "nudge-owned")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            f.identities.set(.live(terminalID: claude.id.uuidString), for: claude.tmuxPaneID)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            #expect(
+                Array(f.recorder.pastedPanes.dropFirst(before)) == [claude.tmuxPaneID],
+                "a pane that agrees it is this terminal must be nudged")
+        }
+
+        /// A consultation that cannot be RUN at all is not an answer about the
+        /// pane. The candidate is dropped, matching how the sibling
+        /// `paneCurrentCommand` check already treats a wedged server (`try?` →
+        /// skip). Skipping costs one tick; pasting into a pane nobody could
+        /// look at is the thing the check exists to stop.
+        @Test("a pane whose identity cannot be read is not nudged")
+        func testNudgeSkipsPaneWhoseIdentityCannotBeRead() async throws {
+            let f = try makeDeskFixture(tag: "nudge-wedged")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            f.identities.markUnreachable(claude.tmuxPaneID)
+            f.spawnFailures.setFailing(true)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            let targets = Array(f.recorder.pastedPanes.dropFirst(before))
+            #expect(targets.isEmpty, "an unverifiable pane must receive nothing, got \(targets)")
+        }
+
+        /// `postShiftWrapUp` reaches the same candidate list on the same timer,
+        /// so it inherits the same exclusion — and its completion notification
+        /// must not fire for a shift summary that was never posted.
+        @Test("a pane owned by another terminal gets no wrap-up prompt")
+        func testWrapUpSkipsPaneOwnedByAnotherTerminal() async throws {
+            let f = try makeDeskFixture(tag: "wrapup-stranger")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            f.identities.set(.live(terminalID: UUID().uuidString), for: claude.tmuxPaneID)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.postShiftWrapUp(worktreeID: desk.id)
+
+            let targets = Array(f.recorder.pastedPanes.dropFirst(before))
+            #expect(targets.isEmpty, "a stranger's pane must receive no wrap-up, got \(targets)")
+
+            let notifications = try await f.db.notifications.unread(worktreeID: desk.id)
+            #expect(
+                !notifications.contains(where: { $0.type == .taskComplete }),
+                "no wrap-up was posted, so nothing should announce that one was")
+        }
+
+        /// Dropping a stranger makes the lease logic *more* correct rather than
+        /// less. Two live-looking rows with no lease are ambiguous and fail
+        /// closed — but one of them is a recycled pane id, not a rival judge.
+        /// Excluding it leaves exactly one real candidate, so the desk takes a
+        /// lease and gets nudged instead of stalling on a phantom contention.
+        @Test("a stranger's pane is not a rival judge candidate")
+        func testStrangerPaneDoesNotCreateJudgeContention() async throws {
+            let f = try makeDeskFixture(tag: "judge-stranger")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // A newer row whose pane id has since been recycled to someone else.
+            _ = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@9", tmuxPaneID: "%9",
+                label: TerminalLabel.claudeCode)
+            f.identities.set(.live(terminalID: UUID().uuidString), for: "%9")
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: true)
+
+            #expect(
+                Array(f.recorder.pastedPanes.dropFirst(before)) == [claude.tmuxPaneID],
+                "the one real candidate must be nudged, and the stranger left alone")
+            let lease = try await f.db.watchDeskLeases.status(worktreeID: desk.id)
+            #expect(lease?.terminalID == claude.id, "the lease must name the real candidate")
         }
 
         @Test("agent command matching distinguishes Claude, Codex, and a fallen-back shell")

--- a/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
+++ b/Tests/TBDDaemonTests/LimitResumeActuatorTests.swift
@@ -33,6 +33,17 @@ final class FakeResumeTmux: ResumeSendingTmux, @unchecked Sendable {
         }
     }
     func panePID(server: String, paneID: String) async throws -> String { panePIDValue }
+    /// What the pane answers when the actuator asks who it is. Defaults to
+    /// "alive, carrying no identity" — the branch that proceeds — so every
+    /// pre-existing test behaves exactly as it did before the actuator started
+    /// consulting its target.
+    var paneTarget: PaneSendTarget = .live(terminalID: nil)
+    /// When set, the consultation itself fails to run (wedged tmux).
+    var paneTargetError: Error?
+    func paneSendTarget(server: String, paneID: String) async throws -> PaneSendTarget {
+        if let paneTargetError { throw paneTargetError }
+        return paneTarget
+    }
     func sendKeys(server: String, paneID: String, text: String) async throws {
         queue.sync { _sends.append("text:\(text)") }
     }
@@ -134,6 +145,69 @@ struct FakeInspector: PaneProcessInspecting {
         tmux.windowAlive = false
         let outcome = await makeActuator().actuate(row)
         #expect(outcome == .terminalGone)
+    }
+
+    // MARK: - Pane target consultation (eligibility step 1a)
+    //
+    // The auto-resume actuator is the component issue #384 caught typing into
+    // a stranger: `windowExists` proves a window id resolves, never that the
+    // pane still belongs to this terminal. Same rule as `terminal.send` —
+    // only a POSITIVE disagreement refuses.
+
+    @Test func paneOwnedByAnotherTerminalTypesNothing() async throws {
+        tmux.paneTarget = .live(terminalID: UUID().uuidString)
+        let outcome = await makeActuator().actuate(row)
+        guard case .failed(let message) = outcome else {
+            Issue.record("expected .failed, got \(outcome)")
+            return
+        }
+        #expect(message.contains(terminalID.uuidString))
+        #expect(message.contains("%1"))
+        #expect(tmux.sends.isEmpty)
+    }
+
+    @Test func paneWithNoIdentityStillGetsTheResume() async throws {
+        // The no-regression branch: absence is not disagreement.
+        tmux.paneTarget = .live(terminalID: nil)
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .sent)
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func paneIdentityMatchIsCaseInsensitiveAndSends() async throws {
+        tmux.paneTarget = .live(terminalID: terminalID.uuidString.lowercased())
+        try await db.terminals.setActivityState(id: terminalID, activityState: .working)
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .sent)
+        #expect(tmux.sends == ["key:Escape", "text:continue", "key:Enter"])
+    }
+
+    @Test func vanishedPaneIsTerminalGone() async throws {
+        tmux.paneTarget = .missing
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .terminalGone)
+        #expect(tmux.sends.isEmpty)
+    }
+
+    @Test func deadPaneIsTerminalGone() async throws {
+        // The case tmux reports as success: `send-keys` into a remain-on-exit
+        // pane exits 0, so only the consultation can catch it.
+        tmux.paneTarget = .dead
+        let outcome = await makeActuator().actuate(row)
+        #expect(outcome == .terminalGone)
+        #expect(tmux.sends.isEmpty)
+    }
+
+    @Test func unrunnableConsultationTypesNothing() async throws {
+        tmux.paneTargetError = FakeTmuxSendError()
+        let outcome = await makeActuator().actuate(row)
+        guard case .failed(let message) = outcome else {
+            Issue.record("expected .failed, got \(outcome)")
+            return
+        }
+        #expect(message.contains("could not verify the target pane"))
+        #expect(tmux.sends.isEmpty)
     }
 
     @Test func newerTranscriptRecordCancels() async throws {

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -14,13 +14,22 @@ struct PaneSendTargetQueryTests {
 
     // MARK: - Command builders
 
-    @Test("the target query asks one list-panes for all three facts")
+    @Test("the target query asks one list-panes for all four facts")
     func queryShape() {
         let args = TmuxManager.paneSendTargetQuery(server: "tbd-acme", paneID: "%7")
         #expect(args == [
             "-L", "tbd-acme", "list-panes", "-t", "%7", "-F",
-            "#{pane_dead}\t#{@tbd_terminal_id}\t#{pane_start_command}",
+            "#{pane_id}\t#{pane_dead}\t#{@tbd_terminal_id}\t#{pane_start_command}",
         ])
+    }
+
+    /// `list-panes -t %N` lists every pane in `%N`'s *window*, not just `%N`.
+    /// Without `#{pane_id}` in the format there is no way to tell which line
+    /// answered, so the query must keep asking for it.
+    @Test("the target query asks each line to name its own pane")
+    func queryCarriesPaneID() {
+        let args = TmuxManager.paneSendTargetQuery(server: "tbd-acme", paneID: "%7")
+        #expect(args.last?.hasPrefix("#{pane_id}\t") == true)
     }
 
     /// `display-message -p` prints an empty line and exits 0 for a pane that is
@@ -45,40 +54,76 @@ struct PaneSendTargetQueryTests {
 
     @Test("a live unstamped pane with no planted id resolves to no identity")
     func parseLiveUnknown() {
-        #expect(TmuxManager.parsePaneSendTarget("0\t\t/bin/zsh -ic \"sleep 300\"\n")
+        #expect(TmuxManager.parsePaneSendTarget("%7\t0\t\t/bin/zsh -ic \"sleep 300\"\n", paneID: "%7")
             == .live(terminalID: nil))
     }
 
     @Test("pane_dead=1 is dead regardless of what else the pane answers")
     func parseDead() {
-        #expect(TmuxManager.parsePaneSendTarget("1\tF1A2\t/bin/zsh -ic \"claude\"\n") == .dead)
+        #expect(TmuxManager.parsePaneSendTarget(
+            "%7\t1\tF1A2\t/bin/zsh -ic \"claude\"\n", paneID: "%7") == .dead)
     }
 
     @Test("the stamped pane option wins over the start command")
     func parseStampedWins() {
-        let line = "0\tSTAMPED\t/bin/zsh -ic \"export TBD_TERMINAL_ID='INLINED'; claude\"\n"
-        #expect(TmuxManager.parsePaneSendTarget(line) == .live(terminalID: "STAMPED"))
+        let line = "%7\t0\tSTAMPED\t/bin/zsh -ic \"export TBD_TERMINAL_ID='INLINED'; claude\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7") == .live(terminalID: "STAMPED"))
     }
 
     @Test("an unstamped pane still answers from its start command")
     func parseFallsBackToStartCommand() {
-        let line = "0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='INLINED'; claude\"\n"
-        #expect(TmuxManager.parsePaneSendTarget(line) == .live(terminalID: "INLINED"))
+        let line = "%7\t0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='INLINED'; claude\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7") == .live(terminalID: "INLINED"))
     }
 
     /// The start command is last precisely so its own tabs and separators stay
-    /// inside it — the split takes the remainder rather than a fourth field.
-    @Test("a tab inside the start command does not split it into a fourth field")
+    /// inside it — the split takes the remainder rather than a fifth field.
+    @Test("a tab inside the start command does not split it into a fifth field")
     func parseStartCommandWithTab() {
-        let line = "0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='ID9'; printf 'a\tb'\"\n"
-        #expect(TmuxManager.parsePaneSendTarget(line) == .live(terminalID: "ID9"))
+        let line = "%7\t0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='ID9'; printf 'a\tb'\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7") == .live(terminalID: "ID9"))
+    }
+
+    // MARK: - Selecting the pane the send actually named
+
+    /// `list-panes -t %N` answers for every pane in `%N`'s window. A user who
+    /// splits a TBD window by hand therefore gets two lines back, and the first
+    /// one is whichever pane tmux lists first — a stranger. Reading it would
+    /// refuse a perfectly healthy send.
+    @Test("a split window answers for the named pane, not the first one listed")
+    func parseSelectsNamedPaneInASplitWindow() {
+        let output = """
+            %1\t0\tSTRANGER\t/bin/zsh -ic "vim"
+            %2\t0\tMINE\t/bin/zsh -ic "claude"
+
+            """
+        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%2") == .live(terminalID: "MINE"))
+        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%1")
+            == .live(terminalID: "STRANGER"))
+    }
+
+    /// The same hazard for liveness: a dead sibling pane must not make a live
+    /// target look dead, nor a live sibling make a dead target look sendable.
+    @Test("a dead sibling pane does not decide the named pane's liveness")
+    func parseSelectsLivenessOfNamedPane() {
+        let output = "%1\t1\t\tsh\n%2\t0\tMINE\tclaude\n"
+        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%2") == .live(terminalID: "MINE"))
+        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%1") == .dead)
+    }
+
+    /// A prefix match is not a match: `%1` must not answer for `%12`.
+    @Test("pane ids are compared whole, not by prefix")
+    func parsePaneIDMatchIsExact() {
+        let output = "%12\t0\tMINE\tclaude\n"
+        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%1") == .missing)
+        #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%12") == .live(terminalID: "MINE"))
     }
 
     @Test("empty or malformed output names nothing")
     func parseEmpty() {
-        #expect(TmuxManager.parsePaneSendTarget("") == .missing)
-        #expect(TmuxManager.parsePaneSendTarget("\n") == .missing)
-        #expect(TmuxManager.parsePaneSendTarget("0\tonly-two-fields\n") == .missing)
+        #expect(TmuxManager.parsePaneSendTarget("", paneID: "%7") == .missing)
+        #expect(TmuxManager.parsePaneSendTarget("\n", paneID: "%7") == .missing)
+        #expect(TmuxManager.parsePaneSendTarget("%7\t0\tonly-three\n", paneID: "%7") == .missing)
     }
 
     // MARK: - Identity resolution

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -119,6 +119,18 @@ struct PaneSendTargetQueryTests {
         #expect(TmuxManager.parsePaneSendTarget(output, paneID: "%12") == .live(terminalID: "MINE"))
     }
 
+    /// A pane started without an explicit command — `tmux new-session -d` with
+    /// no argument — reports an empty `#{pane_start_command}`, so the last
+    /// field is genuinely empty rather than absent. It must still parse as four
+    /// fields, not fall through to `.missing`.
+    @Test("an empty trailing start command is still a complete answer")
+    func parseEmptyStartCommand() {
+        #expect(TmuxManager.parsePaneSendTarget("%0\t0\t\t\n", paneID: "%0")
+            == .live(terminalID: nil))
+        #expect(TmuxManager.parsePaneSendTarget("%0\t0\tMINE\t\n", paneID: "%0")
+            == .live(terminalID: "MINE"))
+    }
+
     @Test("empty or malformed output names nothing")
     func parseEmpty() {
         #expect(TmuxManager.parsePaneSendTarget("", paneID: "%7") == .missing)

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Tier 1 — the read-only target consultation's command shapes and its parsing,
+/// with no tmux server anywhere.
+///
+/// These are the queries `terminal.send` reads before it types. They are
+/// deliberately NOT actuations: nothing here touches a process, a pty, or a
+/// lifecycle, which is why none of them appears in the SwiftLint
+/// `actuation_primitive_allowlist` regex.
+@Suite("Pane send-target query")
+struct PaneSendTargetQueryTests {
+
+    // MARK: - Command builders
+
+    @Test("the target query asks one list-panes for all three facts")
+    func queryShape() {
+        let args = TmuxManager.paneSendTargetQuery(server: "tbd-acme", paneID: "%7")
+        #expect(args == [
+            "-L", "tbd-acme", "list-panes", "-t", "%7", "-F",
+            "#{pane_dead}\t#{@tbd_terminal_id}\t#{pane_start_command}",
+        ])
+    }
+
+    /// `display-message -p` prints an empty line and exits 0 for a pane that is
+    /// gone, so it cannot distinguish "vanished" from "healthy". `list-panes`
+    /// exits non-zero with `can't find pane`. The builder must stay on
+    /// `list-panes` for the missing-pane branch to exist at all.
+    @Test("the target query uses list-panes, not display-message")
+    func queryUsesListPanes() {
+        let args = TmuxManager.paneSendTargetQuery(server: "tbd-acme", paneID: "%7")
+        #expect(args.contains("list-panes"))
+        #expect(!args.contains("display-message"))
+    }
+
+    @Test("the stamp command sets the pane-scoped option on the given target")
+    func stampShape() {
+        let args = TmuxManager.setPaneTerminalIDCommand(
+            server: "tbd-acme", target: "%7", terminalID: "F1A2")
+        #expect(args == ["-L", "tbd-acme", "set-option", "-p", "-t", "%7", "@tbd_terminal_id", "F1A2"])
+    }
+
+    // MARK: - Parsing
+
+    @Test("a live unstamped pane with no planted id resolves to no identity")
+    func parseLiveUnknown() {
+        #expect(TmuxManager.parsePaneSendTarget("0\t\t/bin/zsh -ic \"sleep 300\"\n")
+            == .live(terminalID: nil))
+    }
+
+    @Test("pane_dead=1 is dead regardless of what else the pane answers")
+    func parseDead() {
+        #expect(TmuxManager.parsePaneSendTarget("1\tF1A2\t/bin/zsh -ic \"claude\"\n") == .dead)
+    }
+
+    @Test("the stamped pane option wins over the start command")
+    func parseStampedWins() {
+        let line = "0\tSTAMPED\t/bin/zsh -ic \"export TBD_TERMINAL_ID='INLINED'; claude\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line) == .live(terminalID: "STAMPED"))
+    }
+
+    @Test("an unstamped pane still answers from its start command")
+    func parseFallsBackToStartCommand() {
+        let line = "0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='INLINED'; claude\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line) == .live(terminalID: "INLINED"))
+    }
+
+    /// The start command is last precisely so its own tabs and separators stay
+    /// inside it — the split takes the remainder rather than a fourth field.
+    @Test("a tab inside the start command does not split it into a fourth field")
+    func parseStartCommandWithTab() {
+        let line = "0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='ID9'; printf 'a\tb'\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line) == .live(terminalID: "ID9"))
+    }
+
+    @Test("empty or malformed output names nothing")
+    func parseEmpty() {
+        #expect(TmuxManager.parsePaneSendTarget("") == .missing)
+        #expect(TmuxManager.parsePaneSendTarget("\n") == .missing)
+        #expect(TmuxManager.parsePaneSendTarget("0\tonly-two-fields\n") == .missing)
+    }
+
+    // MARK: - Identity resolution
+
+    @Test("the quoted export form TBD actually plants is read back exactly")
+    func resolveQuotedExport() {
+        // The literal shape `newWindowCommand` produces from the `env` map.
+        let command = "/bin/zsh -ic \"export TBD_TERMINAL_ID='9C1E-AB'; "
+            + "export TBD_WORKTREE_ID='11'; claude\""
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command) == "9C1E-AB")
+    }
+
+    @Test("an unquoted planted value stops at the first separator")
+    func resolveUnquoted() {
+        #expect(TmuxManager.resolvePaneTerminalID(
+            paneOption: "", startCommand: "env TBD_TERMINAL_ID=9C1E-AB claude") == "9C1E-AB")
+        #expect(TmuxManager.resolvePaneTerminalID(
+            paneOption: "", startCommand: "TBD_TERMINAL_ID=9C1E-AB; claude") == "9C1E-AB")
+    }
+
+    @Test("a pane carrying neither source resolves to nil, never to a guess")
+    func resolveNothing() {
+        #expect(TmuxManager.resolvePaneTerminalID(
+            paneOption: "", startCommand: "/bin/zsh -ic \"vim\"") == nil)
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "   ", startCommand: "") == nil)
+        #expect(TmuxManager.resolvePaneTerminalID(
+            paneOption: "", startCommand: "/bin/zsh -ic \"export TBD_TERMINAL_ID=''; vim\"") == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
+++ b/Tests/TBDDaemonTests/TBDWorktreeIDLeakTests.swift
@@ -171,6 +171,19 @@ func testHandleTerminalRecreateWindowSetsWorktreeID() async throws {
     let expected = "export TBD_WORKTREE_ID='\(wt.id.uuidString)';"
     #expect(bodies.contains { $0.contains(expected) },
             "handleTerminalRecreateWindow must export TBD_WORKTREE_ID; got bodies: \(bodies)")
+
+    // TBD_TERMINAL_ID too, and for a second reason: it is what `createWindow`
+    // stamps onto the new pane as `@tbd_terminal_id`. Without it this branch
+    // mints panes that `terminal.send` can never verify, because a pane with no
+    // identity is sent to unchecked — a permanent hole in the stale-coordinate
+    // refusal for every terminal recreated this way.
+    let expectedTerminal = "export TBD_TERMINAL_ID='\(terminal.id.uuidString)';"
+    #expect(bodies.contains { $0.contains(expectedTerminal) },
+            "handleTerminalRecreateWindow must export TBD_TERMINAL_ID; got bodies: \(bodies)")
+    #expect(recorded.snapshot().contains { call in
+        call.contains("set-option") && call.contains(TmuxManager.terminalIDPaneOption)
+            && call.contains(terminal.id.uuidString)
+    }, "the recreated pane must be stamped with its terminal id")
 }
 
 

--- a/Tests/TBDDaemonTests/TerminalSendSerializerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendSerializerTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Tier 2 — real concurrency, no tmux and no wall-clock deadlines in the
+/// assertions: each arm hands control back through a continuation, so the proof
+/// is ordering, not timing.
+@Suite("terminal.send serialization")
+struct TerminalSendSerializerTests {
+
+    /// Records entry/exit order across tasks.
+    private actor Trace {
+        private(set) var events: [String] = []
+        func note(_ event: String) { events.append(event) }
+    }
+
+    /// A one-shot gate a test can open from the outside.
+    private actor Gate {
+        private var opened = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func open() {
+            opened = true
+            for waiter in waiters { waiter.resume() }
+            waiters.removeAll()
+        }
+
+        func wait() async {
+            if opened { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+    }
+
+    /// Poll until `condition` holds or the deadline passes. Bounded wait, not a
+    /// sleep-as-synchronization: it bounds a hang and asserts nothing on its own.
+    private func waitUntil(
+        _ description: String, _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now + .seconds(15)
+        while ContinuousClock.now < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        struct Timeout: Error, CustomStringConvertible { let description: String }
+        throw Timeout(description: "timed out waiting for \(description)")
+    }
+
+    @Test("a second send to the same terminal queues behind the first, and is not refused")
+    func sameTerminalSerializes() async throws {
+        let serializer = TerminalSendSerializer()
+        let trace = Trace()
+        let gate = Gate()
+        let terminal = UUID()
+
+        async let first: Void = serializer.run(terminalID: terminal) {
+            await trace.note("first-in")
+            await gate.wait()
+            await trace.note("first-out")
+        }
+        // Let the first send take the lane before the second asks for it.
+        try await waitUntil("the first send to enter") { await trace.events == ["first-in"] }
+
+        async let second: Void = serializer.run(terminalID: terminal) {
+            await trace.note("second-in")
+            await trace.note("second-out")
+        }
+        // The second send must still be waiting: nothing new on the trace.
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await trace.events == ["first-in"])
+
+        await gate.open()
+        _ = try await (first, second)
+
+        // Queued, not interleaved — and not refused: both bodies ran.
+        #expect(await trace.events == ["first-in", "first-out", "second-in", "second-out"])
+    }
+
+    @Test("sends to different terminals overlap")
+    func differentTerminalsOverlap() async throws {
+        let serializer = TerminalSendSerializer()
+        let trace = Trace()
+        let gate = Gate()
+
+        async let first: Void = serializer.run(terminalID: UUID()) {
+            await trace.note("a-in")
+            await gate.wait()
+            await trace.note("a-out")
+        }
+        try await waitUntil("the first send to enter") { await trace.events == ["a-in"] }
+
+        // A different terminal is a different composer: this must run to
+        // completion while the first is still holding its own lane.
+        try await serializer.run(terminalID: UUID()) {
+            await trace.note("b-in")
+            await trace.note("b-out")
+        }
+        #expect(await trace.events == ["a-in", "b-in", "b-out"])
+
+        await gate.open()
+        try await first
+        #expect(await trace.events == ["a-in", "b-in", "b-out", "a-out"])
+    }
+
+    @Test("a send that throws releases the lane and does not poison its successor")
+    func throwingSendReleasesLane() async throws {
+        struct Boom: Error {}
+        let serializer = TerminalSendSerializer()
+        let terminal = UUID()
+
+        await #expect(throws: Boom.self) {
+            try await serializer.run(terminalID: terminal) { throw Boom() }
+        }
+        let value = try await serializer.run(terminalID: terminal) { 42 }
+        #expect(value == 42)
+    }
+
+    @Test("lanes are pruned once idle, so the table does not grow per terminal")
+    func lanesArePruned() async throws {
+        let serializer = TerminalSendSerializer()
+        for _ in 0..<5 {
+            try await serializer.run(terminalID: UUID()) {}
+        }
+        try await waitUntil("lanes to drain") { await serializer.trackedTerminalCount == 0 }
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSendTargetCheckTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendTargetCheckTests.swift
@@ -1,0 +1,342 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — dry-run tmux plus a real (temp-directory) actuation log.
+///
+/// `terminal.send` consults its target before it types. These prove what each
+/// answer produces: which sends are refused, with which reason on the record,
+/// which still go through, and that the healthy path emits exactly the tmux
+/// commands it emitted before the check existed.
+@Suite("terminal.send target check")
+struct TerminalSendTargetCheckTests {
+
+    // MARK: - Fixture
+
+    /// Thread-safe collector for tmux argv lists invoked during dryRun.
+    private final class ArgvRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _calls: [[String]] = []
+        var calls: [[String]] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+        func record(_ args: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            _calls.append(args)
+        }
+    }
+
+    /// What the fixture's pane answers when asked who it is. Spelled relative to
+    /// the terminal rather than as a literal, because the interesting cases are
+    /// agreement and disagreement with an id the fixture only mints later.
+    private enum PaneAnswer: Sendable {
+        case missing
+        case dead
+        /// Alive, carrying no identity at all.
+        case unresolvable
+        /// Alive, answering with the requested terminal's own id.
+        case matching
+        /// Alive, answering with the requested id in the other case.
+        case matchingLowercased
+        /// Alive, answering with somebody else's id.
+        case stranger(String)
+    }
+
+    /// Lets the dryRun hook — constructed before the terminal row exists —
+    /// answer with that terminal's id once it does.
+    private final class TerminalIDBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _id: String = ""
+        var id: String {
+            get { lock.lock(); defer { lock.unlock() }; return _id }
+            set { lock.lock(); defer { lock.unlock() }; _id = newValue }
+        }
+    }
+
+    private struct Fixture {
+        let router: RPCRouter
+        let terminal: Terminal
+        let recorder: ArgvRecorder
+        let logPath: String
+    }
+
+    private func makeFixture(answer: PaneAnswer) async throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-send-target-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let logPath = directory.appendingPathComponent("actuations.jsonl").path
+
+        let recorder = ArgvRecorder()
+        let box = TerminalIDBox()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunPaneSendTarget: { _, _ in
+                switch answer {
+                case .missing: return .missing
+                case .dead: return .dead
+                case .unresolvable: return .live(terminalID: nil)
+                case .matching: return .live(terminalID: box.id)
+                case .matchingLowercased: return .live(terminalID: box.id.lowercased())
+                case .stranger(let other): return .live(terminalID: other)
+                }
+            })
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: ActuationLog(path: logPath))
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7")
+        box.id = terminal.id.uuidString
+        return Fixture(router: router, terminal: terminal, recorder: recorder, logPath: logPath)
+    }
+
+    private func send(
+        _ fixture: Fixture, text: String = "status?", submit: Bool = true
+    ) async throws -> RPCResponse {
+        await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: fixture.terminal.id, text: text, submit: submit)))
+    }
+
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    private func lastOutcome(at path: String) throws -> [String: Any] {
+        try #require(try rows(at: path).last)
+    }
+
+    // MARK: - Refusals
+
+    @Test("a dead pane is refused as not-eligible instead of reporting success")
+    func deadPaneRefused() async throws {
+        // The whole point: `send-keys` into a `remain-on-exit` dead pane exits 0,
+        // so tmux's own status would have called this a successful send.
+        let fixture = try await makeFixture(answer: .dead)
+        let response = try await send(fixture)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("%7") == true)
+        #expect(response.error?.contains("dead") == true)
+        #expect(fixture.recorder.calls.isEmpty)
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        #expect(written.first?["kind"] as? String == "send")
+        let outcome = try #require(written.last)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-eligible")
+        #expect(!written.contains { $0["result"] as? String == "dispatched" })
+    }
+
+    @Test("a pane tmux cannot find is refused as not-found")
+    func missingPaneRefused() async throws {
+        let fixture = try await makeFixture(answer: .missing)
+        let response = try await send(fixture)
+
+        #expect(!response.success)
+        #expect(fixture.recorder.calls.isEmpty)
+        let outcome = try lastOutcome(at: fixture.logPath)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-found")
+        #expect(!(try rows(at: fixture.logPath))
+            .contains { $0["result"] as? String == "dispatched" })
+    }
+
+    @Test("a pane that answers with a different terminal is refused, naming both ids")
+    func mismatchedPaneRefused() async throws {
+        let stranger = UUID().uuidString
+        let fixture = try await makeFixture(answer: .stranger(stranger))
+        let response = try await send(fixture)
+
+        #expect(!response.success)
+        let error = try #require(response.error)
+        // Both ids, so the reader can tell which coordinate went stale.
+        #expect(error.contains(stranger))
+        #expect(error.contains(fixture.terminal.id.uuidString))
+        #expect(fixture.recorder.calls.isEmpty)
+
+        let outcome = try lastOutcome(at: fixture.logPath)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "target-mismatch")
+        #expect(!(try rows(at: fixture.logPath))
+            .contains { $0["result"] as? String == "dispatched" })
+    }
+
+    // MARK: - The branches that still send
+
+    @Test("a pane that agrees on its identity sends normally")
+    func matchingPaneSends() async throws {
+        let fixture = try await makeFixture(answer: .matching)
+        let response = try await send(fixture)
+
+        #expect(response.success)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
+    }
+
+    /// UUIDs round-trip through tmux and the DB as strings; a case difference is
+    /// the same session, not a stranger.
+    @Test("identity comparison is case-insensitive")
+    func identityComparisonIsCaseInsensitive() async throws {
+        let fixture = try await makeFixture(answer: .matchingLowercased)
+        let response = try await send(fixture)
+
+        #expect(response.success)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
+    }
+
+    /// Absence is not disagreement. A pane spawned before TBD stamped
+    /// identities — or by something outside TBD — carries no id, and refusing
+    /// on that would make this fix a regression for every such pane.
+    @Test("a pane with no identity to compare still sends")
+    func unresolvablePaneSends() async throws {
+        let fixture = try await makeFixture(answer: .unresolvable)
+        let response = try await send(fixture)
+
+        #expect(response.success)
+        let outcome = try lastOutcome(at: fixture.logPath)
+        #expect(outcome["result"] as? String == "dispatched")
+        #expect(outcome["reason"] == nil)
+    }
+
+    /// The healthy path must emit the SAME tmux commands, with the same
+    /// arguments, that it emitted before the target check existed: an explicit
+    /// bracketed paste (load-buffer + paste-buffer -d -p) then a separate Enter.
+    /// The consultation is a read-only query and contributes no command here.
+    @Test("a healthy send emits exactly the tmux commands it always did")
+    func healthySendCommandsUnchanged() async throws {
+        let fixture = try await makeFixture(answer: .matching)
+        let response = try await send(fixture, text: "rebase onto main")
+        #expect(response.success)
+
+        let calls = fixture.recorder.calls
+        #expect(calls.count == 3)
+
+        let load = try #require(calls.first { $0.contains("load-buffer") })
+        #expect(load[0] == "-L")
+        #expect(load[1] == "tbd-acme")
+        #expect(load[2] == "load-buffer")
+        #expect(load[3] == "-b")
+
+        let paste = try #require(calls.first { $0.contains("paste-buffer") })
+        #expect(paste.contains("-d"))
+        #expect(paste.contains("-p"))
+        #expect(paste.contains("-t"))
+        #expect(paste.contains("%7"))
+
+        let enter = try #require(calls.first { $0.contains("send-keys") })
+        #expect(enter == ["-L", "tbd-acme", "send-keys", "-t", "%7", "Enter"])
+
+        // Order: paste, then the Enter that must land outside it.
+        let pasteIdx = try #require(calls.firstIndex { $0.contains("paste-buffer") })
+        let enterIdx = try #require(calls.firstIndex { $0.contains("send-keys") })
+        #expect(pasteIdx < enterIdx)
+    }
+
+    @Test("a send without submit still skips the Enter")
+    func noSubmitStillSkipsEnter() async throws {
+        let fixture = try await makeFixture(answer: .matching)
+        #expect(try await send(fixture, submit: false).success)
+        #expect(!fixture.recorder.calls.contains { $0.contains("send-keys") })
+    }
+
+    // MARK: - Serialization wiring
+
+    /// A one-shot gate a test can open from the outside.
+    private actor Gate {
+        private var opened = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+        private var entered = false
+
+        func open() {
+            opened = true
+            for waiter in waiters { waiter.resume() }
+            waiters.removeAll()
+        }
+
+        func wait() async {
+            entered = true
+            if opened { return }
+            await withCheckedContinuation { waiters.append($0) }
+        }
+
+        var hasEntered: Bool { entered }
+    }
+
+    /// Two payloads spliced into one composer is a transport bug: neither caller
+    /// asked for the message that would arrive. This holds the terminal's lane
+    /// from outside the handler and proves the handler waits for it — nothing is
+    /// typed while another send owns the terminal, and the queued send is
+    /// delivered afterwards rather than refused.
+    @Test("a send waits for the terminal's lane before typing anything")
+    func sendQueuesBehindTheLane() async throws {
+        let fixture = try await makeFixture(answer: .matching)
+        let gate = Gate()
+
+        // Occupy this terminal's lane the way an in-flight send would.
+        async let holder: Void = fixture.router.terminalSendSerializer
+            .run(terminalID: fixture.terminal.id) { await gate.wait() }
+        let deadline = ContinuousClock.now + .seconds(15)
+        while await !gate.hasEntered && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(await gate.hasEntered)
+
+        async let response = send(fixture, text: "queued")
+        // Bounded window: with the lane held, the send must type nothing.
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(fixture.recorder.calls.isEmpty)
+
+        await gate.open()
+        try await holder
+        #expect(try await response.success)
+        #expect(!fixture.recorder.calls.isEmpty)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
+    }
+
+    /// A send to a DIFFERENT terminal must not wait behind this one: the lane is
+    /// per composer, not a global send lock.
+    @Test("a busy terminal's lane does not block another terminal's send")
+    func otherTerminalsAreUnaffected() async throws {
+        let fixture = try await makeFixture(answer: .unresolvable)
+        let gate = Gate()
+        let other = try await fixture.router.db.terminals.create(
+            worktreeID: fixture.terminal.worktreeID, tmuxWindowID: "@4", tmuxPaneID: "%8")
+
+        async let holder: Void = fixture.router.terminalSendSerializer
+            .run(terminalID: fixture.terminal.id) { await gate.wait() }
+        let deadline = ContinuousClock.now + .seconds(15)
+        while await !gate.hasEntered && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(await gate.hasEntered)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(terminalID: other.id, text: "hi", submit: true)))
+        #expect(response.success)
+        #expect(fixture.recorder.calls.contains { $0.contains("%8") })
+
+        await gate.open()
+        try await holder
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSendTargetCheckTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendTargetCheckTests.swift
@@ -42,7 +42,14 @@ struct TerminalSendTargetCheckTests {
         case matchingLowercased
         /// Alive, answering with somebody else's id.
         case stranger(String)
+        /// The consultation could not be run at all — a wedged tmux tripping
+        /// the subprocess timeout. Not an answer about the pane.
+        case unreachable
     }
+
+    /// The error a `.unreachable` consultation fails with, so the test can
+    /// assert the handler propagated *that* error rather than inventing one.
+    private struct WedgedTmux: Error {}
 
     /// Lets the dryRun hook — constructed before the terminal row exists —
     /// answer with that terminal's id once it does.
@@ -81,6 +88,7 @@ struct TerminalSendTargetCheckTests {
                 case .matching: return .live(terminalID: box.id)
                 case .matchingLowercased: return .live(terminalID: box.id.lowercased())
                 case .stranger(let other): return .live(terminalID: other)
+                case .unreachable: throw WedgedTmux()
                 }
             })
         let db = try TBDDatabase(inMemory: true)
@@ -155,11 +163,14 @@ struct TerminalSendTargetCheckTests {
 
         #expect(!response.success)
         #expect(fixture.recorder.calls.isEmpty)
-        let outcome = try lastOutcome(at: fixture.logPath)
+        let written = try rows(at: fixture.logPath)
+        // Exactly the request row and its outcome — a refusal must not also
+        // leave a second outcome behind.
+        #expect(written.count == 2)
+        let outcome = try #require(written.last)
         #expect(outcome["result"] as? String == "refused")
         #expect(outcome["reason"] as? String == "not-found")
-        #expect(!(try rows(at: fixture.logPath))
-            .contains { $0["result"] as? String == "dispatched" })
+        #expect(!written.contains { $0["result"] as? String == "dispatched" })
     }
 
     @Test("a pane that answers with a different terminal is refused, naming both ids")
@@ -175,11 +186,35 @@ struct TerminalSendTargetCheckTests {
         #expect(error.contains(fixture.terminal.id.uuidString))
         #expect(fixture.recorder.calls.isEmpty)
 
-        let outcome = try lastOutcome(at: fixture.logPath)
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        let outcome = try #require(written.last)
         #expect(outcome["result"] as? String == "refused")
         #expect(outcome["reason"] as? String == "target-mismatch")
-        #expect(!(try rows(at: fixture.logPath))
-            .contains { $0["result"] as? String == "dispatched" })
+        #expect(!written.contains { $0["result"] as? String == "dispatched" })
+    }
+
+    /// The consultation failing to *run* is not an answer about the pane, so it
+    /// is not a refusal: the daemon reached for the transport and the transport
+    /// did not answer. The caller gets the underlying error, not a verdict about
+    /// its target, and the record says `transport-failed`.
+    @Test("a consultation that cannot be run is a transport failure, not a refusal")
+    func unreachableConsultationIsTransportFailure() async throws {
+        let fixture = try await makeFixture(answer: .unreachable)
+
+        // The handler rethrows; the router turns that into an error response.
+        let response = try await send(fixture)
+        #expect(!response.success)
+        #expect(response.error?.contains("WedgedTmux") == true)
+        #expect(fixture.recorder.calls.isEmpty)
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        let outcome = try #require(written.last)
+        #expect(outcome["result"] as? String == "transport-failed")
+        // Not misfiled as any flavour of refusal.
+        #expect(outcome["reason"] == nil)
+        #expect(!written.contains { $0["result"] as? String == "dispatched" })
     }
 
     // MARK: - The branches that still send
@@ -232,10 +267,10 @@ struct TerminalSendTargetCheckTests {
         #expect(calls.count == 3)
 
         let load = try #require(calls.first { $0.contains("load-buffer") })
-        #expect(load[0] == "-L")
-        #expect(load[1] == "tbd-acme")
-        #expect(load[2] == "load-buffer")
-        #expect(load[3] == "-b")
+        // Compared as a prefix rather than by index: `#require` proves the call
+        // exists, not that it is four arguments long, and indexing past its end
+        // would crash the run instead of failing it.
+        #expect(load.prefix(4) == ["-L", "tbd-acme", "load-buffer", "-b"])
 
         let paste = try #require(calls.first { $0.contains("paste-buffer") })
         #expect(paste.contains("-d"))

--- a/docs/tmux-integration.md
+++ b/docs/tmux-integration.md
@@ -148,21 +148,26 @@ This is the key feature that makes embedding work — multiple viewers can look 
 
 ## Known issues
 
-### `terminal send` silently no-ops on dead panes
+### A pane can be alive but no longer running an agent
 
-`tbd terminal send --terminal <id> --text "..." --submit` reports **"Text sent"**
-even when the target tmux pane is dead (`pane_dead=1`). The text goes nowhere and
-the caller gets no failure signal. During a 2026-07-01 multi-session rescue this
-masked five dead Claude sessions — every nudge "succeeded" while none delivered.
-
-Related trap: a pane can be alive (`pane_dead=0`) after its Claude process exits,
-leaving a bare `zsh` prompt — `send` then types into a shell, not a session.
-Ground truth today requires raw tmux:
+A pane can be alive (`pane_dead=0`) after its Claude process exits, leaving a
+bare `zsh` prompt — `terminal send` then types into a shell, not a session, and
+that is a real send into a real pane, so nothing refuses it. Ground truth still
+requires raw tmux:
 
 ```sh
 tmux -L <server> list-panes -a -F '#{pane_id} dead=#{pane_dead} cmd=#{pane_current_command}'
 ```
 
-Suggested fix: check `#{pane_dead}` before sending and exit non-zero with a
-respawn hint when dead; surface `pane_current_command` in `terminal list`/`output`
-so callers can tell "Claude running" from "shell prompt" without raw tmux.
+Worth doing: surface `pane_current_command` in `terminal list` / `output` so
+callers can tell "Claude running" from "shell prompt" without raw tmux.
+
+The two neighbouring failures are fixed. `terminal.send` consults its target
+before typing (one `list-panes` reading `#{pane_dead}`, the `@tbd_terminal_id`
+pane option and `#{pane_start_command}`) and returns an error rather than
+reporting success when the pane is gone, when the pane's process has exited, or
+when the pane answers with a different terminal's id than the caller named.
+`send-keys` into a `remain-on-exit` dead pane exits **0**, so tmux's own status
+was never the signal; and pane ids are reused, so a stale DB coordinate used to
+type into a live stranger (issue #384). Refusal requires *positive*
+disagreement — a pane carrying no identity is sent to as before.

--- a/docs/tmux-integration.md
+++ b/docs/tmux-integration.md
@@ -163,10 +163,13 @@ Worth doing: surface `pane_current_command` in `terminal list` / `output` so
 callers can tell "Claude running" from "shell prompt" without raw tmux.
 
 The two neighbouring failures are fixed. `terminal.send` consults its target
-before typing (one `list-panes` reading `#{pane_dead}`, the `@tbd_terminal_id`
-pane option and `#{pane_start_command}`) and returns an error rather than
-reporting success when the pane is gone, when the pane's process has exited, or
-when the pane answers with a different terminal's id than the caller named.
+before typing (one `list-panes` reading `#{pane_id}`, `#{pane_dead}`, the
+`@tbd_terminal_id` pane option and `#{pane_start_command}`) and returns an error
+rather than reporting success when the pane is gone, when the pane's process has
+exited, or when the pane answers with a different terminal's id than the caller
+named. `#{pane_id}` is in that list because `list-panes -t %N` answers for every
+pane in `%N`'s **window** — `%N` only picks the window — so in a hand-split
+window the send has to select its own pane's line rather than the first one.
 `send-keys` into a `remain-on-exit` dead pane exits **0**, so tmux's own status
 was never the signal; and pane ids are reused, so a stale DB coordinate used to
 type into a live stranger (issue #384). Refusal requires *positive*


### PR DESCRIPTION
## What's broken

`terminal.send` reports success in two cases where nothing was delivered.

**A dead pane.** `send-keys` into a `remain-on-exit` pane exits **0**. tmux's exit
status is not a liveness signal, so the daemon typed into a corpse and told the
caller "Text sent."

**A misidentified pane.** tmux reuses pane IDs. A terminal row holding a stale
`tmuxPaneID` points at a pane now owned by a *different* live session, and the
keystrokes land there — with no error by any mechanical measure. This is issue
#384, observed in the field: row `BD3B78AC` pointed at `%256`, actually owned by
another terminal, and the auto-resume actuator passed every eligibility check and
typed into the wrong session.

## Why it happens

Neither failure is detectable from the transport's return value, so the send path
never asked. Honest answers require *deliberate consultation* of pane metadata
before typing — which is what this PR adds.

## Provenance

Not a regression — the send path has never checked. The paste mechanics were last
touched in #389 (bracketed paste for large payloads), which changed *how* bytes
are delivered but not whether the target was real. It went uncaught because both
failures are silent by construction: the only observable is a message that never
arrives, which reads as an unresponsive agent rather than a failed send. Slice 1a
(#593) made it visible by giving every act a row, and this slice makes what those
rows say true.

## What this PR does

Before anything is typed, one `list-panes` call reads `#{pane_id}`,
`#{pane_dead}`, `#{@tbd_terminal_id}` and `#{pane_start_command}` together and
classifies the target. Identity resolves from a per-pane tmux user option stamped
centrally at spawn, falling back to parsing `TBD_TERMINAL_ID` out of the pane's
start command — which every pane alive today already carries, since the env map is
inlined as an `export` prefix.

Reading the pane process's *environment* was the obvious approach and is not
possible: macOS hides process environments under SIP, so `ps eww` prints nothing
even for a process you own and just spawned. tmux's `show-environment` is
session-scoped, and TBD puts every terminal of a worktree in one session. Pane
metadata is the machine interface that remains, and it is metadata rather than
rendered text, so no screen-scraping is involved.

**Three callers consult, not one.** `terminal.send` is the generic primitive, but
it is not what typed into the wrong session in the field. `LimitResumeActuator` —
auto-resume — types Escape/continue/Enter on a timer with no user gesture, and it
reaches tmux directly rather than through the RPC handler. Its eligibility list
checked `windowExists`, which proves a window id resolves to *some* window and
never that the pane still belongs to this terminal, so a reused pane id passed
every remaining check (window alive, Claude foreground, not in copy-mode) and got
"continue" typed into it. That is the incident below, so it runs the same
consultation on the same rule.

`DeskSessionManager` is the third, and had the same shape of hole: its
`liveAgentTerminals` selected a desk terminal on window-exists plus a matching
agent kind, neither of which compares pane identity, and `nudgeDeskSession` and
`postShiftWrapUp` then pasted and submitted on a timer. What they paste is a
judge prompt, so a same-kind stranger on a recycled pane id would not merely
receive a stray keystroke — it would read and act on instructions addressed to
another session, with permissions bypassed. The consultation goes at the
`liveAgentTerminals` chokepoint, so both pastes, the judge-candidate list and
the desk's liveness probe are covered by one guard. An excluded candidate is
simply not live, so the callers' existing "no uniquely owned live terminal …
skipping" path handles it — and the judge lease gets *more* correct, since a
recycled pane id can no longer masquerade as the lease owner or pad the
candidate count into a fail-closed contention report about a rival that does not
exist.

Sends to the same terminal now serialize behind one another; two different
terminals still send concurrently. Interleaving two payloads into one composer was
a transport bug.

## Behavior change

Sends that used to report success into a dead or misidentified pane now return an
error. That is the fix, not a regression. Affected:

- **`tbd terminal send`** (hooks, scripts, operator tooling) surfaces the RPC error already.
- **Nightwatch's Python** discards exit codes inside bare `except`, so it degrades
  from silent *false* success to silent *honest* failure — strictly better, and no
  change to its happy path. Nightwatch keeps working; it is deleted at the end of
  the migration, in its own PR.
- **Auto-resume** can now end a scheduled row without typing. A vanished or dead
  pane cancels it silently as `terminal-gone`, the `windowExists` check one level
  finer. A pane answering with a *different* terminal fails the row with a message
  naming both ids — not a retry, because the row's coordinate stays stale until
  something respawns the window, so retrying would only aim at the same stranger.
- **The app**'s `AppState.sendToTerminal` now raises an error alert instead of
  logging and swallowing. Worth noting: that method currently has **no callers** —
  GUI typing goes through control mode, not this RPC — so the alert is
  correct-if-wired rather than reachable today. Deleting the dead method is
  unrelated churn and was left alone.

**Refusal requires positive disagreement, never absence.** A pane that resolves to
no identity — spawned before this change, or outside TBD — is sent to exactly as
before, with a `.debug` log line. This is what keeps the fix from regressing
existing sessions.

## Actuation vocabulary

Both checks run *before* the transport is touched, which by 1a's boundary makes
them `refused`, not `transportFailed`:

- **pane gone** → `not-found` — the coordinate names nothing.
- **pane dead** → `not-eligible` — the row and the pane object exist; the pane just
  cannot receive input, and Recreate Window already recovers that state.
- **identity mismatch** → **new reason `target-mismatch`.** Neither neighbour is
  honest about a stale coordinate: `not-found` claims the terminal row is gone (it
  is not) and `not-eligible` claims a wrong state (it is not — a healthy stranger
  answered).

**These are the first refusals reachable on `terminal.send`,** which #593
documented as dispatched-or-transport-failed only. Anything reading the actuation
record for send outcomes must now handle refusals, and `target-mismatch` is a raw
value older readers have not seen.

## What is still exposed, deliberately

**Issue #384 stays open, and this PR should not close it.** Three callers now
consult their target before acting on a stored coordinate — `terminal.send`,
`LimitResumeActuator` and `DeskSessionManager`. Three still act on an unverified
one: two destructive paths that carry a user's gesture, and the control-mode
input path, which is a different question entirely. This is the full list, so
that nobody reads this PR as the definitive account and gets a shorter one. All
three are pre-existing — none is introduced or worsened here.

### The two destructive paths

**Both can destroy a stranger, not merely talk to one.** Each runs
`gracefullyInterruptPane` — Escape, `C-c C-c`, then `kill(pid, SIGTERM)` on the
pid behind a pane id read from the terminal row — and then `respawn-window -k`,
which force-replaces whatever that window is running:

- `inPlaceSwapRespawn` in `RPCRouter+TerminalHandlers.swift`, the "Switch account"
  in-place respawn, off `oldTerminal.tmuxPaneID`/`tmuxWindowID`.
- `HibernationCoordinator.hibernateForMerge`, off `terminal.tmuxPaneID`, with a
  near-identical copy of the same helper.

If either coordinate is stale — the premise this whole PR exists to stop trusting —
the outcome is worse than #384's: not a message in a stranger's composer but a
SIGTERM to their process and a forced respawn of their window.

They are named here rather than fixed here because **the distinction is not how
dangerous the act is, it is who asked for it.** Both of these serve a *user
gesture*: someone clicked "Switch account" or merged a worktree. Declining there
fails something a human asked for, so what should happen instead — fail it
outright, mark the row, fall back to a coordinate-free path, tell the user what
to do next — is a product decision with a user-visible answer, and per CLAUDE.md
that is spec-and-flag work on a load-bearing path rather than the bug fix this PR
is. Bolting a refusal onto a destructive path to satisfy a completeness argument
is how you ship a hibernate that silently stops working.

The three sites wired here have no such question to answer. `terminal.send`
returns an ordinary error to a caller that already handles errors; auto-resume
and the Watch Desk skip an act that nobody requested, on a timer that fires
again shortly. Nothing user-facing fails, so refusal needs no design — which is
exactly why they could be wired in a bug fix and these two cannot.

### The control-mode input path — out of scope by design, not by triage

The third is different in kind, and it is listed separately so it is not read as
a smaller version of the two above. `RPCRouter+AttachHandlers.swift` takes the
attach request's pane id — the same stored `tmuxPaneID`, resolved the same way —
registers it as an input route, and `ControlModeInputRouter` then hands the
attached client's keystrokes to `PasteExecutor.paste` with no `paneSendTarget`
consultation anywhere on the path.

**This slice must not wire it.** Design §6 places control-mode input outside the
actuation record: it carries the operator's own keystrokes to the operator's own
pane, at typing latency, and interposing a `list-panes` round trip per input
frame is a decision about that subsystem's design rather than a bug fix to this
one. It is out of scope **by design**, not because it was triaged as lower
priority and deferred.

Two facts bound what is exposed in the meantime, and both are properties the
other paths lack:

- It is reachable only behind **`control_mode_enabled`, which defaults off** —
  the gate is evaluated per attach, so a pane only ever routes input this way for
  an operator who deliberately turned it on.
- **The operator is watching the pane as they type.** Control-mode input goes to
  the pane whose live rendered content is on screen in front of them, so a stale
  coordinate shows up as visibly the wrong content rather than as a silent
  misdelivery. Silence is what makes the other paths dangerous; here the human is
  the check.

**Not exposed, for the record:** `armLoginSession`'s auto-`/login` typer uses the
pane id straight off the window object it just created, not a stored coordinate, so
it has nothing stale to go wrong with.

#384 tracks the two destructive paths and closes when the last of them stops
trusting a stored coordinate. The control-mode path is not part of that
accounting — it is disclosed here, but its answer belongs to control mode's own
design rather than to #384.

## Design notes

- **No DB-driven backfill of the pane option.** Stamping panes from stored
  coordinates would write the terminal's ID onto the wrong pane whenever a
  coordinate is stale — turning the check into a rubber stamp for exactly the case
  it exists to catch.
- **A modal-prompt check is deliberately absent.** Design §12 names that third
  failure class and declines it: the sentinel detects the aftermath, and no field
  failure has shown the race itself biting.
- **No flag and no spec.** This is a bug fix restoring the send path to its
  existing theory; §12 is the normative text. No policy, no allow/deny, no payload
  inspection — the daemon still never reads message content.
- **TOCTOU is narrowed, not closed.** A pane can still die between the consult and
  the paste; that degrades to a transport error, never a false `dispatched`.

## Review found three High-severity bugs, all fixed

1. **`list-panes -t %N` lists every pane in `%N`'s *window*,** not just `%N` — the
   id merely selects the window. Reading `.first` meant a hand-split TBD tab made
   every send read a stranger's `pane_dead` and identity: a **false refusal of a
   healthy pane**, the precise regression this design forbids. The format now leads
   with `#{pane_id}` and the parse selects the line the send named.
2. **`terminal.recreateWindow`'s shell branch never planted `TBD_TERMINAL_ID`** —
   the one spawn path that didn't. Since absence never refuses, panes from that
   branch opted out of the stale-coordinate check permanently.
3. **The check reached `terminal.send` but not the actuator that caused the
   incident.** Wiring only the RPC handler left `LimitResumeActuator` — the
   component #384 actually observed typing into a stranger — with the identical
   failure mode after merge, while the PR read as closing it. Auto-resume now runs
   the same consultation; see "Two callers consult, not one" above.

## Test plan

- [x] A dead `remain-on-exit` pane errors instead of succeeding — the case tmux reports as success
- [x] A pane whose resolved identity disagrees is refused, and the error names both ids
- [x] An *unresolvable* pane still succeeds (the no-regression branch)
- [x] A healthy send emits byte-identical tmux argv to before
- [x] A split window answers for the named pane, not its neighbour (live tmux)
- [x] Two concurrent sends to one terminal serialize; two to different terminals overlap
- [x] Auto-resume refuses a pane owned by another terminal, and types nothing
- [x] Auto-resume still resumes a pane carrying no identity (the no-regression branch), and matches case-insensitively
- [x] Auto-resume cancels on a vanished or dead pane, and fails rather than types when the consultation cannot be run
- [x] The Watch Desk never pastes into a pane owned by another terminal, on either the nudge or the wrap-up path, and fires no completion notification for a wrap-up that was not posted
- [x] The Watch Desk still nudges a pane carrying no identity (the no-regression branch) and one that names its own terminal
- [x] The Watch Desk skips a candidate whose identity cannot be read at all, matching how its sibling `paneCurrentCommand` check already treats a wedged server
- [x] A stranger's pane is no longer counted as a rival judge candidate, so the desk takes its lease and gets nudged instead of failing closed on phantom contention
- [x] Each failure writes exactly one actuation row with the right reason and no `dispatched` row
- [x] `transport-failed` writes no reason
- [x] Mutation-checked: the `actuation_primitive_allowlist` rule fires on a primitive added to a non-allowlisted file; the target-check and stamping tests go red on revert. Deleting the actuator's step 1a reddens its four refusal tests and makes the mutant type "continue" into the stranger pane — #384 exactly — while the two no-regression tests stay green, as they must. Removing the desk's exclusion reddens its four refusal tests — the recorder shows the judge prompt pasted into the stranger's pane and the wrap-up's completion notification firing for a summary never posted — and leaves its two no-regression tests green
- [x] Identity resolution ignores the pane's user-authored text: instructions carrying a bare `TBD_TERMINAL_ID=` literal, and ones carrying a quoted decoy value, both still resolve the real id; a non-UUID or truncated value in the real slot resolves to nil and the send proceeds; the pane-option path is unaffected by any of it. Asserted against what `newWindowCommand` actually emits, with the decoy proven to precede the real assignment, plus one case pinning that both spawn builders still emit the anchor the resolver depends on. Mutation-checked: reverting to the unanchored substring search reddens three of them with four issues
- [x] `swiftlint --strict` — 0 violations in 675 files; no new scraping/allowlist exclusions, `.swiftlint.yml` untouched
- [x] Full suite: 5201 tests in 560 suites, all passing

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=DBCFE501-2BAF-4573-8625-304825DE975A)


