### PR TITLE
fix: resume incomplete Claude review sessions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -400,10 +400,11 @@ jobs:
           # as outdated (spec §3.5), which is the opposite of editing a single
           # comment in place. It selects its own comments by its own sentinel.
           #
-          # Installs a Stop hook that refuses to end the session until
-          # review-result.json exists and parses as JSON. Unlike v1 it does NOT
-          # gate on a verdict token — in v2 the model never types the verdict;
-          # validate.py computes it from the findings' severities.
+          # Installs a bounded Stop hook that blocks repeated stop attempts while
+          # review-result.json is absent or malformed. Unlike v1 it does NOT gate
+          # on a verdict token — in v2 the model never types the verdict;
+          # validate.py computes it from the findings' severities, and the
+          # same-session recovery step below handles an exhausted hook ceiling.
           settings: ${{ github.workspace }}/.github/workflows/claude-review-v2/hooks/settings.json
           prompt: |
             You are the ORCHESTRATOR of a fan-out code review of ${{ github.repository }}/pull/${{ github.event.pull_request.number }} (base branch: ${{ github.event.pull_request.base.ref }}). You spawn exactly two specialist subagents, merge their findings, and write one machine-read result file. You post nothing: the workflow posts the review comment from that file, and a validation script — not you — computes the final verdict.
@@ -472,7 +473,7 @@ jobs:
               List any tool calls that failed or were denied (e.g. "Write to /tmp/ blocked", "gh api denied") — across the specialists too, if they reported any. If none failed, say so. This helps us tune the workflow permissions and allowedTools over time.
               </details>
 
-            STEP 3 — HAND OFF. Post NOTHING. The workflow posts the review itself: after validation it takes `review-result.json`'s `comment_body` verbatim, adds this run's machine-read state markers above it, and posts that as a new review comment on the PR. You have no GitHub write tool and must not reach for one: do NOT use `gh pr comment` (it would post a stray second comment), do NOT submit a formal GitHub review (no `gh pr review`), and do NOT write verdict.txt or claude-verdict.txt — the verdict is computed by the validation script from review-result.json. Your outputs are exactly two things: the two specialists' findings files (written by them) and `review-result.json`. A stop hook will refuse to let the session end until review-result.json exists and parses as JSON.
+            STEP 3 — HAND OFF. Post NOTHING. The workflow posts the review itself: after validation it takes `review-result.json`'s `comment_body` verbatim, adds this run's machine-read state markers above it, and posts that as a new review comment on the PR. You have no GitHub write tool and must not reach for one: do NOT use `gh pr comment` (it would post a stray second comment), do NOT submit a formal GitHub review (no `gh pr review`), and do NOT write verdict.txt or claude-verdict.txt — the verdict is computed by the validation script from review-result.json. Your outputs are exactly two things: the two specialists' findings files (written by them) and `review-result.json`. A bounded stop hook will block repeated stop attempts while review-result.json is absent or malformed; complete the artifacts before handing off.
           # 100 matches v1's budget rationale: 80 was set after a large review
           # (#364) exhausted its turns without writing its result (which fails
           # closed); the fan-out orchestration and the correctness specialist's
@@ -486,6 +487,82 @@ jobs:
           claude_args: |
             --max-turns 100
             --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cat:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git merge-base:*),WebSearch,Read,Write,Glob,Grep,Task"
