### PR TITLE
Fix: Archiving a worktree left it on disk and registered with git (36 GiB in 59 husks)

### DIFF
--- a/Sources/TBDApp/ReclaimedSectionView.swift
+++ b/Sources/TBDApp/ReclaimedSectionView.swift
@@ -39,6 +39,9 @@ struct ReclaimedSectionView: View {
                     if let rollup = summary.scratchpadRollup {
                         scratchpadRow(rollup)
                     }
+                    if let rollup = summary.archivedWorktreeRollup {
+                        archivedWorktreeRow(rollup)
+                    }
                 }
             }
         }
@@ -78,6 +81,24 @@ struct ReclaimedSectionView: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
             Text("\(rollup.count) scratchpad\(rollup.count == 1 ? "" : "s") cleaned · \(Self.byteString(rollup.bytes))")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+    }
+
+    private func archivedWorktreeRow(_ rollup: (count: Int, bytes: Int64)) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: Self.glyph)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text(
+                "\(rollup.count) interrupted archive\(rollup.count == 1 ? "" : "s") reclaimed · " +
+                "\(Self.byteString(rollup.bytes))"
+            )
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)

--- a/Sources/TBDApp/ReclaimedSummary.swift
+++ b/Sources/TBDApp/ReclaimedSummary.swift
@@ -52,9 +52,9 @@ struct ReclaimedSummary {
     /// `.archivedWorktree` records rolled up into a single (count, bytes)
     /// pair, same shape and same reason as `scratchpadRollup`: these are
     /// directories the sweep reclaimed after an archive failed to remove
-    /// them (or drained from a pool's `.deleting/` queue), and like
-    /// scratchpads they aren't individually restorable — `OrphanGC.restore`
-    /// only accepts `.agentWorktree`. `nil` when there are none to summarize.
+    /// them, and like scratchpads they aren't individually restorable —
+    /// `OrphanGC.restore` only accepts `.agentWorktree`. `nil` when there are
+    /// none to summarize.
     var archivedWorktreeRollup: (count: Int, bytes: Int64)? {
         let archived = records.filter { $0.kind == .archivedWorktree }
         guard !archived.isEmpty else { return nil }

--- a/Sources/TBDApp/ReclaimedSummary.swift
+++ b/Sources/TBDApp/ReclaimedSummary.swift
@@ -49,6 +49,19 @@ struct ReclaimedSummary {
         return (scratch.count, bytes)
     }
 
+    /// `.archivedWorktree` records rolled up into a single (count, bytes)
+    /// pair, same shape and same reason as `scratchpadRollup`: these are
+    /// directories the sweep reclaimed after an archive failed to remove
+    /// them (or drained from a pool's `.deleting/` queue), and like
+    /// scratchpads they aren't individually restorable — `OrphanGC.restore`
+    /// only accepts `.agentWorktree`. `nil` when there are none to summarize.
+    var archivedWorktreeRollup: (count: Int, bytes: Int64)? {
+        let archived = records.filter { $0.kind == .archivedWorktree }
+        guard !archived.isEmpty else { return nil }
+        let bytes = archived.reduce(Int64(0)) { $0 + ($1.apparentBytes ?? 0) }
+        return (archived.count, bytes)
+    }
+
     /// Subset excluding already-restored records — a restored agent worktree
     /// is no longer reclaimed disk. This is what the "Reclaimed (N · X GB)"
     /// header counts; the expanded row list still shows every `agentRecords`

--- a/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
+++ b/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
@@ -79,8 +79,8 @@ public struct DeletionQueueCollector: Sendable {
     }
 
     @discardableResult
-    public func drain(_ entry: QueuedDeletion) -> Bool {
-        queue.drain(entry)
+    public func drain(_ entry: QueuedDeletion) async -> Bool {
+        await queue.drain(entry)
     }
 
     // MARK: - Interrupted archives

--- a/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
+++ b/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
@@ -117,9 +117,10 @@ public struct DeletionQueueCollector: Sendable {
         }
     }
 
-    /// Gate order mirrors `AgentWorktreeCollector.decide`: locked, then
-    /// namespace, then linkage, then live-cwd. Each check short-circuits the
-    /// rest, and every direction favors keeping.
+    /// Gates a candidate in order: locked, then namespace (`allowedPrefixes`),
+    /// then linkage (proof the directory is really this repo's worktree),
+    /// then live-cwd. Each check short-circuits the rest, and every
+    /// direction favors keeping.
     public func decide(
         _ candidate: InterruptedArchive, liveCWDs: [String]
     ) async -> DeletionQueueDecision {
@@ -146,7 +147,7 @@ public struct DeletionQueueCollector: Sendable {
             return .keep(reason: "no-repo")
         }
 
-        if liveCWDs.contains(where: { isUnder($0, prefix: candidate.path) || $0 == candidate.path }) {
+        if liveCWDs.contains(where: { isUnder($0, prefix: candidate.path) }) {
             return .keep(reason: "live-cwd")
         }
 
@@ -202,14 +203,22 @@ public struct DeletionQueueCollector: Sendable {
     /// to different prefixes — exactly the trap `GitManager.isLinkedWorktree`
     /// documents for `URL.resolvingSymlinksInPath()`.
     func resolvedPath(_ path: String) -> String {
+        let standardized = (path as NSString).standardizingPath
+        // Every caller here deals in absolute paths. Guard it explicitly:
+        // for a relative input, `deletingLastPathComponent` on `""` returns
+        // `""` forever, so the walk-up loop below would never reach `"/"`
+        // and never terminate — a hang inside a background sweep is a far
+        // worse failure mode than returning an unresolved path.
+        guard standardized.hasPrefix("/") else { return standardized }
+
         var suffix: [String] = []
-        var current = (path as NSString).standardizingPath
+        var current = standardized
         while !FileManager.default.fileExists(atPath: current), current != "/" {
             suffix.insert((current as NSString).lastPathComponent, at: 0)
             current = (current as NSString).deletingLastPathComponent
         }
         guard let real = realpath(current, nil) else {
-            return (path as NSString).standardizingPath
+            return standardized
         }
         defer { free(real) }
         let base = String(cString: real)

--- a/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
+++ b/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
@@ -16,22 +16,28 @@ public struct InterruptedArchive: Sendable, Equatable {
     /// As reported by `git worktree list --porcelain`. A locked worktree is
     /// one the user pinned deliberately, and that outranks every other signal.
     public let locked: Bool
+    /// When the row was flipped to `.archived`, straight off `Worktree`.
+    /// `nil` for a row whose status was set by something other than the
+    /// archive transaction, which stamps this field and the status together.
+    public let archivedAt: Date?
 
     public init(
         worktreeID: UUID, path: String, repoPath: String?,
-        allowedPrefixes: [String], locked: Bool
+        allowedPrefixes: [String], locked: Bool, archivedAt: Date? = nil
     ) {
         self.worktreeID = worktreeID
         self.path = path
         self.repoPath = repoPath
         self.allowedPrefixes = allowedPrefixes
         self.locked = locked
+        self.archivedAt = archivedAt
     }
 }
 
 public enum DeletionQueueDecision: Sendable, Equatable {
-    /// `reason` is one of `"locked"`, `"not-tbd-prefix"`, `"not-linked"`,
-    /// `"no-repo"`, `"live-cwd"`. Each is a spec invariant with its own test.
+    /// `reason` is one of `"locked"`, `"grace"`, `"not-tbd-prefix"`,
+    /// `"not-linked"`, `"no-repo"`, `"live-cwd"`. Each is a spec invariant
+    /// with its own test.
     case keep(reason: String)
     case reap
 }
@@ -52,10 +58,18 @@ public enum DeletionQueueDecision: Sendable, Equatable {
 public struct DeletionQueueCollector: Sendable {
     let git: GitManager
     let queue: WorktreeDeletionQueue
+    /// Date seam (`Tests/CLAUDE.md`, "Clock and date seams"): the grace gate
+    /// compares a persisted `Date`, so this is the date source, not a clock.
+    let now: @Sendable () -> Date
 
-    public init(git: GitManager, queue: WorktreeDeletionQueue = WorktreeDeletionQueue()) {
+    public init(
+        git: GitManager,
+        queue: WorktreeDeletionQueue = WorktreeDeletionQueue(),
+        now: @escaping @Sendable () -> Date = Date.init
+    ) {
         self.git = git
         self.queue = queue
+        self.now = now
     }
 
     // MARK: - Queued entries
@@ -112,19 +126,47 @@ public struct DeletionQueueCollector: Sendable {
             }
             return InterruptedArchive(
                 worktreeID: wt.id, path: wt.path,
-                repoPath: repoPath, allowedPrefixes: prefixes, locked: locked
+                repoPath: repoPath, allowedPrefixes: prefixes, locked: locked,
+                archivedAt: wt.archivedAt
             )
         }
     }
 
-    /// Gates a candidate in order: locked, then namespace (`allowedPrefixes`),
+    /// Gates a candidate in order: locked, then grace (the archive that owns
+    /// this row may still be running), then namespace (`allowedPrefixes`),
     /// then linkage (proof the directory is really this repo's worktree),
     /// then live-cwd. Each check short-circuits the rest, and every
     /// direction favors keeping.
+    ///
+    /// `locked` and `grace` come first because they are pure row/listing data
+    /// and answer "is this directory anyone else's business right now?" — no
+    /// point proving provenance for a directory we may not touch either way.
+    ///
+    /// `graceSeconds` is the sweep's `config.gcGraceSeconds`, the same knob
+    /// `AgentWorktreeCollector.decide` gates on. Archiving flips the row to
+    /// `.archived` in phase 1 and only renames the directory in phase 2,
+    /// after an archive hook that may run for a minute — so between those two
+    /// points a *healthy* archive presents exactly this collector's candidate
+    /// shape, and reaping it would rename the directory out from under the
+    /// running hook. `repo.remove`'s cascade puts many such archives in
+    /// flight at once. Waiting costs nothing: a genuinely interrupted archive
+    /// is reclaimed by the next hourly sweep instead of this one.
     public func decide(
-        _ candidate: InterruptedArchive, liveCWDs: [String]
+        _ candidate: InterruptedArchive, liveCWDs: [String], graceSeconds: Int
     ) async -> DeletionQueueDecision {
         if candidate.locked { return .keep(reason: "locked") }
+
+        // A row with no `archivedAt` is NOT held. Both archive entry points
+        // (`WorktreeStore.archive`, reached from `worktree.archive` and from
+        // `scratch.archive`) stamp the timestamp in the same transaction that
+        // sets the status, so an unstamped archived row cannot be an archive
+        // that is running right now — holding it would just make pre-stamp
+        // leftovers permanently unreclaimable, which is the state this
+        // collector exists to end.
+        if let archivedAt = candidate.archivedAt,
+           now().timeIntervalSince(archivedAt) < Double(graceSeconds) {
+            return .keep(reason: "grace")
+        }
 
         guard candidate.allowedPrefixes.contains(where: { isUnder(candidate.path, prefix: $0) })
         else {
@@ -140,10 +182,24 @@ public struct DeletionQueueCollector: Sendable {
                 return .keep(reason: "not-linked")
             }
         } else {
-            // A scratch space is not a linked worktree of any repo, so linkage
-            // cannot apply and the namespace is the available proof. The
-            // prefix check above already established it; a repoless candidate
-            // reaching here with a non-scratch prefix is unprovable.
+            // A repoless candidate is a scratch space, and a scratch space is
+            // NEVER reclaimable — including the ordinary case of one sitting
+            // squarely inside `~/tbd/scratch/`, which is why this returns
+            // unconditionally rather than re-checking the namespace.
+            //
+            // `scratch.archive` deliberately leaves the folder on disk (it
+            // flips the row to `.archived` and moves nothing; only
+            // `scratch.delete` sends anything to Trash), and `scratch.revive`
+            // needs that folder to bring the space back. So "archived row
+            // whose directory exists" is the normal, supported, user-chosen
+            // state of an archived scratch space — not the signature of an
+            // interrupted archive. Reaping on that signature would delete
+            // every archived scratch space on the machine.
+            //
+            // This is not over-conservatism to be tightened later: there is
+            // no repo to prove linkage against, and the namespace proves only
+            // that TBD owns the directory, never that the user is done with
+            // it.
             return .keep(reason: "no-repo")
         }
 

--- a/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
+++ b/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
@@ -1,0 +1,218 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "gc")
+
+/// An archive that never finished: a worktree row reads `.archived` but its
+/// directory is still on disk. `allowedPrefixes` are the TBD-owned locations
+/// this particular worktree could legitimately occupy.
+public struct InterruptedArchive: Sendable, Equatable {
+    public let worktreeID: UUID
+    public let path: String
+    /// `nil` for a scratch space, which belongs to no repo.
+    public let repoPath: String?
+    public let allowedPrefixes: [String]
+    /// As reported by `git worktree list --porcelain`. A locked worktree is
+    /// one the user pinned deliberately, and that outranks every other signal.
+    public let locked: Bool
+
+    public init(
+        worktreeID: UUID, path: String, repoPath: String?,
+        allowedPrefixes: [String], locked: Bool
+    ) {
+        self.worktreeID = worktreeID
+        self.path = path
+        self.repoPath = repoPath
+        self.allowedPrefixes = allowedPrefixes
+        self.locked = locked
+    }
+}
+
+public enum DeletionQueueDecision: Sendable, Equatable {
+    /// `reason` is one of `"locked"`, `"not-tbd-prefix"`, `"not-linked"`,
+    /// `"no-repo"`, `"live-cwd"`. Each is a spec invariant with its own test.
+    case keep(reason: String)
+    case reap
+}
+
+/// Reclaims worktree directories that outlived their archive.
+///
+/// Two kinds of work. Entries already sitting in a pool's `.deleting/` queue
+/// are unconditionally reclaimable — TBD put them there itself, and the rename
+/// that placed them was the point at which the worktree stopped existing.
+/// Interrupted archives are directories that a pre-queue archive failed to
+/// remove; reclaiming one means finishing that archive with the same mechanism
+/// a fresh archive uses, so there is one deletion path rather than two.
+///
+/// Every gate fails toward keeping. A database row is not proof that TBD
+/// created a directory — `adoptWorktree` can point a row at a worktree TBD
+/// never made, and adopted worktrees may live anywhere — so provenance must be
+/// established from the filesystem, not from the row alone.
+public struct DeletionQueueCollector: Sendable {
+    let git: GitManager
+    let queue: WorktreeDeletionQueue
+
+    public init(git: GitManager, queue: WorktreeDeletionQueue = WorktreeDeletionQueue()) {
+        self.git = git
+        self.queue = queue
+    }
+
+    // MARK: - Queued entries
+
+    public func pendingEntries(pools: [String]) -> [QueuedDeletion] {
+        Array(Set(pools)).sorted().flatMap { queue.pending(pool: $0) }
+    }
+
+    @discardableResult
+    public func drain(_ entry: QueuedDeletion) -> Bool {
+        queue.drain(entry)
+    }
+
+    // MARK: - Interrupted archives
+
+    /// Archived rows whose directory is still present. The inverse of the
+    /// filter the sweep already applies when reconciling scratchpads.
+    ///
+    /// Resolves lock state with one `worktreeListDetailed` call per repo
+    /// rather than one per candidate. A repo whose listing fails contributes
+    /// no lock information, and its candidates are treated as locked — a
+    /// listing failure must not read as "nothing is locked".
+    public func interruptedArchives(
+        worktrees: [Worktree],
+        repoPathByID: [UUID: String],
+        prefixesByRepoID: [UUID: [String]],
+        scratchPrefix: String
+    ) async -> [InterruptedArchive] {
+        let surviving = worktrees.filter {
+            $0.status == .archived && FileManager.default.fileExists(atPath: $0.path)
+        }
+
+        // repoPath -> (lockedPaths, listingSucceeded)
+        var lockState: [String: (locked: Set<String>, ok: Bool)] = [:]
+        for repoPath in Set(surviving.compactMap { $0.repoID.flatMap { repoPathByID[$0] } }) {
+            if let entries = try? await git.worktreeListDetailed(repoPath: repoPath) {
+                let locked = Set(entries.filter(\.locked).map { resolvedPath($0.path) })
+                lockState[repoPath] = (locked, true)
+            } else {
+                lockState[repoPath] = ([], false)
+                logger.warning("""
+                gc: worktree listing failed for \(repoPath, privacy: .public) — \
+                treating its archived leftovers as locked this sweep
+                """)
+            }
+        }
+
+        return surviving.map { wt in
+            let repoPath = wt.repoID.flatMap { repoPathByID[$0] }
+            let prefixes = wt.repoID.flatMap { prefixesByRepoID[$0] } ?? [scratchPrefix]
+            var locked = false
+            if let repoPath, let state = lockState[repoPath] {
+                locked = !state.ok || state.locked.contains(resolvedPath(wt.path))
+            }
+            return InterruptedArchive(
+                worktreeID: wt.id, path: wt.path,
+                repoPath: repoPath, allowedPrefixes: prefixes, locked: locked
+            )
+        }
+    }
+
+    /// Gate order mirrors `AgentWorktreeCollector.decide`: locked, then
+    /// namespace, then linkage, then live-cwd. Each check short-circuits the
+    /// rest, and every direction favors keeping.
+    public func decide(
+        _ candidate: InterruptedArchive, liveCWDs: [String]
+    ) async -> DeletionQueueDecision {
+        if candidate.locked { return .keep(reason: "locked") }
+
+        guard candidate.allowedPrefixes.contains(where: { isUnder(candidate.path, prefix: $0) })
+        else {
+            return .keep(reason: "not-tbd-prefix")
+        }
+
+        if let repoPath = candidate.repoPath, !repoPath.isEmpty {
+            // The `.git` file must resolve into this repo's worktree
+            // administration — that is what proves the directory is this
+            // repo's linked worktree and not something that merely sits here.
+            guard await git.isLinkedWorktree(candidatePath: candidate.path, repoPath: repoPath)
+            else {
+                return .keep(reason: "not-linked")
+            }
+        } else {
+            // A scratch space is not a linked worktree of any repo, so linkage
+            // cannot apply and the namespace is the available proof. The
+            // prefix check above already established it; a repoless candidate
+            // reaching here with a non-scratch prefix is unprovable.
+            return .keep(reason: "no-repo")
+        }
+
+        if liveCWDs.contains(where: { isUnder($0, prefix: candidate.path) || $0 == candidate.path }) {
+            return .keep(reason: "live-cwd")
+        }
+
+        return .reap
+    }
+
+    /// Finishes the interrupted archive: rename into the queue, then drop the
+    /// stale git registration. Returns the queued entry, or `nil` when the
+    /// rename failed (the sweep keeps the directory and retries next pass).
+    public func reap(_ candidate: InterruptedArchive) async -> QueuedDeletion? {
+        let entry: QueuedDeletion
+        do {
+            entry = try queue.enqueue(worktreePath: candidate.path)
+        } catch {
+            logger.error("""
+            gc: could not queue interrupted archive \(candidate.path, privacy: .public): \
+            \(error, privacy: .public)
+            """)
+            return nil
+        }
+        if let repoPath = candidate.repoPath, !repoPath.isEmpty {
+            do {
+                try await git.worktreePrune(repoPath: repoPath)
+            } catch {
+                logger.error("""
+                gc: prune failed for \(repoPath, privacy: .public) after queueing \
+                \(candidate.path, privacy: .public): \(error, privacy: .public)
+                """)
+            }
+        }
+        return entry
+    }
+
+    // MARK: - Helpers
+
+    /// True when `path` is the prefix itself or sits beneath it. Compares
+    /// resolved paths so a trailing slash, `..`, or a `/var` -> `/private/var`
+    /// style automount symlink cannot smuggle a candidate past the gate.
+    func isUnder(_ path: String, prefix: String) -> Bool {
+        let p = resolvedPath(path)
+        let root = resolvedPath(prefix)
+        return p == root || p.hasPrefix(root + "/")
+    }
+
+    /// Resolves as much of `path` as exists on disk through `realpath(3)` —
+    /// which, unlike `NSString.standardizingPath`, reliably follows macOS's
+    /// `/var` -> `/private/var` style automount symlinks — then re-appends
+    /// any trailing components that don't exist yet, so a live cwd one level
+    /// below a worktree root still compares consistently with the worktree
+    /// root itself. `NSString.standardizingPath` alone only performs that
+    /// substitution when the full path already resolves, which makes an
+    /// existing worktree root and a not-yet-existing path beneath it resolve
+    /// to different prefixes — exactly the trap `GitManager.isLinkedWorktree`
+    /// documents for `URL.resolvingSymlinksInPath()`.
+    func resolvedPath(_ path: String) -> String {
+        var suffix: [String] = []
+        var current = (path as NSString).standardizingPath
+        while !FileManager.default.fileExists(atPath: current), current != "/" {
+            suffix.insert((current as NSString).lastPathComponent, at: 0)
+            current = (current as NSString).deletingLastPathComponent
+        }
+        guard let real = realpath(current, nil) else {
+            return (path as NSString).standardizingPath
+        }
+        defer { free(real) }
+        let base = String(cString: real)
+        return suffix.isEmpty ? base : ([base] + suffix).joined(separator: "/")
+    }
+}

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -237,6 +237,11 @@ public actor OrphanGC {
                     planned.append("KEEP enqueue-failed \(candidate.path)")
                     continue
                 }
+                // The count and the record reflect the commit point (queued +
+                // pruned from git), not confirmed byte removal — `drain`'s
+                // result is intentionally not gating either one. If this
+                // immediate drain doesn't finish, the entry stays in
+                // `.deleting/` and step 1 above reclaims it on a later sweep.
                 deletionQueueCollector.drain(entry)
                 await insertReapRecord(ReapRecord(
                     kind: .archivedWorktree,

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -320,9 +320,13 @@ public actor OrphanGC {
     /// scope), stamped onto the resulting record; pass `""` when unknown.
     ///
     /// Verifies the worktree directory is actually gone before doing
-    /// anything else: `completeArchiveWorktree` fires this callback after a
-    /// `try?`-swallowed `git.worktreeRemove`, so a failed removal must not
-    /// orphan-classify (and delete) a scratchpad that's still in active use.
+    /// anything else. `completeArchiveWorktree` already fires this callback
+    /// only once it has confirmed the path is gone — queued out of its pool
+    /// slot on the success leg, or a verified `git.worktreeRemove` on the
+    /// fallback leg — so this is defense in depth against a future caller
+    /// that doesn't uphold that contract, not a workaround for a swallowed
+    /// failure: a failed removal must never orphan-classify (and delete) a
+    /// scratchpad that's still in active use.
     ///
     /// The `gcEnabled` master switch governs ALL GC deletion, including this
     /// event-driven path — one toggle covers both collectors. A config read

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -243,7 +243,7 @@ public actor OrphanGC {
         for entry in deletionQueueCollector.pendingEntries(pools: Array(pools)) {
             planned.append("REAP queued-deletion \(entry.path)")
             guard !dryRun else { continue }
-            if deletionQueueCollector.drain(entry) {
+            if await deletionQueueCollector.drain(entry) {
                 reaped += 1
                 logger.info("gc: drained queued deletion \(entry.path, privacy: .public)")
             }
@@ -307,7 +307,7 @@ public actor OrphanGC {
                 // result is intentionally not gating either one. If this
                 // immediate drain doesn't finish, the entry stays in
                 // `.deleting/` and step 1 above reclaims it on a later sweep.
-                deletionQueueCollector.drain(entry)
+                await deletionQueueCollector.drain(entry)
                 await insertReapRecord(ReapRecord(
                     kind: .archivedWorktree,
                     repoPath: candidate.repoPath ?? "",

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -105,7 +105,7 @@ public actor OrphanGC {
         self.snapshot = snap
         self.agentCollector = AgentWorktreeCollector(git: git, snapshot: snap, now: resolvedNow)
         self.scratchpadCollector = ScratchpadCollector(base: resolvedScratchpadBase)
-        self.deletionQueueCollector = DeletionQueueCollector(git: git)
+        self.deletionQueueCollector = DeletionQueueCollector(git: git, now: resolvedNow)
     }
 
     // MARK: - Sweep
@@ -163,12 +163,21 @@ public actor OrphanGC {
             }
         }
 
+        // One read of the archived rows for both consumers below: the deletion
+        // queue wants the ones whose directory survives, scratchpad
+        // reconciliation the ones whose directory is gone.
+        let archived = (try? await db.worktrees.list(status: .archived)) ?? []
+
         await reclaimDeletionQueue(
-            repos: repos, live: live, dryRun: dryRun,
+            repos: repos, archived: archived, live: live,
+            graceSeconds: config.gcGraceSeconds, dryRun: dryRun,
             planned: &planned, reaped: &reaped
         )
 
-        await reconcileScratchpads(repos: repos, dryRun: dryRun, planned: &planned, reaped: &reaped)
+        await reconcileScratchpads(
+            repos: repos, archived: archived, dryRun: dryRun,
+            planned: &planned, reaped: &reaped
+        )
 
         // Snapshot retention never runs in dryRun; the outer guard already
         // establishes gcEnabled for any non-dry run.
@@ -181,15 +190,16 @@ public actor OrphanGC {
     }
 
     /// Reclaims worktree directories that outlived their archive: entries
-    /// already queued in a pool's `.deleting/`, plus archives that a
-    /// pre-queue release failed to remove.
+    /// already queued in a pool's `.deleting/`, archives that a pre-queue
+    /// release failed to remove, and git registrations that outlived the
+    /// directory they point at.
     ///
     /// The archived-row scan is deliberately the mirror of
     /// `reconcileScratchpads`, which reads the same rows and keeps the ones
     /// whose directory is *gone*. The ones that remain are exactly this
-    /// method's input.
+    /// method's step-2 input; the ones it keeps are step 3's.
     private func reclaimDeletionQueue(
-        repos: [Repo], live: [String], dryRun: Bool,
+        repos: [Repo], archived: [Worktree], live: [String], graceSeconds: Int, dryRun: Bool,
         planned: inout [String], reaped: inout Int
     ) async {
         let layout = WorktreeLayout()
@@ -204,6 +214,20 @@ public actor OrphanGC {
             pools.formUnion(prefixes)
         }
         pools.insert(scratchPrefix)
+        // `WorktreeDeletionQueue.enqueue` derives the pool from the worktree's
+        // own parent directory, and an adopted worktree can live anywhere — so
+        // archiving one creates a `.deleting/` queue outside every layout
+        // prefix, which an interrupted drain would otherwise leave in the
+        // user's own directory forever. Every archived row's parent is
+        // therefore a pool worth draining. This widens only what gets
+        // DRAINED, never what step 2 may reclaim: an entry sitting in
+        // `.deleting/<uuid>` is there because TBD renamed it there, so it
+        // needs no provenance gate.
+        for row in archived {
+            let parent = (row.path as NSString).deletingLastPathComponent
+            guard parent.hasPrefix("/"), parent != "/" else { continue }
+            pools.insert(parent)
+        }
 
         // 1. Entries already queued — unconditionally reclaimable.
         for entry in deletionQueueCollector.pendingEntries(pools: Array(pools)) {
@@ -216,15 +240,16 @@ public actor OrphanGC {
         }
 
         // 2. Archives that never finished.
-        let allWorktrees = (try? await db.worktrees.list(status: .archived)) ?? []
         let candidates = await deletionQueueCollector.interruptedArchives(
-            worktrees: allWorktrees,
+            worktrees: archived,
             repoPathByID: repoPathByID,
             prefixesByRepoID: prefixesByRepoID,
             scratchPrefix: scratchPrefix
         )
         for candidate in candidates {
-            switch await deletionQueueCollector.decide(candidate, liveCWDs: live) {
+            switch await deletionQueueCollector.decide(
+                candidate, liveCWDs: live, graceSeconds: graceSeconds
+            ) {
             case .keep(let reason):
                 planned.append("KEEP \(reason) \(candidate.path)")
                 logger.debug("""
@@ -233,6 +258,14 @@ public actor OrphanGC {
             case .reap:
                 planned.append("REAP archived-worktree \(candidate.path)")
                 guard !dryRun else { continue }
+                // Measure BEFORE the reap, the same order
+                // `ScratchpadCollector.cleanUp` and
+                // `AgentWorktreeCollector.reap` use: `reap` renames the
+                // directory into the queue and the drain below unlinks it, so
+                // this is the last moment its size can be read. A `nil` here
+                // (du failed or timed out) is the unmeasured record we would
+                // have written anyway.
+                let bytes = await GCDiskUsage.apparentBytes(path: candidate.path)
                 guard let entry = await deletionQueueCollector.reap(candidate) else {
                     planned.append("KEEP enqueue-failed \(candidate.path)")
                     continue
@@ -246,11 +279,80 @@ public actor OrphanGC {
                 await insertReapRecord(ReapRecord(
                     kind: .archivedWorktree,
                     repoPath: candidate.repoPath ?? "",
-                    worktreePath: candidate.path
+                    worktreePath: candidate.path,
+                    apparentBytes: bytes,
+                    reapedAt: now()
                 ))
                 reaped += 1
                 logger.info("""
                 gc: reclaimed archived worktree \(candidate.path, privacy: .public)
+                """)
+            }
+        }
+
+        // 3. Registrations that outlived their directory.
+        await pruneStaleRegistrations(
+            repoPathByID: repoPathByID, archived: archived,
+            dryRun: dryRun, planned: &planned
+        )
+    }
+
+    /// Prunes repos where an archived row's directory is gone but git still
+    /// lists a worktree at that path.
+    ///
+    /// This is the exact failure the deletion queue exists to end, arriving
+    /// through a narrower door: the archive renames the directory and then
+    /// prunes, so a prune that throws — or a daemon killed between the two —
+    /// leaves a registration with no directory. Nothing else recovers it.
+    /// Step 1 only drains bytes, step 2 only sees candidates whose directory
+    /// still *exists*, and revive's preflight throws `worktreeAlreadyRegistered`
+    /// forever, so the worktree is permanently unrevivable until someone
+    /// prunes by hand.
+    ///
+    /// `git worktree prune` is the right instrument rather than a blunt one:
+    /// it drops administrative entries only for worktrees whose directory is
+    /// missing, and skips locked ones outright, so it can never remove a
+    /// registration that still has a directory behind it. The scan is still
+    /// scoped to repos with a matching archived row, so a repo with no
+    /// evidence of this failure is never touched.
+    private func pruneStaleRegistrations(
+        repoPathByID: [UUID: String], archived: [Worktree],
+        dryRun: Bool, planned: inout [String]
+    ) async {
+        var goneByRepo: [String: [String]] = [:]
+        for row in archived where !FileManager.default.fileExists(atPath: row.path) {
+            guard let repoID = row.repoID, let repoPath = repoPathByID[repoID] else { continue }
+            goneByRepo[repoPath, default: []].append(row.path)
+        }
+
+        for (repoPath, paths) in goneByRepo.sorted(by: { $0.key < $1.key }) {
+            guard let entries = try? await git.worktreeListDetailed(repoPath: repoPath) else {
+                logger.warning("""
+                gc: worktree listing failed for \(repoPath, privacy: .public) — \
+                cannot check for stale registrations this sweep
+                """)
+                continue
+            }
+            // Both sides through `resolvedPath`: git's listing is canonical,
+            // while the row's path names a directory that no longer exists,
+            // so a plain `realpath` on it would resolve nothing.
+            let registered = Set(entries.map { deletionQueueCollector.resolvedPath($0.path) })
+            let stale = paths.filter { registered.contains(deletionQueueCollector.resolvedPath($0)) }
+            guard !stale.isEmpty else { continue }
+
+            for path in stale {
+                planned.append("PRUNE stale-registration \(path)")
+            }
+            guard !dryRun else { continue }
+            do {
+                try await git.worktreePrune(repoPath: repoPath)
+                logger.info("""
+                gc: pruned \(stale.count, privacy: .public) stale registration(s) \
+                in \(repoPath, privacy: .public)
+                """)
+            } catch {
+                logger.error("""
+                gc: prune failed for \(repoPath, privacy: .public): \(error, privacy: .public)
                 """)
             }
         }
@@ -259,7 +361,9 @@ public actor OrphanGC {
     /// Scratchpad reconciliation: archived TBD worktrees whose directory is
     /// already gone but whose Claude Code scratchpad survives. Mirrors the
     /// same keep-biased `dryRun`/`gcEnabled` gate as the agent-worktree loop.
-    /// `repos` is the sweep's own already-loaded repo list, reused here to
+    /// `archived` is the sweep's single read of the archived rows, shared with
+    /// `reclaimDeletionQueue`, which wants the complementary half of the same
+    /// list. `repos` is the sweep's own already-loaded repo list, reused here to
     /// resolve each archived row's `repoID` to a `repo.path` without a second
     /// DB round trip; a row with no resolvable repo (deleted repo, no
     /// `repoID`) stamps `""` — fails toward the previous behavior rather than
@@ -272,10 +376,10 @@ public actor OrphanGC {
     /// `reconcile` always mutates, so dry-run planning recomputes the
     /// candidate list read-only instead.
     private func reconcileScratchpads(
-        repos: [Repo], dryRun: Bool, planned: inout [String], reaped: inout Int
+        repos: [Repo], archived: [Worktree], dryRun: Bool,
+        planned: inout [String], reaped: inout Int
     ) async {
         let repoPathByID = Dictionary(uniqueKeysWithValues: repos.map { ($0.id, $0.path) })
-        let archived = (try? await db.worktrees.list(status: .archived)) ?? []
         let gone = archived
             .filter { !FileManager.default.fileExists(atPath: $0.path) }
             .map { (worktreePath: $0.path, repoPath: $0.repoID.flatMap { repoPathByID[$0] } ?? "") }

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -56,6 +56,7 @@ public actor OrphanGC {
     private let snapshot: ReapSnapshot
     private let agentCollector: AgentWorktreeCollector
     private let scratchpadCollector: ScratchpadCollector
+    private let deletionQueueCollector: DeletionQueueCollector
 
     /// Production seam: an injected `lsofProvider` returns a non-optional
     /// `[String]` — by definition authoritative, it can't signal
@@ -104,6 +105,7 @@ public actor OrphanGC {
         self.snapshot = snap
         self.agentCollector = AgentWorktreeCollector(git: git, snapshot: snap, now: resolvedNow)
         self.scratchpadCollector = ScratchpadCollector(base: resolvedScratchpadBase)
+        self.deletionQueueCollector = DeletionQueueCollector(git: git)
     }
 
     // MARK: - Sweep
@@ -161,6 +163,11 @@ public actor OrphanGC {
             }
         }
 
+        await reclaimDeletionQueue(
+            repos: repos, live: live, dryRun: dryRun,
+            planned: &planned, reaped: &reaped
+        )
+
         await reconcileScratchpads(repos: repos, dryRun: dryRun, planned: &planned, reaped: &reaped)
 
         // Snapshot retention never runs in dryRun; the outer guard already
@@ -171,6 +178,77 @@ public actor OrphanGC {
 
         if reaped > 0 { broadcast(.reapRecordsChanged) }
         return .init(planned: planned, reaped: reaped)
+    }
+
+    /// Reclaims worktree directories that outlived their archive: entries
+    /// already queued in a pool's `.deleting/`, plus archives that a
+    /// pre-queue release failed to remove.
+    ///
+    /// The archived-row scan is deliberately the mirror of
+    /// `reconcileScratchpads`, which reads the same rows and keeps the ones
+    /// whose directory is *gone*. The ones that remain are exactly this
+    /// method's input.
+    private func reclaimDeletionQueue(
+        repos: [Repo], live: [String], dryRun: Bool,
+        planned: inout [String], reaped: inout Int
+    ) async {
+        let layout = WorktreeLayout()
+        let scratchPrefix = TBDConstants.scratchDir.path
+        var repoPathByID: [UUID: String] = [:]
+        var prefixesByRepoID: [UUID: [String]] = [:]
+        var pools: Set<String> = []
+        for repo in repos {
+            repoPathByID[repo.id] = repo.path
+            let prefixes = layout.legacyAndCanonicalPrefixes(for: repo)
+            prefixesByRepoID[repo.id] = prefixes
+            pools.formUnion(prefixes)
+        }
+        pools.insert(scratchPrefix)
+
+        // 1. Entries already queued — unconditionally reclaimable.
+        for entry in deletionQueueCollector.pendingEntries(pools: Array(pools)) {
+            planned.append("REAP queued-deletion \(entry.path)")
+            guard !dryRun else { continue }
+            if deletionQueueCollector.drain(entry) {
+                reaped += 1
+                logger.info("gc: drained queued deletion \(entry.path, privacy: .public)")
+            }
+        }
+
+        // 2. Archives that never finished.
+        let allWorktrees = (try? await db.worktrees.list(status: .archived)) ?? []
+        let candidates = await deletionQueueCollector.interruptedArchives(
+            worktrees: allWorktrees,
+            repoPathByID: repoPathByID,
+            prefixesByRepoID: prefixesByRepoID,
+            scratchPrefix: scratchPrefix
+        )
+        for candidate in candidates {
+            switch await deletionQueueCollector.decide(candidate, liveCWDs: live) {
+            case .keep(let reason):
+                planned.append("KEEP \(reason) \(candidate.path)")
+                logger.debug("""
+                gc: keep \(reason, privacy: .public) \(candidate.path, privacy: .public)
+                """)
+            case .reap:
+                planned.append("REAP archived-worktree \(candidate.path)")
+                guard !dryRun else { continue }
+                guard let entry = await deletionQueueCollector.reap(candidate) else {
+                    planned.append("KEEP enqueue-failed \(candidate.path)")
+                    continue
+                }
+                deletionQueueCollector.drain(entry)
+                await insertReapRecord(ReapRecord(
+                    kind: .archivedWorktree,
+                    repoPath: candidate.repoPath ?? "",
+                    worktreePath: candidate.path
+                ))
+                reaped += 1
+                logger.info("""
+                gc: reclaimed archived worktree \(candidate.path, privacy: .public)
+                """)
+            }
+        }
     }
 
     /// Scratchpad reconciliation: archived TBD worktrees whose directory is

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -57,6 +57,14 @@ public actor OrphanGC {
     private let agentCollector: AgentWorktreeCollector
     private let scratchpadCollector: ScratchpadCollector
     private let deletionQueueCollector: DeletionQueueCollector
+    /// Test-only injection seam: awaited once inside `reclaimDeletionQueue`,
+    /// after the interrupted-archive candidate list has been computed and
+    /// before any candidate is reaped. That is the exact window the pre-reap
+    /// row re-read closes, and nothing else in the sweep is slow or
+    /// interruptible enough to land a concurrent `forgetWorktree` in it
+    /// deterministically. `nil` in production (both public inits omit it), so
+    /// the sweep is unchanged there.
+    private let beforeInterruptedArchiveReap: (@Sendable () async -> Void)?
 
     /// Production seam: an injected `lsofProvider` returns a non-optional
     /// `[String]` — by definition authoritative, it can't signal
@@ -90,7 +98,8 @@ public actor OrphanGC {
         broadcast: @escaping @Sendable (StateDelta) -> Void,
         liveCWDsProvider: (@Sendable () async -> [String]?)?,
         scratchpadBase: URL? = nil,
-        now: (@Sendable () -> Date)? = nil
+        now: (@Sendable () -> Date)? = nil,
+        beforeInterruptedArchiveReap: (@Sendable () async -> Void)? = nil
     ) {
         let resolvedNow = now ?? Date.init
         let resolvedScratchpadBase = scratchpadBase ?? TBDConstants.claudeScratchpadBase
@@ -103,6 +112,7 @@ public actor OrphanGC {
         self.scratchpadBase = resolvedScratchpadBase
         self.now = resolvedNow
         self.snapshot = snap
+        self.beforeInterruptedArchiveReap = beforeInterruptedArchiveReap
         self.agentCollector = AgentWorktreeCollector(git: git, snapshot: snap, now: resolvedNow)
         self.scratchpadCollector = ScratchpadCollector(base: resolvedScratchpadBase)
         self.deletionQueueCollector = DeletionQueueCollector(git: git, now: resolvedNow)
@@ -246,6 +256,7 @@ public actor OrphanGC {
             prefixesByRepoID: prefixesByRepoID,
             scratchPrefix: scratchPrefix
         )
+        await beforeInterruptedArchiveReap?()
         for candidate in candidates {
             switch await deletionQueueCollector.decide(
                 candidate, liveCWDs: live, graceSeconds: graceSeconds
@@ -266,6 +277,27 @@ public actor OrphanGC {
                 // (du failed or timed out) is the unmeasured record we would
                 // have written anyway.
                 let bytes = await GCDiskUsage.apparentBytes(path: candidate.path)
+                // Re-read the row immediately before acting on it. The
+                // candidate list above is a snapshot, and `forgetWorktree`
+                // hard-deletes a row while promising the directory stays
+                // put — so a forget landing between the snapshot and here
+                // would otherwise still get its directory reaped, silently
+                // breaking that promise. A revive (status back to `.active`)
+                // is the same hazard through a different door. The check
+                // lives here rather than in `DeletionQueueCollector`
+                // deliberately: that type has no database access, and
+                // keeping it that way is worth a round trip per reap. A read
+                // failure reads as "skip", the keep-favoring direction every
+                // other gate in this sweep takes.
+                let refreshed = (try? await db.worktrees.get(id: candidate.worktreeID)) ?? nil
+                guard refreshed?.status == .archived else {
+                    planned.append("KEEP row-changed \(candidate.path)")
+                    logger.info("""
+                    gc: keep row-changed \(candidate.path, privacy: .public) — \
+                    its row was deleted or left .archived after this sweep listed it
+                    """)
+                    continue
+                }
                 guard let entry = await deletionQueueCollector.reap(candidate) else {
                     planned.append("KEEP enqueue-failed \(candidate.path)")
                     continue

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -341,12 +341,25 @@ public actor OrphanGC {
     /// forever, so the worktree is permanently unrevivable until someone
     /// prunes by hand.
     ///
-    /// `git worktree prune` is the right instrument rather than a blunt one:
-    /// it drops administrative entries only for worktrees whose directory is
-    /// missing, and skips locked ones outright, so it can never remove a
-    /// registration that still has a directory behind it. The scan is still
-    /// scoped to repos with a matching archived row, so a repo with no
-    /// evidence of this failure is never touched.
+    /// `git worktree prune` is **repo-wide**, and there is no way to scope it
+    /// to one worktree — git offers no such flag. So an archived row with a
+    /// missing directory is only the *trigger*: the prune that follows drops
+    /// every registration in that repo whose directory git finds missing,
+    /// including ones this sweep never looked at. What bounds the blast radius
+    /// is not the trigger but git itself. It re-checks directory existence at
+    /// prune time rather than trusting this sweep's stale listing, it skips
+    /// locked worktrees outright, and it removes only the administrative entry
+    /// — never a directory. So the collateral entries it drops are ones whose
+    /// directory is genuinely gone at that instant, which is the same
+    /// wreckage this method exists to clear.
+    ///
+    /// The residual case is a worktree on a temporarily unmounted volume:
+    /// git sees the directory as missing and prunes a registration the user
+    /// still wants. `git worktree lock` is git's own designated mitigation for
+    /// exactly that, and prune honors it.
+    ///
+    /// Repo selection is still narrow: a repo with no archived row whose
+    /// directory is gone is never pruned at all.
     private func pruneStaleRegistrations(
         repoPathByID: [UUID: String], archived: [Worktree],
         dryRun: Bool, planned: inout [String]

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -438,9 +438,28 @@ public struct GitManager: Sendable {
     }
 
     /// Removes a worktree at the given path.
-    public func worktreeRemove(repoPath: String, worktreePath: String) async throws {
-        _ = try await run(arguments: ["worktree", "remove", worktreePath, "--force"], at: repoPath)
+    ///
+    /// `timeout` overrides the instance default. The archive path passes a
+    /// raised value on its fallback leg: removal unlinks every file in the
+    /// worktree, which for a dependency-heavy repo runs for minutes, and the
+    /// default 120 s ceiling kills git partway through — leaving a
+    /// half-deleted directory that is still registered with git, because git
+    /// drops the administrative entry only after the working-tree removal
+    /// returns success.
+    public func worktreeRemove(
+        repoPath: String, worktreePath: String, timeout: Duration? = nil
+    ) async throws {
+        _ = try await run(
+            arguments: ["worktree", "remove", worktreePath, "--force"],
+            at: repoPath,
+            timeout: timeout
+        )
     }
+
+    /// Ceiling for the archive path's fallback removal. Generous rather than
+    /// unbounded — the queue's rename is the intended path, and this leg only
+    /// runs when the rename could not be performed at all.
+    public static let worktreeRemoveFallbackTimeout: Duration = .seconds(900)
 
     /// Prunes stale worktree tracking entries.
     public func worktreePrune(repoPath: String) async throws {

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -459,6 +459,15 @@ public struct GitManager: Sendable {
     /// Ceiling for the archive path's fallback removal. Generous rather than
     /// unbounded — the queue's rename is the intended path, and this leg only
     /// runs when the rename could not be performed at all.
+    ///
+    /// Derived from the throughput measured for the deletion-queue design
+    /// (`docs/specs/2026-08-10-worktree-deletion-queue-design.md`): worktrees
+    /// of 200,000–235,000 filesystem entries, unlinked at between 587
+    /// entries/s (six concurrent removals) and 3,100 entries/s (one removal on
+    /// a quiet machine). The largest tree at the slowest measured rate is
+    /// ~400 s, so 900 s clears the slow end of that range by better than 2x —
+    /// enough margin for a machine worse than the one measured, while still
+    /// bounding a genuinely wedged subprocess.
     public static let worktreeRemoveFallbackTimeout: Duration = .seconds(900)
 
     /// Prunes stale worktree tracking entries.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeDeletionQueue.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeDeletionQueue.swift
@@ -64,6 +64,29 @@ public struct WorktreeDeletionQueue: Sendable {
     /// other dotfiles.
     public static let dirName = ".deleting"
 
+    /// Where `drain`'s unlink loop actually runs.
+    ///
+    /// Serial, and `static` so every drain in the process shares it — an
+    /// archive's inline drain, a concurrent archive's, and the GC sweep's all
+    /// queue behind one another even though each holds its own
+    /// `WorktreeDeletionQueue` value. That is the design's stated position
+    /// (spec, "`WorktreeDeletionQueue`"): draining one entry at a time costs
+    /// nothing, because nothing waits on the queue emptying, while parallel
+    /// drains saturate the disk against whatever the developer is doing and
+    /// give each removal a quarter of the throughput anyway.
+    ///
+    /// It is also what keeps a minutes-long `removeItem` off the cooperative
+    /// pool. `drain` is called from detached tasks, so running the unlink
+    /// inline would park a pool thread for the whole removal — 70 s to several
+    /// minutes for a dependency-heavy worktree — and concurrent archives would
+    /// park one each.
+    ///
+    /// Internal rather than private so a test can occupy it and prove `drain`
+    /// really queues behind it instead of unlinking inline.
+    static let drainQueue = DispatchQueue(
+        label: "com.tbd.daemon.deletion-queue.drain", qos: .utility
+    )
+
     /// The rename primitive `enqueue` calls. Defaults to the real `rename(2)`
     /// syscall; tests substitute a stub to force specific `errno` values
     /// (e.g. `EXDEV`) without needing two real filesystems, and to prove that
@@ -138,8 +161,12 @@ public struct WorktreeDeletionQueue: Sendable {
     /// same defense `ScratchpadCollector.cleanUp` puts in front of its own
     /// `removeItem`. Returning `false` (not `true`) keeps the failure visible:
     /// nothing was reclaimed.
+    ///
+    /// The two guards are cheap `stat`-level checks and stay on the caller's
+    /// thread; only the unlink loop hops to `drainQueue` (see its comment for
+    /// why that queue is serial and process-wide).
     @discardableResult
-    public func drain(_ entry: QueuedDeletion) -> Bool {
+    public func drain(_ entry: QueuedDeletion) async -> Bool {
         guard (entry.path as NSString).pathComponents.contains(Self.dirName) else {
             logger.error("""
             deletionQueue: refusing to drain \(entry.path, privacy: .public) — \
@@ -148,16 +175,21 @@ public struct WorktreeDeletionQueue: Sendable {
             return false
         }
         guard FileManager.default.fileExists(atPath: entry.path) else { return true }
-        do {
-            try FileManager.default.removeItem(atPath: entry.path)
-            logger.debug("deletionQueue: drained \(entry.path, privacy: .public)")
-            return true
-        } catch {
-            logger.error("""
-            deletionQueue: drain of \(entry.path, privacy: .public) failed, \
-            will resume next sweep: \(error, privacy: .public)
-            """)
-            return false
+        let path = entry.path
+        return await withCheckedContinuation { continuation in
+            Self.drainQueue.async {
+                do {
+                    try FileManager.default.removeItem(atPath: path)
+                    logger.debug("deletionQueue: drained \(path, privacy: .public)")
+                    continuation.resume(returning: true)
+                } catch {
+                    logger.error("""
+                    deletionQueue: drain of \(path, privacy: .public) failed, \
+                    will resume next sweep: \(error, privacy: .public)
+                    """)
+                    continuation.resume(returning: false)
+                }
+            }
         }
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeDeletionQueue.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeDeletionQueue.swift
@@ -1,0 +1,124 @@
+import Foundation
+import os
+import TBDShared
+
+private let logger = Logger(subsystem: "com.tbd.daemon", category: "deletionQueue")
+
+/// A worktree directory that has been renamed out of its pool slot and is
+/// waiting for its bytes to be reclaimed.
+public struct QueuedDeletion: Sendable, Equatable {
+    /// Where the directory lives now: `<pool>/.deleting/<uuid>`.
+    public let path: String
+    /// The pool slot it was renamed out of. Retained for logging and reap
+    /// records; nothing reads it back off disk.
+    public let originalPath: String
+
+    public init(path: String, originalPath: String) {
+        self.path = path
+        self.originalPath = originalPath
+    }
+}
+
+public enum WorktreeDeletionQueueError: Error, CustomStringConvertible, Equatable {
+    /// `rename(2)` refused. `errno` is `EXDEV` when the queue directory landed
+    /// on a different filesystem than the worktree — the case the archive
+    /// path's fallback exists for.
+    case renameFailed(from: String, to: String, errno: Int32)
+
+    public var description: String {
+        switch self {
+        case let .renameFailed(from, to, code):
+            return "rename(\(from) -> \(to)) failed: \(String(cString: strerror(code))) (errno \(code))"
+        }
+    }
+}
+
+/// Owns the hand-off point between "this worktree is archived" and "its bytes
+/// are gone".
+///
+/// Removing a worktree means unlinking every file in it, which for a
+/// dependency-heavy repo is 200,000+ entries and minutes of wall clock — far
+/// past any subprocess deadline. Renaming it is one syscall and takes
+/// milliseconds regardless of size. So archiving renames the directory into
+/// `<pool>/.deleting/<uuid>` and treats that as the commit point: once the
+/// rename lands and git's registration is pruned, the worktree is gone as far
+/// as TBD and git are concerned, and reclaiming the bytes can take as long as
+/// it needs. An interrupted drain leaves an entry that is unambiguously
+/// garbage, which the GC sweep finishes later.
+///
+/// The queue directory is a sibling of the worktree directories rather than one
+/// global location because `rename(2)` cannot cross filesystems and pools may
+/// live outside `TBD_HOME`.
+public struct WorktreeDeletionQueue: Sendable {
+    /// Leading dot so pool-listing loops skip it the way they already skip
+    /// other dotfiles.
+    public static let dirName = ".deleting"
+
+    public init() {}
+
+    public func queueDir(forPool pool: String) -> String {
+        (pool as NSString).appendingPathComponent(Self.dirName)
+    }
+
+    /// Renames `worktreePath` into its pool's queue directory.
+    ///
+    /// Uses `rename(2)` rather than `FileManager.moveItem`, which silently
+    /// degrades to a recursive copy-then-delete across filesystems — turning a
+    /// millisecond operation into a multi-minute one that also doubles peak
+    /// disk usage. Failing fast with `EXDEV` is the correct outcome; the caller
+    /// falls back to an in-place removal.
+    public func enqueue(worktreePath: String) throws -> QueuedDeletion {
+        let pool = (worktreePath as NSString).deletingLastPathComponent
+        let dir = queueDir(forPool: pool)
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true
+        )
+        let destination = (dir as NSString).appendingPathComponent(UUID().uuidString)
+
+        if rename(worktreePath, destination) != 0 {
+            let code = errno
+            throw WorktreeDeletionQueueError.renameFailed(
+                from: worktreePath, to: destination, errno: code
+            )
+        }
+        logger.debug("""
+        deletionQueue: enqueued \(worktreePath, privacy: .public) \
+        as \(destination, privacy: .public)
+        """)
+        return QueuedDeletion(path: destination, originalPath: worktreePath)
+    }
+
+    /// Entries awaiting reclamation in this pool, including ones a previous
+    /// daemon run left behind. `originalPath` is unknown for those, so it is
+    /// reported as the entry path itself.
+    public func pending(pool: String) -> [QueuedDeletion] {
+        let dir = queueDir(forPool: pool)
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: dir) else {
+            return []
+        }
+        return names.sorted().map { name in
+            let path = (dir as NSString).appendingPathComponent(name)
+            return QueuedDeletion(path: path, originalPath: path)
+        }
+    }
+
+    /// Reclaims one entry's bytes. Returns `true` when the entry is gone —
+    /// including when it was already gone, so a repeated sweep is a no-op
+    /// rather than a reported failure. A partially deleted entry is resumed on
+    /// the next call.
+    @discardableResult
+    public func drain(_ entry: QueuedDeletion) -> Bool {
+        guard FileManager.default.fileExists(atPath: entry.path) else { return true }
+        do {
+            try FileManager.default.removeItem(atPath: entry.path)
+            logger.debug("deletionQueue: drained \(entry.path, privacy: .public)")
+            return true
+        } catch {
+            logger.error("""
+            deletionQueue: drain of \(entry.path, privacy: .public) failed, \
+            will resume next sweep: \(error, privacy: .public)
+            """)
+            return false
+        }
+    }
+}

--- a/Sources/TBDDaemon/Lifecycle/WorktreeDeletionQueue.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeDeletionQueue.swift
@@ -130,8 +130,23 @@ public struct WorktreeDeletionQueue: Sendable {
     /// including when it was already gone, so a repeated sweep is a no-op
     /// rather than a reported failure. A partially deleted entry is resumed on
     /// the next call.
+    ///
+    /// Refuses any path that is not inside a `.deleting/` directory. Entries
+    /// normally come from `enqueue` or `pending`, both of which can only
+    /// produce queue paths — but `QueuedDeletion.init` is public, so this is a
+    /// recursive delete of a caller-supplied path, and the anchor check is the
+    /// same defense `ScratchpadCollector.cleanUp` puts in front of its own
+    /// `removeItem`. Returning `false` (not `true`) keeps the failure visible:
+    /// nothing was reclaimed.
     @discardableResult
     public func drain(_ entry: QueuedDeletion) -> Bool {
+        guard (entry.path as NSString).pathComponents.contains(Self.dirName) else {
+            logger.error("""
+            deletionQueue: refusing to drain \(entry.path, privacy: .public) — \
+            not inside a \(Self.dirName, privacy: .public) queue directory
+            """)
+            return false
+        }
         guard FileManager.default.fileExists(atPath: entry.path) else { return true }
         do {
             try FileManager.default.removeItem(atPath: entry.path)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeDeletionQueue.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeDeletionQueue.swift
@@ -1,8 +1,18 @@
 import Foundation
 import os
-import TBDShared
 
 private let logger = Logger(subsystem: "com.tbd.daemon", category: "deletionQueue")
+
+/// Thread-safe rendering of an errno value. `strerror(3)` returns a pointer
+/// into a shared static buffer and is not safe to call concurrently;
+/// `strerror_r(3)` fills a caller-owned buffer instead.
+private func describeErrno(_ code: Int32) -> String {
+    var buffer = [CChar](repeating: 0, count: 256)
+    if strerror_r(code, &buffer, buffer.count) == 0 {
+        return String(cString: buffer)
+    }
+    return "errno \(code)"
+}
 
 /// A worktree directory that has been renamed out of its pool slot and is
 /// waiting for its bytes to be reclaimed.
@@ -28,7 +38,7 @@ public enum WorktreeDeletionQueueError: Error, CustomStringConvertible, Equatabl
     public var description: String {
         switch self {
         case let .renameFailed(from, to, code):
-            return "rename(\(from) -> \(to)) failed: \(String(cString: strerror(code))) (errno \(code))"
+            return "rename(\(from) -> \(to)) failed: \(describeErrno(code)) (errno \(code))"
         }
     }
 }
@@ -54,7 +64,21 @@ public struct WorktreeDeletionQueue: Sendable {
     /// other dotfiles.
     public static let dirName = ".deleting"
 
-    public init() {}
+    /// The rename primitive `enqueue` calls. Defaults to the real `rename(2)`
+    /// syscall; tests substitute a stub to force specific `errno` values
+    /// (e.g. `EXDEV`) without needing two real filesystems, and to prove that
+    /// production really goes through the syscall rather than
+    /// `FileManager.moveItem`'s cross-filesystem copy-then-delete fallback.
+    private let renameItem: @Sendable (String, String) -> Int32
+
+    public init() {
+        self.renameItem = { rename($0, $1) }
+    }
+
+    /// Test seam: inject a stand-in for `rename(2)`.
+    init(renameItem: @escaping @Sendable (String, String) -> Int32) {
+        self.renameItem = renameItem
+    }
 
     public func queueDir(forPool pool: String) -> String {
         (pool as NSString).appendingPathComponent(Self.dirName)
@@ -75,7 +99,7 @@ public struct WorktreeDeletionQueue: Sendable {
         )
         let destination = (dir as NSString).appendingPathComponent(UUID().uuidString)
 
-        if rename(worktreePath, destination) != 0 {
+        if renameItem(worktreePath, destination) != 0 {
             let code = errno
             throw WorktreeDeletionQueueError.renameFailed(
                 from: worktreePath, to: destination, errno: code

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -159,15 +159,60 @@ extension WorktreeLifecycle {
             }
         }
 
-        // git worktree remove
-        try? await git.worktreeRemove(
-            repoPath: repo.path,
-            worktreePath: worktree.path
-        )
+        // Hand the directory to the deletion queue rather than removing it in
+        // place. `git worktree remove` must unlink every file, which for a
+        // dependency-heavy worktree runs past any subprocess deadline; when the
+        // deadline killed it, the result was a half-deleted directory that was
+        // still registered with git and still occupied its pool slot, while the
+        // row already read `.archived`. The rename is one syscall, so the
+        // archive completes regardless of tree size and the bytes are reclaimed
+        // afterwards with no clock attached.
+        var removed = false
+        do {
+            let queued = try deletionQueue.enqueue(worktreePath: worktree.path)
+            removed = true
 
-        // The directory is gone from disk — fire the event-driven scratchpad
-        // cleanup hook (Task 8) rather than waiting for the next hourly sweep.
-        if let onWorktreeRemoved {
+            // The directory no longer sits at the registered path, so git's
+            // administrative entry is stale — drop it. A failure here is
+            // logged, not fatal: the next GC sweep prunes.
+            do {
+                try await git.worktreePrune(repoPath: repo.path)
+            } catch {
+                archiveLogger.error("""
+                archive: prune failed for \(repo.path, privacy: .public) \
+                after queueing \(worktree.path, privacy: .public): \(error, privacy: .public)
+                """)
+            }
+
+            // Reclaim the bytes. `completeArchiveWorktree` is already invoked
+            // from a detached task, so this blocks nothing the caller awaits,
+            // and an interrupted drain leaves a queue entry the sweep finishes.
+            deletionQueue.drain(queued)
+        } catch {
+            archiveLogger.error("""
+            archive: could not queue \(worktree.path, privacy: .public) for deletion \
+            (\(error, privacy: .public)) — falling back to in-place removal
+            """)
+            do {
+                try await git.worktreeRemove(
+                    repoPath: repo.path,
+                    worktreePath: worktree.path,
+                    timeout: GitManager.worktreeRemoveFallbackTimeout
+                )
+                removed = !FileManager.default.fileExists(atPath: worktree.path)
+            } catch {
+                archiveLogger.error("""
+                archive: in-place removal of \(worktree.path, privacy: .public) \
+                also failed: \(error, privacy: .public) — the GC sweep will retry
+                """)
+            }
+        }
+
+        // Only claim the directory is gone when it actually is. This callback
+        // drives scratchpad reclamation, whose consumer previously had to
+        // re-check the path itself because this fired unconditionally after a
+        // swallowed failure.
+        if removed, let onWorktreeRemoved {
             await onWorktreeRemoved(worktree.path, repo.path)
         }
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -172,7 +172,12 @@ extension WorktreeLifecycle {
 
             // The directory no longer sits at the registered path, so git's
             // administrative entry is stale — drop it. A failure here is
-            // logged, not fatal: the next GC sweep prunes.
+            // logged, not fatal: the next GC sweep prunes, because
+            // `OrphanGC.pruneStaleRegistrations` looks for exactly this
+            // wreckage — an archived row whose directory is gone while git
+            // still lists a worktree at its path. Without that, a registration
+            // outliving its directory would be permanent, since revive's
+            // preflight refuses a path git still has registered.
             do {
                 try await git.worktreePrune(repoPath: repo.path)
             } catch {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -167,10 +167,8 @@ extension WorktreeLifecycle {
         // row already read `.archived`. The rename is one syscall, so the
         // archive completes regardless of tree size and the bytes are reclaimed
         // afterwards with no clock attached.
-        var removed = false
         do {
             let queued = try deletionQueue.enqueue(worktreePath: worktree.path)
-            removed = true
 
             // The directory no longer sits at the registered path, so git's
             // administrative entry is stale — drop it. A failure here is
@@ -184,9 +182,26 @@ extension WorktreeLifecycle {
                 """)
             }
 
-            // Reclaim the bytes. `completeArchiveWorktree` is already invoked
-            // from a detached task, so this blocks nothing the caller awaits,
-            // and an interrupted drain leaves a queue entry the sweep finishes.
+            // The rename above is the commit point (design spec "The commit
+            // point"): the directory has already left its pool slot, so the
+            // callback's precondition — the path is gone — holds here, before
+            // the bytes are actually reclaimed by the drain below. Firing now
+            // rather than after drain matches the design's ordering and keeps
+            // the event-driven scratchpad cleanup this callback exists to
+            // trigger prompt even when the drain that follows is slow.
+            if let onWorktreeRemoved {
+                await onWorktreeRemoved(worktree.path, repo.path)
+            }
+
+            // Reclaim the bytes inline, with no deadline attached. Every
+            // production caller that reaches this method through an RPC —
+            // `worktree.archive`, `repo.remove`'s cascade, and auto-archive on
+            // merge — invokes it from a detached task, so draining here blocks
+            // nothing an RPC is waiting on. The synchronous
+            // `archiveWorktree(worktreeID:force:)` wrapper (tests, and any
+            // future CLI use) deliberately blocks until the drain finishes —
+            // archive completion is meant to mean "the bytes are gone" there.
+            // An interrupted drain leaves a queue entry the GC sweep finishes.
             deletionQueue.drain(queued)
         } catch {
             archiveLogger.error("""
@@ -199,21 +214,20 @@ extension WorktreeLifecycle {
                     worktreePath: worktree.path,
                     timeout: GitManager.worktreeRemoveFallbackTimeout
                 )
-                removed = !FileManager.default.fileExists(atPath: worktree.path)
+                // Only claim the directory is gone when it actually is. This
+                // callback drives scratchpad reclamation, whose consumer
+                // previously had to re-check the path itself because this
+                // fired unconditionally after a swallowed failure.
+                let removed = !FileManager.default.fileExists(atPath: worktree.path)
+                if removed, let onWorktreeRemoved {
+                    await onWorktreeRemoved(worktree.path, repo.path)
+                }
             } catch {
                 archiveLogger.error("""
                 archive: in-place removal of \(worktree.path, privacy: .public) \
                 also failed: \(error, privacy: .public) — the GC sweep will retry
                 """)
             }
-        }
-
-        // Only claim the directory is gone when it actually is. This callback
-        // drives scratchpad reclamation, whose consumer previously had to
-        // re-check the path itself because this fired unconditionally after a
-        // swallowed failure.
-        if removed, let onWorktreeRemoved {
-            await onWorktreeRemoved(worktree.path, repo.path)
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -207,7 +207,10 @@ extension WorktreeLifecycle {
             // future CLI use) deliberately blocks until the drain finishes —
             // archive completion is meant to mean "the bytes are gone" there.
             // An interrupted drain leaves a queue entry the GC sweep finishes.
-            deletionQueue.drain(queued)
+            // The unlink itself runs on the queue's own serial dispatch queue,
+            // so a multi-minute removal neither holds a cooperative-pool
+            // thread nor races another archive's drain for the disk.
+            await deletionQueue.drain(queued)
         } catch {
             archiveLogger.error("""
             archive: could not queue \(worktree.path, privacy: .public) for deletion \

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -91,10 +91,13 @@ public struct WorktreeLifecycle: Sendable {
     /// Default `preSession` hook timeout (production value).
     public static let defaultPreSessionTimeout: TimeInterval = 600
 
-    /// Fired immediately after a worktree's directory is actually removed
-    /// from disk (`completeArchiveWorktree`'s `git.worktreeRemove`), with the
-    /// removed worktree's path and its owning repo's path (the archive
-    /// caller has `repo` in scope). `nil` by default (tests, older callers).
+    /// Fired once a worktree's directory has genuinely left its pool slot —
+    /// on the success path, right after `completeArchiveWorktree` renames it
+    /// into `WorktreeDeletionQueue` (bytes may still be draining); on the
+    /// fallback leg, only once `git.worktreeRemove` is verified to have
+    /// actually removed it from disk. Carries the removed worktree's path and
+    /// its owning repo's path (the archive caller has `repo` in scope). `nil`
+    /// by default (tests, older callers).
     /// `Daemon` wires this to
     /// `OrphanGC.scratchpadCleanup(forRemovedWorktreePath:repoPath:)` so the
     /// worktree's Claude Code scratchpad is reclaimed event-driven instead of

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle.swift
@@ -84,6 +84,9 @@ public struct WorktreeLifecycle: Sendable {
     /// so every copy of this struct shares one registry (same rationale as
     /// `conflictSweepCache`).
     public let preSessionRuns = PreSessionRunRegistry()
+    /// Where archived worktree directories go before their bytes are
+    /// reclaimed. See `WorktreeDeletionQueue`.
+    let deletionQueue = WorktreeDeletionQueue()
 
     /// Default `preSession` hook timeout (production value).
     public static let defaultPreSessionTimeout: TimeInterval = 600

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -1,5 +1,8 @@
 import Foundation
+import os
 import TBDShared
+
+private let repoLogger = Logger(subsystem: "com.tbd.daemon", category: "rpcRepo")
 
 extension RPCRouter {
 
@@ -75,76 +78,126 @@ extension RPCRouter {
         // Check for active worktrees
         let activeWorktrees = try await db.worktrees.list(repoID: repo.id, status: .active)
 
-        if !activeWorktrees.isEmpty {
-            if params.force {
-                // A forced removal tears down every active worktree's sessions,
-                // killing live windows the operator can see. One row per
-                // worktree, each naming that worktree with no terminal: the
-                // handler resolves the list itself and archives each through its
-                // own `archiveWorktree` call, so these are separate teardowns —
-                // the same reasoning that gives reconcile a row per act, and the
-                // same worktree-named shape `worktree.archive` uses for one.
-                //
-                // Every row is written BEFORE the first teardown, not
-                // interleaved. Fail-closed means an unrecordable act does not
-                // happen, and a cascade that stopped halfway would leave the
-                // repo half-dismantled; rowing the whole set first makes the
-                // refusal all-or-nothing, with the repo and every session it
-                // owns still standing.
-                // The edge that leaves: if an append throws partway through
-                // this loop, the rows already written stay unconfirmed and
-                // render that way — while nothing at all was torn down. That is
-                // the honest shape rather than a gap to repair. No refusal
-                // reason means "the record itself failed", and minting one here
-                // would grow the outcome contract for a case where the appends
-                // that carried it would very likely fail too — the log was
-                // unwritable one row ago.
-                var actuationIDs: [String] = []
-                for wt in activeWorktrees {
-                    actuationIDs.append(try await beginActuation(
-                        .repoRemove, actor: actor,
-                        target: ActuationTarget(worktree: wt.id.uuidString)))
-                }
+        guard !activeWorktrees.isEmpty else {
+            // Nothing to archive, so nothing to wait for: the removal finishes
+            // inline and this RPC returns with the rows already deleted and
+            // `.repoRemoved` already broadcast. Detaching here would only
+            // delay that announcement for no gain.
+            try await completeRepoRemoval(repo: repo)
+            return .ok()
+        }
 
-                // Cascade-archive all active worktrees. Two-phase, same split
-                // as `handleWorktreeArchive`: phase 1 (`beginArchiveWorktree`)
-                // is the throwing part — DB status flip, session capture,
-                // tmux teardown — and runs synchronously in this loop so the
-                // actuation bookkeeping below still applies to it. Phase 2
-                // (`completeArchiveWorktree` — hook + deletion-queue drain)
-                // never throws and can run for minutes on a large worktree,
-                // so it runs detached per worktree instead of being awaited
-                // here; otherwise this RPC would block on N unbounded drains.
-                for (index, wt) in activeWorktrees.enumerated() {
-                    let worktree: Worktree
-                    let wtRepo: Repo
-                    do {
-                        (worktree, wtRepo) = try await lifecycle.beginArchiveWorktree(worktreeID: wt.id, force: true)
-                    } catch {
-                        // The throw ends the cascade, so this row and every row
-                        // behind it names a teardown that did not happen. They
-                        // are confirmed as transport-failed together rather than
-                        // left unconfirmed, which the record would otherwise
-                        // read as an outcome that was merely lost.
-                        for pending in actuationIDs[index...] {
-                            await finishActuation(pending, .transportFailed, error: "\(error)")
-                        }
-                        throw error
-                    }
-                    await finishActuation(actuationIDs[index], .dispatched)
+        guard params.force else {
+            return RPCResponse(
+                error: "Repository has \(activeWorktrees.count) active worktree(s). Use force to archive them first."
+            )
+        }
 
-                    let lifecycle = self.lifecycle
-                    Task.detached {
-                        await lifecycle.completeArchiveWorktree(worktree: worktree, repo: wtRepo, force: true)
-                    }
+        // A forced removal tears down every active worktree's sessions,
+        // killing live windows the operator can see. One row per
+        // worktree, each naming that worktree with no terminal: the
+        // handler resolves the list itself and archives each through its
+        // own `archiveWorktree` call, so these are separate teardowns —
+        // the same reasoning that gives reconcile a row per act, and the
+        // same worktree-named shape `worktree.archive` uses for one.
+        //
+        // Every row is written BEFORE the first teardown, not
+        // interleaved. Fail-closed means an unrecordable act does not
+        // happen, and a cascade that stopped halfway would leave the
+        // repo half-dismantled; rowing the whole set first makes the
+        // refusal all-or-nothing, with the repo and every session it
+        // owns still standing.
+        // The edge that leaves: if an append throws partway through
+        // this loop, the rows already written stay unconfirmed and
+        // render that way — while nothing at all was torn down. That is
+        // the honest shape rather than a gap to repair. No refusal
+        // reason means "the record itself failed", and minting one here
+        // would grow the outcome contract for a case where the appends
+        // that carried it would very likely fail too — the log was
+        // unwritable one row ago.
+        var actuationIDs: [String] = []
+        for wt in activeWorktrees {
+            actuationIDs.append(try await beginActuation(
+                .repoRemove, actor: actor,
+                target: ActuationTarget(worktree: wt.id.uuidString)))
+        }
+
+        // Cascade-archive all active worktrees. Two-phase, same split
+        // as `handleWorktreeArchive`: phase 1 (`beginArchiveWorktree`)
+        // is the throwing part — DB status flip, session capture,
+        // tmux teardown — and runs synchronously in this loop so the
+        // actuation bookkeeping below still applies to it, and so a
+        // failure still reaches this RPC's caller. Phase 2
+        // (`completeArchiveWorktree` — hook + deletion-queue drain)
+        // never throws and can run for minutes on a large worktree, so
+        // it is collected here and run by the detached tail below;
+        // otherwise this RPC would block on N unbounded drains.
+        var pendingCompletions: [(worktree: Worktree, repo: Repo)] = []
+        for (index, wt) in activeWorktrees.enumerated() {
+            let worktree: Worktree
+            let wtRepo: Repo
+            do {
+                (worktree, wtRepo) = try await lifecycle.beginArchiveWorktree(worktreeID: wt.id, force: true)
+            } catch {
+                // The throw ends the cascade, so this row and every row
+                // behind it names a teardown that did not happen. They
+                // are confirmed as transport-failed together rather than
+                // left unconfirmed, which the record would otherwise
+                // read as an outcome that was merely lost.
+                for pending in actuationIDs[index...] {
+                    await finishActuation(pending, .transportFailed, error: "\(error)")
                 }
-            } else {
-                return RPCResponse(
-                    error: "Repository has \(activeWorktrees.count) active worktree(s). Use force to archive them first."
-                )
+                throw error
+            }
+            await finishActuation(actuationIDs[index], .dispatched)
+            pendingCompletions.append((worktree, wtRepo))
+        }
+
+        // The whole cleanup tail is detached, not just the completions,
+        // because the row deletions below it must not overtake them —
+        // see `completeRepoRemoval` for why rows have to outlive their
+        // directories. Completions run one at a time: a background
+        // reclaim that saturates the developer's disk competes with
+        // whatever they are doing, and nothing waits on the queue
+        // draining quickly (design doc, "`WorktreeDeletionQueue`").
+        Task.detached { [self] in
+            for pending in pendingCompletions {
+                await self.lifecycle.completeArchiveWorktree(
+                    worktree: pending.worktree, repo: pending.repo, force: true)
+            }
+            do {
+                try await self.completeRepoRemoval(repo: repo)
+            } catch {
+                // Nothing is left to return this to: the RPC answered when
+                // phase 1 finished. Log rather than swallow — the repo row
+                // survives, so the next sweep still sees the leftovers.
+                repoLogger.error("""
+                repo.remove: cleanup after cascade failed for \
+                \(repo.path, privacy: .public): \(error, privacy: .public)
+                """)
             }
         }
 
+        return .ok()
+    }
+
+    /// Everything `repo.remove` does once its worktrees have been dealt with:
+    /// reclaim scratchpads while the rows can still resolve them, delete the
+    /// worktree rows, delete the repo, announce it.
+    ///
+    /// Split out because the cascade path must run it only after every
+    /// `completeArchiveWorktree` has returned. Rows have to outlive
+    /// directories: `OrphanGC` builds its pool scan from `db.repos.list()`
+    /// and `db.worktrees.list(status: .archived)`, so a directory — or a
+    /// `.deleting/` entry — left behind by an interrupted drain is invisible
+    /// to every later sweep once its rows are gone. Deleting the rows while
+    /// drains are still in flight would reintroduce exactly the permanently
+    /// unreclaimable leftover this deletion queue exists to eliminate, in the
+    /// highest-concurrency caller there is.
+    ///
+    /// Throws so the no-cascade path can still surface a DB failure to the
+    /// RPC caller; the cascade path runs it detached and logs instead.
+    private func completeRepoRemoval(repo: Repo) async throws {
         // Reclaim scratchpads for EVERY worktree row this repo owns (every
         // status, including archived) before the rows below vanish — once
         // they're gone, reconciliation has no path left to resolve them by.
@@ -153,13 +206,11 @@ extension RPCRouter {
         }
 
         // Delete any remaining worktrees (e.g. main worktree) for this repo
-        try await db.worktrees.deleteForRepo(repoID: params.repoID)
+        try await db.worktrees.deleteForRepo(repoID: repo.id)
 
-        try await db.repos.remove(id: params.repoID)
+        try await db.repos.remove(id: repo.id)
 
-        subscriptions.broadcast(delta: .repoRemoved(RepoIDDelta(repoID: params.repoID)))
-
-        return .ok()
+        subscriptions.broadcast(delta: .repoRemoved(RepoIDDelta(repoID: repo.id)))
     }
 
     func handleRepoList() async throws -> RPCResponse {

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -106,10 +106,20 @@ extension RPCRouter {
                         target: ActuationTarget(worktree: wt.id.uuidString)))
                 }
 
-                // Cascade-archive all active worktrees
+                // Cascade-archive all active worktrees. Two-phase, same split
+                // as `handleWorktreeArchive`: phase 1 (`beginArchiveWorktree`)
+                // is the throwing part — DB status flip, session capture,
+                // tmux teardown — and runs synchronously in this loop so the
+                // actuation bookkeeping below still applies to it. Phase 2
+                // (`completeArchiveWorktree` — hook + deletion-queue drain)
+                // never throws and can run for minutes on a large worktree,
+                // so it runs detached per worktree instead of being awaited
+                // here; otherwise this RPC would block on N unbounded drains.
                 for (index, wt) in activeWorktrees.enumerated() {
+                    let worktree: Worktree
+                    let wtRepo: Repo
                     do {
-                        try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
+                        (worktree, wtRepo) = try await lifecycle.beginArchiveWorktree(worktreeID: wt.id, force: true)
                     } catch {
                         // The throw ends the cascade, so this row and every row
                         // behind it names a teardown that did not happen. They
@@ -122,6 +132,11 @@ extension RPCRouter {
                         throw error
                     }
                     await finishActuation(actuationIDs[index], .dispatched)
+
+                    let lifecycle = self.lifecycle
+                    Task.detached {
+                        await lifecycle.completeArchiveWorktree(worktree: worktree, repo: wtRepo, force: true)
+                    }
                 }
             } else {
                 return RPCResponse(

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -1143,7 +1143,13 @@ public struct TerminalHistoryEntry: Codable, Sendable, Identifiable, Equatable {
 }
 
 /// Kind of reaped directory a `ReapRecord` describes.
-public enum ReapKind: String, Codable, Sendable { case agentWorktree, scratchpad }
+public enum ReapKind: String, Codable, Sendable {
+    case agentWorktree
+    case scratchpad
+    /// A TBD worktree directory reclaimed after its archive failed to remove
+    /// it, or drained from a pool's `.deleting/` queue.
+    case archivedWorktree
+}
 
 /// Record of a directory the daemon-owned orphan GC swept and (optionally)
 /// snapshotted before removal. Persisted so a swept worktree/scratchpad can

--- a/Tests/TBDAppTests/ReapRecordsStateTests.swift
+++ b/Tests/TBDAppTests/ReapRecordsStateTests.swift
@@ -111,6 +111,40 @@ struct ReapRecordsStateTests {
         #expect(rollup?.bytes == 500)
     }
 
+    @Test func archivedWorktreeRollupNilWhenNoArchivedWorktrees() {
+        let summary = ReclaimedSummary(records: [record(kind: .agentWorktree, apparentBytes: 10)])
+        #expect(summary.archivedWorktreeRollup == nil)
+    }
+
+    @Test func archivedWorktreeRollupAggregatesCountAndBytes() {
+        let records = [
+            record(kind: .archivedWorktree, apparentBytes: 300),
+            record(kind: .archivedWorktree, apparentBytes: nil),
+            record(kind: .archivedWorktree, apparentBytes: 200),
+            record(kind: .agentWorktree, apparentBytes: 9_999),
+            record(kind: .scratchpad, apparentBytes: 1),
+        ]
+        let summary = ReclaimedSummary(records: records)
+        let rollup = summary.archivedWorktreeRollup
+        #expect(rollup?.count == 3)
+        #expect(rollup?.bytes == 500)
+    }
+
+    @Test func archivedWorktreeRecordsCountTowardHeaderTotalsButNotAgentRecords() {
+        // The gap the review caught: `.archivedWorktree` records must
+        // contribute to `count` / `totalApparentBytes` (the header) exactly
+        // like every other kind, but must NOT appear in `agentRecords` (the
+        // per-row restorable list) — they render via the rollup instead.
+        let records = [
+            record(kind: .archivedWorktree, apparentBytes: 700),
+            record(kind: .agentWorktree, worktreePath: "/tmp/agent", apparentBytes: 300),
+        ]
+        let summary = ReclaimedSummary(records: records)
+        #expect(summary.count == 2)
+        #expect(summary.totalApparentBytes == 1_000)
+        #expect(summary.agentRecords.map(\.worktreePath) == ["/tmp/agent"])
+    }
+
     @Test func unrestoredExcludesRestoredRecordsFromCountAndBytes() {
         let restored = record(kind: .agentWorktree, apparentBytes: 1_000, restoredAt: Date())
         let live = record(kind: .agentWorktree, apparentBytes: 500)

--- a/Tests/TBDDaemonTests/DeletionQueueCollectorTests.swift
+++ b/Tests/TBDDaemonTests/DeletionQueueCollectorTests.swift
@@ -1,0 +1,173 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+import TestSupport
+
+@Suite("DeletionQueueCollector")
+struct DeletionQueueCollectorTests {
+
+    private func makeCollector() -> DeletionQueueCollector {
+        DeletionQueueCollector(git: GitManager())
+    }
+
+    /// A real linked worktree at `<pool>/<name>` where `<pool>` is treated as
+    /// a TBD-owned prefix. Returns (tmp, repoPath, pool, worktreePath).
+    private func makeLinkedWorktree(
+        name: String = "wt"
+    ) async throws -> (tmp: URL, repo: String, pool: String, worktree: String) {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        let pool = tmp.appendingPathComponent("pool").path
+        try FileManager.default.createDirectory(atPath: pool, withIntermediateDirectories: true)
+        let wt = (pool as NSString).appendingPathComponent(name)
+        try await shell("git worktree add \(wt) -b \(name)", at: repo)
+        return (tmp, repo.path, pool, wt)
+    }
+
+    // MARK: - Provenance gate
+
+    @Test func reapsAnArchivedLinkedWorktreeInsideATBDPrefix() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: f.worktree,
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: []) == .reap)
+    }
+
+    @Test func keepsALockedWorktree() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // The user locked it deliberately; that outranks every other signal.
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: f.worktree,
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: true
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: [])
+                == .keep(reason: "locked"))
+    }
+
+    @Test func keepsAWorktreeOutsideEveryTBDPrefix() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // An adopted worktree can live anywhere; TBD did not create it and
+        // must never reclaim it.
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: f.worktree,
+            repoPath: f.repo, allowedPrefixes: ["/some/other/pool"], locked: false
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: [])
+                == .keep(reason: "not-tbd-prefix"))
+    }
+
+    @Test func keepsADirectoryThatIsNotALinkedWorktreeOfItsRepo() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // A plain directory sitting in the pool: right place, no linkage proof.
+        let decoy = (f.pool as NSString).appendingPathComponent("decoy")
+        try FileManager.default.createDirectory(atPath: decoy, withIntermediateDirectories: true)
+
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: decoy,
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: [])
+                == .keep(reason: "not-linked"))
+    }
+
+    @Test func keepsARepolessCandidateOutsideTheScratchPrefix() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // repoPath nil means scratch, and scratch is only ever under the
+        // scratch prefix. Anything else is unprovable.
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: f.worktree,
+            repoPath: nil, allowedPrefixes: [f.pool], locked: false
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: [])
+                == .keep(reason: "no-repo"))
+    }
+
+    @Test func keepsAWorktreeWithALiveProcessInside() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: f.worktree,
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: [f.worktree + "/src"])
+                == .keep(reason: "live-cwd"))
+    }
+
+    // MARK: - Candidate enumeration
+
+    @Test func interruptedArchivesSelectsOnlyArchivedRowsWhoseDirectoryExists() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        let repoID = UUID()
+        // `Worktree.init` requires `displayName` and `tmuxServer`; neither has
+        // a default. Keep every field the collector reads explicit.
+        func row(name: String, path: String, status: WorktreeStatus) -> Worktree {
+            Worktree(
+                id: UUID(), repoID: repoID, name: name, displayName: name,
+                branch: name, path: path, status: status, tmuxServer: "tbd-test"
+            )
+        }
+        let present = row(name: "present", path: f.worktree, status: .archived)
+        let vanished = row(name: "gone", path: f.pool + "/gone", status: .archived)
+        let active = row(name: "active", path: f.worktree, status: .active)
+
+        let found = await makeCollector().interruptedArchives(
+            worktrees: [present, vanished, active],
+            repoPathByID: [repoID: f.repo],
+            prefixesByRepoID: [repoID: [f.pool]],
+            scratchPrefix: "/nonexistent-scratch"
+        )
+        #expect(found.map(\.path) == [f.worktree])
+    }
+
+    @Test func aForgottenWorktreeIsNeverACandidate() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // `forgetWorktree` hard-deletes the row rather than flipping it to
+        // `.archived`, precisely so a directory the user chose to keep cannot
+        // be reclaimed. With no row, the directory is invisible here however
+        // TBD-shaped its path looks.
+        let found = await makeCollector().interruptedArchives(
+            worktrees: [],
+            repoPathByID: [UUID(): f.repo],
+            prefixesByRepoID: [:],
+            scratchPrefix: "/nonexistent-scratch"
+        )
+        #expect(found.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: f.worktree))
+    }
+
+    // MARK: - Reap
+
+    @Test func reapMovesTheDirectoryIntoTheQueueAndReturnsTheEntry() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: f.worktree,
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false
+        )
+        let entry = await makeCollector().reap(candidate)
+
+        #expect(entry != nil)
+        #expect(!FileManager.default.fileExists(atPath: f.worktree))
+        // Registration dropped too, so nothing re-adopts it.
+        let registered = try await GitManager().worktreeList(repoPath: f.repo)
+        #expect(!registered.contains { $0.path == f.worktree })
+    }
+}

--- a/Tests/TBDDaemonTests/DeletionQueueCollectorTests.swift
+++ b/Tests/TBDDaemonTests/DeletionQueueCollectorTests.swift
@@ -140,16 +140,36 @@ struct DeletionQueueCollectorTests {
 
         // `forgetWorktree` hard-deletes the row rather than flipping it to
         // `.archived`, precisely so a directory the user chose to keep cannot
-        // be reclaimed. With no row, the directory is invisible here however
-        // TBD-shaped its path looks.
+        // be reclaimed. `f.worktree` is TBD-shaped in every way this
+        // collector can check on disk — inside a TBD-owned prefix, a real
+        // linked worktree of `f.repo` — so if `interruptedArchives` ever
+        // stopped filtering on row presence (e.g. started enumerating the
+        // prefix directly instead of walking `worktrees:`), this directory
+        // is exactly what it would wrongly pick up. With no row for it, it
+        // must never appear, however TBD-shaped its path looks.
+        let repoID = UUID()
         let found = await makeCollector().interruptedArchives(
             worktrees: [],
-            repoPathByID: [UUID(): f.repo],
-            prefixesByRepoID: [:],
+            repoPathByID: [repoID: f.repo],
+            prefixesByRepoID: [repoID: [f.pool]],
             scratchPrefix: "/nonexistent-scratch"
         )
         #expect(found.isEmpty)
         #expect(FileManager.default.fileExists(atPath: f.worktree))
+    }
+
+    // MARK: - Path resolution
+
+    @Test func resolvedPathReturnsPromptlyForANonAbsolutePath() {
+        // The walk-up loop climbs `deletingLastPathComponent` until it hits
+        // `"/"`. For a relative path that never happens — `""` deletes its
+        // last component to `""` forever — so a non-absolute input must be
+        // rejected up front rather than fed into the loop. Without that
+        // guard this call hangs the calling thread indefinitely, which
+        // inside a background sweep means hanging the daemon; this test's
+        // whole point is that the call returns at all.
+        let result = makeCollector().resolvedPath("relative/path")
+        #expect(result == "relative/path")
     }
 
     // MARK: - Reap

--- a/Tests/TBDDaemonTests/DeletionQueueCollectorTests.swift
+++ b/Tests/TBDDaemonTests/DeletionQueueCollectorTests.swift
@@ -7,8 +7,13 @@ import TestSupport
 @Suite("DeletionQueueCollector")
 struct DeletionQueueCollectorTests {
 
-    private func makeCollector() -> DeletionQueueCollector {
-        DeletionQueueCollector(git: GitManager())
+    /// Every gate except `grace` is independent of the clock, so the default
+    /// collector pins `now` to a fixed instant and the grace tests pass their
+    /// own. `graceSeconds: 0` in a test means "the grace gate cannot fire".
+    private static let fixedNow = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func makeCollector(now: Date = fixedNow) -> DeletionQueueCollector {
+        DeletionQueueCollector(git: GitManager(), now: { now })
     }
 
     /// A real linked worktree at `<pool>/<name>` where `<pool>` is treated as
@@ -24,17 +29,34 @@ struct DeletionQueueCollectorTests {
         return (tmp, repo.path, pool, wt)
     }
 
+    /// `Worktree.init` requires `displayName` and `tmuxServer`; neither has a
+    /// default. Keeps every field the collector reads explicit.
+    private func row(
+        repoID: UUID?, name: String, path: String,
+        status: WorktreeStatus = .archived, archivedAt: Date? = nil
+    ) -> Worktree {
+        Worktree(
+            id: UUID(), repoID: repoID, name: name, displayName: name,
+            branch: name, path: path, status: status,
+            archivedAt: archivedAt, tmuxServer: "tbd-test"
+        )
+    }
+
     // MARK: - Provenance gate
 
     @Test func reapsAnArchivedLinkedWorktreeInsideATBDPrefix() async throws {
         let f = try await makeLinkedWorktree()
         defer { try? FileManager.default.removeItem(at: f.tmp) }
 
+        // `archivedAt` nil with a wide grace window on purpose: an unstamped
+        // row must NOT be held by the grace gate (see `decide`), or every
+        // pre-stamp leftover would become permanently unreclaimable.
         let candidate = InterruptedArchive(
             worktreeID: UUID(), path: f.worktree,
-            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false,
+            archivedAt: nil
         )
-        #expect(await makeCollector().decide(candidate, liveCWDs: []) == .reap)
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 86400) == .reap)
     }
 
     @Test func keepsALockedWorktree() async throws {
@@ -46,8 +68,39 @@ struct DeletionQueueCollectorTests {
             worktreeID: UUID(), path: f.worktree,
             repoPath: f.repo, allowedPrefixes: [f.pool], locked: true
         )
-        #expect(await makeCollector().decide(candidate, liveCWDs: [])
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 0)
                 == .keep(reason: "locked"))
+    }
+
+    @Test func keepsACandidateArchivedInsideTheGraceWindow() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // The shape of an archive still in phase 2: the row already reads
+        // `.archived` (phase 1 flipped it) while the archive hook is still
+        // running and the rename has not happened yet. Reaping here would
+        // rename the directory out from under that hook.
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: f.worktree,
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false,
+            archivedAt: Self.fixedNow.addingTimeInterval(-30)
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 3600)
+                == .keep(reason: "grace"))
+    }
+
+    @Test func reapsACandidateArchivedBeforeTheGraceWindow() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // Same fixture, same stamped row — only older than the window. The
+        // grace gate must delay a reclaim, never prevent one.
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: f.worktree,
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false,
+            archivedAt: Self.fixedNow.addingTimeInterval(-7200)
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 3600) == .reap)
     }
 
     @Test func keepsAWorktreeOutsideEveryTBDPrefix() async throws {
@@ -60,8 +113,33 @@ struct DeletionQueueCollectorTests {
             worktreeID: UUID(), path: f.worktree,
             repoPath: f.repo, allowedPrefixes: ["/some/other/pool"], locked: false
         )
-        #expect(await makeCollector().decide(candidate, liveCWDs: [])
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 0)
                 == .keep(reason: "not-tbd-prefix"))
+    }
+
+    @Test func keepsASymlinkPlantedInsideAPoolThatPointsOutsideIt() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // The authorization boundary this gate exists for. A path that merely
+        // *reads* as TBD-owned is not proof: anyone who can write into a pool
+        // (or a row that names such a path) could otherwise point the sweep's
+        // recursive delete at an arbitrary directory. `resolvedPath` runs both
+        // sides through `realpath(3)` precisely so the comparison is made on
+        // where the path lands, not on how it spells.
+        let outside = f.tmp.appendingPathComponent("outside").path
+        try FileManager.default.createDirectory(atPath: outside, withIntermediateDirectories: true)
+        try "precious".write(toFile: outside + "/keepme.txt", atomically: true, encoding: .utf8)
+        let evil = (f.pool as NSString).appendingPathComponent("evil")
+        try FileManager.default.createSymbolicLink(atPath: evil, withDestinationPath: outside)
+
+        let candidate = InterruptedArchive(
+            worktreeID: UUID(), path: evil,
+            repoPath: f.repo, allowedPrefixes: [f.pool], locked: false
+        )
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 0)
+                == .keep(reason: "not-tbd-prefix"))
+        #expect(FileManager.default.fileExists(atPath: outside + "/keepme.txt"))
     }
 
     @Test func keepsADirectoryThatIsNotALinkedWorktreeOfItsRepo() async throws {
@@ -76,22 +154,37 @@ struct DeletionQueueCollectorTests {
             worktreeID: UUID(), path: decoy,
             repoPath: f.repo, allowedPrefixes: [f.pool], locked: false
         )
-        #expect(await makeCollector().decide(candidate, liveCWDs: [])
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 0)
                 == .keep(reason: "not-linked"))
     }
 
-    @Test func keepsARepolessCandidateOutsideTheScratchPrefix() async throws {
-        let f = try await makeLinkedWorktree()
-        defer { try? FileManager.default.removeItem(at: f.tmp) }
+    @Test func anArchivedScratchSpaceKeepsItsFolder() async throws {
+        let (tmp, _) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
 
-        // repoPath nil means scratch, and scratch is only ever under the
-        // scratch prefix. Anything else is unprovable.
+        // `scratch.archive` flips the row to `.archived` and leaves the folder
+        // on disk — unlike `scratch.delete`, nothing goes to Trash — and
+        // `scratch.revive` needs that folder. So an archived scratch row whose
+        // directory exists is a normal, supported, user-chosen state, and
+        // reaping on it would delete every archived scratch space on the
+        // machine.
+        //
+        // The fixture sits SQUARELY INSIDE its allowed prefix and passes every
+        // other gate, so the assertion can only land on the repoless branch:
+        // were that branch changed to reap, this test goes red.
+        let scratchPrefix = tmp.appendingPathComponent("scratch").path
+        let space = (scratchPrefix as NSString).appendingPathComponent("my-notes")
+        try FileManager.default.createDirectory(atPath: space, withIntermediateDirectories: true)
+        try "notes".write(toFile: space + "/notes.md", atomically: true, encoding: .utf8)
+
         let candidate = InterruptedArchive(
-            worktreeID: UUID(), path: f.worktree,
-            repoPath: nil, allowedPrefixes: [f.pool], locked: false
+            worktreeID: UUID(), path: space,
+            repoPath: nil, allowedPrefixes: [scratchPrefix], locked: false,
+            archivedAt: Self.fixedNow.addingTimeInterval(-86400)
         )
-        #expect(await makeCollector().decide(candidate, liveCWDs: [])
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 3600)
                 == .keep(reason: "no-repo"))
+        #expect(FileManager.default.fileExists(atPath: space + "/notes.md"))
     }
 
     @Test func keepsAWorktreeWithALiveProcessInside() async throws {
@@ -102,8 +195,9 @@ struct DeletionQueueCollectorTests {
             worktreeID: UUID(), path: f.worktree,
             repoPath: f.repo, allowedPrefixes: [f.pool], locked: false
         )
-        #expect(await makeCollector().decide(candidate, liveCWDs: [f.worktree + "/src"])
-                == .keep(reason: "live-cwd"))
+        #expect(await makeCollector().decide(
+            candidate, liveCWDs: [f.worktree + "/src"], graceSeconds: 0
+        ) == .keep(reason: "live-cwd"))
     }
 
     // MARK: - Candidate enumeration
@@ -113,17 +207,9 @@ struct DeletionQueueCollectorTests {
         defer { try? FileManager.default.removeItem(at: f.tmp) }
 
         let repoID = UUID()
-        // `Worktree.init` requires `displayName` and `tmuxServer`; neither has
-        // a default. Keep every field the collector reads explicit.
-        func row(name: String, path: String, status: WorktreeStatus) -> Worktree {
-            Worktree(
-                id: UUID(), repoID: repoID, name: name, displayName: name,
-                branch: name, path: path, status: status, tmuxServer: "tbd-test"
-            )
-        }
-        let present = row(name: "present", path: f.worktree, status: .archived)
-        let vanished = row(name: "gone", path: f.pool + "/gone", status: .archived)
-        let active = row(name: "active", path: f.worktree, status: .active)
+        let present = row(repoID: repoID, name: "present", path: f.worktree)
+        let vanished = row(repoID: repoID, name: "gone", path: f.pool + "/gone")
+        let active = row(repoID: repoID, name: "active", path: f.worktree, status: .active)
 
         let found = await makeCollector().interruptedArchives(
             worktrees: [present, vanished, active],
@@ -132,6 +218,68 @@ struct DeletionQueueCollectorTests {
             scratchPrefix: "/nonexistent-scratch"
         )
         #expect(found.map(\.path) == [f.worktree])
+    }
+
+    @Test func interruptedArchivesCarriesTheRowsArchivedAt() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // The grace gate is only as good as the timestamp reaching it: a
+        // candidate built without `archivedAt` would read as unstamped and
+        // skip the gate entirely.
+        let repoID = UUID()
+        let stamp = Self.fixedNow.addingTimeInterval(-42)
+        let found = await makeCollector().interruptedArchives(
+            worktrees: [row(repoID: repoID, name: "wt", path: f.worktree, archivedAt: stamp)],
+            repoPathByID: [repoID: f.repo],
+            prefixesByRepoID: [repoID: [f.pool]],
+            scratchPrefix: "/nonexistent-scratch"
+        )
+        #expect(found.first?.archivedAt == stamp)
+    }
+
+    @Test func aGitLockedWorktreeIsDerivedAsLocked() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // `locked` is DERIVED from `git worktree list --porcelain`, not handed
+        // in — a hand-built `InterruptedArchive(locked: true)` proves only
+        // that `decide` reads the field. This proves the field gets set.
+        try await shell("git worktree lock \(f.worktree)", at: URL(fileURLWithPath: f.repo))
+
+        let repoID = UUID()
+        let found = await makeCollector().interruptedArchives(
+            worktrees: [row(repoID: repoID, name: "wt", path: f.worktree)],
+            repoPathByID: [repoID: f.repo],
+            prefixesByRepoID: [repoID: [f.pool]],
+            scratchPrefix: "/nonexistent-scratch"
+        )
+        let candidate = try #require(found.first)
+        #expect(candidate.locked)
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 0)
+                == .keep(reason: "locked"))
+    }
+
+    @Test func aRepoWhoseListingFailsMakesItsCandidatesReadAsLocked() async throws {
+        let f = try await makeLinkedWorktree()
+        defer { try? FileManager.default.removeItem(at: f.tmp) }
+
+        // A listing failure must never read as "nothing is locked": the sweep
+        // would then reclaim directories whose lock state it never learned.
+        let notARepo = f.tmp.appendingPathComponent("not-a-repo").path
+        try FileManager.default.createDirectory(atPath: notARepo, withIntermediateDirectories: true)
+
+        let repoID = UUID()
+        let found = await makeCollector().interruptedArchives(
+            worktrees: [row(repoID: repoID, name: "wt", path: f.worktree)],
+            repoPathByID: [repoID: notARepo],
+            prefixesByRepoID: [repoID: [f.pool]],
+            scratchPrefix: "/nonexistent-scratch"
+        )
+        let candidate = try #require(found.first)
+        #expect(candidate.locked)
+        #expect(await makeCollector().decide(candidate, liveCWDs: [], graceSeconds: 0)
+                == .keep(reason: "locked"))
     }
 
     @Test func aForgottenWorktreeIsNeverACandidate() async throws {
@@ -144,17 +292,24 @@ struct DeletionQueueCollectorTests {
         // collector can check on disk — inside a TBD-owned prefix, a real
         // linked worktree of `f.repo` — so if `interruptedArchives` ever
         // stopped filtering on row presence (e.g. started enumerating the
-        // prefix directly instead of walking `worktrees:`), this directory
-        // is exactly what it would wrongly pick up. With no row for it, it
-        // must never appear, however TBD-shaped its path looks.
+        // prefix directly instead of walking `worktrees:`), this directory is
+        // exactly what it would wrongly pick up.
+        //
+        // A SECOND, archived worktree shares the pool so the call is not
+        // vacuous: the row filter has something to return, and the assertion
+        // is that it returns that one and only that one. Passing an empty
+        // `worktrees:` would assert nothing but `[].isEmpty`.
+        let archivedPath = (f.pool as NSString).appendingPathComponent("archived")
+        try await shell("git worktree add \(archivedPath) -b archived", at: URL(fileURLWithPath: f.repo))
+
         let repoID = UUID()
         let found = await makeCollector().interruptedArchives(
-            worktrees: [],
+            worktrees: [row(repoID: repoID, name: "archived", path: archivedPath)],
             repoPathByID: [repoID: f.repo],
             prefixesByRepoID: [repoID: [f.pool]],
             scratchPrefix: "/nonexistent-scratch"
         )
-        #expect(found.isEmpty)
+        #expect(found.map(\.path) == [archivedPath])
         #expect(FileManager.default.fileExists(atPath: f.worktree))
     }
 

--- a/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
@@ -18,14 +18,16 @@ private final class BroadcastDeltas: @unchecked Sendable {
 struct OrphanGCDeletionQueueTests {
 
     private func makeGC(
-        db: TBDDatabase, git: GitManager = GitManager(), now: @escaping @Sendable () -> Date = { Date() }
+        db: TBDDatabase, git: GitManager = GitManager(), now: @escaping @Sendable () -> Date = { Date() },
+        beforeInterruptedArchiveReap: (@Sendable () async -> Void)? = nil
     ) -> OrphanGC {
         OrphanGC(
             db: db, git: git,
             broadcast: { _ in },
-            lsofProvider: { [] },
+            liveCWDsProvider: { [] },
             scratchpadBase: nil,
-            now: now
+            now: now,
+            beforeInterruptedArchiveReap: beforeInterruptedArchiveReap
         )
     }
 
@@ -306,6 +308,62 @@ struct OrphanGCDeletionQueueTests {
         // adopted worktree itself is still outside every TBD prefix.
         #expect(FileManager.default.fileExists(atPath: path))
         #expect(result.planned.contains("KEEP not-tbd-prefix \(path)"))
+    }
+
+    /// `forgetWorktree` hard-deletes the row and promises the directory stays
+    /// where it is. The sweep snapshots archived rows once and acts on them
+    /// later, so a forget landing in that window would otherwise still have
+    /// its directory reaped. The pre-reap re-read closes it.
+    @Test func sweepSkipsACandidateWhoseRowWasForgottenMidSweep() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+        let path = try await makeInterruptedArchive(
+            db: db, repo: repo, repoID: repoRow.id, name: "forgotten")
+        let wtID = try #require(
+            (try await db.worktrees.list(status: .archived)).first { $0.path == path }?.id)
+
+        // Interleaved exactly where the race lives: after the candidate list
+        // was built, before anything is reaped.
+        let gc = makeGC(db: db, beforeInterruptedArchiveReap: {
+            try? await db.worktrees.delete(id: wtID)
+        })
+        let result = await gc.sweep()
+
+        #expect(FileManager.default.fileExists(atPath: path),
+                "forget promises the directory stays put — the sweep must not reap it")
+        #expect(result.planned.contains("KEEP row-changed \(path)"))
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+    }
+
+    /// The same window, entered through the other door: the row survives but
+    /// is no longer `.archived` (a revive that landed mid-sweep). Reaping then
+    /// would rename a live worktree's directory out from under it.
+    @Test func sweepSkipsACandidateRevivedMidSweep() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+        let path = try await makeInterruptedArchive(
+            db: db, repo: repo, repoID: repoRow.id, name: "revived")
+        let wtID = try #require(
+            (try await db.worktrees.list(status: .archived)).first { $0.path == path }?.id)
+
+        let gc = makeGC(db: db, beforeInterruptedArchiveReap: {
+            try? await db.worktrees.updateStatus(id: wtID, status: .active)
+        })
+        let result = await gc.sweep()
+
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(result.planned.contains("KEEP row-changed \(path)"))
     }
 
     @Test func sweepDoesNothingWhenGCDisabled() async throws {

--- a/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
@@ -17,21 +17,32 @@ private final class BroadcastDeltas: @unchecked Sendable {
 @Suite("OrphanGC reclaims the deletion queue")
 struct OrphanGCDeletionQueueTests {
 
-    private func makeGC(db: TBDDatabase, git: GitManager = GitManager()) -> OrphanGC {
+    private func makeGC(
+        db: TBDDatabase, git: GitManager = GitManager(), now: @escaping @Sendable () -> Date = { Date() }
+    ) -> OrphanGC {
         OrphanGC(
             db: db, git: git,
             broadcast: { _ in },
             lsofProvider: { [] },
             scratchpadBase: nil,
-            now: { Date() }
+            now: now
         )
     }
 
     /// A real linked worktree at `<repo>/.tbd/worktrees/<name>` with an
     /// `.archived` row pointing at it — the shape a pre-queue archive left
     /// behind when its removal was killed partway.
+    ///
+    /// `stampArchivedAt` picks which of the two archived-row shapes the
+    /// fixture wears. `false` uses `updateStatus`, leaving `archivedAt` nil —
+    /// the pre-stamp leftover the grace gate deliberately does not hold.
+    /// `true` goes through `WorktreeStore.archive`, which stamps the row
+    /// `now`, so the grace window applies and the caller controls whether the
+    /// sweep sees it as recent by choosing the GC's `now`.
+    @discardableResult
     private func makeInterruptedArchive(
-        db: TBDDatabase, repo: URL, repoID: UUID, name: String
+        db: TBDDatabase, repo: URL, repoID: UUID, name: String,
+        stampArchivedAt: Bool = false
     ) async throws -> String {
         try await shell("mkdir -p .tbd/worktrees", at: repo)
         try await shell("git worktree add .tbd/worktrees/\(name) -b \(name)", at: repo)
@@ -40,7 +51,11 @@ struct OrphanGCDeletionQueueTests {
             repoID: repoID, name: name, branch: name,
             path: path, tmuxServer: "tbd-test"
         )
-        try await db.worktrees.updateStatus(id: wt.id, status: .archived)
+        if stampArchivedAt {
+            try await db.worktrees.archive(id: wt.id)
+        } else {
+            try await db.worktrees.updateStatus(id: wt.id, status: .archived)
+        }
         return path
     }
 
@@ -93,8 +108,62 @@ struct OrphanGCDeletionQueueTests {
         let registered = try await GitManager().worktreeList(repoPath: repo.path)
         #expect(!registered.contains { $0.path == path })
         let records = try await db.reapRecords.list(repoPath: nil)
-        #expect(records.contains { $0.kind == .archivedWorktree && $0.worktreePath == path })
+        let record = try #require(records.first {
+            $0.kind == .archivedWorktree && $0.worktreePath == path
+        })
+        // The record has to carry what was reclaimed, not just that something
+        // was. `ReclaimedSummary.archivedWorktreeRollup` sums `?? 0`, so a nil
+        // here renders "N interrupted archives reclaimed · Zero KB" on a
+        // machine where the motivating measurement was tens of gigabytes.
+        // Measuring must therefore happen before the rename, while the
+        // directory is still at `path`.
+        let bytes = try #require(record.apparentBytes)
+        #expect(bytes > 0)
         #expect(result.reaped >= 1)
+    }
+
+    @Test func sweepKeepsAnArchiveInsideTheGraceWindow() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+        // Stamped just now: indistinguishable, by row and directory alone,
+        // from an archive whose phase-2 hook is still running.
+        let path = try await makeInterruptedArchive(
+            db: db, repo: repo, repoID: repoRow.id, name: "inflight",
+            stampArchivedAt: true)
+
+        let result = await makeGC(db: db).sweep()
+
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(result.planned.contains("KEEP grace \(path)"))
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+    }
+
+    @Test func sweepReclaimsAStampedArchiveOnceTheGraceWindowHasPassed() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+        let path = try await makeInterruptedArchive(
+            db: db, repo: repo, repoID: repoRow.id, name: "stale",
+            stampArchivedAt: true)
+
+        // Same fixture as the grace test — only the sweep's clock differs, so
+        // this pair isolates the gate rather than anything else about the row.
+        // The default grace window is one hour (`Config.defaultGCGraceSeconds`).
+        let later = Date().addingTimeInterval(Double(Config.defaultGCGraceSeconds) + 600)
+        let result = await makeGC(db: db, now: { later }).sweep()
+
+        #expect(!FileManager.default.fileExists(atPath: path))
+        #expect(result.planned.contains("REAP archived-worktree \(path)"))
     }
 
     @Test func sweepKeepsAnArchivedWorktreeOutsideTBDPrefixes() async throws {
@@ -149,6 +218,94 @@ struct OrphanGCDeletionQueueTests {
         #expect(result.planned.contains("REAP queued-deletion \(entry)"))
         let records = try await db.reapRecords.list(repoPath: nil)
         #expect(records.isEmpty)
+    }
+
+    @Test func sweepPrunesARegistrationWhoseDirectoryIsGoneAndRevivesAfterwards() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        // The wreckage a failed prune leaves: the directory has left its pool
+        // slot (renamed into the queue and drained, or removed by hand) while
+        // `.git/worktrees/<id>` survives. Nothing else in the sweep recovers
+        // it — step 1 only drains bytes, and step 2 only ever sees candidates
+        // whose directory still exists — so without an explicit prune the
+        // worktree is unrevivable forever.
+        try await shell("mkdir -p .tbd/worktrees", at: repo)
+        try await shell("git worktree add .tbd/worktrees/zombie -b zombie", at: repo)
+        let path = repo.path + "/.tbd/worktrees/zombie"
+        let wt = try await db.worktrees.create(
+            repoID: repoRow.id, name: "zombie", branch: "zombie",
+            path: path, tmuxServer: "tbd-test")
+        try await db.worktrees.archive(id: wt.id)
+        try FileManager.default.removeItem(atPath: path)
+
+        let git = GitManager()
+        let before = try await git.worktreeList(repoPath: repo.path)
+        try #require(
+            before.contains { $0.path == path },
+            "fixture invalid: git must still register the path for this to test anything")
+
+        // The stale registration is pruned even inside the grace window: the
+        // directory is already gone, so there is nothing a running archive
+        // could still be using.
+        let result = await makeGC(db: db, git: git).sweep()
+
+        #expect(result.planned.contains("PRUNE stale-registration \(path)"))
+        let after = try await git.worktreeList(repoPath: repo.path)
+        #expect(!after.contains { $0.path == path })
+
+        // The point of pruning: revive's preflight throws
+        // `worktreeAlreadyRegistered` while the registration survives.
+        let lifecycle = WorktreeLifecycle(
+            db: db, git: git, tmux: TmuxManager(dryRun: true), hooks: HookResolver())
+        let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
+        #expect(revived.status == .active)
+        #expect(FileManager.default.fileExists(atPath: path))
+    }
+
+    @Test func sweepDrainsAQueueBesideAnAdoptedWorktree() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        // An adopted worktree lives wherever the user put it, and
+        // `WorktreeDeletionQueue.enqueue` derives the pool from the worktree's
+        // own parent — so archiving one puts `.deleting/` in a directory no
+        // layout prefix covers. An interrupted drain there would otherwise sit
+        // in the user's own directory forever.
+        let outside = tmp.appendingPathComponent("elsewhere").path
+        try FileManager.default.createDirectory(
+            atPath: outside, withIntermediateDirectories: true)
+        let path = outside + "/adopted"
+        try await shell("git worktree add \(path) -b adopted", at: repo)
+        let wt = try await db.worktrees.create(
+            repoID: repoRow.id, name: "adopted", branch: "adopted",
+            path: path, tmuxServer: "tbd-test")
+        try await db.worktrees.updateStatus(id: wt.id, status: .archived)
+
+        let queueDir = WorktreeDeletionQueue().queueDir(forPool: outside)
+        let entry = queueDir + "/" + UUID().uuidString
+        try FileManager.default.createDirectory(
+            atPath: entry, withIntermediateDirectories: true)
+        try "junk".write(toFile: entry + "/f.txt", atomically: true, encoding: .utf8)
+
+        let result = await makeGC(db: db).sweep()
+
+        #expect(!FileManager.default.fileExists(atPath: entry))
+        #expect(result.planned.contains("REAP queued-deletion \(entry)"))
+        // Draining that pool must not widen what may be RECLAIMED: the
+        // adopted worktree itself is still outside every TBD prefix.
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(result.planned.contains("KEEP not-tbd-prefix \(path)"))
     }
 
     @Test func sweepDoesNothingWhenGCDisabled() async throws {

--- a/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
@@ -1,0 +1,157 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+import TestSupport
+
+/// Thread-safe `StateDelta` collector, matching `OrphanGCTests`.
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+}
+
+@Suite("OrphanGC reclaims the deletion queue")
+struct OrphanGCDeletionQueueTests {
+
+    private func makeGC(db: TBDDatabase, git: GitManager = GitManager()) -> OrphanGC {
+        OrphanGC(
+            db: db, git: git,
+            broadcast: { _ in },
+            lsofProvider: { [] },
+            scratchpadBase: nil,
+            now: { Date() }
+        )
+    }
+
+    /// A real linked worktree at `<repo>/.tbd/worktrees/<name>` with an
+    /// `.archived` row pointing at it — the shape a pre-queue archive left
+    /// behind when its removal was killed partway.
+    private func makeInterruptedArchive(
+        db: TBDDatabase, repo: URL, repoID: UUID, name: String
+    ) async throws -> String {
+        try await shell("mkdir -p .tbd/worktrees", at: repo)
+        try await shell("git worktree add .tbd/worktrees/\(name) -b \(name)", at: repo)
+        let path = repo.path + "/.tbd/worktrees/" + name
+        let wt = try await db.worktrees.create(
+            repoID: repoID, name: name, branch: name,
+            path: path, tmuxServer: "tbd-test"
+        )
+        try await db.worktrees.updateStatus(id: wt.id, status: .archived)
+        return path
+    }
+
+    @Test func sweepDrainsLeftoverQueueEntries() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        _ = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        // An entry a previous daemon run queued but never finished draining.
+        let pool = repo.path + "/.tbd/worktrees"
+        let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool)
+        let entry = queueDir + "/" + UUID().uuidString
+        try FileManager.default.createDirectory(
+            atPath: entry, withIntermediateDirectories: true)
+        try "junk".write(
+            toFile: entry + "/f.txt", atomically: true, encoding: .utf8)
+
+        let result = await makeGC(db: db).sweep()
+
+        #expect(!FileManager.default.fileExists(atPath: entry))
+        #expect(result.planned.contains("REAP queued-deletion \(entry)"))
+    }
+
+    @Test func sweepReclaimsAnInterruptedArchive() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+        let path = try await makeInterruptedArchive(
+            db: db, repo: repo, repoID: repoRow.id, name: "zombie")
+
+        let result = await makeGC(db: db).sweep()
+
+        #expect(!FileManager.default.fileExists(atPath: path))
+        let registered = try await GitManager().worktreeList(repoPath: repo.path)
+        #expect(!registered.contains { $0.path == path })
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.contains { $0.kind == .archivedWorktree && $0.worktreePath == path })
+        #expect(result.reaped >= 1)
+    }
+
+    @Test func sweepKeepsAnArchivedWorktreeOutsideTBDPrefixes() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+
+        // An adopted worktree: real, linked, archived — but somewhere TBD
+        // never puts its own worktrees, so provenance is unprovable.
+        let outside = tmp.appendingPathComponent("elsewhere").path
+        try FileManager.default.createDirectory(
+            atPath: outside, withIntermediateDirectories: true)
+        let path = outside + "/adopted"
+        try await shell("git worktree add \(path) -b adopted", at: repo)
+        let wt = try await db.worktrees.create(
+            repoID: repoRow.id, name: "adopted", branch: "adopted",
+            path: path, tmuxServer: "tbd-test")
+        try await db.worktrees.updateStatus(id: wt.id, status: .archived)
+
+        let result = await makeGC(db: db).sweep()
+
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(result.planned.contains("KEEP not-tbd-prefix \(path)"))
+    }
+
+    @Test func dryRunPlansWithoutTouchingDisk() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+        let path = try await makeInterruptedArchive(
+            db: db, repo: repo, repoID: repoRow.id, name: "zombie")
+
+        let result = await makeGC(db: db).sweep(dryRun: true)
+
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(result.reaped == 0)
+        #expect(result.planned.contains("REAP archived-worktree \(path)"))
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+    }
+
+    @Test func sweepDoesNothingWhenGCDisabled() async throws {
+        let (tmp, repo) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(false)
+        let repoRow = try await db.repos.create(
+            path: repo.path, displayName: "acme", defaultBranch: "main")
+        let path = try await makeInterruptedArchive(
+            db: db, repo: repo, repoID: repoRow.id, name: "zombie")
+
+        let result = await makeGC(db: db).sweep()
+
+        #expect(FileManager.default.fileExists(atPath: path))
+        #expect(result.reaped == 0)
+        let records = try await db.reapRecords.list(repoPath: nil)
+        #expect(records.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
@@ -44,6 +44,21 @@ struct OrphanGCDeletionQueueTests {
         return path
     }
 
+    /// A stray `.deleting/<uuid>` entry a previous daemon run queued but
+    /// never finished draining — the step-1 fixture shape, factored out so
+    /// the gated-behavior tests can prove step 1 respects the same gates as
+    /// step 2 without duplicating the queue-dir plumbing.
+    private func makeQueuedEntry(repo: URL) throws -> String {
+        let pool = repo.path + "/.tbd/worktrees"
+        let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool)
+        let entry = queueDir + "/" + UUID().uuidString
+        try FileManager.default.createDirectory(
+            atPath: entry, withIntermediateDirectories: true)
+        try "junk".write(
+            toFile: entry + "/f.txt", atomically: true, encoding: .utf8)
+        return entry
+    }
+
     @Test func sweepDrainsLeftoverQueueEntries() async throws {
         let (tmp, repo) = try await createTestRepoResolvingSymlinks()
         defer { try? FileManager.default.removeItem(at: tmp) }
@@ -53,14 +68,7 @@ struct OrphanGCDeletionQueueTests {
         _ = try await db.repos.create(
             path: repo.path, displayName: "acme", defaultBranch: "main")
 
-        // An entry a previous daemon run queued but never finished draining.
-        let pool = repo.path + "/.tbd/worktrees"
-        let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool)
-        let entry = queueDir + "/" + UUID().uuidString
-        try FileManager.default.createDirectory(
-            atPath: entry, withIntermediateDirectories: true)
-        try "junk".write(
-            toFile: entry + "/f.txt", atomically: true, encoding: .utf8)
+        let entry = try makeQueuedEntry(repo: repo)
 
         let result = await makeGC(db: db).sweep()
 
@@ -126,12 +134,19 @@ struct OrphanGCDeletionQueueTests {
             path: repo.path, displayName: "acme", defaultBranch: "main")
         let path = try await makeInterruptedArchive(
             db: db, repo: repo, repoID: repoRow.id, name: "zombie")
+        // Also cover step 1 (already-queued entries): without this fixture,
+        // nothing here proves `dryRun` suppresses `deletionQueueCollector
+        // .drain(entry)` in the queued-deletion loop — only that it
+        // suppresses step 2's archive reap.
+        let entry = try makeQueuedEntry(repo: repo)
 
         let result = await makeGC(db: db).sweep(dryRun: true)
 
         #expect(FileManager.default.fileExists(atPath: path))
+        #expect(FileManager.default.fileExists(atPath: entry))
         #expect(result.reaped == 0)
         #expect(result.planned.contains("REAP archived-worktree \(path)"))
+        #expect(result.planned.contains("REAP queued-deletion \(entry)"))
         let records = try await db.reapRecords.list(repoPath: nil)
         #expect(records.isEmpty)
     }
@@ -146,10 +161,15 @@ struct OrphanGCDeletionQueueTests {
             path: repo.path, displayName: "acme", defaultBranch: "main")
         let path = try await makeInterruptedArchive(
             db: db, repo: repo, repoID: repoRow.id, name: "zombie")
+        // Also cover step 1: without this fixture, nothing here proves
+        // `gcEnabled == false` suppresses `deletionQueueCollector.drain(entry)`
+        // in the queued-deletion loop — only that it suppresses step 2.
+        let entry = try makeQueuedEntry(repo: repo)
 
         let result = await makeGC(db: db).sweep()
 
         #expect(FileManager.default.fileExists(atPath: path))
+        #expect(FileManager.default.fileExists(atPath: entry))
         #expect(result.reaped == 0)
         let records = try await db.reapRecords.list(repoPath: nil)
         #expect(records.isEmpty)

--- a/Tests/TBDDaemonTests/RepoRemoveCascadeTests.swift
+++ b/Tests/TBDDaemonTests/RepoRemoveCascadeTests.swift
@@ -1,0 +1,275 @@
+import Testing
+import Foundation
+import TestSupport
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Thread-safe `StateDelta` collector, matching the other RPC suites.
+private final class BroadcastDeltas: @unchecked Sendable {
+    private let lock = NSLock()
+    private var deltas: [StateDelta] = []
+    func append(_ delta: StateDelta) {
+        lock.lock(); defer { lock.unlock() }
+        deltas.append(delta)
+    }
+    func snapshot() -> [StateDelta] {
+        lock.lock(); defer { lock.unlock() }
+        return deltas
+    }
+    func containsRepoRemoved(_ repoID: UUID) -> Bool {
+        snapshot().contains {
+            if case .repoRemoved(let delta) = $0 { return delta.repoID == repoID }
+            return false
+        }
+    }
+}
+
+/// Parks `completeArchiveWorktree` at a known point, per worktree path.
+///
+/// Wired through `WorktreeLifecycle.onWorktreeRemoved`, which phase 2 awaits
+/// after the deletion-queue rename and before the drain — i.e. squarely inside
+/// the "archive still in flight" window these tests are about. Waiting is
+/// bounded rather than indefinite on purpose: if the cleanup tail were
+/// synchronous again, `router.handle` would park here, and a bounded wait turns
+/// that into a clean assertion failure a few seconds later instead of a hang.
+private final class PathGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var opened: Set<String> = []
+    private var entered: [String] = []
+
+    func open(_ path: String) {
+        lock.lock(); defer { lock.unlock() }
+        opened.insert(path)
+    }
+
+    func enteredPaths() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return entered
+    }
+
+    private func isOpen(_ path: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return opened.contains(path)
+    }
+
+    func wait(_ path: String, timeout: TimeInterval = 10) async {
+        lock.withLock { entered.append(path) }
+        let deadline = Date().addingTimeInterval(timeout)
+        while !isOpen(path), Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}
+
+/// Carries the observed state on the primary failure line (assertion-hygiene
+/// rule 4: only `Issue.record(_: some Error)` — which a thrown error becomes —
+/// survives into the CI summary).
+private struct CascadeWaitTimeout: Error, CustomStringConvertible {
+    let what: String
+    let observed: String
+    let seconds: TimeInterval
+    var description: String {
+        "timed out waiting for \(what) — observed \(observed) after polling up to \(seconds) seconds"
+    }
+}
+
+@Suite("repo.remove cascade cleanup ordering")
+struct RepoRemoveCascadeTests {
+
+    private func waitUntil(
+        _ what: String, timeout: TimeInterval = 10,
+        observed: @Sendable () async -> String = { "still false" },
+        _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        throw CascadeWaitTimeout(what: what, observed: await observed(), seconds: timeout)
+    }
+
+    /// Router sharing one `StateSubscriptionManager` with its lifecycle, with
+    /// every broadcast delta captured. `gate`, when supplied, parks phase 2 of
+    /// each archive at `onWorktreeRemoved`.
+    private func makeRouter(
+        db: TBDDatabase, gate: PathGate? = nil
+    ) -> (router: RPCRouter, deltas: BroadcastDeltas) {
+        let deltas = BroadcastDeltas()
+        let subs = StateSubscriptionManager()
+        subs.addSubscriber { data in
+            if let delta = try? JSONDecoder().decode(StateDelta.self, from: data) {
+                deltas.append(delta)
+            }
+            return true
+        }
+        var lifecycle = WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver())
+        if let gate {
+            lifecycle.onWorktreeRemoved = { path, _ in await gate.wait(path) }
+        }
+        let router = RPCRouter(
+            db: db, lifecycle: lifecycle, tmux: TmuxManager(dryRun: true),
+            subscriptions: subs, actuationLog: makeTestActuationLog())
+        return (router, deltas)
+    }
+
+    /// A real directory holding a file, so the deletion queue's `rename(2)`
+    /// succeeds and phase 2 reaches `onWorktreeRemoved` on its success path.
+    private func makeActiveWorktree(
+        db: TBDDatabase, repoID: UUID, sandbox: URL, name: String
+    ) async throws -> Worktree {
+        let path = sandbox.appendingPathComponent(name).path
+        try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+        try "content".write(toFile: path + "/file.txt", atomically: true, encoding: .utf8)
+        return try await db.worktrees.create(
+            repoID: repoID, name: name, branch: name, path: path, tmuxServer: "tbd-test")
+    }
+
+    private func makeSandbox() throws -> URL {
+        let sandbox = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("repo-remove-cascade-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+        return sandbox
+    }
+
+    /// Branch 1 of the gating conditional: no active worktrees, so there is
+    /// nothing to await and the tail must stay inline. The RPC may not return
+    /// until the rows are deleted and `.repoRemoved` has been broadcast.
+    @Test func removalWithoutACascadeFinishesBeforeTheRPCReturns() async throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let (router, deltas) = makeRouter(db: db)
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path,
+            displayName: "acme", defaultBranch: "main")
+        // An archived row: still deleted by the tail, but it puts no archive in
+        // flight, so this stays the no-cascade branch.
+        let archived = try await makeActiveWorktree(
+            db: db, repoID: repo.id, sandbox: sandbox, name: "already-archived")
+        try await db.worktrees.archive(id: archived.id)
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove, params: RepoRemoveParams(repoID: repo.id, force: true)))
+        #expect(response.success)
+
+        // Asserted with no intervening wait: the work has to be done already.
+        #expect(deltas.containsRepoRemoved(repo.id),
+                "the no-cascade path must broadcast .repoRemoved before returning")
+        let repoRow = try await db.repos.get(id: repo.id)
+        #expect(repoRow == nil, "the no-cascade path must delete the repo row before returning")
+        let worktreeRow = try await db.worktrees.get(id: archived.id)
+        #expect(worktreeRow == nil, "the no-cascade path must delete worktree rows before returning")
+    }
+
+    /// Branch 2: a cascade is in flight, so the tail detaches. The RPC returns
+    /// while phase 2 is still parked, and the rows and the broadcast arrive
+    /// only once every completion has finished.
+    @Test func forcedRemovalReturnsBeforeTheCleanupTailAndFinishesItAfterwards() async throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let gate = PathGate()
+        let (router, deltas) = makeRouter(db: db, gate: gate)
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path,
+            displayName: "acme", defaultBranch: "main")
+        let worktree = try await makeActiveWorktree(
+            db: db, repoID: repo.id, sandbox: sandbox, name: "in-flight")
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove, params: RepoRemoveParams(repoID: repo.id, force: true)))
+        #expect(response.success)
+
+        // Phase 2 is parked in the gate, so a tail that had NOT been detached
+        // could not have reached any of this.
+        #expect(!deltas.containsRepoRemoved(repo.id),
+                "the RPC returned only after the detached tail broadcast — it was not detached")
+        let repoWhileParked = try await db.repos.get(id: repo.id)
+        #expect(repoWhileParked != nil)
+        let rowWhileParked = try await db.worktrees.get(id: worktree.id)
+        #expect(rowWhileParked?.status == .archived,
+                "phase 1 must have run synchronously, flipping the row before the RPC answered")
+
+        gate.open(worktree.path)
+
+        try await waitUntil("the detached tail to delete the repo row") {
+            ((try? await db.repos.get(id: repo.id)) ?? nil) == nil
+        }
+        let rowAfter = try await db.worktrees.get(id: worktree.id)
+        #expect(rowAfter == nil, "the tail must delete the worktree rows too")
+        #expect(deltas.containsRepoRemoved(repo.id),
+                "the tail must still broadcast .repoRemoved once it completes")
+    }
+
+    /// The invariant the detached tail exists to preserve: rows outlive
+    /// directories. `OrphanGC` builds its pool scan from `db.repos.list()` and
+    /// `db.worktrees.list(status: .archived)`, so while any archive is still
+    /// draining, both must still name this repo — otherwise an interrupted
+    /// drain leaves a `.deleting/` entry no sweep can ever see.
+    ///
+    /// Two worktrees, released one at a time: after the first completion has
+    /// finished, the rows must STILL be there, because the second is parked.
+    /// That distinguishes "awaits every completion" from "awaits the first".
+    @Test func rowsSurviveUntilEveryCascadedCompletionHasFinished() async throws {
+        let sandbox = try makeSandbox()
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let gate = PathGate()
+        let (router, _) = makeRouter(db: db, gate: gate)
+        let repo = try await db.repos.create(
+            path: sandbox.appendingPathComponent("repo").path,
+            displayName: "acme", defaultBranch: "main")
+        let first = try await makeActiveWorktree(
+            db: db, repoID: repo.id, sandbox: sandbox, name: "first")
+        let second = try await makeActiveWorktree(
+            db: db, repoID: repo.id, sandbox: sandbox, name: "second")
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove, params: RepoRemoveParams(repoID: repo.id, force: true)))
+        #expect(response.success)
+
+        // Both rows and the repo are still visible to the two lists the sweep
+        // scans, while their directories are mid-drain.
+        let archivedWhileParked = try await db.worktrees.list(status: .archived)
+        #expect(archivedWhileParked.contains { $0.id == first.id })
+        #expect(archivedWhileParked.contains { $0.id == second.id })
+        let reposWhileParked = try await db.repos.list()
+        #expect(reposWhileParked.contains { $0.id == repo.id })
+
+        // Release whichever archive got there first — the cascade follows the
+        // DB's list order, not creation order, so the pair is identified by
+        // what actually parked rather than by name.
+        try await waitUntil(
+            "a cascaded archive to reach phase 2",
+            observed: { "entered=\(gate.enteredPaths())" }
+        ) { !gate.enteredPaths().isEmpty }
+        let released = gate.enteredPaths()[0]
+        let stillParked = try #require([first, second].first { $0.path != released })
+        gate.open(released)
+
+        // Its completion finishes; the other is still parked, so nothing
+        // downstream of it may have run.
+        try await waitUntil(
+            "the second archive to reach phase 2",
+            observed: { "entered=\(gate.enteredPaths())" }
+        ) { gate.enteredPaths().contains(stillParked.path) }
+
+        let reposAfterFirst = try await db.repos.list()
+        #expect(reposAfterFirst.contains { $0.id == repo.id },
+                "the tail must await EVERY completion, not just the first")
+        let archivedAfterFirst = try await db.worktrees.list(status: .archived)
+        #expect(archivedAfterFirst.contains { $0.id == stillParked.id })
+
+        gate.open(stillParked.path)
+        try await waitUntil("the detached tail to delete the repo row") {
+            ((try? await db.repos.get(id: repo.id)) ?? nil) == nil
+        }
+        let remaining = try await db.worktrees.list(repoID: repo.id)
+        #expect(remaining.isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
@@ -86,6 +86,46 @@ struct WorktreeArchiveDeletionQueueTests {
         let registered = try await harness.git.worktreeList(repoPath: harness.repoPath)
         #expect(!registered.contains { $0.path == harness.worktreePath })
     }
+
+    @Test func onWorktreeRemovedNeverFiresWhenBothEnqueueAndFallbackFail() async throws {
+        // The headline guarantee — the callback fires only when the directory
+        // is genuinely gone — has no coverage unless BOTH removal paths are
+        // made to fail. Otherwise a regression back to an unconditional
+        // `if let onWorktreeRemoved` would go undetected: every other test
+        // here has one path succeed, so the callback firing looks correct
+        // either way.
+        let observed = ObservedRemoval()
+        let harness = try await ArchiveHarness.make(onWorktreeRemoved: { path, _ in
+            await observed.record(
+                path: path,
+                existedAtCallTime: FileManager.default.fileExists(atPath: path)
+            )
+        })
+        defer { harness.cleanUp() }
+
+        // Force `enqueue` to fail: occupy the queue-dir name with a regular
+        // file, same technique as `enqueueFailureFallsBackToGitWorktreeRemove`.
+        let pool = (harness.worktreePath as NSString).deletingLastPathComponent
+        let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool)
+        try "not a directory".write(toFile: queueDir, atomically: true, encoding: .utf8)
+
+        // Force the fallback `git worktree remove --force` to fail too: mark
+        // a file inside the worktree user-immutable (`chflags uchg`), which
+        // makes the recursive delete underneath `git worktree remove` return
+        // "Operation not permitted" and leave the directory in place —
+        // verified directly: exit code 255, directory and marker both
+        // survive. `--force` bypasses git's own dirty/locked-worktree
+        // refusals but has no effect on a filesystem-level EPERM.
+        let markerPath = (harness.worktreePath as NSString).appendingPathComponent("immutable-marker")
+        #expect(FileManager.default.createFile(atPath: markerPath, contents: Data("x".utf8)))
+        try #require(chflags(markerPath, UInt32(UF_IMMUTABLE)) == 0, "chflags must succeed for this test to force a real removal failure")
+        defer { chflags(markerPath, 0) } // clear before cleanUp()'s removeItem, else that fails too
+
+        try await harness.lifecycle.archiveWorktree(worktreeID: harness.worktreeID)
+
+        #expect(await observed.paths.isEmpty, "the callback must never fire when neither removal path succeeded")
+        #expect(FileManager.default.fileExists(atPath: harness.worktreePath), "nothing removed the worktree — it must still be there")
+    }
 }
 
 /// Records `onWorktreeRemoved` invocations and whether the path still existed

--- a/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
@@ -27,8 +27,18 @@ struct WorktreeArchiveDeletionQueueTests {
         let pool = (harness.worktreePath as NSString).deletingLastPathComponent
         #expect(WorktreeDeletionQueue().pending(pool: pool).isEmpty)
         let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool)
-        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: queueDir)) ?? []
-        #expect(leftovers.isEmpty)
+        // Assert existence explicitly rather than swallowing the lookup error
+        // with `try?` — a queue dir that was never created and one that was
+        // created-then-emptied both read as "no leftovers" under `try? … ?? []`,
+        // which made the old form pass whether or not the queue was ever used.
+        // Existence proves `enqueue` ran (only `enqueue` creates `.deleting/`);
+        // emptiness proves `drain` ran.
+        var isDirectory: ObjCBool = false
+        let exists = FileManager.default.fileExists(atPath: queueDir, isDirectory: &isDirectory)
+        #expect(exists, "the queue directory must exist — its absence means archive never went through the queue")
+        #expect(isDirectory.boolValue)
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: queueDir)
+        #expect(leftovers.isEmpty, "drain must have removed the queued entry")
     }
 
     @Test func onWorktreeRemovedFiresOnceThePathIsGone() async throws {
@@ -61,6 +71,15 @@ struct WorktreeArchiveDeletionQueueTests {
         try "not a directory".write(toFile: queueDir, atomically: true, encoding: .utf8)
 
         try await harness.lifecycle.archiveWorktree(worktreeID: harness.worktreeID)
+
+        // The planted file is still there and still a plain file — proves
+        // `enqueue`'s `createDirectory` genuinely failed to turn `.deleting/`
+        // into a usable directory, i.e. the archive really took the fallback
+        // leg rather than the queue succeeding some other way.
+        var isDirectory: ObjCBool = false
+        let stillExists = FileManager.default.fileExists(atPath: queueDir, isDirectory: &isDirectory)
+        #expect(stillExists, "the planted file must still occupy the queue-dir path")
+        #expect(!isDirectory.boolValue, "the queue dir must never have become usable — proves enqueue failed")
 
         // Fallback still removed the worktree and its registration.
         #expect(!FileManager.default.fileExists(atPath: harness.worktreePath))

--- a/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
@@ -87,6 +87,50 @@ struct WorktreeArchiveDeletionQueueTests {
         #expect(!registered.contains { $0.path == harness.worktreePath })
     }
 
+    @Test func theFallbackRemovalArmsItsOwnRaisedTimeout() async throws {
+        let harness = try await ArchiveHarness.make()
+        defer { harness.cleanUp() }
+
+        // The entire bug was a removal killed by a deadline, so dropping the
+        // `timeout:` argument at the fallback call site — or shrinking the
+        // constant — must go red. This gives the archive a `GitManager` whose
+        // INSTANCE deadline no real subprocess can meet: if the fallback leg
+        // stopped passing its own raised timeout, `git worktree remove` would
+        // be killed and the directory would survive.
+        //
+        // `runBoundedProcess` makes that discriminating rather than racy —
+        // its completion path compares real elapsed time against the armed
+        // deadline and reports `.timedOut` even when every armer was late, so
+        // a 1 ms deadline cannot accidentally pass.
+        let impatient = GitManager(subprocessTimeout: .milliseconds(1))
+
+        // Control: prove that deadline really is fatal, on a throwaway
+        // worktree of the same repo. Without this, a fallback that silently
+        // did nothing would look identical to one that succeeded.
+        let control = (harness.tempDir.path as NSString).appendingPathComponent("control-wt")
+        try await shell(
+            "git worktree add \(control) -b control-branch",
+            at: URL(fileURLWithPath: harness.repoPath))
+        await #expect(throws: GitTimeoutError.self) {
+            try await impatient.worktreeRemove(
+                repoPath: harness.repoPath, worktreePath: control)
+        }
+        #expect(FileManager.default.fileExists(atPath: control))
+
+        // Force the archive onto the fallback leg: occupy the queue-dir name
+        // with a regular file so `enqueue` cannot create `.deleting/`.
+        let pool = (harness.worktreePath as NSString).deletingLastPathComponent
+        let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool)
+        try "not a directory".write(toFile: queueDir, atomically: true, encoding: .utf8)
+
+        let lifecycle = WorktreeLifecycle(
+            db: harness.db, git: impatient,
+            tmux: TmuxManager(dryRun: true), hooks: HookResolver())
+        try await lifecycle.archiveWorktree(worktreeID: harness.worktreeID)
+
+        #expect(!FileManager.default.fileExists(atPath: harness.worktreePath))
+    }
+
     @Test func onWorktreeRemovedNeverFiresWhenBothEnqueueAndFallbackFail() async throws {
         // The headline guarantee — the callback fires only when the directory
         // is genuinely gone — has no coverage unless BOTH removal paths are
@@ -144,6 +188,7 @@ private actor ObservedRemoval {
 /// `ArchiveScratchpadCleanupTests`'s database/repo/worktree construction.
 struct ArchiveHarness {
     let lifecycle: WorktreeLifecycle
+    let db: TBDDatabase
     let git: GitManager
     let repoPath: String
     let worktreePath: String
@@ -168,6 +213,7 @@ struct ArchiveHarness {
 
         return ArchiveHarness(
             lifecycle: lifecycle,
+            db: db,
             git: lifecycle.git,
             repoPath: repo.path,
             worktreePath: worktree.path,

--- a/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
@@ -1,0 +1,123 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+import TestSupport
+
+@Suite("Worktree archive uses the deletion queue")
+struct WorktreeArchiveDeletionQueueTests {
+
+    @Test func archiveClearsThePoolSlotAndDropsTheGitRegistration() async throws {
+        let harness = try await ArchiveHarness.make()
+        defer { harness.cleanUp() }
+
+        try await harness.lifecycle.archiveWorktree(worktreeID: harness.worktreeID)
+
+        #expect(!FileManager.default.fileExists(atPath: harness.worktreePath))
+        let registered = try await harness.git.worktreeList(repoPath: harness.repoPath)
+        #expect(!registered.contains { $0.path == harness.worktreePath })
+    }
+
+    @Test func archiveDrainsTheQueueSoNoBytesRemain() async throws {
+        let harness = try await ArchiveHarness.make()
+        defer { harness.cleanUp() }
+
+        try await harness.lifecycle.archiveWorktree(worktreeID: harness.worktreeID)
+
+        let pool = (harness.worktreePath as NSString).deletingLastPathComponent
+        #expect(WorktreeDeletionQueue().pending(pool: pool).isEmpty)
+        let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool)
+        let leftovers = (try? FileManager.default.contentsOfDirectory(atPath: queueDir)) ?? []
+        #expect(leftovers.isEmpty)
+    }
+
+    @Test func onWorktreeRemovedFiresOnceThePathIsGone() async throws {
+        // `WorktreeLifecycle` is a struct, so the callback is supplied at
+        // construction rather than assigned onto a stored instance.
+        let observed = ObservedRemoval()
+        let harness = try await ArchiveHarness.make(onWorktreeRemoved: { path, _ in
+            await observed.record(
+                path: path,
+                existedAtCallTime: FileManager.default.fileExists(atPath: path)
+            )
+        })
+        defer { harness.cleanUp() }
+
+        try await harness.lifecycle.archiveWorktree(worktreeID: harness.worktreeID)
+
+        #expect(await observed.paths == [harness.worktreePath])
+        // The whole point of moving the callback after a verified removal.
+        #expect(await observed.everSawSurvivingPath == false)
+    }
+
+    @Test func enqueueFailureFallsBackToGitWorktreeRemove() async throws {
+        let harness = try await ArchiveHarness.make()
+        defer { harness.cleanUp() }
+
+        // Make the queue directory un-creatable so `enqueue` throws: occupy its
+        // name with a regular file.
+        let pool = (harness.worktreePath as NSString).deletingLastPathComponent
+        let queueDir = WorktreeDeletionQueue().queueDir(forPool: pool)
+        try "not a directory".write(toFile: queueDir, atomically: true, encoding: .utf8)
+
+        try await harness.lifecycle.archiveWorktree(worktreeID: harness.worktreeID)
+
+        // Fallback still removed the worktree and its registration.
+        #expect(!FileManager.default.fileExists(atPath: harness.worktreePath))
+        let registered = try await harness.git.worktreeList(repoPath: harness.repoPath)
+        #expect(!registered.contains { $0.path == harness.worktreePath })
+    }
+}
+
+/// Records `onWorktreeRemoved` invocations and whether the path still existed
+/// when the callback ran.
+private actor ObservedRemoval {
+    private(set) var paths: [String] = []
+    private(set) var everSawSurvivingPath = false
+
+    func record(path: String, existedAtCallTime: Bool) {
+        paths.append(path)
+        if existedAtCallTime { everSawSurvivingPath = true }
+    }
+}
+
+/// Shared setup for the archive-through-the-queue tests, modeled on
+/// `ArchiveScratchpadCleanupTests`'s database/repo/worktree construction.
+struct ArchiveHarness {
+    let lifecycle: WorktreeLifecycle
+    let git: GitManager
+    let repoPath: String
+    let worktreePath: String
+    let worktreeID: UUID
+    let tempDir: URL
+
+    static func make(
+        onWorktreeRemoved: (@Sendable (_ worktreePath: String, _ repoPath: String) async -> Void)? = nil
+    ) async throws -> ArchiveHarness {
+        let (tempDir, repoDir) = try await createTestRepo()
+        let db = try TBDDatabase(inMemory: true)
+        var lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver()
+        )
+        lifecycle.onWorktreeRemoved = onWorktreeRemoved
+
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let worktree = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+        return ArchiveHarness(
+            lifecycle: lifecycle,
+            git: lifecycle.git,
+            repoPath: repo.path,
+            worktreePath: worktree.path,
+            worktreeID: worktree.id,
+            tempDir: tempDir
+        )
+    }
+
+    func cleanUp() {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
@@ -111,30 +111,30 @@ struct WorktreeDeletionQueueTests {
         #expect(WorktreeDeletionQueue().pending(pool: pool).isEmpty)
     }
 
-    @Test func drainRemovesEntryBytesAndReportsSuccess() throws {
+    @Test func drainRemovesEntryBytesAndReportsSuccess() async throws {
         let (tmp, pool, wt) = try makePool()
         defer { try? FileManager.default.removeItem(at: tmp) }
 
         let queue = WorktreeDeletionQueue()
         let entry = try queue.enqueue(worktreePath: wt)
 
-        #expect(queue.drain(entry) == true)
+        #expect(await queue.drain(entry) == true)
         #expect(!FileManager.default.fileExists(atPath: entry.path))
         #expect(queue.pending(pool: pool).isEmpty)
     }
 
-    @Test func drainIsIdempotentOnAnAlreadyDrainedEntry() throws {
+    @Test func drainIsIdempotentOnAnAlreadyDrainedEntry() async throws {
         let (tmp, _, wt) = try makePool()
         defer { try? FileManager.default.removeItem(at: tmp) }
 
         let queue = WorktreeDeletionQueue()
         let entry = try queue.enqueue(worktreePath: wt)
-        #expect(queue.drain(entry) == true)
+        #expect(await queue.drain(entry) == true)
         // A second sweep must treat a vanished entry as done, not as failure.
-        #expect(queue.drain(entry) == true)
+        #expect(await queue.drain(entry) == true)
     }
 
-    @Test func drainResumesAfterAPartiallyDeletedEntry() throws {
+    @Test func drainResumesAfterAPartiallyDeletedEntry() async throws {
         let (tmp, pool, wt) = try makePool()
         defer { try? FileManager.default.removeItem(at: tmp) }
 
@@ -143,11 +143,11 @@ struct WorktreeDeletionQueueTests {
         // Simulate an interrupted drain: some children already gone, dir remains.
         try FileManager.default.removeItem(atPath: entry.path + "/file.txt")
 
-        #expect(queue.drain(entry) == true)
+        #expect(await queue.drain(entry) == true)
         #expect(queue.pending(pool: pool).isEmpty)
     }
 
-    @Test func drainRefusesAPathOutsideAQueueDirectory() throws {
+    @Test func drainRefusesAPathOutsideAQueueDirectory() async throws {
         let (tmp, _, wt) = try makePool()
         defer { try? FileManager.default.removeItem(at: tmp) }
 
@@ -157,7 +157,84 @@ struct WorktreeDeletionQueueTests {
         // Here the "entry" names a live worktree directory rather than
         // anything TBD renamed into `.deleting/`.
         let queue = WorktreeDeletionQueue()
-        #expect(queue.drain(QueuedDeletion(path: wt, originalPath: wt)) == false)
+        #expect(await queue.drain(QueuedDeletion(path: wt, originalPath: wt)) == false)
         #expect(FileManager.default.fileExists(atPath: wt + "/file.txt"))
+    }
+
+    /// Tier 2. The unlink must run on the type's serial drain queue, not on
+    /// the caller's thread: `drain` is reached from detached tasks on the
+    /// cooperative pool, and removing a dependency-heavy worktree takes
+    /// minutes, so an inline `removeItem` parks a pool thread for that long —
+    /// one per concurrent archive.
+    ///
+    /// Occupies the drain queue with a gated work item, then starts a drain
+    /// and shows the bytes are still there while the queue is busy, and gone
+    /// once it is released. An inline implementation — including an `async`
+    /// one that simply never hops — deletes the entry while the gate is still
+    /// held and fails the middle assertion.
+    @Test func drainQueuesTheUnlinkBehindTheSerialDrainQueue() async throws {
+        let (tmp, pool, wt) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let queue = WorktreeDeletionQueue()
+        let entry = try queue.enqueue(worktreePath: wt)
+
+        // Signalled in a `defer` so a failure anywhere below cannot leave the
+        // process-wide drain queue blocked for other suites.
+        let gate = DispatchSemaphore(value: 0)
+        defer { gate.signal() }
+        let occupied = Flag()
+        WorktreeDeletionQueue.drainQueue.async {
+            occupied.set()
+            gate.wait()
+        }
+        try await waitUntil(occupied.isSet, "drain queue never picked up the gate item")
+
+        let entered = Flag()
+        let drained = Task { () -> Bool in
+            entered.set()
+            return await queue.drain(entry)
+        }
+        try await waitUntil(entered.isSet, "drain task never started")
+        // Room for an inline implementation to have finished: the entry is one
+        // small file, so its removal would land in microseconds once the task
+        // is running.
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(FileManager.default.fileExists(atPath: entry.path))
+
+        gate.signal()
+        #expect(await drained.value == true)
+        #expect(!FileManager.default.fileExists(atPath: entry.path))
+        #expect(queue.pending(pool: pool).isEmpty)
+    }
+
+    /// Bounded poll (no wall-clock assertion): fails with a named diagnostic
+    /// rather than hanging if the condition never becomes true.
+    private func waitUntil(
+        _ condition: @autoclosure () -> Bool, _ what: String,
+        timeout: Duration = .seconds(10)
+    ) async throws {
+        let step = Duration.milliseconds(10)
+        var waited = Duration.zero
+        while !condition() {
+            if waited >= timeout { throw WaitTimeout(what: what, after: timeout) }
+            try await Task.sleep(for: step)
+            waited += step
+        }
+    }
+
+    private struct WaitTimeout: Error, CustomStringConvertible {
+        let what: String
+        let after: Duration
+        var description: String { "timed out after \(after): \(what)" }
+    }
+
+    /// Minimal lock-guarded boolean; the drain queue sets it from a dispatch
+    /// thread while the test task reads it.
+    private final class Flag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+        func set() { lock.lock(); value = true; lock.unlock() }
+        var isSet: Bool { lock.lock(); defer { lock.unlock() }; return value }
     }
 }

--- a/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
@@ -51,9 +51,46 @@ struct WorktreeDeletionQueueTests {
         defer { try? FileManager.default.removeItem(at: tmp) }
 
         let queue = WorktreeDeletionQueue()
-        #expect(throws: WorktreeDeletionQueueError.self) {
-            try queue.enqueue(worktreePath: pool + "/does-not-exist")
+        let source = pool + "/does-not-exist"
+        #expect {
+            try queue.enqueue(worktreePath: source)
+        } throws: { error in
+            guard case let .renameFailed(from, to, code) = error as? WorktreeDeletionQueueError else {
+                return false
+            }
+            return from == source
+                && to.hasPrefix(pool + "/" + WorktreeDeletionQueue.dirName + "/")
+                && code == ENOENT
         }
+    }
+
+    /// Proves `enqueue` really calls the `rename(2)` syscall and not
+    /// `FileManager.moveItem`, which would silently succeed across
+    /// filesystems via copy-then-delete instead of surfacing `EXDEV`. The
+    /// injected stub simulates the destination being on a different
+    /// filesystem; a regression to `moveItem` would not exercise this seam at
+    /// all, since `moveItem` never calls it.
+    @Test func enqueueSurfacesEXDEVFromTheInjectedRenameSeam() throws {
+        let (tmp, pool, wt) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let queue = WorktreeDeletionQueue(renameItem: { _, _ in
+            errno = EXDEV
+            return -1
+        })
+
+        #expect {
+            try queue.enqueue(worktreePath: wt)
+        } throws: { error in
+            guard case let .renameFailed(from, to, code) = error as? WorktreeDeletionQueueError else {
+                return false
+            }
+            return from == wt
+                && to.hasPrefix(pool + "/" + WorktreeDeletionQueue.dirName + "/")
+                && code == EXDEV
+        }
+        // The stub never actually moved anything.
+        #expect(FileManager.default.fileExists(atPath: wt))
     }
 
     @Test func pendingEnumeratesEntriesLeftByAPreviousRun() throws {

--- a/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
@@ -1,0 +1,112 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+import TBDShared
+
+@Suite("WorktreeDeletionQueue")
+struct WorktreeDeletionQueueTests {
+
+    /// Builds `<tmp>/pool/<name>/` holding one file, and returns (tmp, pool, worktreePath).
+    private func makePool(name: String = "wt") throws -> (tmp: URL, pool: String, worktree: String) {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("dq-\(UUID().uuidString)")
+        let pool = tmp.appendingPathComponent("pool")
+        let wt = pool.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: wt, withIntermediateDirectories: true)
+        try "hello".write(to: wt.appendingPathComponent("file.txt"), atomically: true, encoding: .utf8)
+        return (tmp, pool.path, wt.path)
+    }
+
+    @Test func enqueueMovesWorktreeIntoQueueDirAndLeavesSlotEmpty() throws {
+        let (tmp, pool, wt) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let queue = WorktreeDeletionQueue()
+        let entry = try queue.enqueue(worktreePath: wt)
+
+        #expect(!FileManager.default.fileExists(atPath: wt))
+        #expect(FileManager.default.fileExists(atPath: entry.path))
+        #expect(entry.path.hasPrefix(pool + "/" + WorktreeDeletionQueue.dirName + "/"))
+        #expect(entry.originalPath == wt)
+        // Contents moved intact, not copied and truncated.
+        let moved = entry.path + "/file.txt"
+        #expect(try String(contentsOfFile: moved, encoding: .utf8) == "hello")
+    }
+
+    @Test func enqueueGivesEachEntryADistinctDestination() throws {
+        let (tmp, _, wtA) = try makePool(name: "a")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let wtB = (wtA as NSString).deletingLastPathComponent + "/b"
+        try FileManager.default.createDirectory(atPath: wtB, withIntermediateDirectories: true)
+
+        let queue = WorktreeDeletionQueue()
+        let a = try queue.enqueue(worktreePath: wtA)
+        let b = try queue.enqueue(worktreePath: wtB)
+
+        #expect(a.path != b.path)
+    }
+
+    @Test func enqueueThrowsRenameFailedWhenSourceMissing() throws {
+        let (tmp, pool, _) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let queue = WorktreeDeletionQueue()
+        #expect(throws: WorktreeDeletionQueueError.self) {
+            try queue.enqueue(worktreePath: pool + "/does-not-exist")
+        }
+    }
+
+    @Test func pendingEnumeratesEntriesLeftByAPreviousRun() throws {
+        let (tmp, pool, wt) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let queue = WorktreeDeletionQueue()
+        let entry = try queue.enqueue(worktreePath: wt)
+
+        let found = queue.pending(pool: pool)
+        #expect(found.map(\.path) == [entry.path])
+    }
+
+    @Test func pendingIsEmptyWhenQueueDirAbsent() throws {
+        let (tmp, pool, _) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        #expect(WorktreeDeletionQueue().pending(pool: pool).isEmpty)
+    }
+
+    @Test func drainRemovesEntryBytesAndReportsSuccess() throws {
+        let (tmp, pool, wt) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let queue = WorktreeDeletionQueue()
+        let entry = try queue.enqueue(worktreePath: wt)
+
+        #expect(queue.drain(entry) == true)
+        #expect(!FileManager.default.fileExists(atPath: entry.path))
+        #expect(queue.pending(pool: pool).isEmpty)
+    }
+
+    @Test func drainIsIdempotentOnAnAlreadyDrainedEntry() throws {
+        let (tmp, _, wt) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let queue = WorktreeDeletionQueue()
+        let entry = try queue.enqueue(worktreePath: wt)
+        #expect(queue.drain(entry) == true)
+        // A second sweep must treat a vanished entry as done, not as failure.
+        #expect(queue.drain(entry) == true)
+    }
+
+    @Test func drainResumesAfterAPartiallyDeletedEntry() throws {
+        let (tmp, pool, wt) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let queue = WorktreeDeletionQueue()
+        let entry = try queue.enqueue(worktreePath: wt)
+        // Simulate an interrupted drain: some children already gone, dir remains.
+        try FileManager.default.removeItem(atPath: entry.path + "/file.txt")
+
+        #expect(queue.drain(entry) == true)
+        #expect(queue.pending(pool: pool).isEmpty)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeDeletionQueueTests.swift
@@ -146,4 +146,18 @@ struct WorktreeDeletionQueueTests {
         #expect(queue.drain(entry) == true)
         #expect(queue.pending(pool: pool).isEmpty)
     }
+
+    @Test func drainRefusesAPathOutsideAQueueDirectory() throws {
+        let (tmp, _, wt) = try makePool()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        // `QueuedDeletion.init` is public and `drain` is a recursive delete of
+        // whatever path it is handed, so it carries an anchor check the same
+        // way `ScratchpadCollector.cleanUp` does before its own `removeItem`.
+        // Here the "entry" names a live worktree directory rather than
+        // anything TBD renamed into `.deleting/`.
+        let queue = WorktreeDeletionQueue()
+        #expect(queue.drain(QueuedDeletion(path: wt, originalPath: wt)) == false)
+        #expect(FileManager.default.fileExists(atPath: wt + "/file.txt"))
+    }
 }

--- a/docs/specs/2026-08-10-worktree-deletion-queue-design.md
+++ b/docs/specs/2026-08-10-worktree-deletion-queue-design.md
@@ -77,7 +77,16 @@ needs.
    survives, so revive still works.
 4. Fire `onWorktreeRemoved`. This callback is finally truthful; today it fires
    even when removal failed, which is why its consumer had to re-check.
-5. Detached, with no deadline: drain the queued entry.
+5. Drain the queued entry inline, with no deadline attached.
+
+Step 5 runs inline rather than in a task of its own because
+`completeArchiveWorktree` is already the detached half of archiving: every
+production caller — `worktree.archive`, `repo.remove`'s cascade, auto-archive
+on merge — invokes it from a detached task, so a drain that takes minutes
+blocks nothing an RPC waits on. Detaching again would only add a second
+untracked task, and it would break the one caller that wants the wait: the
+synchronous `archiveWorktree(worktreeID:force:)` wrapper, where archive
+completion is meant to mean the bytes are gone.
 
 This also unblocks revive. Today a surviving directory trips the
 `worktreePathAlreadyExists` preflight, so a failed archive poisons the path
@@ -130,10 +139,29 @@ direction favors keeping. It produces two kinds of work:
   reclaimable; TBD put it there.
 - **Interrupted archives** — worktree rows with status `.archived` whose
   directory still exists, subject to the provenance gate below.
+- **Stale registrations** — the mirror image: an archived row whose directory
+  is gone while `git worktree list` still names it. That is what a prune
+  failure (or a daemon killed between the rename and the prune) leaves behind,
+  and it is the failure class this design exists to remove, so the sweep
+  prunes the owning repo rather than letting the registration outlive its
+  directory forever. Left in place it is permanent: revive's preflight refuses
+  a path git still has registered.
 
 An interrupted archive is reclaimed by the same mechanism as a fresh one:
-enqueue, prune, drain. Adoption is finishing an archive that stopped early, not
-a second way to delete things.
+measure, enqueue, prune, drain. Adoption is finishing an archive that stopped
+early, not a second way to delete things. The measurement is `du -sk` before
+the rename, exactly as the other two collectors measure before their removal,
+so the reclaim shows up in the History UI as the gigabytes it actually was
+rather than as zero.
+
+Which pools get drained is a wider question than which directories may be
+*reclaimed*. An adopted worktree can live anywhere, and archiving it puts a
+`.deleting/` queue beside it, outside every layout prefix; a queue left there
+by an interrupted drain would otherwise sit in the user's own directory
+forever. So the sweep enumerates the layout prefixes, the scratch dir, and the
+parent directory of every archived row's path. Draining needs no provenance
+gate — a `.deleting/<uuid>` entry is there because TBD renamed it there — so
+widening the pool list costs nothing in safety.
 
 `OrphanGC.sweep` gains a section for this collector, inheriting its hourly
 cadence, its `gcEnabled` master switch, and its `ReapRecord` persistence, which
@@ -157,15 +185,42 @@ anywhere on disk. Reclaiming an interrupted archive therefore requires all of:
 - For a repo-backed worktree, `git.isLinkedWorktree(candidatePath:repoPath:)`
   passes — the directory's `.git` file resolves into `<repo>/.git/worktrees/`,
   proving it is a linked worktree of the repo the row names.
-- For a scratch space, `repoID` is nil and the path is under `~/tbd/scratch/`.
-  Scratch spaces are not linked worktrees of any repo, so linkage cannot apply;
-  the namespace is TBD's own and is the available proof.
+- The row names a repo. A repoless candidate — a scratch space, `repoID` nil —
+  is **never** reclaimed, whatever namespace it sits in. Archiving a scratch
+  space deliberately leaves its folder on disk (`scratch.archive` flips the row
+  to `.archived` and moves nothing; unlike `scratch.delete`, nothing goes to
+  Trash), and `scratch.revive` needs that folder to bring the space back. So
+  "archived row whose directory exists" is the *normal, supported* state of an
+  archived scratch space, not the signature of an interrupted archive, and a
+  sweep that reclaimed on that signature would delete every archived scratch
+  space on the machine. Linkage cannot substitute for the row either: a scratch
+  space is not a linked worktree of any repo, so there is nothing to prove
+  against.
 - The existing `locked` and live-cwd (`lsof`) gates pass, so a directory a live
   process is sitting in is never reclaimed.
 
 Anything failing the gate is logged and skipped permanently. Measuring the
 directories present when this was written, every repo-backed one satisfied the
 linkage check.
+
+### Not stealing a directory from a running archive
+
+Archiving flips the row to `.archived` in phase 1 and only reaches the rename
+in phase 2, which can spend a minute in the archive hook first. In that window
+an archive that is proceeding normally is indistinguishable, by row and
+directory alone, from one that was interrupted — and a sweep landing there
+would rename the directory out from under the running hook. `repo.remove`'s
+cascade puts many such archives in flight at once, so the window is not
+theoretical.
+
+Interrupted archives therefore also pass an age gate on the row's persisted
+`archivedAt`: a candidate archived within the sweep's grace window
+(`gcGraceSeconds`, the same knob `AgentWorktreeCollector` uses) is kept, with
+keep-reason `grace`. Nothing is lost by waiting — a genuinely interrupted
+archive is reclaimed by the next hourly sweep instead of this one. A row with
+no `archivedAt` is not held: both archive paths stamp it in the same
+transaction that sets the status, so an unstamped row cannot be an archive
+that is running right now.
 
 `forgetWorktree` needs no special handling. It hard-deletes the row rather than
 flipping it to `.archived`, so a directory the user deliberately kept can never
@@ -176,7 +231,8 @@ match "archived row whose directory exists."
 - Enqueue fails (`EXDEV`, permissions) — fall back to `git worktree remove`
   with a raised timeout, and log at error level. The row stays archived; the
   sweep retries later.
-- Prune fails — log; the next sweep prunes.
+- Prune fails — log; the next sweep prunes, because it looks for archived rows
+  whose directory is gone and whose path git still lists.
 - Drain interrupted — the entry stays in `.deleting/`; the next sweep resumes.
 - Provenance gate fails — log once per path; never reclaim.
 
@@ -209,17 +265,33 @@ resumable after interruption; `pending` enumerates what a previous run left.
 `DeletionQueueCollector`: one test per keep-reason, matching the existing
 collectors' style of a test per spec invariant — a worktree outside every
 TBD-owned prefix, a repo-backed directory failing linkage, a locked worktree, a
-directory with a live cwd. Plus the reclaim case, and a test that a forgotten
-worktree's directory is never a candidate.
+directory with a live cwd, an archived scratch space whose folder must survive,
+and a row archived inside the grace window (with its counterpart old enough to
+pass). Plus the reclaim case, a test that a forgotten worktree's directory is
+never a candidate, and a symlink planted inside a pool pointing outside it —
+the gate's authorization boundary, where a path that merely *reads* as
+TBD-owned must still be refused.
+
+Lock state is derived, not asserted by hand: one test locks a real worktree
+with `git worktree lock` and expects the candidate to read as locked, and one
+points a repo at a path git cannot list and expects that repo's candidates to
+read as locked too, since a listing failure must never read as "nothing is
+locked".
 
 Archive path: enqueue is used on the success path; the `git worktree remove`
 fallback is used when enqueue throws; `onWorktreeRemoved` fires only once the
-path is actually gone.
+path is actually gone; the fallback's raised timeout is really the one armed —
+asserted by giving the `GitManager` an instance deadline so short that a
+removal which fell back to it could not possibly complete.
 
 Integration: archive a worktree and assert the pool slot is empty, `.deleting/`
 drains, and `git worktree list` no longer registers it. Then assert an
 interrupted archive — a directory restored into a pool slot under an archived
-row — is reclaimed by one sweep.
+row — is reclaimed by one sweep, with a non-zero byte count on its reap record.
+Assert too that the inverse — a registration whose directory is gone — is
+pruned by one sweep and that the worktree revives afterwards, and that a
+`.deleting/` entry beside an adopted worktree, outside every layout prefix, is
+drained.
 
 Tests run under `scripts/test.sh` so `TBD_HOME` and the host stores stay
 fenced. Any retry or poll takes an injected clock, per CLAUDE.md.
@@ -245,8 +317,10 @@ indistinguishable from a real worktree without consulting the database, so
 every reconciliation decision has to be made on inference. The rename converts
 that inference into a fact about where the directory is.
 
-**A grace period before reclaiming bytes.** Hold interrupted archives in
+**A quarantine period before reclaiming bytes.** Hold queued entries in
 `.deleting/` for some days so a mistake could be noticed. Rejected because
 archiving already promises the directory will be deleted; content that survived
-did so only because of this bug, and a grace period would defer the disk
-reclamation that motivates the work.
+did so only because of this bug, and quarantine would defer the disk
+reclamation that motivates the work. This is a different question from the age
+gate above: that one refuses to touch a directory whose archive may still be
+running, and holds nothing back once the archive is provably over.

--- a/docs/specs/2026-08-10-worktree-deletion-queue-design.md
+++ b/docs/specs/2026-08-10-worktree-deletion-queue-design.md
@@ -105,6 +105,14 @@ nothing else:
 
 No database access, no git, no timers. Testable on a temp directory.
 
+A sweep drains its entries one at a time. Deleting several at once raises
+aggregate throughput about fourfold (938 entries/s alone against 3,519 across
+six concurrent deletions), but a background sweep that saturates the disk
+competes with whatever the developer is doing, and nothing depends on the queue
+draining quickly — an entry that waits an hour costs only the disk it already
+occupies. Bounded concurrency stays available if serial draining proves too
+slow in practice.
+
 The queue is a per-pool sibling of the worktree directories rather than one
 global location, because `rename()` fails across filesystems (`EXDEV`) and pools
 can live outside `TBD_HOME` — `<repo>/.tbd/worktrees/` may sit on another

--- a/docs/specs/2026-08-10-worktree-deletion-queue-design.md
+++ b/docs/specs/2026-08-10-worktree-deletion-queue-design.md
@@ -1,0 +1,244 @@
+# Worktree deletion queue
+
+Archiving a worktree is supposed to remove its directory from disk. Often it
+does not, and nothing notices. This design replaces the deletion step with a
+rename into a per-pool `.deleting/` queue, drained without a deadline, and
+teaches the orphan-GC sweep to finish deletions that were interrupted.
+
+## The problem
+
+`completeArchiveWorktree` removes the directory with a single
+`git worktree remove --force` subprocess. Every git subprocess is capped at
+`GitManager.commandTimeout` (120 s) and escalated SIGTERM → SIGKILL when it
+overruns. Removing a worktree means `unlink()`ing every file in it, and a
+worktree of a large app repo is 200,000–235,000 filesystem entries and
+3.5–7.5 GB — only about 3% of which (6,173 files) are tracked repo content.
+The rest is `node_modules`, `.venv`, and `.direnv`.
+
+Measured unlink throughput on a developer machine ranges from 587 entries/s
+(six concurrent removals) to 3,100 entries/s (one removal, machine otherwise
+quiet). One worktree therefore takes somewhere between 70 seconds and several
+minutes. The 120 s cap sits inside that range rather than above it, so the
+outcome is a coin flip that tilts with machine load.
+
+Nothing about the machine makes this slow: Spotlight indexing is disabled on
+both volumes, no Endpoint Security system extensions are registered, and there
+are no APFS local snapshots. The cost is the file count itself.
+
+When the cap is hit, git is killed partway through `remove_dir_recursively`.
+Because git deletes the `.git/worktrees/<id>` administrative entry only after
+the working-tree removal returns success, a killed removal leaves both a
+half-deleted directory and a live git registration. The resulting
+`GitTimeoutError` is discarded by a `try?` with no logging, inside a
+fire-and-forget `Task.detached` whose failure no one observes. The row was
+already flipped to `.archived` in phase 1, so the database reports the worktree
+gone while gigabytes remain on disk.
+
+The failure is silent, unbounded, and self-amplifying: each disk crisis
+prompts mass archiving, mass archiving produces more surviving directories, and
+those directories consume the disk that provoked the next crisis. A single
+2026-08-06 batch archived twelve worktrees in two minutes; ten left husks,
+stopping at scattered points between 20,000 and 190,000 entries deleted.
+
+One consumer already defends against this. `OrphanGC.scratchpadCleanup`
+re-checks that the directory is really gone before classifying a scratchpad as
+orphaned, with a comment noting the removal is "`try?`-swallowed". The failure
+mode was known at the boundary and never fixed at the source.
+
+## Why deleting faster is not the fix
+
+At the best throughput measured, a 225,000-entry worktree still needs about 73
+seconds. Deleting a quarter-million files is inherently a minutes-long
+operation on APFS, and concurrency does not rescue it — running six removals at
+once raises aggregate throughput to 3,519 entries/s but drops each process to
+587 entries/s, so no individual removal gets meaningfully closer to a deadline.
+Any design that tries to fit this work inside a timeout is building on an
+assumption the filesystem will not honor.
+
+Renaming, by contrast, is one syscall. Moving a 199,690-entry, 7.5 GB tree took
+**2.4 ms**, independent of its size.
+
+## Design
+
+### The commit point
+
+The rename is the moment archiving becomes true. Once the directory has been
+renamed out of its pool slot and `git worktree prune` has dropped the
+registration, the worktree no longer exists as far as TBD and git are
+concerned. Only byte reclamation remains, and that can take as long as it
+needs.
+
+`completeArchiveWorktree` becomes:
+
+1. Run the archive hook, unchanged.
+2. `deletionQueue.enqueue(worktreePath:)` — rename the directory into
+   `<pool>/.deleting/<uuid>`.
+3. `git worktree prune` in the owning repo — drops the registration. The branch
+   survives, so revive still works.
+4. Fire `onWorktreeRemoved`. This callback is finally truthful; today it fires
+   even when removal failed, which is why its consumer had to re-check.
+5. Detached, with no deadline: drain the queued entry.
+
+This also unblocks revive. Today a surviving directory trips the
+`worktreePathAlreadyExists` preflight, so a failed archive poisons the path
+against the worktree that owns it.
+
+### Failure stops being terminal
+
+Every step logs on failure; the `try?` is removed. More importantly, an
+interrupted drain is no longer a dead end. What remains is a directory inside
+`.deleting/`, which is unambiguously garbage that TBD placed there itself. The
+sweep finishes it. Compare today's outcome — a half-deleted directory sitting
+in a live pool slot, still registered with git, distinguishable from a real
+worktree only by cross-referencing the database.
+
+### `WorktreeDeletionQueue`
+
+A new type under `Sources/TBDDaemon/Lifecycle/` owning the queue contract and
+nothing else:
+
+- `queueDir(forPool:)` — `<pool>/.deleting`
+- `enqueue(worktreePath:) throws -> QueuedDeletion` — rename into the queue
+  under a fresh UUID
+- `pending(pool:) -> [QueuedDeletion]` — enumerate entries awaiting reclamation
+- `drain(_:) async` — delete an entry's bytes, resumable
+
+No database access, no git, no timers. Testable on a temp directory.
+
+The queue is a per-pool sibling of the worktree directories rather than one
+global location, because `rename()` fails across filesystems (`EXDEV`) and pools
+can live outside `TBD_HOME` — `<repo>/.tbd/worktrees/` may sit on another
+volume. A sibling directory is same-volume by construction. Every loop that
+enumerates a pool must skip the leading-dot entry.
+
+### `DeletionQueueCollector`
+
+A third collector under `Sources/TBDDaemon/GC/`, alongside
+`AgentWorktreeCollector` and `ScratchpadCollector`, following their
+`candidates` / `decide` / `reap` shape and their rule that every failure
+direction favors keeping. It produces two kinds of work:
+
+- **Queued deletions** — anything under a pool's `.deleting/`. Always
+  reclaimable; TBD put it there.
+- **Interrupted archives** — worktree rows with status `.archived` whose
+  directory still exists, subject to the provenance gate below.
+
+An interrupted archive is reclaimed by the same mechanism as a fresh one:
+enqueue, prune, drain. Adoption is finishing an archive that stopped early, not
+a second way to delete things.
+
+`OrphanGC.sweep` gains a section for this collector, inheriting its hourly
+cadence, its `gcEnabled` master switch, and its `ReapRecord` persistence, which
+surfaces reclaimed directories in the existing history UI. The sweep already
+loads every archived row in `reconcileScratchpads` and filters for directories
+that are *gone*; the directories that remain are the exact inverse of a filter
+it already computes.
+
+`ReapKind` gains a case. It persists as a text column and unknown values are
+skipped with a warning on decode, so no migration is required.
+
+### Provenance gate
+
+A database row is not proof that TBD created a directory. `adoptWorktree` can
+point a row at a worktree TBD never made, and adopted worktrees may live
+anywhere on disk. Reclaiming an interrupted archive therefore requires all of:
+
+- The path lies under a TBD-owned prefix — `~/tbd/worktrees/<slot>/`,
+  `<repo>/.tbd/worktrees/`, or `~/tbd/scratch/`. This is the same prefix notion
+  `reconcile` already uses to decide what it may re-adopt.
+- For a repo-backed worktree, `git.isLinkedWorktree(candidatePath:repoPath:)`
+  passes — the directory's `.git` file resolves into `<repo>/.git/worktrees/`,
+  proving it is a linked worktree of the repo the row names.
+- For a scratch space, `repoID` is nil and the path is under `~/tbd/scratch/`.
+  Scratch spaces are not linked worktrees of any repo, so linkage cannot apply;
+  the namespace is TBD's own and is the available proof.
+- The existing `locked` and live-cwd (`lsof`) gates pass, so a directory a live
+  process is sitting in is never reclaimed.
+
+Anything failing the gate is logged and skipped permanently. Measuring the
+directories present when this was written, every repo-backed one satisfied the
+linkage check.
+
+`forgetWorktree` needs no special handling. It hard-deletes the row rather than
+flipping it to `.archived`, so a directory the user deliberately kept can never
+match "archived row whose directory exists."
+
+### Error handling
+
+- Enqueue fails (`EXDEV`, permissions) — fall back to `git worktree remove`
+  with a raised timeout, and log at error level. The row stays archived; the
+  sweep retries later.
+- Prune fails — log; the next sweep prunes.
+- Drain interrupted — the entry stays in `.deleting/`; the next sweep resumes.
+- Provenance gate fails — log once per path; never reclaim.
+
+No path silently swallows a failure.
+
+## Flag policy
+
+CLAUDE.md requires large or risky new behavior to ship behind a default-off
+flag, and this qualifies on two counts: it replaces a load-bearing path and it
+deletes state from a background sweep.
+
+It ships without a new flag by maintainer decision. The reasoning: the bug is
+actively destroying disk and worsening under its own effects, and a default-off
+flag would leave the buggy path as the shipping default until graduation. The
+behavior runs under the existing `gcEnabled` master switch, which already
+defaults to true and already governs every other GC deletion, so the escape
+hatch exists and is one toggle.
+
+Two properties limit the risk. Reclamation touches only directories that pass
+the provenance gate, and the enqueue step is strictly less destructive than the
+`git worktree remove` it replaces — a rename is reversible until the drain
+runs.
+
+## Testing
+
+`WorktreeDeletionQueue`: enqueue renames rather than copies; enqueue across
+filesystems surfaces `EXDEV` rather than partially completing; drain is
+resumable after interruption; `pending` enumerates what a previous run left.
+
+`DeletionQueueCollector`: one test per keep-reason, matching the existing
+collectors' style of a test per spec invariant — a worktree outside every
+TBD-owned prefix, a repo-backed directory failing linkage, a locked worktree, a
+directory with a live cwd. Plus the reclaim case, and a test that a forgotten
+worktree's directory is never a candidate.
+
+Archive path: enqueue is used on the success path; the `git worktree remove`
+fallback is used when enqueue throws; `onWorktreeRemoved` fires only once the
+path is actually gone.
+
+Integration: archive a worktree and assert the pool slot is empty, `.deleting/`
+drains, and `git worktree list` no longer registers it. Then assert an
+interrupted archive — a directory restored into a pool slot under an archived
+row — is reclaimed by one sweep.
+
+Tests run under `scripts/test.sh` so `TBD_HOME` and the host stores stay
+fenced. Any retry or poll takes an injected clock, per CLAUDE.md.
+
+## Rejected alternatives
+
+**Raise or remove the git timeout.** The cheapest change, and it addresses the
+proximate cause. Rejected because it only widens a window that the filesystem
+decides the width of: a slower machine, a larger dependency tree, or more
+concurrent archives puts the operation back over any fixed bound, and the
+failure mode returns unchanged. It survives only as the fallback when a rename
+cannot be performed.
+
+**Serialize archive deletions.** Running one removal at a time gives each the
+full throughput of the volume. Rejected because the best measured single-stream
+rate still needs about 73 seconds for a full worktree, so the largest cases
+remain near the cap while every archive now waits behind the queue.
+
+**Delete in place and reconcile afterwards.** Skip the rename; let the sweep
+find and finish half-deleted directories. Rejected because it leaves the hard
+problem intact — a half-deleted directory in a live pool slot is
+indistinguishable from a real worktree without consulting the database, so
+every reconciliation decision has to be made on inference. The rename converts
+that inference into a fact about where the directory is.
+
+**A grace period before reclaiming bytes.** Hold interrupted archives in
+`.deleting/` for some days so a mistake could be noticed. Rejected because
+archiving already promises the directory will be deleted; content that survived
+did so only because of this bug, and a grace period would defer the disk
+reclamation that motivates the work.

--- a/docs/specs/2026-08-10-worktree-deletion-queue-design.md
+++ b/docs/specs/2026-08-10-worktree-deletion-queue-design.md
@@ -252,9 +252,12 @@ defaults to true and already governs every other GC deletion, so the escape
 hatch exists and is one toggle.
 
 Two properties limit the risk. Reclamation touches only directories that pass
-the provenance gate, and the enqueue step is strictly less destructive than the
-`git worktree remove` it replaces — a rename is reversible until the drain
-runs.
+the provenance gate, and the enqueue step trades a partial unlink for a rename:
+where an interrupted `git worktree remove` left a tree half-deleted in its pool
+slot, an interrupted archive now leaves it whole inside `.deleting/`. That is a
+crash-recovery property, not a window in which a user could change their mind —
+every call path drains immediately after enqueuing, and a holding period is
+rejected below.
 
 ## Testing
 

--- a/docs/specs/2026-08-10-worktree-deletion-queue-design.md
+++ b/docs/specs/2026-08-10-worktree-deletion-queue-design.md
@@ -244,20 +244,34 @@ CLAUDE.md requires large or risky new behavior to ship behind a default-off
 flag, and this qualifies on two counts: it replaces a load-bearing path and it
 deletes state from a background sweep.
 
-It ships without a new flag by maintainer decision. The reasoning: the bug is
-actively destroying disk and worsening under its own effects, and a default-off
-flag would leave the buggy path as the shipping default until graduation. The
-behavior runs under the existing `gcEnabled` master switch, which already
-defaults to true and already governs every other GC deletion, so the escape
-hatch exists and is one toggle.
+It ships without a new flag by maintainer decision, and the two halves are
+mitigated differently — the toggle covers one of them, not both.
 
-Two properties limit the risk. Reclamation touches only directories that pass
-the provenance gate, and the enqueue step trades a partial unlink for a rename:
-where an interrupted `git worktree remove` left a tree half-deleted in its pool
-slot, an interrupted archive now leaves it whole inside `.deleting/`. That is a
-crash-recovery property, not a window in which a user could change their mind —
-every call path drains immediately after enqueuing, and a holding period is
-rejected below.
+**The sweep-side additions are gated.** Draining queued entries, reclaiming
+interrupted archives, and pruning stale registrations all run inside
+`OrphanGC.sweep`, under the existing `gcEnabled` master switch. That switch
+already defaults to true and already governs every other GC deletion, so the
+escape hatch for the autonomous, state-deleting half is one toggle, and both
+branches are tested.
+
+**The archive-path replacement is ungated**, and there is no honest way to
+describe it otherwise: `completeArchiveWorktree` enqueues and drains on every
+`worktree.archive`, `repo.remove` cascade, and auto-archive on merge, with no
+`gcEnabled` check. `gcEnabled` mitigates nothing there. What justifies leaving
+it ungated is that the code it replaces was equally ungated: the deletion step
+of archiving has never been behind a flag, and the change swaps one
+unconditional deletion mechanism for another on the same path. A flag would not
+have added a safety margin that previously existed; it would have made the
+buggy path the shipping default until graduation, while the bug is actively
+destroying disk and worsening under its own effects.
+
+Two properties limit the risk that remains. Reclamation touches only
+directories that pass the provenance gate, and the enqueue step trades a
+partial unlink for a rename: where an interrupted `git worktree remove` left a
+tree half-deleted in its pool slot, an interrupted archive now leaves it whole
+inside `.deleting/`. That is a crash-recovery property, not a window in which a
+user could change their mind — every call path drains immediately after
+enqueuing, and a holding period is rejected below.
 
 ## Testing
 


### PR DESCRIPTION
## What's broken

Archiving a worktree is supposed to delete its directory. Often it didn't, and nothing noticed. On one machine, cross-referencing `tbd worktree list` against disk found **59 directories whose rows read `.archived`** — roughly 36 GiB — some dating to April. Their git state was distinctive: half-deleted trees that `git worktree list` still registered.

They also poisoned their own slot. A surviving directory trips revive's `worktreePathAlreadyExists` preflight, so a failed archive permanently blocks the worktree that owns it.

## Why it happens

`completeArchiveWorktree` removed the directory with one `git worktree remove --force` subprocess. Every git subprocess is capped at `GitManager.commandTimeout` (120 s) and escalated SIGTERM → SIGKILL. But removal means `unlink()`ing every file, and a dependency-heavy worktree is 200,000–235,000 filesystem entries — only ~3% of which are tracked repo content; the rest is `node_modules`, `.venv`, `.direnv`.

Measured unlink throughput on the affected machine: **587 entries/s** (six concurrent removals) to **3,100 entries/s** (one removal, machine quiet). So one worktree takes 70 seconds to several minutes. The 120 s cap sits *inside* that range rather than above it, which is why this failed intermittently rather than always.

Nothing exotic was slowing it down — Spotlight indexing is disabled on both volumes, no Endpoint Security extensions are registered, no APFS local snapshots. It's the file count.

When the cap hit, git was killed partway through `remove_dir_recursively`. Because git deletes the `.git/worktrees/<id>` admin entry **only after** the working-tree removal returns success, a killed removal stranded both a half-deleted directory and a live registration. The resulting `GitTimeoutError` was discarded by a `try?` with no logging, inside a fire-and-forget `Task.detached` nobody observed — while phase 1 had already flipped the row to `.archived`.

## How it got broken

The uniform 120 s cap landed in #367 (2026-07-06), which bounded tmux/git subprocesses to fix a wedged `git fetch` that had hung for 95 minutes. That was the right fix for its problem, but it applied one ceiling to every git command, including the one that legitimately needs minutes. The zombie dates correlate: 54 of the 59 were archived in July–August, against 3 in April–May.

It went unnoticed because the `try?` discarded the only evidence, and because the failure is silent and self-amplifying — a disk crisis prompts mass archiving, mass archiving strands more directories, and those consume the disk that provokes the next crisis. A single 2026-08-06 batch archived twelve worktrees in two minutes; ten left husks.

## What this PR does

Deleting a quarter-million files is inherently a minutes-long job, so no design that fits it inside a deadline can work. Instead the deadline is removed from the path entirely.

**The rename is the commit point.** Archiving now renames the directory into a per-pool `.deleting/` queue — one `rename(2)`, measured at **2.4 ms for a 199,690-entry / 7.5 GB tree**, independent of size — then prunes the registration, then reclaims the bytes with no deadline. Once the rename lands, the worktree is gone as far as TBD and git are concerned. An interrupted drain leaves unambiguous garbage in `.deleting/` that the sweep finishes, rather than a husk indistinguishable from a live worktree without consulting the database.

`rename(2)` is called directly rather than via `FileManager.moveItem`, which silently degrades to recursive copy-then-delete across filesystems; failing fast with `EXDEV` is what the fallback leg needs. The queue is a per-pool sibling because `rename()` can't cross filesystems and pools may live outside `TBD_HOME`.

**A third collector in the hourly `OrphanGC` sweep** drains leftover entries and finishes archives interrupted before this shipped, using the same enqueue-then-prune mechanism — one deletion path, not two. Reclaiming is gated because a database row is *not* proof TBD created a directory: `adoptWorktree` can point a row at a worktree TBD never made. All of these must hold — TBD-owned prefix, `isLinkedWorktree` passes, not locked, no live cwd, and past a grace window keyed on `archivedAt` so a sweep can't rename a directory out from under an archive hook still running. An archived **scratch** space is never reclaimed at all: `scratch.archive` deliberately keeps its folder and revive needs it.

Also here: a stale-registration prune, so a registration that outlives its directory (prune failure, or a daemon killed between rename and prune) no longer blocks revive forever; and reclaimed directories now surface in the Reclaimed history UI with real byte counts.

Design: [`docs/specs/2026-08-10-worktree-deletion-queue-design.md`](docs/specs/2026-08-10-worktree-deletion-queue-design.md).

**No feature flag**, by maintainer decision — recorded with its reasoning in the spec's Flag policy section. The bug actively destroys disk and worsens under its own effects, and a default-off flag would leave the buggy path as the shipping default. It runs under the existing `gcEnabled` switch, which already governs every other GC deletion.

## Test plan

- [x] Full suite: 5435 tests. Only known load flakes (`ProviderEventsSupervisor` ×2, `CodexUsageFetcherLifecycle`, `MarkdownStylesheet` FileWatcher) — all green in isolation, none in code this branch touches.
- [x] `swiftlint --strict`: 0 violations across 683 files.
- [x] The four deletion-queue suites against real git repos: 41/41.
- [x] Both branches of the gated behavior asserted: `gcEnabled == false` and `dryRun` each leave disk *and* database untouched, on both sweep steps.
- [x] Deliberate mutation checks on the review fixes — 9 mutations, each producing exactly the expected red and no others.
- [ ] **Live-daemon check outstanding**, deliberately skipped: it needs `scripts/restart.sh`, which would restart a running fleet. Worth doing before merge — archive a worktree and confirm the pool slot empties immediately and `git worktree list` no longer registers it.

## Follow-ups (not blocking)

- **Revive-path race**, the mirror of the grace gate's: `beginReviveWorktree` recreates the directory and registration while leaving the row `.archived` with a stale `archivedAt`, so the grace gate can't hold it and a sweep landing in that window could reap a just-revived worktree. Pre-existing; window is seconds against an hourly sweep. Fix is to clear `archivedAt` before `git worktree add`.
- A `.deleting/` entry orphaned after `repo.remove` deletes both the rows and the repo has nothing left to name its pool. Residual is unreclaimed bytes in a tree the user asked TBD to forget.
- `pruneStaleRegistrations` makes `git worktree prune` hourly and fleet-wide; git's prune drops every missing-directory registration in that repo, including an active worktree on a temporarily unmounted volume. `git worktree lock` is git's designated mitigation.
- `OrphanGC.swift` is ~600 lines over six concerns; split by concern when a seventh arrives.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=898A56B4-C3BC-48A1-A8C0-57F415DE20B5)