### PR TITLE
Refactor: one env-export builder, so a pane's identity guarantee can't drift apart

### DIFF
--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -216,17 +216,41 @@ public struct TmuxManager: Sendable {
         ["-L", server, "has-session", "-t", session]
     }
 
-    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil) -> [String] {
-        // Use shell -ic so commands with arguments work (e.g. "claude --dangerously-skip-permissions")
-        // -i keeps it interactive (loads .zshrc), -c runs the command
-        // After the command exits, the pane closes (tmux default behavior)
-        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+    /// Prefix `shellCommand` with one `export KEY='value'; ` per `env` entry,
+    /// sorted by key, single-quoting each value with the standard `'\''`
+    /// escape for an embedded quote.
+    ///
+    /// Shared by `newWindowCommand` and `respawnWindowCommand` deliberately.
+    /// `resolvePaneTerminalID` reads a pane's identity back out of exactly this
+    /// text, anchored on `terminalIDExportAnchor`, and that anchor is only safe
+    /// while every spawn path emits the identical shape. Two independently
+    /// maintained copies could drift and reopen the forgery hole on one path.
+    static func envExportPrefixed(_ shellCommand: String, env: [String: String]) -> String {
         var envPrefix = ""
         for (key, value) in env.sorted(by: { $0.key < $1.key }) {
             let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
             envPrefix += "export \(key)='\(escaped)'; "
         }
-        let fullCommand = envPrefix.isEmpty ? shellCommand : "\(envPrefix)\(shellCommand)"
+        return envPrefix.isEmpty ? shellCommand : "\(envPrefix)\(shellCommand)"
+    }
+
+    /// tmux `-e KEY=VALUE` flags, sorted by key. Shared by the two spawn
+    /// builders for the same reason as `envExportPrefixed`.
+    static func sensitiveEnvFlags(_ sensitiveEnv: [String: String]) -> [String] {
+        var eFlags: [String] = []
+        for (key, value) in sensitiveEnv.sorted(by: { $0.key < $1.key }) {
+            eFlags.append("-e")
+            eFlags.append("\(key)=\(value)")
+        }
+        return eFlags
+    }
+
+    public static func newWindowCommand(server: String, session: String, cwd: String, shellCommand: String, env: [String: String] = [:], sensitiveEnv: [String: String] = [:], cols: Int? = nil, rows: Int? = nil) -> [String] {
+        // Use shell -ic so commands with arguments work (e.g. "claude --dangerously-skip-permissions")
+        // -i keeps it interactive (loads .zshrc), -c runs the command
+        // After the command exits, the pane closes (tmux default behavior)
+        let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let fullCommand = envExportPrefixed(shellCommand, env: env)
         // `sensitiveEnv` carries values that must be in the spawned window's
         // PROCESS environment before the shell starts, via tmux's -e KEY=VALUE
         // flag — NOT inlined into the shell command argv like `env` above.
@@ -239,11 +263,7 @@ public struct TmuxManager: Sendable {
         //   - rc-affecting toggles (e.g. DISABLE_AUTO_UPDATE on hook panes):
         //     the `env` export-prefix runs after `.zshrc` completes, so only
         //     -e values are visible while rc files execute.
-        var eFlags: [String] = []
-        for (key, value) in sensitiveEnv.sorted(by: { $0.key < $1.key }) {
-            eFlags.append("-e")
-            eFlags.append("\(key)=\(value)")
-        }
+        let eFlags = sensitiveEnvFlags(sensitiveEnv)
         // Note: size flags (-x/-y) are intentionally NOT emitted here. tmux's
         // `new-window` does not support those flags (only `new-session`,
         // `split-window`, `resize-window`, and `resize-pane` do). The session's
@@ -259,8 +279,9 @@ public struct TmuxManager: Sendable {
     }
 
     /// Respawn (replace the running program of) an existing window's pane
-    /// IN PLACE, keeping the same window id and pane id. Mirrors
-    /// `newWindowCommand`'s env handling — the `env` map is inlined as an
+    /// IN PLACE, keeping the same window id and pane id. Shares
+    /// `newWindowCommand`'s env handling through `envExportPrefixed` and
+    /// `sensitiveEnvFlags` — the `env` map is inlined as an
     /// `export …; ` prefix on the shell command (runs AFTER rc files), while
     /// `sensitiveEnv` is passed via tmux `-e KEY=VALUE` so it's in the process
     /// environment before the shell starts (kept out of `ps aux`, and visible
@@ -279,17 +300,8 @@ public struct TmuxManager: Sendable {
         sensitiveEnv: [String: String] = [:]
     ) -> [String] {
         let userShell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
-        var envPrefix = ""
-        for (key, value) in env.sorted(by: { $0.key < $1.key }) {
-            let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
-            envPrefix += "export \(key)='\(escaped)'; "
-        }
-        let fullCommand = envPrefix.isEmpty ? shellCommand : "\(envPrefix)\(shellCommand)"
-        var eFlags: [String] = []
-        for (key, value) in sensitiveEnv.sorted(by: { $0.key < $1.key }) {
-            eFlags.append("-e")
-            eFlags.append("\(key)=\(value)")
-        }
+        let fullCommand = envExportPrefixed(shellCommand, env: env)
+        let eFlags = sensitiveEnvFlags(sensitiveEnv)
         return ["-L", server, "respawn-window", "-k", "-t", windowID, "-c", cwd]
             + eFlags
             + [userShell, "-ic", fullCommand]
@@ -457,9 +469,9 @@ public struct TmuxManager: Sendable {
     }
 
     /// The exact assignment shape `newWindowCommand` and `respawnWindowCommand`
-    /// emit for one entry of the `env` map. Both build the prefix identically,
-    /// so a pane spawned either way — including the in-place profile swap —
-    /// carries this literal.
+    /// emit for one entry of the `env` map. Both build the prefix from the one
+    /// shared `envExportPrefixed`, so a pane spawned either way — including the
+    /// in-place profile swap — carries this literal.
     static let terminalIDExportAnchor = "export TBD_TERMINAL_ID='"
 
     /// Which TBD terminal a pane says it is, or nil when the pane carries no
@@ -487,13 +499,29 @@ public struct TmuxManager: Sendable {
     /// the send proceed.
     ///
     /// Every occurrence of the anchor is scanned rather than just the first, so
-    /// instructions containing a quoted non-UUID decoy are stepped over and the
-    /// real id further along still resolves. Residual adversarial case:
-    /// instructions containing a complete `export TBD_TERMINAL_ID='<valid
-    /// uuid>'` would still be read first. That can only cause a false
-    /// *refusal* of a healthy pane, never a false *accept* — a stranger's pane
-    /// cannot be made to answer with this terminal's id, and the false accept
-    /// is the direction that would actually type into someone else's composer.
+    /// a decoy anchor earlier in the string is stepped over and the real id
+    /// further along still resolves.
+    ///
+    /// What a decoy anchor sitting inside an env *value* actually yields is
+    /// worth stating exactly, because it is never the decoy's own payload.
+    /// `envExportPrefixed` escapes an embedded `'` as `'\''`, so instructions
+    /// reading `export TBD_TERMINAL_ID='decoy'` are emitted as
+    /// `export TBD_TERMINAL_ID='\''decoy'\''`: the anchor consumes that first
+    /// quote and the value read is everything up to the next quote — a lone
+    /// backslash. A decoy that instead ends the env entry right at the `=`
+    /// reads as the `; export …=` text that always follows the entry's closing
+    /// quote. Neither parses as a `UUID`, so the scan steps past and finds the
+    /// real id. That guarantee comes from the escaping, not from the resolver,
+    /// which is why the two must stay coupled — see `envExportPrefixed`.
+    ///
+    /// Residual adversarial case: an *unescaped* complete
+    /// `export TBD_TERMINAL_ID='<valid uuid>'` earlier in the start command
+    /// would be read first. No `env` value can produce one, per the escaping
+    /// above, so it would have to arrive through `shellCommand` itself. And it
+    /// can only cause a false *refusal* of a healthy pane, never a false
+    /// *accept* — a stranger's pane cannot be made to answer with this
+    /// terminal's id, and the false accept is the direction that would actually
+    /// type into someone else's composer.
     static func resolvePaneTerminalID(paneOption: String, startCommand: String) -> String? {
         let stamped = paneOption.trimmingCharacters(in: .whitespaces)
         if !stamped.isEmpty { return stamped }

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -166,24 +166,54 @@ struct PaneSendTargetQueryTests {
 
     // MARK: - User-authored text in the start command cannot forge an identity
 
+    /// The two spawn paths that plant `TBD_TERMINAL_ID` into a pane's start
+    /// command. Every adversarial case below is driven through both.
+    ///
+    /// They share one env-prefix builder (`TmuxManager.envExportPrefixed`), so
+    /// today the two arms exercise the same code — but the resolver's anchor is
+    /// only safe while *every* spawn path emits the identical shape, and the
+    /// in-place profile swap that goes through `respawnWindowCommand` is the
+    /// path a reader is least likely to check. Parameterising rather than
+    /// copying the suite means the two can never drift apart in coverage.
+    enum SpawnBuilder: CaseIterable, Sendable, CustomStringConvertible {
+        case newWindow
+        case respawnWindow
+
+        var description: String {
+            switch self {
+            case .newWindow: "newWindowCommand"
+            case .respawnWindow: "respawnWindowCommand"
+            }
+        }
+
+        /// The shell command string the builder hands tmux — the same text tmux
+        /// reports back as `#{pane_start_command}`.
+        func startCommand(env: [String: String]) throws -> String {
+            let args: [String]
+            switch self {
+            case .newWindow:
+                args = TmuxManager.newWindowCommand(
+                    server: "tbd-acme", session: "main", cwd: "/tmp",
+                    shellCommand: "claude", env: env)
+            case .respawnWindow:
+                args = TmuxManager.respawnWindowCommand(
+                    server: "tbd-acme", windowID: "@3", cwd: "/tmp",
+                    shellCommand: "claude", env: env)
+            }
+            return try #require(args.last)
+        }
+    }
+
     /// Both spawn paths inline the env map the same way, so the anchor the
     /// resolver looks for holds for the in-place profile swap too. Asserted
     /// against the builders rather than a hand-written literal, because the
     /// resolver's narrowness is only safe while this stays true.
-    @Test("both spawn paths emit the assignment shape the resolver anchors on")
-    func bothSpawnPathsEmitTheAnchor() throws {
-        let env = ["TBD_TERMINAL_ID": Self.plantedID]
-        let spawned = try #require(TmuxManager.newWindowCommand(
-            server: "tbd-acme", session: "main", cwd: "/tmp", shellCommand: "claude",
-            env: env).last)
-        let respawned = try #require(TmuxManager.respawnWindowCommand(
-            server: "tbd-acme", windowID: "@3", cwd: "/tmp", shellCommand: "claude",
-            env: env).last)
-        #expect(spawned.contains(TmuxManager.terminalIDExportAnchor))
-        #expect(respawned.contains(TmuxManager.terminalIDExportAnchor))
-        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: spawned)
-            == Self.plantedID)
-        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: respawned)
+    @Test("a spawn path emits the assignment shape the resolver anchors on",
+          arguments: SpawnBuilder.allCases)
+    func spawnPathEmitsTheAnchor(builder: SpawnBuilder) throws {
+        let command = try builder.startCommand(env: ["TBD_TERMINAL_ID": Self.plantedID])
+        #expect(command.contains(TmuxManager.terminalIDExportAnchor))
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
             == Self.plantedID)
     }
 