+
+      - name: Resume incomplete Claude review
+        if: steps.trust.outputs.trusted == 'true' && steps.prepare.outputs.skip != 'true'
+        # The action returns on the SDK's first result message. The Stop hook
+        # normally delays that result until review-result.json exists, but its
+        # five-block ceiling deliberately lets a persistently incomplete model
+        # terminate rather than wedging the job. If background specialists need
+        # longer than those rapid nudges, continue the SAME on-disk session in a
+        # fresh CLI process. Each resume is a full lifecycle opportunity, so two
+        # attempts bound token/process cost without turning the hook's nudge
+        # count into an accidental wall-clock timeout.
+        #
+        # Failure here remains fail-closed without stopping the deterministic
+        # bookends: this step never creates placeholder findings or a result.
+        # After bounded exhaustion, validate.py below remains the authority and
+        # rejects missing/invalid specialist and merged artifacts.
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          SESSION_ID: ${{ steps.claude-review.outputs.session_id }}
+        run: |
+          set -uo pipefail
+          result_file="$GITHUB_WORKSPACE/review-result.json"
+          counter_file="${TMPDIR:-/tmp}/claude-review-v2-block-count"
+          claude="$HOME/.local/bin/claude"
+          max_resume_attempts=2
+
+          result_is_parseable() {
+            python3 -c 'import json, sys; json.load(open(sys.argv[1], encoding="utf-8"))' \
+              "$result_file" >/dev/null 2>&1
+          }
+
+          if result_is_parseable; then
+            echo "Claude review result already parses; no resume needed."
+            exit 0
+          fi
+          if [ -z "$SESSION_ID" ]; then
+            echo "::warning::Claude review result is absent or malformed, but the action returned no session id. The validator will fail closed."
+            exit 0
+          fi
+          if [ ! -x "$claude" ]; then
+            echo "::warning::Claude review result is absent or malformed, but the installed Claude CLI is unavailable at $claude. The validator will fail closed."
+            exit 0
+          fi
+
+          corrective_prompt="$(cat <<'PROMPT'
+          The prior fan-out invocation ended before producing a parseable review-result.json. Continue this SAME review session and complete its existing contract. Work only from the checked-out repository and the review artifacts in its root; use no GitHub write commands or tools and post nothing.
+
+          Inspect the on-disk findings-correctness.json and findings-conventions.json; specialist findings content is not present in the orchestrator transcript. Do not fabricate either specialist's findings, replace missing work with empty findings, or write a partial merged result. Ensure both specialists actually complete: wait for any still-running specialist, and if a specialist is no longer running and its findings file is missing, malformed, or incomplete, relaunch only that missing specialist with its original role and instructions from this session's history and wait for it. Only after both valid findings files exist, read them, merge every finding with complete dispositions, and write review-result.json per .github/workflows/claude-review-v2/schemas/review-result.schema.json. The workflow's validator remains authoritative. Do not write a verdict file.
+          PROMPT
+          )"
+
+          attempt=1
+          while [ "$attempt" -le "$max_resume_attempts" ]; do
+            # The Stop hook counter lives outside session state. A counter left
+            # at its ceiling would silently disable every nudge in this process.
+            # If it cannot be reset, do not spend a resume that has no backstop.
+            if ! rm -f "$counter_file"; then
+              echo "::warning::Could not reset the Claude review Stop-hook counter before resume attempt $attempt. The validator will fail closed."
+              break
+            fi
+            echo "Resuming incomplete Claude review session (attempt $attempt/$max_resume_attempts)."
+            if "$claude" -p --resume "$SESSION_ID" "$corrective_prompt" \
+                 --max-turns 100 \
+                 --allowedTools "Bash(cat:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git merge-base:*),WebSearch,Read,Write,Glob,Grep,Task"; then
+              echo "Claude review resume attempt $attempt exited normally."
+            else
+              echo "::warning::Claude review resume attempt $attempt exited non-zero; checking artifacts before continuing."
+            fi
+            if result_is_parseable; then
+              echo "Claude review produced a parseable result after resume attempt $attempt."
+              exit 0
+            fi
+            attempt=$((attempt + 1))
+          done
+
+          echo "::warning::Claude review resume attempts exhausted without a parseable review-result.json; the validator will fail closed without fabricated output."
 
       - name: Re-restore the review pipeline from the base branch
         if: steps.trust.outputs.trusted == 'true' && steps.prepare.outputs.skip != 'true'

--- a/.github/workflows/claude-review-v2/hooks/stop-hook.sh
+++ b/.github/workflows/claude-review-v2/hooks/stop-hook.sh
@@ -2,8 +2,9 @@
 # Stop hook for the claude-review-v2 session.
 # Part of the PR review v2 pipeline (docs/specs/2026-08-03-pr-review-fanout-design.md §3.5).
 #
-# Refuses to let the review session end until review-result.json exists in the
-# workspace root and parses as JSON. Unlike the v1 hook (claude-review-hooks/
+# Blocks a bounded number of stop attempts while review-result.json is absent
+# from the workspace root or does not parse as JSON. Unlike the v1 hook
+# (claude-review-hooks/
 # verdict-gate.sh), this hook does NOT gate on a verdict token — the model never
 # types the verdict in v2. The validate script computes APPROVE/REJECT from the
 # result file's findings, schema-validates it, and fails closed if the file is
@@ -48,7 +49,7 @@ if [ "$count" -ge "$max_blocks" ]; then
 fi
 printf '%s' "$((count + 1))" > "$count_file" 2>/dev/null || exit 0
 
