### PR TITLE
Fix: stop terminal wake claiming "already awake" without asking tmux

### DIFF
--- a/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationOutcome+Park.swift
@@ -42,6 +42,15 @@ extension ActuationOutcome {
         case .inFlight: return .refused(.inFlight)
         // The terminal row is gone, or the directory its worktree named is.
         case .notFound, .worktreeMissing: return .refused(.notFound)
+        // The row claims awake but its pane disagrees. A stale coordinate that
+        // resolved to a live stranger is `targetMismatch` — the one reason that
+        // can say so; a gone or exited pane is the named target genuinely being
+        // absent.
+        case .sessionGone(_, let detail):
+            switch detail {
+            case .paneBelongsToAnotherTerminal: return .refused(.targetMismatch)
+            case .paneMissing, .processExited: return .refused(.notFound)
+            }
         // The row is there but cannot be woken as asked: nothing to resume, or
         // the profile it was pinned to no longer exists.
         case .noSessionID, .profileMissing: return .refused(.notEligible)
@@ -57,6 +66,13 @@ extension ActuationOutcome {
         case .noSessionID: return "No session ID to resume"
         case .respawnFailed(let reason): return reason
         case .worktreeMissing(let path): return "Worktree directory missing on disk: \(path)"
+        case .sessionGone(let paneID, let detail):
+            switch detail {
+            case .paneMissing: return "Pane \(paneID) is gone"
+            case .processExited: return "Pane \(paneID) survives but its process exited"
+            case .paneBelongsToAnotherTerminal(let actual):
+                return "Pane \(paneID) answers with a different terminal: \(actual)"
+            }
         case .profileMissing(let profileID):
             return "Profile no longer exists: \(profileID.uuidString)"
         }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -11,9 +11,33 @@ public enum HibernateResult: Equatable, Sendable {
     case notFound
 }
 
+/// How an unparked terminal's pane disagreed with the row that claims it is
+/// awake. Only states tmux gave a positive answer for appear here; "the probe
+/// failed" is deliberately not a case, because it is not a disagreement.
+public enum UnparkedPaneDisagreement: Equatable, Sendable {
+    /// tmux cannot find the pane — it, its window, or the whole server is gone.
+    case paneMissing
+    /// The pane object survives (`remain-on-exit`) but its process has exited,
+    /// so the row's "awake" refers to a shell, not a session.
+    case processExited
+    /// The pane is alive but answers with a DIFFERENT terminal's id: this row's
+    /// coordinate went stale and now points at a stranger's pane after tmux
+    /// reused the id (#384). Someone else's live pane is not evidence that this
+    /// session is healthy.
+    case paneBelongsToAnotherTerminal(actualTerminalID: String)
+}
+
 public enum WakeResult: Equatable, Sendable {
     case ok
     case notHibernated   // idempotent no-op: nothing to wake
+    /// The row is NOT parked — TBD believes this terminal is awake — but its
+    /// pane says otherwise, so there is no live session for an "already awake"
+    /// answer to refer to. `detail` names which way it disagreed. Distinct from
+    /// `.notHibernated` so a caller can tell a benign idempotent no-op from a
+    /// terminal that needs recovery, and so a dropped `prompt` is reported
+    /// rather than silently discarded. Nothing is respawned — see
+    /// `classifyUnparkedWake` for why repair is a separate change.
+    case sessionGone(paneID: String, detail: UnparkedPaneDisagreement)
     case notFound        // terminal/worktree DB row missing — NOT tmux failures
     case noSessionID
     case inFlight        // a wake for this terminal is already respawning
@@ -480,14 +504,85 @@ public actor HibernationCoordinator {
 
     // MARK: - Wake
 
+    /// Answer a wake aimed at a row TBD believes is already awake.
+    ///
+    /// The previous answer was an unconditional `.notHibernated` — "already
+    /// awake, nothing to do" — read straight off the DB parked flags. That is
+    /// a claim about a live tmux session made without ever looking at tmux,
+    /// and on a fleet it is often false: a window dies (server restart,
+    /// `kill-window`, a crash) without anything clearing the row. Measured on
+    /// a live fleet, 34 of 49 rows the DB called awake had no pane. The caller
+    /// then got neither a wake nor an error, and any `initialPrompt` was
+    /// silently dropped.
+    ///
+    /// So ask — using the SAME probe `terminal.send` asks with
+    /// (`TmuxManager.paneSendTarget`), rather than adding a second liveness
+    /// primitive that would drift from it. That probe already answers both
+    /// halves of the question: is a process there, and is the pane still ours.
+    ///
+    /// Only a POSITIVE disagreement downgrades the answer, exactly as on the
+    /// send path. A probe that merely threw keeps the benign historical no-op:
+    /// a failed tmux call proves nothing, and tmux calls fail spuriously
+    /// precisely when the machine is loaded enough for the session to be alive.
+    /// A pane carrying no identity at all is likewise left alone.
+    ///
+    /// This reports; it deliberately does NOT repair. Respawning an unparked
+    /// row would make tmux authoritative over the parked flag, and then one
+    /// false-negative probe destroys a live session's in-flight work.
+    /// Auto-recovery needs a human design decision and is tracked in #586, not
+    /// decided here. Recovery today stays the parked-row path below and the
+    /// explicit `terminal.recreateWindow` RPC.
+    private func classifyUnparkedWake(_ terminal: Terminal) async -> WakeResult {
+        // No worktree row means no server name to probe with — nothing can be
+        // proven, so keep the benign historical answer.
+        guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+            return .notHibernated
+        }
+        let target: PaneSendTarget
+        do {
+            target = try await tmux.paneSendTarget(
+                server: worktree.tmuxServer, paneID: terminal.tmuxPaneID)
+        } catch {
+            // Couldn't ask. Fail closed to the benign answer.
+            return .notHibernated
+        }
+
+        let disagreement: UnparkedPaneDisagreement
+        switch target {
+        case .live(let paneTerminalID):
+            // No identity to compare, or it agrees — the historical no-op.
+            guard let paneTerminalID,
+                  paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString) != .orderedSame
+            else { return .notHibernated }
+            disagreement = .paneBelongsToAnotherTerminal(actualTerminalID: paneTerminalID)
+        case .missing:
+            disagreement = .paneMissing
+        case .dead:
+            disagreement = .processExited
+        }
+
+        logger.warning("""
+            wake: terminal \(terminal.id, privacy: .public) is unparked but its pane \
+            \(terminal.tmuxPaneID, privacy: .public) on server \
+            \(worktree.tmuxServer, privacy: .public) disagrees \
+            (\(String(describing: disagreement), privacy: .public)) — reporting sessionGone \
+            instead of "already awake"
+            """)
+        return .sessionGone(paneID: terminal.tmuxPaneID, detail: disagreement)
+    }
+
     /// Respawn `claude --resume <sessionID>` in the hibernated terminal's
     /// kept-alive window. Idempotent: a non-hibernated terminal is a no-op, and
     /// concurrent wakes for the same terminal collapse to one respawn.
     ///
-    /// If the window is GONE (killed, or the whole tmux server died — e.g. a
-    /// machine reboot), the window is recreated (ensureServer + createWindow)
-    /// and the same resume command spawned there; the terminal row keeps its
-    /// identity and gets the new window/pane ids persisted.
+    /// For a PARKED row whose window is GONE (killed, or the whole tmux server
+    /// died — e.g. a machine reboot), the window is recreated (ensureServer +
+    /// createWindow) and the same resume command spawned there; the terminal
+    /// row keeps its identity and gets the new window/pane ids persisted.
+    ///
+    /// That recovery covers parked rows ONLY, because it lives downstream of
+    /// the parked check below. An UNPARKED row whose session died is reported
+    /// (`.sessionGone`) but not repaired — see `classifyUnparkedWake`.
     public func wake(terminalID: UUID, cols: Int? = nil, rows: Int? = nil, allowDefaultProfileFallback: Bool = false, initialPrompt: String? = nil) async -> WakeResult {
         guard let terminal = try? await db.terminals.get(id: terminalID) else {
             return .notFound
@@ -495,7 +590,7 @@ public actor HibernationCoordinator {
         // Wake ANY parked row, not just `hibernatedAt`-marked ones: legacy rows
         // and the reconcile / recreate-window paths may carry only `suspendedAt`.
         // `clearHibernated` nils both columns, so this fully un-parks either.
-        guard terminal.isParked else { return .notHibernated }
+        guard terminal.isParked else { return await classifyUnparkedWake(terminal) }
         guard let sessionID = terminal.claudeSessionID else { return .noSessionID }
         guard !wakesInFlight.contains(terminalID) else { return .inFlight }
         guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -533,8 +533,19 @@ public actor HibernationCoordinator {
     /// decided here. Recovery today stays the parked-row path below and the
     /// explicit `terminal.recreateWindow` RPC.
     private func classifyUnparkedWake(_ terminal: Terminal) async -> WakeResult {
-        // No worktree row means no server name to probe with — nothing can be
-        // proven, so keep the benign historical answer.
+        // No worktree row means no server name to probe with, so nothing can be
+        // proven and the benign historical answer stands.
+        //
+        // The parked path returns `.notFound` for this same condition, and the
+        // asymmetry is deliberate rather than an oversight. There, the missing
+        // worktree blocks an action the caller asked for, so it has to be
+        // reported. Here it blocks only a *diagnosis*: the caller asked to wake
+        // something the row already calls awake, and failing to look it up is
+        // not evidence that the session is dead. Reporting `.notFound` would
+        // turn "I couldn't check" into "your terminal is gone" — the same
+        // conflation this whole change exists to remove. Practically
+        // unreachable either way: `terminal.worktreeID` is a cascading foreign
+        // key, so a terminal row outliving its worktree does not happen.
         guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
             return .notHibernated
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+HibernationHandlers.swift
@@ -3,6 +3,30 @@ import TBDShared
 
 extension RPCRouter {
 
+    /// The message for a wake aimed at an unparked row whose pane disagrees.
+    /// Shared by `terminal.wake` and `terminal.resume` so the two verbs cannot
+    /// describe the same state differently. Always names
+    /// `tbd terminal conversation`, which still reads a dead session's messages
+    /// — context can be rebuilt before the terminal is closed.
+    static func unparkedWakeMessage(
+        paneID: String, detail: UnparkedPaneDisagreement
+    ) -> String {
+        let cause: String
+        switch detail {
+        case .paneMissing:
+            cause = "its tmux pane (\(paneID)) is gone"
+        case .processExited:
+            cause = "its tmux pane (\(paneID)) is still there but its process has exited"
+        case .paneBelongsToAnotherTerminal(let actual):
+            cause = "its pane coordinate (\(paneID)) now points at a different terminal (\(actual))"
+        }
+        return """
+            TBD's row says this terminal is awake, but \(cause) — so nothing was woken and any \
+            prompt was NOT delivered. Its conversation is still readable with `tbd terminal \
+            conversation <id>`, so context can be rebuilt before closing it.
+            """
+    }
+
     /// `terminal.hibernate` — manually hibernate one Claude terminal (kill its
     /// process, keep the tmux window). Honors the running/permission rails.
     func handleTerminalHibernate(
@@ -58,6 +82,14 @@ extension RPCRouter {
             // autonomous callers know their `prompt` was NOT delivered (the
             // terminal is live; pasting into it now could hit a human session).
             return try RPCResponse(result: TerminalWakeResult(woken: false))
+        case .sessionGone(let paneID, let detail):
+            // NOT a benign no-op: the row claims awake but its pane disagrees,
+            // so there was nothing live to deliver `prompt` to. An error (not
+            // `woken: false`) is what lets an autonomous caller tell this apart
+            // from "already awake and healthy".
+            return RPCResponse(
+                error: RPCRouter.unparkedWakeMessage(paneID: paneID, detail: detail),
+                code: RPCErrorCode.terminalSessionGone.rawValue)
         case .notFound:
             return RPCResponse(error: "Terminal not found")
         case .noSessionID:

--- a/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ManualSuspendHandlers.swift
@@ -60,6 +60,12 @@ extension RPCRouter {
         case .ok, .notHibernated, .inFlight:
             // notHibernated / inFlight are benign no-ops for an idempotent wake.
             return .ok()
+        case .sessionGone(let paneID, let detail):
+            // Not benign: the row claims awake but its pane disagrees, so this
+            // resume reached nothing. Same honest answer as `terminal.wake`.
+            return RPCResponse(
+                error: RPCRouter.unparkedWakeMessage(paneID: paneID, detail: detail),
+                code: RPCErrorCode.terminalSessionGone.rawValue)
         case .notFound:
             return RPCResponse(error: "Terminal not found")
         case .noSessionID:

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -108,6 +108,12 @@ public enum RPCErrorCode: String, Sendable {
     /// terminal is mid-turn or holding a permission prompt AND its window is
     /// still alive. The CLI maps this to exit 2; `--force` drops the rails.
     case terminalBusy
+    /// A `terminal.wake` was aimed at a row TBD believes is awake whose pane
+    /// positively disagrees — it is gone, its process exited, or it answers
+    /// with another terminal's id. Reported as an error rather than the benign
+    /// `woken: false` no-op, because there is no live session behind the row:
+    /// the caller's `prompt` went nowhere and the terminal needs recovery.
+    case terminalSessionGone
 }
 
 // MARK: - RPC Method Names

--- a/Tests/TBDDaemonTests/ActuationLogTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTests.swift
@@ -210,6 +210,22 @@ struct ActuationLogTests {
         #expect(ActuationOutcome.classify(WakeResult.noSessionID) == .refused(.notEligible))
         #expect(ActuationOutcome.classify(WakeResult.profileMissing(profileID: UUID()))
             == .refused(.notEligible))
+
+        // A row that claims awake whose pane disagrees. The two shapes must not
+        // collapse onto one reason: a gone or exited pane is the named target
+        // genuinely being absent, while a stale coordinate that resolved to a
+        // live STRANGER is the case `targetMismatch` was added for — calling
+        // that one `notFound` would claim a target is missing when a perfectly
+        // healthy other one answered.
+        #expect(ActuationOutcome.classify(
+            WakeResult.sessionGone(paneID: "%0", detail: .paneMissing)) == .refused(.notFound))
+        #expect(ActuationOutcome.classify(
+            WakeResult.sessionGone(paneID: "%0", detail: .processExited)) == .refused(.notFound))
+        #expect(ActuationOutcome.classify(
+            WakeResult.sessionGone(
+                paneID: "%0",
+                detail: .paneBelongsToAnotherTerminal(actualTerminalID: UUID().uuidString)))
+            == .refused(.targetMismatch))
     }
 
     // MARK: - Rotation

--- a/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogWiringTests.swift
@@ -20,22 +20,26 @@ struct ActuationLogWiringTests {
         let logPath: String
     }
 
-    private func makeFixture(logPath: String? = nil) throws -> Fixture {
+    private func makeFixture(
+        logPath: String? = nil,
+        paneTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil
+    ) throws -> Fixture {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-actuation-wiring-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let path = logPath ?? directory.appendingPathComponent("actuations.jsonl").path
 
         let db = try TBDDatabase(inMemory: true)
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: paneTarget)
         let router = RPCRouter(
             db: db,
             lifecycle: WorktreeLifecycle(
                 db: db,
                 git: GitManager(),
-                tmux: TmuxManager(dryRun: true),
+                tmux: tmux,
                 hooks: HookResolver()
             ),
-            tmux: TmuxManager(dryRun: true),
+            tmux: tmux,
             startTime: Date(),
             actuationLog: ActuationLog(path: path)
         )
@@ -304,6 +308,46 @@ struct ActuationLogWiringTests {
         // not a decline the operator's controls made.
         #expect(written.last?["result"] as? String == "refused")
         #expect(written.last?["reason"] as? String == "noop")
+    }
+
+    /// A wake at a row that claims awake but whose pane is GONE must land in
+    /// the record as `not-found`, not the benign `noop` above. The two are one
+    /// character apart in the JSONL and mean opposite things to anyone auditing
+    /// what the daemon actually did.
+    @Test("a wake at a vanished pane records not-found, not the benign no-op")
+    func wakeAtMissingPaneRecordsNotFound() async throws {
+        let fixture = try makeFixture(paneTarget: { _, _ in .missing })
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        _ = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id)))
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.last?["result"] as? String == "refused")
+        #expect(written.last?["reason"] as? String == "not-found")
+    }
+
+    /// Pane-id reuse (#384): the coordinate resolved to a live STRANGER. The
+    /// record has to be able to say that happened — `not-found` would claim the
+    /// named target is gone when a healthy other one answered.
+    @Test("a wake whose pane answers as another terminal records target-mismatch")
+    func wakeAtReusedPaneRecordsTargetMismatch() async throws {
+        let stranger = UUID().uuidString
+        let fixture = try makeFixture(paneTarget: { _, _ in .live(terminalID: stranger) })
+        let worktree = try await makeWorktree(in: fixture.db)
+        let terminal = try await fixture.db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@1", tmuxPaneID: "%1")
+
+        _ = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id)))
+
+        let written = try rows(at: fixture.logPath)
+        #expect(written.last?["result"] as? String == "refused")
+        #expect(written.last?["reason"] as? String == "target-mismatch")
     }
 
     @Test("worktree.resume fans out one row per parked terminal")

