### PR TITLE
Feat: Confirm a payload actually landed, instead of trusting that keystrokes left the daemon

### DIFF
--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -116,20 +116,84 @@ struct TerminalList: AsyncParsableCommand {
 struct TerminalSend: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "send",
-        abstract: "Send text to a terminal"
+        abstract: "Send a payload to a terminal: text, or named keys",
+        discussion: """
+            Exactly one payload per call.
+
+              --text "…"          the message. Typed into the composer and left
+                                  standing unless --submit is also passed.
+              --text "…" --submit  the message, submitted. This is the pair every
+                                  delivery uses.
+              --keys "Escape Enter"  whitespace-separated tmux key names, sent one
+                                  at a time. Interrupt is a keys payload
+                                  (--keys "C-c"). Enter is itself a key, so
+                                  --submit does not apply here.
+
+            Every non-empty text payload is delivered behind a one-line
+            attribution envelope carrying the send's record id and the caller's
+            declared identity, then the message verbatim. The receiving agent
+            sees who is addressing it.
+
+            --verify additionally asks the daemon to confirm the payload landed,
+            by looking for that envelope in the session's transcript. It needs
+            --submit (text left standing in a composer never enters the
+            conversation) and cannot be combined with --keys (keys reach no
+            transcript). It is refused, rather than quietly downgraded, while
+            delivery verification is disabled daemon-side.
+            """
     )
 
     @Option(name: .long, help: "Terminal ID")
     var terminal: String
 
     @Option(name: .long, help: "Text to send")
-    var text: String
+    var text: String?
+
+    @Option(name: .long, help: "Whitespace-separated tmux key names to send, e.g. \"Escape Enter\" or \"C-c\"")
+    var keys: String?
 
     @Flag(name: .long, help: "Press Enter after sending text")
     var submit = false
 
+    @Flag(name: .long, help: "Confirm the payload landed in the session's transcript (requires --submit; not valid with --keys)")
+    var verify = false
+
     @Flag(name: .long, help: "Output JSON")
     var json = false
+
+    /// The same four shape rules the daemon enforces, checked here so a human
+    /// gets a clean message before a socket is opened. Deliberately duplicated
+    /// rather than delegated: the CLI is not the only caller, so the daemon
+    /// cannot rely on this — and a human should not have to read an RPC error
+    /// to learn they passed two payloads.
+    func validate() throws {
+        if text != nil && keys != nil {
+            throw ValidationError("Pass exactly one payload: --text or --keys, not both.")
+        }
+        if text == nil && keys == nil {
+            throw ValidationError("Pass a payload: --text or --keys.")
+        }
+        if keys != nil && submit {
+            throw ValidationError(
+                "--submit is incoherent with --keys: Enter is itself a key. "
+                + "Put it in the sequence instead, e.g. --keys \"Escape Enter\".")
+        }
+        if keys != nil && verify {
+            throw ValidationError(
+                "--verify cannot be used with --keys: keys reach no transcript, "
+                + "so delivery cannot be observed.")
+        }
+        if verify && !submit {
+            throw ValidationError(
+                "--verify requires --submit: text left standing in a composer never "
+                + "enters the conversation, so delivery cannot be observed.")
+        }
+        if verify, text?.isEmpty == true {
+            throw ValidationError(
+                "--verify requires a non-empty --text: an empty payload pastes nothing, "
+                + "so there is no dispatch envelope to observe.")
+        }
+    }
 
     mutating func run() async throws {
         guard let terminalID = UUID(uuidString: terminal) else {
@@ -139,13 +203,21 @@ struct TerminalSend: AsyncParsableCommand {
         let client = SocketClient()
         try client.callVoid(
             method: RPCMethod.terminalSend,
-            params: TerminalSendParams(terminalID: terminalID, text: text, submit: submit)
+            params: TerminalSendParams(
+                terminalID: terminalID,
+                text: text,
+                keys: keys,
+                // Preserved exactly: `--submit` is sent as a plain bool for a
+                // text payload, as it always was. A keys payload never carries
+                // it (validate() has already refused the combination).
+                submit: keys == nil ? submit : nil,
+                verify: verify ? true : nil)
         )
 
         if json {
             printJSON(["status": "sent"])
         } else {
-            print("Text sent.")
+            print(keys == nil ? "Text sent." : "Keys sent.")
         }
     }
 }

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -161,11 +161,18 @@ struct TerminalSend: AsyncParsableCommand {
     @Flag(name: .long, help: "Output JSON")
     var json = false
 
-    /// The same four shape rules the daemon enforces, checked here so a human
-    /// gets a clean message before a socket is opened. Deliberately duplicated
-    /// rather than delegated: the CLI is not the only caller, so the daemon
-    /// cannot rely on this — and a human should not have to read an RPC error
-    /// to learn they passed two payloads.
+    /// The payload-shape rules, checked here so a human gets a clean message
+    /// before a socket is opened. Deliberately duplicated rather than
+    /// delegated: the CLI is not the only caller, so the daemon cannot rely on
+    /// this — and a human should not have to read an RPC error to learn they
+    /// passed two payloads.
+    ///
+    /// Not a complete mirror of the daemon's `validateSendShape`, and not meant
+    /// to be: the daemon additionally refuses a `--keys` value that tokenizes
+    /// to nothing or to more than `PacedKeySender.maxKeys` keys. Duplicating
+    /// the tokenizer here would mean two copies of a bound that must agree,
+    /// which is a worse failure than one extra round trip — the daemon's
+    /// refusal is specific and reaches the user as an ordinary error.
     func validate() throws {
         if text != nil && keys != nil {
             throw ValidationError("Pass exactly one payload: --text or --keys, not both.")

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -129,17 +129,22 @@ struct TerminalSend: AsyncParsableCommand {
                                   (--keys "C-c"). Enter is itself a key, so
                                   --submit does not apply here.
 
-            Every non-empty text payload is delivered behind a one-line
-            attribution envelope carrying the send's record id and the caller's
-            declared identity, then the message verbatim. The receiving agent
-            sees who is addressing it.
+            A non-empty text payload sent to an AGENT session is delivered
+            behind a one-line attribution envelope carrying the send's record id
+            and the caller's declared identity, then the message verbatim, so
+            the receiving agent sees who is addressing it. A shell target gets
+            the text alone: nothing there reads the tag, and --submit would run
+            it as a command line of its own.
 
             --verify additionally asks the daemon to confirm the payload landed,
             by looking for that envelope in the session's transcript. It needs
             --submit (text left standing in a composer never enters the
             conversation) and cannot be combined with --keys (keys reach no
-            transcript). It is refused, rather than quietly downgraded, while
-            delivery verification is disabled daemon-side.
+            transcript). It is available for Claude sessions only — a shell
+            keeps no transcript, and Codex's acknowledgement arrives by a
+            different mechanism that is not built yet. It is refused, rather
+            than quietly downgraded, while delivery verification is disabled
+            daemon-side.
             """
     )
 

--- a/Sources/TBDDaemon/Actuation/ActuationLog.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationLog.swift
@@ -169,13 +169,65 @@ public actor ActuationLog {
     /// `result` and `reason` both come off the one `ActuationOutcome`, so a row
     /// carries a reason exactly when it says `refused` — the caller cannot
     /// forget one or attach the other.
+    ///
+    /// This door can only produce `.synchronous`. Claiming a payload landed is
+    /// not merely forbidden here, it is unspellable: the observed vocabulary
+    /// lives in a type this signature does not accept (`ObservedResult`), and
+    /// reaches the file only through `appendObservation`.
     func appendOutcome(confirms: String, result: ActuationOutcome, error: String? = nil) {
         var row = ActuationRow(actor: .daemon(), kind: .outcome)
         row.id = Self.mintID()
         row.confirms = confirms
-        row.result = result.result
+        row.result = .synchronous(result.result)
         row.reason = result.reason
         row.error = error
+        try? appendWithOneRetry(row, failClosed: false)
+    }
+
+    /// Append what a later, independent observation established about a payload
+    /// this daemon already dispatched — the third rung of the claims ladder.
+    ///
+    /// The second door beside `appendOutcome`, and the only one that can write
+    /// an `ObservedResult`. That asymmetry is the point: a synchronous send
+    /// path holds no value it could pass here, so "only an observed outcome may
+    /// claim a payload landed" is a property of the two signatures rather than
+    /// a rule someone has to remember.
+    ///
+    /// `observedAt` is when the machine facts were *read*, which the row keeps
+    /// distinct from `ts`, when the row was *written*. It comes through the
+    /// caller's `Date` because it is persisted data, not behavior — the same
+    /// reason this actor stamps `ts` from a `now` seam and never from a `Clock`.
+    ///
+    /// `detail` names what the observation could not establish (or what it found
+    /// instead), and rides the row's `error` field: the shared free-text slot
+    /// for "why this outcome is not a clean success", already read by anything
+    /// that renders a row.
+    ///
+    /// **One request row may legitimately carry several outcome rows.** The
+    /// ladder for a verified send that needed its single retry reads
+    /// `dispatched` → `not-landed` → `dispatched` → `landed-and-acting`: the
+    /// retry re-delivers the identical payload under the identical envelope id,
+    /// so it is the same actuation-level intent and opens no second request row
+    /// (`ActuationSurface`'s boundary rule), while each of its own synchronous
+    /// and observed results is a separate fact about that one act. A reader
+    /// that assumes one outcome per request is wrong, not the record.
+    ///
+    /// Best-effort-loud, exactly like `appendOutcome`: a second failure is
+    /// `.fault`-logged and swallowed. A lost observation leaves the act
+    /// unconfirmed by the query-time rule, which is honest — silence never
+    /// reads as delivery.
+    func appendObservation(
+        confirms: String,
+        result: ObservedResult,
+        observedAt: Date,
+        detail: String? = nil
+    ) {
+        var row = ActuationRow(actor: .daemon(), kind: .outcome)
+        row.id = Self.mintID()
+        row.confirms = confirms
+        row.result = .observed(result)
+        row.observedAt = timestampFormatter.string(from: observedAt)
+        row.error = detail
         try? appendWithOneRetry(row, failClosed: false)
     }
 

--- a/Sources/TBDDaemon/Actuation/ActuationRecordReader.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRecordReader.swift
@@ -33,20 +33,48 @@ struct ActuationRecordReader: Sendable {
     /// The files that make up the record, oldest first: the rotated day
     /// segments in name order, then the active file.
     ///
-    /// Name order is chronological by construction — segments are stamped
-    /// `YYYY-MM-DD`, which sorts lexicographically — and rotation writes no
-    /// header, footer or marker row, so concatenating them *is* the record
-    /// (§6). The active file always comes last: it holds the newest rows.
+    /// Segments are stamped `YYYY-MM-DD`, which sorts lexicographically, and
+    /// rotation writes no header, footer or marker row — so concatenating them
+    /// *is* the record (§6). The active file always comes last: it holds the
+    /// newest rows.
+    ///
+    /// **Sorted by (day, collision index), not by name.** A plain `.sorted()`
+    /// gets the one case rotation's collision handling exists for exactly
+    /// backwards: `ActuationLog.rotationDestination` leaves the earlier segment
+    /// as `actuations-<day>.jsonl` and names the later one
+    /// `actuations-<day>-1.jsonl`, and `-` (0x2D) sorts before `.` (0x2E), so
+    /// name order puts the later segment first. That writer chose a numeric
+    /// suffix over concatenation precisely so nobody's record would be silently
+    /// reordered; reading it back by name would reorder it anyway. The rule is
+    /// cheap to state and the cost of being wrong is no longer cosmetic —
+    /// `DeliveryRecord.statuses` reads outcomes in record order.
     func segmentPaths() -> [String] {
         let directory = (activePath as NSString).deletingLastPathComponent
         let names = (try? fileManager.contentsOfDirectory(atPath: directory)) ?? []
         let activeName = (activePath as NSString).lastPathComponent
         let rotated = names
             .filter { $0 != activeName && $0.hasPrefix("actuations-") && $0.hasSuffix(".jsonl") }
-            .sorted()
-            .map { (directory as NSString).appendingPathComponent($0) }
+            .map { (name: $0, order: Self.segmentOrder(ofName: $0)) }
+            .sorted { ($0.order.day, $0.order.index) < ($1.order.day, $1.order.index) }
+            .map { (directory as NSString).appendingPathComponent($0.name) }
         guard fileManager.fileExists(atPath: activePath) else { return rotated }
         return rotated + [activePath]
+    }
+
+    /// A rotated segment's place in the record: its stamped day, and which
+    /// segment of that day it is. `actuations-2026-08-05.jsonl` is index 0 and
+    /// `actuations-2026-08-05-1.jsonl` is index 1, matching the order
+    /// `ActuationLog.rotationDestination` writes them in.
+    ///
+    /// A name that fits neither shape keeps its whole stem as the day and sorts
+    /// by that — unknown, but stable and never interleaved into a real day.
+    static func segmentOrder(ofName name: String) -> (day: String, index: Int) {
+        let stem = String(name.dropFirst("actuations-".count).dropLast(".jsonl".count))
+        let parts = stem.split(separator: "-", omittingEmptySubsequences: false)
+        if parts.count == 4, let index = Int(parts[3]) {
+            return (parts[0..<3].joined(separator: "-"), index)
+        }
+        return (stem, 0)
     }
 
     /// Every parseable row in the record, oldest first.
@@ -154,10 +182,6 @@ enum DeliveryRecord {
         now: Date,
         deadline: TimeInterval = acknowledgementDeadline
     ) -> [DeliveryAssessment] {
-        // The newest observed result per confirmed request. Later rows win:
-        // one request may carry several outcomes (dispatched → not-landed →
-        // dispatched → landed-and-acting), and the last observation is the one
-        // that still stands.
         // What each act's outcomes leave it standing at, walked in record order.
         //
         // Order matters, and the retry is why: it shares the original act's id

--- a/Sources/TBDDaemon/Actuation/ActuationRecordReader.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRecordReader.swift
@@ -1,0 +1,198 @@
+import Foundation
+import os
+
+private let recordReaderLogger = Logger(subsystem: "com.tbd.daemon", category: "actuation-record")
+
+/// Reads the actuation record back: the active `actuations.jsonl` plus its
+/// rotated `actuations-<date>.jsonl` segments, in record order.
+///
+/// The writer's counterpart, and deliberately a separate type with no shared
+/// state: it opens nothing the writer holds, takes no lock, and can run while
+/// the daemon appends. A row that lands mid-read simply belongs to the next
+/// read — the record is append-only, so nothing already returned can change.
+///
+/// **Unparseable lines are skipped, never thrown.** The writer goes to real
+/// lengths to leave whole lines (`ActuationLog.appendWithOneRetry`), but the
+/// cases it cannot cover — a crash between `write` and `fsync`, a hand-edit —
+/// leave a fragment behind, and a reader that threw on one would let a single
+/// junk byte blind an entire replay. One bad line costs one row.
+struct ActuationRecordReader: Sendable {
+    /// The active file. Rotated segments are looked for beside it.
+    let activePath: String
+
+    init(activePath: String) {
+        self.activePath = activePath
+    }
+
+    /// `FileManager.default` is documented thread-safe for the three read-only
+    /// calls below, and holding one would cost this type its `Sendable`
+    /// conformance for nothing — the reader has no state worth injecting, and
+    /// its tests read real files out of a temp directory.
+    private var fileManager: FileManager { .default }
+
+    /// The files that make up the record, oldest first: the rotated day
+    /// segments in name order, then the active file.
+    ///
+    /// Name order is chronological by construction — segments are stamped
+    /// `YYYY-MM-DD`, which sorts lexicographically — and rotation writes no
+    /// header, footer or marker row, so concatenating them *is* the record
+    /// (§6). The active file always comes last: it holds the newest rows.
+    func segmentPaths() -> [String] {
+        let directory = (activePath as NSString).deletingLastPathComponent
+        let names = (try? fileManager.contentsOfDirectory(atPath: directory)) ?? []
+        let activeName = (activePath as NSString).lastPathComponent
+        let rotated = names
+            .filter { $0 != activeName && $0.hasPrefix("actuations-") && $0.hasSuffix(".jsonl") }
+            .sorted()
+            .map { (directory as NSString).appendingPathComponent($0) }
+        guard fileManager.fileExists(atPath: activePath) else { return rotated }
+        return rotated + [activePath]
+    }
+
+    /// Every parseable row in the record, oldest first.
+    func readRows() -> [ActuationRow] {
+        segmentPaths().flatMap { rows(inFileAt: $0) }
+    }
+
+    /// Every parseable row in one segment.
+    func rows(inFileAt path: String) -> [ActuationRow] {
+        guard let data = fileManager.contents(atPath: path) else {
+            recordReaderLogger.debug(
+                "actuation record segment unreadable: \(path, privacy: .public)")
+            return []
+        }
+        return Self.rows(inLinesOf: data, path: path)
+    }
+
+    /// Decode one row per newline-delimited line, skipping what will not parse.
+    ///
+    /// Splitting on the byte rather than on `String` lines keeps a segment with
+    /// invalid UTF-8 in it — the other thing a torn write leaves — costing only
+    /// the lines it damaged.
+    static func rows(inLinesOf data: Data, path: String = "") -> [ActuationRow] {
+        let decoder = JSONDecoder()
+        var rows: [ActuationRow] = []
+        var skipped = 0
+        for line in data.split(separator: 0x0A, omittingEmptySubsequences: true) {
+            if let row = try? decoder.decode(ActuationRow.self, from: Data(line)) {
+                rows.append(row)
+            } else {
+                skipped += 1
+            }
+        }
+        if skipped > 0 {
+            recordReaderLogger.debug(
+                """
+                skipped \(skipped, privacy: .public) unparseable line(s) \
+                in \(path, privacy: .public)
+                """)
+        }
+        return rows
+    }
+}
+
+// MARK: - The query-time delivery rule
+
+/// What the record says about one dispatched payload's delivery.
+///
+/// Computed, never stored. No row ever says `unconfirmed`: that is the whole
+/// design (§12). Writing a "gave up" row would make the record's claims depend
+/// on a sweep having run, and a daemon that was down when the deadline passed
+/// would leave a permanent lie behind. Because the rule lives here instead, an
+/// act whose observation never ran renders unconfirmed by construction, and a
+/// late observation simply moves it.
+enum DeliveryStatus: Sendable, Equatable {
+    /// An observation ran and established something. What it established is the
+    /// `ObservedResult` — including `notLanded` and `undetermined`, which are
+    /// findings, not absences.
+    case observed(ObservedResult)
+    /// Verification is armed and the acknowledgement deadline has not passed
+    /// yet. Nothing is owed and nothing is wrong.
+    case awaitingObservation
+    /// Verification is armed, the deadline has passed, and no *observed*
+    /// outcome confirms the act. Renders as loudly as an anomaly, and is the
+    /// startup replay's work list: these are the acts whose observation the
+    /// daemon performs late.
+    case unconfirmed
+}
+
+/// One act and what the record says about its delivery.
+struct DeliveryAssessment: Sendable, Equatable {
+    /// The request row — the act itself, not its outcomes.
+    let request: ActuationRow
+    let status: DeliveryStatus
+}
+
+/// The query-time delivery rule of §12, as a pure function over parsed rows.
+///
+/// No daemon, no filesystem, no clock: rows in, `now` in, assessments out. The
+/// startup replay is its first consumer and the account will be its second,
+/// and both want the same answer from the same evidence.
+enum DeliveryRecord {
+    /// How long after a request row's timestamp an observation is owed.
+    ///
+    /// §13's compiled-numbers table: "Post-intervention re-check — 60 s — §4
+    /// step 7, §12". The one place this repo spells that number; §12's ladder
+    /// and §7's in-memory timers both derive their deadline from it, so a
+    /// second copy would be a second answer.
+    static let acknowledgementDeadline: TimeInterval = 60
+
+    /// The delivery status of every act in `rows` that armed verification.
+    ///
+    /// Acts that did not arm it are absent from the result entirely — they are
+    /// owed no observation, so there is no honest status to report about them,
+    /// and reporting `unconfirmed` for a plain send would drown the real ones.
+    ///
+    /// The join is deliberately narrow: only an outcome row whose `result` is
+    /// an **observed** value counts as confirming. A synchronous `dispatched`
+    /// is the second rung of the ladder and says only that the transport
+    /// accepted the payload — the exact claim the field failure this whole
+    /// mechanism exists for made falsely, for hours, into a dead pane. So a
+    /// dispatched-only act past its deadline still renders `unconfirmed`.
+    static func statuses(
+        in rows: [ActuationRow],
+        now: Date,
+        deadline: TimeInterval = acknowledgementDeadline
+    ) -> [DeliveryAssessment] {
+        // The newest observed result per confirmed request. Later rows win:
+        // one request may carry several outcomes (dispatched → not-landed →
+        // dispatched → landed-and-acting), and the last observation is the one
+        // that still stands.
+        var observations: [String: ObservedResult] = [:]
+        for row in rows where row.kind == .outcome {
+            guard let confirms = row.confirms, let observed = row.result?.observed else { continue }
+            observations[confirms] = observed
+        }
+
+        return rows.compactMap { row in
+            guard row.kind != .outcome, row.verify == true, !row.id.isEmpty else { return nil }
+            if let observed = observations[row.id] {
+                return DeliveryAssessment(request: row, status: .observed(observed))
+            }
+            // Fail-closed on an unreadable timestamp: a deadline that cannot be
+            // computed is not a deadline that has not passed. §12's rule is
+            // "never default to landed", and this is the same instinct one
+            // level down.
+            guard let stamped = parseTimestamp(row.ts) else {
+                return DeliveryAssessment(request: row, status: .unconfirmed)
+            }
+            let due = stamped.addingTimeInterval(deadline)
+            return DeliveryAssessment(
+                request: row, status: now < due ? .awaitingObservation : .unconfirmed)
+        }
+    }
+
+    /// Reads back what `ActuationLog` stamps: ISO8601 UTC, with fractional
+    /// seconds. The fractionless form parses too — §6's own example rows are
+    /// written that way, and a hand-authored fixture will be.
+    static func parseTimestamp(_ raw: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.timeZone = TimeZone(secondsFromGMT: 0)
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: raw) { return date }
+        let plain = ISO8601DateFormatter()
+        plain.timeZone = TimeZone(secondsFromGMT: 0)
+        plain.formatOptions = [.withInternetDateTime]
+        return plain.date(from: raw)
+    }
+}

--- a/Sources/TBDDaemon/Actuation/ActuationRecordReader.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRecordReader.swift
@@ -158,42 +158,60 @@ enum DeliveryRecord {
         // one request may carry several outcomes (dispatched → not-landed →
         // dispatched → landed-and-acting), and the last observation is the one
         // that still stands.
-        var observations: [String: ObservedResult] = [:]
-        // Which acts the transport ever accepted, and which it answered with a
-        // terminal refusal. `verify == true` says the caller *asked* for an
-        // observation, not that one is owed: the request row is written before
-        // the flag check and before the pane consultation, so a refused send
-        // carries the flag too. An act that never dispatched can have landed
-        // nothing, so it owes no observation — and without this it would render
-        // unconfirmed forever and be "observed" by the startup replay, writing a
-        // landing verdict about a payload that never reached a pane.
-        var everDispatched: Set<String> = []
-        var refusedOrFailed: Set<String> = []
+        // What each act's outcomes leave it standing at, walked in record order.
+        //
+        // Order matters, and the retry is why: it shares the original act's id
+        // by design, so a retried send's ladder is
+        // `dispatched → not-landed → dispatched → landed`, four rows on one id.
+        // Taking "the newest observed row" alone would let a restart between the
+        // retry's dispatch and its own re-check leave the stale `not-landed`
+        // standing as the act's final word — settled, so the startup replay
+        // skips it, and the retry is never observed at all. A delivery that
+        // happened after the last observation is a delivery still owed one.
+        enum Standing {
+            /// A payload reached the pane and nothing has observed it since.
+            case awaitingObservation
+            /// The newest observation, with no later delivery after it.
+            case observed(ObservedResult)
+            /// The transport never accepted this act at all.
+            case neverDispatched
+        }
+        var standing: [String: Standing] = [:]
         for row in rows where row.kind == .outcome {
             guard let confirms = row.confirms else { continue }
             if let observed = row.result?.observed {
-                observations[confirms] = observed
+                standing[confirms] = .observed(observed)
                 continue
             }
             switch row.result {
-            case .synchronous(.dispatched): everDispatched.insert(confirms)
+            case .synchronous(.dispatched):
+                standing[confirms] = .awaitingObservation
             case .synchronous(.refused), .synchronous(.transportFailed):
-                refusedOrFailed.insert(confirms)
+                // A refusal only settles an act that never got off the ground.
+                // The same result on an act that already dispatched is the
+                // single retry failing, which erases neither the delivery that
+                // did happen nor the observation of it.
+                if standing[confirms] == nil { standing[confirms] = .neverDispatched }
             default: break
             }
         }
 
         return rows.compactMap { row in
             guard row.kind != .outcome, row.verify == true, !row.id.isEmpty else { return nil }
-            if let observed = observations[row.id] {
+            switch standing[row.id] {
+            case .observed(let observed):
                 return DeliveryAssessment(request: row, status: .observed(observed))
-            }
-            // Settled synchronously and never dispatched: the refusal or the
-            // transport failure IS the whole answer. A dispatch anywhere in the
-            // act's outcomes outranks a later refusal, which can only be the
-            // single retry failing after a real first delivery.
-            if refusedOrFailed.contains(row.id) && !everDispatched.contains(row.id) {
+            case .neverDispatched:
+                // `verify == true` says the caller *asked* for an observation,
+                // not that one is owed: the request row is written before the
+                // flag check and before the pane consultation, so a refused send
+                // carries the flag too. Nothing was typed, so nothing can have
+                // landed — and without this the act would render unconfirmed
+                // forever and the startup replay would "observe" it, writing a
+                // landing verdict about a payload that never reached a pane.
                 return nil
+            case .awaitingObservation, nil:
+                break
             }
             // Fail-closed on an unreadable timestamp: a deadline that cannot be
             // computed is not a deadline that has not passed. §12's rule is

--- a/Sources/TBDDaemon/Actuation/ActuationRecordReader.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRecordReader.swift
@@ -159,15 +159,41 @@ enum DeliveryRecord {
         // dispatched → landed-and-acting), and the last observation is the one
         // that still stands.
         var observations: [String: ObservedResult] = [:]
+        // Which acts the transport ever accepted, and which it answered with a
+        // terminal refusal. `verify == true` says the caller *asked* for an
+        // observation, not that one is owed: the request row is written before
+        // the flag check and before the pane consultation, so a refused send
+        // carries the flag too. An act that never dispatched can have landed
+        // nothing, so it owes no observation — and without this it would render
+        // unconfirmed forever and be "observed" by the startup replay, writing a
+        // landing verdict about a payload that never reached a pane.
+        var everDispatched: Set<String> = []
+        var refusedOrFailed: Set<String> = []
         for row in rows where row.kind == .outcome {
-            guard let confirms = row.confirms, let observed = row.result?.observed else { continue }
-            observations[confirms] = observed
+            guard let confirms = row.confirms else { continue }
+            if let observed = row.result?.observed {
+                observations[confirms] = observed
+                continue
+            }
+            switch row.result {
+            case .synchronous(.dispatched): everDispatched.insert(confirms)
+            case .synchronous(.refused), .synchronous(.transportFailed):
+                refusedOrFailed.insert(confirms)
+            default: break
+            }
         }
 
         return rows.compactMap { row in
             guard row.kind != .outcome, row.verify == true, !row.id.isEmpty else { return nil }
             if let observed = observations[row.id] {
                 return DeliveryAssessment(request: row, status: .observed(observed))
+            }
+            // Settled synchronously and never dispatched: the refusal or the
+            // transport failure IS the whole answer. A dispatch anywhere in the
+            // act's outcomes outranks a later refusal, which can only be the
+            // single retry failing after a real first delivery.
+            if refusedOrFailed.contains(row.id) && !everDispatched.contains(row.id) {
+                return nil
             }
             // Fail-closed on an unreadable timestamp: a deadline that cannot be
             // computed is not a deadline that has not passed. §12's rule is

--- a/Sources/TBDDaemon/Actuation/ActuationRow.swift
+++ b/Sources/TBDDaemon/Actuation/ActuationRow.swift
@@ -25,6 +25,100 @@ enum ActuationResult: String, Codable, Sendable {
     case transportFailed = "transport-failed"
 }
 
+/// What a later, independent observation established about a payload that was
+/// already dispatched.
+///
+/// A different fact class from `ActuationResult`, and deliberately a different
+/// type. `ActuationResult` says what the daemon saw as the act returned;
+/// `ObservedResult` says what a second look at a machine interface — the
+/// transcript, the session's state — found afterwards. **Only a value of this
+/// type may claim a payload landed** (§12's never-claim).
+///
+/// Keeping the two vocabularies apart is what makes that claim unspellable
+/// rather than merely forbidden: were `landedAndActing` a case of
+/// `ActuationResult`, `appendOutcome(confirms:result: .landedAndActing)` would
+/// compile from the synchronous send path and the never-claim would rest on
+/// review instead of on the compiler. `RefusedReason` made "a refusal always
+/// names why" a property of the type in exactly this way; this is the same move
+/// one rung up the claims ladder.
+///
+/// New raw values are additive, as everywhere else in the record: see
+/// `RecordedResult.unrecognized`.
+enum ObservedResult: String, Codable, Sendable, CaseIterable, Equatable {
+    /// Delivery confirmed and the session is working. Done.
+    case landedAndActing = "landed-and-acting"
+    /// Delivery confirmed and the session is blocked again — a fresh case.
+    case landedButStillBlocked = "landed-but-still-blocked"
+    /// Positive evidence of non-delivery: the transcript is readable, the
+    /// envelope is absent, and the session is verifiably not mid-turn.
+    case notLanded = "not-landed"
+    /// The observation could not be made at all — transcript unreadable,
+    /// session state unknown, adapter result ambiguous. Never retried:
+    /// retrying into uncertainty risks double-instructing an agent that did
+    /// receive the first copy.
+    case undetermined
+}
+
+/// The one `result` field of an outcome row, as it appears on the wire.
+///
+/// §6's line shape puts both vocabularies in a single `result` string, so this
+/// union codes as that string and nothing else — there is no discriminator key,
+/// no nesting, and a row written before this type existed still decodes.
+///
+/// `unrecognized` is what makes §6's additive-raw-values promise real: a reader
+/// on an older daemon meeting a name neither vocabulary knows learns a name it
+/// did not know rather than failing to parse the row — and can still say so,
+/// verbatim, in whatever it renders.
+enum RecordedResult: Codable, Sendable, Equatable {
+    /// What the daemon saw as the act returned. The only thing a synchronous
+    /// path can produce.
+    case synchronous(ActuationResult)
+    /// What a later observation established. The only thing that may claim a
+    /// payload landed.
+    case observed(ObservedResult)
+    /// A raw value neither vocabulary knows — a newer daemon's name, or a
+    /// hand-edited row. Carried through verbatim.
+    case unrecognized(String)
+
+    var rawValue: String {
+        switch self {
+        case .synchronous(let result): return result.rawValue
+        case .observed(let result): return result.rawValue
+        case .unrecognized(let raw): return raw
+        }
+    }
+
+    /// Classifies a wire string by trying each closed vocabulary in turn. The
+    /// two raw-value sets are disjoint, so the order of the attempts is not a
+    /// tiebreak — it is just a lookup.
+    init(rawValue: String) {
+        if let synchronous = ActuationResult(rawValue: rawValue) {
+            self = .synchronous(synchronous)
+        } else if let observed = ObservedResult(rawValue: rawValue) {
+            self = .observed(observed)
+        } else {
+            self = .unrecognized(rawValue)
+        }
+    }
+
+    init(from decoder: any Decoder) throws {
+        self.init(rawValue: try decoder.singleValueContainer().decode(String.self))
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    /// The observed result, when this row carries one. The join the delivery
+    /// query reads: a synchronous `dispatched` says nothing about delivery, so
+    /// it must not answer here.
+    var observed: ObservedResult? {
+        if case .observed(let result) = self { return result }
+        return nil
+    }
+}
+
 /// Why a refusal refused, as a closed vocabulary beside the free-text detail.
 ///
 /// `refused` alone covers two opposite facts: a genuine decline ("this may not
@@ -144,6 +238,10 @@ struct ActuationRow: Codable, Sendable, Equatable {
     /// Payload verbatim, never filtered: a stale premise has to stay visible.
     var message: String?
     var submit: Bool?
+    /// Set on a request row when the caller armed delivery verification, and
+    /// only then. Without it the startup replay and the account cannot tell
+    /// which sends owe an observation from the ones that never asked for one.
+    var verify: Bool?
     var prompt: String?
     var agent: String?
     var profile: String?
@@ -151,7 +249,12 @@ struct ActuationRow: Codable, Sendable, Equatable {
     // Outcome-row body.
     /// The `id` of the request row this outcome confirms.
     var confirms: String?
-    var result: ActuationResult?
+    var result: RecordedResult?
+    /// When the observation behind an `observed` result was made. Set on — and
+    /// only on — observation rows, by `appendObservation`. It is the moment the
+    /// machine facts were read, which can be materially earlier than `ts`, the
+    /// moment the row was written.
+    var observedAt: String?
     /// Set on — and only on — a `refused` outcome, by `appendOutcome` from the
     /// same `ActuationOutcome` that decided `result`.
     var reason: RefusedReason?

--- a/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
+++ b/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
@@ -280,8 +280,14 @@ actor DeliveryVerifier: DeliveryVerificationArming {
     /// when the caller knows it. The startup replay does not — the record keeps
     /// no session id — and passes `nil`, which skips the comparison; that is
     /// safe there precisely because the replay never re-delivers.
+    /// `mayConcludeNotLanded` is the caller's attestation that the bounded tail
+    /// window can actually span the interval since dispatch — true for the
+    /// one-minute re-check, false for the startup replay, where the act may be a
+    /// day old and its envelope megabytes behind the window's edge. Absence is
+    /// only evidence when presence would have been visible.
     func observe(
-        actuationID: String, terminalID: UUID, expectedSessionID: String? = nil
+        actuationID: String, terminalID: UUID, expectedSessionID: String? = nil,
+        mayConcludeNotLanded: Bool = true
     ) async -> DeliveryObservation {
         guard let facts = await source.facts(forTerminal: terminalID) else {
             return DeliveryObservation(
@@ -335,6 +341,24 @@ actor DeliveryVerifier: DeliveryVerificationArming {
             // The only positive evidence of non-delivery §12 accepts: the
             // transcript is readable, the envelope is absent, and the session
             // is verifiably not mid-turn.
+            //
+            // ...but absence is only evidence when presence would have been
+            // visible. The window's soundness argument is that the envelope was
+            // pasted within the last minute, so nothing could have pushed it out
+            // of 64 KiB without the session being `.working`. A replayed act has
+            // no such bound — it can be a day old, and a live transcript here
+            // measured 7.1 MB, over a hundred times the window — so the same
+            // absence proves nothing. Claiming `not-landed` there would
+            // manufacture a non-delivery verdict, loudly, about a payload that
+            // very likely landed. Finding the envelope still counts: that is
+            // positive evidence either way.
+            guard mayConcludeNotLanded else {
+                return DeliveryObservation(
+                    .undetermined,
+                    detail: "no dispatch envelope in the transcript tail, but this observation "
+                        + "is running late and the bounded tail cannot span the interval since "
+                        + "dispatch — absence is not evidence here")
+            }
             return DeliveryObservation(
                 .notLanded,
                 detail: "no dispatch envelope in the transcript tail and the session is "
@@ -461,7 +485,8 @@ actor DeliveryVerifier: DeliveryVerificationArming {
                 continue
             }
             let observation = await observe(
-                actuationID: assessment.request.id, terminalID: terminalID)
+                actuationID: assessment.request.id, terminalID: terminalID,
+                mayConcludeNotLanded: false)
             await record(observation, confirming: assessment.request.id)
             if observation.result != .landedAndActing
                 && observation.result != .landedButStillBlocked {

--- a/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
+++ b/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
@@ -17,6 +17,15 @@ struct TerminalDeliveryFacts: Sendable, Equatable {
     /// which is an *undetermined* observation, never a non-delivery.
     let transcriptPath: String?
     let activityState: TerminalActivityState
+    /// `terminals.claudeSessionID` — which *conversation* currently occupies
+    /// this terminal, as distinct from which pane occupies its coordinate.
+    ///
+    /// A third fact, and it earns its place: `/clear` and the account swap both
+    /// rebind a live terminal to a new session and a new, empty transcript
+    /// without disturbing the pane. The pane consultation cannot see that — it
+    /// compares pane ids — so without this the observation would read a
+    /// stranger's transcript, find no envelope, and call it non-delivery.
+    var sessionID: String?
 }
 
 /// Everything the observation reads from outside itself.
@@ -49,7 +58,8 @@ struct DatabaseDeliveryObservationSource: DeliveryObservationSource {
         guard let terminal = try? await db.terminals.get(id: terminalID) else { return nil }
         return TerminalDeliveryFacts(
             transcriptPath: terminal.transcriptPath,
-            activityState: terminal.activityState)
+            activityState: terminal.activityState,
+            sessionID: terminal.claudeSessionID)
     }
 
     func transcriptTail(atPath path: String, maxBytes: Int) async -> Data? {
@@ -151,11 +161,12 @@ actor DeliveryVerifier: DeliveryVerificationArming {
     func armVerification(
         actuationID: String,
         terminalID: UUID,
+        sessionID: String?,
         deliveredPayload: String,
         submit: Bool
     ) async {
         let armed = ArmedDelivery(
-            actuationID: actuationID, terminalID: terminalID,
+            actuationID: actuationID, terminalID: terminalID, sessionID: sessionID,
             payload: deliveredPayload, submit: submit)
         // Detached from the caller's send: the RPC response is the caller's
         // synchronous result and must not wait a minute for an observation.
@@ -171,6 +182,10 @@ actor DeliveryVerifier: DeliveryVerificationArming {
     private struct ArmedDelivery: Sendable {
         let actuationID: String
         let terminalID: UUID
+        /// The conversation this payload was delivered into. Compared at every
+        /// observation, so a session rebound between dispatch and re-check is
+        /// caught before the retry can type into a stranger.
+        let sessionID: String?
         let payload: String
         let submit: Bool
     }
@@ -192,7 +207,9 @@ actor DeliveryVerifier: DeliveryVerificationArming {
 
     private func runReCheckCycle(_ armed: ArmedDelivery) async {
         try? await clock.sleep(for: deadline)
-        let first = await observe(actuationID: armed.actuationID, terminalID: armed.terminalID)
+        let first = await observe(
+            actuationID: armed.actuationID, terminalID: armed.terminalID,
+            expectedSessionID: armed.sessionID)
         await record(first, confirming: armed.actuationID)
 
         // `undetermined` is NEVER retried, and the reason is not caution about
@@ -239,7 +256,9 @@ actor DeliveryVerifier: DeliveryVerificationArming {
         }
 
         try? await clock.sleep(for: deadline)
-        let second = await observe(actuationID: armed.actuationID, terminalID: armed.terminalID)
+        let second = await observe(
+            actuationID: armed.actuationID, terminalID: armed.terminalID,
+            expectedSessionID: armed.sessionID)
         await record(second, confirming: armed.actuationID)
         // Two silent failures indicate a structural problem with the session,
         // and a third send without evidence would risk duplicate-message bugs.
@@ -257,11 +276,35 @@ actor DeliveryVerifier: DeliveryVerificationArming {
     /// `CLAUDE.md`, "No TUI screen-scraping"). The transcript is the machine
     /// interface, and the envelope reaches it without the agent cooperating in
     /// anything.
-    func observe(actuationID: String, terminalID: UUID) async -> DeliveryObservation {
+    /// `expectedSessionID` is the conversation the payload was delivered into,
+    /// when the caller knows it. The startup replay does not — the record keeps
+    /// no session id — and passes `nil`, which skips the comparison; that is
+    /// safe there precisely because the replay never re-delivers.
+    func observe(
+        actuationID: String, terminalID: UUID, expectedSessionID: String? = nil
+    ) async -> DeliveryObservation {
         guard let facts = await source.facts(forTerminal: terminalID) else {
             return DeliveryObservation(
                 .undetermined,
                 detail: "terminal \(terminalID.uuidString) is gone — no session left to observe")
+        }
+        // The terminal is alive but a DIFFERENT conversation now occupies it:
+        // `/clear`, `/compact`, or an account swap rebinds the session and
+        // starts an empty transcript, leaving the pane untouched — so the pane
+        // consultation, which compares pane ids, cannot see it. Reading on would
+        // find no envelope in a transcript that never had one and call that
+        // non-delivery, and the retry would then paste the payload into an
+        // unrelated conversation. That is the instruction-injection hazard §3
+        // names, arriving through the one door the pane check does not cover.
+        // The observation simply could not be made about the session that was
+        // addressed, which is what `undetermined` means — and undetermined is
+        // never retried.
+        if let expectedSessionID, facts.sessionID != expectedSessionID {
+            return DeliveryObservation(
+                .undetermined,
+                detail: "terminal \(terminalID.uuidString) has been rebound to a different "
+                    + "session since dispatch — the conversation that was addressed is no "
+                    + "longer there to observe")
         }
         guard let path = facts.transcriptPath, !path.isEmpty else {
             return DeliveryObservation(

--- a/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
+++ b/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
@@ -117,12 +117,33 @@ actor DeliveryVerifier: DeliveryVerificationArming {
     /// and an absent envelope there is `undetermined`, never `not-landed`.
     static let tailWindowBytes = 64 * 1024
 
+    /// The window a *second* read uses before the observation is allowed to
+    /// accuse the transport of losing a payload.
+    ///
+    /// The 64 KiB window's soundness argument is about the interval — nothing
+    /// could push a just-pasted envelope out of it without the session being
+    /// busy — but the mapping tests `activityState` at *observation* time, and a
+    /// session can receive a payload, emit far more than 64 KiB acting on it
+    /// (tool results are stored verbatim), and be back to `.idle` well before
+    /// second sixty. That reads as absence, and absence is the sole licence for
+    /// the retry — so the cheap window alone would re-paste an instruction the
+    /// agent already received.
+    ///
+    /// So absence escalates rather than concludes: re-read a far larger window,
+    /// and only claim non-delivery when that read provably covered the whole
+    /// file. It costs one big read on the rare path that is about to do
+    /// something consequential, and nothing at all on the common one. Still a
+    /// bounded tail read and still no parse (§3) — a byte search over 8 MiB is
+    /// milliseconds, and the largest transcript measured on this machine was
+    /// 7.1 MB.
+    static let escalatedWindowBytes = 8 * 1024 * 1024
+
     private let log: ActuationLog
     private let source: any DeliveryObservationSource
     /// Re-delivers an identical payload under its identical envelope id, and
     /// reports what the transport did — so a refused or transport-failed retry
     /// is classified honestly instead of collapsing into "the payload failed".
-    private let redeliver: @Sendable (UUID, String, Bool) async -> ActuationOutcome
+    private let redeliver: @Sendable (UUID, String?, String, Bool) async -> ActuationOutcome
     private let deadline: Duration
     private let now: @Sendable () -> Date
     private let clock: any Clock<Duration>
@@ -143,7 +164,7 @@ actor DeliveryVerifier: DeliveryVerificationArming {
     init(
         log: ActuationLog,
         source: any DeliveryObservationSource,
-        redeliver: @escaping @Sendable (UUID, String, Bool) async -> ActuationOutcome,
+        redeliver: @escaping @Sendable (UUID, String?, String, Bool) async -> ActuationOutcome,
         deadline: Duration = .seconds(DeliveryRecord.acknowledgementDeadline),
         now: @escaping @Sendable () -> Date = { Date() },
         clock: any Clock<Duration> = ContinuousClock()
@@ -183,8 +204,10 @@ actor DeliveryVerifier: DeliveryVerificationArming {
         let actuationID: String
         let terminalID: UUID
         /// The conversation this payload was delivered into. Compared at every
-        /// observation, so a session rebound between dispatch and re-check is
-        /// caught before the retry can type into a stranger.
+        /// observation *and* again inside the re-delivery, because the gap
+        /// between the two spans a DB write, two reads and a serializer queue —
+        /// long enough for a `/clear` to land in it. Checking only at the
+        /// observation would leave the retry typing into a stranger.
         let sessionID: String?
         let payload: String
         let submit: Bool
@@ -228,7 +251,8 @@ actor DeliveryVerifier: DeliveryVerificationArming {
         // shares the original request row (`ActuationSurface`'s boundary rule).
         // Its own synchronous result is still a fact about that act, so it gets
         // an outcome row confirming the same id.
-        let retry = await redeliver(armed.terminalID, armed.payload, armed.submit)
+        let retry = await redeliver(
+            armed.terminalID, armed.sessionID, armed.payload, armed.submit)
         // `error` stays nil when the retry dispatched. A row reading
         // `dispatched` with a populated error field reads as a failure to
         // anything querying the record, and the second dispatch needs no
@@ -343,15 +367,11 @@ actor DeliveryVerifier: DeliveryVerificationArming {
             // is verifiably not mid-turn.
             //
             // ...but absence is only evidence when presence would have been
-            // visible. The window's soundness argument is that the envelope was
-            // pasted within the last minute, so nothing could have pushed it out
-            // of 64 KiB without the session being `.working`. A replayed act has
-            // no such bound — it can be a day old, and a live transcript here
-            // measured 7.1 MB, over a hundred times the window — so the same
-            // absence proves nothing. Claiming `not-landed` there would
-            // manufacture a non-delivery verdict, loudly, about a payload that
-            // very likely landed. Finding the envelope still counts: that is
-            // positive evidence either way.
+            // visible, and two things can hide a delivered envelope from a
+            // bounded tail. A replayed act can be a day old, which the caller
+            // declares. And a live session can simply have written past the
+            // window since dispatch — so before accusing the transport, look
+            // harder.
             guard mayConcludeNotLanded else {
                 return DeliveryObservation(
                     .undetermined,
@@ -359,10 +379,8 @@ actor DeliveryVerifier: DeliveryVerificationArming {
                         + "is running late and the bounded tail cannot span the interval since "
                         + "dispatch — absence is not evidence here")
             }
-            return DeliveryObservation(
-                .notLanded,
-                detail: "no dispatch envelope in the transcript tail and the session is "
-                    + "\(facts.activityState.rawValue) — verifiably not mid-turn")
+            return await concludeAbsence(
+                actuationID: actuationID, path: path, state: facts.activityState)
         case (false, .working):
             // Absence while mid-turn proves nothing: the harness may not have
             // written the line yet. No positive evidence, so no retry.
@@ -376,6 +394,45 @@ actor DeliveryVerifier: DeliveryVerificationArming {
                 detail: "no dispatch envelope in the transcript tail and the session state "
                     + "is unknown")
         }
+    }
+
+    /// Absence in the cheap window is a question, not an answer: re-read a far
+    /// larger one, and claim non-delivery only if that read provably covered the
+    /// whole file.
+    ///
+    /// `transcriptTail` seeks to `size - maxBytes` and reads to the end, so a
+    /// result shorter than the window it asked for *is* the whole file — which
+    /// is exactly the proof this needs, at no extra syscall. Anything larger and
+    /// still missing the envelope leaves the question open, which is
+    /// `undetermined`, which is never retried.
+    private func concludeAbsence(
+        actuationID: String, path: String, state: TerminalActivityState
+    ) async -> DeliveryObservation {
+        guard let wide = await source.transcriptTail(
+            atPath: path, maxBytes: Self.escalatedWindowBytes) else {
+            return DeliveryObservation(
+                .undetermined,
+                detail: "the transcript became unreadable at \(path) while confirming an "
+                    + "absent dispatch envelope")
+        }
+        if Self.envelopeAppears(actuationID: actuationID, inTail: wide) {
+            // It landed after all, and the cheap window simply could not see
+            // that far back. The session is not mid-turn, so it is blocked again.
+            return DeliveryObservation(
+                state == .working ? .landedAndActing : .landedButStillBlocked)
+        }
+        guard wide.count < Self.escalatedWindowBytes else {
+            return DeliveryObservation(
+                .undetermined,
+                detail: "no dispatch envelope in the last "
+                    + "\(Self.escalatedWindowBytes) bytes, but the transcript is longer than "
+                    + "that — the payload may have been delivered and written past the window, "
+                    + "so absence is not evidence")
+        }
+        return DeliveryObservation(
+            .notLanded,
+            detail: "no dispatch envelope anywhere in the transcript and the session is "
+                + "\(state.rawValue) — verifiably not mid-turn")
     }
 
     /// Whether the dispatch envelope for `actuationID` appears in the tail.
@@ -454,8 +511,10 @@ actor DeliveryVerifier: DeliveryVerificationArming {
     /// **It never re-delivers.** §12 puts "what to *do* about an unconfirmed
     /// act — re-send, journal, shrug" in playbook judgment, never compiled
     /// repair, and a payload whose premise is an unbounded interval old is
-    /// exactly the stale-premise send §3 forbids. So a replayed `not-landed`
-    /// records the outcome and the anomaly, and stops.
+    /// exactly the stale-premise send §3 forbids. It also cannot conclude
+    /// `not-landed` at all — `mayConcludeNotLanded: false` — because a bounded
+    /// tail cannot span an interval of unknown length. It records what it can
+    /// establish, writes the anomaly, and stops.
     ///
     /// `.awaitingObservation` acts are left alone: their deadline has not
     /// passed, so nothing is owed yet.

--- a/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
+++ b/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
@@ -62,14 +62,29 @@ struct DatabaseDeliveryObservationSource: DeliveryObservationSource {
             sessionID: terminal.claudeSessionID)
     }
 
+    /// Every failure here answers `nil`, and none of them may answer empty.
+    ///
+    /// The two values mean opposite things to the caller: empty is
+    /// *readable-and-the-envelope-is-not-there*, which is the positive evidence
+    /// that licenses a re-paste, while `nil` is "no observation could be made".
+    /// A swallowed `seek` or `read` error collapsing into `Data()` would turn a
+    /// disk hiccup into a claim about an agent's conversation — a silent failure
+    /// re-entering the one system built to end them.
     func transcriptTail(atPath path: String, maxBytes: Int) async -> Data? {
         guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
         defer { try? handle.close() }
         guard let size = try? handle.seekToEnd() else { return nil }
         guard size > 0 else { return Data() }
         let window = UInt64(max(maxBytes, 0))
-        try? handle.seek(toOffset: size > window ? size - window : 0)
-        return (try? handle.readToEnd()) ?? Data()
+        do {
+            try handle.seek(toOffset: size > window ? size - window : 0)
+            // `readToEnd` answers nil only at EOF, which the size guard above
+            // has already excluded — so this coalesce is for the type, not for
+            // a failure.
+            return try handle.readToEnd() ?? Data()
+        } catch {
+            return nil
+        }
     }
 }
 

--- a/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
+++ b/Sources/TBDDaemon/Actuation/DeliveryVerifier.swift
@@ -1,0 +1,436 @@
+import Foundation
+import TBDShared
+import os
+
+private let verifierLogger = Logger(subsystem: "com.tbd.daemon", category: "delivery-verification")
+
+// MARK: - The observation's inputs
+
+/// The two machine facts the observation reads about a session (§12): where its
+/// transcript lives, and what state it is in.
+///
+/// A value type rather than the `Terminal` row so the mapping cannot start
+/// consulting fields §12 does not license — the observation is deliberately
+/// two facts wide.
+struct TerminalDeliveryFacts: Sendable, Equatable {
+    /// `terminals.transcriptPath`. `nil` when the session never reported one,
+    /// which is an *undetermined* observation, never a non-delivery.
+    let transcriptPath: String?
+    let activityState: TerminalActivityState
+}
+
+/// Everything the observation reads from outside itself.
+///
+/// Narrow on purpose: with the transcript tail and the session state behind one
+/// injected seam, §12's four-result mapping is a tier-1 test with no database,
+/// no filesystem and no daemon — and a fake that *counts* reads can prove that
+/// a send which never armed verification costs no transcript read at all.
+protocol DeliveryObservationSource: Sendable {
+    /// The session's facts, or `nil` when the terminal row is gone.
+    func facts(forTerminal terminalID: UUID) async -> TerminalDeliveryFacts?
+
+    /// A bounded window off the **end** of the transcript, or `nil` when the
+    /// file cannot be read.
+    ///
+    /// Bounded, never a full parse: §3 forbids paying for a whole transcript on
+    /// a path that runs once a minute per verified send, and the envelope this
+    /// looks for was written seconds ago, so the tail is where it is. An empty
+    /// but readable file answers with empty data — readable-and-absent, which
+    /// is evidence; unreadable answers `nil`, which is not.
+    func transcriptTail(atPath path: String, maxBytes: Int) async -> Data?
+}
+
+/// The production source: the terminal row from the database, the tail straight
+/// off the file.
+struct DatabaseDeliveryObservationSource: DeliveryObservationSource {
+    let db: TBDDatabase
+
+    func facts(forTerminal terminalID: UUID) async -> TerminalDeliveryFacts? {
+        guard let terminal = try? await db.terminals.get(id: terminalID) else { return nil }
+        return TerminalDeliveryFacts(
+            transcriptPath: terminal.transcriptPath,
+            activityState: terminal.activityState)
+    }
+
+    func transcriptTail(atPath path: String, maxBytes: Int) async -> Data? {
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        guard let size = try? handle.seekToEnd() else { return nil }
+        guard size > 0 else { return Data() }
+        let window = UInt64(max(maxBytes, 0))
+        try? handle.seek(toOffset: size > window ? size - window : 0)
+        return (try? handle.readToEnd()) ?? Data()
+    }
+}
+
+// MARK: - What one observation established
+
+/// One observation's finding: the result §12 names, plus what the observation
+/// could not establish (or found instead), which rides the outcome row's
+/// free-text slot.
+struct DeliveryObservation: Sendable, Equatable {
+    let result: ObservedResult
+    let detail: String?
+
+    init(_ result: ObservedResult, detail: String? = nil) {
+        self.result = result
+        self.detail = detail
+    }
+}
+
+// MARK: - The verifier
+
+/// The one-minute re-check, the single evidence-bounded retry, and the startup
+/// replay — the third rung of the record's claims ladder (design §12).
+///
+/// **Armed state is in memory, deliberately.** §7 keeps these timers
+/// non-durable *because* everything they encode derives from the durable
+/// record: an actuation row's timestamp fixes its observation deadline, and the
+/// envelope is durable in the transcript. So a restart costs cadence, never
+/// data — the acts whose timers died render `unconfirmed` by
+/// `DeliveryRecord.statuses`, and `replayMissedObservations` performs those
+/// observations late.
+///
+/// **It calls no tmux primitive.** Re-delivery arrives as a closure supplied by
+/// `RPCRouter`, whose implementation reuses the send path's own
+/// consult-then-paste code inside the file the actuation audit already covers.
+/// That keeps `.swiftlint.yml`'s `actuation_primitive_allowlist` untouched and
+/// makes the retry a counted fake in tests.
+actor DeliveryVerifier: DeliveryVerificationArming {
+    /// How much of the transcript's end one observation reads.
+    ///
+    /// 64 KiB is the same window `ActuationLog` tails its own segment with, and
+    /// the reason is the same: it bounds the read without needing a parse. The
+    /// envelope was pasted within the last minute, so anything that could push
+    /// it out of this window is a session that generated 64 KiB of transcript
+    /// since — which, by the mapping below, is a session that is `.working`,
+    /// and an absent envelope there is `undetermined`, never `not-landed`.
+    static let tailWindowBytes = 64 * 1024
+
+    private let log: ActuationLog
+    private let source: any DeliveryObservationSource
+    /// Re-delivers an identical payload under its identical envelope id, and
+    /// reports what the transport did — so a refused or transport-failed retry
+    /// is classified honestly instead of collapsing into "the payload failed".
+    private let redeliver: @Sendable (UUID, String, Bool) async -> ActuationOutcome
+    private let deadline: Duration
+    private let now: @Sendable () -> Date
+    private let clock: any Clock<Duration>
+
+    /// The armed re-checks, keyed by the actuation id they will confirm. In
+    /// memory only (§7); an entry is removed when its cycle ends.
+    private var pending: [String: Task<Void, Never>] = [:]
+
+    /// - Parameters:
+    ///   - deadline: how long after dispatch the observation runs. Defaults to
+    ///     the one place this repo spells the number (§13's compiled-numbers
+    ///     table, via `DeliveryRecord.acknowledgementDeadline`) — injectable so
+    ///     a test crosses it in one advance rather than sixty.
+    ///   - now: the `observedAt` stamp. `Date` is data, so it comes through the
+    ///     date seam, never off the clock.
+    ///   - clock: the re-check timer. Existential, last, defaulted, per the
+    ///     repo rule (`Tests/CLAUDE.md`, "Clock and date seams").
+    init(
+        log: ActuationLog,
+        source: any DeliveryObservationSource,
+        redeliver: @escaping @Sendable (UUID, String, Bool) async -> ActuationOutcome,
+        deadline: Duration = .seconds(DeliveryRecord.acknowledgementDeadline),
+        now: @escaping @Sendable () -> Date = { Date() },
+        clock: any Clock<Duration> = ContinuousClock()
+    ) {
+        self.log = log
+        self.source = source
+        self.redeliver = redeliver
+        self.deadline = deadline
+        self.now = now
+        self.clock = clock
+    }
+
+    // MARK: - Arming
+
+    func armVerification(
+        actuationID: String,
+        terminalID: UUID,
+        deliveredPayload: String,
+        submit: Bool
+    ) async {
+        let armed = ArmedDelivery(
+            actuationID: actuationID, terminalID: terminalID,
+            payload: deliveredPayload, submit: submit)
+        // Detached from the caller's send: the RPC response is the caller's
+        // synchronous result and must not wait a minute for an observation.
+        pending[actuationID] = Task { [self] in
+            await runReCheckCycle(armed)
+            forget(actuationID: actuationID)
+        }
+    }
+
+    /// The armed payload, exactly as it reached the pane. The envelope's id
+    /// *is* `actuationID`, so a retry of these bytes still joins on the
+    /// original row and opens no second request row.
+    private struct ArmedDelivery: Sendable {
+        let actuationID: String
+        let terminalID: UUID
+        let payload: String
+        let submit: Bool
+    }
+
+    private func forget(actuationID: String) {
+        pending[actuationID] = nil
+    }
+
+    /// Await every armed re-check still in flight.
+    ///
+    /// For tests, which drive the clock and then need the cycle's writes to
+    /// have landed before they read the record. Production never waits on
+    /// these — that is the whole point of arming them.
+    func awaitPendingObservations() async {
+        for task in pending.values { await task.value }
+    }
+
+    // MARK: - The cycle: observe, retry at most once, observe again
+
+    private func runReCheckCycle(_ armed: ArmedDelivery) async {
+        try? await clock.sleep(for: deadline)
+        let first = await observe(actuationID: armed.actuationID, terminalID: armed.terminalID)
+        await record(first, confirming: armed.actuationID)
+
+        // `undetermined` is NEVER retried, and the reason is not caution about
+        // wasted work: retrying into uncertainty risks double-instructing an
+        // agent that DID receive the first copy, and a message to an agent
+        // running with permissions bypassed is arbitrary instruction injection
+        // (§3) — so delivering it twice is not a neutral event. Only positive
+        // evidence of non-delivery licenses a second send.
+        guard first.result == .notLanded else {
+            if first.result == .undetermined { announceAnomaly(first, confirming: armed) }
+            return
+        }
+
+        // The single evidence-bounded retry: the identical payload under the
+        // identical envelope id, so it is the same actuation-level intent and
+        // shares the original request row (`ActuationSurface`'s boundary rule).
+        // Its own synchronous result is still a fact about that act, so it gets
+        // an outcome row confirming the same id.
+        let retry = await redeliver(armed.terminalID, armed.payload, armed.submit)
+        // `error` stays nil when the retry dispatched. A row reading
+        // `dispatched` with a populated error field reads as a failure to
+        // anything querying the record, and the second dispatch needs no
+        // annotation to be legible: the `not-landed` observation sitting
+        // between the two dispatches is what says why there are two.
+        await log.appendOutcome(
+            confirms: armed.actuationID, result: retry,
+            error: retry == .dispatched
+                ? nil
+                : "single evidence-bounded re-delivery after a not-landed observation")
+        guard retry == .dispatched else {
+            // The re-delivery never reached the pane. Its synchronous outcome
+            // row above records exactly that, and the first re-check's
+            // `not-landed` already stands on real evidence — so there is
+            // nothing left to *observe* here, and writing a second observation
+            // row would claim a look that never happened. That is the whole
+            // point of keeping `ObservedResult` out of `ActuationResult`: a
+            // synchronous fact must not be able to wear an observed result's
+            // clothes, least of all in the code that owns the distinction.
+            announceAnomaly(
+                first, confirming: armed,
+                note: "re-delivery did not reach the pane (\(retry.result.rawValue)"
+                    + (retry.reason.map { ": \($0.rawValue)" } ?? "") + ")")
+            return
+        }
+
+        try? await clock.sleep(for: deadline)
+        let second = await observe(actuationID: armed.actuationID, terminalID: armed.terminalID)
+        await record(second, confirming: armed.actuationID)
+        // Two silent failures indicate a structural problem with the session,
+        // and a third send without evidence would risk duplicate-message bugs.
+        // There is no third send, on any branch, ever.
+        if second.result != .landedAndActing && second.result != .landedButStillBlocked {
+            announceAnomaly(second, confirming: armed)
+        }
+    }
+
+    // MARK: - The observation
+
+    /// §12's four results, from two machine facts and nothing else.
+    ///
+    /// Never a pane read: screen text is a display surface, not an API (root
+    /// `CLAUDE.md`, "No TUI screen-scraping"). The transcript is the machine
+    /// interface, and the envelope reaches it without the agent cooperating in
+    /// anything.
+    func observe(actuationID: String, terminalID: UUID) async -> DeliveryObservation {
+        guard let facts = await source.facts(forTerminal: terminalID) else {
+            return DeliveryObservation(
+                .undetermined,
+                detail: "terminal \(terminalID.uuidString) is gone — no session left to observe")
+        }
+        guard let path = facts.transcriptPath, !path.isEmpty else {
+            return DeliveryObservation(
+                .undetermined,
+                detail: "no transcript path recorded for terminal \(terminalID.uuidString)")
+        }
+        guard let tail = await source.transcriptTail(
+            atPath: path, maxBytes: Self.tailWindowBytes) else {
+            return DeliveryObservation(
+                .undetermined, detail: "transcript unreadable at \(path)")
+        }
+
+        let found = Self.envelopeAppears(actuationID: actuationID, inTail: tail)
+        switch (found, facts.activityState) {
+        case (true, .working):
+            return DeliveryObservation(.landedAndActing)
+        case (true, .idle), (true, .waitingForUser):
+            return DeliveryObservation(.landedButStillBlocked)
+        case (true, .unknown):
+            // Half an observation is not an observation: the payload is in the
+            // conversation but nothing can be said about what the session did
+            // with it. Safe to leave here precisely because undetermined is
+            // never retried.
+            return DeliveryObservation(
+                .undetermined,
+                detail: "envelope found in the transcript, but the session state is unknown")
+        case (false, .idle), (false, .waitingForUser):
+            // The only positive evidence of non-delivery §12 accepts: the
+            // transcript is readable, the envelope is absent, and the session
+            // is verifiably not mid-turn.
+            return DeliveryObservation(
+                .notLanded,
+                detail: "no dispatch envelope in the transcript tail and the session is "
+                    + "\(facts.activityState.rawValue) — verifiably not mid-turn")
+        case (false, .working):
+            // Absence while mid-turn proves nothing: the harness may not have
+            // written the line yet. No positive evidence, so no retry.
+            return DeliveryObservation(
+                .undetermined,
+                detail: "no dispatch envelope in the transcript tail, but the session is "
+                    + "mid-turn — not verifiably non-delivery")
+        case (false, .unknown):
+            return DeliveryObservation(
+                .undetermined,
+                detail: "no dispatch envelope in the transcript tail and the session state "
+                    + "is unknown")
+        }
+    }
+
+    /// Whether the dispatch envelope for `actuationID` appears in the tail.
+    ///
+    /// **Both spellings count.** The transcript is JSONL and the envelope's
+    /// quotes are part of a JSON string value, so the line on disk carries
+    /// `id=\"a3f1\"`, not `id="a3f1"`. Searching only the raw form would find
+    /// nothing in a real transcript and report `not-landed` for every delivered
+    /// payload; searching only the escaped form would miss a transcript format
+    /// that quotes differently. Both needles are composed from the id, so
+    /// neither can drift from the string the send path actually pastes.
+    ///
+    /// Matched on **bytes**, not on a decoded string: a fixed-size window off
+    /// the end of a file can begin in the middle of a multi-byte character, and
+    /// a failable `String` conversion would then throw the whole window away
+    /// and report an absent envelope — a not-landed verdict manufactured by the
+    /// reader. The needles are ASCII, so a byte search is exact.
+    static func envelopeAppears(actuationID: String, inTail tail: Data) -> Bool {
+        needles(forActuationID: actuationID).contains { tail.range(of: Data($0.utf8)) != nil }
+    }
+
+    /// The two spellings of the envelope's identifying attribute. Tests assert
+    /// on these composed strings rather than on a predicate's verdict, so a
+    /// needle that stopped matching what `dispatchEnvelope` writes goes red.
+    static func needles(forActuationID id: String) -> [String] {
+        [
+            "tbd-dispatch id=\"\(id)\"",
+            "tbd-dispatch id=\\\"\(id)\\\"",
+        ]
+    }
+
+    // MARK: - Recording, and the anomaly
+
+    private func record(
+        _ observation: DeliveryObservation, confirming actuationID: String
+    ) async {
+        await log.appendObservation(
+            confirms: actuationID, result: observation.result,
+            observedAt: now(), detail: observation.detail)
+    }
+
+    /// The anomaly, in the two halves it has until the ledger exists (§7 builds
+    /// no supervision storage yet): the observed outcome row — already written
+    /// by `record`, carrying the detail — and a loud `.fault` line. When the
+    /// ledger slice lands its `anomaly` line joins these; the row is the
+    /// durable half either way.
+    /// `note` carries something the log line should say that the *record* must
+    /// not — a failed re-delivery, whose synchronous outcome row already stands
+    /// on its own. Diagnostics may narrate; the record may only attest.
+    private func announceAnomaly(
+        _ observation: DeliveryObservation,
+        confirming armed: ArmedDelivery,
+        note: String? = nil
+    ) {
+        verifierLogger.fault(
+            """
+            delivery anomaly: act \(armed.actuationID, privacy: .public) to terminal \
+            \(armed.terminalID.uuidString, privacy: .public) observed \
+            \(observation.result.rawValue, privacy: .public) — \
+            \(observation.detail ?? "no detail", privacy: .public)\
+            \(note.map { "; \($0)" } ?? "", privacy: .public)
+            """)
+    }
+
+    // MARK: - The startup replay
+
+    /// Perform, late, the observations whose timers died with the last daemon.
+    ///
+    /// **Reads only the active segment.** An act older than
+    /// `actuations.jsonl`'s current day is one whose transcript may have rolled
+    /// over, and re-delivery is forbidden here anyway, so a late read buys only
+    /// a more precise word for something the query-time rule already renders
+    /// honestly. The writer's own daily rotation therefore bounds both the read
+    /// and the work, with no new threshold to pick.
+    ///
+    /// **It never re-delivers.** §12 puts "what to *do* about an unconfirmed
+    /// act — re-send, journal, shrug" in playbook judgment, never compiled
+    /// repair, and a payload whose premise is an unbounded interval old is
+    /// exactly the stale-premise send §3 forbids. So a replayed `not-landed`
+    /// records the outcome and the anomaly, and stops.
+    ///
+    /// `.awaitingObservation` acts are left alone: their deadline has not
+    /// passed, so nothing is owed yet.
+    func replayMissedObservations(activeSegmentPath: String) async {
+        let reader = ActuationRecordReader(activePath: activeSegmentPath)
+        let rows = reader.rows(inFileAt: activeSegmentPath)
+        let unconfirmed = DeliveryRecord.statuses(in: rows, now: now())
+            .filter { $0.status == .unconfirmed }
+        guard !unconfirmed.isEmpty else { return }
+        verifierLogger.info(
+            """
+            startup replay: \(unconfirmed.count, privacy: .public) verified send(s) in the \
+            active segment are past their acknowledgement deadline with no observation
+            """)
+        for assessment in unconfirmed {
+            guard let terminalRaw = assessment.request.target?.terminal,
+                  let terminalID = UUID(uuidString: terminalRaw) else {
+                let observation = DeliveryObservation(
+                    .undetermined,
+                    detail: "the request row names no local terminal to observe")
+                await record(observation, confirming: assessment.request.id)
+                verifierLogger.fault(
+                    """
+                    delivery anomaly: act \(assessment.request.id, privacy: .public) observed \
+                    undetermined at startup — \(observation.detail ?? "", privacy: .public)
+                    """)
+                continue
+            }
+            let observation = await observe(
+                actuationID: assessment.request.id, terminalID: terminalID)
+            await record(observation, confirming: assessment.request.id)
+            if observation.result != .landedAndActing
+                && observation.result != .landedButStillBlocked {
+                verifierLogger.fault(
+                    """
+                    delivery anomaly: act \(assessment.request.id, privacy: .public) to terminal \
+                    \(terminalID.uuidString, privacy: .public) observed late at startup as \
+                    \(observation.result.rawValue, privacy: .public) — \
+                    \(observation.detail ?? "no detail", privacy: .public); not re-delivered \
+                    (§12 leaves repair to playbook judgment)
+                    """)
+            }
+        }
+    }
+}

--- a/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
+++ b/Sources/TBDDaemon/Actuation/RPCRouter+Actuation.swift
@@ -22,6 +22,7 @@ extension RPCRouter {
         target: ActuationTarget,
         message: String? = nil,
         submit: Bool? = nil,
+        verify: Bool? = nil,
         prompt: String? = nil,
         agent: String? = nil,
         profile: String? = nil
@@ -31,6 +32,7 @@ extension RPCRouter {
         row.target = target
         row.message = message
         row.submit = submit
+        row.verify = verify
         row.prompt = prompt
         row.agent = agent
         row.profile = profile

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -270,9 +270,10 @@ public final class Daemon: Sendable {
         let verifier = DeliveryVerifier(
             log: actuationLog,
             source: source ?? DatabaseDeliveryObservationSource(db: database),
-            redeliver: { [rpcRouter] terminalID, payload, submit in
+            redeliver: { [rpcRouter] terminalID, sessionID, payload, submit in
                 await rpcRouter.redeliverVerifiedPayload(
-                    terminalID: terminalID, payload: payload, submit: submit)
+                    terminalID: terminalID, sessionID: sessionID,
+                    payload: payload, submit: submit)
             })
         rpcRouter.deliveryVerifier = verifier
         await verifier.replayMissedObservations(activeSegmentPath: actuationLog.path)

--- a/Sources/TBDDaemon/Daemon.swift
+++ b/Sources/TBDDaemon/Daemon.swift
@@ -231,6 +231,54 @@ public final class Daemon: Sendable {
         await healthValidator.validateAll(db: database)
     }
 
+    /// Wire the delivery verifier and perform the startup replay, gated on
+    /// `delivery_verification_enabled` and skipped in mock mode.
+    ///
+    /// Extracted from `start()` for the same reason
+    /// `performStartupReconciliation` was: both branches of the flag have to be
+    /// testable without spawning sockets or background tasks.
+    ///
+    /// **While the flag is off the verifier is simply absent.** Nothing arms,
+    /// nothing replays, and no transcript is ever read — and an armed send
+    /// never gets that far, because `terminal.send` refuses `--verify` ahead of
+    /// touching the pane.
+    ///
+    /// The flag is read once, here; `terminal.send` reads the column per call.
+    /// Those two clocks disagree for exactly one window — the flag flipped on,
+    /// this daemon not yet restarted — and the send path closes it by refusing
+    /// on an absent verifier as well as on an off column. Otherwise a send in
+    /// that window would dispatch with nothing armed and render `unconfirmed`
+    /// forever: a silence that reads like a delivery failure when nothing ever
+    /// looked. So the two halves fail closed together, and enabling the flag
+    /// means enabling it *and* restarting, which is what the soak instructions
+    /// say.
+    @discardableResult
+    static func wireDeliveryVerification(
+        mockMode: MockMode?,
+        database: TBDDatabase,
+        rpcRouter: RPCRouter,
+        actuationLog: ActuationLog,
+        source: (any DeliveryObservationSource)? = nil
+    ) async -> DeliveryVerifier? {
+        guard mockMode == nil else {
+            daemonLogger.info("Mock mode: skipping delivery verification")
+            return nil
+        }
+        guard (try? await database.config.get())?.deliveryVerificationEnabled == true else {
+            return nil
+        }
+        let verifier = DeliveryVerifier(
+            log: actuationLog,
+            source: source ?? DatabaseDeliveryObservationSource(db: database),
+            redeliver: { [rpcRouter] terminalID, payload, submit in
+                await rpcRouter.redeliverVerifiedPayload(
+                    terminalID: terminalID, payload: payload, submit: submit)
+            })
+        rpcRouter.deliveryVerifier = verifier
+        await verifier.replayMissedObservations(activeSegmentPath: actuationLog.path)
+        return verifier
+    }
+
     /// Recreate the base scratch directory if it's missing. Safe to call every startup.
     static func ensureScratchDir() {
         let fm = FileManager.default
@@ -565,6 +613,12 @@ public final class Daemon: Sendable {
         // 11. Perform DB-mutating reconciliation (skipped in mock mode so fixtures render as authored)
         await performStartupReconciliation(
             mockMode: mockMode, database: database, git: git, lifecycle: lifecycle,
+            actuationLog: actuationLog)
+
+        // 11b. Delivery acknowledgement (design §12): wire the verifier and
+        // replay the observations the last daemon's timers died owing.
+        await Daemon.wireDeliveryVerification(
+            mockMode: mockMode, database: database, rpcRouter: rpcRouter,
             actuationLog: actuationLog)
 
         if mockMode == nil {

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -41,6 +41,9 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var daemon_panel_surface_enabled: Bool?
     var agent_panel_control_enabled: Bool?
     var remote_backends_enabled: Bool?
+    /// Delivery acknowledgement (design §12). Nil/absent means OFF — the
+    /// `v69_config_delivery_verification` column default.
+    var delivery_verification_enabled: Bool?
 
     func toModel() -> Config {
         Config(
@@ -79,7 +82,8 @@ struct ConfigRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             gcSnapshotRetentionDays: gc_snapshot_retention_days ?? Config.defaultGCSnapshotRetentionDays,
             panelSurfaceEnabled: daemon_panel_surface_enabled ?? false,
             agentPanelControlEnabled: agent_panel_control_enabled ?? false,
-            remoteBackendsEnabled: remote_backends_enabled ?? false
+            remoteBackendsEnabled: remote_backends_enabled ?? false,
+            deliveryVerificationEnabled: delivery_verification_enabled ?? false
         )
     }
 }
@@ -286,6 +290,21 @@ public struct ConfigStore: Sendable {
         try await writer.write { db in
             try db.execute(
                 sql: "UPDATE config SET hibernate_input_veto_enabled = ? WHERE id = ?",
+                arguments: [enabled, Self.singletonID]
+            )
+        }
+    }
+
+    /// Persist the delivery-acknowledgement opt-in (default OFF, soaking).
+    /// `terminal.send` re-reads it per call — but only when the caller armed
+    /// `--verify`, so an ordinary send pays nothing — and it therefore applies
+    /// to the next send with no daemon restart. Turning it off does not cancel
+    /// observations already armed; it stops new ones from being armed and makes
+    /// `--verify` a refusal again.
+    public func setDeliveryVerification(enabled: Bool) async throws {
+        try await writer.write { db in
+            try db.execute(
+                sql: "UPDATE config SET delivery_verification_enabled = ? WHERE id = ?",
                 arguments: [enabled, Self.singletonID]
             )
         }

--- a/Sources/TBDDaemon/Database/ConfigStore.swift
+++ b/Sources/TBDDaemon/Database/ConfigStore.swift
@@ -296,11 +296,17 @@ public struct ConfigStore: Sendable {
     }
 
     /// Persist the delivery-acknowledgement opt-in (default OFF, soaking).
-    /// `terminal.send` re-reads it per call — but only when the caller armed
-    /// `--verify`, so an ordinary send pays nothing — and it therefore applies
-    /// to the next send with no daemon restart. Turning it off does not cancel
-    /// observations already armed; it stops new ones from being armed and makes
-    /// `--verify` a refusal again.
+    ///
+    /// **Enabling it takes effect at the next daemon start.** `terminal.send`
+    /// re-reads this column per call — but only when the caller armed
+    /// `--verify`, so an ordinary send pays nothing — while the observation
+    /// machinery it gates is wired once, at startup. In between, `--verify` is
+    /// refused with a message naming the restart, rather than dispatched with
+    /// nothing armed.
+    ///
+    /// Turning it off does not cancel observations already armed; it stops new
+    /// ones from being armed and makes `--verify` a refusal again — and that
+    /// half does apply to the next send.
     public func setDeliveryVerification(enabled: Bool) async throws {
         try await writer.write { db in
             try db.execute(

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1210,7 +1210,9 @@ public final class TBDDatabase: Sendable {
         // migration is ever needed to flip the default later.
         //
         // The flag does not gate the dispatch envelope — attribution rides
-        // every text send regardless (§12).
+        // every text send to an agent regardless, verified or not (§12).
+        // Whether a target gets one at all is a property of the target: a shell
+        // would execute the tag, so it receives the text alone.
         migrator.registerMigration("v69_config_delivery_verification") { db in
             try db.addColumnIfMissing(
                 table: "config", column: "delivery_verification_enabled",

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1201,6 +1201,22 @@ public final class TBDDatabase: Sendable {
             }
         }
 
+        // Soak flag for delivery acknowledgement (fleet-supervision design
+        // §12). Default false, following the `hibernate_input_veto_enabled`
+        // (v51) / `control_mode_enabled` precedent rather than the v39/v50
+        // cautionary one: the re-check acts on no user gesture and its retry
+        // types into a live session, so the whole path ships off and is opted
+        // into for its soak. Shipping OFF also means no forcing `UPDATE`
+        // migration is ever needed to flip the default later.
+        //
+        // The flag does not gate the dispatch envelope — attribution rides
+        // every text send regardless (§12).
+        migrator.registerMigration("v69_config_delivery_verification") { db in
+            try db.addColumnIfMissing(
+                table: "config", column: "delivery_verification_enabled",
+                type: .boolean, defaults: false)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Server/DeliveryVerificationArming.swift
+++ b/Sources/TBDDaemon/Server/DeliveryVerificationArming.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The hand-off from a dispatched send to the observation that will establish
+/// whether it landed — the second rung of the record's ladder handing to the
+/// third (fleet-supervision design §12).
+///
+/// The send path deliberately owns none of the observation. It knows only that
+/// it typed something, which is precisely the claim §12 forbids conflating with
+/// delivery, so the whole of "did it land" lives behind this one method: the
+/// one-minute re-check, the transcript tail read, the four-result mapping, the
+/// evidence-bounded single retry, and the startup replay.
+///
+/// **Contract.**
+/// - Called **exactly once** per send, and only for a send that was
+///   `.dispatched`, carried a non-empty **text** payload, and whose caller
+///   armed `--verify` while `delivery_verification_enabled` was on. Never for
+///   a verify-less send, a refused send, a transport failure, or a `--keys`
+///   payload (keys reach no transcript, so there is nothing to observe).
+/// - `deliveredPayload` is the bytes that actually reached the pane —
+///   **envelope line included** — so a retry re-delivers byte-identically and
+///   still joins on the original row. The envelope's id *is* `actuationID`;
+///   there is no second identifier namespace.
+/// - Implementations must not block the send: the RPC response is the caller's
+///   synchronous result, and the observation happens a minute later.
+///
+/// **Unimplemented on purpose.** Nothing conforms to this yet. The conforming
+/// type is `DeliveryVerifier` — the re-check actor, the retry, the anomaly, and
+/// the startup replay — which lands beside this and is wired onto
+/// `RPCRouter.deliveryVerifier` in `Daemon.swift` next to
+/// `performStartupReconciliation`. Until then `deliveryVerifier` is nil, an
+/// armed send is simply never observed, and `DeliveryRecord.statuses` renders
+/// it `unconfirmed` — the fail-closed answer, and the reason no repair row is
+/// ever written to say so.
+protocol DeliveryVerificationArming: Sendable {
+    func armVerification(
+        actuationID: String,
+        terminalID: UUID,
+        deliveredPayload: String,
+        submit: Bool
+    ) async
+}

--- a/Sources/TBDDaemon/Server/DeliveryVerificationArming.swift
+++ b/Sources/TBDDaemon/Server/DeliveryVerificationArming.swift
@@ -20,21 +20,25 @@ import Foundation
 ///   **envelope line included** — so a retry re-delivers byte-identically and
 ///   still joins on the original row. The envelope's id *is* `actuationID`;
 ///   there is no second identifier namespace.
+/// - `sessionID` is the conversation those bytes went into. The observation
+///   compares it before reasoning about a transcript, because `/clear` and an
+///   account swap rebind a terminal to a new session without disturbing its
+///   pane — so the pane consultation, which compares pane ids, cannot see it.
+///   `nil` when the terminal had reported no session yet.
 /// - Implementations must not block the send: the RPC response is the caller's
 ///   synchronous result, and the observation happens a minute later.
 ///
-/// **Unimplemented on purpose.** Nothing conforms to this yet. The conforming
-/// type is `DeliveryVerifier` — the re-check actor, the retry, the anomaly, and
-/// the startup replay — which lands beside this and is wired onto
-/// `RPCRouter.deliveryVerifier` in `Daemon.swift` next to
-/// `performStartupReconciliation`. Until then `deliveryVerifier` is nil, an
-/// armed send is simply never observed, and `DeliveryRecord.statuses` renders
-/// it `unconfirmed` — the fail-closed answer, and the reason no repair row is
-/// ever written to say so.
+/// The conforming type is `DeliveryVerifier`, wired onto
+/// `RPCRouter.deliveryVerifier` in `Daemon.swift` beside
+/// `performStartupReconciliation` and only when
+/// `delivery_verification_enabled` is on. While it is nil an armed send is
+/// refused outright rather than dispatched unobserved: a caller that asked for
+/// evidence must never be answered with a silence that reads like confirmation.
 protocol DeliveryVerificationArming: Sendable {
     func armVerification(
         actuationID: String,
         terminalID: UUID,
+        sessionID: String?,
         deliveredPayload: String,
         submit: Bool
     ) async

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -109,6 +109,18 @@ extension RPCRouter {
         return .ok()
     }
 
+    /// Persist the delivery-acknowledgement soak flag (design §12). This is
+    /// how an operator enables the flag for its soak. `terminal.send` reads it
+    /// per `--verify` call, so it applies to the next send immediately — no
+    /// daemon restart. Turning it off makes `--verify` a refusal again.
+    func handleConfigSetDeliveryVerification(_ paramsData: Data) async throws -> RPCResponse {
+        let params = try decoder.decode(ConfigSetDeliveryVerificationParams.self, from: paramsData)
+        try await db.config.setDeliveryVerification(enabled: params.enabled)
+        // Broadcast so the app reloads daemon capabilities.
+        subscriptions.broadcast(delta: .modelProfilesChanged)
+        return .ok()
+    }
+
     /// Persist the auto-close-setup-tab soak flag. Read fresh at spawn time,
     /// so it applies to the next worktree creation immediately — already-open
     /// setup tabs are unaffected.

--- a/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ConfigHandlers.swift
@@ -109,10 +109,12 @@ extension RPCRouter {
         return .ok()
     }
 
-    /// Persist the delivery-acknowledgement soak flag (design §12). This is
-    /// how an operator enables the flag for its soak. `terminal.send` reads it
-    /// per `--verify` call, so it applies to the next send immediately — no
-    /// daemon restart. Turning it off makes `--verify` a refusal again.
+    /// Persist the delivery-acknowledgement soak flag (design §12). This is how
+    /// an operator enables the flag for its soak — **and enabling it means
+    /// restarting the daemon afterwards**, because the observation machinery is
+    /// wired once at startup while this column is read per `--verify` call.
+    /// Until the restart, `--verify` is refused with a message saying so.
+    /// Turning it off makes `--verify` a refusal again on the next send.
     func handleConfigSetDeliveryVerification(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ConfigSetDeliveryVerificationParams.self, from: paramsData)
         try await db.config.setDeliveryVerification(enabled: params.enabled)

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2187,7 +2187,7 @@ extension RPCRouter {
     /// since. And it queues in the same per-terminal lane, so a retry can never
     /// splice itself into a concurrent send's paste.
     func redeliverVerifiedPayload(
-        terminalID: UUID, payload: String, submit: Bool
+        terminalID: UUID, sessionID: String?, payload: String, submit: Bool
     ) async -> ActuationOutcome {
         guard let terminal = try? await db.terminals.get(id: terminalID),
               let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
@@ -2201,6 +2201,15 @@ extension RPCRouter {
         // for the second.
         guard Self.supportsDeliveryObservation(terminal) else {
             return .refused(.notEligible)
+        }
+        // And the conversation is re-checked here, not only at the observation.
+        // The gap between the two spans a DB write, two reads and this
+        // serializer's queue — long enough for a `/clear` to land in it — and
+        // the payload being held is an instruction addressed to the session
+        // that is no longer there. A rebind makes this a send to a stranger,
+        // which is the one thing the retry must never be.
+        guard terminal.claudeSessionID == sessionID else {
+            return .refused(.targetMismatch)
         }
         let outcome: ActuationOutcome
         do {

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -60,6 +60,19 @@ actor TranscriptParseCache {
     }
 }
 
+// MARK: - The pane consultation's verdict
+
+/// A pane consultation that came back "do not type here", with the outcome the
+/// record gets and the message the caller sees.
+///
+/// One type for both typing paths — the send handler and the verifier's
+/// retry — so a refusal cannot be classified two ways depending on which one
+/// asked.
+struct PaneSendRefusal: Sendable {
+    let outcome: ActuationOutcome
+    let message: String
+}
+
 extension RPCRouter {
 
     // MARK: - Terminal Handlers
@@ -1932,78 +1945,56 @@ extension RPCRouter {
         // shows the near-miss so the morning can see what the flag stopped.
         //
         // Read per call and only when `--verify` was armed, so an ordinary send
-        // pays no config read — and flipping the flag needs no daemon restart.
+        // pays no config read.
+        //
+        // Two conditions, because the flag and the machinery it enables are
+        // read at different times: the column per call, the verifier once at
+        // daemon start. Between flipping the flag on and restarting, the column
+        // says yes and there is still nothing to arm — and a send that
+        // dispatched with nothing armed would render `unconfirmed` forever,
+        // handing the caller a silence that reads like a delivery failure when
+        // nothing ever looked. Both conditions therefore refuse, and neither
+        // types anything.
         if payload.isVerifyArmed {
             let enabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
             if !enabled {
                 let message = """
                     terminal.send --verify was refused: delivery verification is disabled \
                     (config.delivery_verification_enabled is off) — nothing was sent. Enable \
-                    it with the config.setDeliveryVerification RPC, or resend without --verify \
-                    to accept an unverified send.
+                    it with the config.setDeliveryVerification RPC and restart the daemon, or \
+                    resend without --verify to accept an unverified send.
+                    """
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
+                return RPCResponse(error: message)
+            }
+            if deliveryVerifier == nil {
+                let message = """
+                    terminal.send --verify was refused: delivery verification is enabled but \
+                    this daemon has no verifier wired, so the flag was turned on after it \
+                    started — nothing was sent. Restart the daemon to arm the observation, or \
+                    resend without --verify to accept an unverified send.
                     """
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
             }
         }
 
-        // Ask the pane about itself before typing into it. tmux's own exit
-        // status cannot carry this: `send-keys` into a `remain-on-exit` dead
-        // pane exits 0, and keys sent to a reused pane id land in a live
-        // stranger's composer with no error anywhere (issue #384). Both answers
-        // arrive from ONE read-only `list-panes`, and both are read BEFORE any
-        // byte is written — so a decline here is a refusal, never a transport
-        // failure: the daemon declined without touching the transport.
-        let target: PaneSendTarget
+        // Ask the pane about itself before typing into it — the honest-transport
+        // check of issue #384 and the dead-pane class beside it. A decline here
+        // is a refusal, never a transport failure: the daemon declined without
+        // touching the transport. The consultation itself failing is the
+        // opposite, and is classified as such.
+        let refusal: PaneSendRefusal?
         do {
-            target = try await tmux.paneSendTarget(
-                server: worktree.tmuxServer, paneID: terminal.tmuxPaneID)
+            refusal = try await consultPaneBeforeTyping(
+                terminal: terminal, server: worktree.tmuxServer)
         } catch {
-            // The consultation itself could not be run (a wedged tmux tripping
-            // the subprocess timeout). That is a tmux command failing, not an
-            // answer about the pane, and it is classified as such.
             await finishActuation(actuationID, .transportFailed, error: "\(error)")
             throw error
         }
-
-        switch target {
-        case .missing:
-            let message = """
-                tmux pane \(terminal.tmuxPaneID) for terminal \(terminal.id.uuidString) \
-                no longer exists on server \(worktree.tmuxServer) — nothing was sent
-                """
-            await finishActuation(actuationID, .refused(.notFound), error: message)
-            return RPCResponse(error: message)
-        case .dead:
-            let message = """
-                tmux pane \(terminal.tmuxPaneID) for terminal \(terminal.id.uuidString) is \
-                dead (its process has exited) — nothing was sent; recreate the terminal's \
-                window first
-                """
-            await finishActuation(actuationID, .refused(.notEligible), error: message)
-            return RPCResponse(error: message)
-        case .live(let paneTerminalID):
-            guard let paneTerminalID else {
-                // Absence is not disagreement. A pane spawned before TBD stamped
-                // identities, or by something outside TBD, answers with nothing —
-                // and refusing on nothing would turn this fix into a regression
-                // for every such pane. Only a POSITIVE disagreement refuses.
-                logger.debug("""
-                    terminal.send: pane \(terminal.tmuxPaneID, privacy: .public) claims no \
-                    terminal identity; proceeding without verifying it is terminal \
-                    \(terminal.id.uuidString, privacy: .public)
-                    """)
-                break
-            }
-            if paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString) != .orderedSame {
-                let message = """
-                    tmux pane \(terminal.tmuxPaneID) now belongs to terminal \
-                    \(paneTerminalID), not the requested terminal \(terminal.id.uuidString) \
-                    — nothing was sent (tmux reuses pane ids, so this coordinate is stale)
-                    """
-                await finishActuation(actuationID, .refused(.targetMismatch), error: message)
-                return RPCResponse(error: message)
-            }
+        if let refusal {
+            await finishActuation(actuationID, refusal.outcome, error: refusal.message)
+            return RPCResponse(error: refusal.message)
         }
 
         // What actually reached the pane, envelope included — nil for a payload
@@ -2093,6 +2084,116 @@ extension RPCRouter {
                 submit: payload.recordedSubmit ?? false)
         }
         return .ok()
+    }
+
+    // MARK: - The pane consultation, and the verifier's re-delivery
+
+    /// Consult the pane the send names, and classify the answer.
+    ///
+    /// `nil` means "proceed" — the pane is alive and either agrees it is this
+    /// terminal or claims no identity at all. Anything else is a refusal the
+    /// caller records and returns, with the message a human reads.
+    ///
+    /// tmux's own exit status cannot carry this: `send-keys` into a
+    /// `remain-on-exit` dead pane exits 0, and keys sent to a reused pane id
+    /// land in a live stranger's composer with no error anywhere (issue #384).
+    /// Both answers arrive from ONE read-only `list-panes`, read BEFORE any
+    /// byte is written. Throws only when the consultation could not be RUN — a
+    /// wedged tmux tripping the subprocess timeout — which is a tmux command
+    /// failing, not an answer about the pane.
+    ///
+    /// Shared by the send path and by `redeliverVerifiedPayload`, so the retry
+    /// cannot re-type into a pane the first send would have refused.
+    private func consultPaneBeforeTyping(
+        terminal: Terminal, server: String
+    ) async throws -> PaneSendRefusal? {
+        switch try await tmux.paneSendTarget(server: server, paneID: terminal.tmuxPaneID) {
+        case .missing:
+            return PaneSendRefusal(outcome: .refused(.notFound), message: """
+                tmux pane \(terminal.tmuxPaneID) for terminal \(terminal.id.uuidString) \
+                no longer exists on server \(server) — nothing was sent
+                """)
+        case .dead:
+            return PaneSendRefusal(outcome: .refused(.notEligible), message: """
+                tmux pane \(terminal.tmuxPaneID) for terminal \(terminal.id.uuidString) is \
+                dead (its process has exited) — nothing was sent; recreate the terminal's \
+                window first
+                """)
+        case .live(let paneTerminalID):
+            guard let paneTerminalID else {
+                // Absence is not disagreement. A pane spawned before TBD stamped
+                // identities, or by something outside TBD, answers with nothing —
+                // and refusing on nothing would turn this fix into a regression
+                // for every such pane. Only a POSITIVE disagreement refuses.
+                logger.debug("""
+                    terminal.send: pane \(terminal.tmuxPaneID, privacy: .public) claims no \
+                    terminal identity; proceeding without verifying it is terminal \
+                    \(terminal.id.uuidString, privacy: .public)
+                    """)
+                return nil
+            }
+            guard paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString)
+                != .orderedSame else { return nil }
+            return PaneSendRefusal(outcome: .refused(.targetMismatch), message: """
+                tmux pane \(terminal.tmuxPaneID) now belongs to terminal \
+                \(paneTerminalID), not the requested terminal \(terminal.id.uuidString) \
+                — nothing was sent (tmux reuses pane ids, so this coordinate is stale)
+                """)
+        }
+    }
+
+    /// Re-deliver an already-recorded payload, byte-identically, for the
+    /// delivery verifier's single evidence-bounded retry (§12).
+    ///
+    /// **Writes no row of its own, and mints no id.** The retry re-delivers the
+    /// identical payload under the identical envelope id, so it is the same
+    /// actuation-level intent as the original send — a second request row would
+    /// split one intent in two and break the join that makes the ladder
+    /// readable. The verifier records this call's *outcome* against the
+    /// original request id, which is why the outcome is returned rather than
+    /// thrown: a refused or transport-failed retry must be classified as what
+    /// it was, not collapsed into "the payload failed".
+    ///
+    /// It runs the same pane consultation the first send ran, through the same
+    /// helper: a minute has passed, and the pane may have died or been reused
+    /// since. And it queues in the same per-terminal lane, so a retry can never
+    /// splice itself into a concurrent send's paste.
+    func redeliverVerifiedPayload(
+        terminalID: UUID, payload: String, submit: Bool
+    ) async -> ActuationOutcome {
+        guard let terminal = try? await db.terminals.get(id: terminalID),
+              let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+            return .refused(.notFound)
+        }
+        let outcome: ActuationOutcome
+        do {
+            outcome = try await terminalSendSerializer.run(terminalID: terminalID) {
+                if let refusal = try await self.consultPaneBeforeTyping(
+                    terminal: terminal, server: worktree.tmuxServer) {
+                    return refusal.outcome
+                }
+                try await self.tmux.pasteText(
+                    server: worktree.tmuxServer,
+                    paneID: terminal.tmuxPaneID,
+                    bytes: Data(payload.utf8))
+                if submit {
+                    try await self.tmux.sendKey(
+                        server: worktree.tmuxServer,
+                        paneID: terminal.tmuxPaneID,
+                        key: "Enter")
+                }
+                return .dispatched
+            }
+        } catch {
+            // Either the consultation could not be run or the paste itself
+            // failed. Both are the transport, not a decision.
+            logger.warning("""
+                delivery retry: re-delivery to terminal \(terminalID.uuidString, privacy: .public) \
+                failed: \(error, privacy: .public)
+                """)
+            return .transportFailed
+        }
+        return outcome
     }
 
     // MARK: - terminal.send payload shape

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1956,6 +1956,19 @@ extension RPCRouter {
         // nothing ever looked. Both conditions therefore refuse, and neither
         // types anything.
         if payload.isVerifyArmed {
+            // A shell has no transcript, so no observation can ever be made
+            // about it: verification would arm a re-check that must return
+            // `undetermined` every time. Refuse rather than promise evidence
+            // this target can never produce.
+            if !Self.carriesDispatchEnvelope(terminal) {
+                let message = """
+                    terminal.send --verify was refused: terminal \
+                    \(terminal.id.uuidString) is a shell, which keeps no transcript for a \
+                    delivery to be observed in — nothing was sent. Resend without --verify.
+                    """
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
+                return RPCResponse(error: message)
+            }
             let enabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
             if !enabled {
                 let message = """
@@ -2032,9 +2045,19 @@ extension RPCRouter {
                 // terminal send --text "" --submit` is a real way to press Enter
                 // and must not start pasting a tag.
                 if !text.isEmpty {
-                    let composed = Self.dispatchEnvelope(
-                        id: actuationID, from: (actor ?? .anonymous).dispatchLabel
-                    ) + "\n" + text
+                    // ...and it rides every send to an AGENT. A shell is not a
+                    // reader of envelopes: it has no transcript to join back to,
+                    // and a `--submit` there would execute the tag as a command
+                    // line of its own before the caller's text ever ran. Every
+                    // sentence §12 uses to justify the envelope is about a
+                    // receiving agent and its transcript JSONL; a shell target
+                    // satisfies none of them, so prefixing one would be framing
+                    // nobody reads, delivered as a syntax error.
+                    let composed = Self.carriesDispatchEnvelope(terminal)
+                        ? Self.dispatchEnvelope(
+                            id: actuationID, from: (actor ?? .anonymous).dispatchLabel
+                        ) + "\n" + text
+                        : text
                     try await tmux.pasteText(
                         server: worktree.tmuxServer,
                         paneID: terminal.tmuxPaneID,
@@ -2208,6 +2231,27 @@ extension RPCRouter {
     /// can close the tag or open a second attribute.
     static func dispatchEnvelope(id: String, from label: String) -> String {
         "<tbd-dispatch id=\"\(id)\" from=\"\(label)\"/>"
+    }
+
+    /// Whether this target is one the envelope means anything to.
+    ///
+    /// Agent sessions only. The envelope exists so a receiving agent can see who
+    /// is addressing it and so a later reader can join a transcript message back
+    /// to its actuation row — and a shell has neither property: nothing reads the
+    /// tag, no transcript records it, and `--submit` would run it as a command
+    /// line of its own. `tbd terminal send` into a plain shell pane is a
+    /// supported thing to do (`docs/tmux-integration.md`), so this is a real
+    /// target rather than a theoretical one.
+    ///
+    /// A terminal with no recorded kind is treated as a shell — the same
+    /// defaulting the rest of this file uses (`terminal.kind ?? .shell`), and the
+    /// conservative direction: it withholds framing rather than typing a tag into
+    /// something that may execute it.
+    static func carriesDispatchEnvelope(_ terminal: Terminal) -> Bool {
+        switch terminal.kind ?? .shell {
+        case .claude, .codex: return true
+        case .shell: return false
+        }
     }
 
     /// Reject the payload shapes that name no coherent act, before a row exists.

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1956,15 +1956,19 @@ extension RPCRouter {
         // nothing ever looked. Both conditions therefore refuse, and neither
         // types anything.
         if payload.isVerifyArmed {
-            // A shell has no transcript, so no observation can ever be made
-            // about it: verification would arm a re-check that must return
-            // `undetermined` every time. Refuse rather than promise evidence
-            // this target can never produce.
-            if !Self.carriesDispatchEnvelope(terminal) {
+            // Only a target with an adapter that can answer may be verified. A
+            // shell keeps no transcript at all, and Codex's adapter is a
+            // different mechanism §12 describes but this slice does not build —
+            // either way the one observation that exists would return
+            // `undetermined` every time. Refuse rather than promise evidence the
+            // target cannot produce.
+            if !Self.supportsDeliveryObservation(terminal) {
+                let kindName = (terminal.kind ?? .shell).rawValue
                 let message = """
                     terminal.send --verify was refused: terminal \
-                    \(terminal.id.uuidString) is a shell, which keeps no transcript for a \
-                    delivery to be observed in — nothing was sent. Resend without --verify.
+                    \(terminal.id.uuidString) is a \(kindName) session, and delivery can only \
+                    be observed for a Claude session today — nothing was sent. Resend without \
+                    --verify.
                     """
                 await finishActuation(actuationID, .refused(.notEligible), error: message)
                 return RPCResponse(error: message)
@@ -2030,15 +2034,15 @@ extension RPCRouter {
                 // behave as before. Skip an empty body entirely (don't paste an empty
                 // buffer) but still press Enter below if requested.
                 //
-                // Every NON-EMPTY text payload rides behind the dispatch
+                // A non-empty text payload to an AGENT rides behind the dispatch
                 // envelope (§12): a one-line tag carrying this row's id and the
                 // identity the row was attributed to, then the caller's message
                 // verbatim. It is attribution the receiving agent can read, and
                 // — because a submitted message's verbatim content lands in the
                 // transcript JSONL — it is the machine fact a later observation
-                // looks for, requiring nothing of the agent. It rides every text
-                // send, verified or not: a prefix that appears only sometimes is
-                // one no reader can rely on.
+                // looks for, requiring nothing of the agent. Unconditional along
+                // the axis that matters: verified or not, a prefix that appears
+                // only sometimes is one no reader can rely on.
                 //
                 // An EMPTY payload keeps today's behaviour exactly: nothing is
                 // pasted, and a bare `--submit` still presses Enter. `tbd
@@ -2189,6 +2193,15 @@ extension RPCRouter {
               let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
             return .refused(.notFound)
         }
+        // The kind is re-read too, not just the pane. A `recreateWindow` landing
+        // between the observation and this retry can turn an agent terminal into
+        // a shell while keeping its id, and the payload we are holding opens
+        // with an envelope — which a shell would run as a command line of its
+        // own. The eligibility that admitted the first send has to still hold
+        // for the second.
+        guard Self.supportsDeliveryObservation(terminal) else {
+            return .refused(.notEligible)
+        }
         let outcome: ActuationOutcome
         do {
             outcome = try await terminalSendSerializer.run(terminalID: terminalID) {
@@ -2222,7 +2235,8 @@ extension RPCRouter {
 
     // MARK: - terminal.send payload shape
 
-    /// The dispatch envelope §12 puts ahead of every non-empty text payload.
+    /// The dispatch envelope §12 puts ahead of a non-empty text payload bound
+    /// for an agent (see `carriesDispatchEnvelope` for which targets those are).
     ///
     /// `id` is the actuation row's own id — there is no second identifier
     /// namespace, so dispatch, transcript receipt and outcome all join on one
@@ -2252,6 +2266,26 @@ extension RPCRouter {
         case .claude, .codex: return true
         case .shell: return false
         }
+    }
+
+    /// Whether an adapter exists that can actually observe a delivery to this
+    /// target — the narrower question `--verify` turns on.
+    ///
+    /// Claude only, today. §12 is explicit that the envelope-in-the-transcript
+    /// read is *the Claude adapter's* implementation of the observation, and
+    /// that "the Codex adapter gets the same answer from the app-server
+    /// protocol's in-protocol acknowledgement" — a different mechanism, and one
+    /// this slice does not build. A Codex session records no Claude-shaped
+    /// transcript path, so the one observation that exists would answer
+    /// `undetermined` every time.
+    ///
+    /// So this is the same refusal a shell gets, for the same stated reason:
+    /// promising evidence a target cannot produce is the failure this whole
+    /// mechanism exists to end. Codex still receives the envelope — attribution
+    /// is worth having to any agent, and a composer does not execute it — but it
+    /// cannot be verified until its adapter lands.
+    static func supportsDeliveryObservation(_ terminal: Terminal) -> Bool {
+        (terminal.kind ?? .shell) == .claude
     }
 
     /// Reject the payload shapes that name no coherent act, before a row exists.

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -1876,6 +1876,28 @@ extension RPCRouter {
     private func performTerminalSend(
         _ params: TerminalSendParams, actor: ActuationActor?
     ) async throws -> RPCResponse {
+        // ─── The first of two refusal lines, and the reason they differ ───
+        //
+        // A malformed payload SHAPE is rejected here, before any row exists, as
+        // an ordinary RPC error. `RPCRouter+Actuation.swift` draws this line
+        // already: a row must not be written for a request that was never about
+        // to be dispatched. None of these combinations names a coherent act —
+        // there is no send to record, only a caller that asked for nothing, or
+        // for two contradictory things at once.
+        //
+        // The second line is below, at the flag: `--verify` while delivery
+        // verification is off IS a coherent act, one the daemon declined, so it
+        // gets a row and a refusal outcome. See there.
+        //
+        // The CLI validates these same shapes so a human gets a clean message
+        // before a socket is opened; the daemon enforces them independently
+        // because the CLI is not the only caller.
+        let payload: TerminalSendPayload
+        switch Self.validateSendShape(params) {
+        case .valid(let validated): payload = validated
+        case .malformed(let message): return RPCResponse(error: message)
+        }
+
         guard let terminal = try await db.terminals.get(id: params.terminalID) else {
             return RPCResponse(error: "Terminal not found: \(params.terminalID)")
         }
@@ -1888,10 +1910,42 @@ extension RPCRouter {
         // Request row first: the target is resolved and the payload is known,
         // and nothing has touched the pane yet. The paste and the Enter are
         // sub-steps of one send, so they share this one row.
+        //
+        // The row records the caller's payload VERBATIM and without the
+        // envelope (§3, "the log records the message verbatim"). The envelope is
+        // transport framing built at delivery, and its id is this row's own id,
+        // so storing it would duplicate the row's identifier into its own body.
         let actuationID = try await beginActuation(
             .terminalSend, actor: actor,
             target: .local(worktree: terminal.worktreeID, terminal: terminal.id),
-            message: params.text, submit: params.submit == true)
+            message: payload.recordedMessage,
+            submit: payload.recordedSubmit,
+            verify: payload.recordedVerify)
+
+        // ─── The second refusal line: a well-formed act the daemon declines ───
+        //
+        // `--verify` while `delivery_verification_enabled` is off is a refusal,
+        // not a silent downgrade to an unverified send. A caller that asked for
+        // evidence must never be answered with a silence that reads like
+        // confirmation — that would rebuild, one layer up, the exact
+        // silent-failure class §12 exists to end. Nothing is typed, and the row
+        // shows the near-miss so the morning can see what the flag stopped.
+        //
+        // Read per call and only when `--verify` was armed, so an ordinary send
+        // pays no config read — and flipping the flag needs no daemon restart.
+        if payload.isVerifyArmed {
+            let enabled = (try? await db.config.get())?.deliveryVerificationEnabled ?? false
+            if !enabled {
+                let message = """
+                    terminal.send --verify was refused: delivery verification is disabled \
+                    (config.delivery_verification_enabled is off) — nothing was sent. Enable \
+                    it with the config.setDeliveryVerification RPC, or resend without --verify \
+                    to accept an unverified send.
+                    """
+                await finishActuation(actuationID, .refused(.notEligible), error: message)
+                return RPCResponse(error: message)
+            }
+        }
 
         // Ask the pane about itself before typing into it. tmux's own exit
         // status cannot carry this: `send-keys` into a `remain-on-exit` dead
@@ -1952,32 +2006,72 @@ extension RPCRouter {
             }
         }
 
-        // Deliver the body as an EXPLICIT bracketed paste (load-buffer +
-        // paste-buffer -d -p) rather than raw `send-keys -l`. For payloads
-        // larger than the pty buffer (~1 KB) the pty splits `send-keys -l` into
-        // multiple rapid reads, which a TUI's non-bracketed paste-burst
-        // detection mistakes for a paste and coalesces — absorbing the trailing
-        // Enter so nothing submits. The explicit `ESC[201~` terminator puts the
-        // Enter provably outside the paste. tmux emits the wrappers iff the pane
-        // has bracketed-paste mode on — agent TUIs and modern interactive shells
-        // both enable it at the prompt; cooked-mode consumers get bare bytes and
-        // behave as before. Skip an empty body entirely (don't paste an empty
-        // buffer) but still press Enter below if requested.
-        do {
-            if !params.text.isEmpty {
-                try await tmux.pasteText(
-                    server: worktree.tmuxServer,
-                    paneID: terminal.tmuxPaneID,
-                    bytes: Data(params.text.utf8)
-                )
-            }
+        // What actually reached the pane, envelope included — nil for a payload
+        // that pasted nothing (empty text, or keys). Handed to the arming seam
+        // below so a retry can re-deliver byte-identically.
+        var deliveredPayload: String?
 
-            if params.submit == true {
-                try await tmux.sendKey(
-                    server: worktree.tmuxServer,
-                    paneID: terminal.tmuxPaneID,
-                    key: "Enter"
-                )
+        do {
+            switch payload {
+            case .text(let text, let submit, _):
+                // Deliver the body as an EXPLICIT bracketed paste (load-buffer +
+                // paste-buffer -d -p) rather than raw `send-keys -l`. For payloads
+                // larger than the pty buffer (~1 KB) the pty splits `send-keys -l` into
+                // multiple rapid reads, which a TUI's non-bracketed paste-burst
+                // detection mistakes for a paste and coalesces — absorbing the trailing
+                // Enter so nothing submits. The explicit `ESC[201~` terminator puts the
+                // Enter provably outside the paste. tmux emits the wrappers iff the pane
+                // has bracketed-paste mode on — agent TUIs and modern interactive shells
+                // both enable it at the prompt; cooked-mode consumers get bare bytes and
+                // behave as before. Skip an empty body entirely (don't paste an empty
+                // buffer) but still press Enter below if requested.
+                //
+                // Every NON-EMPTY text payload rides behind the dispatch
+                // envelope (§12): a one-line tag carrying this row's id and the
+                // identity the row was attributed to, then the caller's message
+                // verbatim. It is attribution the receiving agent can read, and
+                // — because a submitted message's verbatim content lands in the
+                // transcript JSONL — it is the machine fact a later observation
+                // looks for, requiring nothing of the agent. It rides every text
+                // send, verified or not: a prefix that appears only sometimes is
+                // one no reader can rely on.
+                //
+                // An EMPTY payload keeps today's behaviour exactly: nothing is
+                // pasted, and a bare `--submit` still presses Enter. `tbd
+                // terminal send --text "" --submit` is a real way to press Enter
+                // and must not start pasting a tag.
+                if !text.isEmpty {
+                    let composed = Self.dispatchEnvelope(
+                        id: actuationID, from: (actor ?? .anonymous).dispatchLabel
+                    ) + "\n" + text
+                    try await tmux.pasteText(
+                        server: worktree.tmuxServer,
+                        paneID: terminal.tmuxPaneID,
+                        bytes: Data(composed.utf8)
+                    )
+                    deliveredPayload = composed
+                }
+
+                if submit {
+                    try await tmux.sendKey(
+                        server: worktree.tmuxServer,
+                        paneID: terminal.tmuxPaneID,
+                        key: "Enter"
+                    )
+                }
+
+            case .keys(let names, _):
+                // Named keys, one at a time, paced — see `PacedKeySender` for
+                // why back-to-back keys get dropped by a redrawing TUI. The
+                // `sendKey` call stays here, inside the file the actuation audit
+                // covers, and the pacing lives behind the closure.
+                try await pacedKeySender.send(names) { key in
+                    try await self.tmux.sendKey(
+                        server: worktree.tmuxServer,
+                        paneID: terminal.tmuxPaneID,
+                        key: key
+                    )
+                }
             }
         } catch {
             await finishActuation(actuationID, .transportFailed, error: "\(error)")
@@ -1985,7 +2079,103 @@ extension RPCRouter {
         }
 
         await finishActuation(actuationID, .dispatched)
+
+        // Hand off to the observation — the record's third rung. Reached only
+        // from here, only after `.dispatched`, and only for a verify-armed text
+        // payload that actually pasted something, so a verify-less send, a
+        // refusal and a transport failure all arm nothing. See
+        // `DeliveryVerificationArming` for the full contract.
+        if payload.isVerifyArmed, let deliveredPayload {
+            await deliveryVerifier?.armVerification(
+                actuationID: actuationID,
+                terminalID: terminal.id,
+                deliveredPayload: deliveredPayload,
+                submit: payload.recordedSubmit ?? false)
+        }
         return .ok()
+    }
+
+    // MARK: - terminal.send payload shape
+
+    /// The dispatch envelope §12 puts ahead of every non-empty text payload.
+    ///
+    /// `id` is the actuation row's own id — there is no second identifier
+    /// namespace, so dispatch, transcript receipt and outcome all join on one
+    /// string. `from` comes from `ActuationActor.dispatchLabel`, which is
+    /// whitelisted to `[A-Za-z0-9._:-]` and capped, so no rail or project name
+    /// can close the tag or open a second attribute.
+    static func dispatchEnvelope(id: String, from label: String) -> String {
+        "<tbd-dispatch id=\"\(id)\" from=\"\(label)\"/>"
+    }
+
+    /// Reject the payload shapes that name no coherent act, before a row exists.
+    ///
+    /// Returns the validated payload, or the error text the caller sees. Pure
+    /// and static so both the daemon path and its tests can reach it without a
+    /// database.
+    static func validateSendShape(
+        _ params: TerminalSendParams
+    ) -> TerminalSendShape {
+        let submit = params.submit == true
+        let verify = params.verify == true
+
+        switch (params.text, params.keys) {
+        case (.some, .some):
+            // Two payloads in one call. Which one was meant is unknowable, and
+            // guessing would type something nobody asked for.
+            return .malformed(
+                "terminal.send takes exactly one payload: --text or --keys, not both")
+
+        case (.none, .none):
+            return .malformed(
+                "terminal.send needs a payload: pass --text or --keys")
+
+        case (.none, .some(let keys)):
+            // Enter is itself a key. `--submit --keys` asks the daemon to append
+            // a keystroke to a key sequence the caller already wrote out in
+            // full, which cannot be what was meant — spell it "… Enter".
+            if submit {
+                return .malformed(
+                    "terminal.send --submit is incoherent with --keys (Enter is itself a "
+                    + "key — put it in the sequence: --keys \"Escape Enter\")")
+            }
+            // Keys never reach a transcript, so there is no observation to make
+            // and nothing an envelope could be found in (§12).
+            if verify {
+                return .malformed(
+                    "terminal.send --verify cannot be used with --keys: keys reach no "
+                    + "transcript, so delivery cannot be observed")
+            }
+            guard let names = PacedKeySender.tokenize(keys) else {
+                return .malformed(
+                    "terminal.send --keys must name between 1 and \(PacedKeySender.maxKeys) "
+                    + "whitespace-separated tmux keys (for example: --keys \"Escape Enter\")")
+            }
+            return .valid(.keys(names: names, verbatim: keys))
+
+        case (.some(let text), .none):
+            if verify {
+                // Text that is never submitted never enters the conversation and
+                // so can never appear in a transcript; verifying it would build
+                // a machine that reports not-landed every time and then retries.
+                // An EMPTY payload fails for the same reason one step earlier —
+                // nothing is pasted, so no envelope is ever written to be found.
+                // Both are refused rather than downgraded, per the never-answer-
+                // a-request-for-evidence-with-silence rule (§12).
+                if !submit {
+                    return .malformed(
+                        "terminal.send --verify requires --submit: text left standing in a "
+                        + "composer never enters the conversation, so delivery cannot be "
+                        + "observed")
+                }
+                if text.isEmpty {
+                    return .malformed(
+                        "terminal.send --verify requires a non-empty --text: an empty payload "
+                        + "pastes nothing, so there is no dispatch envelope to observe")
+                }
+            }
+            return .valid(.text(text, submit: submit, verify: verify))
+        }
     }
 
     // MARK: - Main Area Size Broadcast

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2208,7 +2208,17 @@ extension RPCRouter {
         // the payload being held is an instruction addressed to the session
         // that is no longer there. A rebind makes this a send to a stranger,
         // which is the one thing the retry must never be.
-        guard terminal.claudeSessionID == sessionID else {
+        //
+        // A `nil` expected id is not a mismatch, and this is the same rule
+        // `DeliveryVerifier.observe` applies: it means the conversation was not
+        // identified when the payload was dispatched — a terminal whose session
+        // id had not been recorded yet — so there is no identity to compare and
+        // no rebind the comparison could detect. A session id appearing by the
+        // time the retry runs is the terminal becoming knowable, not a stranger
+        // arriving. Refusing on it would spend the one retry the mechanism gets
+        // on an absence that is evidence of nothing. A *known* id that no longer
+        // matches is still a stranger, and still refused.
+        if let sessionID, terminal.claudeSessionID != sessionID {
             return .refused(.targetMismatch)
         }
         let outcome: ActuationOutcome

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -2080,6 +2080,7 @@ extension RPCRouter {
             await deliveryVerifier?.armVerification(
                 actuationID: actuationID,
                 terminalID: terminal.id,
+                sessionID: terminal.claudeSessionID,
                 deliveredPayload: deliveredPayload,
                 submit: payload.recordedSubmit ?? false)
         }

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -47,6 +47,17 @@ public final class RPCRouter: Sendable {
     /// Session-limit auto-resume scheduler. `nil` in mock mode / tests that
     /// don't need it; set post-construction like `claudeUsagePoller`.
     public nonisolated(unsafe) var limitResumeScheduler: LimitResumeScheduler?
+    /// Delivery acknowledgement (design §12). `terminal.send` hands a
+    /// dispatched, verify-armed text send here and this is the only caller —
+    /// see `DeliveryVerificationArming`. `nil` everywhere until the verifier
+    /// lands; a nil verifier means the observation is simply never armed, and
+    /// the act renders `unconfirmed` by `DeliveryRecord.statuses`, which is the
+    /// honest answer rather than a claim. Set post-construction like
+    /// `claudeUsagePoller`.
+    nonisolated(unsafe) var deliveryVerifier: (any DeliveryVerificationArming)?
+    /// Paces the keys of a `--keys` payload. A `var` so tests can inject a
+    /// `TestClock`; production never replaces the default.
+    nonisolated(unsafe) var pacedKeySender = PacedKeySender()
     /// Live connected-client count, supplied by the SocketServer after it is
     /// constructed (the router is built first in Daemon.swift, so it cannot
     /// take the server as an init dependency). Mirrors `claudeUsagePoller`
@@ -456,6 +467,8 @@ public final class RPCRouter: Sendable {
                 return try await handleConfigSetControlMode(request.paramsData)
             case RPCMethod.configSetHibernateInputVeto:
                 return try await handleConfigSetHibernateInputVeto(request.paramsData)
+            case RPCMethod.configSetDeliveryVerification:
+                return try await handleConfigSetDeliveryVerification(request.paramsData)
             case RPCMethod.configSetAutoCloseSetup:
                 return try await handleConfigSetAutoCloseSetup(request.paramsData)
             case RPCMethod.configSetAutoTrustWorktrees:
@@ -527,6 +540,7 @@ public final class RPCRouter: Sendable {
             controlModeSupported: version.map { $0 >= TmuxVersion.controlModeMinimum } ?? false,
             hibernateInputVetoEnabled: config.hibernateInputVetoEnabled,
             autoCloseSetupEnabled: config.autoCloseSetupEnabled,
+            deliveryVerificationEnabled: config.deliveryVerificationEnabled,
             autoTrustWorktrees: config.autoTrustWorktrees,
             panelSurfaceEnabled: config.panelSurfaceEnabled,
             remoteBackendsEnabled: config.remoteBackendsEnabled,

--- a/Sources/TBDDaemon/Server/TerminalSendPayload.swift
+++ b/Sources/TBDDaemon/Server/TerminalSendPayload.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// What one `terminal.send` request is asking for, once its shape has passed
+/// `RPCRouter.validateSendShape`.
+///
+/// Exactly one payload kind, by construction: the params type can spell
+/// "both `--text` and `--keys`" and "neither", and this type cannot, so every
+/// step past validation reads one payload without re-deriving which one it has.
+/// The flags that only make sense for text — `--submit`, `--verify` — ride on
+/// the text case for the same reason.
+/// The verdict of `RPCRouter.validateSendShape`: a payload the daemon can act
+/// on, or the error text a malformed request gets back before any row exists.
+enum TerminalSendShape: Sendable, Equatable {
+    case valid(TerminalSendPayload)
+    case malformed(String)
+}
+
+enum TerminalSendPayload: Sendable, Equatable {
+    /// The caller's message verbatim, without the dispatch envelope: the
+    /// envelope is transport framing built at delivery time (§12, and D16's
+    /// reading of §3's "the log records the message verbatim").
+    case text(String, submit: Bool, verify: Bool)
+    /// Named tmux keys, already tokenized and bounded by `PacedKeySender`.
+    /// `verbatim` is the caller's string as written, which is what the record
+    /// stores — the tokens are an implementation detail of delivery.
+    case keys(names: [String], verbatim: String)
+
+    /// The `message` field of the request row. The caller's payload as written,
+    /// for both kinds.
+    var recordedMessage: String {
+        switch self {
+        case .text(let text, _, _): return text
+        case .keys(_, let verbatim): return verbatim
+        }
+    }
+
+    /// The `submit` field of the request row. Absent for a keys payload:
+    /// submission is not a thing a key sequence has, and recording `false`
+    /// would imply the question was asked and answered no.
+    var recordedSubmit: Bool? {
+        switch self {
+        case .text(_, let submit, _): return submit
+        case .keys: return nil
+        }
+    }
+
+    /// The `verify` field of the request row. Set only when the caller armed
+    /// verification, so its presence alone identifies the sends that owe an
+    /// observation — which is what the startup replay and the account read.
+    var recordedVerify: Bool? {
+        switch self {
+        case .text(_, _, let verify): return verify ? true : nil
+        case .keys: return nil
+        }
+    }
+
+    /// Whether this send asked for delivery to be confirmed.
+    var isVerifyArmed: Bool {
+        if case .text(_, _, let verify) = self { return verify }
+        return false
+    }
+}

--- a/Sources/TBDDaemon/Server/TerminalSendPayload.swift
+++ b/Sources/TBDDaemon/Server/TerminalSendPayload.swift
@@ -16,9 +16,11 @@ enum TerminalSendShape: Sendable, Equatable {
 }
 
 enum TerminalSendPayload: Sendable, Equatable {
-    /// The caller's message verbatim, without the dispatch envelope: the
-    /// envelope is transport framing built at delivery time (§12, and D16's
-    /// reading of §3's "the log records the message verbatim").
+    /// The caller's message verbatim, without the dispatch envelope. §3's "the
+    /// log records the message verbatim" means the message as the caller wrote
+    /// it; the envelope is transport framing built at delivery time, and its id
+    /// is the row's own — so recording it would copy the row's identifier into
+    /// its own body (§12).
     case text(String, submit: Bool, verify: Bool)
     /// Named tmux keys, already tokenized and bounded by `PacedKeySender`.
     /// `verbatim` is the caller's string as written, which is what the record

--- a/Sources/TBDDaemon/Tmux/PacedKeySender.swift
+++ b/Sources/TBDDaemon/Tmux/PacedKeySender.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Sends a sequence of named tmux keys one at a time, with a fixed pause
+/// between them.
+///
+/// **Why paced at all.** `LimitResumeActuator.sendContinueSequence` established
+/// the reason and the number: an agent TUI redraws between keystrokes, and keys
+/// delivered back-to-back through the pty during a redraw get dropped or
+/// reordered — the failure that produced `"ontinue"` in a composer. 150 ms
+/// between keys is what that rail settled on, and a `--keys` payload types into
+/// the same TUIs under the same conditions, so it takes the same pacing rather
+/// than inventing a second number.
+///
+/// **Why the send is a closure.** The type is deliberately ignorant of tmux:
+/// the actual `sendKey` call stays inside `RPCRouter+TerminalHandlers.swift`,
+/// the file the actuation audit already covers, so a paced sequence cannot
+/// become a new unrecorded actuation site (`.swiftlint.yml`'s
+/// `actuation_primitive_allowlist`). It also makes the pacing a tier-1 test
+/// with no tmux and no daemon.
+struct PacedKeySender: Sendable {
+    /// The pause between consecutive keys. Same value, same reason, as
+    /// `LimitResumeActuator.interKeyPause`.
+    static let interKeyPause: Duration = .milliseconds(150)
+
+    /// Upper bound on one payload's key count. A `--keys` value is a
+    /// whitespace-split string, so a quoting mistake ("$(seq 1 10000)") turns
+    /// one call into a runaway that types for minutes into a live session.
+    /// Bounded refusal is cheap; an unbounded one is not undoable.
+    static let maxKeys = 32
+
+    private let clock: any Clock<Duration>
+
+    /// - Parameter clock: injected so tests run on virtual time
+    ///   (`Tests/CLAUDE.md`, "Clock and date seams"). Existential, last, and
+    ///   defaulted, per the repo rule.
+    init(clock: any Clock<Duration> = ContinuousClock()) {
+        self.clock = clock
+    }
+
+    /// Split a `--keys` value into tmux key names.
+    ///
+    /// Returns `nil` when the value names no coherent key sequence: no tokens
+    /// at all (empty or all-whitespace), or more than `maxKeys` of them. Empty
+    /// tokens cannot survive the split — runs of whitespace collapse — so
+    /// `"Escape   Enter"` is two keys, not four.
+    static func tokenize(_ keys: String) -> [String]? {
+        let tokens = keys
+            .split(whereSeparator: { $0.isWhitespace })
+            .map(String.init)
+        guard !tokens.isEmpty, tokens.count <= maxKeys else { return nil }
+        return tokens
+    }
+
+    /// Send each key in order, pausing between them but not after the last —
+    /// a trailing pause would delay the caller's response for nothing.
+    ///
+    /// The first `send` that throws stops the sequence and propagates, so a
+    /// partially delivered sequence surfaces as a transport failure rather than
+    /// as a success that typed half of what was asked for.
+    func send(
+        _ keys: [String],
+        through send: @Sendable (String) async throws -> Void
+    ) async throws {
+        for (index, key) in keys.enumerated() {
+            if index > 0 {
+                try await clock.sleep(for: Self.interKeyPause)
+            }
+            try await send(key)
+        }
+    }
+}

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -90,6 +90,13 @@ public struct TmuxManager: Sendable {
     /// transport failure rather than a refusal, and a non-throwing hook would
     /// leave that branch with no way to be exercised.
     public let dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)?
+    /// Optional test hook consulted by `pasteText` in dryRun mode:
+    /// `(server, paneID, bytes)` — the payload that would have been written to
+    /// the buffer file. `dryRunRecorder` cannot carry it: the real path passes
+    /// the body through a temp FILE, so the recorded argv holds a path and not
+    /// one byte of the content. Tests that assert on WHAT was pasted — the
+    /// dispatch envelope, for one — need the bytes themselves.
+    public let dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)?
     /// Optional test hook for real (non-dryRun) mode: override the result of
     /// `windowExists(server:windowID:)`. Allows tests to force a window as dead
     /// while still having a live process running in the pane (for testing the
@@ -121,7 +128,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -134,6 +141,7 @@ public struct TmuxManager: Sendable {
         self.dryRunRespawnWindowError = dryRunRespawnWindowError
         self.dryRunKillWindowError = dryRunKillWindowError
         self.dryRunPaneSendTarget = dryRunPaneSendTarget
+        self.dryRunPasteBytes = dryRunPasteBytes
         self.realModeWindowExistsOverride = realModeWindowExistsOverride
         self.realModePaneCurrentCommandOverride = realModePaneCurrentCommandOverride
     }
@@ -771,9 +779,11 @@ public struct TmuxManager: Sendable {
         let pasteArgs = Self.pasteBufferCommand(server: server, bufferName: bufferName, paneID: paneID)
 
         if dryRun {
-            // Record the intended argv without touching the filesystem.
+            // Record the intended argv without touching the filesystem — plus
+            // the payload, which the argv cannot carry (it names a temp file).
             dryRunRecorder?(loadArgs)
             dryRunRecorder?(pasteArgs)
+            dryRunPasteBytes?(server, paneID, bytes)
             return
         }
 

--- a/Sources/TBDShared/ActuationActor.swift
+++ b/Sources/TBDShared/ActuationActor.swift
@@ -87,4 +87,66 @@ public struct ActuationActor: Codable, Sendable, Equatable {
             worktree: environment["TBD_WORKTREE_ID"],
             terminal: environment["TBD_TERMINAL_ID"])
     }
+
+    // MARK: - Dispatch attribution
+
+    /// How this actor names itself in a dispatch envelope's `from` attribute —
+    /// `<tbd-dispatch id="a3f1b2c3d4e5" from="daemon:limit-resume"/>`.
+    ///
+    /// Attribution a human reads, not a join key: the row already carries the
+    /// worktree and terminal UUIDs, and the envelope's `id` is what dispatch,
+    /// transcript receipt and outcome join on. So a session says plainly
+    /// `session` and spends no envelope width on coordinates.
+    ///
+    /// The kinds that have a meaningful sub-identity qualify it after a colon —
+    /// `daemon:<rail>`, `supervisor:<project>` — and every kind falls back to
+    /// its bare name when the qualifier is absent or unspellable.
+    ///
+    /// Sanitized, always: see `sanitizedDispatchLabelComponent`.
+    public var dispatchLabel: String {
+        // An empty kind — only reachable from a hand-edited or corrupt row —
+        // must still produce a label, and must not borrow `anonymous`, which
+        // means the specific thing "nobody declared an identity".
+        var base = Self.sanitizedDispatchLabelComponent(kind)
+        if base.isEmpty { base = "unknown" }
+        let qualifier: String?
+        switch kind {
+        case Kind.daemon: qualifier = rail
+        case Kind.supervisor: qualifier = project
+        default: qualifier = nil
+        }
+        let sanitizedQualifier = qualifier.map(Self.sanitizedDispatchLabelComponent) ?? ""
+        let label = sanitizedQualifier.isEmpty ? base : "\(base):\(sanitizedQualifier)"
+        return String(label.prefix(Self.dispatchLabelLimit))
+    }
+
+    /// The longest label an envelope will carry. The envelope opens a payload a
+    /// human is about to read; a rail or project name that ran away would push
+    /// the message itself off the first screen, and nothing downstream parses
+    /// the label, so truncating it loses no fact anyone joins on.
+    static let dispatchLabelLimit = 64
+
+    /// The characters a label may contain: `[A-Za-z0-9._:-]`, everything else
+    /// replaced with `_`.
+    ///
+    /// A whitelist rather than a blacklist of dangerous characters, because the
+    /// hazard is structural, not lexical. Every one of `rail`, `project` and
+    /// `kind` is a string some caller chose, and the label is interpolated into
+    /// an XML-ish attribute the receiving agent reads: a `"` would close the
+    /// attribute, a space would open a second one, and `/>` or `<` would close
+    /// or open the tag. Whitelisting makes all of those impossible at once —
+    /// including the ones nobody thought of — rather than one at a time.
+    ///
+    /// Non-ASCII scalars are replaced too. That is deliberate breadth: the
+    /// envelope is machine-facing framing around a human-facing payload, and
+    /// there is nothing a label needs to say that this alphabet cannot spell.
+    static func sanitizedDispatchLabelComponent(_ raw: String) -> String {
+        String(raw.unicodeScalars.map { scalar -> Character in
+            let isAllowed = (scalar >= "a" && scalar <= "z")
+                || (scalar >= "A" && scalar <= "Z")
+                || (scalar >= "0" && scalar <= "9")
+                || scalar == "." || scalar == "_" || scalar == ":" || scalar == "-"
+            return isAllowed ? Character(scalar) : "_"
+        })
+    }
 }

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -907,8 +907,10 @@ public struct Config: Codable, Sendable, Equatable {
     /// confirmation.
     ///
     /// What it deliberately does NOT gate: the dispatch envelope. Attribution
-    /// belongs on every text dispatch, and a prefix that comes and goes with a
-    /// config column is worse than one that is always there.
+    /// belongs on every text dispatch to an agent, verified or not, and a prefix
+    /// that comes and goes with a config column is worse than one that is always
+    /// there. (Whether a target receives the envelope at all is a property of
+    /// the target, not of this flag: shells do not.)
     public var deliveryVerificationEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -895,6 +895,21 @@ public struct Config: Codable, Sendable, Equatable {
     /// the daemon polls provider executables in the background and can stop
     /// remote sessions, so it is opt-in until it soaks.
     public var remoteBackendsEnabled: Bool
+    /// Soak flag for delivery acknowledgement — the machinery that establishes
+    /// whether a dispatched payload actually landed (fleet-supervision design
+    /// §12). Default OFF: the re-check acts on no user gesture and its single
+    /// retry types into a live session, so the whole path is opt-in.
+    ///
+    /// What it gates: arming the re-check, the evidence-bounded retry, and the
+    /// startup replay. While it is off, `terminal.send --verify` is *refused*
+    /// with the flag named and nothing is typed — a caller that asked for
+    /// evidence must never be answered with a silence that reads like
+    /// confirmation.
+    ///
+    /// What it deliberately does NOT gate: the dispatch envelope. Attribution
+    /// belongs on every text dispatch, and a prefix that comes and goes with a
+    /// config column is worse than one that is always there.
+    public var deliveryVerificationEnabled: Bool
 
     /// Default idle-timeout for auto-hibernation, in minutes.
     public static let defaultHibernateIdleMinutes = 30
@@ -934,7 +949,8 @@ public struct Config: Codable, Sendable, Equatable {
                 gcSnapshotRetentionDays: Int = Config.defaultGCSnapshotRetentionDays,
                 panelSurfaceEnabled: Bool = false,
                 agentPanelControlEnabled: Bool = false,
-                remoteBackendsEnabled: Bool = false) {
+                remoteBackendsEnabled: Bool = false,
+                deliveryVerificationEnabled: Bool = false) {
         self.defaultProfileID = defaultProfileID
         self.primaryAgentPreference = primaryAgentPreference
         self.envSettingOverrides = envSettingOverrides
@@ -959,6 +975,7 @@ public struct Config: Codable, Sendable, Equatable {
         self.panelSurfaceEnabled = panelSurfaceEnabled
         self.agentPanelControlEnabled = agentPanelControlEnabled
         self.remoteBackendsEnabled = remoteBackendsEnabled
+        self.deliveryVerificationEnabled = deliveryVerificationEnabled
     }
 
     public init(from decoder: Decoder) throws {
@@ -1008,6 +1025,10 @@ public struct Config: Codable, Sendable, Equatable {
             Bool.self, forKey: .agentPanelControlEnabled) ?? false
         remoteBackendsEnabled = try c.decodeIfPresent(
             Bool.self, forKey: .remoteBackendsEnabled) ?? false
+        // Absent (older daemon / older persisted JSON) defaults to OFF, matching
+        // the v69 column default — the soak has to be opted into.
+        deliveryVerificationEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .deliveryVerificationEnabled) ?? false
     }
 }
 

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -239,6 +239,7 @@ public enum RPCMethod {
     public static let terminalCancelScheduledResume = "terminal.cancelScheduledResume"
     public static let configSetControlMode = "config.setControlMode"
     public static let configSetHibernateInputVeto = "config.setHibernateInputVeto"
+    public static let configSetDeliveryVerification = "config.setDeliveryVerification"
     public static let configSetAutoCloseSetup = "config.setAutoCloseSetup"
     public static let configSetAutoTrustWorktrees = "config.setAutoTrustWorktrees"
     public static let gcList = "gc.list"
@@ -1499,13 +1500,43 @@ public struct TerminalListParams: Codable, Sendable {
     public init(worktreeID: UUID? = nil) { self.worktreeID = worktreeID }
 }
 
+/// One `terminal.send` request. Exactly one payload kind per call — `text` or
+/// `keys`, never both and never neither (design §3, "Payloads, not verbs").
+///
+/// **`text` is optional only to admit `keys`.** An older CLI sending
+/// `{terminalID, text, submit}` decodes and behaves byte-identically: `keys`
+/// and `verify` are absent, which is exactly a text send. `--text` and
+/// `--submit` keep their exact current semantics — bare `--text` types without
+/// submitting, and `--submit` is not deprecated.
 public struct TerminalSendParams: Codable, Sendable {
     public let terminalID: UUID
-    public let text: String
+    /// The message, verbatim. Delivered behind a `<tbd-dispatch …/>` envelope
+    /// line (§12); the record stores what the caller wrote, not the envelope.
+    /// An empty string keeps its existing meaning: nothing is pasted, and a
+    /// bare `--submit` still presses Enter.
+    public let text: String?
+    /// Whitespace-separated tmux key names — `"Escape"`, `"C-c"`,
+    /// `"Escape Enter"` — sent one at a time, paced. Mutually exclusive with
+    /// `text`. Carries no envelope (a key sequence has nowhere to put a line of
+    /// text) and cannot be verified (keys reach no transcript).
+    public let keys: String?
     /// When true, sends an Enter keypress after the text to submit it.
+    /// Incoherent with `keys`, where Enter is itself a key.
     public let submit: Bool?
-    public init(terminalID: UUID, text: String, submit: Bool? = nil) {
-        self.terminalID = terminalID; self.text = text; self.submit = submit
+    /// Arms delivery acknowledgement for this send (§12). Requires `submit`
+    /// (unsubmitted text never enters the conversation, so it can never reach a
+    /// transcript) and is incompatible with `keys`. Refused, never silently
+    /// downgraded, while `delivery_verification_enabled` is off.
+    public let verify: Bool?
+    public init(
+        terminalID: UUID, text: String? = nil, keys: String? = nil,
+        submit: Bool? = nil, verify: Bool? = nil
+    ) {
+        self.terminalID = terminalID
+        self.text = text
+        self.keys = keys
+        self.submit = submit
+        self.verify = verify
     }
 }
 
@@ -1796,6 +1827,15 @@ public struct ConfigSetHibernateInputVetoParams: Codable, Sendable {
     public init(enabled: Bool) { self.enabled = enabled }
 }
 
+/// Params for `config.setDeliveryVerification` — the delivery-acknowledgement
+/// soak flag (default OFF, fleet-supervision design §12). Read per `--verify`
+/// send, so the change applies to the next one; no daemon restart required.
+/// This is the operator's enable path for the soak.
+public struct ConfigSetDeliveryVerificationParams: Codable, Sendable {
+    public let enabled: Bool
+    public init(enabled: Bool) { self.enabled = enabled }
+}
+
 /// Params for `config.setAutoCloseSetup` — the auto-close-setup-tab soak
 /// flag (default OFF). Read fresh at spawn time; applies to the next
 /// worktree creation, no daemon restart required.
@@ -1957,6 +1997,11 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
     /// Whether the setup-hook tab auto-closes after a clean run (soak flag,
     /// default OFF). Re-evaluated by the daemon on every call.
     public let autoCloseSetupEnabled: Bool
+    /// Whether delivery acknowledgement is armed (`delivery_verification_enabled`,
+    /// design §12). Default OFF while it soaks. This is the read-back for the
+    /// soak's enable path: while it is false, `terminal.send --verify` is
+    /// refused rather than quietly downgraded. Re-evaluated on every call.
+    public let deliveryVerificationEnabled: Bool
     /// Whether TBD pre-accepts Claude's folder-trust dialog for the worktrees of
     /// registered repos — the ones TBD created plus the repo's own checkout, but
     /// never a fork-PR-head checkout (default ON). Re-evaluated by the daemon on
@@ -1992,6 +2037,7 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
                 controlModeSupported: Bool = false,
                 hibernateInputVetoEnabled: Bool = false,
                 autoCloseSetupEnabled: Bool = false,
+                deliveryVerificationEnabled: Bool = false,
                 autoTrustWorktrees: Bool = true,
                 panelSurfaceEnabled: Bool = false,
                 remoteBackendsEnabled: Bool = false,
@@ -2001,6 +2047,7 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         self.controlModeSupported = controlModeSupported
         self.hibernateInputVetoEnabled = hibernateInputVetoEnabled
         self.autoCloseSetupEnabled = autoCloseSetupEnabled
+        self.deliveryVerificationEnabled = deliveryVerificationEnabled
         self.autoTrustWorktrees = autoTrustWorktrees
         self.panelSurfaceEnabled = panelSurfaceEnabled
         self.remoteBackendsEnabled = remoteBackendsEnabled
@@ -2018,6 +2065,9 @@ public struct DaemonCapabilitiesResult: Codable, Sendable {
         hibernateInputVetoEnabled = try c.decodeIfPresent(Bool.self, forKey: .hibernateInputVetoEnabled) ?? false
         // New field for setup-tab auto-close; absent from older daemons defaults to false (soaking).
         autoCloseSetupEnabled = try c.decodeIfPresent(Bool.self, forKey: .autoCloseSetupEnabled) ?? false
+        // New field for delivery acknowledgement; absent from older daemons defaults to false (soaking).
+        deliveryVerificationEnabled = try c.decodeIfPresent(
+            Bool.self, forKey: .deliveryVerificationEnabled) ?? false
         // New field for worktree auto-trust; absent from older daemons defaults
         // to true, matching the column default (it is not a soak flag).
         autoTrustWorktrees = try c.decodeIfPresent(Bool.self, forKey: .autoTrustWorktrees) ?? true

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1510,8 +1510,9 @@ public struct TerminalListParams: Codable, Sendable {
 /// submitting, and `--submit` is not deprecated.
 public struct TerminalSendParams: Codable, Sendable {
     public let terminalID: UUID
-    /// The message, verbatim. Delivered behind a `<tbd-dispatch …/>` envelope
-    /// line (§12); the record stores what the caller wrote, not the envelope.
+    /// The message, verbatim. Delivered to an agent session behind a
+    /// `<tbd-dispatch …/>` envelope line (§12) and to a shell as-is; either way
+    /// the record stores what the caller wrote, not the envelope.
     /// An empty string keeps its existing meaning: nothing is pasted, and a
     /// bare `--submit` still presses Enter.
     public let text: String?

--- a/Sources/TBDShared/RPCProtocol.swift
+++ b/Sources/TBDShared/RPCProtocol.swift
@@ -1828,9 +1828,12 @@ public struct ConfigSetHibernateInputVetoParams: Codable, Sendable {
 }
 
 /// Params for `config.setDeliveryVerification` — the delivery-acknowledgement
-/// soak flag (default OFF, fleet-supervision design §12). Read per `--verify`
-/// send, so the change applies to the next one; no daemon restart required.
-/// This is the operator's enable path for the soak.
+/// soak flag (default OFF, fleet-supervision design §12). This is the
+/// operator's enable path for the soak, and **enabling it means restarting the
+/// daemon afterwards**: the column is read per `--verify` send, but the
+/// observation machinery it gates is wired once at startup. Until that restart
+/// `--verify` is refused with a message saying so. Turning it off makes
+/// `--verify` a refusal again on the next send, with no restart.
 public struct ConfigSetDeliveryVerificationParams: Codable, Sendable {
     public let enabled: Bool
     public init(enabled: Bool) { self.enabled = enabled }

--- a/Tests/TBDCLITests/TerminalSendCommandTests.swift
+++ b/Tests/TBDCLITests/TerminalSendCommandTests.swift
@@ -1,0 +1,103 @@
+import ArgumentParser
+import Testing
+@testable import TBDCLI
+
+/// Tier 1 — argument parsing and validation only; no socket, no daemon.
+///
+/// The daemon enforces every one of these shapes independently, because the CLI
+/// is not its only caller. These exist so a human gets the message before a
+/// socket is opened, and so the two never drift apart silently.
+@Suite("tbd terminal send parsing")
+struct TerminalSendCommandTests {
+
+    /// `ParsableCommand.parse` runs `validate()`, so a rejected shape throws
+    /// here rather than reaching `run()`.
+    private func parse(_ arguments: [String]) throws -> TerminalSend {
+        try TerminalSend.parse(arguments)
+    }
+
+    // MARK: - The shapes that stand
+
+    @Test("--text alone parses and does not submit")
+    func textAlone() throws {
+        let cmd = try parse(["--terminal", "ABC", "--text", "hello"])
+        #expect(cmd.text == "hello")
+        #expect(cmd.keys == nil)
+        #expect(cmd.submit == false)
+        #expect(cmd.verify == false)
+    }
+
+    /// The pair every delivery uses, and the one Nightwatch's Python dispatches.
+    @Test("--text --submit parses unchanged")
+    func textSubmit() throws {
+        let cmd = try parse(["--terminal", "ABC", "--text", "hello", "--submit"])
+        #expect(cmd.text == "hello")
+        #expect(cmd.submit == true)
+    }
+
+    @Test("--keys parses on its own")
+    func keysAlone() throws {
+        let cmd = try parse(["--terminal", "ABC", "--keys", "Escape Enter"])
+        #expect(cmd.keys == "Escape Enter")
+        #expect(cmd.text == nil)
+    }
+
+    @Test("--verify parses alongside --text --submit")
+    func verifyWithTextSubmit() throws {
+        let cmd = try parse(["--terminal", "ABC", "--text", "hi", "--submit", "--verify"])
+        #expect(cmd.verify == true)
+    }
+
+    /// An empty text payload is a real way to press Enter, and must stay
+    /// parseable — it is only `--verify` that an empty payload cannot support.
+    @Test("empty --text with --submit parses")
+    func emptyTextSubmit() throws {
+        let cmd = try parse(["--terminal", "ABC", "--text", "", "--submit"])
+        #expect(cmd.text == "")
+        #expect(cmd.submit == true)
+    }
+
+    // MARK: - The shapes that are refused
+
+    @Test("--text and --keys together are refused")
+    func bothPayloadsRefused() {
+        #expect(throws: (any Error).self) {
+            _ = try parse(["--terminal", "ABC", "--text", "hi", "--keys", "Enter"])
+        }
+    }
+
+    @Test("no payload at all is refused")
+    func noPayloadRefused() {
+        #expect(throws: (any Error).self) {
+            _ = try parse(["--terminal", "ABC"])
+        }
+    }
+
+    @Test("--submit with --keys is refused")
+    func submitWithKeysRefused() {
+        #expect(throws: (any Error).self) {
+            _ = try parse(["--terminal", "ABC", "--keys", "Escape", "--submit"])
+        }
+    }
+
+    @Test("--verify with --keys is refused")
+    func verifyWithKeysRefused() {
+        #expect(throws: (any Error).self) {
+            _ = try parse(["--terminal", "ABC", "--keys", "Escape", "--verify"])
+        }
+    }
+
+    @Test("--verify without --submit is refused")
+    func verifyWithoutSubmitRefused() {
+        #expect(throws: (any Error).self) {
+            _ = try parse(["--terminal", "ABC", "--text", "hi", "--verify"])
+        }
+    }
+
+    @Test("--verify with an empty --text is refused")
+    func verifyWithEmptyTextRefused() {
+        #expect(throws: (any Error).self) {
+            _ = try parse(["--terminal", "ABC", "--text", "", "--submit", "--verify"])
+        }
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationObservationTests.swift
+++ b/Tests/TBDDaemonTests/ActuationObservationTests.swift
@@ -1,0 +1,279 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — real filesystem for the writer's half, pure in-process for the
+/// vocabulary's and the envelope label's. No clocks, no subprocesses.
+///
+/// Every test injects its own log path into `ActuationLog(path:)` rather than
+/// touching `TBD_HOME`, matching `ActuationLogTests`.
+@Suite("Observed outcomes and the recorded-result vocabulary")
+struct ActuationObservationTests {
+
+    // MARK: - Fixture
+
+    private static func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    /// Every JSON object in a file, in order.
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                let object = try JSONSerialization.jsonObject(with: Data(line.utf8))
+                return try #require(object as? [String: Any])
+            }
+    }
+
+    private func date(_ iso: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.formatOptions = [.withInternetDateTime]
+        return try #require(formatter.date(from: iso))
+    }
+
+    private func sendRow(message: String = "please rebase onto main") -> ActuationRow {
+        var row = ActuationRow(actor: .app, kind: .send)
+        row.method = ActuationSurface.terminalSend.method
+        row.target = ActuationTarget(
+            worktree: "1B7E2C90-88AA-4F60-B1D0-9E8F7A6B5C4D",
+            terminal: "6D40F3A1-2B14-4E14-9C4A-0F1D2E3A4B5C")
+        row.message = message
+        row.submit = true
+        row.verify = true
+        return row
+    }
+
+    private func roundTrip(_ row: ActuationRow) throws -> ActuationRow {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return try JSONDecoder().decode(ActuationRow.self, from: encoder.encode(row))
+    }
+
+    // MARK: - The two vocabularies through one wire field
+
+    @Test("the observed vocabulary is closed, and every name is query-shaped")
+    func observedResultVocabulary() {
+        #expect(Set(ObservedResult.allCases.map(\.rawValue)) == [
+            "landed-and-acting", "landed-but-still-blocked", "not-landed", "undetermined",
+        ])
+    }
+
+    @Test("both vocabularies code as the one `result` string and decode back to their own case")
+    func recordedResultRoundTripsThroughASingleString() throws {
+        let synchronous: [ActuationResult] = [.dispatched, .refused, .transportFailed]
+        for result in synchronous {
+            var row = ActuationRow(actor: .daemon(), kind: .outcome)
+            row.result = .synchronous(result)
+            let encoded = try JSONEncoder().encode(row)
+            let object = try #require(
+                try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+            // One field, one plain string — no discriminator, no nesting.
+            #expect(object["result"] as? String == result.rawValue)
+            #expect(try roundTrip(row).result == .synchronous(result))
+        }
+
+        for result in ObservedResult.allCases {
+            var row = ActuationRow(actor: .daemon(), kind: .outcome)
+            row.result = .observed(result)
+            let encoded = try JSONEncoder().encode(row)
+            let object = try #require(
+                try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+            #expect(object["result"] as? String == result.rawValue)
+            #expect(try roundTrip(row).result == .observed(result))
+        }
+    }
+
+    @Test("a name neither vocabulary knows is carried through verbatim, not rejected")
+    func unrecognizedResultPreservesItsRawValue() throws {
+        // The row a newer daemon might write, met by today's reader.
+        let line = #"{"actor":{"kind":"daemon"},"id":"a1","kind":"outcome","result":"landed-and-hibernating","ts":"2026-08-05T14:02:11.482Z"}"#
+
+        let row = try JSONDecoder().decode(ActuationRow.self, from: Data(line.utf8))
+        #expect(row.result == .unrecognized("landed-and-hibernating"))
+        // And it must not have been mistaken for an observation.
+        #expect(row.result?.observed == nil)
+        // Re-encoding says exactly what the file said.
+        #expect(try roundTrip(row).result == .unrecognized("landed-and-hibernating"))
+    }
+
+    @Test("a row written before the observed rung existed still decodes")
+    func legacyOutcomeRowStillDecodes() throws {
+        let line = #"{"actor":{"kind":"daemon"},"confirms":"a1","id":"a2","kind":"outcome","reason":"not-eligible","result":"refused","ts":"2026-08-05T14:02:11.482Z"}"#
+
+        let row = try JSONDecoder().decode(ActuationRow.self, from: Data(line.utf8))
+        #expect(row.result == .synchronous(.refused))
+        #expect(row.reason == .notEligible)
+        #expect(row.observedAt == nil)
+        #expect(row.verify == nil)
+    }
+
+    // MARK: - The second door
+
+    @Test("an observation row carries the observed result and when the facts were read")
+    func observationRowShape() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let stamped = try date("2026-08-05T14:02:11Z").addingTimeInterval(0.482)
+        let log = ActuationLog(path: path, now: { stamped })
+
+        let requestID = try await log.appendRequest(sendRow())
+        await log.appendObservation(
+            confirms: requestID,
+            result: .landedAndActing,
+            observedAt: try date("2026-08-05T14:02:09Z"))
+
+        let written = try rows(at: path)
+        #expect(written.count == 2)
+        let observation = try #require(written.last)
+        // Whitelist: exactly the keys an observation row is allowed to carry.
+        #expect(Set(observation.keys)
+            == ["actor", "confirms", "id", "kind", "observedAt", "result", "ts"])
+        #expect(observation["kind"] as? String == "outcome")
+        #expect(observation["confirms"] as? String == requestID)
+        #expect(observation["result"] as? String == "landed-and-acting")
+        #expect(observation["observedAt"] as? String == "2026-08-05T14:02:09.000Z")
+        // `observedAt` is when the facts were read; `ts` is when the row was
+        // written, and the two are deliberately not the same moment.
+        #expect(observation["ts"] as? String == "2026-08-05T14:02:11.482Z")
+        let actor = try #require(observation["actor"] as? [String: Any])
+        #expect(actor["kind"] as? String == "daemon")
+    }
+
+    @Test("an undetermined observation names what could not be established")
+    func observationCarriesItsDetail() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        let requestID = try await log.appendRequest(sendRow())
+        await log.appendObservation(
+            confirms: requestID,
+            result: .undetermined,
+            observedAt: try date("2026-08-05T14:02:09Z"),
+            detail: "no transcript path recorded for this terminal")
+
+        let observation = try #require(try rows(at: path).last)
+        #expect(observation["result"] as? String == "undetermined")
+        #expect(observation["error"] as? String == "no transcript path recorded for this terminal")
+    }
+
+    @Test("the request row records that the caller armed verification")
+    func requestRowCarriesVerify() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        _ = try await log.appendRequest(sendRow())
+        var unverified = sendRow()
+        unverified.verify = nil
+        _ = try await log.appendRequest(unverified)
+
+        let written = try rows(at: path)
+        #expect(written.first?["verify"] as? Bool == true)
+        // Absent, not `false`: a send that never asked for confirmation is owed
+        // no observation, and the record says so by saying nothing.
+        #expect(written.last?["verify"] == nil)
+    }
+
+    @Test("one request row legitimately carries the whole claims ladder")
+    func oneRequestCarriesSeveralOutcomes() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        // dispatched → not-landed → dispatched (the single retry, same envelope
+        // id, no second request row) → landed-and-acting.
+        let requestID = try await log.appendRequest(sendRow())
+        await log.appendOutcome(confirms: requestID, result: .dispatched)
+        await log.appendObservation(
+            confirms: requestID, result: .notLanded,
+            observedAt: try date("2026-08-05T14:03:09Z"))
+        await log.appendOutcome(confirms: requestID, result: .dispatched)
+        await log.appendObservation(
+            confirms: requestID, result: .landedAndActing,
+            observedAt: try date("2026-08-05T14:04:09Z"))
+
+        let record = ActuationRecordReader(activePath: path).readRows()
+        #expect(record.count == 5)
+        // Exactly one request row, and every outcome joins onto it.
+        let requests = record.filter { $0.kind != .outcome }
+        #expect(requests.count == 1)
+        let outcomes = record.filter { $0.kind == .outcome }
+        #expect(outcomes.count == 4)
+        #expect(outcomes.allSatisfy { $0.confirms == requestID })
+        #expect(outcomes.map { $0.result } == [
+            .synchronous(.dispatched),
+            .observed(.notLanded),
+            .synchronous(.dispatched),
+            .observed(.landedAndActing),
+        ])
+        // Only the observed rows say when they looked.
+        #expect(outcomes.compactMap { $0.observedAt }.count == 2)
+    }
+
+    // MARK: - The envelope's `from`
+
+    @Test("each actor kind names itself, qualified only where it has a sub-identity")
+    func dispatchLabelPerKind() {
+        #expect(ActuationActor.anonymous.dispatchLabel == "anonymous")
+        #expect(ActuationActor.app.dispatchLabel == "app")
+        #expect(ActuationActor.daemon().dispatchLabel == "daemon")
+        #expect(ActuationActor.daemon(rail: "limit-resume").dispatchLabel == "daemon:limit-resume")
+        // A session says plainly `session`: the row already carries its UUIDs,
+        // and the envelope is attribution a human reads, not a join key.
+        let session = ActuationActor.session(
+            worktree: "1B7E2C90-88AA-4F60-B1D0-9E8F7A6B5C4D", terminal: nil)
+        #expect(session?.dispatchLabel == "session")
+        #expect(ActuationActor(kind: ActuationActor.Kind.supervisor).dispatchLabel == "supervisor")
+        #expect(ActuationActor(kind: ActuationActor.Kind.supervisor, project: "acme-web")
+            .dispatchLabel == "supervisor:acme-web")
+        // A rail on a non-daemon actor is not that kind's sub-identity.
+        #expect(ActuationActor(kind: ActuationActor.Kind.app, rail: "limit-resume")
+            .dispatchLabel == "app")
+    }
+
+    @Test("a label can neither close the envelope tag nor open a second attribute")
+    func dispatchLabelCannotEscapeTheEnvelope() {
+        let hostile = ActuationActor.daemon(rail: #"x" onload="evil"/><tbd-dispatch id="b"#)
+        let label = hostile.dispatchLabel
+
+        // Whitelist, not blacklist: the label is spelled in this alphabet and
+        // nothing else, so the characters nobody thought of are excluded too.
+        let allowed = Set(
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:-")
+        #expect(label.allSatisfy { allowed.contains($0) })
+        #expect(label == #"daemon:x__onload__evil____tbd-dispatch_id__b"#)
+
+        // Composed into the envelope the dispatch path writes, the tag still
+        // has exactly one attribute pair beyond the id.
+        let envelope = #"<tbd-dispatch id="a3f1b2c3d4e5" from="\#(label)"/>"#
+        #expect(envelope.filter { $0 == "\"" }.count == 4)
+        #expect(envelope.filter { $0 == "<" }.count == 1)
+        #expect(envelope.filter { $0 == ">" }.count == 1)
+    }
+
+    @Test("a non-ASCII or whitespace label is replaced, never passed through")
+    func dispatchLabelReplacesEverythingOutsideTheAlphabet() {
+        #expect(ActuationActor.daemon(rail: "night watch").dispatchLabel == "daemon:night_watch")
+        #expect(ActuationActor.daemon(rail: "rail\nid").dispatchLabel == "daemon:rail_id")
+        #expect(ActuationActor.daemon(rail: "réveil").dispatchLabel == "daemon:r_veil")
+        // Sanitizing to nothing is not possible, but supplying nothing is:
+        // an empty qualifier leaves the bare kind rather than a dangling colon.
+        #expect(ActuationActor.daemon(rail: "").dispatchLabel == "daemon")
+        #expect(ActuationActor(kind: "").dispatchLabel == "unknown")
+    }
+
+    @Test("a runaway qualifier is capped rather than shoved onto the reader's first screen")
+    func dispatchLabelIsCapped() {
+        let label = ActuationActor.daemon(rail: String(repeating: "r", count: 500)).dispatchLabel
+        #expect(label.count == ActuationActor.dispatchLabelLimit)
+        #expect(label.hasPrefix("daemon:rrr"))
+    }
+}

--- a/Tests/TBDDaemonTests/ActuationRecordReaderTests.swift
+++ b/Tests/TBDDaemonTests/ActuationRecordReaderTests.swift
@@ -214,14 +214,45 @@ struct DeliveryRecordTests {
         let now = try date("2026-08-05T14:10:00Z")
         let nonAnswers: [RecordedResult] = [
             .synchronous(.dispatched),
-            .synchronous(.refused),
-            .synchronous(.transportFailed),
             .unrecognized("landed-and-hibernating"),
         ]
         for result in nonAnswers {
             let rows = [request(id: "a1"), outcome(id: "a2", confirms: "a1", result: result)]
             #expect(DeliveryRecord.statuses(in: rows, now: now).map { $0.status } == [.unconfirmed])
         }
+    }
+
+    /// An act the transport never accepted is settled by that answer alone.
+    ///
+    /// `verify == true` on the request row says the caller *asked* for an
+    /// observation — the row is written before the flag check and before the
+    /// pane consultation, so a refused send carries the flag too. Nothing was
+    /// typed, so nothing can have landed and no observation is owed. Rendering
+    /// it `unconfirmed` would put it on the startup replay's work list, and the
+    /// replay would write a landing verdict about a payload that never reached
+    /// a pane.
+    @Test("a send the transport never accepted is owed no observation")
+    func refusedSendsAreSettledNotUnconfirmed() throws {
+        let now = try date("2026-08-05T14:10:00Z")
+        for result in [RecordedResult.synchronous(.refused), .synchronous(.transportFailed)] {
+            let rows = [request(id: "a1"), outcome(id: "a2", confirms: "a1", result: result)]
+            #expect(DeliveryRecord.statuses(in: rows, now: now).isEmpty)
+        }
+    }
+
+    /// A dispatch anywhere in an act's outcomes outranks a later refusal — that
+    /// can only be the single retry failing after a real first delivery, and
+    /// the act genuinely did reach a pane once.
+    @Test("a failed retry after a real dispatch leaves the act still owed an observation")
+    func dispatchOutranksALaterRefusal() throws {
+        let rows = [
+            request(id: "a1"),
+            outcome(id: "a2", confirms: "a1", result: .synchronous(.dispatched)),
+            outcome(id: "a3", confirms: "a1", result: .synchronous(.refused)),
+        ]
+        let statuses = DeliveryRecord.statuses(
+            in: rows, now: try date("2026-08-05T14:10:00Z"))
+        #expect(statuses.map { $0.status } == [.unconfirmed])
     }
 
     @Test("an act that never armed verification is owed no observation at all")

--- a/Tests/TBDDaemonTests/ActuationRecordReaderTests.swift
+++ b/Tests/TBDDaemonTests/ActuationRecordReaderTests.swift
@@ -255,6 +255,43 @@ struct DeliveryRecordTests {
         #expect(statuses.map { $0.status } == [.unconfirmed])
     }
 
+    /// A restart between the retry's dispatch and its own re-check.
+    ///
+    /// The retry shares the original act's id, so the ladder is
+    /// `dispatched → not-landed → dispatched`, all on one id, with the second
+    /// observation never written. Reading "the newest observed row" alone would
+    /// leave the stale `not-landed` standing as the act's final word — settled,
+    /// so the startup replay skips it and the retry is never observed at all. A
+    /// delivery after the last observation is a delivery still owed one.
+    @Test("a retry dispatched after the last observation is still owed one")
+    func aDeliveryAfterTheLastObservationIsStillOwed() throws {
+        let rows = [
+            request(id: "a1"),
+            outcome(id: "a2", confirms: "a1", result: .synchronous(.dispatched)),
+            outcome(id: "a3", confirms: "a1", result: .observed(.notLanded)),
+            outcome(id: "a4", confirms: "a1", result: .synchronous(.dispatched)),
+        ]
+        let statuses = DeliveryRecord.statuses(
+            in: rows, now: try date("2026-08-05T14:10:00Z"))
+        #expect(statuses.map { $0.status } == [.unconfirmed])
+    }
+
+    /// The same ladder, completed: the retry's own observation lands, and the
+    /// act is settled by it rather than by the stale first one.
+    @Test("a completed retry ladder settles on the final observation")
+    func aCompletedRetryLadderSettlesOnTheFinalObservation() throws {
+        let rows = [
+            request(id: "a1"),
+            outcome(id: "a2", confirms: "a1", result: .synchronous(.dispatched)),
+            outcome(id: "a3", confirms: "a1", result: .observed(.notLanded)),
+            outcome(id: "a4", confirms: "a1", result: .synchronous(.dispatched)),
+            outcome(id: "a5", confirms: "a1", result: .observed(.landedAndActing)),
+        ]
+        let statuses = DeliveryRecord.statuses(
+            in: rows, now: try date("2026-08-05T14:10:00Z"))
+        #expect(statuses.map { $0.status } == [.observed(.landedAndActing)])
+    }
+
     @Test("an act that never armed verification is owed no observation at all")
     func unverifiedActsAreNotAssessed() throws {
         let now = try date("2026-08-06T00:00:00Z")

--- a/Tests/TBDDaemonTests/ActuationRecordReaderTests.swift
+++ b/Tests/TBDDaemonTests/ActuationRecordReaderTests.swift
@@ -1,0 +1,278 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — real filesystem, no clocks, no subprocesses.
+///
+/// Every test injects its own log path rather than touching `TBD_HOME`, matching
+/// `ActuationLogTests`.
+@Suite("Actuation record reader")
+struct ActuationRecordReaderTests {
+
+    private static func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-actuation-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func date(_ iso: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.formatOptions = [.withInternetDateTime]
+        return try #require(formatter.date(from: iso))
+    }
+
+    private func sendRow(message: String) -> ActuationRow {
+        var row = ActuationRow(actor: .app, kind: .send)
+        row.method = ActuationSurface.terminalSend.method
+        row.message = message
+        row.submit = true
+        return row
+    }
+
+    @Test("the record reads back as rows, request and outcome alike")
+    func readsWhatTheWriterWrote() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        let requestID = try await log.appendRequest(sendRow(message: "please rebase onto main"))
+        await log.appendOutcome(confirms: requestID, result: .dispatched)
+
+        let rows = ActuationRecordReader(activePath: path).readRows()
+        #expect(rows.count == 2)
+        #expect(rows.first?.id == requestID)
+        #expect(rows.first?.message == "please rebase onto main")
+        #expect(rows.last?.confirms == requestID)
+        #expect(rows.last?.result == .synchronous(.dispatched))
+    }
+
+    @Test("a crash-left fragment costs its own line and nothing else")
+    func skipsUnparseableLinesWithoutBlindingTheReplay() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let log = ActuationLog(path: path)
+
+        _ = try await log.appendRequest(sendRow(message: "first"))
+        // The two shapes a torn write leaves behind: a truncated JSON object,
+        // and bytes that are not valid JSON at all.
+        let handle = try #require(FileHandle(forWritingAtPath: path))
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(#"{"actor":{"kind":"app"},"kind":"se"# .utf8))
+        try handle.write(contentsOf: Data("\nnot json at all\n".utf8))
+        try handle.close()
+        _ = try await log.appendRequest(sendRow(message: "second"))
+
+        let rows = ActuationRecordReader(activePath: path).readRows()
+        #expect(rows.count == 2)
+        #expect(rows.map { $0.message } == ["first", "second"])
+    }
+
+    @Test("rotated segments concatenate in name order, then the active file")
+    func concatenatesRotatedSegmentsInOrder() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let dates = TestDateSource(try date("2026-08-04T12:00:00Z"))
+        let log = ActuationLog(path: path, now: dates.provider)
+
+        _ = try await log.appendRequest(sendRow(message: "day one"))
+        dates.now = try date("2026-08-05T12:00:00Z")
+        _ = try await log.appendRequest(sendRow(message: "day two"))
+        dates.now = try date("2026-08-06T12:00:00Z")
+        _ = try await log.appendRequest(sendRow(message: "day three"))
+
+        let reader = ActuationRecordReader(activePath: path)
+        #expect(reader.segmentPaths().map { ($0 as NSString).lastPathComponent } == [
+            "actuations-2026-08-04.jsonl", "actuations-2026-08-05.jsonl", "actuations.jsonl",
+        ])
+        #expect(reader.readRows().map { $0.message } == ["day one", "day two", "day three"])
+    }
+
+    @Test("a record with nothing in it yet reads as no rows, not as a failure")
+    func absentRecordReadsEmpty() {
+        let reader = ActuationRecordReader(
+            activePath: "/nonexistent-\(UUID().uuidString)/actuations.jsonl")
+        #expect(reader.segmentPaths().isEmpty)
+        #expect(reader.readRows().isEmpty)
+    }
+
+    @Test("reader and query-time rule compose over a record written by the daemon")
+    func readsAndAssessesARealRecord() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        let stamped = try date("2026-08-05T14:00:00Z")
+        let log = ActuationLog(path: path, now: { stamped })
+
+        var armed = sendRow(message: "please rebase onto main")
+        armed.verify = true
+        let armedID = try await log.appendRequest(armed)
+        // Dispatched and nothing more: the exact shape that must still read as
+        // unconfirmed once the acknowledgement window closes.
+        await log.appendOutcome(confirms: armedID, result: .dispatched)
+        _ = try await log.appendRequest(sendRow(message: "no verification asked for"))
+
+        let rows = ActuationRecordReader(activePath: path).readRows()
+        let statuses = DeliveryRecord.statuses(in: rows, now: try date("2026-08-05T14:05:00Z"))
+        #expect(statuses.count == 1)
+        #expect(statuses.first?.request.id == armedID)
+        #expect(statuses.first?.status == .unconfirmed)
+    }
+}
+
+/// Tier 1 — pure function over parsed rows. No daemon, no filesystem, no clock.
+///
+/// This is the point of §12's query-time rule being a query: the whole delivery
+/// vocabulary is decidable from the record plus a `now`.
+@Suite("Query-time delivery status")
+struct DeliveryRecordTests {
+
+    private func date(_ iso: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.formatOptions = [.withInternetDateTime]
+        return try #require(formatter.date(from: iso))
+    }
+
+    private func request(
+        id: String,
+        ts: String = "2026-08-05T14:00:00Z",
+        verify: Bool? = true
+    ) -> ActuationRow {
+        var row = ActuationRow(actor: .app, kind: .send)
+        row.id = id
+        row.ts = ts
+        row.method = ActuationSurface.terminalSend.method
+        row.message = "please rebase onto main"
+        row.submit = true
+        row.verify = verify
+        return row
+    }
+
+    private func outcome(id: String, confirms: String, result: RecordedResult) -> ActuationRow {
+        var row = ActuationRow(actor: .daemon(), kind: .outcome)
+        row.id = id
+        row.ts = "2026-08-05T14:00:01Z"
+        row.confirms = confirms
+        row.result = result
+        return row
+    }
+
+    @Test("the deadline is the one §13 compiles")
+    func acknowledgementDeadlineIsSixtySeconds() {
+        #expect(DeliveryRecord.acknowledgementDeadline == 60)
+    }
+
+    @Test("an armed act past its deadline with no observation renders unconfirmed")
+    func unconfirmedPastTheDeadline() throws {
+        let rows = [request(id: "a1")]
+        let statuses = DeliveryRecord.statuses(
+            in: rows, now: try date("2026-08-05T14:01:01Z"))
+        #expect(statuses.map { $0.status } == [.unconfirmed])
+        #expect(statuses.first?.request.id == "a1")
+    }
+
+    @Test("inside the acknowledgement window nothing is owed yet")
+    func awaitingObservationInsideTheWindow() throws {
+        let statuses = DeliveryRecord.statuses(
+            in: [request(id: "a1")], now: try date("2026-08-05T14:00:59Z"))
+        #expect(statuses.map { $0.status } == [.awaitingObservation])
+    }
+
+    @Test("an observed outcome answers the question, whatever it found")
+    func observedOutcomeSettlesTheAct() throws {
+        let now = try date("2026-08-05T14:10:00Z")
+        for result in ObservedResult.allCases {
+            let rows = [
+                request(id: "a1"),
+                outcome(id: "a2", confirms: "a1", result: .observed(result)),
+            ]
+            #expect(DeliveryRecord.statuses(in: rows, now: now).map { $0.status }
+                == [.observed(result)])
+        }
+    }
+
+    @Test("a merely-dispatched act still renders unconfirmed past its deadline")
+    func synchronousDispatchDoesNotConfirmDelivery() throws {
+        // The load-bearing case. `dispatched` is the second rung of the ladder:
+        // the transport accepted the payload. That is exactly the claim
+        // `terminal.send` once made truthfully-looking for hours into a dead
+        // pane, so it must not be allowed to answer the delivery question.
+        let rows = [
+            request(id: "a1"),
+            outcome(id: "a2", confirms: "a1", result: .synchronous(.dispatched)),
+        ]
+        let statuses = DeliveryRecord.statuses(
+            in: rows, now: try date("2026-08-05T14:01:01Z"))
+        #expect(statuses.map { $0.status } == [.unconfirmed])
+    }
+
+    @Test("no synchronous result confirms delivery, and neither does an unknown name")
+    func onlyObservedResultsConfirm() throws {
+        let now = try date("2026-08-05T14:10:00Z")
+        let nonAnswers: [RecordedResult] = [
+            .synchronous(.dispatched),
+            .synchronous(.refused),
+            .synchronous(.transportFailed),
+            .unrecognized("landed-and-hibernating"),
+        ]
+        for result in nonAnswers {
+            let rows = [request(id: "a1"), outcome(id: "a2", confirms: "a1", result: result)]
+            #expect(DeliveryRecord.statuses(in: rows, now: now).map { $0.status } == [.unconfirmed])
+        }
+    }
+
+    @Test("an act that never armed verification is owed no observation at all")
+    func unverifiedActsAreNotAssessed() throws {
+        let now = try date("2026-08-06T00:00:00Z")
+        #expect(DeliveryRecord.statuses(in: [request(id: "a1", verify: nil)], now: now).isEmpty)
+        #expect(DeliveryRecord.statuses(in: [request(id: "a1", verify: false)], now: now).isEmpty)
+    }
+
+    @Test("the ladder's last observation is the one that stands")
+    func lastObservationWins() throws {
+        let rows = [
+            request(id: "a1"),
+            outcome(id: "a2", confirms: "a1", result: .synchronous(.dispatched)),
+            outcome(id: "a3", confirms: "a1", result: .observed(.notLanded)),
+            outcome(id: "a4", confirms: "a1", result: .synchronous(.dispatched)),
+            outcome(id: "a5", confirms: "a1", result: .observed(.landedAndActing)),
+        ]
+        let statuses = DeliveryRecord.statuses(
+            in: rows, now: try date("2026-08-05T14:10:00Z"))
+        #expect(statuses.map { $0.status } == [.observed(.landedAndActing)])
+    }
+
+    @Test("an outcome confirming a different act does not answer for this one")
+    func outcomesJoinOnTheRequestID() throws {
+        let rows = [
+            request(id: "a1"),
+            request(id: "b1"),
+            outcome(id: "a2", confirms: "b1", result: .observed(.landedAndActing)),
+        ]
+        let statuses = DeliveryRecord.statuses(
+            in: rows, now: try date("2026-08-05T14:01:01Z"))
+        #expect(statuses.map { $0.request.id } == ["a1", "b1"])
+        #expect(statuses.map { $0.status } == [.unconfirmed, .observed(.landedAndActing)])
+    }
+
+    @Test("a timestamp that cannot be read fails closed, never toward landed")
+    func unreadableTimestampRendersUnconfirmed() throws {
+        let statuses = DeliveryRecord.statuses(
+            in: [request(id: "a1", ts: "not a timestamp")],
+            now: try date("2026-08-05T14:00:00Z"))
+        #expect(statuses.map { $0.status } == [.unconfirmed])
+    }
+
+    @Test("the deadline is measured from the row's own stamp, fractional seconds included")
+    func deadlineIsMeasuredFromTheRowStamp() throws {
+        let rows = [request(id: "a1", ts: "2026-08-05T14:00:00.500Z")]
+        #expect(DeliveryRecord.statuses(in: rows, now: try date("2026-08-05T14:01:00Z"))
+            .map { $0.status } == [.awaitingObservation])
+        #expect(DeliveryRecord.statuses(in: rows, now: try date("2026-08-05T14:01:01Z"))
+            .map { $0.status } == [.unconfirmed])
+    }
+
+}

--- a/Tests/TBDDaemonTests/ActuationRecordReaderTests.swift
+++ b/Tests/TBDDaemonTests/ActuationRecordReaderTests.swift
@@ -91,6 +91,41 @@ struct ActuationRecordReaderTests {
         #expect(reader.readRows().map { $0.message } == ["day one", "day two", "day three"])
     }
 
+    /// The one case rotation's collision handling exists for, which plain name
+    /// order gets exactly backwards.
+    ///
+    /// `ActuationLog.rotationDestination` leaves the earlier segment as
+    /// `actuations-<day>.jsonl` and names the later one `actuations-<day>-1.jsonl`,
+    /// and `-` (0x2D) sorts before `.` (0x2E) — so `.sorted()` returns the later
+    /// segment first. That writer chose a numeric suffix over concatenation
+    /// precisely so nobody's record would be silently reordered, and reading it
+    /// back by name would reorder it anyway. `DeliveryRecord.statuses` now reads
+    /// outcomes in record order, so this is no longer cosmetic.
+    @Test("a same-day collision segment reads after the segment it followed")
+    func sameDayCollisionSegmentsReadInWriteOrder() async throws {
+        let directory = try Self.makeDirectory()
+        let path = directory.appendingPathComponent("actuations.jsonl").path
+        for (name, message) in [
+            ("actuations-2026-08-05.jsonl", "earlier"),
+            ("actuations-2026-08-05-1.jsonl", "later"),
+            ("actuations-2026-08-06.jsonl", "next day"),
+        ] {
+            var row = sendRow(message: message)
+            row.id = message
+            row.ts = "2026-08-05T12:00:00.000Z"
+            let line = try JSONEncoder().encode(row) + Data("\n".utf8)
+            try line.write(to: directory.appendingPathComponent(name))
+        }
+
+        let reader = ActuationRecordReader(activePath: path)
+        #expect(reader.segmentPaths().map { ($0 as NSString).lastPathComponent } == [
+            "actuations-2026-08-05.jsonl",
+            "actuations-2026-08-05-1.jsonl",
+            "actuations-2026-08-06.jsonl",
+        ])
+        #expect(reader.readRows().map { $0.message } == ["earlier", "later", "next day"])
+    }
+
     @Test("a record with nothing in it yet reads as no rows, not as a failure")
     func absentRecordReadsEmpty() {
         let reader = ActuationRecordReader(

--- a/Tests/TBDDaemonTests/ConfigStoreTests.swift
+++ b/Tests/TBDDaemonTests/ConfigStoreTests.swift
@@ -191,6 +191,29 @@ struct ConfigStoreTests {
         #expect(cfg.hibernateInputVetoEnabled == true)
     }
 
+    /// `delivery_verification_enabled` (v69) ships default OFF: the re-check
+    /// acts on no user gesture and its retry types into a live session.
+    @Test func deliveryVerificationDefaultsToFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.deliveryVerificationEnabled == false)
+    }
+
+    @Test func setAndGetDeliveryVerificationEnabled() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setDeliveryVerification(enabled: true)
+        let cfg = try await db.config.get()
+        #expect(cfg.deliveryVerificationEnabled == true)
+    }
+
+    @Test func setDeliveryVerificationToFalse() async throws {
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setDeliveryVerification(enabled: true)
+        try await db.config.setDeliveryVerification(enabled: false)
+        let cfg = try await db.config.get()
+        #expect(cfg.deliveryVerificationEnabled == false)
+    }
+
     @Test func setHibernateInputVetoToFalse() async throws {
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setHibernateInputVeto(enabled: true)

--- a/Tests/TBDDaemonTests/DeliveryObservationSourceTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryObservationSourceTests.swift
@@ -82,12 +82,18 @@ struct DeliveryObservationSourceTests {
         #expect(tail == Data(repeating: 0x42, count: 1024))
     }
 
-    /// A directory opens as a file handle on darwin but cannot be read, which is
-    /// the closest reachable stand-in for the I/O failure the `do`/`catch`
-    /// exists for. It must answer `nil` — the branch that used to coalesce a
-    /// thrown read into empty data and hand the retry its licence.
-    @Test("a path that opens but cannot be read answers nil, not empty")
-    func unreadableHandleAnswersNil() async throws {
+    /// A directory is not a transcript, and must not read as an empty one.
+    ///
+    /// **This does not exercise the `do`/`catch` around `seek`/`read`** — it was
+    /// written believing it did, and a mutation check proved otherwise: reverting
+    /// that block to `try?`/`?? Data()` left this test green, because
+    /// `FileHandle(forReadingAtPath:)` refuses a directory outright and the
+    /// first guard answers `nil` without ever seeking. The catch branch is
+    /// correct by inspection and unproven by test; forcing a `seek` or `read` to
+    /// throw on a local regular file needs a seam this type does not have, and
+    /// inventing one to test a two-line guard is a worse trade than saying so.
+    @Test("a path that is not a readable file answers nil, not empty")
+    func nonFilePathAnswersNil() async throws {
         let directory = try makeDirectory()
 
         let reader = try source()

--- a/Tests/TBDDaemonTests/DeliveryObservationSourceTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryObservationSourceTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import TBDDaemonLib
+
+/// Tier 2 — real files in a temp directory, no database.
+///
+/// `DatabaseDeliveryObservationSource.transcriptTail` is the only production
+/// implementation of the observation's file read, and every verifier test
+/// supplies its own `Data?` instead — so nothing exercised it. What it returns
+/// is not a detail: empty `Data` means *readable, and the envelope is genuinely
+/// not there*, which is the positive evidence that licenses a re-paste, while
+/// `nil` means no observation could be made. The two must never be confusable,
+/// least of all by a swallowed I/O error.
+@Suite("the observation's transcript read")
+struct DeliveryObservationSourceTests {
+
+    private func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-tail-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func source() throws -> DatabaseDeliveryObservationSource {
+        DatabaseDeliveryObservationSource(db: try TBDDatabase(inMemory: true))
+    }
+
+    /// Unreadable is not absent. A path that cannot be opened must answer `nil`,
+    /// so the mapping reaches `undetermined` rather than claiming the envelope
+    /// is missing from a file it never read.
+    @Test("a transcript that cannot be opened answers nil, never empty")
+    func missingFileAnswersNil() async throws {
+        let directory = try makeDirectory()
+        let absent = directory.appendingPathComponent("never-written.jsonl").path
+
+        let reader = try source()
+        #expect(await reader.transcriptTail(atPath: absent, maxBytes: 64 * 1024) == nil)
+    }
+
+    /// A real, readable, empty file is the one case that legitimately answers
+    /// empty — readable-and-absent, which is evidence.
+    @Test("an empty transcript answers empty data, which is evidence")
+    func emptyFileAnswersEmptyData() async throws {
+        let directory = try makeDirectory()
+        let path = directory.appendingPathComponent("session.jsonl").path
+        FileManager.default.createFile(atPath: path, contents: Data())
+
+        let reader = try source()
+        let tail = await reader.transcriptTail(atPath: path, maxBytes: 64 * 1024)
+        #expect(tail == Data())
+    }
+
+    /// Shorter than the window: the whole file comes back, which is what makes
+    /// `count < maxBytes` a sound proof that nothing was missed.
+    @Test("a transcript shorter than the window returns all of it")
+    func shortFileReturnsWholeContent() async throws {
+        let directory = try makeDirectory()
+        let path = directory.appendingPathComponent("session.jsonl").path
+        let body = Data("{\"type\":\"user\",\"content\":\"hello\"}\n".utf8)
+        try body.write(to: URL(fileURLWithPath: path))
+
+        let reader = try source()
+        let tail = await reader.transcriptTail(atPath: path, maxBytes: 64 * 1024)
+        #expect(tail == body)
+        #expect((tail?.count ?? 0) < 64 * 1024)
+    }
+
+    /// Longer than the window: exactly the last `maxBytes`, and — the property
+    /// the escalation's whole-file proof rests on — a result whose length is the
+    /// window it asked for, never more.
+    @Test("a transcript longer than the window returns exactly its last maxBytes")
+    func longFileReturnsExactlyTheWindow() async throws {
+        let directory = try makeDirectory()
+        let path = directory.appendingPathComponent("session.jsonl").path
+        var body = Data(repeating: 0x41, count: 4096)
+        body.append(Data(repeating: 0x42, count: 1024))
+        try body.write(to: URL(fileURLWithPath: path))
+
+        let reader = try source()
+        let tail = try #require(await reader.transcriptTail(atPath: path, maxBytes: 1024))
+        #expect(tail.count == 1024)
+        #expect(tail == Data(repeating: 0x42, count: 1024))
+    }
+
+    /// A directory opens as a file handle on darwin but cannot be read, which is
+    /// the closest reachable stand-in for the I/O failure the `do`/`catch`
+    /// exists for. It must answer `nil` — the branch that used to coalesce a
+    /// thrown read into empty data and hand the retry its licence.
+    @Test("a path that opens but cannot be read answers nil, not empty")
+    func unreadableHandleAnswersNil() async throws {
+        let directory = try makeDirectory()
+
+        let reader = try source()
+        #expect(await reader.transcriptTail(
+            atPath: directory.path, maxBytes: 64 * 1024) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
@@ -169,7 +169,9 @@ struct DeliveryVerificationWiringTests {
         #expect(source.tailReads == 1)
         let written = observations(at: fixture.logPath)
         #expect(written.count == 1)
-        #expect(written.first?.result == .observed(.notLanded))
+        // `undetermined`, not `not-landed`: a replayed act can be arbitrarily
+        // old, so a bounded tail finding nothing is not evidence of anything.
+        #expect(written.first?.result == .observed(.undetermined))
         #expect(written.first?.confirms == actID)
     }
 

--- a/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
@@ -83,8 +83,9 @@ struct DeliveryVerificationWiringTests {
         let worktree = try await db.worktrees.create(
             repoID: repo.id, name: "acme-wt", branch: "main",
             path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+        // An agent terminal: the envelope rides sends to agents, not to shells.
         let terminal = try await db.terminals.create(
-            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7")
+            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7", kind: .claude)
         return Fixture(
             db: db, router: router, terminal: terminal, logPath: logPath, log: log,
             pastes: pastes)

--- a/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
@@ -205,7 +205,7 @@ struct DeliveryVerificationWiringTests {
         let clock = TestClock()
         fixture.router.deliveryVerifier = DeliveryVerifier(
             log: fixture.log, source: source,
-            redeliver: { _, _, _ in .dispatched }, clock: clock)
+            redeliver: { _, _, _, _ in .dispatched }, clock: clock)
 
         let response = await fixture.router.handle(try RPCRequest(
             method: RPCMethod.terminalSend,
@@ -235,7 +235,7 @@ struct DeliveryVerificationWiringTests {
         let verifier = DeliveryVerifier(
             log: fixture.log,
             source: DatabaseDeliveryObservationSource(db: fixture.db),
-            redeliver: { _, _, _ in .dispatched },
+            redeliver: { _, _, _, _ in .dispatched },
             clock: clock)
         fixture.router.deliveryVerifier = verifier
 

--- a/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerificationWiringTests.swift
@@ -1,0 +1,294 @@
+import Clocks
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// A source that answers nothing and counts every question. Anything that
+/// touches it while the flag is off is a leak.
+private final class CountingObservationSource: DeliveryObservationSource, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _factsCalls = 0
+    private var _tailReads = 0
+    private let facts: TerminalDeliveryFacts?
+    private let tail: Data?
+
+    init(facts: TerminalDeliveryFacts? = nil, tail: Data? = nil) {
+        self.facts = facts
+        self.tail = tail
+    }
+
+    var factsCalls: Int { lock.withLock { _factsCalls } }
+    var tailReads: Int { lock.withLock { _tailReads } }
+
+    func facts(forTerminal terminalID: UUID) async -> TerminalDeliveryFacts? {
+        lock.withLock { _factsCalls += 1 }
+        return facts
+    }
+
+    func transcriptTail(atPath path: String, maxBytes: Int) async -> Data? {
+        lock.withLock { _tailReads += 1 }
+        return tail
+    }
+}
+
+/// Tier 2 — an in-memory database, a dry-run tmux, a real (temp-directory)
+/// actuation log and a `TestClock`. Proves the two branches of
+/// `delivery_verification_enabled` at the wiring seam, and — with the verifier
+/// really wired to a router — that an ordinary send costs no transcript read
+/// and that a verified one joins its observation to its own request row.
+@Suite("delivery verification wiring and the flag's two branches", .clockDriven)
+struct DeliveryVerificationWiringTests {
+
+    private struct Fixture {
+        let db: TBDDatabase
+        let router: RPCRouter
+        let terminal: Terminal
+        let logPath: String
+        let log: ActuationLog
+        let pastes: PasteRecorder
+    }
+
+    final class PasteRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _pastes: [String] = []
+        var pastes: [String] { lock.withLock { _pastes } }
+        func record(_ bytes: Data) {
+            lock.withLock { _pastes.append(String(decoding: bytes, as: UTF8.self)) }
+        }
+    }
+
+    private func makeFixture() async throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-delivery-wiring-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let logPath = directory.appendingPathComponent("actuations.jsonl").path
+        let pastes = PasteRecorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) },
+            dryRunPasteBytes: { _, _, bytes in pastes.record(bytes) })
+        let db = try TBDDatabase(inMemory: true)
+        let log = ActuationLog(path: logPath)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: log)
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7")
+        return Fixture(
+            db: db, router: router, terminal: terminal, logPath: logPath, log: log,
+            pastes: pastes)
+    }
+
+    /// Every row of the record, through the reader any later consumer uses —
+    /// active segment plus rotated ones, so an append that happens to cross a
+    /// UTC day boundary mid-test cannot change what these assertions see.
+    private func rows(at path: String) -> [ActuationRow] {
+        ActuationRecordReader(activePath: path).readRows()
+    }
+
+    /// Only the rows a *later observation* wrote. A synchronous `dispatched`
+    /// says nothing about delivery, so it must not answer here.
+    private func observations(at path: String) -> [ActuationRow] {
+        rows(at: path).filter { $0.result?.observed != nil }
+    }
+
+    /// Seed the record with a verified send whose observation never ran — the
+    /// replay's whole work list.
+    private func seedUnconfirmedAct(
+        at path: String, terminalID: UUID, dispatchedAt: Date
+    ) async throws -> String {
+        let log = ActuationLog(path: path, now: { dispatchedAt })
+        var request = ActuationRow(actor: .anonymous, kind: .send)
+        request.method = RPCMethod.terminalSend
+        request.target = .local(worktree: UUID(), terminal: terminalID)
+        request.verify = true
+        let id = try await log.appendRequest(request)
+        await log.appendOutcome(confirms: id, result: .dispatched)
+        return id
+    }
+
+    // MARK: - The flag's two branches
+
+    /// Off is the shipped default, and off means *inert*: no verifier on the
+    /// router, no replay, and nothing observed. The armed send that would have
+    /// reached it is refused upstream by `terminal.send` itself, which reads
+    /// the same column per call — so the two halves fail closed together.
+    @Test("with the flag off nothing is wired, nothing replays, and nothing is observed")
+    func flagOffWiresNothing() async throws {
+        let fixture = try await makeFixture()
+        #expect(try await fixture.db.config.get().deliveryVerificationEnabled == false)
+        _ = try await seedUnconfirmedAct(
+            at: fixture.logPath, terminalID: fixture.terminal.id,
+            dispatchedAt: Date().addingTimeInterval(-600))
+        let source = CountingObservationSource()
+
+        let verifier = await Daemon.wireDeliveryVerification(
+            mockMode: nil, database: fixture.db, rpcRouter: fixture.router,
+            actuationLog: fixture.log, source: source)
+
+        #expect(verifier == nil)
+        #expect(fixture.router.deliveryVerifier == nil)
+        #expect(source.factsCalls == 0)
+        #expect(source.tailReads == 0)
+        // The seeded act's two rows and nothing else: no observation was written.
+        #expect(rows(at: fixture.logPath).count == 2)
+        #expect(observations(at: fixture.logPath).isEmpty)
+    }
+
+    @Test("with the flag on the verifier is wired and the replay observes the backlog")
+    func flagOnWiresAndReplays() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.db.config.setDeliveryVerification(enabled: true)
+        let actID = try await seedUnconfirmedAct(
+            at: fixture.logPath, terminalID: fixture.terminal.id,
+            dispatchedAt: Date().addingTimeInterval(-600))
+        let source = CountingObservationSource(
+            facts: TerminalDeliveryFacts(
+                transcriptPath: "/tmp/transcript.jsonl", activityState: .idle),
+            tail: Data("{\"type\":\"summary\"}".utf8))
+
+        let verifier = await Daemon.wireDeliveryVerification(
+            mockMode: nil, database: fixture.db, rpcRouter: fixture.router,
+            actuationLog: fixture.log, source: source)
+
+        #expect(verifier != nil)
+        #expect(fixture.router.deliveryVerifier != nil)
+        #expect(source.factsCalls == 1)
+        #expect(source.tailReads == 1)
+        let written = observations(at: fixture.logPath)
+        #expect(written.count == 1)
+        #expect(written.first?.result == .observed(.notLanded))
+        #expect(written.first?.confirms == actID)
+    }
+
+    /// Mock mode renders hand-seeded fixtures exactly as authored; a replay
+    /// writing observation rows into them would not.
+    @Test("mock mode wires no verifier even with the flag on")
+    func mockModeWiresNothing() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.db.config.setDeliveryVerification(enabled: true)
+        let source = CountingObservationSource()
+
+        let verifier = await Daemon.wireDeliveryVerification(
+            mockMode: .enabled(fixturePath: "/tmp/fixture.json"), database: fixture.db,
+            rpcRouter: fixture.router, actuationLog: fixture.log, source: source)
+
+        #expect(verifier == nil)
+        #expect(fixture.router.deliveryVerifier == nil)
+        #expect(source.factsCalls == 0)
+    }
+
+    // MARK: - An ordinary send costs the observation nothing
+
+    /// The verifier is wired and live; the send simply did not ask for
+    /// verification. Nothing must read a transcript on its behalf — proven by a
+    /// source that counts, not by inspection.
+    @Test("a verify-less send costs no transcript read")
+    func verifylessSendReadsNoTranscript() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.db.config.setDeliveryVerification(enabled: true)
+        let source = CountingObservationSource()
+        let clock = TestClock()
+        fixture.router.deliveryVerifier = DeliveryVerifier(
+            log: fixture.log, source: source,
+            redeliver: { _, _, _ in .dispatched }, clock: clock)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: fixture.terminal.id, text: "status?", submit: true)))
+        #expect(response.success)
+
+        #expect(source.factsCalls == 0)
+        #expect(source.tailReads == 0)
+    }
+
+    /// End to end through the real production source: the send pastes the
+    /// envelope, the transcript the session writes carries it, and the
+    /// observation joins back to the send's own request row.
+    @Test("a verified send's observation joins the envelope to its own request row")
+    func verifiedSendObservationJoinsOnTheRowID() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.db.config.setDeliveryVerification(enabled: true)
+        let transcriptPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-transcript-\(UUID().uuidString).jsonl").path
+        try await fixture.db.terminals.updateSession(
+            id: fixture.terminal.id, sessionID: UUID().uuidString,
+            transcriptPath: transcriptPath)
+        try await fixture.db.terminals.setActivityState(
+            id: fixture.terminal.id, activityState: .working)
+        let clock = TestClock()
+        let verifier = DeliveryVerifier(
+            log: fixture.log,
+            source: DatabaseDeliveryObservationSource(db: fixture.db),
+            redeliver: { _, _, _ in .dispatched },
+            clock: clock)
+        fixture.router.deliveryVerifier = verifier
+
+        #expect(await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: fixture.terminal.id, text: "status?", submit: true,
+                verify: true))).success)
+
+        // The session's harness writes the submitted message into its
+        // transcript JSONL — verbatim, envelope included, JSON-escaped.
+        let actID = try #require(rows(at: fixture.logPath).first?.id)
+        struct Line: Encodable { let type: String; let content: String }
+        let payload = try #require(fixture.pastes.pastes.first)
+        var jsonl = Data()
+        jsonl.append(try JSONEncoder().encode(Line(type: "user", content: payload)))
+        jsonl.append(0x0A)
+        try jsonl.write(to: URL(fileURLWithPath: transcriptPath))
+
+        await clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(verifier, observed: {
+            "\(observations(at: fixture.logPath).count) observation row(s)"
+        })
+
+        let observation = try #require(observations(at: fixture.logPath).last)
+        #expect(observation.result == .observed(.landedAndActing))
+        #expect(observation.confirms == actID)
+        #expect(observation.observedAt != nil)
+    }
+
+    /// The flag and the machinery it enables are read at different times — the
+    /// column per call, the verifier once at daemon start — so there is a window
+    /// where the column says yes and there is still nothing to arm. A send that
+    /// dispatched in that window would render `unconfirmed` forever, handing the
+    /// caller a silence that reads like a delivery failure when nothing ever
+    /// looked. It is refused instead, and nothing is typed.
+    @Test("a verified send is refused when the flag is on but no verifier is wired")
+    func verifiedSendRefusedWithoutAWiredVerifier() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.db.config.setDeliveryVerification(enabled: true)
+        #expect(fixture.router.deliveryVerifier == nil)
+
+        let response = await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: fixture.terminal.id, text: "status?", submit: true,
+                verify: true)))
+
+        #expect(!response.success)
+        #expect(response.error?.contains("Restart the daemon") == true)
+        // Nothing reached the pane, and the record shows the near-miss.
+        #expect(fixture.pastes.pastes.isEmpty)
+        let outcome = try #require(rows(at: fixture.logPath).last)
+        #expect(outcome.result == .synchronous(.refused))
+        #expect(outcome.reason == .notEligible)
+        // Refused, never observed: no row may claim a look that never happened.
+        #expect(observations(at: fixture.logPath).isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/DeliveryVerifierTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerifierTests.swift
@@ -50,6 +50,17 @@ private final class ScriptedObservationSource: DeliveryObservationSource, @unche
         self.answers = answers
     }
 
+    /// Re-script the fake after construction. The envelope needle is composed
+    /// from the act's id, and the log mints that id only once the harness
+    /// exists — so a test that wants "the envelope IS there" has to say so
+    /// after seeding.
+    func scriptEnvelope(for id: String, state: TerminalActivityState) {
+        lock.withLock {
+            answers = [Answer.envelope(for: id, state: state)]
+            round = 0
+        }
+    }
+
     var factsCalls: Int { lock.withLock { _factsCalls } }
     var tailReads: Int { lock.withLock { _tailReads } }
     var requestedWindows: [Int] { lock.withLock { _requestedWindows } }
@@ -598,7 +609,10 @@ struct DeliveryVerifierTests {
 
         await harness.verifier.replayMissedObservations(activeSegmentPath: harness.logPath)
 
-        #expect(try results(at: harness.logPath) == ["dispatched", "not-landed"])
+        // `undetermined`, not `not-landed`: a replayed act can be arbitrarily
+        // old, so a bounded tail that finds nothing proves nothing. See
+        // `replayNeverAssertsNonDelivery`.
+        #expect(try results(at: harness.logPath) == ["dispatched", "undetermined"])
         let observation = try #require(try rows(at: harness.logPath).last)
         #expect(observation["confirms"] as? String == id)
         // §12 leaves repair to playbook judgment, and a payload whose premise
@@ -643,6 +657,68 @@ struct DeliveryVerifierTests {
         await harness.verifier.replayMissedObservations(activeSegmentPath: harness.logPath)
         #expect(try results(at: harness.logPath) == ["dispatched"])
         #expect(harness.source.factsCalls == 0)
+    }
+
+    /// The replay can confirm a landing but must never assert a non-delivery.
+    ///
+    /// The 64 KiB tail is sound for the one-minute re-check because nothing can
+    /// push a just-pasted envelope out of it without the session being
+    /// `.working`. A replayed act has no such bound — it can be a day old, and
+    /// real transcripts here run to megabytes — so the same absence proves
+    /// nothing, while `activityState` is still whatever it was when the daemon
+    /// died. Claiming `not-landed` from that would manufacture a loud
+    /// non-delivery verdict about a payload that very likely landed.
+    @Test("a replayed observation reads an absent envelope as undetermined, never not-landed")
+    func replayNeverAssertsNonDelivery() async throws {
+        let dispatchedAt = Self.fixedNow
+        let bootedAt = dispatchedAt.addingTimeInterval(86_400)
+        let harness = try makeHarness(
+            answers: [.silence(state: .idle)], now: bootedAt, logNow: dispatchedAt)
+        let actID = try await seedVerifiedDispatch(harness, dispatchedAt: dispatchedAt)
+
+        await harness.verifier.replayMissedObservations(activeSegmentPath: harness.logPath)
+
+        // The live timer would have called this not-landed and retried; the
+        // replay may not, and re-delivers nothing either way.
+        #expect(try results(at: harness.logPath) == ["dispatched", "undetermined"])
+        #expect(harness.redeliveries.calls.isEmpty)
+        let row = try #require(try rows(at: harness.logPath).last)
+        #expect(row["confirms"] as? String == actID)
+        #expect((row["error"] as? String)?.contains("absence is not evidence") == true)
+    }
+
+    /// Finding the envelope late is still positive evidence — the replay is
+    /// only barred from concluding the negative.
+    @Test("a replayed observation still confirms a landing when the envelope is there")
+    func replayStillConfirmsALanding() async throws {
+        let dispatchedAt = Self.fixedNow
+        let bootedAt = dispatchedAt.addingTimeInterval(86_400)
+        let harness = try makeHarness(
+            answers: [.silence(state: .idle)], now: bootedAt, logNow: dispatchedAt)
+        let actID = try await seedVerifiedDispatch(harness, dispatchedAt: dispatchedAt)
+        harness.source.scriptEnvelope(for: actID, state: .working)
+
+        await harness.verifier.replayMissedObservations(activeSegmentPath: harness.logPath)
+
+        #expect(try results(at: harness.logPath) == ["dispatched", "landed-and-acting"])
+        #expect(harness.redeliveries.calls.isEmpty)
+    }
+
+    /// A verified send whose observation never ran — the replay's work list.
+    @discardableResult
+    private func seedVerifiedDispatch(
+        _ harness: Harness, dispatchedAt: Date
+    ) async throws -> String {
+        let log = ActuationLog(path: harness.logPath, now: { dispatchedAt })
+        var request = ActuationRow(actor: .anonymous, kind: .send)
+        request.method = RPCMethod.terminalSend
+        request.target = .local(worktree: UUID(), terminal: Self.terminal)
+        request.message = "status?"
+        request.submit = true
+        request.verify = true
+        let id = try await log.appendRequest(request)
+        await log.appendOutcome(confirms: id, result: .dispatched)
+        return id
     }
 
     /// The replay's window is the active segment. An act from a rotated day is

--- a/Tests/TBDDaemonTests/DeliveryVerifierTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerifierTests.swift
@@ -20,6 +20,10 @@ private final class ScriptedObservationSource: DeliveryObservationSource, @unche
         var activityState: TerminalActivityState = .idle
         /// `nil` stands for an unreadable transcript.
         var tail: Data? = Data()
+        /// Which conversation currently occupies the terminal. A round whose
+        /// value differs from the armed one stands for a `/clear` or an account
+        /// swap between dispatch and re-check.
+        var sessionID: String?
 
         static func envelope(
             for id: String, state: TerminalActivityState, escaped: Bool = false
@@ -61,7 +65,8 @@ private final class ScriptedObservationSource: DeliveryObservationSource, @unche
             round += 1
             return answer.map {
                 TerminalDeliveryFacts(
-                    transcriptPath: $0.transcriptPath, activityState: $0.activityState)
+                    transcriptPath: $0.transcriptPath, activityState: $0.activityState,
+                    sessionID: $0.sessionID)
             }
         }
     }
@@ -361,7 +366,7 @@ struct DeliveryVerifierTests {
             .silence(state: .idle),
         ])
         await harness.verifier.armVerification(
-            actuationID: id, terminalID: Self.terminal,
+            actuationID: id, terminalID: Self.terminal, sessionID: nil,
             deliveredPayload: "<tbd-dispatch id=\"\(id)\" from=\"anonymous\"/>\nstatus?",
             submit: true)
         await harness.clock.advanceWhenSuspended(by: .seconds(60))
@@ -397,7 +402,7 @@ struct DeliveryVerifierTests {
             .envelope(for: id, state: .working),
         ])
         await harness.verifier.armVerification(
-            actuationID: id, terminalID: Self.terminal, deliveredPayload: "x", submit: true)
+            actuationID: id, terminalID: Self.terminal, sessionID: nil, deliveredPayload: "x", submit: true)
         await harness.clock.advanceWhenSuspended(by: .seconds(60))
         await harness.clock.advanceWhenSuspended(by: .seconds(60))
         await awaitDeliveryCycle(harness.verifier, observed: {
@@ -418,7 +423,7 @@ struct DeliveryVerifierTests {
     func undeterminedNeverRetried() async throws {
         let harness = try makeHarness(answers: [.silence(state: .unknown)])
         await harness.verifier.armVerification(
-            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal,
+            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal, sessionID: nil,
             deliveredPayload: "x", submit: true)
         await harness.clock.advanceWhenSuspended(by: .seconds(60))
         await awaitDeliveryCycle(harness.verifier, observed: {
@@ -432,6 +437,59 @@ struct DeliveryVerifierTests {
         #expect(harness.source.tailReads == 1)
     }
 
+    /// `/clear` between dispatch and re-check rebinds the terminal to a new,
+    /// empty conversation without disturbing its pane — so the pane
+    /// consultation, which compares pane ids, sees nothing wrong. Reading on
+    /// would find no envelope in a transcript that never had one, call that
+    /// `not-landed`, and retry the payload into an unrelated conversation:
+    /// arbitrary instruction injection through the one door the pane check does
+    /// not cover. The observation could not be made about the session that was
+    /// addressed, which is exactly what `undetermined` means — and undetermined
+    /// is never retried.
+    @Test("a session rebound between dispatch and re-check is undetermined, and never retried")
+    func rebindingTheSessionBlocksTheRetry() async throws {
+        let id = "a3f1b2c3d4e5"
+        // The transcript even *contains* a plausible absence — the point is that
+        // the daemon refuses to reason from it at all.
+        var rebound = ScriptedObservationSource.Answer.silence(state: .idle)
+        rebound.sessionID = "session-after-clear"
+        let harness = try makeHarness(answers: [rebound])
+        await harness.verifier.armVerification(
+            actuationID: id, terminalID: Self.terminal, sessionID: "session-at-dispatch",
+            deliveredPayload: "<tbd-dispatch id=\"\(id)\" from=\"anonymous\"/>\nstatus?",
+            submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        #expect(try results(at: harness.logPath) == ["undetermined"])
+        #expect(harness.redeliveries.calls.isEmpty)
+        let row = try #require(try rows(at: harness.logPath).last)
+        #expect((row["error"] as? String)?.contains("rebound") == true)
+    }
+
+    /// The same terminal, the same session: the guard must not fire on the
+    /// ordinary case, or every verified send would degrade to undetermined.
+    @Test("an unchanged session observes normally")
+    func matchingSessionObservesNormally() async throws {
+        let id = "a3f1b2c3d4e5"
+        var answer = ScriptedObservationSource.Answer.envelope(for: id, state: .working)
+        answer.sessionID = "session-at-dispatch"
+        let harness = try makeHarness(answers: [answer])
+        await harness.verifier.armVerification(
+            actuationID: id, terminalID: Self.terminal, sessionID: "session-at-dispatch",
+            deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows"
+        })
+
+        #expect(try results(at: harness.logPath) == ["landed-and-acting"])
+        #expect(harness.redeliveries.calls.isEmpty)
+    }
+
     /// A retry the daemon declined is not "the payload failed" — the record has
     /// to be able to say a stale coordinate was refused, and it confirms the
     /// ORIGINAL request id rather than opening a second one.
@@ -441,7 +499,7 @@ struct DeliveryVerifierTests {
         let harness = try makeHarness(
             answers: [.silence(state: .idle)], retryOutcome: .refused(.targetMismatch))
         await harness.verifier.armVerification(
-            actuationID: id, terminalID: Self.terminal, deliveredPayload: "x", submit: true)
+            actuationID: id, terminalID: Self.terminal, sessionID: nil, deliveredPayload: "x", submit: true)
         await harness.clock.advanceWhenSuspended(by: .seconds(60))
         await awaitDeliveryCycle(harness.verifier, observed: {
             "\((try? results(at: harness.logPath)) ?? []) rows, "
@@ -467,7 +525,7 @@ struct DeliveryVerifierTests {
         let harness = try makeHarness(
             answers: [.silence(state: .idle)], retryOutcome: .transportFailed)
         await harness.verifier.armVerification(
-            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal,
+            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal, sessionID: nil,
             deliveredPayload: "x", submit: true)
         await harness.clock.advanceWhenSuspended(by: .seconds(60))
         await awaitDeliveryCycle(harness.verifier, observed: {
@@ -495,7 +553,7 @@ struct DeliveryVerifierTests {
             .envelope(for: id, state: .working),
         ])
         await harness.verifier.armVerification(
-            actuationID: id, terminalID: Self.terminal, deliveredPayload: "x", submit: true)
+            actuationID: id, terminalID: Self.terminal, sessionID: nil, deliveredPayload: "x", submit: true)
         await harness.clock.advanceWhenSuspended(by: .seconds(60))
         await harness.clock.advanceWhenSuspended(by: .seconds(60))
         await awaitDeliveryCycle(harness.verifier, observed: {
@@ -587,10 +645,11 @@ struct DeliveryVerifierTests {
         #expect(harness.source.factsCalls == 0)
     }
 
-    /// D19: the replay's window is the active segment. An act from a rotated
-    /// day is one whose transcript may have rolled over, and a late read buys
-    /// only a more precise word for something the query-time rule already
-    /// renders honestly.
+    /// The replay's window is the active segment. An act from a rotated day is
+    /// one whose transcript may have rolled over, and a late read buys only a
+    /// more precise word for something the query-time rule already renders
+    /// honestly — so the writer's own daily rotation bounds both the read and
+    /// the work, with no new threshold to pick.
     @Test("the replay reads only the active segment, never rotated ones")
     func startupReplayReadsOnlyTheActiveSegment() async throws {
         let dispatchedAt = Self.fixedNow

--- a/Tests/TBDDaemonTests/DeliveryVerifierTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerifierTests.swift
@@ -1,0 +1,616 @@
+import Clocks
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+// MARK: - Fakes
+
+/// The observation's two inputs, scripted one round at a time.
+///
+/// `facts` is called exactly once per observation and is what advances the
+/// script, so round N's answer is deterministic no matter when the cycle's task
+/// actually runs. It also counts every transcript read, which is how "a send
+/// that never armed verification costs no transcript read" is proven rather
+/// than asserted.
+private final class ScriptedObservationSource: DeliveryObservationSource, @unchecked Sendable {
+    struct Answer: Sendable {
+        var transcriptPath: String? = "/tmp/transcript.jsonl"
+        var activityState: TerminalActivityState = .idle
+        /// `nil` stands for an unreadable transcript.
+        var tail: Data? = Data()
+
+        static func envelope(
+            for id: String, state: TerminalActivityState, escaped: Bool = false
+        ) -> Answer {
+            let tag = escaped
+                ? "{\"content\":\"<tbd-dispatch id=\\\"\(id)\\\" from=\\\"anonymous\\\"/>\"}"
+                : "<tbd-dispatch id=\"\(id)\" from=\"anonymous\"/>"
+            return Answer(activityState: state, tail: Data(tag.utf8))
+        }
+
+        static func silence(state: TerminalActivityState) -> Answer {
+            Answer(activityState: state, tail: Data("{\"type\":\"summary\"}\n".utf8))
+        }
+    }
+
+    private let lock = NSLock()
+    private var answers: [Answer?]
+    private var round = 0
+    private var _factsCalls = 0
+    private var _tailReads = 0
+    private var _requestedWindows: [Int] = []
+
+    init(_ answers: [Answer?]) {
+        self.answers = answers
+    }
+
+    var factsCalls: Int { lock.withLock { _factsCalls } }
+    var tailReads: Int { lock.withLock { _tailReads } }
+    var requestedWindows: [Int] { lock.withLock { _requestedWindows } }
+
+    private func currentAnswer() -> Answer? {
+        answers[min(round, answers.count - 1)]
+    }
+
+    func facts(forTerminal terminalID: UUID) async -> TerminalDeliveryFacts? {
+        lock.withLock {
+            _factsCalls += 1
+            let answer = currentAnswer()
+            round += 1
+            return answer.map {
+                TerminalDeliveryFacts(
+                    transcriptPath: $0.transcriptPath, activityState: $0.activityState)
+            }
+        }
+    }
+
+    func transcriptTail(atPath path: String, maxBytes: Int) async -> Data? {
+        lock.withLock {
+            _tailReads += 1
+            _requestedWindows.append(maxBytes)
+            // `facts` already advanced past this round's answer.
+            return answers[min(max(round - 1, 0), answers.count - 1)]?.tail
+        }
+    }
+}
+
+/// Counts re-deliveries and answers each with a scripted outcome. "No third
+/// send, ever" is a count on this, not a claim about a log line.
+private final class RedeliveryRecorder: @unchecked Sendable {
+    struct Call: Sendable, Equatable {
+        let terminalID: UUID
+        let payload: String
+        let submit: Bool
+    }
+
+    private let lock = NSLock()
+    private var _calls: [Call] = []
+    private let outcome: ActuationOutcome
+
+    init(answering outcome: ActuationOutcome = .dispatched) {
+        self.outcome = outcome
+    }
+
+    var calls: [Call] { lock.withLock { _calls } }
+
+    var seam: @Sendable (UUID, String, Bool) async -> ActuationOutcome {
+        { [self] terminalID, payload, submit in
+            lock.withLock {
+                _calls.append(Call(terminalID: terminalID, payload: payload, submit: submit))
+            }
+            return outcome
+        }
+    }
+}
+
+// MARK: - Awaiting an armed cycle without hanging on it
+
+/// One-shot, thread-safe "the cycle finished".
+private final class CycleCompletion: @unchecked Sendable {
+    private let lock = NSLock()
+    private var done = false
+    var isDone: Bool { lock.withLock { done } }
+    func set() { lock.withLock { done = true } }
+}
+
+private struct DeliveryCycleUnfinished: Error, CustomStringConvertible {
+    let timeout: Swift.Duration
+    let observed: String
+    var description: String {
+        "the armed re-check cycle had not finished after \(timeout) — it took a branch this "
+            + "test never advanced the clock for, so it is parked on a virtual sleep nobody "
+            + "will advance. Observed: \(observed)"
+    }
+}
+
+/// Await every armed re-check, bounded by a real deadline.
+///
+/// `DeliveryVerifier.awaitPendingObservations()` waits on the cycle's task, and
+/// a cycle that took a branch the test did not advance the clock for waits
+/// **forever** — the virtual-time hang `Tests/CLAUDE.md` names, which
+/// `.clockDriven` is documented not to catch reliably when the work sits in a
+/// detached task. Racing it against a real deadline turns "this guard stopped
+/// holding" from an infinite hang into a named failure that says what the cycle
+/// did instead. Bounded polling with a deadline, per assertion-hygiene rule 3;
+/// the diagnostic is a thrown `Error` so it reaches the CI summary, per rule 4.
+///
+/// On timeout the waiting task is left parked deliberately: nothing awaits it,
+/// so the test fails and the run proceeds.
+func awaitDeliveryCycle(
+    _ verifier: DeliveryVerifier,
+    timeout: Swift.Duration = .seconds(30),
+    observed: @escaping @Sendable () -> String = { "nothing recorded" },
+    sourceLocation: SourceLocation = #_sourceLocation
+) async {
+    let completion = CycleCompletion()
+    Task.detached {
+        await verifier.awaitPendingObservations()
+        completion.set()
+    }
+    let deadline = ContinuousClock.now.advanced(by: timeout)
+    while ContinuousClock.now < deadline {
+        if completion.isDone { return }
+        try? await Task.sleep(for: .milliseconds(10))
+    }
+    Issue.record(
+        DeliveryCycleUnfinished(timeout: timeout, observed: observed()),
+        sourceLocation: sourceLocation)
+}
+
+// MARK: - Suite
+
+/// Tier 2 — a real (temp-directory) actuation log and a `TestClock`. No tmux,
+/// no database, no network: the observation's two machine facts arrive through
+/// an injected source, so §12's four-result mapping and the retry ladder are
+/// exercised in-process. The mapping tests themselves touch nothing but the
+/// fake (tier 1); the ladder tests write real rows so the join can be read back
+/// the way any later reader will read it.
+@Suite("delivery verification: the observation, the retry, and the replay", .clockDriven)
+struct DeliveryVerifierTests {
+
+    // MARK: - Fixture
+
+    private struct Harness {
+        let verifier: DeliveryVerifier
+        let clock: TestClock<Duration>
+        let source: ScriptedObservationSource
+        let redeliveries: RedeliveryRecorder
+        let logPath: String
+        let observedAt: Date
+    }
+
+    /// 2023-11-14T22:13:20Z — the same fixed, obviously-synthetic instant
+    /// `TestDateSource` defaults to.
+    private static let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func makeHarness(
+        answers: [ScriptedObservationSource.Answer?],
+        retryOutcome: ActuationOutcome = .dispatched,
+        now: Date = DeliveryVerifierTests.fixedNow,
+        logNow: Date? = nil
+    ) throws -> Harness {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-delivery-verify-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let logPath = directory.appendingPathComponent("actuations.jsonl").path
+        let stamp = logNow ?? now
+        let log = ActuationLog(path: logPath, now: { stamp })
+        let source = ScriptedObservationSource(answers)
+        let redeliveries = RedeliveryRecorder(answering: retryOutcome)
+        let clock = TestClock()
+        return Harness(
+            verifier: DeliveryVerifier(
+                log: log, source: source, redeliver: redeliveries.seam,
+                now: { now }, clock: clock),
+            clock: clock, source: source, redeliveries: redeliveries,
+            logPath: logPath, observedAt: now)
+    }
+
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    private func results(at path: String) throws -> [String] {
+        try rows(at: path).compactMap { $0["result"] as? String }
+    }
+
+    private static let terminal = UUID()
+
+    // MARK: - The four results
+
+    @Test("envelope found while the session is working — landed and acting")
+    func landedAndActing() async throws {
+        let harness = try makeHarness(answers: [.envelope(for: "a3f1b2c3d4e5", state: .working)])
+        let observation = await harness.verifier.observe(
+            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal)
+        #expect(observation == DeliveryObservation(.landedAndActing))
+    }
+
+    @Test("envelope found while the session is blocked again — landed but still blocked")
+    func landedButStillBlocked() async throws {
+        for state in [TerminalActivityState.idle, .waitingForUser] {
+            let harness = try makeHarness(answers: [.envelope(for: "a3f1b2c3d4e5", state: state)])
+            let observation = await harness.verifier.observe(
+                actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal)
+            #expect(observation.result == .landedButStillBlocked)
+        }
+    }
+
+    /// The only positive evidence of non-delivery §12 accepts: readable
+    /// transcript, absent envelope, and a session verifiably not mid-turn.
+    @Test("envelope absent while the session is verifiably not mid-turn — not landed")
+    func notLanded() async throws {
+        for state in [TerminalActivityState.idle, .waitingForUser] {
+            let harness = try makeHarness(answers: [.silence(state: state)])
+            let observation = await harness.verifier.observe(
+                actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal)
+            #expect(observation.result == .notLanded)
+            #expect(observation.detail?.contains(state.rawValue) == true)
+        }
+    }
+
+    /// Every way the observation can fail to establish anything. Each carries a
+    /// detail, because an anomaly that does not say what was missing is not an
+    /// anomaly anyone can act on.
+    @Test("the five ways an observation establishes nothing — undetermined")
+    func undetermined() async throws {
+        let id = "a3f1b2c3d4e5"
+        let cases: [(String, ScriptedObservationSource.Answer?)] = [
+            ("terminal row gone", nil),
+            ("no transcript path", .init(transcriptPath: nil, activityState: .idle)),
+            ("transcript unreadable", .init(activityState: .idle, tail: nil)),
+            ("session state unknown, envelope absent", .silence(state: .unknown)),
+            ("session mid-turn, envelope absent", .silence(state: .working)),
+            ("envelope found, session state unknown", .envelope(for: id, state: .unknown)),
+        ]
+        for (name, answer) in cases {
+            let harness = try makeHarness(answers: [answer])
+            let observation = await harness.verifier.observe(
+                actuationID: id, terminalID: Self.terminal)
+            #expect(observation.result == .undetermined, "\(name)")
+            #expect(observation.detail?.isEmpty == false, "\(name)")
+        }
+    }
+
+    /// A full parse of a long transcript on every re-check is the performance
+    /// trap §3 forbids. Asserted as the literal window AND the constant, so a
+    /// mutated constant cannot drag the assertion along with it.
+    @Test("the observation reads a bounded tail window, never the whole file")
+    func boundedTailRead() async throws {
+        let harness = try makeHarness(answers: [.silence(state: .idle)])
+        _ = await harness.verifier.observe(
+            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal)
+        #expect(harness.source.requestedWindows == [65_536])
+        #expect(DeliveryVerifier.tailWindowBytes == 65_536)
+    }
+
+    // MARK: - The envelope search survives JSON escaping
+
+    /// The transcript is JSONL, so the envelope's quotes are part of a JSON
+    /// string value and reach the file as `\"`. Both spellings are composed
+    /// from the id — asserted here as whole strings, so a needle that drifted
+    /// from what the send path pastes goes red.
+    @Test("both needles are composed from the row id, raw and JSON-escaped")
+    func needlesAreComposedFromTheRowID() {
+        #expect(DeliveryVerifier.needles(forActuationID: "a3f1b2c3d4e5") == [
+            "tbd-dispatch id=\"a3f1b2c3d4e5\"",
+            "tbd-dispatch id=\\\"a3f1b2c3d4e5\\\"",
+        ])
+        // The raw needle is a substring of exactly what `terminal.send` pastes.
+        let envelope = RPCRouter.dispatchEnvelope(id: "a3f1b2c3d4e5", from: "anonymous")
+        #expect(envelope.contains("tbd-dispatch id=\"a3f1b2c3d4e5\""))
+    }
+
+    /// A realistic transcript line: the envelope inside a JSON-encoded message
+    /// body, escaped by the encoder rather than by hand — a hand-written
+    /// fixture that got the escaping wrong would measure a fallback path and
+    /// yield a real-looking wrong answer.
+    @Test("the envelope is found in a realistic JSONL transcript, and joins on the row id")
+    func envelopeFoundInRealisticJSONL() throws {
+        let id = "a3f1b2c3d4e5"
+        let envelope = RPCRouter.dispatchEnvelope(id: id, from: "supervisor:acme-web")
+        struct Line: Encodable { let type: String; let content: String }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var jsonl = Data()
+        jsonl.append(try encoder.encode(Line(type: "summary", content: "earlier turn")))
+        jsonl.append(0x0A)
+        jsonl.append(try encoder.encode(
+            Line(type: "user", content: envelope + "\nrebase onto main")))
+        jsonl.append(0x0A)
+
+        // The encoder really did escape the quotes — the raw needle is absent
+        // from the file, so this fixture can only be matched by the escaped one.
+        let text = String(decoding: jsonl, as: UTF8.self)
+        #expect(text.contains("tbd-dispatch id=\\\"\(id)\\\""))
+        #expect(!text.contains("tbd-dispatch id=\"\(id)\""))
+
+        #expect(DeliveryVerifier.envelopeAppears(actuationID: id, inTail: jsonl))
+        // And it joins on THIS row id: a sibling act's envelope is not this one.
+        #expect(!DeliveryVerifier.envelopeAppears(actuationID: "ffffffffffff", inTail: jsonl))
+    }
+
+    /// The raw spelling still has to match — a transcript that stores the
+    /// message unescaped (or a tail read straddling a plain-text adapter) must
+    /// not read as non-delivery.
+    @Test("the envelope is found unescaped too")
+    func envelopeFoundUnescaped() {
+        let id = "a3f1b2c3d4e5"
+        let raw = Data(RPCRouter.dispatchEnvelope(id: id, from: "anonymous").utf8)
+        #expect(DeliveryVerifier.envelopeAppears(actuationID: id, inTail: raw))
+    }
+
+    // MARK: - The retry, and only one
+
+    /// not-landed → one retry → not-landed → stop. The ladder is written to the
+    /// record in order, every rung confirming the same request id, and the send
+    /// count is a literal 1: there is no third send on any branch, ever.
+    @Test("a not-landed observation retries exactly once, then writes the anomaly")
+    func retryOnceThenAnomaly() async throws {
+        let id = "a3f1b2c3d4e5"
+        let harness = try makeHarness(answers: [
+            .silence(state: .idle),
+            .silence(state: .idle),
+        ])
+        await harness.verifier.armVerification(
+            actuationID: id, terminalID: Self.terminal,
+            deliveredPayload: "<tbd-dispatch id=\"\(id)\" from=\"anonymous\"/>\nstatus?",
+            submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        #expect(try results(at: harness.logPath)
+            == ["not-landed", "dispatched", "not-landed"])
+        #expect(try rows(at: harness.logPath).allSatisfy { $0["confirms"] as? String == id })
+        // Exactly one re-delivery — spelled as a literal, and re-delivering the
+        // identical bytes under the identical envelope id.
+        #expect(harness.redeliveries.calls.count == 1)
+        #expect(harness.redeliveries.calls.first?.payload
+            == "<tbd-dispatch id=\"\(id)\" from=\"anonymous\"/>\nstatus?")
+        #expect(harness.redeliveries.calls.first?.terminalID == Self.terminal)
+        #expect(harness.redeliveries.calls.first?.submit == true)
+        // Two re-checks, and only two.
+        #expect(harness.source.tailReads == 2)
+        // The anomaly's durable half: the last observed row names what was missing.
+        let last = try #require(try rows(at: harness.logPath).last)
+        #expect((last["error"] as? String)?.isEmpty == false)
+        #expect(last["observedAt"] as? String != nil)
+    }
+
+    @Test("a retry that lands is recorded as landed, and nothing further is sent")
+    func retryThatLands() async throws {
+        let id = "a3f1b2c3d4e5"
+        let harness = try makeHarness(answers: [
+            .silence(state: .idle),
+            .envelope(for: id, state: .working),
+        ])
+        await harness.verifier.armVerification(
+            actuationID: id, terminalID: Self.terminal, deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        #expect(try results(at: harness.logPath)
+            == ["not-landed", "dispatched", "landed-and-acting"])
+        #expect(harness.redeliveries.calls.count == 1)
+    }
+
+    /// §12 argues this one directly: retrying into uncertainty risks
+    /// double-instructing an agent that DID receive the first copy, and a
+    /// message to an agent running with permissions bypassed is arbitrary
+    /// instruction injection — so delivering it twice is not a neutral event.
+    @Test("an undetermined observation is never retried, and never re-checked")
+    func undeterminedNeverRetried() async throws {
+        let harness = try makeHarness(answers: [.silence(state: .unknown)])
+        await harness.verifier.armVerification(
+            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal,
+            deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        #expect(harness.redeliveries.calls.isEmpty)
+        #expect(harness.redeliveries.calls.count == 0)
+        #expect(try results(at: harness.logPath) == ["undetermined"])
+        #expect(harness.source.tailReads == 1)
+    }
+
+    /// A retry the daemon declined is not "the payload failed" — the record has
+    /// to be able to say a stale coordinate was refused, and it confirms the
+    /// ORIGINAL request id rather than opening a second one.
+    @Test("a refused retry is recorded as refused, against the original request id")
+    func refusedRetryIsClassified() async throws {
+        let id = "a3f1b2c3d4e5"
+        let harness = try makeHarness(
+            answers: [.silence(state: .idle)], retryOutcome: .refused(.targetMismatch))
+        await harness.verifier.armVerification(
+            actuationID: id, terminalID: Self.terminal, deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        let written = try rows(at: harness.logPath)
+        #expect(written.allSatisfy { $0["confirms"] as? String == id })
+        // Two rows, and deliberately not a third. The refusal is a SYNCHRONOUS
+        // fact about the re-delivery, and the `not-landed` observation before it
+        // already stands on real evidence — so nothing here observed anything,
+        // and an observation row would claim a look that never happened.
+        #expect(try results(at: harness.logPath) == ["not-landed", "refused"])
+        #expect(written.contains { $0["reason"] as? String == "target-mismatch" })
+        // A retry that never reached the pane is not re-checked — and is not
+        // sent a second time either.
+        #expect(harness.redeliveries.calls.count == 1)
+        #expect(harness.source.tailReads == 1)
+    }
+
+    @Test("a transport-failed retry is recorded as transport-failed")
+    func transportFailedRetryIsClassified() async throws {
+        let harness = try makeHarness(
+            answers: [.silence(state: .idle)], retryOutcome: .transportFailed)
+        await harness.verifier.armVerification(
+            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal,
+            deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        // As above: the transport failure is synchronous, so it closes the
+        // cycle without a second observation row.
+        #expect(try results(at: harness.logPath) == ["not-landed", "transport-failed"])
+        #expect(harness.redeliveries.calls.count == 1)
+        #expect(harness.source.tailReads == 1)
+    }
+
+    /// A retry that dispatched leaves no `error` on its outcome row.
+    ///
+    /// A row reading `dispatched` with a populated error field reads as a
+    /// failure to anything querying the record. The `not-landed` observation
+    /// sitting between the two dispatches is what says why there are two.
+    @Test("a dispatched retry's outcome row carries no error text")
+    func dispatchedRetryCarriesNoError() async throws {
+        let id = "a3f1b2c3d4e5"
+        let harness = try makeHarness(answers: [
+            .silence(state: .idle),
+            .envelope(for: id, state: .working),
+        ])
+        await harness.verifier.armVerification(
+            actuationID: id, terminalID: Self.terminal, deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        let written = try rows(at: harness.logPath)
+        let dispatched = try #require(written.first { $0["result"] as? String == "dispatched" })
+        #expect(dispatched["error"] == nil)
+    }
+
+    // MARK: - The startup replay
+
+    /// A daemon that died mid-flight: the act renders `unconfirmed` by the
+    /// query-time rule, and the replay performs the observation late — writing
+    /// the outcome the timer would have written, and re-delivering nothing.
+    @Test("a restart mid-flight renders unconfirmed, and the replay observes it late")
+    func startupReplayObservesLate() async throws {
+        let dispatchedAt = Self.fixedNow
+        let bootedAt = dispatchedAt.addingTimeInterval(600)
+        let harness = try makeHarness(
+            answers: [.silence(state: .idle)], now: bootedAt, logNow: dispatchedAt)
+        let log = ActuationLog(path: harness.logPath, now: { dispatchedAt })
+        var request = ActuationRow(actor: .anonymous, kind: .send)
+        request.method = RPCMethod.terminalSend
+        request.target = .local(worktree: UUID(), terminal: Self.terminal)
+        request.message = "status?"
+        request.submit = true
+        request.verify = true
+        let id = try await log.appendRequest(request)
+        await log.appendOutcome(confirms: id, result: .dispatched)
+
+        // The query-time rule, first: past its deadline with no OBSERVED
+        // outcome, a dispatched act is unconfirmed — that is the replay's work
+        // list, and it is a pure function over the same rows.
+        let parsed = ActuationRecordReader(activePath: harness.logPath)
+            .rows(inFileAt: harness.logPath)
+        let statuses = DeliveryRecord.statuses(in: parsed, now: bootedAt)
+        #expect(statuses.count == 1)
+        #expect(statuses.first?.status == .unconfirmed)
+
+        await harness.verifier.replayMissedObservations(activeSegmentPath: harness.logPath)
+
+        #expect(try results(at: harness.logPath) == ["dispatched", "not-landed"])
+        let observation = try #require(try rows(at: harness.logPath).last)
+        #expect(observation["confirms"] as? String == id)
+        // §12 leaves repair to playbook judgment, and a payload whose premise
+        // is an unbounded interval old is the stale-premise send §3 forbids.
+        #expect(harness.redeliveries.calls.isEmpty)
+    }
+
+    /// The live timer still owns an act inside its deadline. Replaying it would
+    /// observe a payload that may not have reached the transcript yet.
+    @Test("the replay leaves acts still awaiting their deadline alone")
+    func startupReplaySkipsAwaitingActs() async throws {
+        let dispatchedAt = Self.fixedNow
+        let harness = try makeHarness(
+            answers: [.silence(state: .idle)],
+            now: dispatchedAt.addingTimeInterval(10), logNow: dispatchedAt)
+        let log = ActuationLog(path: harness.logPath, now: { dispatchedAt })
+        var request = ActuationRow(actor: .anonymous, kind: .send)
+        request.target = .local(worktree: UUID(), terminal: Self.terminal)
+        request.verify = true
+        let id = try await log.appendRequest(request)
+        await log.appendOutcome(confirms: id, result: .dispatched)
+
+        await harness.verifier.replayMissedObservations(activeSegmentPath: harness.logPath)
+
+        #expect(try results(at: harness.logPath) == ["dispatched"])
+        #expect(harness.source.factsCalls == 0)
+    }
+
+    /// An act that never armed verification is owed no observation at all.
+    @Test("the replay ignores sends that never armed verification")
+    func startupReplayIgnoresUnverifiedSends() async throws {
+        let dispatchedAt = Self.fixedNow
+        let harness = try makeHarness(
+            answers: [.silence(state: .idle)],
+            now: dispatchedAt.addingTimeInterval(600), logNow: dispatchedAt)
+        let log = ActuationLog(path: harness.logPath, now: { dispatchedAt })
+        var request = ActuationRow(actor: .anonymous, kind: .send)
+        request.target = .local(worktree: UUID(), terminal: Self.terminal)
+        let id = try await log.appendRequest(request)
+        await log.appendOutcome(confirms: id, result: .dispatched)
+
+        await harness.verifier.replayMissedObservations(activeSegmentPath: harness.logPath)
+        #expect(try results(at: harness.logPath) == ["dispatched"])
+        #expect(harness.source.factsCalls == 0)
+    }
+
+    /// D19: the replay's window is the active segment. An act from a rotated
+    /// day is one whose transcript may have rolled over, and a late read buys
+    /// only a more precise word for something the query-time rule already
+    /// renders honestly.
+    @Test("the replay reads only the active segment, never rotated ones")
+    func startupReplayReadsOnlyTheActiveSegment() async throws {
+        let dispatchedAt = Self.fixedNow
+        let harness = try makeHarness(
+            answers: [.silence(state: .idle)],
+            now: dispatchedAt.addingTimeInterval(600), logNow: dispatchedAt)
+        let directory = (harness.logPath as NSString).deletingLastPathComponent
+        let rotatedPath = (directory as NSString).appendingPathComponent("actuations-2023-11-13.jsonl")
+        let rotated = ActuationLog(path: rotatedPath, now: { dispatchedAt })
+        var request = ActuationRow(actor: .anonymous, kind: .send)
+        request.target = .local(worktree: UUID(), terminal: Self.terminal)
+        request.verify = true
+        let id = try await rotated.appendRequest(request)
+        await rotated.appendOutcome(confirms: id, result: .dispatched)
+
+        await harness.verifier.replayMissedObservations(activeSegmentPath: harness.logPath)
+
+        #expect(harness.source.factsCalls == 0)
+        #expect(try rows(at: harness.logPath).isEmpty)
+        // The rotated segment is untouched: two rows in, two rows out.
+        #expect(try rows(at: rotatedPath).count == 2)
+    }
+}

--- a/Tests/TBDDaemonTests/DeliveryVerifierTests.swift
+++ b/Tests/TBDDaemonTests/DeliveryVerifierTests.swift
@@ -20,6 +20,10 @@ private final class ScriptedObservationSource: DeliveryObservationSource, @unche
         var activityState: TerminalActivityState = .idle
         /// `nil` stands for an unreadable transcript.
         var tail: Data? = Data()
+        /// What a read wider than the cheap window returns, when that differs —
+        /// the envelope having been pushed out of the last 64 KiB by a session
+        /// that acted on it and went idle inside the deadline.
+        var wideTail: Data?
         /// Which conversation currently occupies the terminal. A round whose
         /// value differs from the armed one stands for a `/clear` or an account
         /// swap between dispatch and re-check.
@@ -87,7 +91,13 @@ private final class ScriptedObservationSource: DeliveryObservationSource, @unche
             _tailReads += 1
             _requestedWindows.append(maxBytes)
             // `facts` already advanced past this round's answer.
-            return answers[min(max(round - 1, 0), answers.count - 1)]?.tail
+            let answer = answers[min(max(round - 1, 0), answers.count - 1)]
+            // A wider read sees what the cheap window could not — the shape of
+            // a session that wrote past 64 KiB since dispatch.
+            if maxBytes > DeliveryVerifier.tailWindowBytes, let wide = answer?.wideTail {
+                return wide
+            }
+            return answer?.tail
         }
     }
 }
@@ -97,6 +107,7 @@ private final class ScriptedObservationSource: DeliveryObservationSource, @unche
 private final class RedeliveryRecorder: @unchecked Sendable {
     struct Call: Sendable, Equatable {
         let terminalID: UUID
+        let sessionID: String?
         let payload: String
         let submit: Bool
     }
@@ -111,10 +122,12 @@ private final class RedeliveryRecorder: @unchecked Sendable {
 
     var calls: [Call] { lock.withLock { _calls } }
 
-    var seam: @Sendable (UUID, String, Bool) async -> ActuationOutcome {
-        { [self] terminalID, payload, submit in
+    var seam: @Sendable (UUID, String?, String, Bool) async -> ActuationOutcome {
+        { [self] terminalID, sessionID, payload, submit in
             lock.withLock {
-                _calls.append(Call(terminalID: terminalID, payload: payload, submit: submit))
+                _calls.append(Call(
+                    terminalID: terminalID, sessionID: sessionID,
+                    payload: payload, submit: submit))
             }
             return outcome
         }
@@ -304,7 +317,10 @@ struct DeliveryVerifierTests {
         let harness = try makeHarness(answers: [.silence(state: .idle)])
         _ = await harness.verifier.observe(
             actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal)
-        #expect(harness.source.requestedWindows == [65_536])
+        // Both reads are bounded, and neither is "the whole file": the cheap
+        // window first, then the escalation that must prove an absence before
+        // the retry may act on it.
+        #expect(harness.source.requestedWindows == [65_536, 8_388_608])
         #expect(DeliveryVerifier.tailWindowBytes == 65_536)
     }
 
@@ -397,8 +413,10 @@ struct DeliveryVerifierTests {
             == "<tbd-dispatch id=\"\(id)\" from=\"anonymous\"/>\nstatus?")
         #expect(harness.redeliveries.calls.first?.terminalID == Self.terminal)
         #expect(harness.redeliveries.calls.first?.submit == true)
-        // Two re-checks, and only two.
-        #expect(harness.source.tailReads == 2)
+        // Two re-checks, and only two. Counted on `facts`, which is called
+        // exactly once per observation — `tailReads` now doubles whenever an
+        // absence escalates to the wider read.
+        #expect(harness.source.factsCalls == 2)
         // The anomaly's durable half: the last observed row names what was missing.
         let last = try #require(try rows(at: harness.logPath).last)
         #expect((last["error"] as? String)?.isEmpty == false)
@@ -501,6 +519,80 @@ struct DeliveryVerifierTests {
         #expect(harness.redeliveries.calls.isEmpty)
     }
 
+    /// The window's soundness argument is about the *interval*, but the mapping
+    /// reads `activityState` at observation time — so a session that receives
+    /// the payload, writes more than 64 KiB acting on it (tool results are
+    /// stored verbatim) and is back to idle before second sixty would read as
+    /// absent-and-not-mid-turn. That is the sole licence for the retry, so the
+    /// cheap window alone would re-paste an instruction the agent already had.
+    /// Absence escalates to a wider read before it accuses.
+    @Test("an envelope pushed past the cheap window is found by the wider read, not retried")
+    func absenceEscalatesBeforeAccusing() async throws {
+        let id = "a3f1b2c3d4e5"
+        var answer = ScriptedObservationSource.Answer.silence(state: .idle)
+        answer.wideTail = ScriptedObservationSource.Answer.envelope(for: id, state: .idle).tail
+        let harness = try makeHarness(answers: [answer])
+        await harness.verifier.armVerification(
+            actuationID: id, terminalID: Self.terminal, sessionID: nil,
+            deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        // It landed. Nothing is re-sent, and the record says so.
+        #expect(try results(at: harness.logPath) == ["landed-but-still-blocked"])
+        #expect(harness.redeliveries.calls.isEmpty)
+        // Two reads: the cheap window, then the escalation.
+        #expect(harness.source.requestedWindows == [65_536, 8_388_608])
+    }
+
+    /// And when the wider read is itself capped — the transcript is longer than
+    /// the escalated window — absence still proves nothing, so the verdict is
+    /// undetermined rather than a manufactured non-delivery.
+    @Test("absence in a transcript longer than the escalated window is undetermined")
+    func absenceInAnOversizeTranscriptIsUndetermined() async throws {
+        var answer = ScriptedObservationSource.Answer.silence(state: .idle)
+        answer.wideTail = Data(repeating: 0x20, count: DeliveryVerifier.escalatedWindowBytes)
+        let harness = try makeHarness(answers: [answer])
+        await harness.verifier.armVerification(
+            actuationID: "a3f1b2c3d4e5", terminalID: Self.terminal, sessionID: nil,
+            deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows"
+        })
+
+        #expect(try results(at: harness.logPath) == ["undetermined"])
+        #expect(harness.redeliveries.calls.isEmpty)
+    }
+
+    /// The escalation must not disarm the retry: a transcript the wide read
+    /// covers entirely, still missing the envelope, is real evidence.
+    @Test("absence proven across the whole transcript still licenses the one retry")
+    func provenAbsenceStillRetries() async throws {
+        let id = "a3f1b2c3d4e5"
+        let harness = try makeHarness(answers: [
+            .silence(state: .idle),
+            .envelope(for: id, state: .working),
+        ])
+        await harness.verifier.armVerification(
+            actuationID: id, terminalID: Self.terminal, sessionID: nil,
+            deliveredPayload: "x", submit: true)
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await harness.clock.advanceWhenSuspended(by: .seconds(60))
+        await awaitDeliveryCycle(harness.verifier, observed: {
+            "\((try? results(at: harness.logPath)) ?? []) rows, "
+                + "\(harness.redeliveries.calls.count) re-deliveries"
+        })
+
+        #expect(try results(at: harness.logPath)
+            == ["not-landed", "dispatched", "landed-and-acting"])
+        #expect(harness.redeliveries.calls.count == 1)
+        #expect(harness.redeliveries.calls.first?.sessionID == nil)
+    }
+
     /// A retry the daemon declined is not "the payload failed" — the record has
     /// to be able to say a stale coordinate was refused, and it confirms the
     /// ORIGINAL request id rather than opening a second one.
@@ -526,9 +618,9 @@ struct DeliveryVerifierTests {
         #expect(try results(at: harness.logPath) == ["not-landed", "refused"])
         #expect(written.contains { $0["reason"] as? String == "target-mismatch" })
         // A retry that never reached the pane is not re-checked — and is not
-        // sent a second time either.
+        // sent a second time either. One observation, whatever it cost in reads.
         #expect(harness.redeliveries.calls.count == 1)
-        #expect(harness.source.tailReads == 1)
+        #expect(harness.source.factsCalls == 1)
     }
 
     @Test("a transport-failed retry is recorded as transport-failed")
@@ -548,7 +640,8 @@ struct DeliveryVerifierTests {
         // cycle without a second observation row.
         #expect(try results(at: harness.logPath) == ["not-landed", "transport-failed"])
         #expect(harness.redeliveries.calls.count == 1)
-        #expect(harness.source.tailReads == 1)
+        // One observation, whatever it cost in reads.
+        #expect(harness.source.factsCalls == 1)
     }
 
     /// A retry that dispatched leaves no `error` on its outcome row.

--- a/Tests/TBDDaemonTests/PacedKeySenderTests.swift
+++ b/Tests/TBDDaemonTests/PacedKeySenderTests.swift
@@ -1,0 +1,133 @@
+import Clocks
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+
+/// Tier 1 — pure logic plus a `TestClock`. No tmux, no daemon, no filesystem.
+///
+/// `PacedKeySender` owns two things a `--keys` payload depends on: the
+/// tokenizer that decides what a keys string even names, and the 150 ms pause
+/// that keeps a redrawing TUI from dropping keys. Both are testable without a
+/// pane because the send itself is a closure.
+@Suite("Paced key sender", .clockDriven)
+struct PacedKeySenderTests {
+
+    /// Records the keys handed to the send closure, in order.
+    private final class KeyRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _keys: [String] = []
+        var keys: [String] {
+            lock.lock(); defer { lock.unlock() }
+            return _keys
+        }
+        func record(_ key: String) {
+            lock.lock(); defer { lock.unlock() }
+            _keys.append(key)
+        }
+    }
+
+    // MARK: - Tokenizing
+
+    @Test("a single key tokenizes to one name")
+    func singleKey() {
+        #expect(PacedKeySender.tokenize("Escape") == ["Escape"])
+    }
+
+    @Test("whitespace separates keys, and runs of it collapse")
+    func whitespaceSeparates() {
+        // Empty tokens cannot survive the split — that is how "reject empty
+        // tokens" is satisfied without making a double space an error.
+        #expect(PacedKeySender.tokenize("Escape   Enter") == ["Escape", "Enter"])
+        #expect(PacedKeySender.tokenize("  C-c\tC-c\n") == ["C-c", "C-c"])
+    }
+
+    @Test("a keys value naming nothing is rejected")
+    func emptyRejected() {
+        #expect(PacedKeySender.tokenize("") == nil)
+        #expect(PacedKeySender.tokenize("   \t \n ") == nil)
+    }
+
+    /// A `--keys` value is whitespace-split, so a quoting mistake turns one
+    /// call into a runaway that types for minutes into a live session.
+    ///
+    /// **Asserted against literals, not against `maxKeys`.** Spelling the
+    /// counts as `maxKeys` and `maxKeys + 1` makes every assertion here move
+    /// with the constant, so raising the cap to 100000 leaves this test green —
+    /// measured, not assumed. The bound is a contract, so its value is asserted
+    /// too.
+    @Test("the key count is capped at 32, inclusive at its edge")
+    func countCapped() {
+        #expect(PacedKeySender.maxKeys == 32)
+
+        let atCap = Array(repeating: "Escape", count: 32).joined(separator: " ")
+        #expect(PacedKeySender.tokenize(atCap)?.count == 32)
+
+        let overCap = Array(repeating: "Escape", count: 33).joined(separator: " ")
+        #expect(PacedKeySender.tokenize(overCap) == nil)
+    }
+
+    // MARK: - Pacing
+
+    @Test("keys are sent in order, one pause apart, with no pause after the last")
+    func pacedInOrder() async throws {
+        let clock = TestClock()
+        let recorder = KeyRecorder()
+        let sender = PacedKeySender(clock: clock)
+
+        async let sent: Void = sender.send(["Escape", "C-c", "Enter"]) { recorder.record($0) }
+
+        // The first key goes out with no preceding pause.
+        await clock.advanceWhenSuspended(by: PacedKeySender.interKeyPause)
+        await clock.advanceWhenSuspended(by: PacedKeySender.interKeyPause)
+        try await sent
+
+        #expect(recorder.keys == ["Escape", "C-c", "Enter"])
+    }
+
+    /// The pause is real virtual time, not a yield: a send that has not been
+    /// advanced past its pause has typed only the keys before it.
+    @Test("an un-advanced pause holds the sequence at the key it reached")
+    func pauseHoldsTheSequence() async throws {
+        let clock = TestClock()
+        let recorder = KeyRecorder()
+        let sender = PacedKeySender(clock: clock)
+
+        async let sent: Void = sender.send(["Escape", "Enter"]) { recorder.record($0) }
+        await clock.waitForSuspension()
+        #expect(recorder.keys == ["Escape"])
+
+        await clock.advance(by: PacedKeySender.interKeyPause)
+        try await sent
+        #expect(recorder.keys == ["Escape", "Enter"])
+    }
+
+    /// A partially delivered sequence must surface as a failure, not as a
+    /// success that typed half of what was asked for.
+    @Test("a throwing send stops the sequence and propagates")
+    func throwingSendStops() async throws {
+        struct PaneGone: Error {}
+        let clock = TestClock()
+        let recorder = KeyRecorder()
+        let sender = PacedKeySender(clock: clock)
+
+        // The throw is on the FIRST key deliberately: a later one would arm a
+        // pause this test would then have to advance, and the point here is
+        // that the sequence stops, not how it is paced.
+        await #expect(throws: PaneGone.self) {
+            try await sender.send(["C-c", "Enter"]) { key in
+                recorder.record(key)
+                if key == "C-c" { throw PaneGone() }
+            }
+        }
+        #expect(recorder.keys == ["C-c"])
+    }
+
+    @Test("a one-key sequence needs no pause at all")
+    func singleKeyNeedsNoPause() async throws {
+        let clock = TestClock()
+        let recorder = KeyRecorder()
+        try await PacedKeySender(clock: clock).send(["C-c"]) { recorder.record($0) }
+        #expect(recorder.keys == ["C-c"])
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
@@ -1,0 +1,578 @@
+import Clocks
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 — dry-run tmux, a real (temp-directory) actuation log, an in-memory
+/// database, and a `TestClock` for the key pacing.
+///
+/// `terminal.send` grew a payload vocabulary (`--text` or `--keys`), a dispatch
+/// envelope on every non-empty text payload, and an opt-in delivery
+/// acknowledgement behind a default-off flag. These prove the composed bytes
+/// that reach the pane, what the record stores about them, which shapes are
+/// refused and on which side of the row, and that the observation is armed for
+/// exactly one kind of send and never for any other.
+@Suite("terminal.send payloads, envelope and verification", .clockDriven)
+struct TerminalSendDispatchTests {
+
+    // MARK: - Fixture
+
+    /// Thread-safe collector for tmux argv lists invoked during dryRun.
+    private final class ArgvRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _calls: [[String]] = []
+        var calls: [[String]] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+        func record(_ args: [String]) {
+            lock.lock(); defer { lock.unlock() }
+            _calls.append(args)
+        }
+    }
+
+    /// Collects the payloads handed to `pasteText` — the argv cannot carry
+    /// them, since the real path passes the body through a temp file.
+    private final class PasteRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _pastes: [String] = []
+        var pastes: [String] {
+            lock.lock(); defer { lock.unlock() }
+            return _pastes
+        }
+        func record(_ bytes: Data) {
+            lock.lock(); defer { lock.unlock() }
+            _pastes.append(String(decoding: bytes, as: UTF8.self))
+        }
+    }
+
+    /// Stands in for the verifier that will fill `RPCRouter.deliveryVerifier`.
+    /// Records every arming, so "exactly once" and "never" are both assertable.
+    private final class RecordingVerifier: DeliveryVerificationArming, @unchecked Sendable {
+        struct Arming: Sendable, Equatable {
+            let actuationID: String
+            let terminalID: UUID
+            let deliveredPayload: String
+            let submit: Bool
+        }
+        private let lock = NSLock()
+        private var _armings: [Arming] = []
+        var armings: [Arming] {
+            lock.lock(); defer { lock.unlock() }
+            return _armings
+        }
+        func armVerification(
+            actuationID: String, terminalID: UUID, deliveredPayload: String, submit: Bool
+        ) async {
+            lock.withLock {
+                _armings.append(Arming(
+                    actuationID: actuationID, terminalID: terminalID,
+                    deliveredPayload: deliveredPayload, submit: submit))
+            }
+        }
+    }
+
+    /// The error a `.transportFails` fixture's paste fails with.
+    private struct PaneVanished: Error {}
+
+    private struct Fixture {
+        let router: RPCRouter
+        let terminal: Terminal
+        let recorder: ArgvRecorder
+        let pastes: PasteRecorder
+        let verifier: RecordingVerifier
+        let logPath: String
+    }
+
+    private func makeFixture(clock: (any Clock<Duration>)? = nil) async throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-send-dispatch-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let logPath = directory.appendingPathComponent("actuations.jsonl").path
+
+        let recorder = ArgvRecorder()
+        let pastes = PasteRecorder()
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            // `.live(terminalID: nil)` — alive, carrying no identity — is the
+            // branch that proceeds, so the target check is not what these are
+            // about. `TerminalSendTargetCheckTests` owns that.
+            dryRunPaneSendTarget: { _, _ in .live(terminalID: nil) },
+            dryRunPasteBytes: { _, _, bytes in
+                pastes.record(bytes)
+            })
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: ActuationLog(path: logPath))
+        let verifier = RecordingVerifier()
+        router.deliveryVerifier = verifier
+        if let clock {
+            router.pacedKeySender = PacedKeySender(clock: clock)
+        }
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7")
+        return Fixture(
+            router: router, terminal: terminal, recorder: recorder, pastes: pastes,
+            verifier: verifier, logPath: logPath)
+    }
+
+    /// A fixture whose paste always throws, for the transport-failure branch.
+    private func makeFailingPasteFixture() async throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-send-fail-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let logPath = directory.appendingPathComponent("actuations.jsonl").path
+
+        let recorder = ArgvRecorder()
+        let pastes = PasteRecorder()
+        // A dry-run TmuxManager cannot be made to fail a paste, so the failure
+        // is staged one layer out: the pane consultation throws, which the
+        // handler classifies as a transport failure. Same branch, same question
+        // — does a failed send arm an observation?
+        let tmux = TmuxManager(
+            dryRun: true,
+            dryRunRecorder: { recorder.record($0) },
+            dryRunPaneSendTarget: { _, _ in throw PaneVanished() },
+            dryRunPasteBytes: { _, _, bytes in pastes.record(bytes) })
+        let db = try TBDDatabase(inMemory: true)
+        let router = RPCRouter(
+            db: db,
+            lifecycle: WorktreeLifecycle(
+                db: db, git: GitManager(), tmux: tmux, hooks: HookResolver()),
+            tmux: tmux,
+            startTime: Date(),
+            actuationLog: ActuationLog(path: logPath))
+        let verifier = RecordingVerifier()
+        router.deliveryVerifier = verifier
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let worktree = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "main",
+            path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+        let terminal = try await db.terminals.create(
+            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7")
+        return Fixture(
+            router: router, terminal: terminal, recorder: recorder, pastes: pastes,
+            verifier: verifier, logPath: logPath)
+    }
+
+    private func send(
+        _ fixture: Fixture,
+        text: String? = nil,
+        keys: String? = nil,
+        submit: Bool? = nil,
+        verify: Bool? = nil,
+        actor: ActuationActor? = nil
+    ) async throws -> RPCResponse {
+        await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.terminalSend,
+            params: TerminalSendParams(
+                terminalID: fixture.terminal.id, text: text, keys: keys,
+                submit: submit, verify: verify),
+            actor: actor))
+    }
+
+    private func rows(at path: String) throws -> [[String: Any]] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else { return [] }
+        return try contents
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { line in
+                try #require(
+                    try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            }
+    }
+
+    private func requestRow(at path: String) throws -> [String: Any] {
+        try #require(try rows(at: path).first)
+    }
+
+    private func lastOutcome(at path: String) throws -> [String: Any] {
+        try #require(try rows(at: path).last)
+    }
+
+    // MARK: - The envelope
+
+    /// The whole composed payload, asserted as one string rather than as
+    /// fragments: the tag, its two attributes in order, the newline, and the
+    /// caller's text untouched behind it. A fragment assertion would pass on a
+    /// payload with the pieces in the wrong places.
+    @Test("the envelope's exact bytes prefix the text, carrying the row's own id")
+    func envelopeExactBytes() async throws {
+        let fixture = try await makeFixture()
+        #expect(try await send(fixture, text: "rebase onto main", submit: true).success)
+
+        let rowID = try #require(try requestRow(at: fixture.logPath)["id"] as? String)
+        #expect(fixture.pastes.pastes == [
+            "<tbd-dispatch id=\"\(rowID)\" from=\"anonymous\"/>\nrebase onto main"
+        ])
+    }
+
+    /// `from` is the row's own actor, not a constant: the receiving agent sees
+    /// who is addressing it, down to the rail when a daemon rail sends.
+    @Test("the envelope's from attribute names the declared actor")
+    func envelopeNamesActor() async throws {
+        let fixture = try await makeFixture()
+        #expect(try await send(
+            fixture, text: "continue", submit: true,
+            actor: .daemon(rail: "limit-resume")).success)
+
+        let rowID = try #require(try requestRow(at: fixture.logPath)["id"] as? String)
+        #expect(fixture.pastes.pastes == [
+            "<tbd-dispatch id=\"\(rowID)\" from=\"daemon:limit-resume\"/>\ncontinue"
+        ])
+    }
+
+    /// The envelope rides every text send, verified or not — a prefix that
+    /// appears only sometimes is one no reader can rely on.
+    @Test("an unverified, unsubmitted send still carries the envelope")
+    func envelopeRidesEveryTextSend() async throws {
+        let fixture = try await makeFixture()
+        #expect(try await send(fixture, text: "note to self").success)
+
+        let rowID = try #require(try requestRow(at: fixture.logPath)["id"] as? String)
+        #expect(fixture.pastes.pastes == [
+            "<tbd-dispatch id=\"\(rowID)\" from=\"anonymous\"/>\nnote to self"
+        ])
+    }
+
+    /// The envelope is transport framing whose id is the row's own, so storing
+    /// it would duplicate the row's identifier into its own body.
+    @Test("the row records the caller's text WITHOUT the envelope")
+    func rowRecordsTextVerbatim() async throws {
+        let fixture = try await makeFixture()
+        #expect(try await send(fixture, text: "rebase onto main", submit: true).success)
+
+        let request = try requestRow(at: fixture.logPath)
+        #expect(request["message"] as? String == "rebase onto main")
+        #expect(request["submit"] as? Bool == true)
+        // Not armed, so the field that identifies sends owing an observation
+        // must be absent — not present-and-false.
+        #expect(request["verify"] == nil)
+    }
+
+    /// `tbd terminal send --text "" --submit` is a real way to press Enter and
+    /// must not start pasting a tag.
+    @Test("empty text still pastes nothing and still presses Enter")
+    func emptyTextPastesNothingStillSubmits() async throws {
+        let fixture = try await makeFixture()
+        #expect(try await send(fixture, text: "", submit: true).success)
+
+        #expect(fixture.pastes.pastes.isEmpty)
+        #expect(!fixture.recorder.calls.contains { $0.contains("load-buffer") })
+        #expect(!fixture.recorder.calls.contains { $0.contains("paste-buffer") })
+        #expect(fixture.recorder.calls.contains {
+            $0.contains("send-keys") && $0.contains("Enter")
+        })
+    }
+
+    @Test("empty text without submit types nothing at all")
+    func emptyTextNoSubmitTypesNothing() async throws {
+        let fixture = try await makeFixture()
+        #expect(try await send(fixture, text: "").success)
+        #expect(fixture.pastes.pastes.isEmpty)
+        #expect(fixture.recorder.calls.isEmpty)
+    }
+
+    // MARK: - Keys
+
+    @Test("--keys sends each named key in order, paced through the injected clock")
+    func keysSentInOrderPaced() async throws {
+        let clock = TestClock()
+        let fixture = try await makeFixture(clock: clock)
+
+        async let response = send(fixture, keys: "Escape C-c Enter")
+        await clock.advanceWhenSuspended(by: PacedKeySender.interKeyPause)
+        await clock.advanceWhenSuspended(by: PacedKeySender.interKeyPause)
+        #expect(try await response.success)
+
+        let sent = fixture.recorder.calls
+            .filter { $0.contains("send-keys") }
+            .compactMap(\.last)
+        #expect(sent == ["Escape", "C-c", "Enter"])
+        // Keys carry no envelope: a key sequence has nowhere to put a line of
+        // text, and typing one ahead of an interrupt would itself be an act.
+        #expect(fixture.pastes.pastes.isEmpty)
+    }
+
+    @Test("a keys row records the keys verbatim, with submit and verify absent")
+    func keysRowShape() async throws {
+        let clock = TestClock()
+        let fixture = try await makeFixture(clock: clock)
+
+        async let response = send(fixture, keys: "Escape Enter")
+        await clock.advanceWhenSuspended(by: PacedKeySender.interKeyPause)
+        #expect(try await response.success)
+
+        let request = try requestRow(at: fixture.logPath)
+        #expect(request["message"] as? String == "Escape Enter")
+        #expect(request["submit"] == nil)
+        #expect(request["verify"] == nil)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
+    }
+
+    /// The cap is enforced at the daemon, before a row exists — a typo that
+    /// expands into thousands of keys names no coherent act. Spelled as a
+    /// literal 33 for the reason `PacedKeySenderTests.countCapped` records:
+    /// `maxKeys + 1` would move with a raised cap and stay green.
+    @Test("a keys payload past the 32-key cap is rejected before any row is written")
+    func keysPastCapRejected() async throws {
+        let fixture = try await makeFixture()
+        let overCap = Array(repeating: "Escape", count: 33).joined(separator: " ")
+
+        let response = try await send(fixture, keys: overCap)
+        #expect(!response.success)
+        #expect(response.error?.contains("32") == true)
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    // The cap's inclusive edge — exactly `maxKeys` is accepted — is proven in
+    // `PacedKeySenderTests.countCapped` rather than here: driving 32 paced keys
+    // through the router would need 31 chained clock advances, and
+    // `Tests/CLAUDE.md` keeps advance chains in single digits.
+
+    @Test("a keys payload naming nothing is rejected before any row is written")
+    func emptyKeysRejected() async throws {
+        let fixture = try await makeFixture()
+        let response = try await send(fixture, keys: "   ")
+        #expect(!response.success)
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    // MARK: - Malformed shapes: rejected BEFORE any row is written
+
+    /// All four (plus the empty-text corollary) share one property that is the
+    /// whole point of the line: no row. `RPCRouter+Actuation`'s rule is that a
+    /// row must not be written for a request that was never about to be
+    /// dispatched, and none of these named a coherent act.
+    @Test("both payloads at once is rejected, with no row")
+    func bothPayloadsRejected() async throws {
+        let fixture = try await makeFixture()
+        let response = try await send(fixture, text: "hi", keys: "Enter")
+        #expect(!response.success)
+        #expect(response.error?.contains("not both") == true)
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    @Test("neither payload is rejected, with no row")
+    func neitherPayloadRejected() async throws {
+        let fixture = try await makeFixture()
+        let response = try await send(fixture)
+        #expect(!response.success)
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    @Test("--verify with --keys is rejected, with no row")
+    func verifyWithKeysRejected() async throws {
+        let fixture = try await makeFixture()
+        let response = try await send(fixture, keys: "Enter", verify: true)
+        #expect(!response.success)
+        #expect(response.error?.contains("transcript") == true)
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    @Test("--submit with --keys is rejected, with no row")
+    func submitWithKeysRejected() async throws {
+        let fixture = try await makeFixture()
+        let response = try await send(fixture, keys: "Escape", submit: true)
+        #expect(!response.success)
+        #expect(response.error?.contains("Enter is itself a key") == true)
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    @Test("--verify without --submit is rejected, with no row")
+    func verifyWithoutSubmitRejected() async throws {
+        let fixture = try await makeFixture()
+        let response = try await send(fixture, text: "hi", verify: true)
+        #expect(!response.success)
+        #expect(response.error?.contains("--submit") == true)
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    /// The same reason one step earlier: an empty payload pastes nothing, so no
+    /// envelope is ever written for an observation to find.
+    @Test("--verify with empty text is rejected, with no row")
+    func verifyWithEmptyTextRejected() async throws {
+        let fixture = try await makeFixture()
+        let response = try await send(fixture, text: "", submit: true, verify: true)
+        #expect(!response.success)
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(try rows(at: fixture.logPath).isEmpty)
+    }
+
+    // MARK: - The flag: both branches
+
+    /// Not a silent downgrade to an unverified send. A caller that asked for
+    /// evidence must never be answered with a silence that reads like
+    /// confirmation — that would rebuild the failure class §12 exists to end.
+    @Test("--verify while the flag is off is refused, after the row, naming the flag")
+    func verifyRefusedWhileFlagOff() async throws {
+        let fixture = try await makeFixture()
+        #expect(try await fixture.router.db.config.get().deliveryVerificationEnabled == false)
+
+        let response = try await send(fixture, text: "status?", submit: true, verify: true)
+        #expect(!response.success)
+        #expect(response.error?.contains("delivery_verification_enabled") == true)
+
+        // Nothing typed.
+        #expect(fixture.recorder.calls.isEmpty)
+        #expect(fixture.pastes.pastes.isEmpty)
+        // But a row and a refusal outcome, so the morning shows the near-miss.
+        let written = try rows(at: fixture.logPath)
+        #expect(written.count == 2)
+        #expect(written.first?["verify"] as? Bool == true)
+        let outcome = try #require(written.last)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-eligible")
+        #expect(!written.contains { $0["result"] as? String == "dispatched" })
+        // And no observation was armed on a send that never happened.
+        #expect(fixture.verifier.armings.isEmpty)
+    }
+
+    @Test("--verify while the flag is on dispatches and arms the observation")
+    func verifyArmedWhileFlagOn() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.router.db.config.setDeliveryVerification(enabled: true)
+
+        #expect(try await send(fixture, text: "status?", submit: true, verify: true).success)
+
+        let request = try requestRow(at: fixture.logPath)
+        let rowID = try #require(request["id"] as? String)
+        #expect(request["verify"] as? Bool == true)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
+
+        // Exactly once, carrying the delivered bytes INCLUDING the envelope so
+        // a retry re-delivers byte-identically and still joins on this row.
+        #expect(fixture.verifier.armings.count == 1)
+        let arming = try #require(fixture.verifier.armings.first)
+        #expect(arming.actuationID == rowID)
+        #expect(arming.terminalID == fixture.terminal.id)
+        #expect(arming.submit)
+        #expect(arming.deliveredPayload
+            == "<tbd-dispatch id=\"\(rowID)\" from=\"anonymous\"/>\nstatus?")
+        #expect(arming.deliveredPayload == fixture.pastes.pastes.first)
+    }
+
+    /// An ordinary send must cost nothing the verification path costs — the
+    /// observation is not armed, so no transcript is ever read for it.
+    @Test("a verify-less send arms no observation")
+    func verifylessSendArmsNothing() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.router.db.config.setDeliveryVerification(enabled: true)
+
+        #expect(try await send(fixture, text: "status?", submit: true).success)
+        #expect(fixture.verifier.armings.isEmpty)
+    }
+
+    @Test("a keys send arms no observation, flag on or off")
+    func keysSendArmsNothing() async throws {
+        let clock = TestClock()
+        let fixture = try await makeFixture(clock: clock)
+        try await fixture.router.db.config.setDeliveryVerification(enabled: true)
+
+        async let response = send(fixture, keys: "Escape Enter")
+        await clock.advanceWhenSuspended(by: PacedKeySender.interKeyPause)
+        #expect(try await response.success)
+        #expect(fixture.verifier.armings.isEmpty)
+    }
+
+    /// A send that never reached the transport has nothing to observe: arming
+    /// one would put an act on the observation ladder that never got dispatched.
+    @Test("a transport failure arms no observation")
+    func transportFailureArmsNothing() async throws {
+        let fixture = try await makeFailingPasteFixture()
+        try await fixture.router.db.config.setDeliveryVerification(enabled: true)
+
+        let response = try await send(fixture, text: "status?", submit: true, verify: true)
+        #expect(!response.success)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "transport-failed")
+        #expect(fixture.verifier.armings.isEmpty)
+    }
+
+    // MARK: - Wire compatibility
+
+    /// The exact JSON an older CLI sends — `text` and `submit`, no `keys`, no
+    /// `verify`. It must decode and behave as it always did.
+    @Test("the old wire shape decodes and behaves exactly as before")
+    func oldWireShapeUnchanged() async throws {
+        let fixture = try await makeFixture()
+        let json = """
+            {"terminalID":"\(fixture.terminal.id.uuidString)","text":"rebase onto main","submit":true}
+            """
+
+        let response = await fixture.router.handle(
+            RPCRequest(method: RPCMethod.terminalSend, params: json))
+        #expect(response.success)
+
+        let request = try requestRow(at: fixture.logPath)
+        #expect(request["message"] as? String == "rebase onto main")
+        #expect(request["submit"] as? Bool == true)
+        #expect(request["verify"] == nil)
+        #expect(try lastOutcome(at: fixture.logPath)["result"] as? String == "dispatched")
+
+        // Same tmux commands as ever: bracketed paste, then a separate Enter.
+        let calls = fixture.recorder.calls
+        #expect(calls.contains { $0.contains("load-buffer") })
+        #expect(calls.contains { $0.contains("paste-buffer") })
+        #expect(calls.contains { $0.contains("send-keys") && $0.contains("Enter") })
+        #expect(fixture.verifier.armings.isEmpty)
+    }
+
+    /// Bare `--text`, the shape that decodes with `submit` absent entirely.
+    @Test("the old wire shape without submit still types without submitting")
+    func oldWireShapeWithoutSubmit() async throws {
+        let fixture = try await makeFixture()
+        let json = """
+            {"terminalID":"\(fixture.terminal.id.uuidString)","text":"hello"}
+            """
+
+        #expect(await fixture.router.handle(
+            RPCRequest(method: RPCMethod.terminalSend, params: json)).success)
+        #expect(!fixture.recorder.calls.contains { $0.contains("send-keys") })
+        #expect(try requestRow(at: fixture.logPath)["submit"] as? Bool == false)
+    }
+
+    // MARK: - The operator's enable path
+
+    /// The flag has to be flippable for its soak, and readable back so an
+    /// operator can tell which branch the daemon is on.
+    @Test("config.setDeliveryVerification flips the flag and capabilities reports it")
+    func operatorEnablePath() async throws {
+        let fixture = try await makeFixture()
+
+        #expect(try await fixture.router.db.config.get().deliveryVerificationEnabled == false)
+        let off = try await fixture.router.handle(
+            RPCRequest(method: RPCMethod.daemonCapabilities))
+            .decodeResult(DaemonCapabilitiesResult.self)
+        #expect(off.deliveryVerificationEnabled == false)
+
+        #expect(await fixture.router.handle(try RPCRequest(
+            method: RPCMethod.configSetDeliveryVerification,
+            params: ConfigSetDeliveryVerificationParams(enabled: true))).success)
+        #expect(try await fixture.router.db.config.get().deliveryVerificationEnabled == true)
+
+        let on = try await fixture.router.handle(
+            RPCRequest(method: RPCMethod.daemonCapabilities))
+            .decodeResult(DaemonCapabilitiesResult.self)
+        #expect(on.deliveryVerificationEnabled == true)
+    }
+}

--- a/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
@@ -333,6 +333,48 @@ struct TerminalSendDispatchTests {
         #expect(fixture.pastes.pastes.isEmpty)
     }
 
+    /// Tier 2. The same conversation, still there, still named: the check the
+    /// test above proves refuses must also let the ordinary case through, or
+    /// the retry would be unreachable whenever the session id is known — which
+    /// is nearly always.
+    @Test("the retry proceeds when the addressed session is still the terminal's own")
+    func redeliveryProceedsWhenTheSessionStillMatches() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.router.db.terminals.updateSession(
+            id: fixture.terminal.id, sessionID: "session-at-dispatch", transcriptPath: nil)
+
+        let outcome = await fixture.router.redeliverVerifiedPayload(
+            terminalID: fixture.terminal.id,
+            sessionID: "session-at-dispatch",
+            payload: "status?", submit: true)
+
+        #expect(outcome == .dispatched)
+        #expect(fixture.pastes.pastes == ["status?"])
+    }
+
+    /// Tier 2. A payload dispatched into a terminal whose session id was not yet
+    /// recorded carries `nil` — the conversation was never identified, so there
+    /// is no identity to compare and nothing a comparison could catch. The
+    /// observation skips its rebind check on exactly this input, and the retry
+    /// has to agree: an id appearing by the time the retry runs is the terminal
+    /// becoming knowable, not a rebind, and refusing it would spend the one
+    /// retry the mechanism gets on an absence that proves nothing.
+    @Test("the retry proceeds when the dispatch never identified a session")
+    func redeliveryProceedsWhenDispatchKnewNoSession() async throws {
+        let fixture = try await makeFixture()
+        #expect(fixture.terminal.claudeSessionID == nil)
+        try await fixture.router.db.terminals.updateSession(
+            id: fixture.terminal.id, sessionID: "session-learned-later", transcriptPath: nil)
+
+        let outcome = await fixture.router.redeliverVerifiedPayload(
+            terminalID: fixture.terminal.id,
+            sessionID: nil,
+            payload: "status?", submit: true)
+
+        #expect(outcome == .dispatched)
+        #expect(fixture.pastes.pastes == ["status?"])
+    }
+
     /// And a target that stopped being verifiable — a `recreateWindow` turning
     /// an agent terminal into a shell while keeping its id — refuses too. The
     /// payload it is holding opens with an envelope a shell would execute.

--- a/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
@@ -253,7 +253,39 @@ struct TerminalSendDispatchTests {
         let response = try await send(fixture, text: "ls", submit: true, verify: true)
 
         #expect(!response.success)
-        #expect(response.error?.contains("keeps no transcript") == true)
+        #expect(response.error?.contains("shell session") == true)
+        #expect(fixture.pastes.pastes.isEmpty)
+        #expect(fixture.verifier.armings.isEmpty)
+        let outcome = try lastOutcome(at: fixture.logPath)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-eligible")
+    }
+
+    /// Codex is an agent, so it gets attribution — a composer does not execute
+    /// the tag, and knowing who is addressing you is worth having on any agent.
+    @Test("a codex target still receives the envelope")
+    func codexTargetGetsTheEnvelope() async throws {
+        let fixture = try await makeFixture(kind: .codex)
+        #expect(try await send(fixture, text: "status?", submit: true).success)
+
+        let rowID = try #require(try requestRow(at: fixture.logPath)["id"] as? String)
+        #expect(fixture.pastes.pastes == [
+            "<tbd-dispatch id=\"\(rowID)\" from=\"anonymous\"/>\nstatus?"
+        ])
+    }
+
+    /// But it cannot be verified. §12 gives Codex a different adapter — the
+    /// app-server protocol's in-protocol acknowledgement — and this slice
+    /// implements only the Claude transcript read, which would answer
+    /// `undetermined` forever. Refuse rather than promise evidence the target
+    /// cannot produce, exactly as for a shell.
+    @Test("--verify against a codex target is refused until its adapter exists")
+    func verifyAgainstCodexRefused() async throws {
+        let fixture = try await makeFixture(kind: .codex)
+        let response = try await send(fixture, text: "status?", submit: true, verify: true)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("only") == true)
         #expect(fixture.pastes.pastes.isEmpty)
         #expect(fixture.verifier.armings.isEmpty)
         let outcome = try lastOutcome(at: fixture.logPath)

--- a/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
@@ -64,7 +64,8 @@ struct TerminalSendDispatchTests {
             return _armings
         }
         func armVerification(
-            actuationID: String, terminalID: UUID, deliveredPayload: String, submit: Bool
+            actuationID: String, terminalID: UUID, sessionID: String?,
+            deliveredPayload: String, submit: Bool
         ) async {
             lock.withLock {
                 _armings.append(Arming(

--- a/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
@@ -87,7 +87,14 @@ struct TerminalSendDispatchTests {
         let logPath: String
     }
 
-    private func makeFixture(clock: (any Clock<Duration>)? = nil) async throws -> Fixture {
+    /// A shell-kind target: the envelope and `--verify` both withhold there.
+    private func makeShellFixture() async throws -> Fixture {
+        try await makeFixture(kind: .shell)
+    }
+
+    private func makeFixture(
+        clock: (any Clock<Duration>)? = nil, kind: TerminalKind = .claude
+    ) async throws -> Fixture {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-send-dispatch-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -123,8 +130,9 @@ struct TerminalSendDispatchTests {
         let worktree = try await db.worktrees.create(
             repoID: repo.id, name: "acme-wt", branch: "main",
             path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+        // Agent by default: the envelope rides sends to agents, not to shells.
         let terminal = try await db.terminals.create(
-            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7")
+            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7", kind: kind)
         return Fixture(
             router: router, terminal: terminal, recorder: recorder, pastes: pastes,
             verifier: verifier, logPath: logPath)
@@ -163,8 +171,9 @@ struct TerminalSendDispatchTests {
         let worktree = try await db.worktrees.create(
             repoID: repo.id, name: "acme-wt", branch: "main",
             path: FileManager.default.temporaryDirectory.path, tmuxServer: "tbd-acme")
+        // An agent terminal: the envelope rides sends to agents, not to shells.
         let terminal = try await db.terminals.create(
-            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7")
+            worktreeID: worktree.id, tmuxWindowID: "@3", tmuxPaneID: "%7", kind: .claude)
         return Fixture(
             router: router, terminal: terminal, recorder: recorder, pastes: pastes,
             verifier: verifier, logPath: logPath)
@@ -219,6 +228,37 @@ struct TerminalSendDispatchTests {
         #expect(fixture.pastes.pastes == [
             "<tbd-dispatch id=\"\(rowID)\" from=\"anonymous\"/>\nrebase onto main"
         ])
+    }
+
+    /// A shell is not a reader of envelopes. It has no transcript to join back
+    /// to, and `--submit` would run the tag as a command line of its own before
+    /// the caller's text ever ran — so a `tbd terminal send --text "ls"
+    /// --submit` into a shell pane would execute a syntax error first. Sending
+    /// into a plain shell is a supported thing to do, so this is a real target.
+    @Test("a shell target receives the caller's text with no envelope")
+    func shellTargetGetsNoEnvelope() async throws {
+        let fixture = try await makeShellFixture()
+        #expect(try await send(fixture, text: "ls -la", submit: true).success)
+
+        #expect(fixture.pastes.pastes == ["ls -la"])
+        #expect(fixture.pastes.pastes.allSatisfy { !$0.contains("tbd-dispatch") })
+    }
+
+    /// And a shell cannot be verified at all: with no transcript, the re-check
+    /// could only ever answer `undetermined`. Refuse rather than promise
+    /// evidence this target can never produce.
+    @Test("--verify against a shell target is refused, and nothing is typed")
+    func verifyAgainstShellRefused() async throws {
+        let fixture = try await makeShellFixture()
+        let response = try await send(fixture, text: "ls", submit: true, verify: true)
+
+        #expect(!response.success)
+        #expect(response.error?.contains("keeps no transcript") == true)
+        #expect(fixture.pastes.pastes.isEmpty)
+        #expect(fixture.verifier.armings.isEmpty)
+        let outcome = try lastOutcome(at: fixture.logPath)
+        #expect(outcome["result"] as? String == "refused")
+        #expect(outcome["reason"] as? String == "not-eligible")
     }
 
     /// `from` is the row's own actor, not a constant: the receiving agent sees

--- a/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendDispatchTests.swift
@@ -293,6 +293,62 @@ struct TerminalSendDispatchTests {
         #expect(outcome["reason"] as? String == "not-eligible")
     }
 
+    // MARK: - The retry's own production path
+
+    /// `redeliverVerifiedPayload` is what the verifier's injected seam actually
+    /// calls, and every verifier test fakes it — so its guards need exercising
+    /// here or nowhere. It re-checks eligibility and the addressed conversation,
+    /// not just the pane, because the gap between the observation and the paste
+    /// spans a DB write, two reads and a serializer queue.
+    @Test("the retry re-pastes the identical bytes when the target still qualifies")
+    func redeliveryPastesWhenEligible() async throws {
+        let fixture = try await makeFixture()
+        let outcome = await fixture.router.redeliverVerifiedPayload(
+            terminalID: fixture.terminal.id,
+            sessionID: fixture.terminal.claudeSessionID,
+            payload: "<tbd-dispatch id=\"abc\" from=\"anonymous\"/>\nstatus?",
+            submit: true)
+
+        #expect(outcome == .dispatched)
+        #expect(fixture.pastes.pastes == [
+            "<tbd-dispatch id=\"abc\" from=\"anonymous\"/>\nstatus?"
+        ])
+    }
+
+    /// A `/clear` between the observation and the retry rebinds the terminal to
+    /// a new conversation while keeping its pane. The payload is an instruction
+    /// addressed to the session that is no longer there.
+    @Test("the retry refuses a terminal rebound to another session, and types nothing")
+    func redeliveryRefusesARebindingSession() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.router.db.terminals.updateSession(
+            id: fixture.terminal.id, sessionID: "session-after-clear", transcriptPath: nil)
+
+        let outcome = await fixture.router.redeliverVerifiedPayload(
+            terminalID: fixture.terminal.id,
+            sessionID: "session-at-dispatch",
+            payload: "status?", submit: true)
+
+        #expect(outcome == .refused(.targetMismatch))
+        #expect(fixture.pastes.pastes.isEmpty)
+    }
+
+    /// And a target that stopped being verifiable — a `recreateWindow` turning
+    /// an agent terminal into a shell while keeping its id — refuses too. The
+    /// payload it is holding opens with an envelope a shell would execute.
+    @Test("the retry refuses a target that is no longer an observable agent")
+    func redeliveryRefusesAnIneligibleTarget() async throws {
+        let fixture = try await makeShellFixture()
+        let outcome = await fixture.router.redeliverVerifiedPayload(
+            terminalID: fixture.terminal.id,
+            sessionID: fixture.terminal.claudeSessionID,
+            payload: "<tbd-dispatch id=\"abc\" from=\"anonymous\"/>\nstatus?",
+            submit: true)
+
+        #expect(outcome == .refused(.notEligible))
+        #expect(fixture.pastes.pastes.isEmpty)
+    }
+
     /// `from` is the row's own actor, not a constant: the receiving agent sees
     /// who is addressing it, down to the rail when a daemon rail sends.
     @Test("the envelope's from attribute names the declared actor")

--- a/Tests/TBDDaemonTests/TerminalSendSerializerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSendSerializerTests.swift
@@ -31,18 +31,38 @@ struct TerminalSendSerializerTests {
         }
     }
 
-    /// Poll until `condition` holds or the deadline passes. Bounded wait, not a
+    /// Poll every 10 ms until `condition` holds, recording an Issue at the
+    /// caller's source location once `deadline` passes. Bounded wait, not a
     /// sleep-as-synchronization: it bounds a hang and asserts nothing on its own.
+    /// A final post-deadline re-check absorbs a sleep slice that overshoots after
+    /// the condition became true.
+    ///
+    /// It records rather than throws so that the test body always runs to
+    /// completion. Both callers hold an `async let` child parked on a `Gate` that
+    /// the body opens further down; unwinding early would leave the scope's
+    /// implicit await on a continuation nobody resumes, and the child cannot be
+    /// cancelled out of it because `TerminalSendSerializer.run` awaits an
+    /// unstructured task. A timeout is therefore reported and the body carries on
+    /// to open the gate. The diagnostic stays an `Error` passed to
+    /// `Issue.record(_: some Error)`: only that form lands on the primary failure
+    /// line, which is the part CI summaries keep.
+    ///
+    /// The signature stays `throws` for the inner `Task.sleep` alone.
     private func waitUntil(
-        _ description: String, _ condition: @Sendable () async -> Bool
+        _ description: String,
+        sourceLocation: SourceLocation = #_sourceLocation,
+        _ condition: @Sendable () async -> Bool
     ) async throws {
-        let deadline = ContinuousClock.now + .seconds(15)
+        let deadline = ContinuousClock.now + ciSafeDeadline
         while ContinuousClock.now < deadline {
             if await condition() { return }
             try await Task.sleep(for: .milliseconds(10))
         }
+        if await condition() { return }
         struct Timeout: Error, CustomStringConvertible { let description: String }
-        throw Timeout(description: "timed out waiting for \(description)")
+        Issue.record(
+            Timeout(description: "timed out waiting for \(description)"),
+            sourceLocation: sourceLocation)
     }
 
     @Test("a second send to the same terminal queues behind the first, and is not refused")

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -381,11 +381,16 @@ actuation row and that caller —
 `<tbd-dispatch id="a3f1b2c3d4e5" from="supervisor:acme-platform"/>` on its
 own line, then your text verbatim — so the receiving agent sees who is
 addressing it and the transcript carries an identifier the record can join
-on. It rides every text send to an agent, verified or not: a script of your
-own that declares no identity still delivers one, reading `from="anonymous"`.
+on. It rides every text send this verb makes to an agent, verified or not: a
+script of your own that declares no identity still delivers one, reading
+`from="anonymous"`.
 A keys payload carries no envelope, and neither does a send to a plain shell
 pane — nothing there reads the tag, and `--submit` would run it as a command
-line of its own, so a shell receives your text alone.
+line of its own, so a shell receives your text alone. Two of TBD's own
+in-daemon rails — the watch desk's nudges and the rate-limit auto-continue —
+type into a session without going through this verb; their sends are in the
+actuation log like any other, but they carry no envelope and cannot be
+verified.
 
 `--verify` opts into landing confirmation — a tail read of the target
 transcript's JSONL for that envelope, with the re-check deadline as its

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -369,7 +369,9 @@ without `--submit` the text is typed into the composer and left there for a
 human to send, so a message meant to be acted on passes both (that pair is
 also how a pending question is answered — the adapter clears a machine-known
 dialog first); `--keys` sends named keys chosen after reading the screen; an
-interrupt is a keys payload. Exactly one payload flag per call. The daemon
+interrupt is a keys payload. Exactly one payload flag per call, and
+`--submit` belongs only to a text payload — Enter is itself a key, so a keys
+sequence that means to submit spells it out (`--keys "Escape Enter"`). The daemon
 does not read a text payload; it records it verbatim — every send lands in
 TBD's actuation log (`~/tbd/actuations.jsonl`) with the caller identity as
 declared, and a caller with no identity is logged as anonymous.
@@ -387,10 +389,13 @@ payload carries no envelope.
 transcript's JSONL for that envelope, with the re-check deadline as its
 default timeout. It requires `--submit`, since text left standing in a
 composer never enters the conversation and so can never reach a transcript,
-and it is refused with `--keys`, which leaves no transcript trace to read.
-It is also gated on the daemon's `delivery_verification_enabled` config,
-shipped off: while that is off a `--verify` send is refused outright with
-the flag named, rather than quietly delivered as an unverified one — a
+and it is refused with `--keys`, which leaves no transcript trace to read,
+and with an empty `--text`, which pastes nothing and so writes no envelope
+to look for. It is also gated on the daemon's `delivery_verification_enabled`
+config, shipped off and flipped with the `config.setDeliveryVerification`
+RPC (`daemon.capabilities` reads it back): while that is off a `--verify`
+send is refused outright with the flag named, rather than quietly delivered
+as an unverified one — a
 caller that asked for confirmation is never answered with silence. TBD makes
 one full attempt — including the single re-delivery it will make on positive
 evidence that the first never landed — and nothing beyond it; the

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -393,9 +393,11 @@ and it is refused with `--keys`, which leaves no transcript trace to read,
 and with an empty `--text`, which pastes nothing and so writes no envelope
 to look for. It is also gated on the daemon's `delivery_verification_enabled`
 config, shipped off and flipped with the `config.setDeliveryVerification`
-RPC (`daemon.capabilities` reads it back): while that is off a `--verify`
-send is refused outright with the flag named, rather than quietly delivered
-as an unverified one — a
+RPC (`daemon.capabilities` reads it back). **Enabling it means enabling it
+and then restarting the daemon**, which wires the observation machinery at
+startup; until that restart `--verify` is refused with a message saying so.
+While the flag is off a `--verify` send is likewise refused outright, with
+the flag named, rather than quietly delivered as an unverified one — a
 caller that asked for confirmation is never answered with silence. TBD makes
 one full attempt — including the single re-delivery it will make on positive
 evidence that the first never landed — and nothing beyond it; the

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -376,18 +376,24 @@ does not read a text payload; it records it verbatim — every send lands in
 TBD's actuation log (`~/tbd/actuations.jsonl`) with the caller identity as
 declared, and a caller with no identity is logged as anonymous.
 
-Every text payload is delivered under a one-line envelope naming the
+A text payload sent to an agent is delivered under a one-line envelope naming the
 actuation row and that caller —
 `<tbd-dispatch id="a3f1b2c3d4e5" from="supervisor:acme-platform"/>` on its
 own line, then your text verbatim — so the receiving agent sees who is
 addressing it and the transcript carries an identifier the record can join
-on. It rides every text send, verified or not: a script of your own that
-declares no identity still delivers one, reading `from="anonymous"`. A keys
-payload carries no envelope.
+on. It rides every text send to an agent, verified or not: a script of your
+own that declares no identity still delivers one, reading `from="anonymous"`.
+A keys payload carries no envelope, and neither does a send to a plain shell
+pane — nothing there reads the tag, and `--submit` would run it as a command
+line of its own, so a shell receives your text alone.
 
 `--verify` opts into landing confirmation — a tail read of the target
 transcript's JSONL for that envelope, with the re-check deadline as its
-default timeout. It requires `--submit`, since text left standing in a
+default timeout. It is available for **Claude sessions only** — a shell keeps
+no transcript to observe, and a Codex session's acknowledgement arrives by a
+different mechanism that is not built yet, so asking to verify either is
+refused rather than accepted and answered *undetermined* forever. It
+requires `--submit`, since text left standing in a
 composer never enters the conversation and so can never reach a transcript,
 and it is refused with `--keys`, which leaves no transcript trace to read,
 and with an empty `--text`, which pastes nothing and so writes no envelope

--- a/docs/cli-supervise.md
+++ b/docs/cli-supervise.md
@@ -360,21 +360,42 @@ script, a wake program, a sweep program's continuation policy, the
 supervisor itself.
 
 ```
-tbd terminal send --terminal <id> --text "…" [--verify]
-tbd terminal send --terminal <id> --keys "…" [--verify]
+tbd terminal send --terminal <id> --text "…" [--submit] [--verify]
+tbd terminal send --terminal <id> --keys "…"
 ```
 
-Payloads, not verbs: `--text` delivers a message and submits it (also how a
-pending question is answered — the adapter clears a machine-known dialog
-first); `--keys` sends named keys chosen after reading the screen; an
+Payloads, not verbs: `--text` carries a message and `--submit` sends it —
+without `--submit` the text is typed into the composer and left there for a
+human to send, so a message meant to be acted on passes both (that pair is
+also how a pending question is answered — the adapter clears a machine-known
+dialog first); `--keys` sends named keys chosen after reading the screen; an
 interrupt is a keys payload. Exactly one payload flag per call. The daemon
 does not read a text payload; it records it verbatim — every send lands in
 TBD's actuation log (`~/tbd/actuations.jsonl`) with the caller identity as
-declared, and a caller with no identity is logged as anonymous. `--verify`
-opts into landing confirmation — a tail read of the target transcript's
-JSONL, with the re-check deadline as its default timeout. TBD makes one
-full attempt and never retries; the synchronous result is honest and
-machine-readable, and what happens next is the caller's policy.
+declared, and a caller with no identity is logged as anonymous.
+
+Every text payload is delivered under a one-line envelope naming the
+actuation row and that caller —
+`<tbd-dispatch id="a3f1b2c3d4e5" from="supervisor:acme-platform"/>` on its
+own line, then your text verbatim — so the receiving agent sees who is
+addressing it and the transcript carries an identifier the record can join
+on. It rides every text send, verified or not: a script of your own that
+declares no identity still delivers one, reading `from="anonymous"`. A keys
+payload carries no envelope.
+
+`--verify` opts into landing confirmation — a tail read of the target
+transcript's JSONL for that envelope, with the re-check deadline as its
+default timeout. It requires `--submit`, since text left standing in a
+composer never enters the conversation and so can never reach a transcript,
+and it is refused with `--keys`, which leaves no transcript trace to read.
+It is also gated on the daemon's `delivery_verification_enabled` config,
+shipped off: while that is off a `--verify` send is refused outright with
+the flag named, rather than quietly delivered as an unverified one — a
+caller that asked for confirmation is never answered with silence. TBD makes
+one full attempt — including the single re-delivery it will make on positive
+evidence that the first never landed — and nothing beyond it; the
+synchronous result is honest and machine-readable, and what happens next is
+the caller's policy.
 
 **Supervisor-identified sends carry act-time preconditions.** When the
 ambient supervisor identity (`TBD_PROJECT`) is present, the daemon rechecks
@@ -407,7 +428,7 @@ project's `proposals.md`, unchanged.
 
 ```
 # A specific next step, decided after reading the transcript
-$ tbd terminal send --terminal t17 --text "PR #522 review comments are in; address the two blocking ones, then re-request review."
+$ tbd terminal send --terminal t17 --text "PR #522 review comments are in; address the two blocking ones, then re-request review." --submit
 ```
 
 ## Related: tbd notify

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -1551,7 +1551,9 @@ account, not a wrong action. The third category is **human-authored process**.
   For re-checks, the startup replay
   surfaces acts past their deadline with no outcome, and
   the daemon performs those observations then: the envelope is durable in the
-  transcript, so a late read resolves what the timer would have (§12). Until
+  transcript, so a late read can still confirm a landing — though not its
+  absence, which a bounded read cannot establish across an unbounded
+  interval (§12). Until
   it runs, such actions render as unconfirmed by construction — the
   query-time rule, not a recovery sweep.
 
@@ -2511,7 +2513,7 @@ race itself biting; if one does, the fix joins this family (the send path
 refusing when the composer is unreachable) and stays content-blind.
 
 **Receipt is a passive machine observation; the agent cooperates in nothing.**
-Every dispatched text payload opens with a one-line envelope carrying the
+A dispatched text payload bound for an agent opens with a one-line envelope carrying the
 actuation row's ID and the identity the row was attributed to —
 `<tbd-dispatch id="a3f1" from="supervisor:acme-web"/>`, then the message
 verbatim — which doubles as honest attribution: the receiving agent sees who
@@ -2611,12 +2613,14 @@ act whose observation never ran renders as unconfirmed by construction
 (§7). The observation itself is recoverable from the record alone — the
 actuation row's timestamp fixes the deadline, and the envelope is durable in
 the transcript — so at startup the daemon replays the record, finds acts
-past their deadline with no outcome, and performs the same observation late,
-writing the outcome the timer would have written (§7). The observation only:
-the replay never re-delivers, because the retry exists to close a
-sixty-second gap, and a payload whose premise is an unbounded interval old
-is exactly the stale-premise send this design refuses to issue (§3). A
-replayed *not landed* records the outcome and the anomaly, and stops. What a
+past their deadline with no outcome, and performs the same observation late
+(§7). Late, it can confirm a landing but never assert the opposite: a bounded
+tail read cannot span an interval of unknown length, so an absent envelope
+there is *undetermined*. It re-delivers nothing either way, because the retry
+exists to close a sixty-second gap, and a payload whose premise is an
+unbounded interval old is exactly the stale-premise send this design refuses
+to issue (§3). The late observation records what it could establish, writes
+the anomaly, and stops. What a
 restart costs is cadence, stated plainly: P1-6's sixty-second window degrades
 to the startup scan or the next evaluation. What to *do* about a late-confirmed or
 unconfirmed act — re-send, journal, shrug — stays playbook judgment, never

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -657,8 +657,10 @@ carried for a hypothetical.
 One configuration column in the daemon, on or off — added by migration and
 **shipped off**, which is the house default-off-flag rule satisfied by the
 switch itself: no second flag hides behind it, and the soak is opt-in
-coverage. (The Channels delivery adapter additionally ships behind its own
-default-off flag, §12.) Settable from the app and the
+coverage. (Two §12 mechanisms carry default-off flags of their own beside
+it: the delivery-verification re-check, which the public send offers every
+caller and supervision only shares, and the Channels delivery adapter.)
+Settable from the app and the
 CLI, broadcast when it changes, surviving restart like every other daemon
 toggle. That is P0-2's one-gesture handover for the whole fleet, unchanged in
 substance: one gesture, one ledger, one account. The switch is
@@ -759,7 +761,9 @@ rather than a capability wall, and the requirements doc records that descope
 There are no desk verbs. Acting on a session is **`tbd terminal send`** —
 the public actuation, one verb for every caller: a human's script, the wake
 program, a sweep program's continuation policy, the supervisor itself.
-Payloads, not verbs: `--text` delivers a message and submits it (also how
+Payloads, not verbs: `--text` carries the message and `--submit` sends
+it — text without `--submit` is typed and left standing in the composer,
+so every delivery this design describes passes both (that pair is also how
 an agent's `AskUserQuestion` is answered, the adapter clearing a
 machine-known dialog first, §2); `--keys` sends named keys chosen after
 reading the screen; interrupt is a keys payload. Splitting text from keys
@@ -773,8 +777,12 @@ message verbatim, so a stale premise is *visible* the moment it ships
 rather than prevented at the door (P0-8). `--verify` opts into the §12
 acknowledgment machinery — confirm the payload landed, within the re-check
 deadline (§13) — implemented as a tail read of the target transcript's
-JSONL, never a full parse. Verification is opt-in because it costs a
-transcript read; supervision's conduct says to use it.
+JSONL, never a full parse. It presupposes the pair above: verification is
+refused without `--submit`, because text left standing in a composer never
+enters the conversation and so can never reach a transcript, and refused
+with `--keys`, which reaches no transcript at all (§12). Verification is
+opt-in because it costs a transcript read; supervision's conduct says to
+use it.
 
 **Every send is logged; nobody is the reporter of their own acts.** The
 daemon executes every actuation on its own surfaces, so it records each in
@@ -2503,9 +2511,17 @@ race itself biting; if one does, the fix joins this family (the send path
 refusing when the composer is unreachable) and stays content-blind.
 
 **Receipt is a passive machine observation; the agent cooperates in nothing.**
-Every dispatched payload opens with a one-line envelope carrying the
-actuation row's ID — `<tbd-dispatch id="a3f1" from="supervision-desk"/>` — which
-doubles as honest attribution: the receiving agent sees who is addressing it.
+Every dispatched text payload opens with a one-line envelope carrying the
+actuation row's ID and the identity the row was attributed to —
+`<tbd-dispatch id="a3f1" from="supervisor:acme-web"/>`, then the message
+verbatim — which doubles as honest attribution: the receiving agent sees who
+is addressing it, down to `from="anonymous"` when the caller declared no
+identity. The envelope rides every text send, `--verify` or not, because a
+prefix that appears only sometimes is one no reader can rely on. A keys
+payload carries none: a key sequence has nowhere to put a line of text, and
+typing one ahead of an interrupt would itself be an intervention. That is
+why `--verify` and `--keys` are refused together (§3) — keys reach no
+transcript, so there is no observation to be made.
 No second ID namespace exists; the row ID is the identifier, so dispatch,
 transcript receipt, and outcome join on one string. When a submitted message
 enters the conversation, the agent's own harness writes its verbatim content
@@ -2543,6 +2559,18 @@ records one of four results as an outcome row referencing the act:
   with permissions bypassed is arbitrary instruction injection (§3), so
   delivering it twice is not a neutral event.
 
+**The machinery carries its own flag, and refuses rather than pretends.**
+The re-check acts on no user gesture and its retry types into a live
+session, so the whole path — arming the timer, the retry, and the startup
+replay below — stands behind a daemon config column,
+`delivery_verification_enabled`, shipped off. While it is off, `--verify` is
+*refused*, with the flag named: nothing is typed, and the caller learns its
+request went unhonored rather than receiving a quiet unverified send. A
+caller that asked for confirmation must never be answered with a silence
+that reads like one. The envelope is deliberately outside the flag —
+attribution belongs on every dispatch, and a prefix that comes and goes with
+a config column is worse than one that is always there.
+
 That one full attempt — adapter fallback and the evidence-bounded single
 retry included — is the whole of TBD-side persistence for any send. Beyond
 it the outcome stands as recorded, and whether to try again belongs to the
@@ -2565,9 +2593,13 @@ act whose observation never ran renders as unconfirmed by construction
 actuation row's timestamp fixes the deadline, and the envelope is durable in
 the transcript — so at startup the daemon replays the record, finds acts
 past their deadline with no outcome, and performs the same observation late,
-writing the outcome the timer would have written (§7). What a restart costs
-is cadence, stated plainly: P1-6's sixty-second window degrades to the
-startup scan or the next evaluation. What to *do* about a late-confirmed or
+writing the outcome the timer would have written (§7). The observation only:
+the replay never re-delivers, because the retry exists to close a
+sixty-second gap, and a payload whose premise is an unbounded interval old
+is exactly the stale-premise send this design refuses to issue (§3). A
+replayed *not landed* records the outcome and the anomaly, and stops. What a
+restart costs is cadence, stated plainly: P1-6's sixty-second window degrades
+to the startup scan or the next evaluation. What to *do* about a late-confirmed or
 unconfirmed act — re-send, journal, shrug — stays playbook judgment, never
 compiled repair.
 

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -2548,8 +2548,13 @@ result vocabulary below, never the tag.
 
 **The one-minute re-check performs the observation.** The timer already exists
 for P1-6 and the transcript path is recorded for each terminal, so this adds
-no machinery. During the re-check the daemon reads two machine facts: whether
-the transcript contains the envelope, and the session's current state. It
+no machinery. During the re-check the daemon reads two machine facts — whether
+the transcript contains the envelope, and the session's current state — plus
+one identity check: that the terminal still holds the conversation the
+payload was addressed to. `/clear`, `/compact` and an account swap all
+rebind a session while leaving its pane untouched, so the transport's
+identity check cannot see them, and reading on would mean judging one
+conversation by another's transcript. It
 records one of four results as an outcome row referencing the act:
 
 - *Landed and acting* — delivery confirmed, session working. Done.
@@ -2562,7 +2567,13 @@ records one of four results as an outcome row referencing the act:
   indicate a structural problem with the session, and a third send without
   evidence would risk duplicate-message bugs.
 - *Undetermined* — the observation could not be made: transcript unreadable,
-  session state unknown, adapter result ambiguous. **Never retried.** Written
+  session state unknown, adapter result ambiguous, the terminal rebound to a
+  different conversation since dispatch, or the envelope simply absent from a
+  bounded read that cannot prove it covered everything written since. That
+  last case is why absence escalates before it accuses: a session can act on a
+  payload, write past the cheap window, and be idle again inside the deadline,
+  which is indistinguishable from non-delivery until a wider read settles it.
+  **Never retried.** Written
   as an outcome and an anomaly, loud in the account. Retry proceeds only from
   *not landed*, because retrying into uncertainty risks double-instructing an
   agent that did receive the first copy — and a message to an agent running

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -2516,10 +2516,18 @@ actuation row's ID and the identity the row was attributed to —
 `<tbd-dispatch id="a3f1" from="supervisor:acme-web"/>`, then the message
 verbatim — which doubles as honest attribution: the receiving agent sees who
 is addressing it, down to `from="anonymous"` when the caller declared no
-identity. The envelope rides every text send, `--verify` or not, because a
-prefix that appears only sometimes is one no reader can rely on. A keys
-payload carries none: a key sequence has nowhere to put a line of text, and
-typing one ahead of an interrupt would itself be an intervention. That is
+identity. The envelope rides every text send to an agent, `--verify` or not,
+because a prefix that appears only sometimes is one no reader can rely on.
+Two targets get none. A keys payload carries no envelope: a key sequence has
+nowhere to put a line of text, and typing one ahead of an interrupt would
+itself be an intervention. And a **shell** session receives the text alone —
+`tbd terminal send` into a plain shell pane is a supported thing to do, and
+every property that makes the envelope worth having is a property of an
+agent: nothing in a shell reads the tag, no transcript records it, there is
+nothing to join back to, and a submitted line would simply be executed. The
+envelope is unconditional along the axis that matters — whether delivery is
+being verified — and conditional only on the target being something it means
+anything to. That is
 why `--verify` and `--keys` are refused together (§3) — keys reach no
 transcript, so there is no observation to be made.
 No second ID namespace exists; the row ID is the identifier, so dispatch,
@@ -2568,8 +2576,19 @@ replay below — stands behind a daemon config column,
 request went unhonored rather than receiving a quiet unverified send. A
 caller that asked for confirmation must never be answered with a silence
 that reads like one. The envelope is deliberately outside the flag —
-attribution belongs on every dispatch, and a prefix that comes and goes with
-a config column is worse than one that is always there.
+attribution belongs on every dispatch that carries one, and a prefix that
+comes and goes with a config column is worse than one that is always there.
+
+Verification is narrower than the envelope, and narrower still than the
+fleet. It is available where an adapter exists that can actually answer:
+today that is a Claude session, whose harness writes the submitted message
+into its transcript JSONL. A shell keeps no transcript, and the Codex
+adapter's answer comes from the app-server protocol's in-protocol
+acknowledgement rather than from an envelope — a different mechanism, and
+one that is not built. Asking to verify either is refused rather than
+accepted and quietly answered *undetermined* forever, for the reason the
+whole section exists: promising evidence a target cannot produce rebuilds
+the silent-failure class one layer up.
 
 That one full attempt — adapter fallback and the evidence-bounded single
 retry included — is the whole of TBD-side persistence for any send. Beyond

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -440,7 +440,13 @@ those keys (§6). If a
 sequence turns out to have been wrong, the record shows exactly what was on the
 screen and exactly what was sent, which is the same accountability the
 three-condition test buys for the automatic path, obtained a different way.
-Sends are named-key and paced, following the rate-limit actuator's precedent.
+Sends are named-key and paced — one key at a time with a fixed pause between
+them (§13), following the rate-limit actuator's precedent, because an agent's
+TUI redraws between keystrokes and keys delivered back-to-back through the pty
+get dropped or reordered. The count of keys in one payload is bounded too
+(§13): `--keys` is a whitespace-split string, so a quoting mistake turns one
+call into a send that types for minutes into a live session, and a bounded
+refusal is cheap where an unbounded send is not undoable.
 In attended mode the desk suggests such a send instead of making it — an entry
 in the project's proposals doc (§6) showing the keys *and* the screen they aim
 at, so saying yes is not an act of faith.
@@ -759,8 +765,9 @@ rather than a capability wall, and the requirements doc records that descope
 ### Acting: one public send, on the record (normative)
 
 There are no desk verbs. Acting on a session is **`tbd terminal send`** —
-the public actuation, one verb for every caller: a human's script, the wake
-program, a sweep program's continuation policy, the supervisor itself.
+the public actuation, and the same one verb for every caller of it: a
+human's script, the wake program, a sweep program's continuation policy,
+the supervisor itself.
 Payloads, not verbs: `--text` carries the message and `--submit` sends
 it — text without `--submit` is typed and left standing in the composer,
 so every delivery this design describes passes both (that pair is also how
@@ -840,6 +847,24 @@ program's case memory skips re-briefing an untreated case and briefings
 carry TBD's act record. The removed gate stays removed: no rule matching,
 no content inspection, no posture judgment. The residual race is the
 milliseconds between check and keystroke.
+
+**Two in-daemon rails still type outside this verb, and closing that is
+known work.** The public send is the only actuation this design describes,
+but it is not yet the only compiled code that types into a session. Two
+older rails paste through tmux directly: the hosted desk's own nudges and
+shift wrap-up prompt, and the rate-limit rail's auto-continue, which types
+`continue` once a limit clears. Both write their own actuation rows, so the
+record's coverage holds for them — but neither carries the dispatch
+envelope and neither can be delivery-verified (§12), and the *absence* of a
+row's confirming outcome therefore says nothing about them either way.
+That is exactly the wrong way round. These two are unattended sends, made
+on no user gesture, into sessions nobody is watching — the shape the
+acknowledgement machinery exists for — while the sends that do carry the
+envelope usually have a human or a supervisor reading the result. Routing
+both through the same actuation the public verb performs, so the envelope
+and the observation cover them without a second implementation of either,
+is the work that closes this gap; until it lands, "every send" in this
+design means every send made through `tbd terminal send`.
 
 *What is deliberately not here.* No **`drive`** — it was send plus the
 record, and the record now rides every send, so a supervise-tier wrapper
@@ -2518,9 +2543,10 @@ actuation row's ID and the identity the row was attributed to —
 `<tbd-dispatch id="a3f1" from="supervisor:acme-web"/>`, then the message
 verbatim — which doubles as honest attribution: the receiving agent sees who
 is addressing it, down to `from="anonymous"` when the caller declared no
-identity. The envelope rides every text send to an agent, `--verify` or not,
-because a prefix that appears only sometimes is one no reader can rely on.
-Two targets get none. A keys payload carries no envelope: a key sequence has
+identity. The envelope rides every text send the public verb makes to an agent,
+`--verify` or not, because a prefix that appears only sometimes is one no
+reader can rely on. Two targets get none. A keys payload carries no
+envelope: a key sequence has
 nowhere to put a line of text, and typing one ahead of an interrupt would
 itself be an intervention. And a **shell** session receives the text alone —
 `tbd terminal send` into a plain shell pane is a supported thing to do, and
@@ -2554,7 +2580,11 @@ one identity check: that the terminal still holds the conversation the
 payload was addressed to. `/clear`, `/compact` and an account swap all
 rebind a session while leaving its pane untouched, so the transport's
 identity check cannot see them, and reading on would mean judging one
-conversation by another's transcript. It
+conversation by another's transcript. The transcript read is a bounded
+tail, never a parse: a cheap 64 KiB window first, and — only where the
+envelope is absent and the next word would be an accusation — a second,
+far wider 8 MiB read that must provably have covered the whole file before
+non-delivery is claimed (§13). It
 records one of four results as an outcome row referencing the act:
 
 - *Landed and acting* — delivery confirmed, session working. Done.
@@ -2601,7 +2631,11 @@ acknowledgement rather than from an envelope — a different mechanism, and
 one that is not built. Asking to verify either is refused rather than
 accepted and quietly answered *undetermined* forever, for the reason the
 whole section exists: promising evidence a target cannot produce rebuilds
-the silent-failure class one layer up.
+the silent-failure class one layer up. It is narrower than the send path
+too: the two in-daemon rails that paste directly rather than through the
+public verb (§3) write no envelope, so there is nothing for an observation
+to find, and bringing them onto the public actuation is what extends this
+section's guarantees to them.
 
 That one full attempt — adapter fallback and the evidence-bounded single
 retry included — is the whole of TBD-side persistence for any send. Beyond
@@ -2773,6 +2807,10 @@ to hunt for the value that governs a behavior:
 | Idle-intervention threshold | 40 min | shipped sweep program (sub-doc §7) |
 | Post-intervention re-check | 60 s | §4 step 7, §12 |
 | Delivery retries before anomaly | 2 sends | §12 |
+| Delivery observation tail read | 64 KiB | §12 |
+| Escalated read before claiming non-delivery | 8 MiB | §12 |
+| Pause between keys in a `--keys` payload | 150 ms | §2, §3 |
+| Keys accepted in one `--keys` payload | 32 | §2, §3 |
 | Supervisor recycle preference | 50% of the effective window, per desk | §9 |
 | Flush nudges | 50% / 60% / 70% fullness | §9 |
 | Unknown-denominator assumption | 200k, labeled | §2, §9 |


### PR DESCRIPTION
## Summary

The record's claims form a ladder — **requested, dispatched, landed**. Slices 1a and 1b built the first two rungs. This one adds the third: whether the payload actually arrived, observed passively from a machine interface with no cooperation from the receiving agent.

The failure this exists to end is real and was silent: `terminal.send` once reported success into a dead pane for hours while a desk nudged it, and every one of those nudges stood in the ledger as delivered work.

- **`--keys`** — named tmux keys, paced 150 ms apart, following `LimitResumeActuator`'s precedent. Mutually exclusive with `--text`.
- **`--verify`** — opt-in, because it costs a transcript read. Arms a one-minute re-check.
- **The dispatch envelope** — every text payload to an agent opens with `<tbd-dispatch id="…" from="…"/>`, carrying the actuation row's own id. One namespace: dispatch, transcript receipt and outcome all join on one string.
- **The re-check** — two machine facts (transcript tail, session state) mapped to §12's four results, with one evidence-bounded retry and a startup replay for observations whose timers died with the last daemon.

`--text` and `--submit` keep their **exact** current semantics. Bare `--text` still does not submit, `--submit` is not deprecated, and Nightwatch's `--submit --text` dispatch is unaffected.

## The vocabulary decision, and why

§12's four observed results did **not** join `ActuationResult`. They are a separate closed vocabulary, `ObservedResult`, reachable only through a second door on the log — `appendObservation`.

The never-claim is "only an observed outcome may claim a payload landed". Had `landedAndActing` been a case of `ActuationResult`, `finishActuation(id, .landedAndActing)` would have been *spellable* from the synchronous send path, and the invariant would rest on review rather than on the compiler. This is the same move 1a made with `refused(RefusedReason)`, applied one rung up: a synchronous path now holds no value it could pass to the observing door.

The wire keeps §6's single `result` string via a small union (`RecordedResult`), which also carries an `.unrecognized` case so a newer daemon's result name is learned rather than fatal.

## ⚠️ This changes what every agent receives

Every text payload TBD delivers to an agent session now gains a machine-readable prefix line the agent will see — **including your own `tbd terminal send`, which reads `from="anonymous"`**. §12 wants it on every dispatch so attribution holds and any later reader can join a transcript message back to its row. Meeting it here rather than in a pane at 3am is the point of this paragraph.

Two carve-outs, both deliberate:
- **Shell targets get the text alone.** A shell would run the tag as a command line of its own under `--submit`. Every property that makes the envelope worth having is a property of an agent.
- **`--keys` carries no envelope** — a key sequence has nowhere to put a line of text, and typing one ahead of an interrupt would itself be an intervention.

## The flag, and its graduation

`delivery_verification_enabled`, migration **v69**, default **OFF** — required by CLAUDE.md, since the re-check acts on no user gesture and its retry types into a live session. It follows the `hibernate_input_veto_enabled` (v51) precedent, not the `auto_hibernate_enabled` cautionary one, so no forcing `UPDATE` is ever needed to flip the default later.

**To soak it:** call the `config.setDeliveryVerification` RPC, **then restart the daemon** — the column is read per `--verify` call, but the observation machinery is wired once at startup. Between the flip and the restart, `--verify` is refused with a message saying so. Read it back on `daemon.capabilities`.

**Graduation:** soak with it on, flip the default once the observation has held, delete the flag later.

`--verify` while the flag is off is a **refusal**, never a quiet unverified send — answering a request for evidence with silence would rebuild the exact failure class this slice exists to end.

## Deliberate decisions worth a reviewer's eye

- **The retry shares the request row** and re-sends the identical envelope, so a retry that lands still joins on the original id. One act, several outcome rows.
- **`undetermined` is never retried.** Retrying into uncertainty risks double-instructing an agent that did receive the first copy, and a message to an agent running with permissions bypassed is arbitrary instruction injection — delivering it twice is not neutral.
- **The startup replay observes but never re-delivers**, and cannot conclude `not-landed` at all: a bounded tail cannot span an interval of unknown length. §12 leaves "re-send, journal, shrug" to playbook judgment, never compiled repair.
- **Absence escalates before it accuses.** A miss in the 64 KiB window triggers a wider read, and non-delivery is claimed only when that read provably covered the whole file. Without this, a session that acted on a payload, wrote past the window and went idle inside the deadline would have been re-sent the same instruction.
- **`--verify` is Claude-only.** §12 gives Codex a different adapter — the app-server protocol's in-protocol acknowledgement — which this slice does not build.

## Known limitations

- **The anomaly is half-built.** `~/tbd/supervision/ledger.jsonl` does not exist on `main`, so an anomaly here is the observed outcome row plus a loud `.fault` line. The ledger's `anomaly` line joins when that slice lands; the row is the durable half either way.
- **`remote.send` is out of scope** — a different adapter.
- **The `do`/`catch` in `transcriptTail` is unproven by test.** Forcing a local regular file's `seek`/`read` to throw needs a seam this type does not have. A mutation check caught a test that claimed to cover it and did not; the comment now says so plainly.
- **A same-day rotation-collision segment** (`actuations-<day>-1.jsonl`) is a writer-side edge this PR reads correctly but does not change.

## Spec amendments (same PR, per the drift rule)

- Design §3's "`--text` delivers a message and submits it" described the *adapter's* contract, not the CLI flag. Rewritten.
- §12 now states the envelope's agent scope, the third identity input to the observation, the two new causes of *undetermined*, the flag, and the replay's narrowed powers.
- `docs/cli-supervise.md`'s send examples show the real invocation, `--submit` included, and its `--verify` refusal list is complete.
- §6 deliberately untouched — its boundary passage is already correct on main.

## Test plan

- [x] 108 tests across 8 delivery/actuation suites, green in ~0.4 s
- [x] Each of the four observed results; retry-once-then-anomaly asserting **no third send**; never-retry-on-undetermined
- [x] Restart mid-flight: the act renders `unconfirmed` by the query-time function, and the replay observes late without re-delivering
- [x] The envelope reaches the pane and joins on the row id, in both raw and JSON-escaped spellings
- [x] A `--verify`-less send costs no transcript read (a counting fake that reds if touched)
- [x] Both branches of the flag, plus flag-on-without-restart
- [x] `--submit --text` behaves as before, proven against the old wire shape
- [x] Every guard mutation-checked — broken, watched red, restored, rebuilt
- [x] `swiftlint --strict` clean
- [ ] **Full suite is 5366 tests and needs a quiet machine.** Two FileWatcher suites (`ThemeStoreTests`, `MarkdownStylesheetTests`) failed locally while `fseventsd` was pegged at 165% CPU — they wait on FSEvents directory notifications. Both pass in isolation in ~2 s, and this branch touches neither. CI is the real check.

## Provenance of the review findings

Five independent review rounds found 19 issues; 16 fixed. Three were genuine correctness bugs that would have shipped: a refused send owing an observation it could never make, a `/clear` letting the retry type into an unrelated conversation, and a live re-check that could re-send a payload the agent had already received.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=A43AFF38-9A2B-43CD-8B66-F40E481857C2)

## A CI wedge this PR exposed but did not cause

The first CI run on this branch was killed at the 30-minute timeout with two
tests in `TerminalSendSerializerTests` started and never reporting. That file
and `TerminalSendSerializer.swift` are byte-identical to `origin/main`.

Both tests hold an `async let` child parked on a `Gate`'s bare
`withCheckedContinuation` that the body opens further down, and the waiter
above that line **threw** on its deadline — unwinding the scope into an
implicit await on a child nobody would resume. Cancellation cannot reach it:
`TerminalSendSerializer.run` executes its closure inside an *unstructured*
`Task` and awaits `task.value`, so the gate body never sees cancellation. A
suite time limit cannot catch it either, since a task group cannot return
while a non-cancellable child is outstanding.

The trigger was the budget. On the green `main` run 30 minutes earlier, those
four tests reported at 19.9 / 22.9 / 25.3 / 25.9 s — the hardcoded 15 s wait
was already smaller than the suite's ordinary per-test latency in the fast
parallel pass. This PR adds ~60 tests and 30% more `advanceWhenSuspended`
sites (two `megaYield`s each), which was enough to cross it. `main` carries
the same defect.

Fixed here rather than in a separate PR because this branch cannot go green
without it and it touches a file this branch otherwise does not. The waiter
now records its diagnostic and returns, following `waitFor`'s precedent, and
uses `ciSafeDeadline`. Mutation-checked: with the condition forced false, the
suite now **fails at 90 s** with the diagnostic on the primary failure line,
where it previously wedged forever.

## Round 6 — the review gate's findings

- **The spec overclaimed, and the gap sits where the argument is strongest.**
  `DeskSessionManager`'s nudges and shift wrap-up, and
  `LimitResumeActuator`'s auto-continue, paste through tmux directly rather
  than through `performTerminalSend`. They write actuation rows, so the
  record covers them — but no envelope, and no possible verification. Those
  are unattended sends into sessions nobody is watching, which is precisely
  the shape this machinery exists for. §3 and §12 now scope "every send" to
  the public verb and name routing those two onto it as the work that closes
  the gap.
- **The retry was stricter than the observation.** `observe` skips its rebind
  check when the expected session id is `nil`; the retry demanded exact
  equality including that case, so a payload dispatched before a terminal's
  session id was recorded burned its one retry on an absence that proves
  nothing. Both directions mutation-proven red.
- **§13 gained four constants** it advertised as exhaustive and lacked: the
  64 KiB observation window, the 8 MiB escalated read, the 150 ms key pacing
  and the 32-key bound.

## Local verification of this round

- Pass 1 (`^TBDDaemonTests\.`) — **2629 tests passed in 173 s**, 1 known issue
  (the quarantine self-test, which fails-then-passes by design). No hang.
- Pass 2 (the complement) — 2673 tests, 2 issues, both
  `ThemeStoreTests."external file additions trigger a reload via the watcher"`.
  That suite passes in isolation in 0.275 s and this branch touches neither
  it nor `FileWatcher`; it is the known FSEvents-under-load flake.
- `scripts/swift-safe build` and `swiftlint --strict` clean.