-reason="You have not written the merged review result. Use the Write tool to create 'review-result.json' in the repository root (${CLAUDE_PROJECT_DIR:-the current working directory}). It must be valid JSON matching .github/workflows/claude-review-v2/schemas/review-result.schema.json: an object with 'findings' (the merged findings array), 'disposition' (one entry per specialist finding ID accounting for what happened to it: kept/merged/downgraded/dropped, with a note when downgraded or dropped), and 'comment_body' (the review comment markdown the workflow posts). Do NOT write a verdict anywhere — the verdict is computed by a script from the findings' severities. The session cannot end until this file exists and parses as JSON."
+reason="You have not written the merged review result. Use the Write tool to create 'review-result.json' in the repository root (${CLAUDE_PROJECT_DIR:-the current working directory}). It must be valid JSON matching .github/workflows/claude-review-v2/schemas/review-result.schema.json: an object with 'findings' (the merged findings array), 'disposition' (one entry per specialist finding ID accounting for what happened to it: kept/merged/downgraded/dropped, with a note when downgraded or dropped), and 'comment_body' (the review comment markdown the workflow posts). Do NOT write a verdict anywhere — the verdict is computed by a script from the findings' severities. Complete this file before stopping."
 
 jq -n --arg reason "$reason" '{decision: "block", reason: $reason}' 2>/dev/null \
   || printf '{"decision":"block","reason":"Write review-result.json (valid JSON per schemas/review-result.schema.json) in the repository root before stopping."}\n'