--- a/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
@@ -62,4 +62,108 @@ import TestSupport
         #expect(cfg.autoHibernateOnMergeDefault == true)
         _ = db
     }
+
+    // MARK: - terminal.wake honesty on a row that claims awake
+
+    /// Router whose tmux reports the pane as gone — the exact live-fleet state
+    /// where the DB says awake and no pane exists.
+    private func makeRouter(paneTarget: @escaping @Sendable (String, String) throws -> PaneSendTarget)
+        throws -> (RPCRouter, TBDDatabase) {
+        let db = try TBDDatabase(inMemory: true)
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: paneTarget)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: makeTestActuationLog()
+        )
+        return (router, db)
+    }
+
+    private func makeUnparkedTerminal(_ db: TBDDatabase, tag: String) async throws -> Terminal {
+        let repo = try await db.repos.create(
+            path: "/tmp/\(tag)-\(UUID().uuidString)", displayName: tag, defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/\(tag)-w-\(UUID().uuidString)", tmuxServer: "s")
+        return try await db.terminals.create(
+            worktreeID: wt.id, tmuxWindowID: "@0", tmuxPaneID: "%0",
+            label: "claude", claudeSessionID: "sess-1", kind: .claude)
+    }
+
+    /// The reported failure, at the level it was actually hit: `terminal.wake`
+    /// on a row that claims awake but has no pane must NOT come back as a
+    /// successful no-op. It carries a machine-readable code so an autonomous
+    /// caller can branch without matching message text.
+    @Test func wakeOnUnparkedRowWithNoPaneIsAnErrorNotASilentNoOp() async throws {
+        let (router, db) = try makeRouter(paneTarget: { _, _ in .missing })
+        let terminal = try await makeUnparkedTerminal(db, tag: "repoW")
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id, prompt: "do the thing"))
+        let resp = await router.handle(req)
+
+        #expect(!resp.success, "a wake that reached no live session must not report success")
+        #expect(resp.errorCode == RPCErrorCode.terminalSessionGone.rawValue)
+        // The caller's prompt went nowhere, and the message has to say so.
+        #expect(resp.error?.contains("NOT delivered") == true,
+                "expected the dropped prompt to be reported; got: \(resp.error ?? "nil")")
+        // The recovery that works is named, so the session's context is not lost.
+        #expect(resp.error?.contains("tbd terminal conversation") == true)
+    }
+
+    /// Pane-id reuse (#384) at the RPC level: a live pane answering with a
+    /// different terminal's id is a refusal, not evidence of health.
+    @Test func wakeOnUnparkedRowWhosePaneAnswersAsAnotherTerminalIsAnError() async throws {
+        let stranger = UUID().uuidString
+        let (router, db) = try makeRouter(paneTarget: { _, _ in .live(terminalID: stranger) })
+        let terminal = try await makeUnparkedTerminal(db, tag: "repoW3")
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id))
+        let resp = await router.handle(req)
+
+        #expect(!resp.success)
+        #expect(resp.errorCode == RPCErrorCode.terminalSessionGone.rawValue)
+        #expect(resp.error?.contains(stranger) == true,
+                "the message should name the terminal that actually answered")
+    }
+
+    /// The other branch: a live pane keeps the benign idempotent no-op —
+    /// success with `woken: false`, exactly as before.
+    @Test func wakeOnUnparkedRowWithLivePaneStaysASuccessfulNoOp() async throws {
+        let (router, db) = try makeRouter(paneTarget: { _, _ in .live(terminalID: nil) })
+        let terminal = try await makeUnparkedTerminal(db, tag: "repoW2")
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id))
+        let resp = await router.handle(req)
+
+        #expect(resp.success)
+        let payload = try #require(resp.result?.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(TerminalWakeResult.self, from: payload)
+        #expect(decoded.woken == false)
+    }
+
+    /// Fail-closed at the RPC level too: a probe that threw keeps the benign
+    /// successful no-op rather than reporting a dead terminal.
+    @Test func wakeOnUnparkedRowWithUnreadablePaneStaysASuccessfulNoOp() async throws {
+        let (router, db) = try makeRouter(paneTarget: { _, _ in
+            throw TmuxError.timedOut(command: "tmux list-panes", timeout: .seconds(15))
+        })
+        let terminal = try await makeUnparkedTerminal(db, tag: "repoW4")
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalWake,
+            params: TerminalWakeParams(terminalID: terminal.id))
+        let resp = await router.handle(req)
+
+        #expect(resp.success, "an unreadable probe must not be reported as a dead terminal")
+    }
+
 }