@@ -192,19 +222,20 @@ struct PaneSendTargetQueryTests {
     /// inlined BEFORE `TBD_TERMINAL_ID` and any unanchored substring search
     /// reads the user's prose as the pane's identity. A pane that misreports
     /// its identity is refused as a stranger for the whole life of its window.
-    @Test("instructions containing the bare env-var name do not poison resolution")
-    func resolveIgnoresBareNameInInstructions() throws {
-        let command = try #require(TmuxManager.newWindowCommand(
-            server: "tbd-acme", session: "main", cwd: "/tmp", shellCommand: "claude",
-            env: [
-                "TBD_PROMPT_INSTRUCTIONS":
-                    "When paging a sibling, read TBD_TERMINAL_ID= from its pane env first.",
-                "TBD_TERMINAL_ID": Self.plantedID,
-            ]).last)
+    @Test("instructions containing the bare env-var name do not poison resolution",
+          arguments: SpawnBuilder.allCases)
+    func resolveIgnoresBareNameInInstructions(builder: SpawnBuilder) throws {
+        let command = try builder.startCommand(env: [
+            "TBD_PROMPT_INSTRUCTIONS":
+                "When paging a sibling, read TBD_TERMINAL_ID= from its pane env first.",
+            "TBD_TERMINAL_ID": Self.plantedID,
+        ])
         // The decoy really does precede the real assignment in the emitted string.
         let decoy = try #require(command.range(of: "TBD_TERMINAL_ID="))
         let real = try #require(command.range(of: TmuxManager.terminalIDExportAnchor))
         #expect(decoy.lowerBound < real.lowerBound)
+        // It is not an anchor at all: no `export ` and no opening quote.
+        #expect(command.ranges(of: TmuxManager.terminalIDExportAnchor).count == 1)
 
         #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
             == Self.plantedID)
