### PR TITLE
feat: name TBD sessions and unify the Claude peer registry across profiles

### DIFF
--- a/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeProfileConfigDirManager.swift
@@ -9,9 +9,12 @@ private let logger = Logger(subsystem: "com.tbd.daemon", category: "claudeProfil
 /// proxy apiKey profiles with an isolated config directory where they can
 /// maintain independent credentials.
 ///
-/// Each profile dir mirrors customization slots from the host's `~/.claude/`
-/// directory via symlinks: `projects/`, `plugins/`, `skills/`, `agents/`,
-/// `commands/`, `hooks/`, `CLAUDE.md`, and `settings.json`. Per-profile identity
+/// Each profile dir mirrors slots from the host's `~/.claude/` directory via
+/// symlinks. Eight are host *customizations* — `projects/`, `plugins/`,
+/// `skills/`, `agents/`, `commands/`, `hooks/`, `CLAUDE.md`, and
+/// `settings.json` — and the ninth, `sessions/`, is not a customization at all
+/// but Claude Code's live cross-session peer registry, mirrored so profiles can
+/// see each other's sessions (see `mirrorSlots`). Per-profile identity
 /// (`.claude.json`, Keychain entry keyed on `CLAUDE_CONFIG_DIR` path, and
 /// `.credentials.json` as a fallback when Keychain is unavailable) is
 /// owned by each profile. The `apiKeyHelper` mode uses the profile's Keychain
@@ -98,10 +101,11 @@ public struct ClaudeProfileConfigDirManager: Sendable {
     /// Slots that each TBD profile dir mirrors from the host's claude config dir.
     /// Symlinked from <profile>/claude/<slot> to <host-base>/<slot>.
     /// `projects` migrates pre-existing real-dir content into the host store
-    /// before symlinking (file-level collision check; atomic abort). Every other
-    /// slot with pre-existing real content is moved to `<slot>.profile-local`
-    /// as a sidecar before the symlink is created — see `ensureMirrorSlot` for
-    /// the full per-slot policy.
+    /// before symlinking (file-level collision check; atomic abort), `sessions`
+    /// merges its rows into the host registry, and every other slot with
+    /// pre-existing real content is moved to `<slot>.profile-local` as a sidecar
+    /// before the symlink is created — see `ensureMirrorSlot` for the full
+    /// per-slot policy.
     private static let mirrorSlots: [String] = [
         "projects",
         "plugins",
@@ -111,7 +115,66 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         "hooks",
         "CLAUDE.md",
         "settings.json",
+        // Claude Code's cross-session peer registry: one small JSON row per
+        // live session (pid, session id, cwd, tmux pane, inbox socket path,
+        // name, status), written to `$CLAUDE_CONFIG_DIR/sessions/<pid>.json`.
+        // It is a discovery *index*, not transcript data, and because it lives
+        // under the config dir, TBD profiles are otherwise mutually invisible
+        // — measured: 24 live sessions in one profile could not be seen from a
+        // session in another. The message sockets themselves already live in a
+        // per-OS-user directory, so sharing the index is enough to make every
+        // TBD session discoverable regardless of which profile spawned it.
+        "sessions",
     ]
+
+    /// Slots whose host directory is created on demand when it does not exist
+    /// yet, instead of skipping the slot (the default in `ensureMirrorSlot`).
+    ///
+    /// Only `sessions` qualifies. The other eight are host *customizations* —
+    /// a profile has nothing to gain from a symlink to an empty directory the
+    /// user never created, and creating one would invent host state. The peer
+    /// registry is the opposite: Claude Code creates it the first time a
+    /// session registers, so on a machine where no session has run yet the
+    /// skip would silently no-op and leave profiles fragmented forever — the
+    /// exact failure this slot exists to prevent.
+    private static let slotsCreatedOnHostIfMissing: Set<String> = ["sessions"]
+
+    /// Slots whose pre-existing profile-side content is **merged** into the
+    /// host entry instead of being parked in a `<slot>.profile-local` sidecar
+    /// (the default in `ensureMirrorSlot`).
+    ///
+    /// Only `sessions` qualifies, and the distinction is not stylistic: the
+    /// other eight slots hold inert user content, while a `sessions/` row is
+    /// live process state. `ensureHostMirrors` runs on every spawn, so a
+    /// sidecar move there would relocate *running* sessions' rows out from
+    /// under them — nothing reads the sidecar, and each session's exit-time
+    /// unlink targets the host path, so the row would be orphaned for good.
+    /// Measured on one developer machine before this landed: 4 profiles held 48
+    /// rows, 47 of them belonging to live PIDs.
+    ///
+    /// Merging is collision-free by construction because rows are named
+    /// `<pid>.json` and PIDs are unique per OS user at any instant; the
+    /// newest-wins tiebreak below exists only for a *stale* row left by a dead
+    /// process whose PID a later session reused under another profile.
+    private static let slotsMergedIntoHost: Set<String> = ["sessions"]
+
+    /// Slots whose host entry must be a directory before it can be mirrored.
+    ///
+    /// Scoped to `sessions` deliberately. The other eight keep their
+    /// pre-existing unchecked behaviour — two of them (`CLAUDE.md`,
+    /// `settings.json`) are files by design, and the rest have never been
+    /// reported wedged. What makes `sessions` different is that TBD *writes*
+    /// through the mirror: a host `sessions` that is a regular file would give
+    /// every profile a symlink to a file and fail every registry write.
+    private static let slotsRequiringHostDirectory: Set<String> = ["sessions"]
+
+    /// Permissions Claude Code creates its own `sessions/` directory with.
+    /// Field-measured on this machine: the host `~/.claude/sessions` and the
+    /// `sessions/` dir of every profile that had run a session were all
+    /// `drwx------`. Matched so a TBD-created directory is indistinguishable
+    /// from one the CLI would have made, and so peer rows — which carry inbox
+    /// socket paths — are not world-readable.
+    private static let sessionsDirectoryPermissions = 0o700
 
     /// Walk `src` against `dst`, returning the path of the first real collision
     /// found, or nil if `src` can be merged into `dst` without overwriting any
@@ -179,8 +242,93 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         try fm.removeItem(at: src)  // now empty
     }
 
+    /// Last-modified stamp for a filesystem entry, `.distantPast` when it
+    /// cannot be read. `attributesOfItem` does not follow symlinks, which is
+    /// what we want: the stamp should describe the entry we are about to move
+    /// or delete, not whatever it might point at.
+    private static func modificationDate(of url: URL) -> Date {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attributes?[.modificationDate] as? Date) ?? .distantPast
+    }
+
+    /// Move every row out of a profile's real registry directory into the host
+    /// registry, then remove the emptied profile directory. Returns false when
+    /// anything is left behind, in which case the caller must **not** symlink
+    /// over it — a partial merge is retried on the next spawn rather than
+    /// buried.
+    ///
+    /// Rows are named `<pid>.json` and PIDs are unique per OS user at any
+    /// instant, so the merge is collision-free by construction. A same-named
+    /// row on both sides therefore means one of them is stale — a dead
+    /// process's row whose PID a later session reused under another profile —
+    /// and the newer modification time wins. The loser is deleted, and logged
+    /// so the deletion is observable. An unreadable stamp loses, since the host
+    /// side is the one live sessions are writing to.
+    private func mergeRegistryRows(from profileEntry: URL, into hostEntry: URL, slot: String) -> Bool {
+        let fm = FileManager.default
+        let rows: [URL]
+        do {
+            rows = try fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)
+        } catch {
+            logger.warning("failed listing profile \(slot, privacy: .public)/ for merge: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+
+        for row in rows {
+            let rowName = row.lastPathComponent
+            let destination = hostEntry.appendingPathComponent(rowName)
+            do {
+                if fm.fileExists(atPath: destination.path) {
+                    if Self.modificationDate(of: row) > Self.modificationDate(of: destination) {
+                        logger.warning("\(slot, privacy: .public) row \(rowName, privacy: .public) exists on both sides; discarding the older host copy")
+                        try fm.removeItem(at: destination)
+                        try fm.moveItem(at: row, to: destination)
+                    } else {
+                        logger.warning("\(slot, privacy: .public) row \(rowName, privacy: .public) exists on both sides; discarding the older profile copy")
+                        try fm.removeItem(at: row)
+                    }
+                } else {
+                    try fm.moveItem(at: row, to: destination)
+                }
+            } catch {
+                logger.warning("failed merging \(slot, privacy: .public) row \(rowName, privacy: .public) into the host registry: \(error.localizedDescription, privacy: .public)")
+                return false
+            }
+        }
+
+        do {
+            try fm.removeItem(at: profileEntry)
+        } catch {
+            logger.warning("failed removing merged profile \(slot, privacy: .public)/: \(error.localizedDescription, privacy: .public)")
+            return false
+        }
+        return true
+    }
+
     /// Ensure one host-mirror slot is a symlink from the profile dir into the
     /// host base. Best-effort: filesystem errors are logged and swallowed.
+    ///
+    /// **Host side.** The slot is skipped unless the host entry is usable: a
+    /// non-directory host entry for a slot in `slotsRequiringHostDirectory`, or
+    /// an entry that exists only as a dangling symlink, is logged and left
+    /// alone rather than symlinked at. When the host entry is absent, the slot
+    /// is normally skipped — except for `slotsCreatedOnHostIfMissing`
+    /// (`sessions`), where the directory is created on demand, non-recursively
+    /// and only if the host base directory already exists. TBD never conjures
+    /// the host store itself; a machine with no `~/.claude` gets no mirror.
+    ///
+    /// **Profile side**, in three policies:
+    ///
+    /// - `projects/` (migrateContent=true) migrates content into the host store
+    ///   with the collision check described below.
+    /// - `sessions/` (`slotsMergedIntoHost`) merges its rows into the host
+    ///   registry entry-by-entry — newest modification time wins a same-named
+    ///   row — then removes the emptied profile directory. It holds live
+    ///   process state, so parking it in a sidecar would orphan running
+    ///   sessions' rows.
+    /// - Everything else with real content is moved to a `<slot>.profile-local`
+    ///   sidecar, which lets the symlink be created without destroying what was
+    ///   there.
     ///
     /// For `projects/` (migrateContent=true), performs file-level collision detection
     /// by recursively walking the full tree structure. Same-named directories on both
@@ -202,8 +350,47 @@ public struct ClaudeProfileConfigDirManager: Sendable {
         let fm = FileManager.default
         let hostEntry = hostBaseDirectory.appendingPathComponent(name)
 
-        // Skip if the host doesn't have this slot at all.
-        guard fm.fileExists(atPath: hostEntry.path) else { return }
+        // Classify the host entry before treating it as a mirror target.
+        // `fileExists` resolves symlinks, so on its own it cannot tell a usable
+        // directory from a regular file, and it answers *false* for a dangling
+        // symlink. `attributesOfItem` does not resolve links, so an entry it can
+        // stat while `fileExists` denies is precisely a dangling link — which
+        // would otherwise send us down the create branch, where
+        // `createDirectory` fails EEXIST on every spawn, forever.
+        var hostIsDir: ObjCBool = false
+        let hostEntryResolves = fm.fileExists(atPath: hostEntry.path, isDirectory: &hostIsDir)
+        let hostPathOccupied = (try? fm.attributesOfItem(atPath: hostEntry.path)) != nil
+
+        if !hostEntryResolves {
+            if hostPathOccupied {
+                logger.warning("host slot \(name, privacy: .public) is a dangling symlink; leaving it alone")
+                return
+            }
+            // Absent host slot: normally "the user does not use this feature",
+            // so skip. For the create-on-demand slots it is instead the
+            // ordinary first-run state, so create it — but never invent the
+            // host store itself, and never recursively (see finding: 0700 on a
+            // conjured `~/.claude` would be host state TBD had no business
+            // making).
+            guard Self.slotsCreatedOnHostIfMissing.contains(name) else { return }
+            guard fm.fileExists(atPath: hostBaseDirectory.path) else {
+                logger.warning("host claude store is absent; not creating slot \(name, privacy: .public)")
+                return
+            }
+            do {
+                try fm.createDirectory(
+                    at: hostEntry,
+                    withIntermediateDirectories: false,
+                    attributes: [.posixPermissions: Self.sessionsDirectoryPermissions]
+                )
+            } catch {
+                logger.warning("failed creating host slot \(name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return
+            }
+        } else if Self.slotsRequiringHostDirectory.contains(name), !hostIsDir.boolValue {
+            logger.warning("host slot \(name, privacy: .public) is not a directory; leaving it alone")
+            return
+        }
 
         let profileEntry = profileClaudeDir.appendingPathComponent(name)
 
@@ -286,6 +473,13 @@ public struct ClaudeProfileConfigDirManager: Sendable {
                     logger.warning("failed migrating \(name, privacy: .public) for profile: \(error.localizedDescription, privacy: .public)")
                     return
                 }
+            } else if isDir.boolValue, Self.slotsMergedIntoHost.contains(name) {
+                // Live-registry directory in profile: merge its rows into the
+                // host registry rather than parking them in a sidecar nothing
+                // reads. Bail without symlinking if anything is left behind, so
+                // a partial merge is retried on the next spawn instead of being
+                // buried under a symlink.
+                guard mergeRegistryRows(from: profileEntry, into: hostEntry, slot: name) else { return }
             } else if isDir.boolValue {
                 // Non-projects directory in profile: move to sidecar if non-empty, otherwise remove.
                 let entries = (try? fm.contentsOfDirectory(at: profileEntry, includingPropertiesForKeys: nil)) ?? []

--- a/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeSpawnCommandBuilder.swift
@@ -21,6 +21,17 @@ import TBDShared
 ///   with optional `--append-system-prompt` and trailing initial-prompt arg.
 /// - Otherwise → `cmd` if set, else `shellFallback`.
 ///
+/// `sessionName`, when non-nil and not blank, adds ` --name <escaped>` to both
+/// claude branches (never to `cmd` / `shellFallback`, which are not claude).
+/// Callers pass the worktree's display name so the session announces itself
+/// under the name the user sees in the app — that is the address peers use for
+/// Claude Code's cross-session `ListAgents` / `SendMessage`. Without it a
+/// session names itself after its working-directory folder slug, which never
+/// matches an app-side rename. The name is fixed at spawn, so a later rename
+/// applies at the next respawn or resume. Display names are unvalidated free
+/// text, so the name is sanitized here rather than at the rename handler (see
+/// `sanitizedSessionName`) — renaming must keep meaning what the user typed.
+///
 /// If we built a claude command (resume or fresh), `sensitiveEnv` carries the
 /// auth + routing env vars for the spawned session (plus
 /// `DISABLE_AUTO_UPDATE=true`, an rc-affecting toggle that must reach the
@@ -67,6 +78,7 @@ enum ClaudeSpawnCommandBuilder {
         settingsOverlayPath: String? = nil,
         pluginDirPath: String? = nil,
         envSettingOverrides: [String: ClaudeEnvValue] = [:],
+        sessionName: String? = nil,
         fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) }
     ) -> Result {
         // Optional --settings flag merged into the claude invocation.
@@ -90,16 +102,27 @@ enum ClaudeSpawnCommandBuilder {
             pluginFlag = ""
         }
 
+        // Session name for Claude Code's cross-session peer registry. Blank,
+        // whitespace-only and control-character-only names are dropped rather
+        // than passed through: `--name ''` would register an unaddressable
+        // session.
+        let nameFlag: String
+        if let sanitized = sanitizedSessionName(sessionName) {
+            nameFlag = " --name \(SystemPromptBuilder.shellEscape(sanitized))"
+        } else {
+            nameFlag = ""
+        }
+
         let base: String
         if let resumeID {
             let forkFlag = forkSession ? " --fork-session" : ""
-            var b = "claude --resume \(resumeID)\(forkFlag) --dangerously-skip-permissions\(settingsFlag)\(pluginFlag)"
+            var b = "claude --resume \(resumeID)\(forkFlag) --dangerously-skip-permissions\(nameFlag)\(settingsFlag)\(pluginFlag)"
             if let p = initialPrompt, !p.isEmpty {
                 b += " \(SystemPromptBuilder.shellEscape(p))"
             }
             base = b
         } else if let sessionID = freshSessionID {
-            var b = "claude --session-id \(sessionID) --dangerously-skip-permissions\(settingsFlag)\(pluginFlag)"
+            var b = "claude --session-id \(sessionID) --dangerously-skip-permissions\(nameFlag)\(settingsFlag)\(pluginFlag)"
             if let prompt = appendSystemPrompt {
                 b += " --append-system-prompt \(SystemPromptBuilder.shellEscape(prompt))"
             }
@@ -189,5 +212,37 @@ enum ClaudeSpawnCommandBuilder {
             .joined(separator: " ")
         let command = inlineExports.isEmpty ? base : "\(inlineExports) \(base)"
         return Result(command: command, sensitiveEnv: env)
+    }
+
+    /// Longest `--name` value TBD will emit. Display names are free text with
+    /// no length ceiling of their own, and the whole invocation ends up in
+    /// `#{pane_start_command}` and in `ps` argv; a name long enough to matter
+    /// there is not an address anyone types anyway.
+    static let maxSessionNameLength = 64
+
+    /// The `--name` value for a display name, or nil when nothing addressable
+    /// survives.
+    ///
+    /// `shellEscape` single-quotes and handles embedded apostrophes, but a
+    /// single-quoted newline is still a newline: it would split
+    /// `#{pane_start_command}` across lines and corrupt anything that reads the
+    /// pane's command back. Control and format characters are stripped rather
+    /// than escaped — they carry no meaning in an address — then the result is
+    /// trimmed, length-capped, and trimmed again so a cap landing mid-space
+    /// cannot leave a trailing blank.
+    ///
+    /// Deliberately here and not in the rename handler: sanitizing there would
+    /// change what a rename means to the user, and the display name has many
+    /// consumers that are perfectly happy with newlines.
+    static func sanitizedSessionName(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let stripped = String(String.UnicodeScalarView(
+            raw.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) }
+        ))
+        let trimmed = stripped.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let capped = String(trimmed.prefix(maxSessionNameLength))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return capped.isEmpty ? nil : capped
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -720,7 +720,8 @@ public actor HibernationCoordinator {
             shellFallback: defaultShell,
             settingsOverlayPath: overlayPath,
             pluginDirPath: PluginDirWriter.pluginDirPath,
-            envSettingOverrides: claudeEnvOverrides
+            envSettingOverrides: claudeEnvOverrides,
+            sessionName: worktree.displayName
         )
         // Inject TBD_WORKTREE_ID + TBD_TERMINAL_ID so notifications and the
         // SessionStart hook attribute to this terminal after the resume rollover.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -860,7 +860,8 @@ extension WorktreeLifecycle {
                     extraSettingsJSON: isResume ? nil : claudeSettingsOverlay
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
-                envSettingOverrides: claudeEnvOverrides
+                envSettingOverrides: claudeEnvOverrides,
+                sessionName: worktree.displayName
             )
             primaryCommand = spawn.command
             primaryEnv = [
@@ -1049,7 +1050,8 @@ extension WorktreeLifecycle {
                         repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
                     ),
                     pluginDirPath: PluginDirWriter.pluginDirPath,
-                    envSettingOverrides: claudeEnvOverrides
+                    envSettingOverrides: claudeEnvOverrides,
+                    sessionName: worktree.displayName
                 )
                 let perTermEnv: [String: String] = [
                     "TBD_WORKTREE_ID": worktreeID.uuidString,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -400,7 +400,8 @@ extension RPCRouter {
                   )
                 : nil,
             pluginDirPath: isClaudeType ? PluginDirWriter.pluginDirPath : nil,
-            envSettingOverrides: claudeEnvOverrides
+            envSettingOverrides: claudeEnvOverrides,
+            sessionName: worktree.displayName
         )
 
         // For Claude terminals, layer the builder's auth/routing env ON TOP of
@@ -738,7 +739,8 @@ extension RPCRouter {
                     repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
-                envSettingOverrides: claudeEnvOverrides
+                envSettingOverrides: claudeEnvOverrides,
+                sessionName: worktree.displayName
             )
             let env: [String: String] = [
                 "TBD_WORKTREE_ID": worktree.id.uuidString,
@@ -1587,7 +1589,8 @@ extension RPCRouter {
                     repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
-                envSettingOverrides: claudeEnvOverrides
+                envSettingOverrides: claudeEnvOverrides,
+                sessionName: worktree.displayName
             )
             storedSessionID = resumeID
             scheduleRecapture = true
@@ -1617,7 +1620,8 @@ extension RPCRouter {
                     repoSettingsJSON: ClaudeHookOverlay.repoSettingsFragment(repoID: repo?.id)
                 ),
                 pluginDirPath: PluginDirWriter.pluginDirPath,
-                envSettingOverrides: claudeEnvOverrides
+                envSettingOverrides: claudeEnvOverrides,
+                sessionName: worktree.displayName
             )
             storedSessionID = newSessionID
             scheduleRecapture = false

--- a/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
+++ b/Sources/TBDDaemon/Tmux/ClaudeStateDetector.swift
@@ -45,6 +45,17 @@ public struct ClaudeStateDetector: Sendable {
     /// so the read lands inside `scripts/test.sh`'s scratch store rather than
     /// failing on the mode-000 decoy the fence puts in its place.
     ///
+    /// This reads the **host** store even for a session spawned under a TBD
+    /// profile, whose `CLAUDE_CONFIG_DIR` is `~/tbd/profiles/<id>/claude`. That
+    /// used to miss for every profile terminal, so session-ID recapture after a
+    /// `--fork-session` resume (`HibernationCoordinator`,
+    /// `SessionRecaptureScheduler`) silently found nothing there and fell back.
+    /// It resolves now only because `ClaudeProfileConfigDirManager` mirrors the
+    /// `sessions/` slot: each profile's `sessions/` is a symlink to the host
+    /// one, so a profile session's row lands at this path. Removing that mirror
+    /// slot would quietly re-break recapture — `ClaudeStateDetectorTests` pins
+    /// the coupling.
+    ///
     /// Internal rather than private so `ClaudeStateDetectorTests` can assert
     /// the path without a real session file to read.
     func sessionFilePath(forPID pid: Int) -> URL {
@@ -83,7 +94,11 @@ public struct ClaudeStateDetector: Sendable {
     }
 
     /// Read a Claude session file for a given PID. Returns nil if file doesn't exist or is invalid.
-    private func readSessionID(forPID pid: Int) -> String? {
+    ///
+    /// Internal rather than private so `ClaudeStateDetectorTests` can pin the
+    /// profile-mirror coupling described on `sessionFilePath(forPID:)` — that a
+    /// profile session's row really is readable through the host store.
+    func readSessionID(forPID pid: Int) -> String? {
         let sessionPath = sessionFilePath(forPID: pid)
         guard let json = try? String(contentsOf: sessionPath, encoding: .utf8) else { return nil }
         return Self.parseSessionID(from: json)

--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -100,6 +100,23 @@ tbd terminal send --terminal <id> --text "..." [--submit]
 tbd terminal output <id> [--lines N]
 ```
 
+### Message a sibling session
+
+Two channels reach another TBD session.
+
+If `ListAgents` and `SendMessage` are among your tools, sibling sessions on this
+machine should show up in `ListAgents` — registration is best-effort, so a
+running session can be missing — and `SendMessage` hands one plain text,
+delivered between the recipient's turns. Rows are labelled with the
+worktree display name, which is **not** unique: several terminals in one
+worktree share it, and so can worktrees in different repos. `ListAgents` prints
+a short `[ref]` on each row; address a peer by that `[ref]` whenever more than
+one row shares a name. If those tools aren't there, use `tbd terminal send`.
+
+`tbd terminal send` / `tbd terminal output` (above) is the daemon-mediated
+channel: it works from any harness, and it can also drive input into a
+session's composer rather than only handing it a message.
+
 ### Pin / unpin a terminal
 
 Pin a terminal to keep it docked and quickly reachable; unpin to remove it from the dock.

--- a/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeProfileConfigDirManagerTests.swift
@@ -1099,6 +1099,382 @@ struct ClaudeProfileConfigDirManagerTests {
         // Verify: profile projects/ is still a real directory (NOT a symlink)
         #expect((try? fm.destinationOfSymbolicLink(atPath: profileProjectsBase.path)) == nil)
     }
+
+    // MARK: - sessions/ mirror slot (cross-session peer registry)
+    //
+    // Claude Code registers each live session as one JSON row under
+    // `$CLAUDE_CONFIG_DIR/sessions/`, so without this slot two TBD profiles
+    // cannot see each other's sessions in `ListAgents`. It differs from the
+    // other eight slots twice over: an absent host `sessions/` is the ordinary
+    // first-run state, so it is created rather than skipped; and pre-existing
+    // profile-side rows are live process state, so they are merged into the
+    // host registry rather than parked in a sidecar nothing reads.
+
+    /// Resolve the symlink at `link` and compare it to `expected`.
+    private func symlinkPoints(_ link: URL, to expected: URL) throws -> Bool {
+        let dest = try FileManager.default.destinationOfSymbolicLink(atPath: link.path)
+        let resolved = URL(fileURLWithPath: dest, relativeTo: link.deletingLastPathComponent())
+            .standardizedFileURL
+        return resolved == expected.standardizedFileURL
+    }
+
+    @Test("sessions/ is symlinked to the host registry when the host slot already exists")
+    func sessionsSlotSymlinkedWhenHostSlotExists() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        let hostSessions = tempHost.appendingPathComponent("sessions", isDirectory: true)
+        try fm.createDirectory(at: hostSessions, withIntermediateDirectories: true)
+        // A peer row already registered by some other session must remain
+        // visible through the profile's symlink.
+        try #"{"pid":1}"#.write(to: hostSessions.appendingPathComponent("1.json"),
+                                atomically: true, encoding: .utf8)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let dir = try manager.ensureOAuthDir(forProfileID: UUID())
+
+        let link = dir.appendingPathComponent("sessions")
+        #expect(try symlinkPoints(link, to: hostSessions))
+        #expect(fm.fileExists(atPath: link.appendingPathComponent("1.json").path))
+    }
+
+    @Test("sessions/ host dir is created 0700 and symlinked when the host lacks it")
+    func sessionsSlotCreatesHostDirWhenMissing() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        // Host store exists but has never run a session — no sessions/ yet.
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let dir = try manager.ensureOAuthDir(forProfileID: UUID())
+
+        let hostSessions = tempHost.appendingPathComponent("sessions", isDirectory: true)
+        var isDir: ObjCBool = false
+        #expect(fm.fileExists(atPath: hostSessions.path, isDirectory: &isDir))
+        #expect(isDir.boolValue)
+
+        // 0700 matches how Claude Code creates the registry itself — peer rows
+        // carry inbox socket paths and should not be world-readable.
+        let mode = try fm.attributesOfItem(atPath: hostSessions.path)[.posixPermissions] as? NSNumber
+        #expect(mode?.int16Value == 0o700)
+
+        #expect(try symlinkPoints(dir.appendingPathComponent("sessions"), to: hostSessions))
+    }
+
+    @Test("sessions/ slot is idempotent — a second ensure leaves the same symlink")
+    func sessionsSlotIdempotent() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+
+        let dir1 = try manager.ensureOAuthDir(forProfileID: profileID)
+        let link = dir1.appendingPathComponent("sessions")
+        let dest1 = try fm.destinationOfSymbolicLink(atPath: link.path)
+
+        let dir2 = try manager.ensureOAuthDir(forProfileID: profileID)
+        let dest2 = try fm.destinationOfSymbolicLink(atPath: link.path)
+
+        #expect(dir1 == dir2)
+        #expect(dest1 == dest2)
+        // No `sessions.profile-local` invented on the idempotent pass.
+        #expect(!fm.fileExists(atPath: dir2.appendingPathComponent("sessions.profile-local").path))
+    }
+
+    /// Seed a profile-side real `sessions/` directory with rows, before any
+    /// `ensure…` call has had a chance to symlink it.
+    private func seedProfileSessions(
+        _ manager: ClaudeProfileConfigDirManager,
+        profileID: UUID,
+        rows: [String: String],
+        modified: Date? = nil
+    ) throws -> URL {
+        let fm = FileManager.default
+        let profileSessions = manager.configDirectory(forProfileID: profileID)
+            .appendingPathComponent("sessions", isDirectory: true)
+        try fm.createDirectory(at: profileSessions, withIntermediateDirectories: true)
+        for (rowName, contents) in rows {
+            let row = profileSessions.appendingPathComponent(rowName)
+            try contents.write(to: row, atomically: true, encoding: .utf8)
+            if let modified {
+                try fm.setAttributes([.modificationDate: modified], ofItemAtPath: row.path)
+            }
+        }
+        return profileSessions
+    }
+
+    /// The merge, not the sidecar: a `sessions/` row is live process state, and
+    /// the row's owner unlinks the *host* path when it exits — so a sidecar
+    /// move would orphan a running session's row where nothing ever reads it.
+    @Test("pre-existing profile sessions/ rows are merged into the host registry")
+    func sessionsSlotMergesProfileRowsIntoHost() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        let hostSessions = tempHost.appendingPathComponent("sessions", isDirectory: true)
+        try fm.createDirectory(at: hostSessions, withIntermediateDirectories: true)
+        try #"{"pid":1}"#.write(to: hostSessions.appendingPathComponent("1.json"),
+                                atomically: true, encoding: .utf8)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileSessions = try seedProfileSessions(
+            manager, profileID: profileID,
+            rows: ["4242.json": #"{"pid":4242}"#, "77.json": #"{"pid":77}"#]
+        )
+
+        let dir = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        // Both profile rows now live in the host registry, contents intact.
+        #expect(try String(contentsOf: hostSessions.appendingPathComponent("4242.json"),
+                           encoding: .utf8) == #"{"pid":4242}"#)
+        #expect(try String(contentsOf: hostSessions.appendingPathComponent("77.json"),
+                           encoding: .utf8) == #"{"pid":77}"#)
+        // The row that was already host-side is untouched.
+        #expect(fm.fileExists(atPath: hostSessions.appendingPathComponent("1.json").path))
+
+        // The emptied profile directory is gone, replaced by the symlink — and
+        // no sidecar was invented on the way.
+        #expect(try symlinkPoints(dir.appendingPathComponent("sessions"), to: hostSessions))
+        #expect(!fm.fileExists(atPath: dir.appendingPathComponent("sessions.profile-local").path))
+        // Reachable through the link the spawned session will actually use.
+        #expect(fm.fileExists(atPath: profileSessions.appendingPathComponent("4242.json").path))
+    }
+
+    /// A duplicate `<pid>.json` across two profiles means one row is stale —
+    /// a dead process whose PID was reused. Newest modification time wins,
+    /// in both directions.
+    @Test("a same-named row on both sides keeps the newer copy")
+    func sessionsSlotMergeKeepsNewerRow() throws {
+        let fm = FileManager.default
+        let old = Date(timeIntervalSince1970: 1_000_000)
+        let new = Date(timeIntervalSince1970: 2_000_000)
+
+        // Arm 1: the profile copy is newer and must replace the host copy.
+        // Arm 2: the host copy is newer and the profile copy is discarded.
+        for profileIsNewer in [true, false] {
+            let tempBase = tempBase()
+            let tempHost = tempHostBase()
+            defer {
+                try? fm.removeItem(at: tempBase)
+                try? fm.removeItem(at: tempHost)
+            }
+
+            let hostSessions = tempHost.appendingPathComponent("sessions", isDirectory: true)
+            try fm.createDirectory(at: hostSessions, withIntermediateDirectories: true)
+            let hostRow = hostSessions.appendingPathComponent("500.json")
+            try #"{"pid":500,"side":"host"}"#.write(to: hostRow, atomically: true, encoding: .utf8)
+            try fm.setAttributes([.modificationDate: profileIsNewer ? old : new],
+                                 ofItemAtPath: hostRow.path)
+
+            let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+            let profileID = UUID()
+            _ = try seedProfileSessions(
+                manager, profileID: profileID,
+                rows: ["500.json": #"{"pid":500,"side":"profile"}"#],
+                modified: profileIsNewer ? new : old
+            )
+
+            let dir = try manager.ensureOAuthDir(forProfileID: profileID)
+
+            let surviving = try String(contentsOf: hostRow, encoding: .utf8)
+            #expect(surviving == (profileIsNewer ? #"{"pid":500,"side":"profile"}"#
+                                                 : #"{"pid":500,"side":"host"}"#),
+                    "newer row must win (profileIsNewer=\(profileIsNewer))")
+            // Exactly one copy survives, and the profile dir is a symlink.
+            #expect(try fm.contentsOfDirectory(atPath: hostSessions.path) == ["500.json"])
+            #expect(try symlinkPoints(dir.appendingPathComponent("sessions"), to: hostSessions))
+            #expect(!fm.fileExists(atPath: dir.appendingPathComponent("sessions.profile-local").path))
+        }
+    }
+
+    @Test("an empty profile sessions/ dir is just replaced by the symlink")
+    func sessionsSlotEmptyProfileDirJustSymlinks() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        let hostSessions = tempHost.appendingPathComponent("sessions", isDirectory: true)
+        try fm.createDirectory(at: hostSessions, withIntermediateDirectories: true)
+        try #"{"pid":9}"#.write(to: hostSessions.appendingPathComponent("9.json"),
+                                atomically: true, encoding: .utf8)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        _ = try seedProfileSessions(manager, profileID: profileID, rows: [:])
+
+        let dir = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        #expect(try symlinkPoints(dir.appendingPathComponent("sessions"), to: hostSessions))
+        #expect(!fm.fileExists(atPath: dir.appendingPathComponent("sessions.profile-local").path))
+        #expect(try fm.contentsOfDirectory(atPath: hostSessions.path) == ["9.json"])
+    }
+
+    /// The merge is scoped to `sessions`. Every other slot still parks
+    /// pre-existing profile content in a `<slot>.profile-local` sidecar — if
+    /// the merge leaked, the profile's file would have landed in the host store
+    /// instead, silently overwriting nothing but destroying the isolation.
+    @Test("merge does not leak — a non-sessions slot still uses the sidecar")
+    func mergeIsScopedToSessionsSlot() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        let hostCommands = tempHost.appendingPathComponent("commands", isDirectory: true)
+        try fm.createDirectory(at: hostCommands, withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let profileID = UUID()
+        let profileCommands = manager.configDirectory(forProfileID: profileID)
+            .appendingPathComponent("commands", isDirectory: true)
+        try fm.createDirectory(at: profileCommands, withIntermediateDirectories: true)
+        try "profile-only".write(to: profileCommands.appendingPathComponent("mine.md"),
+                                 atomically: true, encoding: .utf8)
+
+        let dir = try manager.ensureOAuthDir(forProfileID: profileID)
+
+        let sidecarEntry = dir.appendingPathComponent("commands.profile-local")
+            .appendingPathComponent("mine.md")
+        #expect(try String(contentsOf: sidecarEntry, encoding: .utf8) == "profile-only")
+        // The merge must NOT have moved it into the host store.
+        #expect(try fm.contentsOfDirectory(atPath: hostCommands.path).isEmpty)
+        #expect(try symlinkPoints(dir.appendingPathComponent("commands"), to: hostCommands))
+    }
+
+    /// `fileExists` says "true" for a regular file, so an unvalidated guard
+    /// would symlink every profile at it and fail every registry write.
+    @Test("a host sessions/ that is a regular file is left alone, not symlinked at")
+    func hostSessionsRegularFileIsLeftAlone() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        let hostSessions = tempHost.appendingPathComponent("sessions")
+        try "not a directory".write(to: hostSessions, atomically: true, encoding: .utf8)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let dir = try manager.ensureOAuthDir(forProfileID: UUID())
+
+        #expect((try? fm.destinationOfSymbolicLink(atPath: dir.appendingPathComponent("sessions").path)) == nil)
+        #expect(!fm.fileExists(atPath: dir.appendingPathComponent("sessions").path))
+        // The host file is untouched — TBD does not clobber what it cannot use.
+        #expect(try String(contentsOf: hostSessions, encoding: .utf8) == "not a directory")
+    }
+
+    /// `fileExists` says "false" for a *dangling* symlink, so an unvalidated
+    /// guard would take the create branch, hit EEXIST, log, and return — every
+    /// spawn, forever.
+    @Test("a host sessions/ that is a dangling symlink is left alone")
+    func hostSessionsDanglingSymlinkIsLeftAlone() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+        let hostSessions = tempHost.appendingPathComponent("sessions")
+        let missingTarget = tempHost.appendingPathComponent("gone", isDirectory: true)
+        try fm.createSymbolicLink(at: hostSessions, withDestinationURL: missingTarget)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let dir = try manager.ensureOAuthDir(forProfileID: UUID())
+
+        #expect((try? fm.destinationOfSymbolicLink(atPath: dir.appendingPathComponent("sessions").path)) == nil)
+        #expect(!fm.fileExists(atPath: dir.appendingPathComponent("sessions").path))
+        // Still dangling: nothing was created behind it either.
+        #expect(try fm.destinationOfSymbolicLink(atPath: hostSessions.path) == missingTarget.path)
+        #expect(!fm.fileExists(atPath: missingTarget.path))
+    }
+
+    /// Creating the slot must never conjure the host store itself. On a machine
+    /// with no `~/.claude` at all there is nothing to mirror, and inventing one
+    /// (0700, owned by TBD) is exactly the host state the other slots take care
+    /// not to fabricate.
+    @Test("an absent host base directory is never created for the sessions slot")
+    func absentHostBaseDirectoryIsNeverCreated() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        // Deliberately NOT created: the host store does not exist.
+        #expect(!fm.fileExists(atPath: tempHost.path))
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let dir = try manager.ensureOAuthDir(forProfileID: UUID())
+
+        #expect(!fm.fileExists(atPath: tempHost.path), "host store must not be conjured")
+        #expect(!fm.fileExists(atPath: tempHost.appendingPathComponent("sessions").path))
+        #expect((try? fm.destinationOfSymbolicLink(atPath: dir.appendingPathComponent("sessions").path)) == nil)
+    }
+
+    @Test("create-on-missing does not leak to the other slots — absent host slots still skip")
+    func createOnMissingIsScopedToSessionsSlot() throws {
+        let tempBase = tempBase()
+        let tempHost = tempHostBase()
+        defer {
+            try? FileManager.default.removeItem(at: tempBase)
+            try? FileManager.default.removeItem(at: tempHost)
+        }
+
+        let fm = FileManager.default
+        // Host store is entirely empty: only `sessions` may be conjured.
+        try fm.createDirectory(at: tempHost, withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(baseDirectory: tempBase, hostBaseDirectory: tempHost)
+        let dir = try manager.ensureOAuthDir(forProfileID: UUID())
+
+        for slot in ["projects", "plugins", "skills", "agents", "commands", "hooks", "CLAUDE.md", "settings.json"] {
+            #expect(!fm.fileExists(atPath: tempHost.appendingPathComponent(slot).path),
+                    "host slot \(slot) must not be created")
+            #expect((try? fm.destinationOfSymbolicLink(atPath: dir.appendingPathComponent(slot).path)) == nil,
+                    "profile slot \(slot) must not be symlinked")
+        }
+        #expect(fm.fileExists(atPath: tempHost.appendingPathComponent("sessions").path))
+    }
 }
 
 // Nested under TBDHomeSerialized: mutates a process-global environment

--- a/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeSpawnCommandBuilderTests.swift
@@ -630,6 +630,224 @@ struct ClaudeSpawnCommandBuilderTests {
         #expect(!r.command.contains("--plugin-dir"))
     }
 
+    // MARK: - sessionName / --name (cross-session peer registry)
+
+    // Field-measured on CLI 2.1.227: `claude --name "TBD Name Probe"` writes
+    // `"name": "TBD Name Probe"` verbatim into its peer-registry row and omits
+    // the `"nameSource": "derived"` marker the cwd-slug default carries. So the
+    // string TBD passes here is exactly the address peers see in `ListAgents`.
+
+    @Test("resume branch emits --name after --dangerously-skip-permissions")
+    func resumeEmitsSessionName() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc-123",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "acme-worker"
+        )
+        #expect(r.command == "claude --resume abc-123 --dangerously-skip-permissions --name 'acme-worker'")
+    }
+
+    @Test("fresh branch emits --name after --dangerously-skip-permissions")
+    func freshEmitsSessionName() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "acme-worker"
+        )
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions --name 'acme-worker'")
+    }
+
+    @Test("nil sessionName emits no --name")
+    func nilSessionNameEmitsNothing() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: nil
+        )
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions")
+    }
+
+    @Test("empty sessionName emits no --name")
+    func emptySessionNameEmitsNothing() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: ""
+        )
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions")
+    }
+
+    @Test("whitespace-only sessionName emits no --name")
+    func whitespaceSessionNameEmitsNothing() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: "abc-123",
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "  \n\t "
+        )
+        #expect(r.command == "claude --resume abc-123 --dangerously-skip-permissions")
+    }
+
+    @Test("sessionName with spaces, a single quote and a $ is shell-escaped")
+    func sessionNameIsShellEscaped() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "acme's $HOME fix"
+        )
+        // Single-quoting keeps `$HOME` literal; the embedded quote closes,
+        // escapes, and reopens — the same shape the initial-prompt argv uses.
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions --name 'acme'\\''s $HOME fix'")
+    }
+
+    // MARK: - sessionName sanitizing
+    //
+    // Display names are unvalidated free text and now flow into the tmux
+    // command string. `shellEscape` single-quotes them, but a single-quoted
+    // newline is still a newline: it would split `#{pane_start_command}`.
+
+    @Test("an embedded newline is stripped, not escaped into the command")
+    func sessionNameNewlineIsStripped() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "acme\nworker"
+        )
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions --name 'acmeworker'")
+        #expect(!r.command.contains("\n"))
+    }
+
+    @Test("control characters are stripped from the name")
+    func sessionNameControlCharactersAreStripped() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "a\u{0007}b\u{001B}c\u{007F}d\r"
+        )
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions --name 'abcd'")
+    }
+
+    @Test("the name is surrounded-whitespace-trimmed but keeps its inner spaces")
+    func sessionNameIsTrimmed() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "  acme worker  "
+        )
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions --name 'acme worker'")
+    }
+
+    @Test("an over-long name is capped, and the cap never leaves a trailing space")
+    func sessionNameIsLengthCapped() {
+        let cap = ClaudeSpawnCommandBuilder.maxSessionNameLength
+        // One char past the cap, with a space exactly at the boundary so a
+        // naive prefix would emit `--name 'aaa… '`.
+        let raw = String(repeating: "a", count: cap - 1) + " tail"
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: raw
+        )
+        let expected = String(repeating: "a", count: cap - 1)
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions --name '\(expected)'")
+    }
+
+    @Test("a name made only of control characters emits no flag")
+    func sessionNameOfOnlyControlCharactersEmitsNothing() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: "sid-1",
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "\u{0001}\u{0002}\n\r\t"
+        )
+        #expect(r.command == "claude --session-id sid-1 --dangerously-skip-permissions")
+    }
+
+    @Test("cmd branch is unchanged when sessionName is passed")
+    func cmdBranchIgnoresSessionName() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: "ls -la",
+            shellFallback: "/bin/zsh",
+            sessionName: "acme-worker"
+        )
+        #expect(r.command == "ls -la")
+        #expect(r.sensitiveEnv.isEmpty)
+    }
+
+    @Test("shell-fallback branch is unchanged when sessionName is passed")
+    func shellFallbackBranchIgnoresSessionName() {
+        let r = ClaudeSpawnCommandBuilder.build(
+            resumeID: nil,
+            freshSessionID: nil,
+            appendSystemPrompt: nil,
+            initialPrompt: nil,
+            profileSecret: nil,
+            cmd: nil,
+            shellFallback: "/bin/zsh",
+            sessionName: "acme-worker"
+        )
+        #expect(r.command == "/bin/zsh")
+        #expect(r.sensitiveEnv.isEmpty)
+    }
+
     // MARK: - Bedrock
 
     @Test("bedrock: full env set with AWS_PROFILE")