--- a/.github/workflows/claude-review-v2/tests/test_resume_step.py
+++ b/.github/workflows/claude-review-v2/tests/test_resume_step.py
@@ -1,0 +1,178 @@
+"""Behavior tests for the workflow's same-session recovery shell.
+
+The Claude action can return while background review specialists are still
+running.  These tests execute the workflow step's real ``run:`` block with a
+stub ``$HOME/.local/bin/claude`` and assert the lifecycle contract at the
+process boundary: complete results skip recovery, incomplete results resume
+the original session, and bounded exhaustion leaves the validator to fail
+closed without manufacturing output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from workflow_steps import read_workflow, run_block
+
+RESUME_STEP = "Resume incomplete Claude review"
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SESSION_ID = "session-acme-4242"
+COUNTER_NAME = "claude-review-v2-block-count"
+
+STUB_CLAUDE = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+log_path = Path(os.environ["CLAUDE_CALL_LOG"])
+calls = [
+    json.loads(line)
+    for line in log_path.read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+counter = Path(os.environ["TMPDIR"]) / "claude-review-v2-block-count"
+entry = {
+    "argv": sys.argv[1:],
+    "counter_was_reset": not counter.exists(),
+}
+with log_path.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(entry) + "\n")
+
+# Simulate a resume consuming its full Stop-hook allowance. The next workflow
+# attempt proves it resets this process-external state by removing the file.
+counter.write_text("5", encoding="utf-8")
+
+result_after = os.environ.get("CLAUDE_STUB_RESULT_AFTER")
+if result_after and len(calls) + 1 >= int(result_after):
+    result = {
+        "findings": [],
+        "disposition": [],
+        "comment_body": "The resumed review completed.",
+    }
+    workspace = Path(os.environ["GITHUB_WORKSPACE"])
+    (workspace / "review-result.json").write_text(
+        json.dumps(result), encoding="utf-8"
+    )
+
+raise SystemExit(int(os.environ.get("CLAUDE_STUB_EXIT", "0")))
+'''
+
+
+@dataclass
+class ResumeRun:
+    returncode: int
+    stdout: str
+    stderr: str
+    calls: list[dict]
+    workspace: Path
+    counter: Path
+
+
+def _result() -> dict:
+    return {
+        "findings": [],
+        "disposition": [],
+        "comment_body": "The initial review completed.",
+    }
+
+
+def _run_resume_step(
+    sandbox: Path,
+    *,
+    result: dict | None = None,
+    result_after: int | None = None,
+) -> ResumeRun:
+    workspace = sandbox / "workspace"
+    workspace.mkdir(parents=True)
+    tmpdir = sandbox / "tmp"
+    tmpdir.mkdir()
+    counter = tmpdir / COUNTER_NAME
+    counter.write_text("5", encoding="utf-8")
+
+    if result is not None:
+        (workspace / "review-result.json").write_text(
+            json.dumps(result), encoding="utf-8"
+        )
+
+    claude = sandbox / ".local" / "bin" / "claude"
+    claude.parent.mkdir(parents=True)
+    claude.write_text(STUB_CLAUDE, encoding="utf-8")
+    claude.chmod(0o755)
+    call_log = sandbox / "claude-calls.jsonl"
+    call_log.touch()
+
+    script = sandbox / "resume-step.sh"
+    script.write_text(run_block(read_workflow(), RESUME_STEP), encoding="utf-8")
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": str(sandbox),
+        "TMPDIR": str(tmpdir),
+        "GITHUB_WORKSPACE": str(workspace),
+        "SESSION_ID": SESSION_ID,
+        "CLAUDE_CODE_OAUTH_TOKEN": "stub-token",
+        "CLAUDE_CALL_LOG": str(call_log),
+    }
+    if result_after is not None:
+        env["CLAUDE_STUB_RESULT_AFTER"] = str(result_after)
+
+    completed = subprocess.run(
+        ["bash", "-e", str(script)],
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    calls = [
+        json.loads(line)
+        for line in call_log.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    return ResumeRun(
+        completed.returncode,
+        completed.stdout,
+        completed.stderr,
+        calls,
+        workspace,
+        counter,
+    )
+
+
+def test_a_parseable_result_skips_resume(tmp_path: Path) -> None:
+    run = _run_resume_step(tmp_path, result=_result())
+    assert run.returncode == 0
+    assert run.calls == []
+    assert run.counter.read_text(encoding="utf-8") == "5"
+
+
+def test_a_missing_result_resumes_the_same_session_from_on_disk_findings(
+    tmp_path: Path,
+) -> None:
+    run = _run_resume_step(tmp_path, result_after=1)
+    assert run.returncode == 0
+    assert len(run.calls) == 1
+    call = run.calls[0]
+    assert call["counter_was_reset"] is True
+    assert "--resume" in call["argv"]
+    assert call["argv"][call["argv"].index("--resume") + 1] == SESSION_ID
+    prompt = "\n".join(call["argv"])
+    assert "findings-correctness.json" in prompt
+    assert "findings-conventions.json" in prompt
+    assert "Do not fabricate" in prompt
+    assert "both specialists" in prompt
+    assert (run.workspace / "review-result.json").is_file()
+
+
+def test_resume_exhaustion_leaves_the_validator_to_fail_closed(
+    tmp_path: Path,
+) -> None:
+    run = _run_resume_step(tmp_path)
+    assert run.returncode == 0
+    assert len(run.calls) == 2
+    assert all(call["counter_was_reset"] is True for call in run.calls)
+    assert not (run.workspace / "review-result.json").exists()
+    assert "validator will fail closed" in run.stdout

--- a/.github/workflows/claude-review-v2/tests/test_workflow_structure.py
+++ b/.github/workflows/claude-review-v2/tests/test_workflow_structure.py
@@ -32,6 +32,7 @@ from workflow_steps import (
 RESTORE_STEP = "Restore the review pipeline from the base branch"
 RE_RESTORE_STEP = "Re-restore the review pipeline from the base branch"
 SESSION_STEP = "Run Claude Code Review v2 (fan-out session)"
+RESUME_STEP = "Resume incomplete Claude review"
 VALIDATE_STEP = "Validate review result (schemas, disposition coverage, verdict)"
 POST_STEP = "Post review comment and enforce verdict"
 PREPARE_STEP = "Prepare (skip decision + discussion context)"
@@ -55,6 +56,7 @@ def test_the_pipeline_is_re_restored_between_the_session_and_the_verdict() -> No
         step_index(text, RESTORE_STEP)
         < step_index(text, PREPARE_STEP)
         < step_index(text, SESSION_STEP)
+        < step_index(text, RESUME_STEP)
         < step_index(text, RE_RESTORE_STEP)
         < step_index(text, VALIDATE_STEP)
         < step_index(text, POST_STEP)
@@ -85,6 +87,17 @@ def test_the_re_restore_is_gated_exactly_like_the_step_it_protects() -> None:
     # session-written copy.
     assert _condition(RE_RESTORE_STEP) == _condition(VALIDATE_STEP)
     assert "always()" not in _condition(RE_RESTORE_STEP)
+
+
+def test_recovery_is_gated_exactly_like_the_full_review() -> None:
+    assert _condition(RESUME_STEP) == _condition(SESSION_STEP)
+    assert _condition(RESUME_STEP) == _condition(RE_RESTORE_STEP)
+    assert "always()" not in _condition(RESUME_STEP)
+
+
+def test_recovery_resumes_the_action_session() -> None:
+    source = step_source(read_workflow(), RESUME_STEP)
+    assert "SESSION_ID: ${{ steps.claude-review.outputs.session_id }}" in source
 
 
 def test_the_re_restore_touches_only_the_pipeline_directory() -> None:

--- a/docs/pr-review-gate.md
+++ b/docs/pr-review-gate.md
@@ -51,18 +51,24 @@ why, and for what reviving it actually takes.
 4. **Review.** One model session orchestrates two specialist subagents
    (`correctness`, `conventions`). Each specialist writes a schema-validated
    `findings-<name>.json`; the orchestrator merges them into `review-result.json`
-   with a per-finding disposition list and the review comment's prose. The session
-   holds **no GitHub write tool** — it posts nothing.
+   with a per-finding disposition list and the review comment's prose. If the action
+   returns before that result parses, the workflow makes at most two process-level
+   resumes of the same on-disk session. Before each resume it resets the Stop hook's
+   bounded nudge counter; the corrective prompt requires both specialists' real
+   on-disk findings and forbids placeholder output. The session holds **no GitHub
+   write tool** — it posts nothing.
 5. **Verdict.** `validate.py`, not the model, computes the verdict: it
    schema-validates the findings and the merged result, checks the disposition list
    accounts for every specialist finding id, and writes `REJECT` to `verdict.txt`
    iff any HIGH or MEDIUM finding survives the merge, otherwise `APPROVE`. A `Stop`
    hook
    ([`claude-review-v2/hooks/stop-hook.sh`](../.github/workflows/claude-review-v2/hooks/stop-hook.sh))
-   refuses to end the session until `review-result.json` exists and parses. The job
-   then enforces the verdict with an exact string match: `APPROVE` passes, `REJECT`
-   blocks the merge, and anything else (missing / malformed / killed session) fails
-   closed.
+   blocks up to five stop attempts while `review-result.json` is absent or malformed.
+   That ceiling prevents a non-compliant session from wedging the job; it is not a
+   specialist-completion timeout. The bounded same-session resume step handles
+   incomplete action exits, then the job enforces the verdict with an exact string
+   match: `APPROVE` passes, `REJECT` blocks the merge, and anything else (missing /
+   malformed / killed session) fails closed.
 
 Every file the pipeline reads back out of the workspace — `review-result.json`,
 `verdict.txt`, `skip-decision.json`, `discussion-context.txt`, `findings-*.json` —

--- a/docs/specs/2026-08-03-pr-review-fanout-design.md
+++ b/docs/specs/2026-08-03-pr-review-fanout-design.md
@@ -52,14 +52,25 @@ A single-session reviewer — one model session that types its own verdict into
 ### 3.1 Pipeline shape: deterministic bookends around one model session
 
 ```
-prepare (script)  →  review session (model, fan-out)  →  validate (script)  →  post + enforce (script)
+prepare (script) → review session (model, fan-out) → bounded same-session recovery if incomplete → validate (script) → post + enforce (script)
 ```
 
-Everything before and after the model session is plain Python: argument in, files out,
-no network beyond one `gh` boundary, unit-testable with hand-built fixtures. The model
-session's only contract is "write these files"; scripts own every machine-read decision.
-This is the inverse of a single-session gate, where the session both writes the review
-*and* types the verdict token.
+The deterministic prepare, validate, and render bookends are plain Python: argument in,
+files out, no network beyond one `gh` boundary, unit-testable with hand-built fixtures.
+The model session's only contract is "write these files"; scripts own every machine-read
+decision. This is the inverse of a single-session gate, where the session both writes the
+review *and* types the verdict token.
+
+The action's process can return while background specialists still need time: its SDK
+wrapper treats the first result message as terminal, while the Stop hook deliberately
+stops blocking after five nudges so a non-compliant model cannot wedge the job. A
+parseable `review-result.json` skips recovery. Otherwise the workflow makes at most two
+`claude -p --resume <session_id>` invocations against the same on-disk session, resetting
+the hook's external nudge-counter file before each invocation. The corrective prompt
+points at `findings-correctness.json` and `findings-conventions.json` on disk — specialist
+content does not enter the orchestrator transcript — and requires missing work to finish
+or be relaunched before the merged result is written. Recovery creates no placeholder
+artifact; exhaustion falls through to the unchanged validator and fails closed.
 
 The session holds **no GitHub write tool at all** — it does not post its own review. It
 writes `review-result.json`; the post step renders that file's `comment_body` into the
@@ -152,8 +163,10 @@ validate script checks only its *presence* (an ID-coverage count), not its judgm
 - **Verdict**: the validate script computes `APPROVE`/`REJECT` from
   `review-result.json` — REJECT iff any unaddressed `HIGH` or `MEDIUM` finding survives
   the merge. The model never types the verdict. The Stop hook gates on the *artifact*
-  rather than on a token: it refuses to end the session until `review-result.json`
-  exists and parses. The enforce step is fail-closed — a missing file is a red check.
+  rather than on a token: it blocks up to five stop attempts while
+  `review-result.json` is absent or malformed, after which the bounded same-session
+  recovery described in §3.1 gets another full lifecycle opportunity. The enforce step
+  is fail-closed — a missing file is a red check.
   The validate script also enforces specialist-set completeness
   (`--expected-specialists`): if any named
   specialist contributed no *valid* findings file it fails closed with no verdict
@@ -312,6 +325,10 @@ reviews code that is not in the PR.
   it — run against the real `jq` selector, since a stubbed selector would test the stub.
   Step *position* (the re-restore sits between the session and the verdict) is a
   structural assertion over the same by-name lookup.
+  The recovery step is exercised the same way with a stub CLI: a parseable result skips
+  resume, a missing result resumes the action's session id with a reset hook counter and
+  on-disk corrective prompt, and exhausted attempts leave no fabricated result for the
+  downstream validator.
 - **Where tests run**: scripts are Python 3 stdlib (the workflow already runs on
   `ubuntu-latest`, where the Swift toolchain is absent); a small CI job runs pytest
   over the workflow's script directory. The stub-API e2e test runs where a `claude`
@@ -418,18 +435,8 @@ and the whole test suite.
 - **Discussion fingerprint** (new comments defeat the patch-id skip): add it the first
   time an author's clarifying comment goes unreviewed because the skip suppressed a
   round.
-- **Resume-based retry loop** (the first upgrade rung if reviews die incomplete): a
-  bounded workflow loop of run → check `review-result.json` → `claude -p --resume
-  <session_id>` with a corrective prompt. Verified against the real CLI: session state
-  persists under `CLAUDE_CONFIG_DIR` and resumed requests carry the full prior history;
-  the process does not exit while background specialists are pending, so their findings
-  files land before the post-exit check runs. Two mechanics are mandatory: reset the
-  Stop hook's nudge-counter file between invocations (a stale counter at the ceiling
-  silently disarms the hook — measured), and the corrective prompt must point at the
-  on-disk `findings-*.json`, whose content never enters the orchestrator's own
-  transcript. Add it the first time a review dies incomplete on a real PR.
 - **Interactive PTY driver** (mid-flight nudges, deadline steering): the last-resort
-  rung, only if the resume loop above proves insufficient — e.g. sessions wedging
+  rung, only if the resume loop in §3.1 proves insufficient — e.g. sessions wedging
   rather than ending, which a between-invocation loop cannot reach.
 - **Inline review comments**: findings state their file path and line numbers inside
   the one review comment rather than being anchored to diff lines.


### PR DESCRIPTION
## Summary

- resume the same Claude review session when the action exits before `review-result.json` is parseable
- reset the bounded Stop-hook counter before each process-level resume and require real on-disk specialist findings
- preserve fail-closed specialist completeness, verdict validation, and the base-branch security re-restore
- add deterministic workflow-shell regression coverage and update the gate documentation

## Root cause

The Claude action stops consuming its SDK stream at the first result message. After the Stop hook exhausted its five rapid blocks, the action could return success while background review specialists were still running, leaving neither specialist findings nor a merged result for the validator.

This uses the design's existing recovery rung instead of increasing the hook retry count: at most two same-session CLI resumes, with bounded exhaustion falling through to the unchanged fail-closed validator. No placeholder findings or result are created.

## Verification

- `python3 -m pytest .github/workflows/claude-review-v2/tests/ -q` — 223 passed, 3 skipped
- `swiftlint --strict` — 0 violations
- `scripts/swift-safe build` — passed
- `bash -n .github/workflows/claude-review-v2/hooks/stop-hook.sh` — passed
- `git diff --check origin/main...HEAD` — passed
- independent spec and production-quality reviews — passed

The three skipped tests are the existing real-Claude stub-API scenarios; no `claude` binary is installed locally.

## Merge-gate note

Because this workflow runs on `pull_request_target`, this PR is reviewed by the unfixed workflow from the base branch. If that existing gate hits the same lifecycle defect, the documented admin-merge recovery path is required; the repair can exercise itself only after it lands on `main`.
