### PR TITLE
Fix: stop user-authored repo instructions from forging a pane's identity

### DIFF
--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -456,6 +456,12 @@ public struct TmuxManager: Sendable {
         return .missing
     }
 
+    /// The exact assignment shape `newWindowCommand` and `respawnWindowCommand`
+    /// emit for one entry of the `env` map. Both build the prefix identically,
+    /// so a pane spawned either way — including the in-place profile swap —
+    /// carries this literal.
+    static let terminalIDExportAnchor = "export TBD_TERMINAL_ID='"
+
     /// Which TBD terminal a pane says it is, or nil when the pane carries no
     /// answer at all.
     ///
@@ -467,22 +473,43 @@ public struct TmuxManager: Sendable {
     /// spawned before the option existed still carries its own id. macOS forbids
     /// reading another process's environment (SIP), so the start command, not
     /// `ps eww`, is where the planted value remains legible.
+    ///
+    /// The fallback is deliberately narrow, because the start command also
+    /// carries *user-authored free text*: the env map is inlined sorted by key,
+    /// and `TBD_PROMPT_INSTRUCTIONS` — a repo's custom instructions — sorts
+    /// before `TBD_TERMINAL_ID` and so appears earlier in the same string. A
+    /// bare `TBD_TERMINAL_ID=` substring search would read whatever the user
+    /// happened to write as the pane's identity, and a pane that misreports its
+    /// identity is refused as a stranger for the whole life of its window. So
+    /// the search anchors on the full assignment TBD actually emits, and the
+    /// extracted value must parse as a `UUID` — the only thing TBD ever plants
+    /// there. Anything else resolves to nil, which means "no answer" and lets
+    /// the send proceed.
+    ///
+    /// Every occurrence of the anchor is scanned rather than just the first, so
+    /// instructions containing a quoted non-UUID decoy are stepped over and the
+    /// real id further along still resolves. Residual adversarial case:
+    /// instructions containing a complete `export TBD_TERMINAL_ID='<valid
+    /// uuid>'` would still be read first. That can only cause a false
+    /// *refusal* of a healthy pane, never a false *accept* — a stranger's pane
+    /// cannot be made to answer with this terminal's id, and the false accept
+    /// is the direction that would actually type into someone else's composer.
     static func resolvePaneTerminalID(paneOption: String, startCommand: String) -> String? {
         let stamped = paneOption.trimmingCharacters(in: .whitespaces)
         if !stamped.isEmpty { return stamped }
 
-        let marker = "TBD_TERMINAL_ID="
-        guard let markerRange = startCommand.range(of: marker) else { return nil }
-        let rest = startCommand[markerRange.upperBound...]
-        let value: Substring
-        if rest.first == "'" {
-            let afterQuote = rest.dropFirst()
-            guard let close = afterQuote.firstIndex(of: "'") else { return nil }
-            value = afterQuote[..<close]
-        } else {
-            value = rest.prefix { !$0.isWhitespace && $0 != ";" && $0 != "\"" }
+        var searchFrom = startCommand.startIndex
+        while let anchor = startCommand.range(
+            of: terminalIDExportAnchor, range: searchFrom..<startCommand.endIndex) {
+            searchFrom = anchor.upperBound
+            let rest = startCommand[anchor.upperBound...]
+            // No closing quote anywhere after this anchor means no later
+            // occurrence can be well-formed either.
+            guard let close = rest.firstIndex(of: "'") else { return nil }
+            let value = String(rest[..<close])
+            if UUID(uuidString: value) != nil { return value }
         }
-        return value.isEmpty ? nil : String(value)
+        return nil
     }
 
     public static func panePIDQuery(server: String, paneID: String) -> [String] {

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -12,6 +12,10 @@ import Testing
 @Suite("Pane send-target query")
 struct PaneSendTargetQueryTests {
 
+    /// A stand-in for the only thing TBD ever plants in `TBD_TERMINAL_ID`: a
+    /// terminal row's `id.uuidString`.
+    static let plantedID = "6E4B1C2A-9F03-4D57-8B11-2C7E5A0D9F44"
+
     // MARK: - Command builders
 
     @Test("the target query asks one list-panes for all four facts")
@@ -66,22 +70,24 @@ struct PaneSendTargetQueryTests {
 
     @Test("the stamped pane option wins over the start command")
     func parseStampedWins() {
-        let line = "%7\t0\tSTAMPED\t/bin/zsh -ic \"export TBD_TERMINAL_ID='INLINED'; claude\"\n"
+        let line = "%7\t0\tSTAMPED\t/bin/zsh -ic \"export TBD_TERMINAL_ID='\(Self.plantedID)'; claude\"\n"
         #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7") == .live(terminalID: "STAMPED"))
     }
 
     @Test("an unstamped pane still answers from its start command")
     func parseFallsBackToStartCommand() {
-        let line = "%7\t0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='INLINED'; claude\"\n"
-        #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7") == .live(terminalID: "INLINED"))
+        let line = "%7\t0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='\(Self.plantedID)'; claude\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7")
+            == .live(terminalID: Self.plantedID))
     }
 
     /// The start command is last precisely so its own tabs and separators stay
     /// inside it — the split takes the remainder rather than a fifth field.
     @Test("a tab inside the start command does not split it into a fifth field")
     func parseStartCommandWithTab() {
-        let line = "%7\t0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='ID9'; printf 'a\tb'\"\n"
-        #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7") == .live(terminalID: "ID9"))
+        let line = "%7\t0\t\t/bin/zsh -ic \"export TBD_TERMINAL_ID='\(Self.plantedID)'; printf 'a\tb'\"\n"
+        #expect(TmuxManager.parsePaneSendTarget(line, paneID: "%7")
+            == .live(terminalID: Self.plantedID))
     }
 
     // MARK: - Selecting the pane the send actually named
@@ -143,17 +149,10 @@ struct PaneSendTargetQueryTests {
     @Test("the quoted export form TBD actually plants is read back exactly")
     func resolveQuotedExport() {
         // The literal shape `newWindowCommand` produces from the `env` map.
-        let command = "/bin/zsh -ic \"export TBD_TERMINAL_ID='9C1E-AB'; "
+        let command = "/bin/zsh -ic \"export TBD_TERMINAL_ID='\(Self.plantedID)'; "
             + "export TBD_WORKTREE_ID='11'; claude\""
-        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command) == "9C1E-AB")
-    }
-
-    @Test("an unquoted planted value stops at the first separator")
-    func resolveUnquoted() {
-        #expect(TmuxManager.resolvePaneTerminalID(
-            paneOption: "", startCommand: "env TBD_TERMINAL_ID=9C1E-AB claude") == "9C1E-AB")
-        #expect(TmuxManager.resolvePaneTerminalID(
-            paneOption: "", startCommand: "TBD_TERMINAL_ID=9C1E-AB; claude") == "9C1E-AB")
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
+            == Self.plantedID)
     }
 
     @Test("a pane carrying neither source resolves to nil, never to a guess")