--- a/Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeStateDetectorTests.swift
@@ -63,6 +63,48 @@ struct ClaudeStateDetectorSessionPathTests {
         #expect(detector(environment: [:]).sessionFilePath(forPID: 99).path == expected)
     }
 
+    /// Pins the coupling between the session-file read and the profile
+    /// `sessions/` mirror slot, which is otherwise invisible from either side.
+    ///
+    /// A profile-spawned terminal runs with `CLAUDE_CONFIG_DIR` pointing at
+    /// `~/tbd/profiles/<id>/claude`, so it writes its registry row there — and
+    /// this detector reads the **host** store. That read missed for every
+    /// profile terminal until `ClaudeProfileConfigDirManager` began mirroring
+    /// the slot; now the profile's `sessions/` is a symlink to the host one and
+    /// the row lands where the detector looks. Post-`--fork-session` session-ID
+    /// recapture (`HibernationCoordinator`, `SessionRecaptureScheduler`)
+    /// depends on that, so deleting the mirror slot must red this test rather
+    /// than silently regress recapture.
+    @Test("a profile session's row is readable through the mirrored host registry")
+    func profileSessionRowIsReadableThroughTheHostMirror() throws {
+        let fm = FileManager.default
+        let tempRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("tbd-detector-mirror-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: tempRoot) }
+
+        let hostBase = tempRoot.appendingPathComponent("claude", isDirectory: true)
+        try fm.createDirectory(at: hostBase, withIntermediateDirectories: true)
+
+        let manager = ClaudeProfileConfigDirManager(
+            baseDirectory: tempRoot.appendingPathComponent("profiles", isDirectory: true),
+            hostBaseDirectory: hostBase
+        )
+        let profileDir = try manager.ensureOAuthDir(forProfileID: UUID())
+
+        // The row is written the way a profile-spawned session writes it:
+        // through `$CLAUDE_CONFIG_DIR/sessions/`, not to the host path.
+        try #"{"pid":31337,"sessionId":"mirrored-session"}"#.write(
+            to: profileDir.appendingPathComponent("sessions").appendingPathComponent("31337.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let detector = self.detector(environment: ["TBD_CLAUDE_HOST_HOME": hostBase.path])
+        #expect(detector.sessionFilePath(forPID: 31337).path
+            == hostBase.appendingPathComponent("sessions/31337.json").path)
+        #expect(detector.readSessionID(forPID: 31337) == "mirrored-session")
+    }
+
     /// An empty value is not an override — `TBDConstants.claudeHostHome`
     /// treats it as absent, and a detector that read it literally would resolve
     /// session files under `/sessions/…` at the filesystem root.

--- a/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
@@ -152,9 +152,12 @@ struct WorktreeConversationCarryoverTests {
             db: db, recorder: recorder, claudeHome: claudeHome
         )
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        // Display name deliberately differs from `name`: the `--name` assertion
+        // below would pass on either if they matched.
         let worktree = try await db.worktrees.create(
             repoID: repo.id,
             name: "resume-source",
+            displayName: "Resume Source",
             branch: "tbd/resume-source",
             path: tempDir.appendingPathComponent("resume-source").path,
             tmuxServer: "tbd-test"
@@ -180,6 +183,15 @@ struct WorktreeConversationCarryoverTests {
         #expect(
             isPromptFreeResumeInvocation(command, forkSession: false),
             "archived-session resume must carry no trailing prompt argument: \(command)"
+        )
+        // The one positive assertion on a REAL spawn path that `--name` is
+        // emitted at all. `sessionName:` has a nil default, so dropping it from
+        // a call site compiles, changes behaviour, and is invisible to the
+        // builder unit tests and to the whitelist above (which makes `--name`
+        // optional by design — it must tolerate the non-claude branches).
+        #expect(
+            command.contains("--name 'Resume Source'"),
+            "resume spawn must announce the worktree display name: \(command)"
         )
     }
 
