### PR TITLE
fix: make terminal creation idempotent

### DIFF
--- a/Sources/TBDApp/AppState+History.swift
+++ b/Sources/TBDApp/AppState+History.swift
@@ -165,11 +165,7 @@ extension AppState {
                 resumeSessionID: sessionId,
                 colorFgBg: colorFgBg
             )
-            terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id))
-            tabs[worktreeID, default: []].append(tab)
-            let index = (tabs[worktreeID]?.count ?? 1) - 1
-            setActiveTab(worktreeID: worktreeID, tabIndex: index)
+            mergeCreatedTerminalAndSelect(terminal)
             historyActiveWorktrees.remove(worktreeID)
         } catch {
             handleConnectionError(error)
@@ -184,11 +180,7 @@ extension AppState {
             let size = mainAreaTerminalSize()
             let terminal = try await daemonClient.reviveTerminalHistory(
                 worktreeID: worktreeID, id: entry.id, cols: size.cols, rows: size.rows)
-            terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
-            tabs[worktreeID, default: []].append(tab)
-            let index = (tabs[worktreeID]?.count ?? 1) - 1
-            setActiveTab(worktreeID: worktreeID, tabIndex: index)
+            mergeCreatedTerminalAndSelect(terminal)
             historyActiveWorktrees.remove(worktreeID)
         } catch {
             handleConnectionError(error)

--- a/Sources/TBDApp/AppState+ModelProfiles.swift
+++ b/Sources/TBDApp/AppState+ModelProfiles.swift
@@ -413,11 +413,7 @@ extension AppState {
                 // nothing to add or re-select here.
                 return
             }
-            let worktreeID = resultTerminal.worktreeID
-            terminals[worktreeID, default: []].append(resultTerminal)
-            let newTab = Tab(id: resultTerminal.id, content: .terminal(terminalID: resultTerminal.id))
-            tabs[worktreeID, default: []].append(newTab)
-            setActiveTab(worktreeID: worktreeID, tabIndex: (tabs[worktreeID]?.count ?? 1) - 1)
+            mergeCreatedTerminalAndSelect(resultTerminal)
         } catch {
             logger.error("Failed to swap profile on terminal: \(error, privacy: .public)")
             showAlert("Failed to swap profile: \(error.localizedDescription)", isError: true)

--- a/Sources/TBDApp/AppState+Tabs.swift
+++ b/Sources/TBDApp/AppState+Tabs.swift
@@ -273,7 +273,18 @@ extension AppState {
         }
         if let storedOrder = worktreeTabOrders[worktreeID], !storedOrder.isEmpty,
            let arr = tabs[worktreeID] {
-            let storedIndex = Dictionary(uniqueKeysWithValues: storedOrder.enumerated().map { ($1, $0) })
+            var storedIndex: [UUID: Int] = [:]
+            var repairedOrder: [UUID] = []
+            repairedOrder.reserveCapacity(storedOrder.count)
+            for id in storedOrder where storedIndex[id] == nil {
+                storedIndex[id] = repairedOrder.count
+                repairedOrder.append(id)
+            }
+            if repairedOrder != storedOrder {
+                let discardedCount = storedOrder.count - repairedOrder.count
+                worktreeTabOrders[worktreeID] = repairedOrder
+                logger.warning("Repaired duplicate tab order for \(worktreeID, privacy: .public); discarded \(discardedCount, privacy: .public) entries")
+            }
             // Stable sort: known first (by stored position), unknown after (in input order).
             // Use enumerated original index as a tiebreaker so unknown tabs keep their input order.
             let withIndex = arr.enumerated().map { (origIdx: $0.offset, tab: $0.element) }

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -163,7 +163,7 @@ extension AppState {
            let activeID = activeTabTerminalID(worktreeID: worktreeID),
            activeID != terminal.id,
            self.terminal(id: activeID, in: worktreeID)?.label == Self.preSessionTerminalLabel,
-           let newIdx = tabs[worktreeID]?.firstIndex(where: { $0.id == terminal.id }) {
+           let newIdx = tabIndexRepresentingTerminal(terminal.id, worktreeID: worktreeID) {
             // The daemon already persisted the primary as the active tab
             // (setActiveTabID in spawnPrimaryTerminals) — only the in-memory
             // index needs to move, so skip setActiveTab's re-persist RPC.
@@ -183,6 +183,26 @@ extension AppState {
             Task { [weak self] in
                 await self?.refreshStoredTabOrder(worktreeID: worktreeID)
             }
+        }
+    }
+
+    /// Merge a terminal returned by an explicit creation action and select
+    /// whichever root tab currently represents it, including a split root.
+    func mergeCreatedTerminalAndSelect(_ terminal: Terminal) {
+        mergeCreatedTerminal(terminal)
+        if let index = tabIndexRepresentingTerminal(
+            terminal.id, worktreeID: terminal.worktreeID
+        ) {
+            setActiveTab(worktreeID: terminal.worktreeID, tabIndex: index)
+        }
+    }
+
+    private func tabIndexRepresentingTerminal(
+        _ terminalID: UUID, worktreeID: UUID
+    ) -> Int? {
+        tabs[worktreeID]?.firstIndex { tab in
+            (layouts[tab.id] ?? .pane(tab.content))
+                .allTerminalIDs().contains(terminalID)
         }
     }
 

--- a/Sources/TBDApp/AppState+Terminals.swift
+++ b/Sources/TBDApp/AppState+Terminals.swift
@@ -89,24 +89,58 @@ extension AppState {
             do {
                 let fetched = try await self.daemonClient.listTerminals(worktreeID: delta.worktreeID)
                 guard let terminal = fetched.first(where: { $0.id == delta.terminalID }) else { return }
-                self.appendCreatedTerminal(terminal)
+                self.mergeCreatedTerminal(terminal)
             } catch {
                 logger.error("terminalCreated delta fetch failed for \(delta.terminalID, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
     }
 
-    /// Append a terminal announced by a `.terminalCreated` delta to state,
-    /// add a tab for it, and — when an agent terminal lands while the user is
-    /// still looking at the pre-session hook tab — move the selection to the
-    /// agent (matches the daemon's "active = primary" default).
+    /// Merge a terminal returned by any creation path into local state, add a
+    /// tab for it when needed, and — when an agent terminal lands while the
+    /// user is still looking at the pre-session hook tab — move the selection
+    /// to the agent (matches the daemon's "active = primary" default).
     ///
-    /// Idempotent: re-checks for the terminal so the direct-append path in
-    /// `createTerminal` (which races the delta) never produces duplicates.
-    func appendCreatedTerminal(_ terminal: Terminal) {
+    /// Idempotent: a repeated UUID replaces the earlier terminal snapshot so
+    /// whichever racing path lands last supplies the freshest daemon state.
+    func mergeCreatedTerminal(_ terminal: Terminal) {
         let worktreeID = terminal.worktreeID
-        guard !(terminals[worktreeID] ?? []).contains(where: { $0.id == terminal.id }) else { return }
-        terminals[worktreeID, default: []].append(terminal)
+        let previousActiveTabID = explicitActiveTabID(worktreeID: worktreeID)
+        let inserted: Bool
+        if let existingIndex = terminals[worktreeID]?.firstIndex(where: { $0.id == terminal.id }) {
+            terminals[worktreeID]?[existingIndex] = terminal
+            inserted = false
+        } else {
+            terminals[worktreeID, default: []].append(terminal)
+            inserted = true
+        }
+
+        let splitRepresentationTabIDs = Set((tabs[worktreeID] ?? []).compactMap { tab -> UUID? in
+            guard let layout = layouts[tab.id],
+                  case .split = layout,
+                  layout.allTerminalIDs().contains(terminal.id) else { return nil }
+            return tab.id
+        })
+
+        // A split layout is the authoritative representation. Otherwise keep
+        // the first standalone root and discard later racing copies.
+        var retainedRoot = false
+        var retainedSplitRootIDs = Set<UUID>()
+        tabs[worktreeID]?.removeAll { tab in
+            guard case .terminal(let terminalID) = tab.content,
+                  terminalID == terminal.id else { return false }
+            if splitRepresentationTabIDs.contains(tab.id) {
+                return !retainedSplitRootIDs.insert(tab.id).inserted
+            }
+            if !splitRepresentationTabIDs.isEmpty {
+                return true
+            }
+            if !retainedRoot {
+                retainedRoot = true
+                return false
+            }
+            return true
+        }
 
         // Add a tab unless the terminal is already represented as a tab root
         // or inside a split layout (same rule as reconcileTabs).
@@ -118,12 +152,14 @@ extension AppState {
                 Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
             )
         }
+        repointActiveTab(worktreeID: worktreeID, to: previousActiveTabID)
 
         // When the primary terminal (agent, or shell with skipClaude) arrives
         // while the user is still on the pre-session hook tab, follow it. Any
         // other active tab means the user navigated deliberately — leave the
         // selection alone. The parallel `setup` window never steals selection.
-        if isPrimaryTerminal(terminal),
+        if inserted,
+           isPrimaryTerminal(terminal),
            let activeID = activeTabTerminalID(worktreeID: worktreeID),
            activeID != terminal.id,
            self.terminal(id: activeID, in: worktreeID)?.label == Self.preSessionTerminalLabel,
@@ -143,7 +179,7 @@ extension AppState {
         // the persisted order and re-sort. applyStoredOrder follows the
         // active tab by ID, so neither the hand-off above nor a deliberate
         // user selection is clobbered.
-        if shouldReconcileTabOrderFromDaemon(after: terminal) {
+        if inserted, shouldReconcileTabOrderFromDaemon(after: terminal) {
             Task { [weak self] in
                 await self?.refreshStoredTabOrder(worktreeID: worktreeID)
             }
@@ -173,7 +209,7 @@ extension AppState {
     /// converges on the next full refresh or restart, exactly as before.
     func refreshStoredTabOrder(worktreeID: UUID) async {
         do {
-            let response = try await daemonClient.listTabs(worktreeID: worktreeID)
+            let response = try await tabStatesFetcher(worktreeID)
             adoptPersistedTabOrder(worktreeID: worktreeID, order: response.order)
         } catch {
             logger.error("tab order re-fetch failed for \(worktreeID, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -236,9 +272,7 @@ extension AppState {
             let size = mainAreaTerminalSize()
             let colorFgBg = appearance?.currentColorFgBg
             let terminal = try await daemonClient.createTerminal(worktreeID: worktreeID, cmd: cmd, cols: size.cols, rows: size.rows, colorFgBg: colorFgBg)
-            terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
-            tabs[worktreeID, default: []].append(tab)
+            mergeCreatedTerminal(terminal)
         } catch {
             logger.error("Failed to create terminal: \(error)")
             handleConnectionError(error)
@@ -320,9 +354,7 @@ extension AppState {
                 rows: size.rows,
                 colorFgBg: colorFgBg
             )
-            terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
-            tabs[worktreeID, default: []].append(tab)
+            mergeCreatedTerminal(terminal)
             return terminal
         } catch {
             logger.error("Failed to create Claude terminal: \(error)")
@@ -347,9 +379,7 @@ extension AppState {
                 rows: size.rows,
                 colorFgBg: colorFgBg
             )
-            terminals[worktreeID, default: []].append(terminal)
-            let tab = Tab(id: terminal.id, content: .terminal(terminalID: terminal.id), label: initialTabLabel(for: terminal))
-            tabs[worktreeID, default: []].append(tab)
+            mergeCreatedTerminal(terminal)
         } catch {
             logger.error("Failed to create Codex terminal: \(error)")
             handleConnectionError(error)
@@ -374,7 +404,7 @@ extension AppState {
             guard let terminal = rows.first(where: { $0.id == result.terminalID }) else {
                 throw DaemonClientError.invalidResponse
             }
-            appendCreatedTerminal(terminal)
+            mergeCreatedTerminal(terminal)
             if let index = tabs[source.worktreeID]?.firstIndex(where: { tab in
                 (layouts[tab.id] ?? .pane(tab.content))
                     .allTerminalIDs().contains(terminal.id)

--- a/Tests/TBDAppTests/PreSessionAppStateTests.swift
+++ b/Tests/TBDAppTests/PreSessionAppStateTests.swift
@@ -61,15 +61,15 @@ struct PreSessionAppStateTests {
         return wt
     }
 
-    // MARK: - terminalCreated append + dedupe
+    // MARK: - terminalCreated merge + dedupe
 
-    @Test func appendCreatedTerminalAppendsTerminalAndTab() {
+    @Test func mergeCreatedTerminalAppendsTerminalAndTab() {
         withAppState { state in
             let worktreeID = UUID()
             let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
 
-            state.appendCreatedTerminal(claude)
+            state.mergeCreatedTerminal(claude)
 
             #expect(state.terminals[worktreeID]?.map(\.id) == [pre.id, claude.id])
             #expect(state.tabs[worktreeID]?.map(\.id) == [pre.id, claude.id])
@@ -77,7 +77,7 @@ struct PreSessionAppStateTests {
         }
     }
 
-    @Test func appendCreatedTerminalDedupesAfterDirectAppend() {
+    @Test func mergeCreatedTerminalDedupesAfterDirectAppend() {
         withAppState { state in
             let worktreeID = UUID()
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
@@ -86,10 +86,31 @@ struct PreSessionAppStateTests {
             state.tabs[worktreeID] = [Tab(id: claude.id, content: .terminal(terminalID: claude.id), label: nil)]
 
             // The racing delta-driven append must be a no-op.
-            state.appendCreatedTerminal(claude)
+            state.mergeCreatedTerminal(claude)
 
             #expect(state.terminals[worktreeID]?.count == 1)
             #expect(state.tabs[worktreeID]?.count == 1)
+        }
+    }
+
+    /// Tier 1: deterministic in-process state only.
+    @Test func mergeCreatedTerminalUpdatesSnapshotAfterEventWinsRace() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let terminalID = UUID()
+            let eventSnapshot = makeTerminal(
+                id: terminalID, worktreeID: worktreeID,
+                label: "Starting Claude Code", kind: .claude)
+            let directSnapshot = makeTerminal(
+                id: terminalID, worktreeID: worktreeID,
+                label: "Claude Code", kind: .claude)
+
+            state.mergeCreatedTerminal(eventSnapshot)
+            state.mergeCreatedTerminal(directSnapshot)
+
+            #expect(state.terminals[worktreeID] == [directSnapshot])
+            #expect(state.tabs[worktreeID]?.count == 1)
+            #expect(state.tabs[worktreeID]?.first?.id == terminalID)
         }
     }
 
@@ -109,7 +130,7 @@ struct PreSessionAppStateTests {
         }
     }
 
-    @Test func appendCreatedTerminalSkipsTabWhenTerminalLivesInASplitLayout() {
+    @Test func mergeCreatedTerminalSkipsTabWhenTerminalLivesInASplitLayout() {
         withAppState { state in
             let worktreeID = UUID()
             let rootID = UUID()
@@ -125,11 +146,75 @@ struct PreSessionAppStateTests {
                 ratios: [0.5, 0.5]
             )
 
-            state.appendCreatedTerminal(splitChild)
+            state.mergeCreatedTerminal(splitChild)
 
             #expect(state.terminals[worktreeID]?.map(\.id) == [splitChild.id])
             // No new tab: the terminal is already represented inside a layout.
             #expect(state.tabs[worktreeID]?.map(\.id) == [rootID])
+        }
+    }
+
+    /// Tier 1: deterministic in-process state only.
+    @Test func mergeCreatedTerminalRetainsFirstRootAndActiveTabIdentity() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let terminal = makeTerminal(
+                worktreeID: worktreeID, label: "shell", kind: .shell)
+            let otherID = UUID()
+            state.terminals[worktreeID] = [terminal]
+            state.tabs[worktreeID] = [
+                Tab(
+                    id: terminal.id,
+                    content: .terminal(terminalID: terminal.id),
+                    label: "first"),
+                Tab(
+                    id: terminal.id,
+                    content: .terminal(terminalID: terminal.id),
+                    label: "duplicate"),
+                Tab(
+                    id: otherID,
+                    content: .terminal(terminalID: otherID),
+                    label: "other"),
+            ]
+            state.activeTabIndices[worktreeID] = 2
+
+            state.mergeCreatedTerminal(terminal)
+
+            #expect(state.tabs[worktreeID]?.map(\.label) == ["first", "other"])
+            #expect(state.activeTabIndices[worktreeID] == 1)
+            #expect(state.explicitActiveTabID(worktreeID: worktreeID) == otherID)
+        }
+    }
+
+    /// Tier 1: deterministic in-process state only.
+    @Test func mergeCreatedTerminalPrefersSplitRepresentationOverRootTab() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let splitRootID = UUID()
+            let terminal = makeTerminal(
+                worktreeID: worktreeID, label: "shell", kind: .shell)
+            state.terminals[worktreeID] = [terminal]
+            state.tabs[worktreeID] = [
+                Tab(
+                    id: terminal.id,
+                    content: .terminal(terminalID: terminal.id),
+                    label: "standalone"),
+                Tab(
+                    id: splitRootID,
+                    content: .terminal(terminalID: splitRootID),
+                    label: "split"),
+            ]
+            state.layouts[splitRootID] = .split(
+                id: UUID(), direction: .horizontal,
+                children: [
+                    .pane(.terminal(terminalID: splitRootID)),
+                    .pane(.terminal(terminalID: terminal.id)),
+                ],
+                ratios: [0.5, 0.5])
+
+            state.mergeCreatedTerminal(terminal)
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [splitRootID])
         }
     }
 
@@ -142,10 +227,35 @@ struct PreSessionAppStateTests {
             // Unset index defaults to 0 at the view layer = the pre-session tab.
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
 
-            state.appendCreatedTerminal(claude)
+            state.mergeCreatedTerminal(claude)
 
             #expect(state.activeTabIndices[worktreeID] == 1)
             #expect(state.tabs[worktreeID]?[1].id == claude.id)
+        }
+    }
+
+    /// Tier 1: deterministic in-process state only.
+    @Test func mergeCreatedTerminalHandsOffFocusOnlyOnInsertion() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            let terminalID = UUID()
+            let eventSnapshot = makeTerminal(
+                id: terminalID, worktreeID: worktreeID,
+                label: "Starting Claude Code", kind: .claude)
+            let directSnapshot = makeTerminal(
+                id: terminalID, worktreeID: worktreeID,
+                label: "Claude Code", kind: .claude)
+
+            state.mergeCreatedTerminal(eventSnapshot)
+            #expect(state.explicitActiveTabID(worktreeID: worktreeID) == terminalID)
+
+            // The user deliberately returns to the pre-session tab before the
+            // direct RPC response lands with a newer snapshot.
+            state.activeTabIndices[worktreeID] = 0
+            state.mergeCreatedTerminal(directSnapshot)
+
+            #expect(state.explicitActiveTabID(worktreeID: worktreeID) == pre.id)
         }
     }
 
@@ -160,7 +270,7 @@ struct PreSessionAppStateTests {
             state.activeTabIndices[worktreeID] = 1
 
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
-            state.appendCreatedTerminal(claude)
+            state.mergeCreatedTerminal(claude)
 
             #expect(state.activeTabIndices[worktreeID] == 1)
         }
@@ -174,7 +284,7 @@ struct PreSessionAppStateTests {
             // Phase 3 also broadcasts the parallel `setup` hook terminal —
             // it must never steal the selection.
             let setup = makeTerminal(worktreeID: worktreeID, label: "setup", kind: .shell)
-            state.appendCreatedTerminal(setup)
+            state.mergeCreatedTerminal(setup)
 
             #expect(state.activeTabIndices[worktreeID] == nil)
         }
@@ -189,7 +299,7 @@ struct PreSessionAppStateTests {
             // (label "shell", kind .shell) — it must take the hand-off exactly
             // like an agent terminal would.
             let shell = makeTerminal(worktreeID: worktreeID, label: "shell", kind: .shell)
-            state.appendCreatedTerminal(shell)
+            state.mergeCreatedTerminal(shell)
 
             #expect(state.activeTabIndices[worktreeID] == 1)
             #expect(state.tabs[worktreeID]?[1].id == shell.id)
@@ -202,7 +312,7 @@ struct PreSessionAppStateTests {
             _ = seedPreSessionOnly(state, worktreeID: worktreeID)
             let codex = makeTerminal(worktreeID: worktreeID, label: "Codex", kind: .codex)
 
-            state.appendCreatedTerminal(codex)
+            state.mergeCreatedTerminal(codex)
 
             #expect(state.activeTabIndices[worktreeID] == 1)
         }
@@ -223,8 +333,8 @@ struct PreSessionAppStateTests {
             // Phase-3 deltas land: primary agent, then the parallel setup shell.
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
             let setup = makeTerminal(worktreeID: worktreeID, label: "setup", kind: .shell)
-            state.appendCreatedTerminal(claude)
-            state.appendCreatedTerminal(setup)
+            state.mergeCreatedTerminal(claude)
+            state.mergeCreatedTerminal(setup)
 
             // Plain appends leave the diverged [preSession, primary, setup]…
             #expect(state.tabs[worktreeID]?.map(\.id) == [pre.id, claude.id, setup.id])
@@ -241,13 +351,49 @@ struct PreSessionAppStateTests {
         }
     }
 
+    /// Tier 1: deterministic in-process state only.
+    @Test func mergeCreatedTerminalReconcilesStoredOrderOnlyOnInsertion() async {
+        let suiteName = "PreSessionAppStateTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = AppState(userDefaults: defaults)
+        let worktreeID = seedWorktree(state, status: .creating).id
+        let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+        let terminalID = UUID()
+        let eventSnapshot = makeTerminal(
+            id: terminalID, worktreeID: worktreeID,
+            label: "Starting Claude Code", kind: .claude)
+        let directSnapshot = makeTerminal(
+            id: terminalID, worktreeID: worktreeID,
+            label: "Claude Code", kind: .claude)
+        state.worktreeTabOrders[worktreeID] = [pre.id]
+        var fetchCount = 0
+        state.tabStatesFetcher = { _ in
+            fetchCount += 1
+            return TabListResponse(
+                tabs: [], order: [terminalID, pre.id], activeTabID: terminalID)
+        }
+
+        state.mergeCreatedTerminal(eventSnapshot)
+        for _ in 0..<3 { await Task.yield() }
+        #expect(fetchCount == 1)
+
+        // Keep the gate otherwise armed so only insertion-vs-merge controls
+        // whether this second adoption schedules another reconciliation.
+        state.worktreeTabOrders[worktreeID] = [pre.id]
+        state.mergeCreatedTerminal(directSnapshot)
+        for _ in 0..<3 { await Task.yield() }
+
+        #expect(fetchCount == 1)
+    }
+
     @Test func adoptPersistedTabOrderFollowsDeliberateUserSelectionByID() {
         withAppState { state in
             let worktreeID = UUID()
             let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
             state.worktreeTabOrders[worktreeID] = [pre.id]
             let claude = makeTerminal(worktreeID: worktreeID, label: "Claude Code", kind: .claude)
-            state.appendCreatedTerminal(claude)
+            state.mergeCreatedTerminal(claude)
             // User deliberately clicked back to the pre-session tab before
             // the order re-fetch landed.
             state.activeTabIndices[worktreeID] = 0

--- a/Tests/TBDAppTests/PreSessionAppStateTests.swift
+++ b/Tests/TBDAppTests/PreSessionAppStateTests.swift
@@ -114,6 +114,37 @@ struct PreSessionAppStateTests {
         }
     }
 
+    /// Tier 1: deterministic in-process state only.
+    @Test func mergeCreatedTerminalAndSelectPreservesExplicitCreationSelection() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let existing = makeTerminal(
+                worktreeID: worktreeID, label: "shell", kind: .shell)
+            let terminalID = UUID()
+            let eventSnapshot = makeTerminal(
+                id: terminalID, worktreeID: worktreeID,
+                label: "Starting Claude Code", kind: .claude)
+            let directSnapshot = makeTerminal(
+                id: terminalID, worktreeID: worktreeID,
+                label: "Claude Code", kind: .claude)
+            state.terminals[worktreeID] = [existing]
+            state.tabs[worktreeID] = [
+                Tab(
+                    id: existing.id,
+                    content: .terminal(terminalID: existing.id),
+                    label: nil),
+            ]
+            state.activeTabIndices[worktreeID] = 0
+
+            state.mergeCreatedTerminal(eventSnapshot)
+            state.mergeCreatedTerminalAndSelect(directSnapshot)
+
+            #expect(state.terminals[worktreeID] == [existing, directSnapshot])
+            #expect(state.tabs[worktreeID]?.map(\.id) == [existing.id, terminalID])
+            #expect(state.explicitActiveTabID(worktreeID: worktreeID) == terminalID)
+        }
+    }
+
     @Test func terminalCreatedDeltaForKnownTerminalIsSynchronousNoOp() {
         withAppState { state in
             let worktreeID = UUID()
@@ -231,6 +262,36 @@ struct PreSessionAppStateTests {
 
             #expect(state.activeTabIndices[worktreeID] == 1)
             #expect(state.tabs[worktreeID]?[1].id == claude.id)
+        }
+    }
+
+    /// Tier 1: deterministic in-process state only.
+    @Test func selectionSwitchesToSplitRootContainingNewPrimaryTerminal() {
+        withAppState { state in
+            let worktreeID = UUID()
+            let pre = seedPreSessionOnly(state, worktreeID: worktreeID)
+            let splitRoot = makeTerminal(
+                worktreeID: worktreeID, label: "shell", kind: .shell)
+            let claude = makeTerminal(
+                worktreeID: worktreeID, label: "Claude Code", kind: .claude)
+            state.terminals[worktreeID]?.append(splitRoot)
+            state.tabs[worktreeID]?.append(Tab(
+                id: splitRoot.id,
+                content: .terminal(terminalID: splitRoot.id),
+                label: nil))
+            state.layouts[splitRoot.id] = .split(
+                id: UUID(), direction: .horizontal,
+                children: [
+                    .pane(.terminal(terminalID: splitRoot.id)),
+                    .pane(.terminal(terminalID: claude.id)),
+                ],
+                ratios: [0.5, 0.5])
+            state.activeTabIndices[worktreeID] = 0
+
+            state.mergeCreatedTerminal(claude)
+
+            #expect(state.tabs[worktreeID]?.map(\.id) == [pre.id, splitRoot.id])
+            #expect(state.explicitActiveTabID(worktreeID: worktreeID) == splitRoot.id)
         }
     }
 

--- a/Tests/TBDAppTests/TabReorderTests.swift
+++ b/Tests/TBDAppTests/TabReorderTests.swift
@@ -110,6 +110,26 @@ import TBDShared
 }
 
 @MainActor
+@Test func applyStoredOrderRepairsDuplicateCachedOrder() {
+    // Tier 1: deterministic in-process state only.
+    let state = AppState()
+    let worktreeID = UUID()
+    let known = [UUID(), UUID()]
+    let unknown = [UUID(), UUID()]
+    state.tabs[worktreeID] = [unknown[0], known[0], unknown[1], known[1]].map {
+        Tab(id: $0, content: .terminal(terminalID: $0), label: nil)
+    }
+    state.activeTabIndices[worktreeID] = 0
+    state.worktreeTabOrders[worktreeID] = [known[1], known[0], known[1]]
+
+    state.applyStoredOrder(worktreeID: worktreeID)
+
+    #expect(state.worktreeTabOrders[worktreeID] == [known[1], known[0]])
+    #expect(state.tabs[worktreeID]?.map(\.id) == [known[1], known[0], unknown[0], unknown[1]])
+    #expect(state.explicitActiveTabID(worktreeID: worktreeID) == unknown[0])
+}
+
+@MainActor
 @Test func applyStoredOrderIsNoOpWhenStoredOrderEmpty() {
     let state = AppState()
     let worktreeID = UUID()


### PR DESCRIPTION
## Summary

- converge terminal creation RPC responses and terminal-created events through one idempotent state operation
- preserve split-layout and active-tab identity while removing duplicate terminal roots
- defensively repair duplicate IDs before applying persisted tab order

## Root cause

The create RPC response and the terminal-created event could both append the same terminal and tab UUID. Later tab-order restoration constructed a unique-key dictionary from that duplicated state and trapped.

## Verification

- `scripts/test.sh --filter 'PreSessionAppStateTests|TabReorderTests'` — 49 tests passed
- `scripts/swift-safe build`
- `swiftlint --strict`

## Scope

This PR only changes terminal/tab convergence and stored-order repair. It does not change launch PATH or terminal recovery behavior.