@@ -163,5 +162,98 @@ struct PaneSendTargetQueryTests {
         #expect(TmuxManager.resolvePaneTerminalID(paneOption: "   ", startCommand: "") == nil)
         #expect(TmuxManager.resolvePaneTerminalID(
             paneOption: "", startCommand: "/bin/zsh -ic \"export TBD_TERMINAL_ID=''; vim\"") == nil)
+    }
+
+    // MARK: - User-authored text in the start command cannot forge an identity
+
+    /// Both spawn paths inline the env map the same way, so the anchor the
+    /// resolver looks for holds for the in-place profile swap too. Asserted
+    /// against the builders rather than a hand-written literal, because the
+    /// resolver's narrowness is only safe while this stays true.
+    @Test("both spawn paths emit the assignment shape the resolver anchors on")
+    func bothSpawnPathsEmitTheAnchor() throws {
+        let env = ["TBD_TERMINAL_ID": Self.plantedID]
+        let spawned = try #require(TmuxManager.newWindowCommand(
+            server: "tbd-acme", session: "main", cwd: "/tmp", shellCommand: "claude",
+            env: env).last)
+        let respawned = try #require(TmuxManager.respawnWindowCommand(
+            server: "tbd-acme", windowID: "@3", cwd: "/tmp", shellCommand: "claude",
+            env: env).last)
+        #expect(spawned.contains(TmuxManager.terminalIDExportAnchor))
+        #expect(respawned.contains(TmuxManager.terminalIDExportAnchor))
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: spawned)
+            == Self.plantedID)
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: respawned)
+            == Self.plantedID)
+    }
+
+    /// The env map is inlined sorted by key, and `TBD_PROMPT_INSTRUCTIONS`
+    /// carries a repo's arbitrary user-authored custom instructions — so it is
+    /// inlined BEFORE `TBD_TERMINAL_ID` and any unanchored substring search
+    /// reads the user's prose as the pane's identity. A pane that misreports
+    /// its identity is refused as a stranger for the whole life of its window.
+    @Test("instructions containing the bare env-var name do not poison resolution")
+    func resolveIgnoresBareNameInInstructions() throws {
+        let command = try #require(TmuxManager.newWindowCommand(
+            server: "tbd-acme", session: "main", cwd: "/tmp", shellCommand: "claude",
+            env: [
+                "TBD_PROMPT_INSTRUCTIONS":
+                    "When paging a sibling, read TBD_TERMINAL_ID= from its pane env first.",
+                "TBD_TERMINAL_ID": Self.plantedID,
+            ]).last)
+        // The decoy really does precede the real assignment in the emitted string.
+        let decoy = try #require(command.range(of: "TBD_TERMINAL_ID="))
+        let real = try #require(command.range(of: TmuxManager.terminalIDExportAnchor))
+        #expect(decoy.lowerBound < real.lowerBound)
+
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
+            == Self.plantedID)
+    }
+
+    /// The same hazard one step further: prose that spells the assignment out
+    /// with a quoted value, so an anchored-but-first-match-only search would
+    /// hand back the quoted garbage. Scanning every occurrence steps over it.
+    @Test("instructions containing a quoted decoy value do not poison resolution")
+    func resolveStepsOverQuotedDecoy() throws {
+        let command = try #require(TmuxManager.newWindowCommand(
+            server: "tbd-acme", session: "main", cwd: "/tmp", shellCommand: "claude",
+            env: [
+                "TBD_PROMPT_INSTRUCTIONS":
+                    "Never run: export TBD_TERMINAL_ID='not-a-uuid' — it breaks routing.",
+                "TBD_TERMINAL_ID": Self.plantedID,
+            ]).last)
+        // The quote-escaping leaves a complete anchor inside the instructions.
+        #expect(command.ranges(of: TmuxManager.terminalIDExportAnchor).count == 2)
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
+            == Self.plantedID)
+
+        // The same property stated directly, independent of the escaping rules.
+        let handWritten = "/bin/zsh -ic \"export TBD_TERMINAL_ID='decoy'; "
+            + "export TBD_TERMINAL_ID='\(Self.plantedID)'; claude\""
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: handWritten)
+            == Self.plantedID)
+    }
+
+    /// Fail-open on a value that is not a terminal id at all: nil means "this
+    /// pane gave no answer", and the send proceeds. Returning the garbage would
+    /// be a positive disagreement and refuse a healthy pane.
+    @Test("a non-UUID value in the real slot resolves to nil, not to garbage")
+    func resolveRejectsNonUUIDValue() {
+        let command = "/bin/zsh -ic \"export TBD_TERMINAL_ID='not-a-uuid'; claude\""
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command) == nil)
+        // Truncated: the anchor is there but the quote never closes.
+        #expect(TmuxManager.resolvePaneTerminalID(
+            paneOption: "", startCommand: "export TBD_TERMINAL_ID='\(Self.plantedID)") == nil)
+    }
+
+    /// The pane-option path never reaches the start-command parser, so no
+    /// amount of user text in the command can influence a stamped pane.
+    @Test("the stamped pane option is unaffected by decoys in the start command")
+    func resolveStampWinsOverDecoys() {
+        let command = "/bin/zsh -ic \"export TBD_PROMPT_INSTRUCTIONS='"
+            + "export TBD_TERMINAL_ID=\(Self.plantedID)'; export TBD_TERMINAL_ID='"
+            + "11111111-2222-3333-4444-555555555555'; claude\""
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "STAMPED", startCommand: command)
+            == "STAMPED")
     }
 }