@@ -227,6 +239,27 @@ struct WorktreeConversationCarryoverTests {
         #expect(isPromptFreeResumeInvocation(base, forkSession: true))
         #expect(!isPromptFreeResumeInvocation(base + " 'You have been moved.'", forkSession: true))
         #expect(!isPromptFreeResumeInvocation(base + " 'anything at all'", forkSession: true))
+
+        // `--name '<worktree display name>'` is a permitted flag, not a
+        // positional — its quoted value must not smuggle a prompt past the
+        // guard, so the trailing-argument rejection still has to hold with it
+        // present.
+        let named = "export CLAUDE_CONFIG_DIR='/tmp/cfg'; claude --resume ABC-123"
+            + " --fork-session --dangerously-skip-permissions --name 'acme-worker'"
+            + " --settings '/tmp/overlay.json'"
+        #expect(isPromptFreeResumeInvocation(named, forkSession: true))
+        #expect(!isPromptFreeResumeInvocation(named + " 'You have been moved.'", forkSession: true))
+
+        // A display name containing an apostrophe is escaped as `'acme'\''s'`.
+        // The guard must accept that shape (or it would report a conforming
+        // command as non-conforming) and must still reject a trailing prompt
+        // after it — the escape must not become a hole.
+        let escaped = "export CLAUDE_CONFIG_DIR='/tmp/cfg'; claude --resume ABC-123"
+            + " --fork-session --dangerously-skip-permissions --name 'acme'\\''s worktree'"
+            + " --settings '/tmp/overlay.json'"
+        #expect(isPromptFreeResumeInvocation(escaped, forkSession: true))
+        #expect(!isPromptFreeResumeInvocation(escaped + " 'You have been moved.'", forkSession: true))
+        #expect(!isPromptFreeResumeInvocation(escaped + " 'anything at all'", forkSession: true))
     }
 
     /// Whitelists the permitted shape rather than blacklisting a phrase: the