--- a/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
+++ b/Tests/TBDDaemonTests/AutoHibernateRPCTests.swift
@@ -150,6 +150,36 @@ import TestSupport
         #expect(decoded.woken == false)
     }
 
+    /// The legacy `terminal.resume` shim (still reachable from older CLI and
+    /// app builds) must give the same honest answer as `terminal.wake` — it
+    /// routes through the same coordinator, so a silent no-op here would be the
+    /// original bug surviving at the other entry point.
+    @Test func legacyResumeOnUnparkedRowWithNoPaneIsAnErrorNotASilentNoOp() async throws {
+        let (router, db) = try makeRouter(paneTarget: { _, _ in .missing })
+        let terminal = try await makeUnparkedTerminal(db, tag: "repoW5")
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalResume,
+            params: TerminalResumeParams(terminalID: terminal.id))
+        let resp = await router.handle(req)
+
+        #expect(!resp.success, "terminal.resume must not report success into a dead session")
+        #expect(resp.errorCode == RPCErrorCode.terminalSessionGone.rawValue)
+        #expect(resp.error?.contains("tbd terminal conversation") == true)
+    }
+
+    /// The benign arm of the same shim: a live pane keeps `terminal.resume`'s
+    /// historical success.
+    @Test func legacyResumeOnUnparkedRowWithLivePaneStaysSuccessful() async throws {
+        let (router, db) = try makeRouter(paneTarget: { _, _ in .live(terminalID: nil) })
+        let terminal = try await makeUnparkedTerminal(db, tag: "repoW6")
+
+        let req = try RPCRequest(
+            method: RPCMethod.terminalResume,
+            params: TerminalResumeParams(terminalID: terminal.id))
+        #expect(await router.handle(req).success)
+    }
+
     /// Fail-closed at the RPC level too: a probe that threw keeps the benign
     /// successful no-op rather than reporting a dead terminal.
     @Test func wakeOnUnparkedRowWithUnreadablePaneStaysASuccessfulNoOp() async throws {

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -379,6 +379,123 @@ struct HibernationCoordinatorTests {
                 "a non-parked wake must not touch tmux; got: \(recorded.snapshot())")
     }
 