@@ -212,26 +243,66 @@ struct PaneSendTargetQueryTests {
 
     /// The same hazard one step further: prose that spells the assignment out
     /// with a quoted value, so an anchored-but-first-match-only search would
-    /// hand back the quoted garbage. Scanning every occurrence steps over it.
-    @Test("instructions containing a quoted decoy value do not poison resolution")
-    func resolveStepsOverQuotedDecoy() throws {
-        let command = try #require(TmuxManager.newWindowCommand(
-            server: "tbd-acme", session: "main", cwd: "/tmp", shellCommand: "claude",
-            env: [
-                "TBD_PROMPT_INSTRUCTIONS":
-                    "Never run: export TBD_TERMINAL_ID='not-a-uuid' — it breaks routing.",
-                "TBD_TERMINAL_ID": Self.plantedID,
-            ]).last)
+    /// give up at the decoy and fail open. Scanning every occurrence steps over
+    /// it and still finds the real id.
+    ///
+    /// What the decoy occurrence yields is asserted rather than described,
+    /// because it is *not* the decoy's payload: `'` is escaped as `'\''`, the
+    /// anchor consumes the first of those quotes, and the value read runs to
+    /// the next quote — a lone backslash. `not-a-uuid` is never extracted.
+    @Test("instructions containing a quoted decoy value do not poison resolution",
+          arguments: SpawnBuilder.allCases)
+    func resolveStepsOverQuotedDecoy(builder: SpawnBuilder) throws {
+        let command = try builder.startCommand(env: [
+            "TBD_PROMPT_INSTRUCTIONS":
+                "Never run: export TBD_TERMINAL_ID='not-a-uuid' — it breaks routing.",
+            "TBD_TERMINAL_ID": Self.plantedID,
+        ])
         // The quote-escaping leaves a complete anchor inside the instructions.
         #expect(command.ranges(of: TmuxManager.terminalIDExportAnchor).count == 2)
+        #expect(Self.valueAtFirstAnchor(of: command) == "\\")
         #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
             == Self.plantedID)