@@ -240,9 +273,17 @@ struct WorktreeConversationCarryoverTests {
         let invocation = String(command[start.lowerBound...])
         let fork = forkSession ? " --fork-session" : ""
         let permitted = "^claude --resume [-0-9A-Za-z]+\(fork) --dangerously-skip-permissions"
-            + "( --settings '[^']*')?( --plugin-dir '[^']*')?$"
+            + "( --name \(Self.shellEscapedWordPattern))?( --settings '[^']*')?( --plugin-dir '[^']*')?$"
         return invocation.range(of: permitted, options: .regularExpression) != nil
     }
+
+    /// A single-quoted word as `SystemPromptBuilder.shellEscape` actually emits
+    /// it: an apostrophe inside the value closes the quote, escapes the
+    /// apostrophe and reopens (`'acme'\''s'`), so a naive `'[^']*'` cannot
+    /// match a legitimate command whose display name contains one. The helper
+    /// fails closed there, so it was never a safety hole — but a guard that
+    /// misreads a conforming command is a guard nobody trusts.
+    static let shellEscapedWordPattern = #"'(?:[^']|'\\'')*'"#
 
     private func makeCarryoverLifecycle(
         db: TBDDatabase,

--- a/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
@@ -712,6 +712,26 @@ struct WorktreeReviveFreshTests {
             + " --fork-session --dangerously-skip-permissions --settings '/tmp/overlay.json'"
         #expect(isPromptFreeForkResumeInvocation(base))
         #expect(!isPromptFreeForkResumeInvocation(base + " 'You have been moved.'"))
+
+        // `--name '<worktree display name>'` is a permitted flag, not a
+        // positional — its quoted value must not smuggle a prompt past the
+        // guard, so the trailing-argument rejection still has to hold with it
+        // present.
+        let named = "export CLAUDE_CONFIG_DIR='/tmp/cfg'; claude --resume A"
+            + " --fork-session --dangerously-skip-permissions --name 'acme-worker'"
+            + " --settings '/tmp/overlay.json'"
+        #expect(isPromptFreeForkResumeInvocation(named))
+        #expect(!isPromptFreeForkResumeInvocation(named + " 'You have been moved.'"))
+
+        // A display name containing an apostrophe is escaped as `'acme'\''s'`.
+        // The guard must accept that shape (or it would report a conforming
+        // command as non-conforming) and must still reject a trailing prompt
+        // after it — the escape must not become a hole.
+        let escaped = "export CLAUDE_CONFIG_DIR='/tmp/cfg'; claude --resume A"
+            + " --fork-session --dangerously-skip-permissions --name 'acme'\\''s worktree'"
+            + " --settings '/tmp/overlay.json'"
+        #expect(isPromptFreeForkResumeInvocation(escaped))
+        #expect(!isPromptFreeForkResumeInvocation(escaped + " 'You have been moved.'"))
     }
 
     /// Whitelists the permitted invocation shape instead of blacklisting the
@@ -722,9 +742,18 @@ struct WorktreeReviveFreshTests {
         guard let start = command.range(of: "claude --resume") else { return false }
         let invocation = String(command[start.lowerBound...])
         let permitted = "^claude --resume [-0-9A-Za-z]+ --fork-session"
-            + " --dangerously-skip-permissions( --settings '[^']*')?( --plugin-dir '[^']*')?$"
+            + " --dangerously-skip-permissions( --name \(Self.shellEscapedWordPattern))?"
+            + "( --settings '[^']*')?( --plugin-dir '[^']*')?$"
         return invocation.range(of: permitted, options: .regularExpression) != nil
     }
+
+    /// A single-quoted word as `SystemPromptBuilder.shellEscape` actually emits
+    /// it: an apostrophe inside the value closes the quote, escapes the
+    /// apostrophe and reopens (`'acme'\''s'`), so a naive `'[^']*'` cannot
+    /// match a legitimate command whose display name contains one. The helper
+    /// fails closed there, so it was never a safety hole — but a guard that
+    /// misreads a conforming command is a guard nobody trusts.
+    static let shellEscapedWordPattern = #"'(?:[^']|'\\'')*'"#
 
     /// `isolateTBDHome()` plus `TBD_CLAUDE_HOST_HOME`: the spawn (and the
     /// validation) resolves the profile config dir through the lifecycle's own

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -36,6 +36,26 @@ import Foundation
     #expect(body.contains("--help"))
 }
 