+    // MARK: - Unparked rows: "already awake" must be a provable claim
+
+    /// The bug this section exists to fix. The row is unparked — TBD believes
+    /// the terminal is awake — but its pane is gone. The old answer was an
+    /// unconditional `.notHibernated` ("already awake, no-op"), a claim about a
+    /// live session made without ever asking tmux.
+    @Test func wakeOnUnparkedRowWithMissingPaneReportsSessionGone() async throws {
+        let (db, _, terminalID) = try await setup()
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in .missing })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.wake(terminalID: terminalID)
+                == .sessionGone(paneID: "%0", detail: .paneMissing))
+    }
+
+    /// A pane that outlived its process (`remain-on-exit`) is just as dishonest
+    /// a basis for "already awake" as a missing one — the row refers to a shell.
+    @Test func wakeOnUnparkedRowWithExitedProcessReportsSessionGone() async throws {
+        let (db, _, terminalID) = try await setup()
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in .dead })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.wake(terminalID: terminalID)
+                == .sessionGone(paneID: "%0", detail: .processExited))
+    }
+
+    /// Pane-id reuse (#384): the row's coordinate now names a live STRANGER.
+    /// Someone else's healthy pane is not evidence this session is alive.
+    @Test func wakeOnUnparkedRowWhosePaneBelongsToAnotherTerminalReportsSessionGone() async throws {
+        let (db, _, terminalID) = try await setup()
+        let stranger = UUID().uuidString
+        let tmux = TmuxManager(dryRun: true,
+                               dryRunPaneSendTarget: { _, _ in .live(terminalID: stranger) })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.wake(terminalID: terminalID)
+                == .sessionGone(paneID: "%0",
+                                detail: .paneBelongsToAnotherTerminal(actualTerminalID: stranger)))
+    }
+
+    /// Reporting only — `.sessionGone` must never respawn or recreate. Making
+    /// tmux authoritative over the parked flag is the separate, riskier change
+    /// this deliberately stops short of (#586).
+    @Test func sessionGoneReportsWithoutMutatingTmuxOrTheRow() async throws {
+        let (db, _, terminalID) = try await setup()
+        let recorded = RecordedTmuxCommands()
+        let tmux = TmuxManager(dryRun: true, dryRunRecorder: { recorded.append($0) },
+                               dryRunPaneSendTarget: { _, _ in .missing })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        _ = await coord.wake(terminalID: terminalID)
+        let joined = recorded.snapshot().map { $0.joined(separator: " ") }
+        #expect(!joined.contains { $0.contains("respawn-window") || $0.contains("new-window") },
+                "sessionGone must not respawn or recreate anything; got: \(joined)")
+        let after = try await db.terminals.get(id: terminalID)
+        #expect(after?.isParked == false)
+        #expect(after?.tmuxPaneID == "%0")
+    }
+
+    /// The safety property that makes this shippable without a spec. A probe
+    /// that merely FAILED proves nothing, so it must keep the benign historical
+    /// answer — never be read as a dead terminal. tmux calls fail spuriously
+    /// exactly when the box is loaded enough for the session to be alive.
+    @Test func unreadablePaneProbeFailsClosedToBenignNoOp() async throws {
+        let (db, _, terminalID) = try await setup()
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in
+            throw TmuxError.timedOut(command: "tmux list-panes", timeout: .seconds(15))
+        })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.wake(terminalID: terminalID) == .notHibernated)
+    }
+
+    /// A live pane carrying no identity is left alone — refusal requires
+    /// POSITIVE disagreement, the same rule the send path follows.
+    @Test func wakeOnUnparkedRowWithLivePaneStaysBenignNoOp() async throws {
+        let (db, _, terminalID) = try await setup()
+        let tmux = TmuxManager(dryRun: true,
+                               dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.wake(terminalID: terminalID) == .notHibernated)
+    }
+
+    /// A pane that answers with THIS terminal's own id agrees, so the row's
+    /// "awake" is supported and the benign no-op stands.
+    @Test func wakeOnUnparkedRowWhosePaneAgreesStaysBenignNoOp() async throws {
+        let (db, _, terminalID) = try await setup()
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in
+            .live(terminalID: terminalID.uuidString)
+        })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.wake(terminalID: terminalID) == .notHibernated)
+    }
+
+    /// A parked row still takes the existing recovery path, not the new
+    /// reporting one — `.sessionGone` is reachable only from the unparked gate.
+    @Test func parkedRowWithGoneWindowStillRecoversRatherThanReporting() async throws {
+        let (db, _, terminalID) = try await setup()
+        try await db.terminals.setHibernated(id: terminalID, sessionID: "sess-1")
+        let tmux = TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true },
+                               dryRunPaneSendTarget: { _, _ in .missing })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.wake(terminalID: terminalID) == .ok)
+        #expect(try await db.terminals.get(id: terminalID)?.isParked == false)
+    }
+
     @Test func wakeUnknownTerminalNotFound() async throws {
         let (db, _, _) = try await setup()
         let result = await coordinator(db).wake(terminalID: UUID())

--- a/docs/tmux-integration.md
+++ b/docs/tmux-integration.md
@@ -174,3 +174,35 @@ window the send has to select its own pane's line rather than the first one.
 was never the signal; and pane ids are reused, so a stale DB coordinate used to
 type into a live stranger (issue #384). Refusal requires *positive*
 disagreement — a pane carrying no identity is sent to as before.
+
+### `terminal wake` answered the same question without asking
+
+`terminal.wake` decided "is there anything to wake?" from the database's parked
+flags alone, and answered "already awake (no-op)" whenever they were clear.
+That is a claim about a live session made without consulting tmux. Measured on
+a live fleet, **34 of 49** rows the database called awake had no pane. Because
+a wake no-op never delivers its `--prompt`, an autonomous caller got neither a
+wake nor an error.
+
+Wake now asks the same question `terminal.send` asks, through the same
+`paneSendTarget` probe, and reports what it finds:
+
+- **`.missing` / `.dead`** — no live session behind the row. Wake returns an
+  error naming the state instead of a successful no-op, so a caller can tell a
+  benign "already awake" from a terminal that needs recovery.
+- **`.live` answering a different terminal's id** — the row's pane coordinate
+  has gone stale and now points at a stranger's pane (#384). Also an error;
+  wake must not treat someone else's live pane as evidence that this session is
+  healthy.
+- **`.live` with a matching id, or none at all** — the benign no-op, unchanged.
+  As with send, refusal requires *positive* disagreement.
+- **The probe threw** — unchanged benign no-op. A tmux call that merely failed
+  proves nothing, and tmux calls fail spuriously exactly when the machine is
+  loaded enough for the session to be alive.
+
+**Wake reports here; it does not repair.** Respawning a row the database calls
+awake would make tmux authoritative over the parked flag, and one false-negative
+probe would then destroy a live session's in-flight work. Recovery stays the
+parked-row path and the explicit `terminal.recreateWindow` RPC. Reusing send's
+probe rather than adding a second one is deliberate: two liveness primitives
+would drift, and this is the one that already carries pane identity.


### PR DESCRIPTION
Fixes the reporting half of #586.

## The invariant

**`terminal.wake` may only answer "already awake" about a session it can show is there.**

It previously answered from the database alone:

```swift
// HibernationCoordinator.swift (before)
guard terminal.isParked else { return .notHibernated }
```

`.notHibernated` becomes `woken: false`, which the CLI prints as `Terminal already awake (no-op)`. That is a claim about a live session made without ever looking at tmux — and on a fleet it is frequently false. Measured on a live fleet (#586): of 49 rows the database considered awake, **34 had no matching pane**. Because a wake no-op never delivers its `--prompt` (documented behaviour), an autonomous caller got neither a wake nor an error.

The recovery that would have fixed those rows already exists and is good — it recreates the window and respawns `claude --resume`. But it lives *downstream* of the guard that just refused, so it only ever covered parked rows. The `wake()` docstring promised the killed-window case was handled; that promise held for half the states it appeared to cover. Corrected here.

## It reuses #595's probe rather than adding a second one

This started with its own tri-state window probe. **#595** landed while it was in review and made that the wrong shape: `terminal.send` now consults `TmuxManager.paneSendTarget` before typing, and that probe already answers both halves of the question wake needs — is a process there, and is the pane still ours. Two liveness primitives in one file would drift, and the one that already carries pane identity is the one to keep. So the parallel abstraction is gone and wake asks send's question.

That is also a strictly better question. `paneSendTarget` distinguishes `.dead` — the pane object survived `remain-on-exit` but its process exited — which a window-existence check cannot see at all, and which is just as dishonest a basis for "already awake": the row is referring to a shell.

## Where to start reading

`Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift` — `classifyUnparkedWake` is the whole change, and its doc comment carries the reasoning for what it deliberately does *not* do.

## What now refuses to proceed

One behaviour change, and it has an outage shape, so stating it plainly:

**A wake aimed at an unparked row whose pane positively disagrees is now an RPC error (`terminalSessionGone`) instead of a successful `woken: false`.** It previously exited 0 and printed a benign no-op.

- **CLI** — `tbd terminal wake` now exits non-zero for that terminal. A script looping wakes over many terminals will start failing on dead ones. That is the reported harm being surfaced, not a new fault: those wakes were already reaching nothing.
- **App** — automatic focus-wakes are `userInitiated: false` and stay silent (warning-logged only), which is the existing design so a reboot doesn't fire a modal per terminal. An explicit **Wake** now surfaces a message where it previously did nothing visible.
- The error names the recovery that works: `tbd terminal conversation <id>` still reads the dead session's messages, so context can be rebuilt before closing the tab.

## Fail direction

Refusal requires **positive disagreement** — the same rule #595 established for send:

- **`.missing` / `.dead`** — no live session behind the row. Error.
- **`.live` answering a different terminal's id** — the row's coordinate went stale and now names a stranger's pane after tmux reused the id (**#384**). Error: someone else's healthy pane is not evidence this session is alive. In the same #586 snapshot, two awake rows shared pane `%17` and two shared `%10`.
- **`.live` agreeing, or carrying no identity at all** — benign no-op, unchanged.
- **The probe threw** — benign no-op, unchanged. A tmux call that merely failed proves nothing, and tmux calls fail spuriously exactly when the machine is loaded enough for the session to be alive.

That last line is the property that makes this safe, and it is tested directly.

One inherited limitation, stated rather than papered over: `paneSendTarget` maps *any* `TmuxError.commandFailed` to `.missing`, so a non-"can't find" tmux failure that still exits non-zero would read as a gone pane. Timeouts — the failure mode load actually produces — throw instead, and land on the benign no-op. #595 already accepted this tradeoff for `send`, a *mutating* verb; wake's worst case is a misleading diagnostic.

## What this deliberately does not do

**It reports; it does not repair.** The tempting one-liner — consult the probe in the `isParked` guard and respawn — is not safe, and #586 argues that correctly: respawning an unparked row makes tmux authoritative over the parked flag, and one false-negative probe then destroys a **live** session's in-flight work.

Auto-recovery stays open in #586 (items 1, 2 and 4), along with a CLI surface for `terminal.recreateWindow`, which today has only GUI callers.

## Actuation record

The new append-only log (#593) gets the distinction rather than a flattened refusal: a stale coordinate resolving to a live stranger is `targetMismatch` — the reason added for exactly this case — while a gone or exited pane is `notFound`.

## Why no spec

Judged against the repo's blast-radius convention, and I changed my mind partway: my first read was "plain bug fix", #586's was "spec-then-flag". **#586 is right about auto-recovery** — it respawns processes and can mutate live sessions, so it needs a spec and a flag, and this PR does none of it.

What is left after removing that is a reporting change: it starts no process, kills no process, and writes no state. Its worst case under a wrong probe is a misleading diagnostic, not a destroyed session. That is #586's own item 3, described there as "the cheapest honest first step".

Flagging it default-off would also invert the point: the flag-off branch is the behaviour that lies.

## Validation

- `scripts/swift-safe build` — `TBDDaemon`, `TBDApp`, `TBDCLI` all clean ✅
- `swiftlint --strict` — 0 violations in 675 files ✅
- `scripts/test.sh --filter '^TBDDaemonTests\.'` — **2481 tests in 257 suites passed** ✅ (the 1 "known issue" is the `FlakyQuarantineSelfTests` fixture for #499, which fails once by design every run)
- Commit SSH-signed ✅

Unlike #571, the suite **did** run on this host. The blocker there was the CommandLineTools toolchain having no Swift `Testing` module; the separately-installed 6.3.2 toolchain has it (`PATH=~/Library/Developer/Toolchains/swift-6.3.2-RELEASE.xctoolchain/usr/bin:$PATH`). One local-only caveat remains: `Tests/TBDAppTests/ArchiveTombstoneTests.swift` imports `XCTest`, which that toolchain lacks, so it has to be moved aside for a local run. It is untouched by this PR and CI compiles it fine.

**Mutation-checked.** Reverting the one-line gate back to `return .notHibernated` turns 5 tests red, and the failure output is the reported bug itself:

```
✘ wakeOnUnparkedRowWithNoPaneIsAnErrorNotASilentNoOp
  Expectation failed: !((resp → RPCResponse(success: true,
    result: Optional("{\"woken\":false}"), error: nil, errorCode: nil)).success)
```

## Tests added

Both arms of every new branch:

- `wakeOnUnparkedRowWithMissingPaneReportsSessionGone` — the defect.
- `wakeOnUnparkedRowWithExitedProcessReportsSessionGone` — the `remain-on-exit` shell case.
- `wakeOnUnparkedRowWhosePaneBelongsToAnotherTerminalReportsSessionGone` — pane-id reuse (#384).
- `unreadablePaneProbeFailsClosedToBenignNoOp` — the safety property: a thrown probe must never read as dead.
- `wakeOnUnparkedRowWithLivePaneStaysBenignNoOp` / `...WhosePaneAgreesStaysBenignNoOp` — no identity, and matching identity.
- `sessionGoneReportsWithoutMutatingTmuxOrTheRow` — no respawn, no recreate, row untouched.
- `parkedRowWithGoneWindowStillRecoversRatherThanReporting` — the existing parked-row recovery is unchanged.
- RPC level, where this was actually hit: `wakeOnUnparkedRowWithNoPaneIsAnErrorNotASilentNoOp`, `...WhosePaneAnswersAsAnotherTerminalIsAnError`, `...WithLivePaneStaysASuccessfulNoOp`, `...WithUnreadablePaneStaysASuccessfulNoOp`.

## Merge note

Rebased onto `1bc3faf` after #595 landed. Also overlaps **#597** mechanically in `docs/tmux-integration.md`; the code regions differ entirely (`resolvePaneTerminalID` there, the wake gate here), and #597 hardens the identity read this change now depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