### PR DESCRIPTION
Follow-up to #595, which merged before this was caught. The bug it fixes is **live on `main`** at `TmuxManager.swift:474`.

## What's broken

#595 identifies a tmux pane by reading `TBD_TERMINAL_ID` back out of `#{pane_start_command}`, for any pane not yet carrying the `@tbd_terminal_id` option — which today is every pre-existing terminal. That lookup is an **unanchored** `range(of: "TBD_TERMINAL_ID=")` taking the first hit.

Three facts make that exploitable by ordinary content:

- `newWindowCommand` inlines the env map as `export KEY='value'; ` prefixes, **sorted alphabetically by key**.
- `TBD_PROMPT_INSTRUCTIONS` carries per-repo `customInstructions` — arbitrary user-authored free text (`SystemPromptBuilder.swift:69`).
- `TBD_PROMPT_INSTRUCTIONS` sorts *before* `TBD_TERMINAL_ID`, so it lands earlier in the command string.

A repo whose custom instructions contain the literal `TBD_TERMINAL_ID=` therefore makes the parser read that text as the pane's identity. The pane then disagrees with the terminal that owns it and is **refused as a stranger for the entire remaining life of the window** — until something recreates it.

This is a false refusal of a healthy pane: the exact regression #595's design set out to forbid, in the one branch that exists so pre-stamp panes keep working. It inverts that branch's whole purpose.