+    }
 
-        // The same property stated directly, independent of the escaping rules.
-        let handWritten = "/bin/zsh -ic \"export TBD_TERMINAL_ID='decoy'; "
-            + "export TBD_TERMINAL_ID='\(Self.plantedID)'; claude\""
-        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: handWritten)
+    /// The one decoy shape whose extracted value is neither a backslash nor the
+    /// payload: instructions ending exactly at the `=`, so the anchor closes on
+    /// the env entry's own closing quote and the value read is the `; export …=`
+    /// separator that always follows it. Also not a UUID.
+    @Test("instructions ending at the assignment read the separator, not an id",
+          arguments: SpawnBuilder.allCases)
+    func resolveStepsOverTruncatedDecoy(builder: SpawnBuilder) throws {
+        let command = try builder.startCommand(env: [
+            "TBD_PROMPT_INSTRUCTIONS": "Never write export TBD_TERMINAL_ID=",
+            "TBD_TERMINAL_ID": Self.plantedID,
+        ])
+        #expect(command.ranges(of: TmuxManager.terminalIDExportAnchor).count == 2)
+        #expect(Self.valueAtFirstAnchor(of: command) == "; export TBD_TERMINAL_ID=")
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
             == Self.plantedID)
+    }
+
+    /// Hand-written rather than built, so it holds the property independent of
+    /// the escaping rules: a raw adjacent decoy whose value really *is* read as
+    /// `decoy` still resolves to the real id, because `decoy` is not a UUID.
+    /// No `env` value can produce this shape — only unescaped command text can.
+    @Test("a raw adjacent decoy is stepped over on its UUID check")
+    func resolveStepsOverRawDecoy() {
+        let command = "/bin/zsh -ic \"export TBD_TERMINAL_ID='decoy'; "
+            + "export TBD_TERMINAL_ID='\(Self.plantedID)'; claude\""
+        #expect(Self.valueAtFirstAnchor(of: command) == "decoy")
+        #expect(TmuxManager.resolvePaneTerminalID(paneOption: "", startCommand: command)
+            == Self.plantedID)
+    }
+
+    /// What `resolvePaneTerminalID` would return at the FIRST anchor if it did
+    /// not validate and keep scanning. Spelled out here so the tests above
+    /// assert the extracted text rather than asserting the doc comment.
+    static func valueAtFirstAnchor(of command: String) -> String? {
+        guard let anchor = command.range(of: TmuxManager.terminalIDExportAnchor) else { return nil }
+        let rest = command[anchor.upperBound...]
+        guard let close = rest.firstIndex(of: "'") else { return nil }
+        return String(rest[..<close])
     }
 
     /// Fail-open on a value that is not a terminal id at all: nil means "this


