### PR TITLE
Fix: TBDApp leaked a zombie process on every terminal teardown (67 and climbing from one launch)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,15 @@ let package = Package(
         // property (PR #531) hasn't shipped in a tagged release yet. Switch back
         // to `from: "1.14.0"` (or whichever) once SwiftTerm cuts a release that
         // includes commit dae32cc.
+        //
+        // Re-verify `Sources/TBDApp/Terminal/ChildReaper.swift` on any bump:
+        // it exists because at this revision `LocalProcess` calls `waitpid`
+        // only from its `DispatchSourceProcess` (`.exit`) handler, and both
+        // `deinit` and `terminate()` cancel that source before the child
+        // actually exits — so TBD must reap the PTY child itself. If a later
+        // revision reaps its own children, `ChildReaper` becomes a competing
+        // waiter on a pid the OS may have recycled, which is worse than the
+        // leak it fixes. Its doc comment names the exact lines to re-read.
         .package(url: "https://github.com/migueldeicaza/SwiftTerm", revision: "dae32cc8f9bcda15713f4091bb2ea7e11f6dd57c"),
         .package(url: "https://github.com/raspu/Highlightr", from: "2.2.1"),
         .package(url: "https://github.com/siteline/swiftui-introspect", from: "1.0.0"),

--- a/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
+++ b/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
@@ -89,9 +89,11 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
         /// Recorded when `LocalProcess`'s own exit monitor fires — by then it
         /// has already called `waitpid`, so `cleanup()` must NOT reap this pid
         /// (it is free, and could have been recycled for another child of this
-        /// process). Both sides run on the main queue with the pinned SwiftTerm
-        /// revision; see `ChildExitObservation` for why it is lock-guarded
-        /// anyway and for the reaper thread that also reads it.
+        /// process). Both sides run on the main queue in practice, but unlike
+        /// the panel coordinator's `@MainActor cleanup()` that rests on
+        /// `dismantleNSView` convention rather than on isolation — see
+        /// `ChildExitObservation`, which spells out the difference and why the
+        /// flag is lock-guarded regardless.
         private let childExitObservation = ChildExitObservation()
 
         @MainActor

--- a/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
+++ b/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
@@ -125,8 +125,9 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
 
         /// `@MainActor` like the panel coordinator's sibling: SwiftUI already
         /// calls `dismantleNSView` on the main thread, and annotating it turns
-        /// that convention into a compiler-enforced guarantee. `ChildReaper`'s
-        /// ordering fix depends on this teardown running on the main queue.
+        /// that convention into a compiler-enforced guarantee — which is what
+        /// lets `ChildExitObservation` describe its writer and reader sides as
+        /// serialized rather than merely conventional.
         @MainActor
         func cleanup() {
             // Idempotent: a second call must not re-run the teardown (it would

--- a/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
+++ b/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
@@ -79,9 +79,20 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
     final class Coordinator: NSObject, TerminalViewDelegate, LocalProcessDelegate, @unchecked Sendable {
         weak var terminalView: TerminalView?
         var onExit: ((Int32?) -> Void)?
-        private var localProcess: LocalProcess?
+        /// Internal rather than private so `TerminalTeardownReapTests` can hand
+        /// this coordinator a real `LocalProcess` and drive `cleanup()`
+        /// headlessly — the reap wiring is otherwise unreachable from a test,
+        /// since `start()` needs a live `TerminalView`.
+        var localProcess: LocalProcess?
         private var started = false
         private var tornDown = false
+        /// Recorded when `LocalProcess`'s own exit monitor fires — by then it
+        /// has already called `waitpid`, so `cleanup()` must NOT reap this pid
+        /// (it is free, and could have been recycled for another child of this
+        /// process). Both sides run on the main queue with the pinned SwiftTerm
+        /// revision; see `ChildExitObservation` for why it is lock-guarded
+        /// anyway and for the reaper thread that also reads it.
+        private let childExitObservation = ChildExitObservation()
 
         @MainActor
         func start(terminalView: TerminalView, argv: [String], environment: [String: String]) {
@@ -112,7 +123,13 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
         }
 
         func cleanup() {
+            // Idempotent: a second call must not re-run the teardown (it would
+            // reap a pid whose `LocalProcess` this method already released).
+            guard !tornDown else { return }
             tornDown = true
+            // Capture the pid BEFORE releasing our reference — `LocalProcess`
+            // is the only thing that knows it.
+            let pid = localProcess?.shellPid ?? 0
             // Explicit terminate() — SwiftTerm's LocalProcess.deinit says
             // outright that it does NOT send SIGTERM (see its doc comment):
             // "we intentionally don't send SIGTERM here; terminate() remains
@@ -128,11 +145,24 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
             // unaffected (docs/remote-provider-contract.md § attach).
             localProcess?.terminate()
             localProcess = nil
+            // terminate() cancels `LocalProcess`'s exit monitor (via
+            // childStopped()) before the SIGTERM it just sent can land, so
+            // nothing left will `waitpid` this child — that cancellation is
+            // also what makes `ChildReaper` its sole waiter. Without the reap
+            // it stays `<defunct>` under TBDApp forever.
+            ChildReaper.reap(pid: pid, unless: childExitObservation)
         }
 
         // MARK: - LocalProcessDelegate
 
         func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
+            // `LocalProcess.processTerminated()` calls `waitpid` before it
+            // calls us, so this child is already reaped and its pid is free to
+            // be recycled — a later `cleanup()` must not wait on it, and the
+            // `terminate()` below must not be read as re-killing it. Recorded
+            // before the `async` so the flag is set as early as this callback
+            // can set it.
+            childExitObservation.record()
             DispatchQueue.main.async { [weak self] in
                 guard let self, !self.tornDown else { return }
                 // The child already exited, but `LocalProcess` doesn't close

--- a/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
+++ b/Sources/TBDApp/Remote/LocalPTYTerminalView.swift
@@ -89,11 +89,10 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
         /// Recorded when `LocalProcess`'s own exit monitor fires — by then it
         /// has already called `waitpid`, so `cleanup()` must NOT reap this pid
         /// (it is free, and could have been recycled for another child of this
-        /// process). Both sides run on the main queue in practice, but unlike
-        /// the panel coordinator's `@MainActor cleanup()` that rests on
-        /// `dismantleNSView` convention rather than on isolation — see
-        /// `ChildExitObservation`, which spells out the difference and why the
-        /// flag is lock-guarded regardless.
+        /// process). Both sides are main-isolated — the callback by
+        /// `LocalProcess`'s default `dispatchQueue`, `cleanup()` by its
+        /// `@MainActor` below — so see `ChildExitObservation` for why the flag
+        /// is lock-guarded regardless.
         private let childExitObservation = ChildExitObservation()
 
         @MainActor
@@ -124,6 +123,11 @@ struct LocalPTYTerminalRepresentable: NSViewRepresentable {
             }
         }
 
+        /// `@MainActor` like the panel coordinator's sibling: SwiftUI already
+        /// calls `dismantleNSView` on the main thread, and annotating it turns
+        /// that convention into a compiler-enforced guarantee. `ChildReaper`'s
+        /// ordering fix depends on this teardown running on the main queue.
+        @MainActor
         func cleanup() {
             // Idempotent: a second call must not re-run the teardown (it would
             // reap a pid whose `LocalProcess` this method already released).

--- a/Sources/TBDApp/Terminal/ChildReaper.swift
+++ b/Sources/TBDApp/Terminal/ChildReaper.swift
@@ -11,22 +11,19 @@ private let reaperLogger = Logger(subsystem: "com.tbd.app", category: "childReap
 /// `LocalProcessDelegate.processTerminated` callback; `wasObserved` gates the
 /// teardown reap, both on the main queue and again on the reaper thread.
 ///
-/// Serialization note, stated precisely because the two call sites differ.
-/// The *writer* side is the same for both: `LocalProcess.init` defaults its
+/// Serialization note. The *writer* side: `LocalProcess.init` defaults its
 /// `dispatchQueue` to `DispatchQueue.main`, neither TBD call site passes one,
 /// and the `DispatchSourceProcess` is created with `queue: dispatchQueue`, so
 /// the monitor handler and the delegate callback that calls `record()` run on
-/// the main queue. The *reader* side is where the guarantee weakens:
-/// `TerminalPanelRepresentable.Coordinator.cleanup()` is `@MainActor`, so the
-/// compiler enforces it; `LocalPTYTerminalRepresentable.Coordinator.cleanup()`
-/// carries no isolation annotation, and its main-thread execution rests only
-/// on its sole caller being SwiftUI's `dismantleNSView` — a convention, not a
-/// type-system guarantee.
+/// the main queue. The *reader* side: both `cleanup()` implementations and
+/// `ChildReaper.reap` are `@MainActor`, so the compiler enforces it — this is
+/// a guarantee, not the `dismantleNSView` convention it used to rest on.
 ///
-/// So the lock is not decorative. It is real protection if that convention is
-/// ever violated (a coordinator torn down off the main thread), and it is
-/// load-bearing regardless of any of the above, because `ChildReaper.reap`
-/// re-reads this flag from its own background queue.
+/// The lock is still not decorative, on two independent grounds. It is what
+/// makes the flag safe to read from `ChildReaper`'s own background queue, which
+/// happens on every reap. And a future call site that passed an explicit
+/// `dispatchQueue:` would move the writer off main, where nothing above would
+/// protect it.
 final class ChildExitObservation: Sendable {
     private let observed = OSAllocatedUnfairLock<Bool>(initialState: false)
 
@@ -60,14 +57,32 @@ final class ChildExitObservation: Sendable {
 /// already exited is not guaranteed to deliver `NOTE_EXIT`, which is precisely
 /// the failure being fixed.
 ///
-/// **Sole-waiter invariant.** Never reap a pid that something else may also be
-/// waiting on: whoever wins frees the pid, and the OS may recycle it for
-/// another child of this process, so the loser's `waitpid` can steal an
-/// unrelated child's exit status. Two things establish it at the call sites.
-/// Each releases its `LocalProcess` inside `cleanup()`, so `deinit` runs there
-/// and cancels `childMonitor` at a known moment rather than whenever ARC gets
-/// round to it. And `ChildExitObservation` covers the case where the monitor
-/// had *already* fired, since that path has reaped the child itself.
+/// **Sole-waiter discipline — what is guaranteed, and what is not.** Never
+/// commit a `waitpid` for a pid another waiter may also claim: whoever wins
+/// frees the pid, the OS may recycle it for a newly forked child, and the loser
+/// can then steal that unrelated child's exit status. Three things narrow that
+/// to a residual, and the residual is real.
+///
+/// - Each call site releases its `LocalProcess` inside `cleanup()`, so `deinit`
+///   cancels `childMonitor` at a known moment rather than whenever ARC gets
+///   round to it. No exit handler is scheduled after that.
+/// - `reap` hops once through the main queue before committing. Cancelling a
+///   dispatch source does **not** retroactively un-enqueue a handler invocation
+///   that is already queued, so a child exiting concurrently with teardown can
+///   leave one behind — the case this hop exists for. That handler and this hop
+///   are both main-queue blocks and the main queue is FIFO, so a handler
+///   enqueued before the hop runs first. It records its claim synchronously
+///   (SwiftTerm does its own `waitpid`, then calls the delegate, all inside that
+///   one block), so the re-check after the hop sees the claim and skips.
+/// - `ChildExitObservation` is what carries that claim to the re-checks.
+///
+/// The residual, stated rather than glossed: this rests on libdispatch not
+/// invoking a cancelled source's handler for an event that was pending but not
+/// yet enqueued when `cancel()` ran, and the public contract promises nothing
+/// either way. Were that to happen, both waiters would commit; the loser gets
+/// `ECHILD`, which is harmless *unless* the pid had already been recycled into
+/// a new child of this process inside that window. So this is a narrow race
+/// made narrower, not an impossibility — do not restate it as an absolute.
 ///
 /// **Known limitation, deliberately not handled here:** a child that ignores
 /// `SIGHUP` (and `SIGTERM`, on the path that sends one) never exits, so its
@@ -93,15 +108,29 @@ enum ChildReaper {
 
     /// Reap `pid` in the background unless `observation` says SwiftTerm's own
     /// monitor already did. Fire-and-forget; returns immediately.
+    ///
+    /// `@MainActor` because the ordering argument above depends on it: the hop
+    /// below only orders us behind an already-enqueued exit handler if it is
+    /// enqueued from the main queue too. Both `cleanup()` implementations are
+    /// main-isolated, so this costs no call site anything and makes the
+    /// precondition compiler-enforced rather than assumed.
+    @MainActor
     static func reap(pid: pid_t, unless observation: ChildExitObservation) {
+        // Cheap early-out, and the only check a control-mode panel (pid 0)
+        // ever reaches — it keeps teardown from enqueuing a pointless block.
         guard shouldReap(pid: pid, alreadyObserved: observation.wasObserved) else { return }
-        queue.async {
-            // Re-checked here, not just at the call site: an unbounded amount
-            // of time can pass between that decision and this block running,
-            // and reaping a pid the monitor has since claimed is exactly the
-            // pid-reuse hazard the sole-waiter invariant exists to prevent.
+        DispatchQueue.main.async {
+            // The load-bearing check. A child that exited concurrently with
+            // teardown may have left an exit handler queued ahead of this
+            // block; by now it has run and recorded its claim, and cancelling
+            // the source did not un-enqueue it.
             guard shouldReap(pid: pid, alreadyObserved: observation.wasObserved) else { return }
-            reapBlocking(pid: pid)
+            queue.async {
+                // Belt and braces: an unbounded amount of time can pass before
+                // this block runs, and the check costs one lock acquisition.
+                guard shouldReap(pid: pid, alreadyObserved: observation.wasObserved) else { return }
+                reapBlocking(pid: pid)
+            }
         }
     }
 

--- a/Sources/TBDApp/Terminal/ChildReaper.swift
+++ b/Sources/TBDApp/Terminal/ChildReaper.swift
@@ -1,0 +1,128 @@
+import Darwin
+import Foundation
+import os
+
+private let reaperLogger = Logger(subsystem: "com.tbd.app", category: "childReaper")
+
+/// Records whether SwiftTerm's own exit monitor already observed a child's exit
+/// — and therefore already called `waitpid` on it.
+///
+/// One instance per terminal coordinator. `record()` is called from the
+/// `LocalProcessDelegate.processTerminated` callback; `wasObserved` gates the
+/// teardown reap, both on the main queue and again on the reaper thread.
+///
+/// Serialization note: with the pinned SwiftTerm revision this flag is only
+/// ever touched from the main queue. `LocalProcess.init` defaults its
+/// `dispatchQueue` to `DispatchQueue.main`, neither TBD call site passes one,
+/// and the `DispatchSourceProcess` is created with `queue: dispatchQueue` — so
+/// the monitor handler, the delegate callback and `@MainActor cleanup()` are
+/// all serialized on main. The lock is kept anyway as cheap defence: a future
+/// call site that passes an explicit `dispatchQueue:` would move the delegate
+/// callback off main, and the reaper thread reads this flag regardless.
+final class ChildExitObservation: Sendable {
+    private let observed = OSAllocatedUnfairLock<Bool>(initialState: false)
+
+    var wasObserved: Bool { observed.withLock { $0 } }
+
+    func record() { observed.withLock { $0 = true } }
+}
+
+/// Reaps forked PTY children that nothing else will `waitpid` for.
+///
+/// SwiftTerm's `LocalProcess` calls `waitpid` from exactly one place: the
+/// `DispatchSourceProcess` (`.exit`) handler installed by
+/// `startProcessWithForkpty`. Both of its teardown paths cancel that source
+/// *before* the child has actually exited —
+///
+/// - `deinit` cancels the monitor, then closes the master fd; the child only
+///   notices the resulting `SIGHUP` afterwards.
+/// - `terminate()` closes the fd, sends `SIGTERM`, then cancels the monitor via
+///   `childStopped()`; signal delivery and process teardown are asynchronous.
+///
+/// — so on both paths the `.exit` event never fires, `waitpid` is never called,
+/// and the child stays a zombie under TBDApp for the life of the app. Observed
+/// in the field as 67 permanently-`<defunct>` `tmux … attach` children.
+///
+/// The fix is to guarantee the `waitpid` ourselves at teardown, without
+/// changing *how* the child is asked to die. A blocking `waitpid` is the
+/// deterministic instrument for that: it reaps whether the child is still
+/// running (it blocks until exit), already a zombie (returns immediately), or
+/// already reaped (`ECHILD`, immediately). Registering a second
+/// `DispatchSourceProcess` would not be — arming one against a pid that has
+/// already exited is not guaranteed to deliver `NOTE_EXIT`, which is precisely
+/// the failure being fixed.
+///
+/// **Sole-waiter invariant.** Never reap a pid that something else may also be
+/// waiting on: whoever wins frees the pid, and the OS may recycle it for
+/// another child of this process, so the loser's `waitpid` can steal an
+/// unrelated child's exit status. Two things establish it at the call sites.
+/// Each releases its `LocalProcess` inside `cleanup()`, so `deinit` runs there
+/// and cancels `childMonitor` at a known moment rather than whenever ARC gets
+/// round to it. And `ChildExitObservation` covers the case where the monitor
+/// had *already* fired, since that path has reaped the child itself.
+///
+/// **Known limitation, deliberately not handled here:** a child that ignores
+/// `SIGHUP` (and `SIGTERM`, on the path that sends one) never exits, so its
+/// reaper thread parks forever. Bounding that wait and escalating to `SIGKILL`
+/// is a separate change — it needs an injected clock per `CLAUDE.md` and it
+/// changes how the child is asked to die, which this fix deliberately does not.
+enum ChildReaper {
+    /// Concurrent on purpose: each reap parks a thread until its child exits,
+    /// and a child that ignores `SIGHUP` would block every later reap behind it
+    /// on a serial queue. Utility QoS — nothing waits on the result.
+    private static let queue = DispatchQueue(
+        label: "com.tbd.app.child-reaper", qos: .utility, attributes: .concurrent)
+
+    /// The teardown decision, pure so both branches are directly testable.
+    ///
+    /// `pid <= 0` is rejected because those are not pids to `waitpid`: `0`
+    /// means the caller's whole process group and `-1` means any child, either
+    /// of which would park on, and reap, unrelated processes. A control-mode
+    /// panel has no `LocalProcess` at all and yields `0` here.
+    static func shouldReap(pid: pid_t, alreadyObserved: Bool) -> Bool {
+        pid > 0 && !alreadyObserved
+    }
+
+    /// Reap `pid` in the background unless `observation` says SwiftTerm's own
+    /// monitor already did. Fire-and-forget; returns immediately.
+    static func reap(pid: pid_t, unless observation: ChildExitObservation) {
+        guard shouldReap(pid: pid, alreadyObserved: observation.wasObserved) else { return }
+        queue.async {
+            // Re-checked here, not just at the call site: an unbounded amount
+            // of time can pass between that decision and this block running,
+            // and reaping a pid the monitor has since claimed is exactly the
+            // pid-reuse hazard the sole-waiter invariant exists to prevent.
+            guard shouldReap(pid: pid, alreadyObserved: observation.wasObserved) else { return }
+            reapBlocking(pid: pid)
+        }
+    }
+
+    /// Blocking `waitpid` for `pid`. Returns `waitpid`'s result: the reaped pid,
+    /// or `-1` when there was nothing to reap (`ECHILD`).
+    ///
+    /// Never call this on a thread you care about — it blocks until the child
+    /// exits. `reap(pid:unless:)` is the ordinary entry point; this is exposed
+    /// so the behavior can be tested without a scheduling handshake.
+    @discardableResult
+    static func reapBlocking(pid: pid_t) -> pid_t {
+        guard pid > 0 else { return -1 }
+        var status: Int32 = 0
+        var result: pid_t = -1
+        repeat {
+            result = waitpid(pid, &status, 0)
+        } while result == -1 && errno == EINTR
+        if result == -1 {
+            let code = errno
+            // ECHILD is the expected benign case: someone else already reaped
+            // it, or it was never our child.
+            if code != ECHILD {
+                reaperLogger.error(
+                    "waitpid(\(pid, privacy: .public)) failed: errno \(code, privacy: .public)")
+            }
+        } else {
+            reaperLogger.debug(
+                "reaped child pid \(result, privacy: .public) status \(status, privacy: .public)")
+        }
+        return result
+    }
+}

--- a/Sources/TBDApp/Terminal/ChildReaper.swift
+++ b/Sources/TBDApp/Terminal/ChildReaper.swift
@@ -15,9 +15,9 @@ private let reaperLogger = Logger(subsystem: "com.tbd.app", category: "childReap
 /// `dispatchQueue` to `DispatchQueue.main`, neither TBD call site passes one,
 /// and the `DispatchSourceProcess` is created with `queue: dispatchQueue`, so
 /// the monitor handler and the delegate callback that calls `record()` run on
-/// the main queue. The *reader* side: both `cleanup()` implementations and
-/// `ChildReaper.reap` are `@MainActor`, so the compiler enforces it — this is
-/// a guarantee, not the `dismantleNSView` convention it used to rest on.
+/// the main queue. The *reader* side: both `cleanup()` implementations are
+/// `@MainActor`, so the compiler enforces it — this is a guarantee, not the
+/// `dismantleNSView` convention it used to rest on.
 ///
 /// The lock is still not decorative, on two independent grounds. It is what
 /// makes the flag safe to read from `ChildReaper`'s own background queue, which
@@ -60,29 +60,36 @@ final class ChildExitObservation: Sendable {
 /// **Sole-waiter discipline — what is guaranteed, and what is not.** Never
 /// commit a `waitpid` for a pid another waiter may also claim: whoever wins
 /// frees the pid, the OS may recycle it for a newly forked child, and the loser
-/// can then steal that unrelated child's exit status. Three things narrow that
-/// to a residual, and the residual is real.
+/// can then steal that unrelated child's exit status. Two things narrow that to
+/// a residual, and the residual is real.
 ///
 /// - Each call site releases its `LocalProcess` inside `cleanup()`, so `deinit`
 ///   cancels `childMonitor` at a known moment rather than whenever ARC gets
 ///   round to it. No exit handler is scheduled after that.
-/// - `reap` hops once through the main queue before committing. Cancelling a
-///   dispatch source does **not** retroactively un-enqueue a handler invocation
-///   that is already queued, so a child exiting concurrently with teardown can
-///   leave one behind — the case this hop exists for. That handler and this hop
-///   are both main-queue blocks and the main queue is FIFO, so a handler
-///   enqueued before the hop runs first. It records its claim synchronously
-///   (SwiftTerm does its own `waitpid`, then calls the delegate, all inside that
-///   one block), so the re-check after the hop sees the claim and skips.
-/// - `ChildExitObservation` is what carries that claim to the re-checks.
+/// - `ChildExitObservation` carries the monitor's claim to both of `reap`'s
+///   checks, covering every case where the handler ran before teardown looked.
 ///
-/// The residual, stated rather than glossed: this rests on libdispatch not
-/// invoking a cancelled source's handler for an event that was pending but not
-/// yet enqueued when `cancel()` ran, and the public contract promises nothing
-/// either way. Were that to happen, both waiters would commit; the loser gets
-/// `ECHILD`, which is harmless *unless* the pid had already been recycled into
-/// a new child of this process inside that window. So this is a narrow race
-/// made narrower, not an impossibility — do not restate it as an absolute.
+/// **The residual, stated rather than glossed: this is not airtight.**
+/// Cancelling a dispatch source does *not* retroactively un-enqueue a handler
+/// invocation that is already queued. So a child that exits in the narrow
+/// window before `cleanup()` releases its `LocalProcess` can leave a handler
+/// queued on main that runs after we have already committed a `waitpid`, and
+/// then both of us have waited on one pid.
+///
+/// What that actually costs, so the risk is legible rather than alarming. The
+/// loser's `waitpid` returns `ECHILD` and SwiftTerm reports `exitCode` 0, so
+/// the terminal prints "[View detached — session is still running]" instead of
+/// naming the real exit code: one wrong message, no lost state. The serious
+/// outcome — reaping an unrelated child — additionally requires the pid to be
+/// recycled into a *new* child of this process inside the microseconds between
+/// the winner's `waitpid` and the loser's, which is a coincidence on top of a
+/// race. Note the common teardown path does not even enter this window:
+/// `TmuxBridge.cleanupSession` kills the tmux session from a *detached* task,
+/// so the attach client normally exits after `cleanup()` has already cancelled
+/// the monitor, leaving this reaper as the only waiter.
+///
+/// It is therefore a narrow race that is deliberately left open rather than
+/// closed by making cleanup depend on the main queue — see `reap`.
 ///
 /// **Known limitation, deliberately not handled here:** a child that ignores
 /// `SIGHUP` (and `SIGTERM`, on the path that sends one) never exits, so its
@@ -109,28 +116,22 @@ enum ChildReaper {
     /// Reap `pid` in the background unless `observation` says SwiftTerm's own
     /// monitor already did. Fire-and-forget; returns immediately.
     ///
-    /// `@MainActor` because the ordering argument above depends on it: the hop
-    /// below only orders us behind an already-enqueued exit handler if it is
-    /// enqueued from the main queue too. Both `cleanup()` implementations are
-    /// main-isolated, so this costs no call site anything and makes the
-    /// precondition compiler-enforced rather than assumed.
-    @MainActor
+    /// Deliberately not routed through the main queue. Hopping through main
+    /// before committing would resolve the residual race above, by ordering
+    /// this behind any exit handler already queued there — but it would make
+    /// every reap wait on main-queue liveness, and main is the thread this app
+    /// has a `HangWatchdog` for. Cleanup that stops working precisely when the
+    /// app is unhealthy is the wrong trade for a race whose realistic outcome
+    /// is one wrong exit code in one terminal message.
     static func reap(pid: pid_t, unless observation: ChildExitObservation) {
         // Cheap early-out, and the only check a control-mode panel (pid 0)
         // ever reaches — it keeps teardown from enqueuing a pointless block.
         guard shouldReap(pid: pid, alreadyObserved: observation.wasObserved) else { return }
-        DispatchQueue.main.async {
-            // The load-bearing check. A child that exited concurrently with
-            // teardown may have left an exit handler queued ahead of this
-            // block; by now it has run and recorded its claim, and cancelling
-            // the source did not un-enqueue it.
+        queue.async {
+            // Re-checked here because an unbounded amount of time can pass
+            // before this block runs, and the check costs one lock acquisition.
             guard shouldReap(pid: pid, alreadyObserved: observation.wasObserved) else { return }
-            queue.async {
-                // Belt and braces: an unbounded amount of time can pass before
-                // this block runs, and the check costs one lock acquisition.
-                guard shouldReap(pid: pid, alreadyObserved: observation.wasObserved) else { return }
-                reapBlocking(pid: pid)
-            }
+            reapBlocking(pid: pid)
         }
     }
 

--- a/Sources/TBDApp/Terminal/ChildReaper.swift
+++ b/Sources/TBDApp/Terminal/ChildReaper.swift
@@ -11,14 +11,22 @@ private let reaperLogger = Logger(subsystem: "com.tbd.app", category: "childReap
 /// `LocalProcessDelegate.processTerminated` callback; `wasObserved` gates the
 /// teardown reap, both on the main queue and again on the reaper thread.
 ///
-/// Serialization note: with the pinned SwiftTerm revision this flag is only
-/// ever touched from the main queue. `LocalProcess.init` defaults its
+/// Serialization note, stated precisely because the two call sites differ.
+/// The *writer* side is the same for both: `LocalProcess.init` defaults its
 /// `dispatchQueue` to `DispatchQueue.main`, neither TBD call site passes one,
-/// and the `DispatchSourceProcess` is created with `queue: dispatchQueue` — so
-/// the monitor handler, the delegate callback and `@MainActor cleanup()` are
-/// all serialized on main. The lock is kept anyway as cheap defence: a future
-/// call site that passes an explicit `dispatchQueue:` would move the delegate
-/// callback off main, and the reaper thread reads this flag regardless.
+/// and the `DispatchSourceProcess` is created with `queue: dispatchQueue`, so
+/// the monitor handler and the delegate callback that calls `record()` run on
+/// the main queue. The *reader* side is where the guarantee weakens:
+/// `TerminalPanelRepresentable.Coordinator.cleanup()` is `@MainActor`, so the
+/// compiler enforces it; `LocalPTYTerminalRepresentable.Coordinator.cleanup()`
+/// carries no isolation annotation, and its main-thread execution rests only
+/// on its sole caller being SwiftUI's `dismantleNSView` — a convention, not a
+/// type-system guarantee.
+///
+/// So the lock is not decorative. It is real protection if that convention is
+/// ever violated (a coordinator torn down off the main thread), and it is
+/// load-bearing regardless of any of the above, because `ChildReaper.reap`
+/// re-reads this flag from its own background queue.
 final class ChildExitObservation: Sendable {
     private let observed = OSAllocatedUnfairLock<Bool>(initialState: false)
 

--- a/Sources/TBDApp/Terminal/TerminalPanelView.swift
+++ b/Sources/TBDApp/Terminal/TerminalPanelView.swift
@@ -363,7 +363,18 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         /// over this terminal and should receive scroll/click events instead of
         /// the terminal. Set by `TerminalPanelRepresentable.makeNSView`.
         var shouldSuppressEvents: @MainActor () -> Bool = { false }
-        private var localProcess: LocalProcess?
+        /// Internal rather than private so `TerminalTeardownReapTests` can hand
+        /// this coordinator a real `LocalProcess` and drive `cleanup()`
+        /// headlessly — the reap wiring is otherwise unreachable from a test,
+        /// since everything else about this type needs a live `NSView`.
+        var localProcess: LocalProcess?
+        /// Recorded when `LocalProcess`'s own exit monitor fires — by then it
+        /// has already called `waitpid`, so `cleanup()` must NOT reap this pid
+        /// (it is free, and could have been recycled for another child of this
+        /// process). Both sides run on the main queue with the pinned SwiftTerm
+        /// revision; see `ChildExitObservation` for why it is lock-guarded
+        /// anyway and for the reaper thread that also reads it.
+        private let childExitObservation = ChildExitObservation()
         private var scrollMonitor: Any?
         private var clickMonitor: Any?
         private var recreationAttempts = 0
@@ -616,9 +627,15 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
         @MainActor
         func cleanup() {
             debugLog("PANEL: cleanup for \(panelID.uuidString.prefix(8))")
+            // Idempotent: a second call must not re-run the teardown (it would
+            // reap a pid whose `LocalProcess` this method already released).
+            guard !isTornDown else { return }
             // Before anything else: any in-flight attach establishment must
             // see the teardown at its next await resumption (review H2).
             isTornDown = true
+            // Capture the pid BEFORE anything releases the `LocalProcess` —
+            // it is the only thing that knows it.
+            let ptyChildPid = localProcess?.shellPid ?? 0
             if let monitor = scrollMonitor {
                 NSEvent.removeMonitor(monitor)
                 scrollMonitor = nil
@@ -655,6 +672,26 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
                         routingKey: attach.routingKey, generation: attach.generation)
                 }
             }
+            // Release the PTY child's `LocalProcess` and reap the child.
+            //
+            // How the child dies is unchanged by this block. In practice the
+            // dominant path is the `tmuxBridge?.cleanupSession` call above:
+            // it runs `tmux kill-session`, which ends the session this client
+            // is attached to, so the attach client exits on its own. Failing
+            // that, `LocalProcess.deinit` closes the master fd here and the
+            // child exits on the resulting SIGHUP.
+            //
+            // What *is* deliberate is niling `localProcess` rather than
+            // leaving it to ARC. deinit then runs at a known moment and
+            // cancels SwiftTerm's `childMonitor` here, which is what makes
+            // `ChildReaper` the sole `waitpid` waiter for this pid. deinit
+            // never calls `waitpid` itself, so without the reap the child
+            // stays `<defunct>` under TBDApp forever.
+            //
+            // Control-mode panels have no `LocalProcess` at all, so
+            // `ptyChildPid` is 0 for them and `shouldReap` rejects it.
+            localProcess = nil
+            ChildReaper.reap(pid: ptyChildPid, unless: childExitObservation)
         }
 
         /// Render this panel through the control-mode path: request an attach
@@ -924,6 +961,12 @@ struct TerminalPanelRepresentable: NSViewRepresentable {
 
         func processTerminated(_ source: LocalProcess, exitCode: Int32?) {
             debugLog("PANEL: process terminated, exitCode=\(exitCode ?? -1)")
+            // `LocalProcess.processTerminated()` calls `waitpid` before it
+            // calls us, so this child is already reaped and its pid is free to
+            // be recycled — a later `cleanup()` must not wait on it. Recorded
+            // before the `async` below so the flag is set as early as this
+            // callback can set it.
+            childExitObservation.record()
             DispatchQueue.main.async { [weak self] in
                 // This fires when the *attach client* (the on-screen tmux
                 // viewer) dies. A clean exit (code 0) means the view was torn

--- a/Tests/TBDAppTests/ChildReaperTests.swift
+++ b/Tests/TBDAppTests/ChildReaperTests.swift
@@ -102,9 +102,9 @@ struct ChildReaperTests {
 
     private func waitUntilZombie(_ pid: pid_t) async throws {
         var polls = 0
-        while !isUnreapedZombie(pid), polls < 200 {
+        while !isUnreapedZombie(pid), polls < 50 {
             polls += 1
-            try await Task.sleep(for: .milliseconds(25))
+            try await Task.sleep(for: .milliseconds(100))
         }
         guard isUnreapedZombie(pid) else { throw NeverExited(pid: pid, polls: polls) }
     }
@@ -175,23 +175,21 @@ struct ChildReaperTests {
         #expect(second == -1, "a second reap of the same pid must return -1 (ECHILD)")
     }
 
-    @MainActor
     @Test("background reap: fire-and-forget clears the zombie")
     func backgroundReapClearsTheZombie() async throws {
         let pid = try spawn("/bin/sleep", ["0"])
         ChildReaper.reap(pid: pid, unless: ChildExitObservation())
 
         var polls = 0
-        while processExists(pid), polls < 200 {
+        while processExists(pid), polls < 50 {
             polls += 1
-            try await Task.sleep(for: .milliseconds(25))
+            try await Task.sleep(for: .milliseconds(100))
         }
         if processExists(pid) {
             Issue.record(StillZombie(pid: pid, polls: polls))
         }
     }
 
-    @MainActor
     @Test("background reap: an already-observed child is left alone")
     func backgroundReapSkipsObservedChild() async throws {
         let pid = try spawn("/bin/sleep", ["0"])
@@ -211,59 +209,21 @@ struct ChildReaperTests {
         _ = await reapOffPool(pid)
     }
 
-    // MARK: - The claim can land after the call and still be honoured
+    // MARK: - What is deliberately NOT tested here
     //
-    // Both tests below exploit the same property to be deterministic rather
-    // than racy: a `@MainActor` test body *is* a block occupying the serial
-    // main queue (`Tests/CLAUDE.md`), so nothing else queued there can run
-    // until the body suspends. That lets each one enqueue work and then act
-    // "before" it runs, with no timing assumption at all.
-
-    @MainActor
-    @Test("the re-check after the main-queue hop skips a child claimed in the meantime")
-    func skipsWhenClaimLandsAfterTheSynchronousCheck() async throws {
-        let pid = try spawn("/bin/sleep", ["0"])
-        let observation = ChildExitObservation()
-
-        // Passes the synchronous gate and enqueues the hop...
-        ChildReaper.reap(pid: pid, unless: observation)
-        // ...and the claim lands before that hop can possibly run, since this
-        // body still holds the main queue. Only the post-hop re-check can
-        // catch this; delete it and the child below gets reaped.
-        observation.record()
-
-        try await waitUntilZombie(pid)
-        try await Task.sleep(for: .milliseconds(200))
-        #expect(isUnreapedZombie(pid),
-                "a claim recorded before the hop ran must still stop the reap")
-
-        _ = await reapOffPool(pid)
-    }
-
-    @MainActor
-    @Test("an exit handler already queued on main beats teardown's reap")
-    func yieldsToAnAlreadyEnqueuedExitHandler() async throws {
-        let pid = try spawn("/bin/sleep", ["0"])
-        let observation = ChildExitObservation()
-
-        // Stands in for SwiftTerm's exit handler for a child that exited
-        // concurrently with teardown: a main-queue block, enqueued before
-        // teardown runs, that records the claim. (In production that same
-        // block does SwiftTerm's own `waitpid` first — which is why losing
-        // this race would mean two committed waiters on one pid.) Cancelling
-        // the source does not un-enqueue it, so teardown cannot assume it is
-        // gone; it can only queue itself behind it.
-        DispatchQueue.main.async { observation.record() }
-
-        // Teardown, still holding the main queue: the handler has NOT run yet,
-        // so the synchronous check sees an unclaimed child and proceeds.
-        ChildReaper.reap(pid: pid, unless: observation)
-
-        try await waitUntilZombie(pid)
-        try await Task.sleep(for: .milliseconds(200))
-        #expect(isUnreapedZombie(pid),
-                "the queued handler runs before the hop, so the reap must stand down")
-
-        _ = await reapOffPool(pid)
-    }
+    // `reap`'s second `shouldReap` check — the one inside the background block
+    // — has no dedicated test, and cannot get an honest one. Driving it means
+    // recording the claim after `reap` returns but before that block runs, and
+    // the block is already in flight on a concurrent queue: any test that
+    // appeared to pin it would be winning a race, not asserting a contract, and
+    // would flake the first time the machine was busy. An earlier revision did
+    // exactly that by holding the main queue, and it cost four 60 s timeouts
+    // under full-suite load.
+    //
+    // The branch logic is covered instead where it is deterministic: the
+    // `shouldReap` tests above pin both of its outcomes directly, and
+    // `backgroundReapSkipsObservedChild` covers a claim that is already
+    // recorded when `reap` is called. What remains uncovered is only the
+    // *timing* of a claim landing mid-dispatch, which is the one part no test
+    // can schedule.
 }

--- a/Tests/TBDAppTests/ChildReaperTests.swift
+++ b/Tests/TBDAppTests/ChildReaperTests.swift
@@ -1,0 +1,210 @@
+import Darwin
+import Foundation
+import Testing
+@testable import TBDApp
+
+/// Tier 2: real forked children, but no external server and no wall-clock
+/// assertion — `reapBlocking` is deterministic by construction, and the two
+/// bounded polls here observe children that have already been asked to exit.
+/// It lives in `TBDAppTests` rather than the tier-3 target because
+/// `Tests/TBDDaemonLiveTests` does not link `TBDApp`.
+///
+/// What these pin: the reaper actually reaps. SwiftTerm's `LocalProcess`
+/// cancels its own exit monitor before the child exits, so `waitpid` never
+/// runs and every torn-down terminal leaves a permanent `<defunct>` child under
+/// TBDApp. `ChildReaper` is the guaranteed `waitpid`; a non-blocking (`WNOHANG`)
+/// or event-source implementation fails `reapsAChildThatIsStillRunning` below.
+///
+/// WHY AN EXPLICIT `.timeLimit(.minutes(1))` AND NOT `.clockDriven`. Following
+/// the precedent of `SubprocessTimeoutTests`, which states its reason rather
+/// than inheriting the shared trait: `.clockDriven`'s four minutes is sized for
+/// suites that arm a `TestClock` handshake in the ~4500-test parallel pass, and
+/// nothing here is clock-driven — the longest child lives 0.3 s and the polls
+/// below are capped at 5 s of their own. A limit an order of magnitude above
+/// the work is a hang-catcher; four minutes of a shared box is not free.
+///
+/// The limit's known blind spot, stated rather than glossed: Swift Testing
+/// cannot cancel a thread parked in a synchronous `waitpid`, so it would not
+/// rescue a test that waits on a child that never exits. None can — every child
+/// spawned here is `/bin/sleep` with a bounded argument, which always exits, and
+/// the skip-branch test reaps its own deliberately-unreaped child before
+/// returning.
+@Suite("ChildReaper", .timeLimit(.minutes(1)))
+struct ChildReaperTests {
+
+    // MARK: - Helpers
+
+    private enum SpawnError: Error, CustomStringConvertible {
+        case posixSpawnFailed(Int32)
+        var description: String {
+            switch self {
+            case .posixSpawnFailed(let code): return "posix_spawn failed with code \(code)"
+            }
+        }
+    }
+
+    private struct StillZombie: Error, CustomStringConvertible {
+        let pid: pid_t
+        let polls: Int
+        var description: String {
+            "pid \(pid) was still a live-or-zombie process after \(polls) polls "
+                + "(expected ESRCH once ChildReaper reaped it)"
+        }
+    }
+
+    private struct NeverExited: Error, CustomStringConvertible {
+        let pid: pid_t
+        let polls: Int
+        var description: String {
+            "pid \(pid) had not become a reapable zombie after \(polls) polls"
+        }
+    }
+
+    /// Spawns a child with `posix_spawn` so nothing else in-process reaps it.
+    /// (`Foundation.Process` installs its own `waitpid`, which would mask the
+    /// behavior under test.)
+    private func spawn(_ path: String, _ args: [String]) throws -> pid_t {
+        var pid: pid_t = 0
+        var argv: [UnsafeMutablePointer<CChar>?] = ([path] + args).map { strdup($0) }
+        argv.append(nil)
+        defer { for arg in argv { free(arg) } }
+        let code = posix_spawn(&pid, path, nil, nil, &argv, nil)
+        guard code == 0 else { throw SpawnError.posixSpawnFailed(code) }
+        return pid
+    }
+
+    /// `true` while the pid still names a process this process can signal —
+    /// which includes a zombie, since an unreaped child still exists.
+    private func processExists(_ pid: pid_t) -> Bool {
+        kill(pid, 0) == 0 || errno == EPERM
+    }
+
+    /// `true` once the child has exited and is *still waitable* — i.e. it is an
+    /// unreaped zombie. `WNOWAIT` is what makes this a probe rather than a
+    /// reap: it leaves the child in exactly the state it found it, so a test
+    /// can assert "nobody reaped this" without doing the reaping itself.
+    private func isUnreapedZombie(_ pid: pid_t) -> Bool {
+        var info = siginfo_t()
+        return waitid(P_PID, id_t(pid), &info, WEXITED | WNOWAIT | WNOHANG) == 0 && info.si_pid == pid
+    }
+
+    /// Runs the blocking reap off the cooperative pool. Parking a concurrency
+    /// worker for the child's lifetime would tax every other suite in this
+    /// process (Swift Testing runs them all in one).
+    private func reapOffPool(_ pid: pid_t) async -> pid_t {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: ChildReaper.reapBlocking(pid: pid))
+            }
+        }
+    }
+
+    private func waitUntilZombie(_ pid: pid_t) async throws {
+        var polls = 0
+        while !isUnreapedZombie(pid), polls < 200 {
+            polls += 1
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        guard isUnreapedZombie(pid) else { throw NeverExited(pid: pid, polls: polls) }
+    }
+
+    // MARK: - The teardown decision
+
+    @Test("reaps when SwiftTerm's monitor has not claimed the child")
+    func shouldReapUnobservedChild() {
+        #expect(ChildReaper.shouldReap(pid: 4242, alreadyObserved: false))
+    }
+
+    @Test("skips when SwiftTerm's monitor already reaped the child")
+    func shouldNotReapObservedChild() {
+        // The monitor's own `waitpid` already ran, so the pid is free and may
+        // have been recycled — waiting on it could steal another child's status.
+        #expect(!ChildReaper.shouldReap(pid: 4242, alreadyObserved: true))
+    }
+
+    @Test("skips non-positive pids on either branch")
+    func shouldNotReapNonPositivePids() {
+        // waitpid(0, …) waits on the whole process group and waitpid(-1, …) on
+        // any child — either would park on, and reap, unrelated processes. A
+        // control-mode panel has no LocalProcess and lands here with 0.
+        for observed in [false, true] {
+            #expect(!ChildReaper.shouldReap(pid: 0, alreadyObserved: observed))
+            #expect(!ChildReaper.shouldReap(pid: -1, alreadyObserved: observed))
+        }
+    }
+
+    @Test("ChildExitObservation records once and stays recorded")
+    func observationRecords() {
+        let observation = ChildExitObservation()
+        #expect(!observation.wasObserved)
+        observation.record()
+        #expect(observation.wasObserved)
+        observation.record()
+        #expect(observation.wasObserved)
+    }
+
+    // MARK: - Reaping real children
+
+    @Test("blocking reap: waits out a still-running child and leaves no zombie")
+    func reapsAChildThatIsStillRunning() async throws {
+        // Deliberately still running when the reap starts: a WNOHANG
+        // implementation returns 0 here and leaves the zombie behind.
+        let pid = try spawn("/bin/sleep", ["0.3"])
+
+        let reaped = await reapOffPool(pid)
+
+        #expect(reaped == pid, "blocking waitpid must return the pid it reaped")
+        #expect(!processExists(pid), "reaped child must not linger as a zombie")
+
+        var status: Int32 = 0
+        let second = waitpid(pid, &status, WNOHANG)
+        #expect(second == -1 && errno == ECHILD,
+                "nothing left to wait for once ChildReaper reaped the child")
+    }
+
+    @Test("already-reaped pid is a safe, non-hanging no-op")
+    func reapingTwiceIsHarmless() async throws {
+        let pid = try spawn("/bin/sleep", ["0"])
+
+        let first = await reapOffPool(pid)
+        #expect(first == pid)
+
+        // The suite time limit bounds a hang; the assertion pins the contract.
+        let second = await reapOffPool(pid)
+        #expect(second == -1, "a second reap of the same pid must return -1 (ECHILD)")
+    }
+
+    @Test("background reap: fire-and-forget clears the zombie")
+    func backgroundReapClearsTheZombie() async throws {
+        let pid = try spawn("/bin/sleep", ["0"])
+        ChildReaper.reap(pid: pid, unless: ChildExitObservation())
+
+        var polls = 0
+        while processExists(pid), polls < 200 {
+            polls += 1
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        if processExists(pid) {
+            Issue.record(StillZombie(pid: pid, polls: polls))
+        }
+    }
+
+    @Test("background reap: an already-observed child is left alone")
+    func backgroundReapSkipsObservedChild() async throws {
+        let pid = try spawn("/bin/sleep", ["0"])
+        let observation = ChildExitObservation()
+        observation.record()
+
+        ChildReaper.reap(pid: pid, unless: observation)
+
+        // Let the child actually exit, so "still waitable" means "nobody
+        // reaped it" rather than "it had not exited yet".
+        try await waitUntilZombie(pid)
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(isUnreapedZombie(pid),
+                "an observed child must be left for its real waiter, not reaped here")
+
+        // This test owns the zombie it deliberately kept; don't leak it.
+        _ = await reapOffPool(pid)
+    }
+}

--- a/Tests/TBDAppTests/ChildReaperTests.swift
+++ b/Tests/TBDAppTests/ChildReaperTests.swift
@@ -56,7 +56,8 @@ struct ChildReaperTests {
         let pid: pid_t
         let polls: Int
         var description: String {
-            "pid \(pid) had not become a reapable zombie after \(polls) polls"
+            "pid \(pid) never became a reapable zombie after \(polls) polls "
+                + "(it exited and something else reaped it, or it never exited)"
         }
     }
 
@@ -174,6 +175,7 @@ struct ChildReaperTests {
         #expect(second == -1, "a second reap of the same pid must return -1 (ECHILD)")
     }
 
+    @MainActor
     @Test("background reap: fire-and-forget clears the zombie")
     func backgroundReapClearsTheZombie() async throws {
         let pid = try spawn("/bin/sleep", ["0"])
@@ -189,6 +191,7 @@ struct ChildReaperTests {
         }
     }
 
+    @MainActor
     @Test("background reap: an already-observed child is left alone")
     func backgroundReapSkipsObservedChild() async throws {
         let pid = try spawn("/bin/sleep", ["0"])
@@ -205,6 +208,62 @@ struct ChildReaperTests {
                 "an observed child must be left for its real waiter, not reaped here")
 
         // This test owns the zombie it deliberately kept; don't leak it.
+        _ = await reapOffPool(pid)
+    }
+
+    // MARK: - The claim can land after the call and still be honoured
+    //
+    // Both tests below exploit the same property to be deterministic rather
+    // than racy: a `@MainActor` test body *is* a block occupying the serial
+    // main queue (`Tests/CLAUDE.md`), so nothing else queued there can run
+    // until the body suspends. That lets each one enqueue work and then act
+    // "before" it runs, with no timing assumption at all.
+
+    @MainActor
+    @Test("the re-check after the main-queue hop skips a child claimed in the meantime")
+    func skipsWhenClaimLandsAfterTheSynchronousCheck() async throws {
+        let pid = try spawn("/bin/sleep", ["0"])
+        let observation = ChildExitObservation()
+
+        // Passes the synchronous gate and enqueues the hop...
+        ChildReaper.reap(pid: pid, unless: observation)
+        // ...and the claim lands before that hop can possibly run, since this
+        // body still holds the main queue. Only the post-hop re-check can
+        // catch this; delete it and the child below gets reaped.
+        observation.record()
+
+        try await waitUntilZombie(pid)
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(isUnreapedZombie(pid),
+                "a claim recorded before the hop ran must still stop the reap")
+
+        _ = await reapOffPool(pid)
+    }
+
+    @MainActor
+    @Test("an exit handler already queued on main beats teardown's reap")
+    func yieldsToAnAlreadyEnqueuedExitHandler() async throws {
+        let pid = try spawn("/bin/sleep", ["0"])
+        let observation = ChildExitObservation()
+
+        // Stands in for SwiftTerm's exit handler for a child that exited
+        // concurrently with teardown: a main-queue block, enqueued before
+        // teardown runs, that records the claim. (In production that same
+        // block does SwiftTerm's own `waitpid` first — which is why losing
+        // this race would mean two committed waiters on one pid.) Cancelling
+        // the source does not un-enqueue it, so teardown cannot assume it is
+        // gone; it can only queue itself behind it.
+        DispatchQueue.main.async { observation.record() }
+
+        // Teardown, still holding the main queue: the handler has NOT run yet,
+        // so the synchronous check sees an unclaimed child and proceeds.
+        ChildReaper.reap(pid: pid, unless: observation)
+
+        try await waitUntilZombie(pid)
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(isUnreapedZombie(pid),
+                "the queued handler runs before the hop, so the reap must stand down")
+
         _ = await reapOffPool(pid)
     }
 }

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -1,0 +1,165 @@
+import Darwin
+import Foundation
+import SwiftTerm
+import Testing
+@testable import TBDApp
+
+/// Tier 2: drives the two terminal coordinators' real `cleanup()` against a
+/// real SwiftTerm `LocalProcess` and a real forked child. No tmux server, no
+/// daemon, no `~/tbd` — a bare `Coordinator()` with only `localProcess` set
+/// takes every other branch of `cleanup()` as a nil no-op.
+///
+/// **This is the suite that pins the bug.** `ChildReaperTests` proves the
+/// helper reaps, but it would stay green if someone deleted the
+/// `ChildReaper.reap` call from `cleanup()`. These two tests reproduce the
+/// production sequence end to end — spawn a child that will not exit on its
+/// own, tear the coordinator down, and require the child to be gone — so they
+/// go red if either half of the fix is removed: the reap call itself, or the
+/// `localProcess = nil` that makes `LocalProcess.deinit` (and thus the
+/// monitor cancellation and fd close) happen at a known moment.
+///
+/// **Why the default `dispatchQueue` (main) and not an injected background
+/// queue.** Production passes none, so `LocalProcess` defaults to
+/// `DispatchQueue.main` for both `childMonitor` and the `DispatchIO` cleanup
+/// handler; passing a background queue here would test a configuration TBD
+/// never uses. That is only sound because this process genuinely drains the
+/// main queue (`Tests/CLAUDE.md`, "@MainActor tests: suspend to drain"), so the
+/// monitor is live rather than merely idle — the child outlives the coordinator
+/// precisely because `cleanup()` cancels that live monitor, which is the
+/// behavior under test. The consequence is a discipline these tests must keep:
+/// **suspend, never block, on the main actor.** The fd close that ends the
+/// child is itself a main-queue block, so a synchronous wait here would
+/// deadlock against the very work it is waiting for. Every wait below is an
+/// `await`.
+///
+/// Bounded by construction: each test polls against a 5 s cap and force-kills
+/// its child in a `defer`, so nothing can park on a `waitpid` that never
+/// returns. (`cleanup()` also appends a line to `/tmp/tbd-bridge.log` via the
+/// production `debugLog`; no TBD-owned store is touched.)
+@MainActor
+@Suite("Terminal teardown reaps its PTY child", .timeLimit(.minutes(1)))
+struct TerminalTeardownReapTests {
+
+    private struct ChildSurvivedTeardown: Error, CustomStringConvertible {
+        let pid: pid_t
+        let polls: Int
+        let state: String
+        var description: String {
+            "PTY child \(pid) still existed \(polls) polls after cleanup() — observed \(state). "
+                + "Teardown must reap it; an unreaped child is the <defunct> leak this fixes."
+        }
+    }
+
+    /// `true` while the pid still names a process — running OR an unreaped
+    /// zombie. Both are failures after teardown; the message distinguishes them.
+    private func processExists(_ pid: pid_t) -> Bool {
+        kill(pid, 0) == 0 || errno == EPERM
+    }
+
+    /// Distinguishes "still running" from "leaked as a zombie" for the
+    /// diagnostic, using `WNOWAIT` so the probe does not itself reap.
+    private func describeState(_ pid: pid_t) -> String {
+        var info = siginfo_t()
+        if waitid(P_PID, id_t(pid), &info, WEXITED | WNOWAIT | WNOHANG) == 0, info.si_pid == pid {
+            return "an unreaped zombie (exited, still waitable)"
+        }
+        return processExists(pid) ? "a live process (never exited)" : "gone"
+    }
+
+    /// Polls for the child to disappear entirely. Suspends between checks so
+    /// the main queue keeps draining — see the suite comment.
+    private func waitForChildToVanish(_ pid: pid_t) async -> Bool {
+        var polls = 0
+        while processExists(pid), polls < 200 {
+            polls += 1
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        if processExists(pid) {
+            Issue.record(ChildSurvivedTeardown(pid: pid, polls: polls, state: describeState(pid)))
+            return false
+        }
+        return true
+    }
+
+    /// Starts a child on a real `LocalProcess` owned solely by `assign`, and
+    /// returns its pid.
+    ///
+    /// The `LocalProcess` reference lives and dies inside this call: after it
+    /// returns, the coordinator's own property is the only strong reference, so
+    /// `deinit` fires exactly when `cleanup()` releases it — as in production,
+    /// where the coordinator is likewise the only owner.
+    private func startChild(
+        delegate: LocalProcessDelegate, lifetime: String, assign: (LocalProcess) -> Void
+    ) -> pid_t {
+        let process = LocalProcess(delegate: delegate)
+        process.startProcess(
+            executable: "/bin/sleep", args: [lifetime], environment: nil, execName: nil)
+        assign(process)
+        return process.shellPid
+    }
+
+    /// The panel path does not itself kill the child, so this test asserts what
+    /// the fix actually claims: **a child that exits after teardown is reaped,
+    /// not left `<defunct>`.** The child outlives `cleanup()` and then exits on
+    /// its own, which is the exact sequence that leaked in the field — by the
+    /// time it exits, `cleanup()` has released the `LocalProcess`, and that
+    /// deinit cancelled the only monitor that would have `waitpid`ed it.
+    ///
+    /// Two things this deliberately does NOT assert, both measured here rather
+    /// than assumed. Teardown on this path does not reliably *end* the child:
+    /// `deinit`'s `io?.close()` is a graceful close, and `startProcess` leaves a
+    /// read outstanding, so the cleanup handler that actually closes the master
+    /// fd does not run while that read is pending — a silent child never sees
+    /// the SIGHUP at all (a `sleep 120` child was still running 5 s after
+    /// `cleanup()`). What ends the attach client in production is
+    /// `tmuxBridge.cleanupSession`'s `tmux kill-session`, which needs a real
+    /// server and belongs to tier 3. Reaping is the part that is ours, and it
+    /// is the part under test.
+    @Test("an exiting PTY child is reaped by TerminalPanelView teardown, not left <defunct>")
+    func panelCleanupReapsChild() async throws {
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        // Outlives cleanup(), then exits on its own — see the doc comment.
+        let pid = startChild(delegate: coordinator, lifetime: "0.4") { coordinator.localProcess = $0 }
+        try #require(pid > 0, "forkpty must have produced a child pid")
+
+        var reaped = false
+        defer {
+            // Safety net for the failure path only: on success the pid is
+            // already freed and signalling it could reach a recycled process.
+            if !reaped {
+                kill(pid, SIGKILL)
+                ChildReaper.reapBlocking(pid: pid)
+            }
+        }
+
+        coordinator.cleanup()
+
+        reaped = await waitForChildToVanish(pid)
+        #expect(reaped)
+    }
+
+    /// The remote path *does* end its child — `cleanup()` calls
+    /// `LocalProcess.terminate()`, which sends SIGTERM — so a long-lived child
+    /// is production-faithful here. `terminate()` cancels the exit monitor
+    /// (via `childStopped()`) before that signal can land, so the reap is the
+    /// only thing standing between this teardown and a permanent zombie.
+    @Test("LocalPTYTerminalRepresentable teardown kills AND reaps its child")
+    func localPTYCleanupReapsChild() async throws {
+        let coordinator = LocalPTYTerminalRepresentable.Coordinator()
+        let pid = startChild(delegate: coordinator, lifetime: "120") { coordinator.localProcess = $0 }
+        try #require(pid > 0, "forkpty must have produced a child pid")
+
+        var reaped = false
+        defer {
+            if !reaped {
+                kill(pid, SIGKILL)
+                ChildReaper.reapBlocking(pid: pid)
+            }
+        }
+
+        coordinator.cleanup()
+
+        reaped = await waitForChildToVanish(pid)
+        #expect(reaped)
+    }
+}

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -23,22 +23,36 @@ import Testing
 /// `DispatchQueue.main` for both `childMonitor` and the `DispatchIO` cleanup
 /// handler; passing a background queue here would test a configuration TBD
 /// never uses. That is only sound because this process genuinely drains the
-/// main queue (`Tests/CLAUDE.md`, "@MainActor tests: suspend to drain"), so the
-/// monitor is live rather than merely idle — the child outlives the coordinator
-/// precisely because `cleanup()` cancels that live monitor, which is the
-/// behavior under test. The consequence is a discipline these tests must keep:
-/// **suspend, never block, on the main actor.** The fd close that ends the
-/// child is itself a main-queue block, so a synchronous wait here would
-/// deadlock against the very work it is waiting for. Every wait below is an
-/// `await`.
+/// main queue (`Tests/CLAUDE.md`), so the monitor is live rather than merely
+/// idle — the child outlives the coordinator precisely because `cleanup()`
+/// cancels that live monitor, which is the behavior under test.
+///
+/// **These tests are deliberately NOT `@MainActor`, and each takes exactly one
+/// main-actor hop.** They need main only for the steps that are main-isolated
+/// — `startProcess` (whose delegate callback asserts main isolation) and
+/// `cleanup()` — so each test batches all of those into a single
+/// `MainActor.run`, and everything else (every poll, every `waitpid`) happens
+/// off it. Both halves were measured under full-suite load: the `@MainActor`
+/// version re-acquired main at each of ~200 poll resumptions and blew the 60 s
+/// limit on four tests, and a version that merely moved the polls off main but
+/// still took four separate hops blew it on two. Main is contended by hundreds
+/// of other main-isolated tests in that pass, so the count of hops is the
+/// thing to keep small — and never wait for main-queue work while occupying
+/// the main queue.
 ///
 /// Bounded by construction: each test polls against a 5 s cap and force-kills
 /// its child in a `defer`, so nothing can park on a `waitpid` that never
 /// returns. (`cleanup()` also appends a line to `/tmp/tbd-bridge.log` via the
 /// production `debugLog`; no TBD-owned store is touched.)
-@MainActor
 @Suite("Terminal teardown reaps its PTY child", .timeLimit(.minutes(1)))
 struct TerminalTeardownReapTests {
+
+    /// Everything a one-shot test needs out of its single main-actor hop.
+    private struct OneShotRun {
+        let first: pid_t
+        let probe: pid_t
+        let stillHeld: Bool
+    }
 
     private struct ChildSurvivedTeardown: Error, CustomStringConvertible {
         let pid: pid_t
@@ -70,9 +84,9 @@ struct TerminalTeardownReapTests {
     /// the main queue keeps draining — see the suite comment.
     private func waitForChildToVanish(_ pid: pid_t) async -> Bool {
         var polls = 0
-        while processExists(pid), polls < 200 {
+        while processExists(pid), polls < 50 {
             polls += 1
-            try? await Task.sleep(for: .milliseconds(25))
+            try? await Task.sleep(for: .milliseconds(100))
         }
         if processExists(pid) {
             Issue.record(ChildSurvivedTeardown(pid: pid, polls: polls, state: describeState(pid)))
@@ -88,6 +102,11 @@ struct TerminalTeardownReapTests {
     /// returns, the coordinator's own property is the only strong reference, so
     /// `deinit` fires exactly when `cleanup()` releases it — as in production,
     /// where the coordinator is likewise the only owner.
+    /// `@MainActor` because `startProcess` asks the delegate for the window
+    /// size, and both coordinators answer inside `MainActor.assumeIsolated` —
+    /// which traps off main. Production starts every PTY from a main-isolated
+    /// context, so this matches it; only the waiting below happens off main.
+    @MainActor
     private func startChild(
         delegate: LocalProcessDelegate, lifetime: String, assign: (LocalProcess) -> Void
     ) -> pid_t {
@@ -118,8 +137,15 @@ struct TerminalTeardownReapTests {
     @Test("an exiting PTY child is reaped by TerminalPanelView teardown, not left <defunct>")
     func panelCleanupReapsChild() async throws {
         let coordinator = TerminalPanelRepresentable.Coordinator()
-        // Outlives cleanup(), then exits on its own — see the doc comment.
-        let pid = startChild(delegate: coordinator, lifetime: "0.4") { coordinator.localProcess = $0 }
+        // Every main-isolated step in one hop — see the suite comment.
+        let pid = await MainActor.run { () -> pid_t in
+            // Outlives cleanup(), then exits on its own — see the doc comment.
+            let pid = startChild(delegate: coordinator, lifetime: "0.4") {
+                coordinator.localProcess = $0
+            }
+            coordinator.cleanup()
+            return pid
+        }
         try #require(pid > 0, "forkpty must have produced a child pid")
 
         var reaped = false
@@ -131,8 +157,6 @@ struct TerminalTeardownReapTests {
                 ChildReaper.reapBlocking(pid: pid)
             }
         }
-
-        coordinator.cleanup()
 
         reaped = await waitForChildToVanish(pid)
         #expect(reaped)
@@ -156,7 +180,13 @@ struct TerminalTeardownReapTests {
     @Test("LocalPTYTerminalRepresentable teardown kills AND reaps its child")
     func localPTYCleanupReapsChild() async throws {
         let coordinator = LocalPTYTerminalRepresentable.Coordinator()
-        let pid = startChild(delegate: coordinator, lifetime: "120") { coordinator.localProcess = $0 }
+        let pid = await MainActor.run { () -> pid_t in
+            let pid = startChild(delegate: coordinator, lifetime: "120") {
+                coordinator.localProcess = $0
+            }
+            coordinator.cleanup()
+            return pid
+        }
         try #require(pid > 0, "forkpty must have produced a child pid")
 
         var reaped = false
@@ -166,8 +196,6 @@ struct TerminalTeardownReapTests {
                 ChildReaper.reapBlocking(pid: pid)
             }
         }
-
-        coordinator.cleanup()
 
         reaped = await waitForChildToVanish(pid)
         #expect(reaped)
@@ -194,71 +222,56 @@ struct TerminalTeardownReapTests {
     @Test("a second TerminalPanelView cleanup() tears nothing down")
     func panelCleanupIsOneShot() async throws {
         let coordinator = TerminalPanelRepresentable.Coordinator()
-        let firstPid = startChild(delegate: coordinator, lifetime: "0.4") {
-            coordinator.localProcess = $0
-        }
-        try #require(firstPid > 0, "forkpty must have produced a child pid")
-
-        var firstReaped = false
-        defer {
-            if !firstReaped {
-                kill(firstPid, SIGKILL)
-                ChildReaper.reapBlocking(pid: firstPid)
+        let run = await MainActor.run { () -> OneShotRun in
+            let first = startChild(delegate: coordinator, lifetime: "0.4") {
+                coordinator.localProcess = $0
             }
+            coordinator.cleanup()
+            // Fresh state for the second call to (not) act on.
+            let probe = startChild(delegate: coordinator, lifetime: "120") {
+                coordinator.localProcess = $0
+            }
+            coordinator.cleanup()
+            return OneShotRun(first: first, probe: probe, stillHeld: coordinator.localProcess != nil)
         }
+        try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
+        defer { disposeProbe(pid: run.probe) { coordinator.localProcess = nil } }
 
-        coordinator.cleanup()
-        firstReaped = await waitForChildToVanish(firstPid)
-        try #require(firstReaped, "the first teardown must reap its child")
-
-        let probePid = startChild(delegate: coordinator, lifetime: "120") {
-            coordinator.localProcess = $0
-        }
-        try #require(probePid > 0, "forkpty must have produced a probe pid")
-        defer { disposeProbe(pid: probePid) { coordinator.localProcess = nil } }
-
-        coordinator.cleanup()
-
-        #expect(coordinator.localProcess != nil,
+        #expect(run.stillHeld,
                 "a second cleanup() must not release state it never set up")
-        #expect(processExists(probePid),
+        #expect(processExists(run.probe),
                 "a second cleanup() must not reap or signal anything")
+
+        let firstReaped = await waitForChildToVanish(run.first)
+        #expect(firstReaped, "the real teardown must still have reaped its own child")
     }
 
     @Test("a second LocalPTYTerminalRepresentable cleanup() tears nothing down")
     func localPTYCleanupIsOneShot() async throws {
         let coordinator = LocalPTYTerminalRepresentable.Coordinator()
-        let firstPid = startChild(delegate: coordinator, lifetime: "120") {
-            coordinator.localProcess = $0
-        }
-        try #require(firstPid > 0, "forkpty must have produced a child pid")
-
-        var firstReaped = false
-        defer {
-            if !firstReaped {
-                kill(firstPid, SIGKILL)
-                ChildReaper.reapBlocking(pid: firstPid)
+        let run = await MainActor.run { () -> OneShotRun in
+            let first = startChild(delegate: coordinator, lifetime: "120") {
+                coordinator.localProcess = $0
             }
+            coordinator.cleanup()
+            let probe = startChild(delegate: coordinator, lifetime: "120") {
+                coordinator.localProcess = $0
+            }
+            coordinator.cleanup()
+            return OneShotRun(first: first, probe: probe, stillHeld: coordinator.localProcess != nil)
         }
-
-        coordinator.cleanup()
-        firstReaped = await waitForChildToVanish(firstPid)
-        try #require(firstReaped, "the first teardown must kill and reap its child")
-
-        let probePid = startChild(delegate: coordinator, lifetime: "120") {
-            coordinator.localProcess = $0
-        }
-        try #require(probePid > 0, "forkpty must have produced a probe pid")
-        defer { disposeProbe(pid: probePid) { coordinator.localProcess = nil } }
-
-        coordinator.cleanup()
+        try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
+        defer { disposeProbe(pid: run.probe) { coordinator.localProcess = nil } }
 
         // Sharper here than on the panel path: without the guard this second
         // call reaches `localProcess?.terminate()`, so the probe would be
         // SIGTERMed as well as released.
-        #expect(coordinator.localProcess != nil,
+        #expect(run.stillHeld,
                 "a second cleanup() must not release state it never set up")
-        #expect(processExists(probePid),
+        #expect(processExists(run.probe),
                 "a second cleanup() must not terminate a process it never started")
+
+        let firstReaped = await waitForChildToVanish(run.first)
+        #expect(firstReaped, "the real teardown must still have killed and reaped its own child")
     }
 }

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -138,6 +138,16 @@ struct TerminalTeardownReapTests {
         #expect(reaped)
     }
 
+    /// Drops the coordinator's reference to a probe child's `LocalProcess`
+    /// (whose deinit cancels its exit monitor, making us the sole waiter), then
+    /// kills and reaps it. Probe children outlive their test by design, so
+    /// every test that starts one must call this.
+    private func disposeProbe(pid: pid_t, release: () -> Void) {
+        release()
+        kill(pid, SIGKILL)
+        ChildReaper.reapBlocking(pid: pid)
+    }
+
     /// The remote path *does* end its child — `cleanup()` calls
     /// `LocalProcess.terminate()`, which sends SIGTERM — so a long-lived child
     /// is production-faithful here. `terminate()` cancels the exit monitor
@@ -161,5 +171,94 @@ struct TerminalTeardownReapTests {
 
         reaped = await waitForChildToVanish(pid)
         #expect(reaped)
+    }
+
+    // MARK: - cleanup() is one-shot
+    //
+    // The `guard !isTornDown` / `guard !tornDown` guards make `cleanup()`
+    // idempotent. **What these tests can and cannot pin, stated plainly:** with
+    // the current code a second call is *already* harmless without the guard —
+    // the first call nils `localProcess`, so the pid capture yields 0 and
+    // `shouldReap` rejects it, and every other branch of `cleanup()` is a nil
+    // no-op. A test that merely called `cleanup()` twice would therefore stay
+    // green with the guard deleted, i.e. pin nothing at all.
+    //
+    // So these drive the guard's actual semantics — "once torn down, this
+    // coordinator does no further teardown work" — by handing it fresh state
+    // and requiring the second call to leave that state completely alone.
+    // Production never re-assigns a coordinator after dismantle; the fresh
+    // `LocalProcess` is a probe for the guard, not an endorsement of reuse.
+    // Deleting either guard reds these: the second `cleanup()` releases the
+    // probe, and on the remote path SIGTERMs its child as well.
+
+    @Test("a second TerminalPanelView cleanup() tears nothing down")
+    func panelCleanupIsOneShot() async throws {
+        let coordinator = TerminalPanelRepresentable.Coordinator()
+        let firstPid = startChild(delegate: coordinator, lifetime: "0.4") {
+            coordinator.localProcess = $0
+        }
+        try #require(firstPid > 0, "forkpty must have produced a child pid")
+
+        var firstReaped = false
+        defer {
+            if !firstReaped {
+                kill(firstPid, SIGKILL)
+                ChildReaper.reapBlocking(pid: firstPid)
+            }
+        }
+
+        coordinator.cleanup()
+        firstReaped = await waitForChildToVanish(firstPid)
+        try #require(firstReaped, "the first teardown must reap its child")
+
+        let probePid = startChild(delegate: coordinator, lifetime: "120") {
+            coordinator.localProcess = $0
+        }
+        try #require(probePid > 0, "forkpty must have produced a probe pid")
+        defer { disposeProbe(pid: probePid) { coordinator.localProcess = nil } }
+
+        coordinator.cleanup()
+
+        #expect(coordinator.localProcess != nil,
+                "a second cleanup() must not release state it never set up")
+        #expect(processExists(probePid),
+                "a second cleanup() must not reap or signal anything")
+    }
+
+    @Test("a second LocalPTYTerminalRepresentable cleanup() tears nothing down")
+    func localPTYCleanupIsOneShot() async throws {
+        let coordinator = LocalPTYTerminalRepresentable.Coordinator()
+        let firstPid = startChild(delegate: coordinator, lifetime: "120") {
+            coordinator.localProcess = $0
+        }
+        try #require(firstPid > 0, "forkpty must have produced a child pid")
+
+        var firstReaped = false
+        defer {
+            if !firstReaped {
+                kill(firstPid, SIGKILL)
+                ChildReaper.reapBlocking(pid: firstPid)
+            }
+        }
+
+        coordinator.cleanup()
+        firstReaped = await waitForChildToVanish(firstPid)
+        try #require(firstReaped, "the first teardown must kill and reap its child")
+
+        let probePid = startChild(delegate: coordinator, lifetime: "120") {
+            coordinator.localProcess = $0
+        }
+        try #require(probePid > 0, "forkpty must have produced a probe pid")
+        defer { disposeProbe(pid: probePid) { coordinator.localProcess = nil } }
+
+        coordinator.cleanup()
+
+        // Sharper here than on the panel path: without the guard this second
+        // call reaches `localProcess?.terminate()`, so the probe would be
+        // SIGTERMed as well as released.
+        #expect(coordinator.localProcess != nil,
+                "a second cleanup() must not release state it never set up")
+        #expect(processExists(probePid),
+                "a second cleanup() must not terminate a process it never started")
     }
 }


### PR DESCRIPTION
## Summary

TBDApp accumulated permanently-unreaped `<defunct>` children — 67 under a single app launch, growing for as long as the app ran. Each one holds a PID table entry; on a machine already carrying ~1000 processes this is roughly 700/day from one launch, and it made an unrelated load-average investigation much harder to read.

Every zombie's parent was TBDApp, and TBDApp's live children are exactly the `tmux -u -L tbd-<id> attach -t tbd-view-<id>` PTY clients spawned by `TerminalPanelView`. The leak is one zombie per terminal-panel teardown.

## Root cause

SwiftTerm's `LocalProcess` (pinned at `dae32cc`) calls `waitpid` from exactly one place: the `DispatchSourceProcess(.exit)` handler installed by `startProcessWithForkpty`. Both of its teardown paths cancel that source *before* the child has actually exited:

- `deinit` cancels the monitor, then closes the master fd — the child only notices the resulting `SIGHUP` afterwards.
- `terminate()` closes the fd, sends `SIGTERM`, then cancels the monitor via `childStopped()` — signal delivery and process teardown are asynchronous.

Either way the `.exit` event never fires, `waitpid` is never called, and the child stays `<defunct>` under TBDApp for the life of the app. Only children that exit *while the `LocalProcess` is still alive and monitoring* are reaped — that path fires the `processTerminated` delegate.

The `posix_spawn`/Subprocess path in `LocalProcess` is `#if false` dead code at this revision and is not involved.

## Evidence

The reported "one zombie every ~2 minutes" turned out to be an averaging artifact. Exact spawn timestamps read off the zombies themselves (`ps -o lstart` still reports for a defunct process) are bursty, not periodic: 66 inter-spawn gaps with a median of 39s and a max of 13,800s, including a 3h50m stretch with zero new zombies. Twelve bursts of 1–12, separated by 5–230 min idle gaps. No poller produces that shape; the rate tracks user activity.

Sampling a fresh, unmodified `/Applications/TBD.app` every 10s for 30 minutes gives a 1:1 correlation between panel teardown and zombie creation:

- live children 10 → 11 (new panel), zombies 0 → 0
- live children 11 → 10 (teardown), zombies 0 → 1
- live children 10 → 11 (new panel), zombies 1 → 1
- live children 11 → 10 (teardown), zombies 1 → 2
- live children 10 → 9 (teardown), zombies 2 → 3

Three teardowns, three zombies; two spawns, zero zombies.

The mechanism was also reproduced standalone: three children with their exit monitors cancelled before exit produced 3 zombies; the identical code leaving the monitors active produced 0.

## How it got broken

Not a regression — the flaw has been present since `8ad79824` ("add SwiftTerm terminal panel with tmux bridge integration") first spawned a `LocalProcess`, and it lives in the pinned dependency rather than in TBD's own code. It went unnoticed because a zombie is silent: no error, no crash, no log line, no user-visible symptom. It only becomes legible at this repo's own scale — a long-running app plus heavy panel churn across many worktrees — where it surfaced as ~700 PID-table entries per day from a single launch while an unrelated load-average investigation was underway.

## Test plan

- [x] `scripts/test.sh --filter 'ChildReaperTests|TerminalTeardownReapTests'` — 10 tests in 2 suites pass
- [x] Mutation check: commenting out both `ChildReaper.reap(...)` call sites turns the 2 wiring tests RED (`an unreaped zombie (exited, still waitable)` — the exact field symptom); restored and re-verified green
- [x] Mutation check: `waitpid(..., 0)` to `WNOHANG` reds the 3 reaping tests; dropping the gate reds the 2 gate tests
- [x] `scripts/test.sh --skip '^(TBDDaemonTests|TBDDaemonLiveTests)\.'` — 2688 tests, one unrelated known FileWatcher-family flake (green on rerun, untouched by this diff)
- [x] `scripts/swift-safe build` clean; `swiftlint --strict` 0 violations in 684 files
- [ ] Post-merge: after installing a build containing this change, confirm the zombie count stays flat across terminal-panel teardowns:
      `ps -Ao state,pid,ppid | awk '$3==<TBDApp pid> && substr($1,1,1)=="Z"' | wc -l`

## The fix

`ChildReaper.reap(pid:)` performs a blocking `waitpid` on a background queue, called from `Coordinator.cleanup()` in both `TerminalPanelView` (local tmux attach) and `LocalPTYTerminalView` (remote-provider attach). A blocking `waitpid` is the deterministic instrument here: it reaps whether the child is still running, already a zombie, or already reaped (`ECHILD`). Registering a second `DispatchSourceProcess` would not be — arming one against a pid that has already exited is not guaranteed to deliver `NOTE_EXIT`, which is precisely the failure being fixed.

**How the child is asked to die is unchanged.** No `terminate()` was added to `TerminalPanelView`, and no SIGHUP/SIGTERM behavior was altered. The fix only guarantees the `waitpid`.

Two supporting details:

- `cleanup()` now sets `localProcess = nil`, so `LocalProcess.deinit` runs at a known moment and cancels `childMonitor`. This is what makes `ChildReaper` the sole waiter rather than racing SwiftTerm's still-armed monitor. Previously release depended on ARC deallocating the whole Coordinator after `dismantleNSView` — an unstated SwiftUI timing contract.
- A `ChildExitObservation` flag, set in `processTerminated(_:exitCode:)`, suppresses the reap when `LocalProcess` already reaped the pid. Without it a freed pid could be recycled onto another TBDApp child and have its exit status stolen. The check is re-read on the reaper thread immediately before `waitpid`, not just before the dispatch.

`TerminalTeardownReapTests` drives both real coordinators' `cleanup()` against a real `LocalProcess` and a real forked child — it is the suite that pins the wiring, since `ChildReaperTests` alone would stay green if the `reap` call were deleted. Constructing the coordinators headlessly required widening `localProcess` from `private` to internal in both, documented as the test seam.

## Not done here

A child that ignores `SIGHUP` and never exits would park a reaper thread for the life of the app. That is pre-existing and bounded in practice by `tmux kill-session` and `SIGTERM`; a bounded wait with `SIGKILL` escalation would need an injected clock per CLAUDE.md and is left as follow-up rather than widened into this bug fix.

Two adjacent findings surfaced while measuring, both pre-existing and both left alone:

- `deinit`'s `io?.close()` is a *graceful* close and `startProcess` leaves a read outstanding, so the cleanup handler that closes the master fd does not run while that read is pending. A silent child therefore never receives the SIGHUP at all — measured: a `sleep 120` child was still running 5s after `cleanup()`. What actually ends the attach client in production is `tmuxBridge.cleanupSession`'s `tmux kill-session`. Orthogonal to the zombie leak, but the same code path.
- `LocalPTYTerminalView.processTerminated` calls `terminate()` after `LocalProcess` has already reaped the pid, so its `kill(shellPid, SIGTERM)` could in principle signal a recycled pid.

No spec and no feature flag: this restores existing intended behavior — `waitpid` harvests an exit status, it does not kill anything, and teardown itself is unchanged.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=E340325E-526C-43C4-A608-D5573274021C)