## Provenance

Introduced by #595 itself (merged `1bc3fafc`, ~4 minutes before the review that caught it landed). Not a latent flaw — the fallback is new code. It escaped the first review pass because the parser was tested against well-formed start commands only; nothing exercised a command carrying *other* user-controlled env values, which is precisely where the collision lives.

## What this PR does

Anchors the search on the exact assignment both spawn builders emit — `export TBD_TERMINAL_ID='` — and requires the extracted value to parse as a `UUID`. Anything else resolves to `nil`, meaning "this pane gives no answer", so the send proceeds. Fail-open stays the direction, unchanged.

**Scans all occurrences and takes the first valid UUID**, rather than only the first anchored match. The two differ when instructions contain the anchor with a non-UUID value — which shell quote-escaping produces naturally, since an embedded `'` closes and reopens the quoting and can leave a complete anchor behind. Scanning recovers the real id further along the string where first-match-only would give up and fail open. It can never accept anything first-match would reject, because both validate identically: same safety, more panes correctly identified.

Also drops the unquoted `TBD_TERMINAL_ID=value` branch. Neither builder has ever emitted that shape, so it recognized nothing TBD actually plants while widening the very surface this bug came through.

A residual adversarial case is documented in the doc comment: instructions containing a full `export TBD_TERMINAL_ID='<valid-uuid>'`. It can only cause a false *refusal*, never a false *accept* — and the false accept is the dangerous direction, since that is what types into a stranger.

## Test plan

- [x] Instructions containing the bare literal `TBD_TERMINAL_ID=` no longer poison resolution — the real id still resolves
- [x] Instructions containing a *quoted garbage* decoy likewise do not poison it
- [x] A non-UUID value in the real slot resolves to `nil` (proceeds), not to garbage
- [x] The healthy case still resolves; the `@tbd_terminal_id` pane-option path is unaffected and still takes precedence
- [x] Both `newWindowCommand` and `respawnWindowCommand` emit the anchor — pinned by a test, since the resolver's narrowness is only safe while that holds
- [x] Mutation-checked: restoring the unanchored search reddens 3 tests / 4 issues — the bare decoy resolving `nil`, the quoted decoy resolving an escaping artifact and then `"decoy"`, and a non-UUID resolving as if it were an id
- [x] Full suite: 5201 tests in 560 suites passing; `swiftlint --strict` clean in 675 files, `.swiftlint.yml` untouched

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=DBCFE501-2BAF-4573-8625-304825DE975A)