### PR DESCRIPTION
Closes the two findings the shadow review raised on #597 after it merged.

## Why

#597 stopped user-authored repo instructions from forging a pane's identity, by anchoring the `#{pane_start_command}` fallback on `export TBD_TERMINAL_ID='` and requiring a UUID. That guarantee rests on the env-prefix **escaping** — and the escaping lived in two independently-written, byte-identical blocks (`newWindowCommand` and `respawnWindowCommand`), not shared code.

Every adversarial test #597 added drove `newWindowCommand`. The doc comment claimed the guarantee covered the in-place profile swap, which goes through `respawnWindowCommand`. So the claim for respawned panes was prose, not proof, and a future edit desyncing the two blocks would reopen the vulnerability for in-place profile swaps with nothing to catch it.

That is the same shape as the original bug: not wrong logic, but an input nobody built a test for.

## What this does

**One escaping implementation.** `newWindowCommand` and `respawnWindowCommand` now both call `envExportPrefixed(_:env:)` and `sensitiveEnvFlags(_:)`. The extraction is local and behavior-preserving — the two blocks were byte-identical, both statics, no callers outside the file — and emitted argv is unchanged.

**Coverage that cannot drift even so.** The adversarial cases are parameterised over a `SpawnBuilder` enum (`.newWindow` / `.respawnWindow`) via `@Test(arguments:)`, rather than a duplicated suite. Sharing the implementation is today's answer; the parameterisation is the guard against tomorrow's split.

## What a decoy actually extracts — measured, not asserted

#597's comment said a quoted decoy yields "quoted garbage", implying the decoy's payload is extracted. The review said it is always a lone backslash. **Both were describing different inputs.** Measured against the current anchored parser, over strings built by the real builders:

- **Bare-name decoy** — not an anchor at all; nothing is extracted there.
- **Quoted decoy** — extracts a lone backslash `\`. A `'` is escaped as `'\''`, so the anchor consumes the first of those quotes and the value runs to the next. The payload is *never* extracted.
- **Truncated decoy** (instructions ending exactly at `export TBD_TERMINAL_ID=`) — the anchor closes on the env entry's own closing quote, extracting the separator `; export TBD_TERMINAL_ID=`. Neither backslash nor payload; a third shape, now covered.
- **Raw adjacent decoy** — extracts `decoy`, but this shape cannot come from an `env` value; only unescaped `shellCommand` text produces it.

All four resolve to the real planted UUID, because none parses as a `UUID` and the scan steps on. The earlier "quoted garbage" reading came from a mutation run against the *unanchored* pre-fix parser; the review's reading is correct for anything arriving through an `env` value, which is what the guard exists for.

**The residual adversarial case narrows accordingly.** A complete `export TBD_TERMINAL_ID='<valid uuid>'` read first cannot be produced by any `env` value — the escaping forbids it — so it would have to arrive through `shellCommand`. The comment now says that, and states the mechanism rather than a vague outcome, so a future auditor of this guard isn't misled.

## Test plan

- [x] All four decoy shapes run against **both** spawn builders, parameterised
- [x] The extraction outcomes above are pinned as assertions, not described in prose
- [x] Emitted argv unchanged by the extraction — the suite plus an anchor assertion on both builders
- [x] Mutation A — desync `respawnWindowCommand`'s escaping: the `respawnWindowCommand` arm alone goes red, `newWindowCommand` stays green. Exactly the drift the finding predicted, now caught
- [x] Mutation B — revert the resolver to the unanchored search: 5 tests / 8 issues red across both arms
- [x] Full suite: 5246 tests in 562 suites passing; `swiftlint --strict` clean in 675 files, `.swiftlint.yml` untouched

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=DBCFE501-2BAF-4573-8625-304825DE975A)