+@Test func bodyContainsSiblingMessagingSection() {
+    let body = TBDSkillContent.body
+    #expect(body.contains("### Message a sibling session"))
+    // Both channels are stated; neither is recommended over the other, so
+    // both names must survive an edit of this section.
+    #expect(body.contains("ListAgents"))
+    #expect(body.contains("SendMessage"))
+    #expect(body.contains("worktree display name"))
+    #expect(body.contains("tbd terminal send"))
+    #expect(body.contains("tbd terminal output"))
+    // Display names are not unique — several terminals share one worktree's,
+    // and worktrees in different repos can share one too — so the text must
+    // point at the per-row `[ref]` as the address.
+    #expect(body.contains("[ref]"))
+    // Missing tools have several causes (four env killswitches, and the
+    // non-Claude harnesses this same body is fed to), so the text must not
+    // name one. It states the fallback instead.
+    #expect(!body.contains("predates the feature"))
+}
+
 @Test func bodyContainsScratchPromotionSection() {
     let body = TBDSkillContent.body
     #expect(body.contains("## Scratch spaces & promotion"))

--- a/docs/cross-session-messaging.md
+++ b/docs/cross-session-messaging.md
@@ -1,0 +1,219 @@
+# Cross-session messaging
+
+Claude Code sessions can talk to each other directly. A session lists its
+peers with `ListAgents` and sends one of them plain text with
+`SendMessage`. On a single machine delivery is peer-to-peer: each session
+binds its own Unix socket and publishes a small registry row on disk, and
+messages travel socket-to-socket. No servers are involved, and neither is
+TBD's daemon.
+
+TBD's part is small: it names the sessions it spawns after the worktree
+name you see in the sidebar, and it makes the peer registry whole across
+TBD profiles. Everything else — the transport,
+throttling, and inbound-safety rails — belongs to Claude Code. Upstream
+reference: [Message your other Claude Code
+sessions](https://code.claude.com/docs/en/cross-session-messaging).
+
+## Versions
+
+Two different floors apply, and they are not the same number.
+
+- **TBD's Claude spawn path requires CLI ≥ 2.1.76.** TBD always passes
+  `--name` when it spawns Claude, and `-n` / `--name` shipped in 2.1.76.
+- **Messaging itself requires CLI ≥ 2.1.224.** That is when `ListAgents`
+  and `SendMessage` arrived.
+
+A session on anything in between (2.1.76 through 2.1.223) is perfectly
+healthy — it gets a correct name and simply has no messaging tools.
+Coordinate through `tbd terminal send` / `tbd terminal output` instead.
+
+Below 2.1.76 the failure is loud rather than subtle: every Claude spawn
+exits 1 in the pane with
+
+```
+error: unknown option '--name'
+```
+
+Fix it by updating the CLI (`claude --version` to see where you are;
+Claude Code self-updates by default, so this is unusual).
+
+## Confirming a session has it
+
+Inside the session, run `/list-agents`. If messaging is active you get a
+listing of peer sessions; if it is absent the command is not there.
+`/status` is the other check — with messaging active it shows a
+peer-address row for the session.
+
+## Naming
+
+TBD spawns each Claude session with `--name` set to the worktree's
+**display name** — the human-visible, renamable name in the app — so the
+names in `/list-agents` are the ones you already know from the sidebar.
+
+Without that flag a session names itself after its working-directory
+folder: a slug plus a random suffix, which never matches a name you chose
+in the app.
+
+`--name` is fixed at spawn. Renaming a worktree therefore applies at that
+session's **next respawn or resume**; until then the running session
+still answers to its spawn-time name. Nothing breaks in the meantime —
+the listing tells the two apart, as described next.
+
+## Addressing a peer when names collide
+
+A name is a label, not a unique address. Two things make one name answer
+for several sessions:
+
+- **One worktree, several Claude terminals.** Every Claude session spawned
+  in a worktree gets that worktree's display name, so a worktree running
+  three Claudes shows three rows under one name.
+- **Two worktrees, one name.** Display names are yours to choose and
+  nothing stops you reusing one.
+
+`/list-agents` handles this. Each row carries a short `[ref]` — an
+identifier unique to that live session — alongside the name, working
+directory, and status. Read the listing first, then:
+
+- if exactly one row answers to the name you want, address it by name;
+- if more than one does, address the one you want by its `[ref]`. The
+  working directory and status in the row are how you tell which is
+  which.
+
+Pull a fresh listing rather than reusing one from earlier in a long
+conversation — the pool changes as sessions spawn, respawn, and exit.
+
+## Reach
+
+- **On this machine** — the boundary is the OS user, not the Anthropic
+  account. Every TBD session under your user is reachable from every
+  other, across all TBD profiles, even when those profiles are logged
+  into different Anthropic accounts. Your own plain-terminal `claude`
+  sessions are in the same pool: TBD sessions can see them and they can
+  see TBD sessions.
+- **Expect CLI sessions.** Every registry row observed in practice has
+  come from a terminal (`claude` on the command line, which is what TBD
+  spawns).
+- **Beyond this machine** — remote and web sessions are reachable through
+  Anthropic's servers, same account only, and **reply-only**: a local
+  session can answer a message from a remote or web session, but can
+  never initiate one.
+
+### When a peer you expected is missing
+
+`/list-agents` is the authority. A session that does not appear in the
+listing cannot be addressed, no matter what you know about it being
+alive — so check the listing before concluding a message was lost.
+
+Common reasons a session is absent:
+
+- **It has no messaging.** Its CLI is below 2.1.224, or a killswitch
+  variable is set in its environment (see [Killswitches](#killswitches)).
+  Such a session never registers and never appears.
+- **Its profile's registry was not unified.** TBD links each profile's
+  registry to the shared host one when it seeds the profile, and that
+  step is best-effort: if it fails, the profile keeps a private registry
+  and its sessions see only peers spawned on the same profile. Respawn
+  the session to retry the seeding; the daemon log records the failure.
+- **It exited.** Rows are per live process; a session that ended is gone
+  from the listing.
+
+Falling back is always available: `tbd terminal send` /
+`tbd terminal output` reaches any TBD-managed session through the
+daemon, regardless of whether messaging is present.
+
+## Killswitches
+
+Messaging depends on a feature-flag evaluation, and several environment
+variables switch that evaluation off:
+
+- `DISABLE_TELEMETRY`
+- `DO_NOT_TRACK`
+- `DISABLE_GROWTHBOOK`
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`
+
+TBD's own spawn environment sets none of them. But TBD's free-form
+[environment overrides](env-overrides.md) — settable at global, repo, or
+profile scope — will happily set any of them, and the result is silent:
+sessions spawn fine and simply have no messaging tools, with no error to
+point at the cause.
+
+To check, run this inside a session that is missing the tools:
+
+```sh
+env | grep -E 'DISABLE_TELEMETRY|DO_NOT_TRACK|DISABLE_GROWTHBOOK|CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC'
+```
+
+Any hit is the explanation. Clear it in whichever override scope set it
+(Settings → General for global, the repo settings pane for repo, the
+model-profile sheet for profile) and respawn the session.
+
+## Inbound policy
+
+With no policy set, Claude Code delivers a message when sender and
+receiver are in the same permission class. TBD spawns every Claude
+session with permissions bypassed, so TBD↔TBD messages deliver with no
+approval dialog out of the box.
+
+A repo that wants something stricter sets `crossSessionInbound` in its
+per-repo [Claude settings overlay](claude-settings-overlay.md) — a plain
+JSON file at `~/tbd/repos/<repoID>/claude-settings.json`, editable in the
+repo's settings pane, which deep-merges into the `--settings` overlay TBD
+passes on every spawn:
+
+```json
+{
+  "crossSessionInbound": "hold"
+}
+```
+
+The three values are `accept` (deliver without prompting), `hold` (queue
+for your approval), and `refuse` (reject inbound messages). The setting
+is read fresh at spawn time, so it takes effect on the repo's next
+session — fresh create, resume, wake, or profile swap alike.
+
+## Not in TBD's actuation record
+
+Native peer messages travel session-to-session over Claude Code's own
+sockets and never transit TBD's daemon. They are therefore **outside
+TBD's actuation record, in both directions, by design**. The record
+attests everything sent through TBD's own transport (`tbd terminal send`
+and the supervision paths built on it) and nothing else.
+
+The practical consequence: a peer message is evidenced only by the
+transcripts of the two sessions that exchanged it. If you need an act to
+be in the record — for supervision, audit, or after-the-fact
+reconstruction — send it through TBD's transport instead.
+
+## The peer registry
+
+Each live session publishes one small JSON file, `<pid>.json`, in the
+`sessions/` directory of its Claude config dir. A row holds the pid, the
+session id, the working directory, the tmux pane, the path of the
+session's message socket, the session's name and where that name came
+from, and a coarse status (`idle` / `busy` / `waiting` / `shell`) with a
+timestamp. **It holds no transcript content** — it is an address book,
+not a log. The sockets themselves live at `/tmp/cc-socks/<pid>.sock` and
+are shared across the OS user.
+
+Because the directory hangs off `CLAUDE_CONFIG_DIR`, each TBD profile
+would otherwise keep a private registry and sessions on different
+profiles would be invisible to each other. TBD prevents that by
+symlinking each profile's `claude/sessions` to the `sessions` directory
+of the host Claude config dir (`~/.claude` by default) when it seeds the
+profile — the same host-mirror mechanism it already uses for `projects`,
+`plugins`, `hooks`, `skills`, and `settings.json`. One shared index,
+credentials still isolated per profile.
+
+If the profile already had a registry of its own, its rows are **moved
+into the shared one** before the link is made, so sessions that were
+running at that moment keep their listing and simply become visible to
+everyone else. Nothing is set aside or hidden: rows are named after the
+process id, which is unique on your machine, so they merge without
+clashing. The upgrade adopts your running sessions rather than
+interrupting them.
+
+That symlink is also why your plain-terminal sessions and TBD's sessions
+see each other: the shared target is the host directory those sessions
+already use. Since the mirror moves no transcript content, and
+`projects/` (where transcripts do live) is already mirrored, this changes
+discovery and nothing else.

--- a/docs/specs/2026-08-09-cross-session-messaging-design.md
+++ b/docs/specs/2026-08-09-cross-session-messaging-design.md
@@ -89,17 +89,23 @@ handled the same way.
 
 ### Version gate on `--name`
 
-An unrecognized flag on an older installed CLI would fail every Claude
-spawn — a hard regression for users who have not updated. The daemon
-therefore probes `claude --version` once and caches the result for its
-lifetime; the spawn path passes the builder a `supportsSessionName`
-capability bit, and the builder omits `--name` when it is false or the
-probe failed. A failed or missing probe degrades to today's spawn
-command — the probe must never block or break a spawn.
+An unrecognized flag on an older installed CLI fails every Claude
+spawn — a hard regression for users who have not updated. Measured
+against CLI v2.1.226: a spawn-shaped invocation carrying an unknown
+option exits 1 with `error: unknown option '--…'` before doing anything
+else (`--version` and `--help` are the exceptions — they short-circuit
+and succeed regardless, which also makes `--version` a safe probe). The
+daemon therefore probes `claude --version` once and caches the result
+for its lifetime; the spawn path passes the builder a
+`supportsSessionName` capability bit, and the builder omits `--name`
+when it is false or the probe failed. A failed or missing probe degrades
+to today's spawn command — the probe must never block or break a spawn.
 
-The minimum version that accepts `--name` is a field-verification item
-(the flag may predate messaging itself); the constant lands with the
-implementation. Both branches of the gate get tests, per the
+The gate's constant is **2.1.76**, the version that introduced
+`-n` / `--name` (per the Claude Code changelog; verified accepted on
+v2.1.226). Cross-session messaging itself arrived in 2.1.224 — a
+session on 2.1.76–2.1.223 gets a correct name and simply lacks the
+messaging tools. Both branches of the gate get tests, per the
 conditional-gate rule in `CLAUDE.md`.
 
 No feature flag beyond this gate: nothing here acts autonomously,

--- a/docs/specs/2026-08-09-cross-session-messaging-design.md
+++ b/docs/specs/2026-08-09-cross-session-messaging-design.md
@@ -1,0 +1,230 @@
+# Cross-session messaging for TBD-spawned Claude sessions
+
+Claude Code v2.1.224 added cross-session messaging: a session discovers
+peer sessions with `ListAgents` and sends plain text to one with
+`SendMessage`. On one machine, delivery is peer-to-peer — each session
+binds a per-session Unix inbox socket and registers itself in files on
+disk; no Anthropic servers are involved. Reference:
+[Message your other Claude Code sessions](https://code.claude.com/docs/en/cross-session-messaging).
+
+TBD's workflow — many Claude sessions across parallel worktrees of one
+repo — is exactly what the feature targets. This spec adopts the native
+transport rather than building one: TBD's job is to make its sessions
+addressable, keep discovery whole across profiles, and describe the
+channel; the transport, throttling, and inbound-safety rails are Claude
+Code's.
+
+## Goals
+
+- **Sibling worktree coordination** — orchestrator and worker sessions
+  hand findings, status, and decisions to each other directly, without
+  the human relaying between tabs.
+- **Supervision status channel** — fleet-supervision programs (see
+  `2026-07-26-fleet-supervision-design.md`) may use the channel as
+  authored content, in both directions.
+
+## Non-goals
+
+- No TBD-owned message transport, daemon-side peer-protocol client, or
+  `tbd message` CLI verb.
+- No UI surfacing of peer messages.
+- No compiled preference between native messaging and
+  `tbd terminal send`.
+- No live rename of running sessions.
+- No compiled inbound policy.
+
+Each is expanded under Rejected alternatives.
+
+## How the native feature behaves for TBD sessions
+
+Facts this design leans on, from the Claude Code documentation and the
+TBD spawn path:
+
+- **Same machine, same OS user** — the discovery boundary is the
+  operating-system user, not the Anthropic account. All TBD sessions run
+  in tmux on the host under one user, so registry files and sockets are
+  mutually visible. Sessions logged into different Anthropic accounts
+  (different TBD profiles) can still message each other locally.
+- **Permission classes** — with no `crossSessionInbound` value set,
+  Claude Code delivers a message when sender and receiver are in the
+  same permission class. TBD spawns every Claude session with
+  `--dangerously-skip-permissions`, so TBD↔TBD messages deliver with no
+  approval dialogs out of the box.
+- **Beyond the machine** — cross-machine and web sessions are reachable
+  through Anthropic servers, same account only, and reply-only: a local
+  session can answer a message from one but never initiate.
+- **Killswitches** — `DISABLE_TELEMETRY`, `DO_NOT_TRACK`,
+  `DISABLE_GROWTHBOOK`, and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`
+  can turn off the feature-flag evaluation messaging depends on. TBD's
+  own spawn env sets none of these, but a user's free-form env override
+  (global, repo, or profile scope) can — silently.
+
+## Design
+
+### Session naming — the one compiled change
+
+`ClaudeSpawnCommandBuilder.build` gains an optional `sessionName`
+parameter. When non-nil, non-empty, and the installed CLI supports it
+(next section), both the fresh-spawn and resume branches append
+`--name <value>`, shell-escaped. The `cmd`/shell-fallback branches are
+untouched, and Codex spawns are out of scope — messaging is a Claude
+Code feature.
+
+Callers pass the worktree's **display name** — the human-visible,
+user-renamable name in the app — so `ListAgents` rows and message
+addresses match the sidebar. Without the flag, a session names itself
+after its working-directory folder: the generated slug plus a random
+suffix, which never matches an app rename.
+
+The display name is mutable and `--name` is fixed at spawn, so a rename
+applies at the session's next respawn or resume; until then the running
+session answers to its spawn-time name. This staleness is accepted:
+respawns are frequent in TBD (wake, swap, fresh spawns), renames are
+rare, and Claude Code tolerates the fallout — same-named or stale-named
+sessions are disambiguated with short identifiers and working
+directories in the listing.
+
+Name collisions across worktrees are likewise Claude Code's problem,
+handled the same way.
+
+### Version gate on `--name`
+
+An unrecognized flag on an older installed CLI would fail every Claude
+spawn — a hard regression for users who have not updated. The daemon
+therefore probes `claude --version` once and caches the result for its
+lifetime; the spawn path passes the builder a `supportsSessionName`
+capability bit, and the builder omits `--name` when it is false or the
+probe failed. A failed or missing probe degrades to today's spawn
+command — the probe must never block or break a spawn.
+
+The minimum version that accepts `--name` is a field-verification item
+(the flag may predate messaging itself); the constant lands with the
+implementation. Both branches of the gate get tests, per the
+conditional-gate rule in `CLAUDE.md`.
+
+No feature flag beyond this gate: nothing here acts autonomously,
+destroys state, or replaces a load-bearing path — `--name` is small
+additive spawn surface.
+
+### Cross-profile discovery
+
+Requirement: sessions on different TBD profiles must discover and
+message each other. Profile isolation exists for credentials, not for
+reachability.
+
+The peer registry's on-disk location is undocumented. Verification on a
+macOS host with the feature comes first: spawn sessions under two
+profiles (distinct `CLAUDE_CONFIG_DIR`s) and run `/list-agents` in
+each.
+
+- **If they see each other**, the registry is per-user, not
+  per-config-dir, and no work exists.
+- **If discovery is fragmented**, `ClaudeProfileConfigDirManager` adds
+  one step to profile-dir seeding: symlink the registry subdirectory
+  inside the profile's config dir to the default profile's registry
+  location, so every profile shares one registry while credentials and
+  `.claude.json` stay isolated. Seeding is idempotent and failure is
+  non-fatal (log and continue), matching the plugin and overlay
+  writers. The exact subdirectory name comes out of the same
+  verification.
+
+The contingent fix is not built until fragmentation is confirmed in the
+field.
+
+### Skill content
+
+`TBDSkillContent.body` gains a short section stating the channel as
+fact: sibling TBD sessions are reachable with `ListAgents` /
+`SendMessage` when the installed Claude Code supports messaging, and
+`tbd terminal send` / `tbd terminal output` is the daemon-mediated
+alternative that can also drive input into a session. Both channels are
+described; neither is recommended over the other. The text is phrased so
+a session on a CLI without messaging falls back to `tbd terminal send`
+naturally.
+
+### Inbound policy is user-land, already
+
+Because TBD sessions all bypass permission prompts, the class-based
+default already delivers TBD↔TBD messages. A repo that wants a different
+policy sets `crossSessionInbound` (`accept` / `hold` / `refuse`) in its
+`claude-settings.json`, which deep-merges into TBD's per-spawn
+`--settings` overlay today. Documented in the docs page; no code.
+
+### Supervision and the actuation record
+
+Native peer messages travel session-to-session over Claude Code's
+sockets and never transit the daemon. They are therefore outside TBD's
+actuation record — in both directions, deliberately. The record's
+integrity claim is unchanged in kind but explicit in scope: it attests
+everything sent **through TBD's transport**, and nothing else.
+Supervision programs (sweep, wake, playbooks) may use the native channel
+as authored content, accepting that such messages are evidenced only by
+the participating sessions' own transcripts. The fleet-supervision spec
+needs no amendment — its record only ever claimed acts the daemon
+executed.
+
+### Documentation page
+
+`docs/cross-session-messaging.md` covers, for TBD users:
+
+- the Claude Code version requirement and how to confirm a session has
+  the feature (`/list-agents`, `/status` peer-address row);
+- the killswitch env vars above, with the warning that setting one via
+  TBD env overrides silently disables messaging;
+- naming: sessions answer to the worktree display name; renames apply on
+  next respawn/resume;
+- the per-repo `crossSessionInbound` recipe;
+- reach: same OS user on one machine; same account and reply-only beyond
+  it; native peer messages are not in TBD's actuation record.
+
+## Failure modes
+
+- **Messaging absent** (older CLI, killswitch env, unsupported
+  provider): sessions simply lack the tools; coordination falls back to
+  `tbd terminal send` per the skill text. No TBD surface breaks.
+- **Version probe fails** (claude not on PATH, unparseable output):
+  builder omits `--name`; spawns behave exactly as today.
+- **Contingent symlink seeding fails**: log and continue; the profile
+  works, discovery may be fragmented for it.
+
+## Testing
+
+- Builder unit tests: `--name` emitted and escaped; omitted when
+  `sessionName` is nil or empty or `supportsSessionName` is false.
+- Version-probe parse tests against real and malformed
+  `claude --version` output; probe-failure path yields the degraded
+  capability bit.
+- Skill-content test asserting the messaging section is present.
+- Contingent: symlink-seeding idempotency and isolation tests through
+  the existing `ClaudeProfileConfigDirManager(baseDirectory:hostBaseDirectory:)`
+  seams.
+
+All via `scripts/test.sh`.
+
+## Rejected alternatives
+
+- **A TBD-mediated send path (`tbd message`, daemon speaking the peer
+  socket protocol)** — would put peer messages in the actuation record,
+  but couples TBD to an unversioned wire format at the wrong layer, the
+  same class of coupling the no-screen-scraping rule exists to prevent.
+  Rebuild-worthy evidence: a supervision incident that turns on proving
+  a peer message was or was not sent, where session transcripts were
+  insufficient.
+- **Compiled channel preference (native messaging vs.
+  `tbd terminal send`)** — which channel a session should use is a
+  theory two reasonable projects answer differently; it fails the
+  placement battery's first test. Both channels are stated as facts and
+  the choice stays with the session and its operator.
+- **Live `/rename` push on display-name change** — keeps names current
+  by injecting input into a running session's composer, the same risk
+  class that forced `auto_hibernate_enabled` off. A cosmetic win priced
+  at a default-off flag and a soak; spawn-time naming with accepted
+  staleness costs neither.
+- **Compiled inbound policy (shipping a `crossSessionInbound` value in
+  the overlay)** — the class-based default already delivers TBD↔TBD
+  traffic, and the per-repo overlay merge gives users the knob with zero
+  code. Shipping `accept` would also loosen delivery from the user's
+  non-TBD sessions without being asked.
+- **Slug instead of display name** — immutable, so never stale, but it
+  reproduces what the cwd-derived default already provides and never
+  matches what the user sees in the app.

--- a/docs/specs/2026-08-09-cross-session-messaging-design.md
+++ b/docs/specs/2026-08-09-cross-session-messaging-design.md
@@ -42,9 +42,11 @@ TBD spawn path:
 
 - **Same machine, same OS user** — the discovery boundary is the
   operating-system user, not the Anthropic account. All TBD sessions run
-  in tmux on the host under one user, so registry files and sockets are
-  mutually visible. Sessions logged into different Anthropic accounts
-  (different TBD profiles) can still message each other locally.
+  in tmux on the host under one user, so the message sockets are mutually
+  visible, and TBD unifies the otherwise per-profile peer registry (see
+  Cross-profile discovery). Sessions logged into different Anthropic
+  accounts (different TBD profiles) can therefore message each other
+  locally.
 - **Permission classes** — with no `crossSessionInbound` value set,
   Claude Code delivers a message when sender and receiver are in the
   same permission class. TBD spawns every Claude session with
@@ -70,21 +72,43 @@ untouched, and Codex spawns are out of scope — messaging is a Claude
 Code feature.
 
 Callers pass the worktree's **display name** — the human-visible,
-user-renamable name in the app — so `ListAgents` rows and message
-addresses match the sidebar. Without the flag, a session names itself
+user-renamable name in the app — so `ListAgents` rows read the same as
+the app sidebar. Without the flag, a session names itself
 after its working-directory folder: the generated slug plus a random
-suffix, which never matches an app rename.
+suffix, which never matches an app rename. The flagged value lands
+verbatim as the registry row's `name`, without the
+`"nameSource": "derived"` marker the cwd-slug default carries — so the
+listing distinguishes a deliberately named session from a self-named
+one.
 
 The display name is mutable and `--name` is fixed at spawn, so a rename
 applies at the session's next respawn or resume; until then the running
 session answers to its spawn-time name. This staleness is accepted:
 respawns are frequent in TBD (wake, swap, fresh spawns), renames are
-rare, and Claude Code tolerates the fallout — same-named or stale-named
-sessions are disambiguated with short identifiers and working
-directories in the listing.
+rare, and the listing carries the working directory and a per-session
+identifier next to the name, so a stale name misleads no one who reads
+the row.
 
-Name collisions across worktrees are likewise Claude Code's problem,
-handled the same way.
+#### The name is a label; the ref is the address
+
+A name does not identify one session, and cannot be made to. Every
+Claude session spawned in a worktree carries that worktree's display
+name, and display names carry no uniqueness constraint of their own —
+field measurement on one host found 16 worktrees running more than one
+Claude terminal (four in the largest) and one pair of worktrees already
+sharing a display name. Spawn-time staleness adds a second way for a
+name to answer for the wrong session, but multiplicity is the dominant
+one and exists even when every name is current.
+
+Disambiguation therefore belongs at the addressing layer, not the naming
+one. `ListAgents` prints a short `[ref]` beside each row, unique per
+live session; a sender uses that ref whenever more than one row answers
+to the name it wants, and may use the plain name only when exactly one
+does. Keeping `--name` as the unadorned display name is what makes the
+listing legible against the app sidebar — a human reading either surface
+sees the same words — while the ref is what makes a row addressable.
+Decorating the name to force uniqueness would trade the first property
+away to duplicate the second.
 
 ### CLI version floor: 2.1.76, documented rather than gated
 
@@ -103,34 +127,139 @@ anything else, so the pane shows exactly what to fix (`--version` and
 `--help` are the exceptions — they short-circuit and succeed
 regardless). The docs page states the floor.
 
-No feature flag: nothing here acts autonomously, destroys state, or
-replaces a load-bearing path — `--name` is small additive spawn
-surface.
+No feature flag for `--name`: it acts on no timer, destroys no state,
+and replaces no load-bearing path — it is small additive spawn surface.
+The registry mirror is the other unflagged change here, and it carries
+its own argument below rather than borrowing this one.
 
 ### Cross-profile discovery
 
-Requirement: sessions on different TBD profiles must discover and
-message each other. Profile isolation exists for credentials, not for
-reachability.
+Sessions on different TBD profiles discover and message each other.
+Profile isolation exists for credentials, not for reachability.
 
-The peer registry's on-disk location is undocumented. Verification on a
-macOS host with the feature comes first: spawn sessions under two
-profiles (distinct `CLAUDE_CONFIG_DIR`s) and run `/list-agents` in
-each.
+The peer registry is `$CLAUDE_CONFIG_DIR/sessions/`: one small JSON row
+per live session, named `<pid>.json`, holding the pid, session id,
+working directory, tmux pane, the session's message socket path
+(`messagingSocketPath`), its `name` and `nameSource`, and a coarse
+`status` (`idle` / `busy` / `waiting` / `shell`) with an `updatedAt`
+timestamp. No transcript content. The message sockets themselves live
+outside the config dir, at `/tmp/cc-socks/<pid>.sock`, and are therefore
+already shared per OS user.
 
-- **If they see each other**, the registry is per-user, not
-  per-config-dir, and no work exists.
-- **If discovery is fragmented**, `ClaudeProfileConfigDirManager` adds
-  one step to profile-dir seeding: symlink the registry subdirectory
-  inside the profile's config dir to the default profile's registry
-  location, so every profile shares one registry while credentials and
-  `.claude.json` stay isolated. Seeding is idempotent and failure is
-  non-fatal (log and continue), matching the plugin and overlay
-  writers. The exact subdirectory name comes out of the same
-  verification.
+Fragmentation is entirely in the index. Because the registry hangs off
+`CLAUDE_CONFIG_DIR`, each TBD profile keeps its own, and sessions on
+different profiles are mutually invisible — field measurement found 24
+live sessions in one profile that a session in another profile could not
+list. Since the sockets are already whole across the OS user, unifying
+the index is sufficient; no transport work exists.
 
-The contingent fix is not built until fragmentation is confirmed in the
-field.
+The fix is one entry: `sessions` joins `ClaudeProfileConfigDirManager`'s
+host-mirror slots, so each profile's `claude/sessions` is a symlink to
+the host store's `sessions` directory — the same mechanism that already
+carries `projects`, `plugins`, `hooks`, `skills`, and `settings.json`.
+Seeding is idempotent and failure is non-fatal (log and continue),
+matching the plugin and overlay writers.
+
+#### Creating the host directory, and the guards on doing so
+
+The host `sessions/` directory is created if absent, at mode `0700` —
+field-measured, not assumed: the host directory and every profile-local
+one on the measured machine are `drwx------`, so a TBD-created directory
+is indistinguishable from one the CLI would have made and peer rows are
+never world-readable.
+
+Creating it at all is where this slot departs from the other eight.
+Those mirror host *customizations*, so an absent host entry means "the
+user does not use this" and skipping is right. An absent `sessions/`
+means only that no session has registered on this machine yet — skipping
+would silently no-op and leave that machine's profiles fragmented
+forever, which is the exact failure the slot exists to prevent.
+
+Two guards bound the creation:
+
+- **The host base directory must already exist.** TBD mirrors into a
+  host Claude store; it never conjures one. With no host store on the
+  machine, the slot is skipped rather than materialized.
+- **The host entry, if present, must be a directory.** A regular file or
+  a dangling symlink in that position is refused with a warning instead
+  of being symlinked into every profile, where it would wedge the slot
+  behind a target no session can write a row into.
+
+#### Pre-existing profile-local rows are merged, not set aside
+
+Every other non-`projects` slot moves pre-existing profile-local content
+to a `<slot>.profile-local` sidecar before symlinking. That policy is
+right for cold user content and wrong here, because the registry holds
+**live process state**. Field measurement on one host: four profiles
+held 48 rows between them, 47 of them belonging to processes still
+running. Seeding also runs on every spawn, not once at profile creation,
+so the directory it encounters is a live one by default rather than by
+accident.
+
+A sidecar would move running sessions' rows out from under their own
+processes. Those sessions would drop out of every peer's listing while
+still running, and their rows would be orphaned permanently: a session
+unlinks its row by path at exit, and that path — once the symlink is in
+place — resolves to a host location where the row was never written. The
+sidecar would then accumulate dead rows nothing ever cleans up.
+
+Merging avoids all of it and is collision-free by construction. Rows are
+named `<pid>.json` and PIDs are unique per OS user, so the same filename
+can appear on both sides only when one row is a stale leftover from a
+dead process whose pid was later reused; there the newer row wins. The
+rows move into the host directory, the emptied profile directory is
+removed, and the symlink takes its place. The result is that the
+migration **adopts** already-running sessions into the shared registry
+instead of hiding them.
+
+#### No feature flag for the mirror
+
+The mirror ships unflagged on its own merits, not by extension of the
+`--name` argument:
+
+- **It destroys nothing** — no row is set aside, discarded, or made
+  unreachable. The single loss case is a duplicate filename, where the
+  older of two rows is dropped; by the argument above that row belongs
+  to a dead process.
+- **The operation class is precedented** — `projects` already merges
+  profile content into the host store through the same function, over
+  transcript data, which is far more valuable than an address book.
+- **It is user-initiated** — seeding runs in response to a spawn the
+  user asked for. It acts on no timer, kills no process, and replaces no
+  load-bearing path.
+- **Rollback is a single removal** — delete the symlink and the profile
+  is back to a private registry. The rows stay valid where they are;
+  nothing needs unpicking.
+
+The flag rule exists for behavior that acts on its own or can lose
+state. This does neither, and a flag would buy only the ability to keep
+profiles fragmented — the condition the change exists to end.
+
+Three consequences, stated plainly:
+
+- **The user's own terminal sessions join the pool.** The symlink target
+  is the host store, not some TBD-private directory, so plain-terminal
+  `claude` sessions under the same OS user and TBD sessions become
+  mutually discoverable. That is the intended reach, not a leak: the
+  boundary the feature draws has always been the OS user.
+- **Only discovery changes.** A registry row carries no transcript
+  content, and `projects/` — where transcripts live — is already a host
+  mirror, so nothing newly crosses a profile boundary but the index.
+  Row freshness is unaffected: a session writes its own status row, so
+  the row is equally fresh whichever directory the file lives in.
+- **TBD's own session-ID recapture starts working for profile
+  terminals.** `ClaudeStateDetector` recaptures a session id by reading
+  `<host claude home>/sessions/<pid>.json` — the same registry, read for
+  a different purpose. Before the mirror that read missed for every
+  terminal spawned on a profile, because the row was written into the
+  profile's config dir and the detector only ever looked at the host
+  store. With the mirror the two paths are the same file, so recapture
+  after a `--fork-session` resume now succeeds for profile terminals
+  where it previously did not. This is an intended consequence of
+  unifying the registry, not a side effect to be tidied away: a test
+  pins the detector reading through the mirrored path, so a later reader
+  cannot "fix" it back onto per-profile paths without the failure being
+  visible.
 
 ### Skill content
 
@@ -160,9 +289,9 @@ integrity claim is unchanged in kind but explicit in scope: it attests
 everything sent **through TBD's transport**, and nothing else.
 Supervision programs (sweep, wake, playbooks) may use the native channel
 as authored content, accepting that such messages are evidenced only by
-the participating sessions' own transcripts. The fleet-supervision spec
-needs no amendment — its record only ever claimed acts the daemon
-executed.
+the participating sessions' own transcripts. The fleet-supervision
+design is untouched by this: its record claims only the acts the daemon
+executes.
 
 ### Documentation page
 
@@ -173,11 +302,19 @@ executed.
   feature (`/list-agents`, `/status` peer-address row);
 - the killswitch env vars above, with the warning that setting one via
   TBD env overrides silently disables messaging;
-- naming: sessions answer to the worktree display name; renames apply on
-  next respawn/resume;
+- naming and addressing: sessions answer to the worktree display name,
+  renames apply on next respawn/resume, and the `[ref]` from
+  `/list-agents` is what a sender uses when several rows share a name;
 - the per-repo `crossSessionInbound` recipe;
-- reach: same OS user on one machine; same account and reply-only beyond
-  it; native peer messages are not in TBD's actuation record.
+- reach: same OS user on one machine — across every TBD profile and the
+  user's own plain-terminal sessions; same account and reply-only beyond
+  it; native peer messages are not in TBD's actuation record;
+- the registry: where it lives, what a row holds, that it holds no
+  transcript, that TBD unifies it across profiles by symlinking to the
+  host store, and that a profile's own pre-existing rows are merged in
+  so running sessions stay listed;
+- what to do when an expected peer is missing: seeding is best-effort,
+  so `/list-agents` is the authority on who can be addressed.
 
 ## Failure modes
 
@@ -188,17 +325,33 @@ executed.
   with `error: unknown option '--name'` — loud, immediate, and fixed by
   updating the CLI. Accepted in exchange for not building a version
   probe (see Rejected alternatives).
-- **Contingent symlink seeding fails**: log and continue; the profile
-  works, discovery may be fragmented for it.
+- **Registry symlink seeding fails** (I/O error, no host store yet, or a
+  host `sessions` entry that is not a directory): log and continue; the
+  profile works normally, but its sessions discover only peers that
+  share its own config dir. `ListAgents` in a session is the authority
+  on who is reachable — a peer absent from the listing cannot be
+  addressed, whatever the sender expected.
 
 ## Testing
 
 - Builder unit tests: `--name` emitted and escaped; omitted when
   `sessionName` is nil or empty.
 - Skill-content test asserting the messaging section is present.
-- Contingent: symlink-seeding idempotency and isolation tests through
-  the existing `ClaudeProfileConfigDirManager(baseDirectory:hostBaseDirectory:)`
-  seams.
+- Registry-mirror tests through the existing
+  `ClaudeProfileConfigDirManager(baseDirectory:hostBaseDirectory:)`
+  seams: the `sessions` symlink is created and points at the host store;
+  seeding is idempotent across repeated calls; the host directory is
+  created when absent, at mode `0700`; creation is skipped when the host
+  base directory does not exist; a host entry that is a regular file or
+  a dangling symlink is refused, leaving no symlink behind; a
+  pre-existing profile-local `sessions/` has its rows merged into the
+  host directory, with the emptied profile directory removed and
+  replaced by the symlink; and where the same `<pid>.json` exists on
+  both sides, the newer row is the one that survives.
+- A detector test pinning that `ClaudeStateDetector` reads the session
+  file through the host store — the path the mirror makes reachable from
+  a profile terminal — so the recapture coupling above is not silently
+  undone.
 
 All via `scripts/test.sh`.
 
@@ -228,7 +381,12 @@ All via `scripts/test.sh`.
   non-TBD sessions without being asked.
 - **Slug instead of display name** — immutable, so never stale, but it
   reproduces what the cwd-derived default already provides and never
-  matches what the user sees in the app.
+  matches what the user sees in the app. It also buys no uniqueness: a
+  slug is per-worktree just as the display name is, so the several
+  Claude sessions one worktree runs would still share it, and two
+  worktrees with the same display name would still collide. Ambiguity is
+  resolved by the `[ref]` in the listing whatever the name says, which
+  leaves the slug trading the sidebar match for staleness relief alone.
 - **A `claude --version` capability probe gating `--name`** — a daemon
   probe (run once, cached, plumbed to the builder as a capability bit)
   would spare users on a pre-2.1.76 CLI from failing spawns. The

--- a/docs/specs/2026-08-09-cross-session-messaging-design.md
+++ b/docs/specs/2026-08-09-cross-session-messaging-design.md
@@ -64,9 +64,8 @@ TBD spawn path:
 ### Session naming — the one compiled change
 
 `ClaudeSpawnCommandBuilder.build` gains an optional `sessionName`
-parameter. When non-nil, non-empty, and the installed CLI supports it
-(next section), both the fresh-spawn and resume branches append
-`--name <value>`, shell-escaped. The `cmd`/shell-fallback branches are
+parameter. When non-nil and non-empty, both the fresh-spawn and resume
+branches append `--name <value>`, shell-escaped. The `cmd`/shell-fallback branches are
 untouched, and Codex spawns are out of scope — messaging is a Claude
 Code feature.
 
@@ -87,30 +86,26 @@ directories in the listing.
 Name collisions across worktrees are likewise Claude Code's problem,
 handled the same way.
 
-### Version gate on `--name`
+### CLI version floor: 2.1.76, documented rather than gated
 
-An unrecognized flag on an older installed CLI fails every Claude
-spawn — a hard regression for users who have not updated. Measured
-against CLI v2.1.226: a spawn-shaped invocation carrying an unknown
-option exits 1 with `error: unknown option '--…'` before doing anything
-else (`--version` and `--help` are the exceptions — they short-circuit
-and succeed regardless, which also makes `--version` a safe probe). The
-daemon therefore probes `claude --version` once and caches the result
-for its lifetime; the spawn path passes the builder a
-`supportsSessionName` capability bit, and the builder omits `--name`
-when it is false or the probe failed. A failed or missing probe degrades
-to today's spawn command — the probe must never block or break a spawn.
+`--name` is emitted unconditionally. `-n` / `--name` shipped in CLI
+v2.1.76 (published 2026-03-14, per the Claude Code changelog and npm
+registry; verified accepted on v2.1.226), so TBD's Claude spawn path
+requires CLI ≥ 2.1.76 — a five-month floor on a tool that self-updates
+by default, and one strictly looser than what the feature itself needs:
+messaging arrived in 2.1.224. A session on 2.1.76–2.1.223 gets a correct
+name and simply lacks the messaging tools.
 
-The gate's constant is **2.1.76**, the version that introduced
-`-n` / `--name` (per the Claude Code changelog; verified accepted on
-v2.1.226). Cross-session messaging itself arrived in 2.1.224 — a
-session on 2.1.76–2.1.223 gets a correct name and simply lacks the
-messaging tools. Both branches of the gate get tests, per the
-conditional-gate rule in `CLAUDE.md`.
+On a CLI below the floor the failure is loud and self-describing, not
+silent: measured against v2.1.226, a spawn-shaped invocation carrying an
+unknown option exits 1 with `error: unknown option '--…'` before doing
+anything else, so the pane shows exactly what to fix (`--version` and
+`--help` are the exceptions — they short-circuit and succeed
+regardless). The docs page states the floor.
 
-No feature flag beyond this gate: nothing here acts autonomously,
-destroys state, or replaces a load-bearing path — `--name` is small
-additive spawn surface.
+No feature flag: nothing here acts autonomously, destroys state, or
+replaces a load-bearing path — `--name` is small additive spawn
+surface.
 
 ### Cross-profile discovery
 
@@ -173,8 +168,9 @@ executed.
 
 `docs/cross-session-messaging.md` covers, for TBD users:
 
-- the Claude Code version requirement and how to confirm a session has
-  the feature (`/list-agents`, `/status` peer-address row);
+- the version story: TBD's spawn path requires CLI ≥ 2.1.76 (`--name`),
+  messaging needs ≥ 2.1.224, and how to confirm a session has the
+  feature (`/list-agents`, `/status` peer-address row);
 - the killswitch env vars above, with the warning that setting one via
   TBD env overrides silently disables messaging;
 - naming: sessions answer to the worktree display name; renames apply on
@@ -188,18 +184,17 @@ executed.
 - **Messaging absent** (older CLI, killswitch env, unsupported
   provider): sessions simply lack the tools; coordination falls back to
   `tbd terminal send` per the skill text. No TBD surface breaks.
-- **Version probe fails** (claude not on PATH, unparseable output):
-  builder omits `--name`; spawns behave exactly as today.
+- **CLI below the 2.1.76 floor**: every Claude spawn fails in the pane
+  with `error: unknown option '--name'` — loud, immediate, and fixed by
+  updating the CLI. Accepted in exchange for not building a version
+  probe (see Rejected alternatives).
 - **Contingent symlink seeding fails**: log and continue; the profile
   works, discovery may be fragmented for it.
 
 ## Testing
 
 - Builder unit tests: `--name` emitted and escaped; omitted when
-  `sessionName` is nil or empty or `supportsSessionName` is false.
-- Version-probe parse tests against real and malformed
-  `claude --version` output; probe-failure path yields the degraded
-  capability bit.
+  `sessionName` is nil or empty.
 - Skill-content test asserting the messaging section is present.
 - Contingent: symlink-seeding idempotency and isolation tests through
   the existing `ClaudeProfileConfigDirManager(baseDirectory:hostBaseDirectory:)`
@@ -234,3 +229,13 @@ All via `scripts/test.sh`.
 - **Slug instead of display name** — immutable, so never stale, but it
   reproduces what the cwd-derived default already provides and never
   matches what the user sees in the app.
+- **A `claude --version` capability probe gating `--name`** — a daemon
+  probe (run once, cached, plumbed to the builder as a capability bit)
+  would spare users on a pre-2.1.76 CLI from failing spawns. The
+  population it protects is anyone more than five months behind on a
+  self-updating CLI, the failure it prevents is loud and
+  self-describing rather than silent, and the feature the naming serves
+  needs 2.1.224 anyway — so the probe subsystem, its cache, and its
+  branch tests buy almost nothing. Rebuild-worthy evidence: field
+  reports of spawn failures from users legitimately pinned below
+  2.1.76 (e.g. an enterprise-frozen CLI).


### PR DESCRIPTION
## Summary

Sibling Claude sessions in TBD worktrees can now talk to each other directly. A session lists its peers with `ListAgents` and sends one plain text with `SendMessage`; delivery is peer-to-peer over Unix sockets, and neither Anthropic's servers nor TBD's daemon sit in the path. An orchestrator can hand a finding to a worker, and a worker can report back, without the human relaying between tabs.

TBD's contribution is deliberately small: make its sessions **addressable** under the name you see in the sidebar, and make peer discovery **whole** across TBD profiles. The transport, throttling, and inbound-safety rails are Claude Code's.

Two things had to be true for that, and neither was:

- Sessions named themselves after their working-directory folder — a slug plus a random suffix that never matches an app-side rename.
- Claude Code's peer registry lives under `CLAUDE_CONFIG_DIR`, and TBD gives every profile its own. Sessions on different profiles were mutually invisible: field measurement found 24 live sessions in one profile that a session in another could not list.

## Why this shape

Design spec: [`docs/specs/2026-08-09-cross-session-messaging-design.md`](docs/specs/2026-08-09-cross-session-messaging-design.md). User-facing page: [`docs/cross-session-messaging.md`](docs/cross-session-messaging.md).

**Adopt the native transport rather than build one.** A `tbd message` verb speaking the peer socket protocol would put peer messages in the actuation record, but it would couple TBD to an unversioned wire format at the wrong layer — the same class of coupling the no-screen-scraping rule exists to prevent. Native peer messages are therefore outside TBD's actuation record, in both directions, by decision. The record's claim narrows to "everything sent through TBD's transport", which is all it ever attested.

**The name is a label; the `[ref]` is the address.** `--name` carries the worktree display name so listings match the sidebar. But a worktree can host several Claude terminals — measured: 16 worktrees with more than one, up to 4 — and display names carry no uniqueness constraint, so a name can answer for several sessions. `ListAgents` already prints a short `[ref]` per row for exactly this; the skill text and docs direct senders to it when more than one row shares a name. No suffixing scheme, so the sidebar correspondence survives.

**A documented CLI floor instead of a capability probe.** `--name` is emitted unconditionally. It shipped in CLI 2.1.76, five months old on a self-updating tool and looser than the 2.1.224 the messaging itself needs. Below the floor the failure is loud and self-describing (`error: unknown option '--name'`, exit 1), so a probe subsystem plus its cache and branch tests bought almost nothing.

**Registry unification reuses machinery that already exists.** `sessions` becomes a ninth host-mirror slot, so each profile's `claude/sessions` symlinks to the host store — the same mechanism already carrying `projects`, `plugins`, `hooks`, `skills`, and `settings.json`. Only the index was fragmented; the sockets in `/tmp/cc-socks/` are already shared per OS user, so no transport work exists.

**Merge, not sidecar — this is the decision the change turns on.** Every other non-`projects` slot parks pre-existing profile content in a `<slot>.profile-local` sidecar. That is right for cold user content and wrong here: the registry holds *live process state*, and seeding runs on every spawn, not once at profile creation. Measured: four profiles held 48 rows, 47 belonging to running processes. A sidecar would have moved those rows out from under their own processes, dropped them from every peer's listing while still running, and orphaned them permanently — a session unlinks its row *by path* at exit, which after symlinking resolves to a host location where the row was never written. Rows are `<pid>.json` and PIDs are unique per OS user, so merging is collision-free by construction and the migration **adopts** running sessions instead of hiding them.

**No feature flag**, argued on the mirror's own merits rather than by extension of `--name`: it destroys nothing (the only loss case is a duplicate filename, where the older row belongs to a dead process); the operation class is precedented, since `projects` already merges profile content hostward through the same function, over far more valuable data; it runs only in response to a user-initiated spawn, on no timer, killing no process; and rollback is deleting one symlink, with rows staying valid where they are.

**Inbound policy stays user-land.** TBD spawns with permissions bypassed, so TBD↔TBD messages already deliver under the class-based default. A repo wanting something stricter sets `crossSessionInbound` in its per-repo `claude-settings.json`, which deep-merges into the per-spawn `--settings` overlay today. Shipping a value would also have loosened delivery from the user's non-TBD sessions without being asked.

## What this PR does

- **`ClaudeSpawnCommandBuilder`** gains `sessionName:`, emitting shell-escaped ` --name <value>` after `--dangerously-skip-permissions` in the resume and fresh branches only. The `cmd` / `shellFallback` branches are structurally untouched. Names are sanitized — control characters and newlines stripped, trimmed, length-capped — because a display name is free text that now reaches a command string.
- **Seven call sites** pass `sessionName: worktree.displayName`: two in `WorktreeLifecycle+Create`, one in `HibernationCoordinator`, four in `RPCRouter+TerminalHandlers` (including both arms of the profile-swap handler).
- **`ClaudeProfileConfigDirManager`** adds `sessions` as a ninth mirror slot with three narrowly-scoped carve-outs, each its own named set so the other eight are provably unaffected: the host directory is created when absent (`0700`), rows are merged rather than sidecar'd, and the host entry's type is validated. Guards: the host base directory must already exist, so TBD never conjures a host store; and a regular file or dangling symlink in that position is refused with a warning instead of wedging the slot permanently. A partial merge leaves the symlink uncreated so the next spawn retries rather than burying it.
- **`TBDSkillContent`** gains a short section stating both channels as fact with no preference between them — native messaging, and `tbd terminal send` / `output` as the daemon-mediated alternative that can also drive input — plus the `[ref]` addressing rule.
- **Docs**: the design spec, and a new standalone user page covering versions, confirmation, naming and rename staleness, collision addressing, reach, killswitches, the `crossSessionInbound` recipe, the actuation-record boundary, and the registry.

## Assumptions

- **CLI ≥ 2.1.76.** `--name` is unconditional, so *every* TBD Claude spawn depends on it — not just messaging. Below the floor all spawning fails loudly. Recorded as a rejected alternative with rebuild-worthy evidence (field reports from users legitimately pinned below it, e.g. an enterprise-frozen CLI).
- **The registry layout is undocumented and unversioned.** `sessions/<pid>.json` was established by field measurement, not by contract. If Claude Code relocates it, the mirror slot silently mirrors an unused directory: discovery reverts to per-profile, and nothing else breaks.
- **PIDs are unique per OS user at any instant.** This is what makes the merge collision-free. If two rows share a filename, one is a stale leftover from a reused pid, and the newer wins.
- **Only CLI sessions register.** Every registry row observed came from a terminal. No Claude desktop session was running during measurement, so this is an observation, not a proof — the docs state it at that strength.

## Evidence & verification

**Field measurement** (macOS, CLI 2.1.227) established the facts the design rests on: the registry path and row contents; that sockets live in a shared `/tmp/cc-socks/`; that discovery fragments per profile; and that `claude --name "TBD Name Probe"` lands verbatim as the row's `name`, dropping the `"nameSource": "derived"` marker the cwd-slug default carries.

**Live verification** after `scripts/restart.sh` from this worktree (one `TBDDaemon` from the worktree path; the app bundle rebuilt and relaunched):

- Created a worktree named `🔬 XSess Verify`. Its pane start command carried `--name '🔬 XSess Verify'` in the designed position, and its registry row read `"name": "🔬 XSess Verify"` with no `nameSource` — emoji and space survived the shell escaping.
- **Migration adopted live rows**: the profile's `sessions/` became a symlink to the host store, host rows went 3 → 24 as 20 live rows merged in, and **zero sidecars** were created. The session doing the observing kept working throughout.
- `ListAgents` listed the new session as `🔬 XSess Verify [6fe655]`. `SendMessage` to that address was delivered and **replied to** — a full round trip.
- **Rename staleness confirmed both ways**: after renaming to `🧪 XSess Renamed`, the already-running session still answered to `🔬 XSess Verify` while a newly spawned terminal in the same worktree registered as `🧪 XSess Renamed`.
- Scratch worktree archived afterwards.

**Discriminating tests** — not merely "the suite is green":

- The call-site coverage was **mutation-checked**: with `sessionName:` deleted from the `spawnPrimaryTerminals` call site, `WorktreeConversationCarryoverTests` fails on the missing `--name 'Resume Source'`; restored, it passes. The worktree's `displayName` is deliberately different from its `name` so the assertion cannot pass off the wrong field. Before this, deleting the argument from any of the seven call sites left the whole suite green.
- Two pre-existing whitelist helpers pinning the prompt-free resume shape (the guard against ever pasting into a live session) were relaxed to admit `--name`, and their mutation-check self-tests extended to prove a trailing prompt is *still* rejected with `--name` present — in both directions, and now modelling the escaper's `'\''` form.
- New coverage for the merge (rows move, newer wins a duplicate, empty dir just symlinks), the host-side guards (absent base dir, non-directory, dangling symlink), the create-on-demand carve-out not leaking to the other eight slots, and name sanitization.
- A test pins `ClaudeStateDetector` reading a profile session's row through the mirrored path, so the recapture consequence below cannot be quietly reverted.

**One intended second-order effect, called out because it is easy to miss.** `ClaudeStateDetector` recaptures a session id by reading `<host claude home>/sessions/<pid>.json`. Before the mirror that read missed for every profile-spawned terminal; with it, the two paths are the same file, so session-ID recapture after a `--fork-session` resume now succeeds for profile terminals where it previously did not.

**Suite**: 5417 tests. The only failures are the known load-sensitive flake cluster — two `ProviderEventsSupervisorTests` live-process tests and a `MarkdownStylesheetTests` watcher test — which pass on a targeted re-run (18 tests in 2 suites). `scripts/swift-safe build` clean; `swiftlint --strict` reports 0 violations in 681 files.

[💬 Cross-Session Messaging](https://cheapsteak.github.io/tbd/open/?worktree=C575707C-5617-4EB3-A294-1F00D11CB93B)
