### PR TITLE
Refactor: Fence local-only subsystems from worktrees whose files aren't on this disk

### DIFF
--- a/Sources/TBDApp/AppState.swift
+++ b/Sources/TBDApp/AppState.swift
@@ -443,6 +443,14 @@ final class AppState: ObservableObject {
         return findWorktree(id: id)
     }
 
+    /// The current selection, when it has files on this machine. Views that
+    /// operate on a directory bind to this instead of `selectedWorktree`, so
+    /// they cannot render against a worktree with no local checkout — the
+    /// optimistic `.creating` placeholder (`path: ""`) included.
+    var selectedLocalWorktree: LocalWorktree? {
+        selectedWorktree.flatMap(LocalWorktree.init)
+    }
+
     /// All pinned terminals across all worktrees, sorted by pinnedAt.
     var pinnedTerminals: [Terminal] {
         terminals.values.flatMap { $0 }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -631,7 +631,9 @@ private struct WorktreeDetailAreaView: View {
     var body: some View {
         HStack(spacing: 0) {
             TerminalContainerView()
-            if showFilePanel, let worktree = selectedWorktree, !worktree.path.isEmpty {
+            // Task 7: becomes `let worktree = selectedLocalWorktree`, which
+            // subsumes the empty-path check.
+            if showFilePanel, let worktree = selectedWorktree, !worktree.localPath.isEmpty {
                 FilePanelDivider(panelWidth: Binding(
                     get: { CGFloat(filePanelWidth) },
                     set: { filePanelWidth = Double($0) }

--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -622,18 +622,18 @@ private struct WorktreeDetailAreaView: View {
     @Binding var filePanelWidth: Double
     @State private var contentAreaHeight: CGFloat = 600
 
-    private var selectedWorktree: Worktree? {
-        guard let id = appState.selectedWorktreeIDs.first else { return nil }
-        // findWorktree also resolves scratch spaces (repo-less worktrees).
-        return appState.findWorktree(id: id)
+    /// The file panel reads a directory, so it binds to the local-only
+    /// selection. `LocalWorktree` subsumes the empty-path check this used to
+    /// spell out — the optimistic `.creating` placeholder has no directory yet
+    /// and does not convert.
+    private var selectedLocalWorktree: LocalWorktree? {
+        appState.selectedLocalWorktree
     }
 
     var body: some View {
         HStack(spacing: 0) {
             TerminalContainerView()
-            // Task 7: becomes `let worktree = selectedLocalWorktree`, which
-            // subsumes the empty-path check.
-            if showFilePanel, let worktree = selectedWorktree, !worktree.localPath.isEmpty {
+            if showFilePanel, let worktree = selectedLocalWorktree {
                 FilePanelDivider(panelWidth: Binding(
                     get: { CGFloat(filePanelWidth) },
                     set: { filePanelWidth = Double($0) }

--- a/Sources/TBDApp/FileViewer/FileViewerPanel.swift
+++ b/Sources/TBDApp/FileViewer/FileViewerPanel.swift
@@ -144,9 +144,9 @@ private func parseBranchDiff(_ output: String) -> [BranchFileChange] {
 // MARK: - FileViewerPanel
 
 struct FileViewerPanel: View {
-    // Task 7: this stored property becomes a `LocalWorktree`, and the
-    // `.localPath` reads below become `.path` on the wrapper.
-    let worktree: Worktree
+    /// Every read below is of a directory on this disk, so the panel takes the
+    /// proven-local wrapper rather than a bare `Worktree`.
+    let worktree: LocalWorktree
     @EnvironmentObject var appState: AppState
 
     @State private var staged: [GitFileStatus] = []
@@ -196,16 +196,16 @@ struct FileViewerPanel: View {
                         .padding(.vertical, 20)
                 }
                 if !staged.isEmpty {
-                    FileStatusSection(title: "Staged", files: staged, useIndexStatus: true, worktreePath: worktree.localPath, onFileClick: handleFileClick)
+                    FileStatusSection(title: "Staged", files: staged, useIndexStatus: true, worktreePath: worktree.path, onFileClick: handleFileClick)
                 }
                 if !unstaged.isEmpty {
-                    FileStatusSection(title: "Changes", files: unstaged, useIndexStatus: false, worktreePath: worktree.localPath, onFileClick: handleFileClick)
+                    FileStatusSection(title: "Changes", files: unstaged, useIndexStatus: false, worktreePath: worktree.path, onFileClick: handleFileClick)
                 }
                 if !untracked.isEmpty {
-                    FileStatusSection(title: "Untracked", files: untracked, useIndexStatus: false, worktreePath: worktree.localPath, onFileClick: handleFileClick)
+                    FileStatusSection(title: "Untracked", files: untracked, useIndexStatus: false, worktreePath: worktree.path, onFileClick: handleFileClick)
                 }
                 if !branchChanges.isEmpty {
-                    BranchChangeSection(title: "Branch", files: branchChanges, worktreePath: worktree.localPath, onFileClick: handleFileClick)
+                    BranchChangeSection(title: "Branch", files: branchChanges, worktreePath: worktree.path, onFileClick: handleFileClick)
                 }
             }
             .padding(.vertical, 4)
@@ -213,7 +213,7 @@ struct FileViewerPanel: View {
     }
 
     private func handleFileClick(_ relativePath: String, cmdClick: Bool) {
-        let fullPath = URL(fileURLWithPath: worktree.localPath).appendingPathComponent(relativePath).path
+        let fullPath = URL(fileURLWithPath: worktree.path).appendingPathComponent(relativePath).path
         var tabs = appState.tabs[worktree.id, default: []]
         let fileName = URL(fileURLWithPath: relativePath).lastPathComponent
 
@@ -243,10 +243,10 @@ struct FileViewerPanel: View {
 
     private func refresh() async {
         isLoading = true
-        async let statusTask = loadGitStatus(at: worktree.localPath)
+        async let statusTask = loadGitStatus(at: worktree.path)
         async let branchTask = worktree.status == .main
             ? [BranchFileChange]()
-            : loadBranchDiff(at: worktree.localPath, defaultBranch: defaultBranch)
+            : loadBranchDiff(at: worktree.path, defaultBranch: defaultBranch)
         let statuses = await statusTask
         staged = statuses.filter(\.isStaged)
         unstaged = statuses.filter(\.isUnstaged)

--- a/Sources/TBDApp/FileViewer/FileViewerPanel.swift
+++ b/Sources/TBDApp/FileViewer/FileViewerPanel.swift
@@ -144,6 +144,8 @@ private func parseBranchDiff(_ output: String) -> [BranchFileChange] {
 // MARK: - FileViewerPanel
 
 struct FileViewerPanel: View {
+    // Task 7: this stored property becomes a `LocalWorktree`, and the
+    // `.localPath` reads below become `.path` on the wrapper.
     let worktree: Worktree
     @EnvironmentObject var appState: AppState
 
@@ -194,16 +196,16 @@ struct FileViewerPanel: View {
                         .padding(.vertical, 20)
                 }
                 if !staged.isEmpty {
-                    FileStatusSection(title: "Staged", files: staged, useIndexStatus: true, worktreePath: worktree.path, onFileClick: handleFileClick)
+                    FileStatusSection(title: "Staged", files: staged, useIndexStatus: true, worktreePath: worktree.localPath, onFileClick: handleFileClick)
                 }
                 if !unstaged.isEmpty {
-                    FileStatusSection(title: "Changes", files: unstaged, useIndexStatus: false, worktreePath: worktree.path, onFileClick: handleFileClick)
+                    FileStatusSection(title: "Changes", files: unstaged, useIndexStatus: false, worktreePath: worktree.localPath, onFileClick: handleFileClick)
                 }
                 if !untracked.isEmpty {
-                    FileStatusSection(title: "Untracked", files: untracked, useIndexStatus: false, worktreePath: worktree.path, onFileClick: handleFileClick)
+                    FileStatusSection(title: "Untracked", files: untracked, useIndexStatus: false, worktreePath: worktree.localPath, onFileClick: handleFileClick)
                 }
                 if !branchChanges.isEmpty {
-                    BranchChangeSection(title: "Branch", files: branchChanges, worktreePath: worktree.path, onFileClick: handleFileClick)
+                    BranchChangeSection(title: "Branch", files: branchChanges, worktreePath: worktree.localPath, onFileClick: handleFileClick)
                 }
             }
             .padding(.vertical, 4)
@@ -211,7 +213,7 @@ struct FileViewerPanel: View {
     }
 
     private func handleFileClick(_ relativePath: String, cmdClick: Bool) {
-        let fullPath = URL(fileURLWithPath: worktree.path).appendingPathComponent(relativePath).path
+        let fullPath = URL(fileURLWithPath: worktree.localPath).appendingPathComponent(relativePath).path
         var tabs = appState.tabs[worktree.id, default: []]
         let fileName = URL(fileURLWithPath: relativePath).lastPathComponent
 
@@ -241,10 +243,10 @@ struct FileViewerPanel: View {
 
     private func refresh() async {
         isLoading = true
-        async let statusTask = loadGitStatus(at: worktree.path)
+        async let statusTask = loadGitStatus(at: worktree.localPath)
         async let branchTask = worktree.status == .main
             ? [BranchFileChange]()
-            : loadBranchDiff(at: worktree.path, defaultBranch: defaultBranch)
+            : loadBranchDiff(at: worktree.localPath, defaultBranch: defaultBranch)
         let statuses = await statusTask
         staged = statuses.filter(\.isStaged)
         unstaged = statuses.filter(\.isUnstaged)

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -5,14 +5,14 @@ import TBDShared
 struct StatusBarView: View {
     @EnvironmentObject var appState: AppState
 
-    // Task 7: both helpers below take a `LocalWorktree?`, which retires the
-    // hand-written empty-path guards.
-    /// Path + repo of the resolved single-selected worktree (nil when it has
-    /// no path yet). The caller resolves the selection once per body
-    /// evaluation and passes it in, so this never re-runs `findWorktree`.
-    private static func selectedWorktreeInfo(_ worktree: Worktree?) -> (path: String, repoID: UUID?)? {
-        guard let worktree, !worktree.localPath.isEmpty else { return nil }
-        return (worktree.localPath, worktree.repoID)
+    /// Path + repo of the resolved single-selected worktree. Taking a
+    /// `LocalWorktree?` is what makes "nil when it has no path yet" true —
+    /// the wrapper refuses an empty path, so no hand-written guard is needed.
+    /// The caller resolves the selection once per body evaluation and passes
+    /// it in, so this never re-runs `findWorktree`.
+    private static func selectedWorktreeInfo(_ worktree: LocalWorktree?) -> (path: String, repoID: UUID?)? {
+        guard let worktree else { return nil }
+        return (worktree.path, worktree.repoID)
     }
 
     /// The bottom-left cluster: where the selected worktree lives on disk and
@@ -28,14 +28,14 @@ struct StatusBarView: View {
     /// Pure helper so tests can exercise the formatting without a view.
     /// `home` is injected for the same reason.
     static func locationLabel(
-        _ worktree: Worktree?,
+        _ worktree: LocalWorktree?,
         home: String = NSHomeDirectory()
     ) -> LocationLabel? {
-        guard let worktree, !worktree.localPath.isEmpty else { return nil }
+        guard let worktree else { return nil }
         let branch = worktree.branch.trimmingCharacters(in: .whitespacesAndNewlines)
         return LocationLabel(
-            path: worktree.localPath,
-            displayPath: abbreviateWithTilde(worktree.localPath, home: home),
+            path: worktree.path,
+            displayPath: abbreviateWithTilde(worktree.path, home: home),
             branch: branch.isEmpty ? nil : branch
         )
     }
@@ -89,7 +89,9 @@ struct StatusBarView: View {
         // selectedWorktreeInfo (the editor button) uses it, instead of
         // re-running findWorktree per render.
         let selected = appState.selectedWorktreeIDs.count == 1
-            ? appState.selectedWorktreeIDs.first.flatMap { appState.findWorktree(id: $0) }
+            ? appState.selectedWorktreeIDs.first
+                .flatMap { appState.findWorktree(id: $0) }
+                .flatMap(LocalWorktree.init)
             : nil
         let selectedInfo = Self.selectedWorktreeInfo(selected)
         HStack {

--- a/Sources/TBDApp/Helpers/StatusBarView.swift
+++ b/Sources/TBDApp/Helpers/StatusBarView.swift
@@ -5,12 +5,14 @@ import TBDShared
 struct StatusBarView: View {
     @EnvironmentObject var appState: AppState
 
+    // Task 7: both helpers below take a `LocalWorktree?`, which retires the
+    // hand-written empty-path guards.
     /// Path + repo of the resolved single-selected worktree (nil when it has
     /// no path yet). The caller resolves the selection once per body
     /// evaluation and passes it in, so this never re-runs `findWorktree`.
     private static func selectedWorktreeInfo(_ worktree: Worktree?) -> (path: String, repoID: UUID?)? {
-        guard let worktree, !worktree.path.isEmpty else { return nil }
-        return (worktree.path, worktree.repoID)
+        guard let worktree, !worktree.localPath.isEmpty else { return nil }
+        return (worktree.localPath, worktree.repoID)
     }
 
     /// The bottom-left cluster: where the selected worktree lives on disk and
@@ -29,11 +31,11 @@ struct StatusBarView: View {
         _ worktree: Worktree?,
         home: String = NSHomeDirectory()
     ) -> LocationLabel? {
-        guard let worktree, !worktree.path.isEmpty else { return nil }
+        guard let worktree, !worktree.localPath.isEmpty else { return nil }
         let branch = worktree.branch.trimmingCharacters(in: .whitespacesAndNewlines)
         return LocationLabel(
-            path: worktree.path,
-            displayPath: abbreviateWithTilde(worktree.path, home: home),
+            path: worktree.localPath,
+            displayPath: abbreviateWithTilde(worktree.localPath, home: home),
             branch: branch.isEmpty ? nil : branch
         )
     }
@@ -76,7 +78,7 @@ struct StatusBarView: View {
     private var footerLabel: (text: String, tooltip: String?) {
         let version = "v\(TBDConstants.version)"
         guard let sourcePath = Self.sourceWorktreePath,
-              let worktree = appState.worktrees.values.flatMap({ $0 }).first(where: { $0.path == sourcePath }) else {
+              let worktree = appState.worktrees.values.flatMap({ $0 }).first(where: { $0.localPath == sourcePath }) else {
             return (version, nil)
         }
         return (worktree.displayName, version)

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -43,9 +43,10 @@ enum ParkedPaneWakeModel {
 /// based on PaneContent type. Replaces the former TerminalPanelPlaceholder.
 struct PanePlaceholder: View {
     let content: PaneContent
-    // Task 7: this stored property becomes a `LocalWorktree`, and the
-    // `.localPath` reads below become `.path` on the wrapper.
-    let worktree: Worktree
+    /// Panes root a terminal's working directory and the code viewer's file
+    /// resolution at this worktree's checkout, so the pane tree carries the
+    /// proven-local wrapper rather than a bare `Worktree`.
+    let worktree: LocalWorktree
     let tabID: UUID?
     @Binding var layout: LayoutNode
     @EnvironmentObject var appState: AppState
@@ -343,7 +344,7 @@ struct PanePlaceholder: View {
         case .webview(_, let url):
             WebviewPaneView(url: url, state: webviewState)
         case .codeViewer(_, let path):
-            CodeViewerPaneView(path: path, worktreePath: worktree.localPath, showSourceCode: showSourceCode)
+            CodeViewerPaneView(path: path, worktreePath: worktree.path, showSourceCode: showSourceCode)
         case .note(let noteID):
             NotePaneView(noteID: noteID, worktreeID: worktree.id)
         case .liveTranscript(_, let terminalID):
@@ -411,7 +412,7 @@ struct PanePlaceholder: View {
                     tmuxWindowID: terminal.tmuxWindowID,
                     tmuxBridge: appState.tmuxBridge,
                     tabCloseContext: tabID.map { TabCloseContext(worktreeID: worktree.id, tabID: $0) },
-                    worktreePath: worktree.localPath,
+                    worktreePath: worktree.path,
                     remoteURL: appState.repos.first(where: { $0.id == worktree.repoID })?.remoteURL,
                     onFilePathClicked: { path in
                         let result = routeFileClick(into: layout, terminalID: terminalID, path: path)

--- a/Sources/TBDApp/Panes/PanePlaceholder.swift
+++ b/Sources/TBDApp/Panes/PanePlaceholder.swift
@@ -43,6 +43,8 @@ enum ParkedPaneWakeModel {
 /// based on PaneContent type. Replaces the former TerminalPanelPlaceholder.
 struct PanePlaceholder: View {
     let content: PaneContent
+    // Task 7: this stored property becomes a `LocalWorktree`, and the
+    // `.localPath` reads below become `.path` on the wrapper.
     let worktree: Worktree
     let tabID: UUID?
     @Binding var layout: LayoutNode
@@ -341,7 +343,7 @@ struct PanePlaceholder: View {
         case .webview(_, let url):
             WebviewPaneView(url: url, state: webviewState)
         case .codeViewer(_, let path):
-            CodeViewerPaneView(path: path, worktreePath: worktree.path, showSourceCode: showSourceCode)
+            CodeViewerPaneView(path: path, worktreePath: worktree.localPath, showSourceCode: showSourceCode)
         case .note(let noteID):
             NotePaneView(noteID: noteID, worktreeID: worktree.id)
         case .liveTranscript(_, let terminalID):
@@ -409,7 +411,7 @@ struct PanePlaceholder: View {
                     tmuxWindowID: terminal.tmuxWindowID,
                     tmuxBridge: appState.tmuxBridge,
                     tabCloseContext: tabID.map { TabCloseContext(worktreeID: worktree.id, tabID: $0) },
-                    worktreePath: worktree.path,
+                    worktreePath: worktree.localPath,
                     remoteURL: appState.repos.first(where: { $0.id == worktree.repoID })?.remoteURL,
                     onFilePathClicked: { path in
                         let result = routeFileClick(into: layout, terminalID: terminalID, path: path)

--- a/Sources/TBDApp/ScratchArchivedView.swift
+++ b/Sources/TBDApp/ScratchArchivedView.swift
@@ -73,7 +73,7 @@ struct ScratchArchivedView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
-                    Text(worktree.path)
+                    Text(worktree.localPath)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -36,8 +36,14 @@ struct RowActionMenuActions {
         }
     }
 
-    // Task 7: the empty-path guards here and in `context` become
-    // `LocalWorktree(worktree)`, and `pathIsEmpty` its nil check.
+    /// This row's worktree when it has a checkout on this disk. The
+    /// path-dependent actions (`openInFinder`, `copyPath`) and the hook probe
+    /// resolve through it, so none of them can act on a directory that is not
+    /// there; `RowActionMenu.Context.pathIsEmpty` is its nil check.
+    private var localWorktree: LocalWorktree? {
+        LocalWorktree(worktree)
+    }
+
     /// Does a `preSession` hook resolve for this worktree? Uses the SAME
     /// five-step chain the daemon executes (`HookResolver` lives in TBDShared
     /// precisely so this can't drift): app per-repo config → `.worktree-hooks/`
@@ -48,13 +54,13 @@ struct RowActionMenuActions {
     /// `appHookPath` is nil for them and resolution falls through to the
     /// in-directory hook or the global default.
     private var hasPreSessionHook: Bool {
-        guard !worktree.localPath.isEmpty else { return false }
-        let appHookPath = worktree.repoID.map {
+        guard let local = localWorktree else { return false }
+        let appHookPath = local.repoID.map {
             TBDConstants.hookPath(repoID: $0, eventName: HookEvent.preSession.rawValue)
         }
         return HookResolver().resolve(
             event: .preSession,
-            repoPath: worktree.localPath,
+            repoPath: local.path,
             appHookPath: appHookPath
         ) != nil
     }
@@ -75,7 +81,7 @@ struct RowActionMenuActions {
             },
             autoHibernateEnabled: appState.autoHibernateEnabled,
             hasActiveChildren: !appState.children(of: worktree.id).isEmpty,
-            pathIsEmpty: worktree.localPath.isEmpty,
+            pathIsEmpty: localWorktree == nil,
             hasRepoID: worktree.repoID != nil,
             isScratch: worktree.isScratch,
             isPinned: worktree.pinnedAt != nil,
@@ -100,12 +106,18 @@ struct RowActionMenuActions {
         case .rename:
             onRename()
 
+        // Both path actions are hidden when `pathIsEmpty`, so the nil arm is
+        // unreachable through the menu — the binding is what proves it.
         case .openInFinder:
-            NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.localPath)
+            if let local = localWorktree {
+                NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: local.path)
+            }
 
         case .copyPath:
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(worktree.localPath, forType: .string)
+            if let local = localWorktree {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(local.path, forType: .string)
+            }
 
         case .copyBranch:
             NSPasteboard.general.clearContents()

--- a/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
+++ b/Sources/TBDApp/Sidebar/RowActionMenuActions.swift
@@ -36,6 +36,8 @@ struct RowActionMenuActions {
         }
     }
 
+    // Task 7: the empty-path guards here and in `context` become
+    // `LocalWorktree(worktree)`, and `pathIsEmpty` its nil check.
     /// Does a `preSession` hook resolve for this worktree? Uses the SAME
     /// five-step chain the daemon executes (`HookResolver` lives in TBDShared
     /// precisely so this can't drift): app per-repo config → `.worktree-hooks/`
@@ -46,13 +48,13 @@ struct RowActionMenuActions {
     /// `appHookPath` is nil for them and resolution falls through to the
     /// in-directory hook or the global default.
     private var hasPreSessionHook: Bool {
-        guard !worktree.path.isEmpty else { return false }
+        guard !worktree.localPath.isEmpty else { return false }
         let appHookPath = worktree.repoID.map {
             TBDConstants.hookPath(repoID: $0, eventName: HookEvent.preSession.rawValue)
         }
         return HookResolver().resolve(
             event: .preSession,
-            repoPath: worktree.path,
+            repoPath: worktree.localPath,
             appHookPath: appHookPath
         ) != nil
     }
@@ -73,7 +75,7 @@ struct RowActionMenuActions {
             },
             autoHibernateEnabled: appState.autoHibernateEnabled,
             hasActiveChildren: !appState.children(of: worktree.id).isEmpty,
-            pathIsEmpty: worktree.path.isEmpty,
+            pathIsEmpty: worktree.localPath.isEmpty,
             hasRepoID: worktree.repoID != nil,
             isScratch: worktree.isScratch,
             isPinned: worktree.pinnedAt != nil,
@@ -99,11 +101,11 @@ struct RowActionMenuActions {
             onRename()
 
         case .openInFinder:
-            NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.path)
+            NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: worktree.localPath)
 
         case .copyPath:
             NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(worktree.path, forType: .string)
+            NSPasteboard.general.setString(worktree.localPath, forType: .string)
 
         case .copyBranch:
             NSPasteboard.general.clearContents()

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -308,8 +308,9 @@ struct WorktreeRowView: View {
         // every sidebar row on every body evaluation. Promoted rows are
         // excluded — promotion MOVES the folder, so their directory is expected
         // to be gone; see AppState.scratchRowIsDimmed.
+        // Task 7: the existence probe goes through `LocalWorktree(worktree)`.
         .opacity(AppState.scratchRowIsDimmed(
-            worktree, directoryExists: FileManager.default.fileExists(atPath: worktree.path)
+            worktree, directoryExists: FileManager.default.fileExists(atPath: worktree.localPath)
         ) ? 0.5 : 1.0)
         // The worktree-row hover surface is intentionally reserved: per-session
         // account facts and switching live in the tab bar, and this hover is

--- a/Sources/TBDApp/Sidebar/WorktreeRowView.swift
+++ b/Sources/TBDApp/Sidebar/WorktreeRowView.swift
@@ -308,9 +308,13 @@ struct WorktreeRowView: View {
         // every sidebar row on every body evaluation. Promoted rows are
         // excluded — promotion MOVES the folder, so their directory is expected
         // to be gone; see AppState.scratchRowIsDimmed.
-        // Task 7: the existence probe goes through `LocalWorktree(worktree)`.
+        // The probe runs through `LocalWorktree`, so a row with no checkout on
+        // this disk reports "does not exist" without ever calling `fileExists`
+        // on an empty path.
         .opacity(AppState.scratchRowIsDimmed(
-            worktree, directoryExists: FileManager.default.fileExists(atPath: worktree.localPath)
+            worktree,
+            directoryExists: LocalWorktree(worktree)
+                .map { FileManager.default.fileExists(atPath: $0.path) } ?? false
         ) ? 0.5 : 1.0)
         // The worktree-row hover surface is intentionally reserved: per-session
         // account facts and switching live in the tab bar, and this hover is

--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -110,7 +110,11 @@ private struct PinnedTerminalCell: View {
         // scratch spaces live only in `scratchWorktrees`, never the
         // repo-grouped dict, so a dict-only lookup leaves scratch pins stuck
         // on "Loading..." forever.
+        // Resolved as a `LocalWorktree` so the cell cannot hand
+        // `TerminalPanelView` a working directory that is not on this disk; a
+        // row with no checkout keeps the existing "Loading..." placeholder.
         let worktree = appState.findWorktree(id: terminal.worktreeID)
+            .flatMap(LocalWorktree.init)
         VStack(spacing: 0) {
             // Header: pin icon + worktree name
             HStack(spacing: 4) {
@@ -148,7 +152,7 @@ private struct PinnedTerminalCell: View {
                     tmuxServer: worktree.tmuxServer,
                     tmuxWindowID: terminal.tmuxWindowID,
                     tmuxBridge: appState.tmuxBridge,
-                    worktreePath: worktree.localPath,
+                    worktreePath: worktree.path,
                     onMissingWindow: {
                         await appState.requestAutomaticTerminalRecreation(terminalID: terminal.id)
                     }

--- a/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
+++ b/Sources/TBDApp/Terminal/PinnedTerminalDock.swift
@@ -148,7 +148,7 @@ private struct PinnedTerminalCell: View {
                     tmuxServer: worktree.tmuxServer,
                     tmuxWindowID: terminal.tmuxWindowID,
                     tmuxBridge: appState.tmuxBridge,
-                    worktreePath: worktree.path,
+                    worktreePath: worktree.localPath,
                     onMissingWindow: {
                         await appState.requestAutomaticTerminalRecreation(terminalID: terminal.id)
                     }

--- a/Sources/TBDApp/Terminal/SplitLayoutView.swift
+++ b/Sources/TBDApp/Terminal/SplitLayoutView.swift
@@ -5,7 +5,7 @@ import TBDShared
 
 struct SplitLayoutView: View {
     let node: LayoutNode
-    let worktree: Worktree
+    let worktree: LocalWorktree
     let tabID: UUID?
     @Binding var layout: LayoutNode
 
@@ -41,7 +41,7 @@ struct SplitContainer: View {
     let direction: SplitDirection
     let children: [LayoutNode]
     let ratios: [CGFloat]
-    let worktree: Worktree
+    let worktree: LocalWorktree
     let tabID: UUID?
     @Binding var layout: LayoutNode
 

--- a/Sources/TBDApp/Terminal/TerminalContainerView.swift
+++ b/Sources/TBDApp/Terminal/TerminalContainerView.swift
@@ -201,7 +201,7 @@ struct SingleWorktreeView: View {
                 // measured size to MainAreaSizeKey so the daemon-side tmux
                 // resize matches the actual SwiftTerm pane area (tab bar +
                 // divider above and the resume banner below are excluded).
-                layoutContent(worktree: worktree)
+                layoutContent(worktree: LocalWorktree(worktree))
                     .background(GeometryReader { geometry in
                         Color.clear.preference(key: MainAreaSizeKey.self, value: geometry.size)
                     })
@@ -264,11 +264,16 @@ struct SingleWorktreeView: View {
         }
     }
 
+    /// Panes root a terminal's working directory at the checkout, so the split
+    /// layout takes the proven-local wrapper. A selection with no directory on
+    /// this disk — the optimistic `.creating` placeholder, which writes
+    /// `path: ""` — has no tabs either, so it falls through to the same empty
+    /// state it always did.
     @ViewBuilder
-    private func layoutContent(worktree: Worktree) -> some View {
+    private func layoutContent(worktree: LocalWorktree?) -> some View {
         if appState.historyActiveWorktrees.contains(worktreeID) {
             HistoryPaneView(worktreeID: worktreeID)
-        } else if let tab = activeTab {
+        } else if let tab = activeTab, let worktree {
             let layoutBinding = Binding<LayoutNode>(
                 get: { appState.layouts[tab.id] ?? .pane(tab.content) },
                 set: { appState.layouts[tab.id] = $0 }
@@ -558,6 +563,12 @@ private struct MultiWorktreeCell: View {
         appState.findWorktree(id: worktreeID)
     }
 
+    /// The same row, proven to have a checkout on this disk. The header renders
+    /// from `worktree` (a name needs no directory); the pane below needs one.
+    private var localWorktree: LocalWorktree? {
+        worktree.flatMap(LocalWorktree.init)
+    }
+
     /// The terminal shown in this cell — derived from the active tab's layout
     /// so it stays consistent with the dock's visibleTerminalIDs filter.
     private var primaryTerminal: Terminal? {
@@ -621,7 +632,7 @@ private struct MultiWorktreeCell: View {
 
     @ViewBuilder
     private var terminalContent: some View {
-        if let worktree, let terminal = primaryTerminal {
+        if let worktree = localWorktree, let terminal = primaryTerminal {
             let layoutBinding = Binding<LayoutNode>(
                 get: {
                     appState.gridLayouts[worktreeID]

--- a/Sources/TBDCLI/Commands/ScratchCommands.swift
+++ b/Sources/TBDCLI/Commands/ScratchCommands.swift
@@ -28,7 +28,7 @@ struct ScratchNew: AsyncParsableCommand {
         if json { printJSON(wt) } else {
             print("Created scratch space: \(wt.displayName)")
             print("  ID:   \(wt.id)")
-            print("  Path: \(wt.path)")
+            print("  Path: \(wt.localPath)")
         }
     }
 }
@@ -50,7 +50,7 @@ struct ScratchList: AsyncParsableCommand {
         if scratch.isEmpty { print("No scratch spaces. Use 'tbd scratch new' to create one."); return }
         for wt in scratch {
             let promoted = wt.promotedToRepoID != nil ? "  [promoted]" : ""
-            print("\(wt.id)  \(wt.displayName)\(promoted)  \(wt.path)")
+            print("\(wt.id)  \(wt.displayName)\(promoted)  \(wt.localPath)")
         }
     }
 }

--- a/Sources/TBDCLI/Commands/WorktreeCommands.swift
+++ b/Sources/TBDCLI/Commands/WorktreeCommands.swift
@@ -151,7 +151,7 @@ struct WorktreeCreate: AsyncParsableCommand {
             print("Created worktree: \(worktree.displayName)")
             print("  ID:     \(worktree.id)")
             print("  Branch: \(worktree.branch)")
-            print("  Path:   \(worktree.path)")
+            print("  Path:   \(worktree.localPath)")
         }
     }
 
@@ -329,7 +329,7 @@ struct WorktreeAdopt: AsyncParsableCommand {
             print("Adopted worktree: \(worktree.displayName)")
             print("  ID:     \(worktree.id)")
             print("  Branch: \(worktree.branch)")
-            print("  Path:   \(worktree.path)")
+            print("  Path:   \(worktree.localPath)")
         }
     }
 
@@ -526,7 +526,7 @@ struct WorktreeRevive: AsyncParsableCommand {
             printJSON(worktree)
         } else {
             print("Worktree revived: \(worktree.displayName)")
-            print("  Path: \(worktree.path)")
+            print("  Path: \(worktree.localPath)")
         }
     }
 }

--- a/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
+++ b/Sources/TBDDaemon/Claude/ClaudeTrustSeeder.swift
@@ -151,9 +151,9 @@ enum ClaudeTrustSeeder {
         // in. If the symlink-resolved form differs, seed both — harmless, and it
         // defends against a cwd/symlink mismatch between what TBD stores and what
         // Claude derives at runtime.
-        var projectKeys = [worktree.path]
-        let resolvedPath = URL(fileURLWithPath: worktree.path).resolvingSymlinksInPath().path
-        if resolvedPath != worktree.path {
+        var projectKeys = [worktree.localPath]
+        let resolvedPath = URL(fileURLWithPath: worktree.localPath).resolvingSymlinksInPath().path
+        if resolvedPath != worktree.localPath {
             projectKeys.append(resolvedPath)
         }
 
@@ -161,7 +161,7 @@ enum ClaudeTrustSeeder {
             projectKeys: projectKeys,
             configDirURL: configDirURL,
             claudeJSONPath: claudeJSONPath,
-            worktreePath: worktree.path)
+            worktreePath: worktree.localPath)
     }
 
     /// The process-wide lane every seed's read-merge-write runs on.

--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -259,7 +259,7 @@ public struct LimitResumeActuator: LimitResumeActuating {
         //    (cancel silently), same as a dead window.
         guard let terminal = ((try? await db.terminals.get(id: resume.terminalID)) ?? nil),
               !terminal.isParked,
-              let worktree = ((try? await db.worktrees.get(id: terminal.worktreeID)) ?? nil)
+              let worktree = ((try? await db.worktrees.getLocal(id: terminal.worktreeID)) ?? nil)
         else { return .notEligible(.terminalGone) }
         let server = worktree.tmuxServer
         guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {

--- a/Sources/TBDDaemon/Database/Database.swift
+++ b/Sources/TBDDaemon/Database/Database.swift
@@ -1219,6 +1219,21 @@ public final class TBDDatabase: Sendable {
                 type: .boolean, defaults: false)
         }
 
+        // Where a worktree's files live. Backfilling 'local' states a fact
+        // rather than a preference — every pre-v70 row IS local — so no later
+        // migration has to force it (contrast auto_hibernate_enabled, whose
+        // backfilled default needed a forcing UPDATE in v50). `providerName`
+        // and `providerSessionID` are set together with location = 'remote'
+        // and are null for every local row.
+        migrator.registerMigration("v70_worktree_location") { db in
+            try db.addColumnIfMissing(
+                table: "worktree", column: "location", type: .text, defaults: "local")
+            try db.addColumnIfMissing(
+                table: "worktree", column: "providerName", type: .text)
+            try db.addColumnIfMissing(
+                table: "worktree", column: "providerSessionID", type: .text)
+        }
+
         return migrator
     }
 }

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -203,6 +203,14 @@ public struct WorktreeStore: Sendable {
     /// new worktree's sibling group (same parentWorktreeID), so nested
     /// children get their own contiguous ordering separate from top-level
     /// worktrees in the same repo.
+    ///
+    /// `path` is used verbatim for a local worktree and **ignored** for a
+    /// remote one, whose path is derived from `location` — see
+    /// `WorktreeLocation.storagePath` for why a remote row cannot store the
+    /// caller's value (or an empty placeholder). Deriving here rather than at
+    /// the call site means no future caller can forget and collide with an
+    /// existing remote row on the column's UNIQUE constraint. Prefer
+    /// `createRemote` for remote rows, which does not ask for a path at all.
     public func create(
         repoID: UUID,
         name: String,
@@ -235,7 +243,7 @@ public struct WorktreeStore: Sendable {
                 name: name,
                 displayName: displayName ?? name,
                 branch: branch,
-                path: path,
+                path: location.storagePath ?? path,
                 status: status,
                 tmuxServer: tmuxServer,
                 sortOrder: maxOrder + 1,
@@ -247,6 +255,36 @@ public struct WorktreeStore: Sendable {
             try record.insert(db)
             return wt
         }
+    }
+
+    /// Create a row for an agent session on a machine TBD does not manage.
+    ///
+    /// There is no path and no tmux server to pass: the path is derived from
+    /// the provider binding (`WorktreeLocation.storagePath`) and `tmuxServer`
+    /// is empty, since a remote lane has no tmux server of its own. Both facts
+    /// live here rather than at every call site so that "what does a remote
+    /// row store in the local-only columns" has exactly one answer.
+    public func createRemote(
+        repoID: UUID,
+        name: String,
+        displayName: String? = nil,
+        branch: String,
+        provider: String,
+        sessionID: String,
+        status: WorktreeStatus = .active,
+        parentWorktreeID: UUID? = nil
+    ) async throws -> Worktree {
+        try await create(
+            repoID: repoID,
+            name: name,
+            displayName: displayName,
+            branch: branch,
+            path: "",
+            tmuxServer: "",
+            status: status,
+            parentWorktreeID: parentWorktreeID,
+            location: .remote(provider: provider, sessionID: sessionID)
+        )
     }
 
     /// Create a repo-less "scratch" worktree row (repoID == nil). branch is "".

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -47,7 +47,7 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.name = wt.name
         self.displayName = wt.displayName
         self.branch = wt.branch
-        self.path = wt.path
+        self.path = wt.localPath
         self.status = wt.status.rawValue
         self.hasConflicts = wt.hasConflicts
         self.createdAt = wt.createdAt

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -37,6 +37,9 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
     var panel_surface_imported_at: Date?  // stamped once the legacy layout is imported; nil = never imported
     var pinnedAt: Date?  // sidebar dock pin; nil = unpinned
     var pinSortOrder: Int?  // sidebar dock ordering; nil = falls back to pinnedAt
+    var location: String?  // "local" | "remote"; nil reads as local
+    var providerName: String?  // set only alongside location == "remote"
+    var providerSessionID: String?  // set only alongside location == "remote"
 
     init(from wt: Worktree) {
         self.id = wt.id.uuidString
@@ -68,6 +71,16 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
         self.panel_surface_imported_at = nil  // new worktrees start unimported; stamped via stampPanelSurfaceImported
         self.pinnedAt = wt.pinnedAt
         self.pinSortOrder = wt.pinSortOrder
+        switch wt.location {
+        case .local:
+            self.location = "local"
+            self.providerName = nil
+            self.providerSessionID = nil
+        case let .remote(provider, sessionID):
+            self.location = "remote"
+            self.providerName = provider
+            self.providerSessionID = sessionID
+        }
     }
 
     /// Failable decode: skips (returns nil after a logged warning) only when the
@@ -104,6 +117,16 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             decodeLogger.warning("worktree row \(id, privacy: .public): unknown status \(status, privacy: .public); defaulting to .active")
             worktreeStatus = .active
         }
+        // Mirrors `Worktree.init(from:)`: only a complete "remote" triple is a
+        // remote row. A null column (pre-v70), an unknown kind, or a "remote"
+        // missing either provider field reads as local rather than dropping
+        // the row.
+        let worktreeLocation: WorktreeLocation
+        if location == "remote", let providerName, let providerSessionID {
+            worktreeLocation = .remote(provider: providerName, sessionID: providerSessionID)
+        } else {
+            worktreeLocation = .local
+        }
         return Worktree(
             id: uuid,
             repoID: repoID.flatMap { UUID(uuidString: $0) },
@@ -127,7 +150,8 @@ struct WorktreeRecord: Codable, FetchableRecord, PersistableRecord, Sendable {
             prNumber: pr_number,
             foreignHead: foreign_head ?? false,
             pinnedAt: pinnedAt,
-            pinSortOrder: pinSortOrder
+            pinSortOrder: pinSortOrder,
+            location: worktreeLocation
         )
     }
 }
@@ -188,7 +212,8 @@ public struct WorktreeStore: Sendable {
         tmuxServer: String,
         status: WorktreeStatus = .active,
         parentWorktreeID: UUID? = nil,
-        prNumber: Int? = nil
+        prNumber: Int? = nil,
+        location: WorktreeLocation = .local
     ) async throws -> Worktree {
         try await writer.write { db in
             let maxOrder: Int
@@ -215,7 +240,8 @@ public struct WorktreeStore: Sendable {
                 tmuxServer: tmuxServer,
                 sortOrder: maxOrder + 1,
                 parentWorktreeID: parentWorktreeID,
-                prNumber: prNumber
+                prNumber: prNumber,
+                location: location
             )
             let record = WorktreeRecord(from: wt)
             try record.insert(db)

--- a/Sources/TBDDaemon/Database/WorktreeStore.swift
+++ b/Sources/TBDDaemon/Database/WorktreeStore.swift
@@ -476,6 +476,49 @@ public struct WorktreeStore: Sendable {
         }
     }
 
+    /// `get(id:)` restricted to worktrees with files on this machine.
+    ///
+    /// Local-only callers use this so a remote row cannot reach code that
+    /// would operate on a directory that does not exist. Returning nil for a
+    /// remote id is deliberate and is **not** an error: the caller's existing
+    /// not-found branch is the correct response to "this worktree has nothing
+    /// local to act on".
+    public func getLocal(id: UUID) async throws -> LocalWorktree? {
+        try await get(id: id).flatMap(LocalWorktree.init)
+    }
+
+    /// `list(...)` restricted to worktrees with files on this machine. Takes
+    /// the same filters as `list(...)` and forwards them unchanged.
+    ///
+    /// The filtering happens in Swift rather than SQL so that
+    /// `LocalWorktree.init?` stays the single definition of "local" — a WHERE
+    /// clause would be a second one, free to drift from the empty-path rule.
+    ///
+    /// Consequence: `limit`/`offset` are applied by SQL *before* the filter, so
+    /// a page containing remote rows yields fewer than `limit` locals.
+    /// Acceptable because no local-only caller paginates — the only caller that
+    /// passes `limit`/`offset` is the location-neutral `worktree.list` RPC,
+    /// which stays on `list(...)`.
+    public func listLocal(
+        repoID: UUID? = nil,
+        status: WorktreeStatus? = nil,
+        excludeArchived: Bool = false,
+        scratchOnly: Bool = false,
+        limit: Int? = nil,
+        offset: Int? = nil,
+        nameQuery: String? = nil
+    ) async throws -> [LocalWorktree] {
+        try await list(
+            repoID: repoID,
+            status: status,
+            excludeArchived: excludeArchived,
+            scratchOnly: scratchOnly,
+            limit: limit,
+            offset: offset,
+            nameQuery: nameQuery
+        ).compactMap(LocalWorktree.init)
+    }
+
     /// Archive a worktree (set status to archived and record the timestamp).
     /// Optionally saves Claude session IDs and the captured HEAD SHA in the
     /// same transaction so they survive terminal deletion and crashes.

--- a/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
+++ b/Sources/TBDDaemon/GC/DeletionQueueCollector.swift
@@ -99,7 +99,7 @@ public struct DeletionQueueCollector: Sendable {
         scratchPrefix: String
     ) async -> [InterruptedArchive] {
         let surviving = worktrees.filter {
-            $0.status == .archived && FileManager.default.fileExists(atPath: $0.path)
+            $0.status == .archived && FileManager.default.fileExists(atPath: $0.localPath)
         }
 
         // repoPath -> (lockedPaths, listingSucceeded)
@@ -122,10 +122,10 @@ public struct DeletionQueueCollector: Sendable {
             let prefixes = wt.repoID.flatMap { prefixesByRepoID[$0] } ?? [scratchPrefix]
             var locked = false
             if let repoPath, let state = lockState[repoPath] {
-                locked = !state.ok || state.locked.contains(resolvedPath(wt.path))
+                locked = !state.ok || state.locked.contains(resolvedPath(wt.localPath))
             }
             return InterruptedArchive(
-                worktreeID: wt.id, path: wt.path,
+                worktreeID: wt.id, path: wt.localPath,
                 repoPath: repoPath, allowedPrefixes: prefixes, locked: locked,
                 archivedAt: wt.archivedAt
             )

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -426,8 +426,8 @@ public actor OrphanGC {
     ) async {
         let repoPathByID = Dictionary(uniqueKeysWithValues: repos.map { ($0.id, $0.path) })
         let gone = archived
-            .filter { !FileManager.default.fileExists(atPath: $0.path) }
-            .map { (worktreePath: $0.path, repoPath: $0.repoID.flatMap { repoPathByID[$0] } ?? "") }
+            .filter { !FileManager.default.fileExists(atPath: $0.localPath) }
+            .map { (worktreePath: $0.localPath, repoPath: $0.repoID.flatMap { repoPathByID[$0] } ?? "") }
 
         guard !dryRun else {
             for entry in gone {
@@ -472,7 +472,7 @@ public actor OrphanGC {
             return
         }
         guard let rows = try? await db.worktrees.list(repoID: repoID) else { return }
-        let pairs = rows.map { (worktreePath: $0.path, repoPath: repoPath) }
+        let pairs = rows.map { (worktreePath: $0.localPath, repoPath: repoPath) }
         let records = await scratchpadCollector.reconcile(knownPaths: pairs, now: now())
         for record in records {
             await insertReapRecord(record)

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -425,9 +425,18 @@ public actor OrphanGC {
         planned: inout [String], reaped: inout Int
     ) async {
         let repoPathByID = Dictionary(uniqueKeysWithValues: repos.map { ($0.id, $0.path) })
+        // Narrowed to local rows, and that is load-bearing rather than
+        // tidiness: "its directory is already gone" is the whole reap
+        // criterion, and a remote row's path — the synthetic `remote://` URI —
+        // is absent from disk by construction, so every archived remote lane
+        // would otherwise be a standing reap candidate on every sweep. The
+        // narrowing happens here rather than at the caller's shared read
+        // because `reclaimDeletionQueue` consumes that same list and asks a
+        // different question of it.
         let gone = archived
-            .filter { !FileManager.default.fileExists(atPath: $0.localPath) }
-            .map { (worktreePath: $0.localPath, repoPath: $0.repoID.flatMap { repoPathByID[$0] } ?? "") }
+            .compactMap(LocalWorktree.init)
+            .filter { !FileManager.default.fileExists(atPath: $0.path) }
+            .map { (worktreePath: $0.path, repoPath: $0.repoID.flatMap { repoPathByID[$0] } ?? "") }
 
         guard !dryRun else {
             for entry in gone {
@@ -471,8 +480,12 @@ public actor OrphanGC {
             """)
             return
         }
-        guard let rows = try? await db.worktrees.list(repoID: repoID) else { return }
-        let pairs = rows.map { (worktreePath: $0.localPath, repoPath: repoPath) }
+        // `listLocal` for the same reason the sweep's own reconciliation
+        // narrows: a remote row's synthetic `remote://` path is absent from
+        // disk by construction, which is exactly the shape `reconcile` reads
+        // as "the worktree is gone, reap its scratchpad".
+        guard let rows = try? await db.worktrees.listLocal(repoID: repoID) else { return }
+        let pairs = rows.map { (worktreePath: $0.path, repoPath: repoPath) }
         let records = await scratchpadCollector.reconcile(knownPaths: pairs, now: now())
         for record in records {
             await insertReapRecord(record)

--- a/Sources/TBDDaemon/GC/OrphanGC.swift
+++ b/Sources/TBDDaemon/GC/OrphanGC.swift
@@ -234,7 +234,7 @@ public actor OrphanGC {
         // `.deleting/<uuid>` is there because TBD renamed it there, so it
         // needs no provenance gate.
         for row in archived {
-            let parent = (row.path as NSString).deletingLastPathComponent
+            let parent = (row.localPath as NSString).deletingLastPathComponent
             guard parent.hasPrefix("/"), parent != "/" else { continue }
             pools.insert(parent)
         }
@@ -365,9 +365,9 @@ public actor OrphanGC {
         dryRun: Bool, planned: inout [String]
     ) async {
         var goneByRepo: [String: [String]] = [:]
-        for row in archived where !FileManager.default.fileExists(atPath: row.path) {
+        for row in archived where !FileManager.default.fileExists(atPath: row.localPath) {
             guard let repoID = row.repoID, let repoPath = repoPathByID[repoID] else { continue }
-            goneByRepo[repoPath, default: []].append(row.path)
+            goneByRepo[repoPath, default: []].append(row.localPath)
         }
 
         for (repoPath, paths) in goneByRepo.sorted(by: { $0.key < $1.key }) {

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -828,7 +828,7 @@ public actor HibernationCoordinator {
                 try await tmux.respawnWindow(
                     server: server,
                     windowID: windowID,
-                    cwd: worktree.path,
+                    cwd: worktree.localPath,
                     shellCommand: spawnCommand,
                     env: env,
                     sensitiveEnv: sensitiveEnv,
@@ -856,7 +856,7 @@ public actor HibernationCoordinator {
                 let bootstrapWindowID = try await tmux.ensureServer(
                     server: server,
                     session: "main",
-                    cwd: worktree.path,
+                    cwd: worktree.localPath,
                     cols: resolvedCols,
                     rows: resolvedRows
                 )
@@ -864,7 +864,7 @@ public actor HibernationCoordinator {
                 let window = try await tmux.createWindow(
                     server: server,
                     session: "main",
-                    cwd: worktree.path,
+                    cwd: worktree.localPath,
                     shellCommand: spawnCommand,
                     env: env,
                     sensitiveEnv: sensitiveEnv,

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -352,7 +352,7 @@ public actor HibernationCoordinator {
         guard let sessionID = terminal.claudeSessionID else {
             return .notEligible(reason: "No session id to resume later")
         }
-        guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return .notFound
         }
         let server = worktree.tmuxServer
@@ -546,7 +546,7 @@ public actor HibernationCoordinator {
         // conflation this whole change exists to remove. Practically
         // unreachable either way: `terminal.worktreeID` is a cascading foreign
         // key, so a terminal row outliving its worktree does not happen.
-        guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return .notHibernated
         }
         let target: PaneSendTarget
@@ -604,7 +604,7 @@ public actor HibernationCoordinator {
         guard terminal.isParked else { return await classifyUnparkedWake(terminal) }
         guard let sessionID = terminal.claudeSessionID else { return .noSessionID }
         guard !wakesInFlight.contains(terminalID) else { return .inFlight }
-        guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return .notFound
         }
         // Never respawn into a missing directory: tmux's `-c` silently falls
@@ -683,7 +683,7 @@ public actor HibernationCoordinator {
         // machine-invisible. Cheap no-op once already trusted. `config` is a
         // `try?` read; fall back to the shipped default.
         await ClaudeTrustSeeder.ensureTrusted(
-            worktree: worktree,
+            worktree: worktree.worktree,
             autoTrustNonScratch: config?.autoTrustWorktrees ?? true,
             profileConfigDir: profileConfigDir)
         // Pre-resume freshness: if the worktree was moved/promoted while this
@@ -743,7 +743,7 @@ public actor HibernationCoordinator {
         // the delayed session-recapture Task below.
         let outcome = await withServerLock(server) {
             await self.wakeTmuxSection(
-                terminal: terminal, worktree: worktree, server: server,
+                terminal: terminal, worktree: worktree.worktree, server: server,
                 windowID: windowID, paneID: paneID, spawnCommand: spawn.command,
                 env: env, sensitiveEnv: sensitiveEnv, cols: cols, rows: rows
             )
@@ -1030,7 +1030,7 @@ public actor HibernationCoordinator {
         guard let allTerminals = try? await db.terminals.list() else { return }
 
         for terminal in allTerminals where terminal.isParked {
-            guard let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else { continue }
+            guard let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else { continue }
             let server = worktree.tmuxServer
 
             // Check if the window still exists AND is running claude
@@ -1169,7 +1169,7 @@ public actor HibernationCoordinator {
         server: String, windowID: String, excluding terminalID: UUID
     ) async -> Bool {
         guard let terminals = try? await db.terminals.list(),
-              let worktrees = try? await db.worktrees.list() else { return false }
+              let worktrees = try? await db.worktrees.listLocal() else { return false }
         let serverWorktreeIDs = Set(worktrees.filter { $0.tmuxServer == server }.map(\.id))
         return terminals.contains {
             $0.id != terminalID

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Adopt.swift
@@ -63,12 +63,12 @@ extension WorktreeLifecycle {
 
         // Idempotency: check for an existing row at this exact path.
         let existingActive = try await db.worktrees.list(repoID: repoID, status: .active)
-        if let match = existingActive.first(where: { $0.path == path }) {
+        if let match = existingActive.first(where: { $0.localPath == path }) {
             adoptLogger.info("adoptWorktree: \(path, privacy: .public) already active as \(match.id, privacy: .public)")
             return .unchanged(match)
         }
         let existingArchived = try await db.worktrees.list(repoID: repoID, status: .archived)
-        if let match = existingArchived.first(where: { $0.path == path }) {
+        if let match = existingArchived.first(where: { $0.localPath == path }) {
             adoptLogger.info("adoptWorktree: reviving archived row \(match.id, privacy: .public) for \(path, privacy: .public)")
             try await db.worktrees.updateStatus(id: match.id, status: .active)
             // Honor caller's displayName override on revival — without this, a

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -76,8 +76,8 @@ extension WorktreeLifecycle {
         // captured before we lose the live worktree. Without this, revive
         // would later try to check out a stale branch that no longer exists.
         // git canonicalizes worktree paths (e.g. /var → /private/var on macOS),
-        // so compare resolved-symlink forms when matching against `worktree.path`.
-        let resolvedWtPath = (URL(fileURLWithPath: worktree.path).resolvingSymlinksInPath()).path
+        // so compare resolved-symlink forms when matching against `worktree.localPath`.
+        let resolvedWtPath = (URL(fileURLWithPath: worktree.localPath).resolvingSymlinksInPath()).path
         if let gitWorktrees = try? await git.worktreeList(repoPath: repo.path),
            let gitWt = gitWorktrees.first(where: {
                let resolvedGitPath = (URL(fileURLWithPath: $0.path).resolvingSymlinksInPath()).path
@@ -97,11 +97,11 @@ extension WorktreeLifecycle {
         // exists on disk. Persisted as a fallback for revive when the branch
         // has been renamed or deleted.
         var capturedSHA: String? = nil
-        if FileManager.default.fileExists(atPath: worktree.path) {
+        if FileManager.default.fileExists(atPath: worktree.localPath) {
             do {
-                capturedSHA = try await git.headSHA(worktreePath: worktree.path)
+                capturedSHA = try await git.headSHA(worktreePath: worktree.localPath)
             } catch {
-                archiveLogger.warning("archive: failed to capture HEAD SHA for \(worktreeID, privacy: .public) at \(worktree.path, privacy: .public): \(error, privacy: .public)")
+                archiveLogger.warning("archive: failed to capture HEAD SHA for \(worktreeID, privacy: .public) at \(worktree.localPath, privacy: .public): \(error, privacy: .public)")
             }
         }
 
@@ -137,7 +137,7 @@ extension WorktreeLifecycle {
         if !force {
             let archiveHookPath = hooks.resolve(
                 event: .archive,
-                repoPath: worktree.path,
+                repoPath: worktree.localPath,
                 appHookPath: worktree.repoID.map {
                     TBDConstants.hookPath(repoID: $0, eventName: HookEvent.archive.rawValue)
                 }
@@ -145,12 +145,12 @@ extension WorktreeLifecycle {
             if let hookPath = archiveHookPath {
                 _ = try? await hooks.execute(
                     hookPath: hookPath,
-                    cwd: worktree.path,
+                    cwd: worktree.localPath,
                     env: [
                         "TBD_EVENT": "archive",
                         "TBD_WORKTREE_ID": worktree.id.uuidString,
                         "TBD_WORKTREE_NAME": worktree.name,
-                        "TBD_WORKTREE_PATH": worktree.path,
+                        "TBD_WORKTREE_PATH": worktree.localPath,
                         "TBD_REPO_PATH": repo.path,
                         "TBD_BRANCH": worktree.branch,
                     ],
@@ -168,7 +168,7 @@ extension WorktreeLifecycle {
         // archive completes regardless of tree size and the bytes are reclaimed
         // afterwards with no clock attached.
         do {
-            let queued = try deletionQueue.enqueue(worktreePath: worktree.path)
+            let queued = try deletionQueue.enqueue(worktreePath: worktree.localPath)
 
             // The directory no longer sits at the registered path, so git's
             // administrative entry is stale — drop it. A failure here is
@@ -183,7 +183,7 @@ extension WorktreeLifecycle {
             } catch {
                 archiveLogger.error("""
                 archive: prune failed for \(repo.path, privacy: .public) \
-                after queueing \(worktree.path, privacy: .public): \(error, privacy: .public)
+                after queueing \(worktree.localPath, privacy: .public): \(error, privacy: .public)
                 """)
             }
 
@@ -195,7 +195,7 @@ extension WorktreeLifecycle {
             // the event-driven scratchpad cleanup this callback exists to
             // trigger prompt even when the drain that follows is slow.
             if let onWorktreeRemoved {
-                await onWorktreeRemoved(worktree.path, repo.path)
+                await onWorktreeRemoved(worktree.localPath, repo.path)
             }
 
             // Reclaim the bytes inline, with no deadline attached. Every
@@ -213,26 +213,26 @@ extension WorktreeLifecycle {
             await deletionQueue.drain(queued)
         } catch {
             archiveLogger.error("""
-            archive: could not queue \(worktree.path, privacy: .public) for deletion \
+            archive: could not queue \(worktree.localPath, privacy: .public) for deletion \
             (\(error, privacy: .public)) — falling back to in-place removal
             """)
             do {
                 try await git.worktreeRemove(
                     repoPath: repo.path,
-                    worktreePath: worktree.path,
+                    worktreePath: worktree.localPath,
                     timeout: GitManager.worktreeRemoveFallbackTimeout
                 )
                 // Only claim the directory is gone when it actually is. This
                 // callback drives scratchpad reclamation, whose consumer
                 // previously had to re-check the path itself because this
                 // fired unconditionally after a swallowed failure.
-                let removed = !FileManager.default.fileExists(atPath: worktree.path)
+                let removed = !FileManager.default.fileExists(atPath: worktree.localPath)
                 if removed, let onWorktreeRemoved {
-                    await onWorktreeRemoved(worktree.path, repo.path)
+                    await onWorktreeRemoved(worktree.localPath, repo.path)
                 }
             } catch {
                 archiveLogger.error("""
-                archive: in-place removal of \(worktree.path, privacy: .public) \
+                archive: in-place removal of \(worktree.localPath, privacy: .public) \
                 also failed: \(error, privacy: .public) — the GC sweep will retry
                 """)
             }
@@ -303,21 +303,21 @@ extension WorktreeLifecycle {
         }
 
         // Create parent directory if needed
-        let parentDir = (worktree.path as NSString).deletingLastPathComponent
+        let parentDir = (worktree.localPath as NSString).deletingLastPathComponent
         try FileManager.default.createDirectory(
             atPath: parentDir,
             withIntermediateDirectories: true
         )
 
         // Preflight: ensure nothing exists at the target path on disk.
-        if FileManager.default.fileExists(atPath: worktree.path) {
-            throw WorktreeLifecycleError.worktreePathAlreadyExists(worktree.path)
+        if FileManager.default.fileExists(atPath: worktree.localPath) {
+            throw WorktreeLifecycleError.worktreePathAlreadyExists(worktree.localPath)
         }
 
         // Preflight: ensure git does not already have a worktree registered at this path.
         let existing = (try? await git.worktreeList(repoPath: repo.path)) ?? []
-        if existing.contains(where: { $0.path == worktree.path }) {
-            throw WorktreeLifecycleError.worktreeAlreadyRegistered(worktree.path)
+        if existing.contains(where: { $0.path == worktree.localPath }) {
+            throw WorktreeLifecycleError.worktreeAlreadyRegistered(worktree.localPath)
         }
 
         // Re-add the git worktree. Prefer the existing branch; fall back to
@@ -327,14 +327,14 @@ extension WorktreeLifecycle {
         if branchExists {
             try await git.worktreeAddExisting(
                 repoPath: repo.path,
-                worktreePath: worktree.path,
+                worktreePath: worktree.localPath,
                 branch: worktree.branch
             )
         } else if let sha = worktree.archivedHeadSHA, !sha.isEmpty {
             archiveLogger.info("revive: branch '\(worktree.branch, privacy: .public)' missing for \(worktreeID, privacy: .public), recreating from archived SHA \(sha, privacy: .public)")
             try await git.worktreeAddNewBranch(
                 repoPath: repo.path,
-                worktreePath: worktree.path,
+                worktreePath: worktree.localPath,
                 branch: worktree.branch,
                 sha: sha
             )
@@ -358,7 +358,7 @@ extension WorktreeLifecycle {
         // terminals spawn. Mirrors completeCreateWorktree's 5a branch.
         if let preSession = try await spawnPreSessionTerminal(
             worktree: worktree.worktree, repo: repo,
-            worktreePath: worktree.path,
+            worktreePath: worktree.localPath,
             cols: cols, rows: rows
         ) {
             subscriptions?.broadcast(delta: .terminalCreated(TerminalDelta(
@@ -375,7 +375,7 @@ extension WorktreeLifecycle {
                 await runPreSessionPhase3(
                     preSession: preSession,
                     worktree: worktree.worktree, repo: repo,
-                    worktreePath: worktree.path,
+                    worktreePath: worktree.localPath,
                     skipClaude: skipClaude,
                     archivedClaudeSessions: sessions,
                     cols: cols, rows: rows,
@@ -394,7 +394,7 @@ extension WorktreeLifecycle {
         // No preSession hook → spawn all terminals inline (today's behavior).
         _ = try await spawnPrimaryTerminals(
             worktree: worktree.worktree, repo: repo,
-            worktreePath: worktree.path,
+            worktreePath: worktree.localPath,
             skipClaude: skipClaude,
             archivedClaudeSessions: sessions,
             cols: cols, rows: rows,

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -45,7 +45,7 @@ extension WorktreeLifecycle {
     /// Phase 1 (fast): Validates, updates DB status, kills tmux windows.
     /// Returns the worktree and repo for phase 2.
     public func beginArchiveWorktree(worktreeID: UUID, force: Bool = false) async throws -> (Worktree, Repo) {
-        guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
 
@@ -128,7 +128,7 @@ extension WorktreeLifecycle {
             await pendingQuestions.clear(terminalID: terminal.id)
         }
 
-        return (worktree, repo)
+        return (worktree.worktree, repo)
     }
 
     /// Phase 2 (slow, fire-and-forget): Runs archive hook and removes git worktree.
@@ -266,10 +266,10 @@ extension WorktreeLifecycle {
         if case .preSessionPending(_, let phase3) = completion {
             await phase3.value
         }
-        guard let revived = try await db.worktrees.get(id: worktreeID) else {
+        guard let revived = try await db.worktrees.getLocal(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
-        return revived
+        return revived.worktree
     }
 
     /// Non-blocking revive. Validates, re-adds the git worktree, then:
@@ -290,7 +290,7 @@ extension WorktreeLifecycle {
     /// with revive semantics: the archived sessions are restored into
     /// terminals and the row finishes via `.revive(clearSessions: true)`.
     public func beginReviveWorktree(worktreeID: UUID, skipClaude: Bool = false, cols: Int? = nil, rows: Int? = nil, preferredSessionID: String? = nil) async throws -> WorktreeReviveCompletion {
-        guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
 
@@ -357,7 +357,7 @@ extension WorktreeLifecycle {
         // Gated path: a preSession hook must finish before the primary
         // terminals spawn. Mirrors completeCreateWorktree's 5a branch.
         if let preSession = try await spawnPreSessionTerminal(
-            worktree: worktree, repo: repo,
+            worktree: worktree.worktree, repo: repo,
             worktreePath: worktree.path,
             cols: cols, rows: rows
         ) {
@@ -374,7 +374,7 @@ extension WorktreeLifecycle {
             let phase3 = Task.detached { [self] in
                 await runPreSessionPhase3(
                     preSession: preSession,
-                    worktree: worktree, repo: repo,
+                    worktree: worktree.worktree, repo: repo,
                     worktreePath: worktree.path,
                     skipClaude: skipClaude,
                     archivedClaudeSessions: sessions,
@@ -385,15 +385,15 @@ extension WorktreeLifecycle {
                     completionAction: .revive(clearSessions: !skipClaude)
                 )
             }
-            guard let pending = try await db.worktrees.get(id: worktreeID) else {
+            guard let pending = try await db.worktrees.getLocal(id: worktreeID) else {
                 throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
             }
-            return .preSessionPending(worktree: pending, phase3: phase3)
+            return .preSessionPending(worktree: pending.worktree, phase3: phase3)
         }
 
         // No preSession hook → spawn all terminals inline (today's behavior).
         _ = try await spawnPrimaryTerminals(
-            worktree: worktree, repo: repo,
+            worktree: worktree.worktree, repo: repo,
             worktreePath: worktree.path,
             skipClaude: skipClaude,
             archivedClaudeSessions: sessions,
@@ -421,9 +421,9 @@ extension WorktreeLifecycle {
         }
 
         // Return updated worktree
-        guard let revived = try await db.worktrees.get(id: worktreeID) else {
+        guard let revived = try await db.worktrees.getLocal(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
-        return .ready(revived)
+        return .ready(revived.worktree)
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -54,10 +54,10 @@ extension WorktreeLifecycle {
         if case .preSessionPending(let phase3) = completion {
             await phase3.value
         }
-        guard let completed = try await db.worktrees.get(id: pending.id) else {
+        guard let completed = try await db.worktrees.getLocal(id: pending.id) else {
             throw WorktreeLifecycleError.worktreeNotFound(pending.id)
         }
-        return completed
+        return completed.worktree
     }
 
     // MARK: - Two-Phase Create
@@ -125,7 +125,11 @@ extension WorktreeLifecycle {
             // paths already reserved by ANY row (active, archived, creating,
             // main). An archived worktree keeps its `path` even after its
             // directory is deleted, so a filesystem-only check would collide
-            // and the insert would throw `UNIQUE constraint failed`.
+            // and the insert would throw `UNIQUE constraint failed`. This
+            // fetch deliberately stays on the location-neutral `list(...)`:
+            // the constraint it mirrors spans every row on the table, so a
+            // path withheld from this set is not a harmless omission — the
+            // insert below would abort on it.
             let reserved = Set(try await db.worktrees.list().map(\.path))
             resolvedName = Self.uniqueFolderName(
                 base: baseFolder, in: canonicalBase, reserved: reserved
@@ -223,7 +227,7 @@ extension WorktreeLifecycle {
     /// rendered or persisted the pending row's generated identity.
     @discardableResult
     public func completeCreateWorktree(worktreeID: UUID, skipClaude: Bool = false, initialPrompt: String? = nil, userSpecifiedFolder: Bool = false, userSpecifiedBranch: Bool = false, cols: Int? = nil, rows: Int? = nil, existingBranchRef: String? = nil, checkoutPRHead: Bool = false, overrideProfileID: UUID? = nil, modelOverride: String? = nil, primaryAgentPreference: PrimaryAgentPreference? = nil, claudeSettingsOverlay: String? = nil, carryover: ConversationCarryover? = nil, retryGeneratedNameOnCollision: Bool = true) async throws -> WorktreeCreateCompletion {
-        guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
         guard let rid = worktree.repoID, let repo = try await db.repos.get(id: rid) else {
@@ -354,7 +358,7 @@ extension WorktreeLifecycle {
             // row, so carry the `foreignHead` stamp onto the in-memory copy —
             // otherwise the very first Claude spawn would still seed trust for
             // a tree it just fetched from a fork.
-            var stamped = worktree
+            var stamped = worktree.worktree
             stamped.foreignHead = stamped.foreignHead || checkedOutForeignHead
             let spawnWorktree = stamped
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -130,7 +130,7 @@ extension WorktreeLifecycle {
             // the constraint it mirrors spans every row on the table, so a
             // path withheld from this set is not a harmless omission — the
             // insert below would abort on it.
-            let reserved = Set(try await db.worktrees.list().map(\.path))
+            let reserved = Set(try await db.worktrees.list().map(\.localPath))
             resolvedName = Self.uniqueFolderName(
                 base: baseFolder, in: canonicalBase, reserved: reserved
             )
@@ -671,7 +671,7 @@ extension WorktreeLifecycle {
     ) async throws -> [(id: UUID, label: String)] {
         let worktreeID = worktree.id
         let tmuxServer = worktree.tmuxServer
-        let worktreePath = worktreePath ?? worktree.path
+        let worktreePath = worktreePath ?? worktree.localPath
         let config = try await db.config.get()
         let claudeEnvOverrides = config.envSettingOverrides
         let primaryTerminalKind: TerminalKind = carryover == nil

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Forget.swift
@@ -36,7 +36,7 @@ extension WorktreeLifecycle {
     /// when the user deliberately re-adds the path (adopt or create), which
     /// restores normal reconcile behavior.
     public func forgetWorktree(worktreeID: UUID) async throws {
-        guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else {
             throw WorktreeLifecycleError.worktreeNotFound(worktreeID)
         }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -307,7 +307,7 @@ extension WorktreeLifecycle {
         // than tear down a valid worktree.
         let rowExists: Bool
         do {
-            rowExists = try await db.worktrees.get(id: worktree.id) != nil
+            rowExists = try await db.worktrees.getLocal(id: worktree.id) != nil
         } catch {
             logger.warning("phase-3: worktree existence check failed for \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public) — assuming the row still exists and proceeding")
             rowExists = true
@@ -527,7 +527,7 @@ extension WorktreeLifecycle {
     func rerunPreSessionHook(
         worktreeID: UUID, cols: Int? = nil, rows: Int? = nil
     ) async throws {
-        guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else {
             throw RerunPreSessionError.worktreeNotFound(worktreeID)
         }
         // A `.creating` worktree is already running its hook under phase 3.
@@ -548,7 +548,7 @@ extension WorktreeLifecycle {
         let spawn: PreSessionSpawn?
         do {
             spawn = try await spawnPreSessionTerminal(
-                worktree: worktree, repo: repo,
+                worktree: worktree.worktree, repo: repo,
                 worktreePath: worktree.path,
                 cols: cols, rows: rows,
                 claimsFocus: false
@@ -567,7 +567,7 @@ extension WorktreeLifecycle {
 
         let lifecycle = self
         Task.detached {
-            await lifecycle.finishRerunPreSession(worktree: worktree, preSession: spawn)
+            await lifecycle.finishRerunPreSession(worktree: worktree.worktree, preSession: spawn)
         }
     }
 

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+PreSession.swift
@@ -305,9 +305,13 @@ extension WorktreeLifecycle {
         // left to flip or notify. A thrown DB error is NOT proof the row is
         // gone — treat it as transient and proceed with the spawn rather
         // than tear down a valid worktree.
+        // Location-neutral on purpose: the question is "did the row vanish",
+        // and `getLocal` would answer nil for a row that exists but is remote
+        // — indistinguishable here from deleted, and the branch below kills a
+        // live tmux window. Existence is not a locality question.
         let rowExists: Bool
         do {
-            rowExists = try await db.worktrees.getLocal(id: worktree.id) != nil
+            rowExists = try await db.worktrees.get(id: worktree.id) != nil
         } catch {
             logger.warning("phase-3: worktree existence check failed for \(worktree.id, privacy: .public): \(error.localizedDescription, privacy: .public) — assuming the row still exists and proceeding")
             rowExists = true

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -191,17 +191,21 @@ extension WorktreeLifecycle {
         // its path would violate the UNIQUE path constraint and abort this
         // repo's reconcile.
         //
-        // This one set deliberately stays on the location-neutral `list(...)`
-        // and states its two exclusions itself. What it must contain is "every
-        // path a live creating row already claims", and a path missing from it
-        // is not a harmless omission: the re-adopt pass would treat that path
-        // as unknown, create a second row on it, and abort this repo's whole
-        // reconcile on the UNIQUE path constraint. `LocalWorktree.init?` is a
-        // predicate about a worktree TBD may act on right now, which is a
-        // different question — it already rejects the empty path, and any
-        // later tightening of it (say, requiring the directory to exist, which
-        // a creating row's does not yet) would silently shrink this set. So
-        // the exclusions live here, where breaking them is visible.
+        // This one set deliberately fetches through the location-neutral
+        // `list(...)` and then states its two exclusions here, in the open,
+        // rather than borrowing `LocalWorktree.init?`. What it must contain is
+        // "every path a live creating row already claims", and a path missing
+        // from it is not a harmless omission: the re-adopt pass would treat
+        // that path as unknown, create a second row on it, and abort this
+        // repo's whole reconcile on the UNIQUE path constraint.
+        // `LocalWorktree.init?` is a predicate about a worktree TBD may act on
+        // right now, which is a different question — and any later tightening
+        // of it (say, requiring the directory to exist, which a creating row's
+        // does not yet) would silently shrink this set.
+        //
+        // Both exclusions are safe because neither kind of row can claim a
+        // path `git worktree list` will ever report back: a remote row's
+        // `remote://` path is synthetic, and an empty path is no path at all.
         let creatingPaths = Set(
             (try await db.worktrees.list(repoID: repoID, status: .creating))
                 .filter { $0.location.isLocal }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -25,7 +25,7 @@ extension WorktreeLifecycle {
         if let gitWorktrees = try? await git.worktreeList(repoPath: repo.path) {
             let branchByPath = Dictionary(gitWorktrees.map { ($0.path, $0.branch) }, uniquingKeysWith: { _, b in b })
             for (i, wt) in worktrees.enumerated() {
-                if let gitBranch = branchByPath[wt.path], gitBranch != wt.branch {
+                if let gitBranch = branchByPath[wt.localPath], gitBranch != wt.branch {
                     try? await db.worktrees.updateBranch(id: wt.id, branch: gitBranch)
                     worktrees[i].branch = gitBranch  // use updated branch for conflict check below
                 }
@@ -205,7 +205,7 @@ extension WorktreeLifecycle {
         let creatingPaths = Set(
             (try await db.worktrees.list(repoID: repoID, status: .creating))
                 .filter { $0.location.isLocal }
-                .map(\.path)
+                .map(\.localPath)
                 .filter { !$0.isEmpty }
         )
         let dbPaths = Set(dbWorktrees.map(\.path)).union(creatingPaths)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -12,7 +12,13 @@ extension WorktreeLifecycle {
     /// Runs git checks concurrently and updates the DB + broadcasts deltas.
     public func refreshGitStatuses(repoID: UUID) async {
         guard let repo = try? await db.repos.get(id: repoID) else { return }
-        var worktrees = (try? await db.worktrees.list(repoID: repoID, status: .active)) ?? []
+        // Fetched through `listLocal`: a remote row has no checkout on this
+        // disk, so it has no path to match against `git worktree list` and no
+        // branch for the conflict probes below. Unwrapped back to bare rows
+        // because the branch-sync pass mutates elements in place and
+        // `LocalWorktree` forwards reads only — the fence is at the fetch.
+        var worktrees = ((try? await db.worktrees.listLocal(repoID: repoID, status: .active)) ?? [])
+            .map(\.worktree)
 
         // Sync branch names: one `git worktree list` call gives us
         // the current branch for every worktree — update DB if changed.
@@ -144,7 +150,14 @@ extension WorktreeLifecycle {
 
         let gitWorktrees = try await git.worktreeList(repoPath: repo.path)
         let correctTmuxServer = TmuxManager.serverName(forRepoPath: repo.path)
-        var dbWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
+        // Every fetch in this sweep is `listLocal`, not `list`. Reconcile's
+        // whole job is to make DB rows agree with what git and tmux report on
+        // THIS disk, so a row with no local checkout is not stale — it is out
+        // of scope. Handed the location-neutral `list`, the archival pass
+        // below would archive every remote row on every sweep (its path is
+        // never in `gitPaths`) and the canonicalization pass would stamp a
+        // tmux server name onto rows that have no tmux server at all.
+        var dbWorktrees = try await db.worktrees.listLocal(repoID: repoID, status: .active)
 
         // Fix stale tmux server names (e.g. after migration from UUID-based to
         // path-based naming). CAUTION: a non-canonical stored server is NOT
@@ -156,7 +169,7 @@ extension WorktreeLifecycle {
         // So: canonicalize ONLY when the stored server has no live window for
         // this worktree's terminals — the genuinely-stale case the self-heal
         // was built for.
-        let mainWorktrees = try await db.worktrees.list(repoID: repoID, status: .main)
+        let mainWorktrees = try await db.worktrees.listLocal(repoID: repoID, status: .main)
         for wt in (dbWorktrees + mainWorktrees) where wt.tmuxServer != correctTmuxServer {
             if await hasLiveWindow(server: wt.tmuxServer, worktreeID: wt.id) {
                 logger.info("reconcile: keeping non-canonical tmux server \(wt.tmuxServer, privacy: .public) for worktree \(wt.id, privacy: .public) — it has live windows (promoted-scratch inheritance)")
@@ -169,7 +182,7 @@ extension WorktreeLifecycle {
             }
         }
         // Re-fetch with corrected names
-        dbWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
+        dbWorktrees = try await db.worktrees.listLocal(repoID: repoID, status: .active)
 
         let gitPaths = Set(gitWorktrees.map(\.path))
         // Include `.creating` rows so a worktree whose pre-session phase-3
@@ -177,8 +190,23 @@ extension WorktreeLifecycle {
         // finishes) isn't "unknown" to the re-adopt pass below — re-adopting
         // its path would violate the UNIQUE path constraint and abort this
         // repo's reconcile.
+        //
+        // This one set deliberately stays on the location-neutral `list(...)`
+        // and states its two exclusions itself. What it must contain is "every
+        // path a live creating row already claims", and a path missing from it
+        // is not a harmless omission: the re-adopt pass would treat that path
+        // as unknown, create a second row on it, and abort this repo's whole
+        // reconcile on the UNIQUE path constraint. `LocalWorktree.init?` is a
+        // predicate about a worktree TBD may act on right now, which is a
+        // different question — it already rejects the empty path, and any
+        // later tightening of it (say, requiring the directory to exist, which
+        // a creating row's does not yet) would silently shrink this set. So
+        // the exclusions live here, where breaking them is visible.
         let creatingPaths = Set(
-            (try await db.worktrees.list(repoID: repoID, status: .creating)).map(\.path)
+            (try await db.worktrees.list(repoID: repoID, status: .creating))
+                .filter { $0.location.isLocal }
+                .map(\.path)
+                .filter { !$0.isEmpty }
         )
         let dbPaths = Set(dbWorktrees.map(\.path)).union(creatingPaths)
 
@@ -266,8 +294,8 @@ extension WorktreeLifecycle {
         // machine with many worktrees that spawned N simultaneous `claude
         // --resume` processes (~0.5-1.5 GB each) and OOM'd the machine (#284).
         // Lazy recreate-on-demand keeps idle worktrees as cheap suspended rows.
-        let allLiveWorktrees = try await db.worktrees.list(repoID: repoID, status: .active)
-            + (try await db.worktrees.list(repoID: repoID, status: .main))
+        let allLiveWorktrees = try await db.worktrees.listLocal(repoID: repoID, status: .active)
+            + (try await db.worktrees.listLocal(repoID: repoID, status: .main))
         // Probe the server each worktree row actually STORES, not the
         // canonical name: after a scratch promote the main worktree's windows
         // live on the inherited scratch server, and probing the canonical
@@ -377,7 +405,12 @@ extension WorktreeLifecycle {
         // For the canonical per-repo server — referenced by nothing outside
         // this repo — this reduces to the previous behavior: killed when the
         // repo has no live worktrees, orphan-swept otherwise.
-        let repoRows = try await db.worktrees.list(repoID: repoID)
+        // Local rows only, at all three fetches below: the servers to visit and
+        // the rows that keep one alive are both tmux facts, and a remote row
+        // names no tmux server. Including one would put its empty server name
+        // in `referencedServers` and make that same row count as a live
+        // reference to it.
+        let repoRows = try await db.worktrees.listLocal(repoID: repoID)
         var referencedServers = Set(repoRows.map(\.tmuxServer))
         referencedServers.insert(correctTmuxServer)
         // Also visit every server referenced by scratch rows (repoID nil,
@@ -392,9 +425,9 @@ extension WorktreeLifecycle {
         // servers into every repo's reconcile makes whichever repo reconciles
         // next sweep those orphans; the live-row checks below already span
         // all repos + scratch spaces, so live scratch windows stay safe.
-        let scratchRows = try await db.worktrees.list(scratchOnly: true)
+        let scratchRows = try await db.worktrees.listLocal(scratchOnly: true)
         referencedServers.formUnion(scratchRows.map(\.tmuxServer))
-        let globalLiveRows = try await db.worktrees.list(excludeArchived: true)
+        let globalLiveRows = try await db.worktrees.listLocal(excludeArchived: true)
 
         for server in referencedServers.sorted() {
             let liveRowsOnServer = globalLiveRows.filter { $0.tmuxServer == server }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -18,6 +18,7 @@ extension WorktreeLifecycle {
     /// startup BEFORE the per-repo reconcile loop.
     ///
     /// Per `.creating` row:
+    /// - Remote row → mark it `.failed`; see the guard below.
     /// - Checkout missing on disk → creation never completed; delete the row
     ///   (and its terminal/tab records).
     /// - Checkout exists and primary (non-pre-session) terminals exist → the
@@ -43,23 +44,51 @@ extension WorktreeLifecycle {
     /// ignores them.
     @discardableResult
     public func recoverCreatingWorktrees() async -> [Task<Void, Never>] {
-        let creating = (try? await db.worktrees.listLocal(status: .creating)) ?? []
+        // Location-neutral: this sweep is the only thing that resolves a
+        // `.creating` row, so fencing it to local rows would strand every
+        // remote one. The fence is the per-row guard below instead, which
+        // gives a remote row an outcome rather than skipping it.
+        let creating = (try? await db.worktrees.list(status: .creating)) ?? []
         var resumed: [Task<Void, Never>] = []
-        for worktree in creating {
-            let terminals = (try? await db.terminals.list(worktreeID: worktree.id)) ?? []
+        for row in creating {
+            // A remote `.creating` row has no checkout to inspect and no
+            // pre-session wait to resume, and reconcile is fenced from remote
+            // rows too — so nothing else would ever resolve it and the lane
+            // would spin forever. Mark it `.failed`, the terminal state the
+            // creation flow already uses for a create that did not finish.
+            // Deleting instead would make "the create never ran" and "the row
+            // silently vanished" indistinguishable, and would orphan a session
+            // the provider may well have started before the daemon died.
+            guard row.location.isLocal else {
+                logger.warning("recovery: marking remote .creating worktree \(row.id, privacy: .public) as .failed — the daemon died mid-create and no other sweep resolves a remote creating row")
+                do {
+                    try await db.worktrees.updateStatus(id: row.id, status: .failed)
+                } catch {
+                    logger.warning("recovery: failed to mark remote .creating worktree \(row.id, privacy: .public) as .failed: \(error.localizedDescription, privacy: .public)")
+                }
+                continue
+            }
+
+            let terminals = (try? await db.terminals.list(worktreeID: row.id)) ?? []
             let preSessionTerminal = terminals.first { $0.label == TerminalLabel.preSession }
             let hasPrimaries = terminals.contains { $0.label != TerminalLabel.preSession }
 
-            guard FileManager.default.fileExists(atPath: worktree.path) else {
-                logger.warning("recovery: deleting .creating worktree \(worktree.id, privacy: .public) — checkout missing at \(worktree.path, privacy: .public)")
+            // Everything past here needs a directory, so convert once. The
+            // conversion also covers a local row with no path at all — the
+            // daemon computes the path before the insert, so that shape should
+            // not persist, and if it ever does it is the same "creation never
+            // completed" case as a missing checkout.
+            guard FileManager.default.fileExists(atPath: row.localPath),
+                  let worktree = LocalWorktree(row) else {
+                logger.warning("recovery: deleting .creating worktree \(row.id, privacy: .public) — checkout missing at \(row.localPath, privacy: .public)")
                 do {
-                    try await db.terminals.deleteForWorktree(worktreeID: worktree.id)
-                    try await db.tabs.deleteForWorktree(worktreeID: worktree.id)
+                    try await db.terminals.deleteForWorktree(worktreeID: row.id)
+                    try await db.tabs.deleteForWorktree(worktreeID: row.id)
                     // Hard delete: closed-terminal history (rows + files) goes too.
-                    try await db.terminalHistory.deleteForWorktree(worktreeID: worktree.id)
-                    try await db.worktrees.delete(id: worktree.id)
+                    try await db.terminalHistory.deleteForWorktree(worktreeID: row.id)
+                    try await db.worktrees.delete(id: row.id)
                 } catch {
-                    logger.warning("recovery: cleanup of missing-checkout worktree \(worktree.id, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+                    logger.warning("recovery: cleanup of missing-checkout worktree \(row.id, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
                 }
                 continue
             }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Recovery.swift
@@ -43,7 +43,7 @@ extension WorktreeLifecycle {
     /// ignores them.
     @discardableResult
     public func recoverCreatingWorktrees() async -> [Task<Void, Never>] {
-        let creating = (try? await db.worktrees.list(status: .creating)) ?? []
+        let creating = (try? await db.worktrees.listLocal(status: .creating)) ?? []
         var resumed: [Task<Void, Never>] = []
         for worktree in creating {
             let terminals = (try? await db.terminals.list(worktreeID: worktree.id)) ?? []
@@ -146,7 +146,7 @@ extension WorktreeLifecycle {
             let task = Task.detached { [self] in
                 await runPreSessionPhase3(
                     preSession: spawn,
-                    worktree: worktree, repo: repo,
+                    worktree: worktree.worktree, repo: repo,
                     worktreePath: worktree.path,
                     skipClaude: false,
                     archivedClaudeSessions: isMidRevive ? archivedSessions : nil,

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -239,9 +239,9 @@ public actor DeskSessionManager: DeskSessionManaging {
 
         // Mirror handleScratchCreate: tell connected clients immediately.
         subscriptions?.broadcast(delta: .worktreeCreated(WorktreeDelta(
-            worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path, status: wt.status)))
+            worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.localPath, status: wt.status)))
 
-        logger.info("Created Watch Desk session: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
+        logger.info("Created Watch Desk session: \(wt.id, privacy: .public) at \(wt.localPath, privacy: .public)")
         return wt
     }
 
@@ -909,7 +909,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         // reads them on its own initiative — before its first tick ever fires —
         // finds them there. Best-effort: the nudge path rewrites this every tick
         // and falls back to the inline prompt if it can't.
-        writeJudgeInstructions(deskPath: worktree.path, mode: mode).map { path in
+        writeJudgeInstructions(deskPath: worktree.localPath, mode: mode).map { path in
             logger.debug("Wrote judge instructions to \(path, privacy: .public)")
         }
 

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -136,7 +136,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         // processes can exit before their terminal row is removed, so require a
         // live pane owned by the currently configured primary agent.
         if let cachedID = deskWorktreeID,
-           let existing = try await db.worktrees.get(id: cachedID),
+           let existing = try await db.worktrees.getLocal(id: cachedID),
            existing.status == .active {
             if try await liveAgentTerminal(
                 worktreeID: existing.id,
@@ -150,7 +150,7 @@ public actor DeskSessionManager: DeskSessionManaging {
                 // rather than per tick, reuse-without-respawn is exactly the case where a memorized copy
                 // can go stale — `nudgeDeskSession` compares against `lastNudgedMode` and flags the flip.
                 // Initial frame is one-time; steady-state mode is driven per-tick.
-                return existing
+                return existing.worktree
             }
         }
 
@@ -160,7 +160,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         // Query by displayName to detect existing desk worktrees (active only).
         // This recovery path excludes archived worktrees so off→on cycles don't
         // resurrect dead desk sessions. (survives daemon restart since displayName is stable).
-        let activeWorktrees = try await db.worktrees.list(excludeArchived: true)
+        let activeWorktrees = try await db.worktrees.listLocal(excludeArchived: true)
         if let existing = activeWorktrees.first(where: { $0.displayName == NightwatchDeskPrompts.deskDisplayName && $0.isScratch }) {
             deskWorktreeID = existing.id
 
@@ -173,7 +173,7 @@ public actor DeskSessionManager: DeskSessionManaging {
             ) == nil {
                 logger.info("Recovered Watch Desk \(existing.id, privacy: .public) but no live \(preferredKind.rawValue, privacy: .public) terminal; respawning")
                 do {
-                    _ = try await spawnDeskTerminal(worktree: existing, mode: mode)
+                    _ = try await spawnDeskTerminal(worktree: existing.worktree, mode: mode)
                 } catch {
                     logger.warning("Failed to respawn terminal on recovery: \(error.localizedDescription, privacy: .public)")
                     // Best-effort; don't fail the recovery
@@ -181,7 +181,7 @@ public actor DeskSessionManager: DeskSessionManaging {
             }
 
             logger.info("Reusing existing Watch Desk session: \(existing.id, privacy: .public)")
-            return existing
+            return existing.worktree
         }
 
         // Create a new scratch space
@@ -527,13 +527,13 @@ public actor DeskSessionManager: DeskSessionManaging {
 
         do {
             // Worktree first: resolving a live terminal needs the tmux server to query.
-            guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+            guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else {
                 logger.warning("Watch Desk worktree not found: \(worktreeID, privacy: .public)")
                 return
             }
 
             guard let (agentTerminal, _, _) = try await leasedJudgeTerminal(
-                worktree: worktree
+                worktree: worktree.worktree
             ) else {
                 logger.warning("No uniquely owned live terminal in Watch Desk; skipping wrap-up prompt")
                 return
@@ -613,15 +613,15 @@ public actor DeskSessionManager: DeskSessionManaging {
 
         do {
             // Worktree first: resolving a live terminal needs the tmux server to query.
-            guard let worktree = try await db.worktrees.get(id: worktreeID) else {
+            guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else {
                 logger.warning("Watch Desk worktree not found: \(worktreeID, privacy: .public)")
                 return
             }
 
             var preferredKind = try await preferredAgentKind()
-            var judge = try await leasedJudgeTerminal(worktree: worktree)
+            var judge = try await leasedJudgeTerminal(worktree: worktree.worktree)
             if judge == nil,
-               try await liveJudgeCandidates(worktree: worktree).isEmpty {
+               try await liveJudgeCandidates(worktree: worktree.worktree).isEmpty {
                 // A terminal row can survive a process/pane exit. Recover in the
                 // nudge path itself so one failed launch does not turn into a
                 // silent all-night outage waiting for a mode toggle or daemon
@@ -630,10 +630,10 @@ public actor DeskSessionManager: DeskSessionManaging {
                 // worktrees.
                 logger.notice("No live \(preferredKind.rawValue, privacy: .public) Watch Desk terminal; retrying spawn before nudge")
                 do {
-                    try await spawnDeskTerminal(worktree: worktree, mode: mode)
+                    try await spawnDeskTerminal(worktree: worktree.worktree, mode: mode)
                     // Re-read in case the preference changed while spawning.
                     preferredKind = try await preferredAgentKind()
-                    judge = try await leasedJudgeTerminal(worktree: worktree)
+                    judge = try await leasedJudgeTerminal(worktree: worktree.worktree)
                 } catch {
                     logger.warning("Failed to recover Watch Desk terminal before nudge: \(error.localizedDescription, privacy: .public)")
                 }
@@ -750,7 +750,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         guard let worktreeID = deskWorktreeID else { return }
 
         do {
-            guard let wt = try await db.worktrees.get(id: worktreeID) else {
+            guard let wt = try await db.worktrees.getLocal(id: worktreeID) else {
                 logger.warning("Watch Desk worktree not found during close: \(worktreeID, privacy: .public)")
                 deskWorktreeID = nil
                 return
@@ -824,8 +824,8 @@ public actor DeskSessionManager: DeskSessionManaging {
         await gateAcquire()
         defer { gateRelease() }
         do {
-            guard let worktree = try await db.worktrees.get(id: worktreeID) else { return }
-            _ = try await leasedJudgeTerminal(worktree: worktree)
+            guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else { return }
+            _ = try await leasedJudgeTerminal(worktree: worktree.worktree)
         } catch {
             logger.error("Failed to maintain Watch Desk judge lease: \(error.localizedDescription, privacy: .public)")
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+AppearanceHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AppearanceHandlers.swift
@@ -11,12 +11,14 @@ extension RPCRouter {
     func handleAppearanceUpdateColorFgBg(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(AppearanceUpdateColorFgBgParams.self, from: paramsData)
 
-        // Discover tmux servers from active worktrees only. Archived worktrees
-        // have had their tmux servers killed, so attempting setenv -g against them
-        // spawns dead `tmux` processes that fail and log a warning on every
-        // debounce tick. `handleSetMainAreaSize` in this codebase filters the
-        // same way for the same reason.
-        let worktrees = try await db.worktrees.list(status: .active)
+        // Discover tmux servers from active LOCAL worktrees only. Archived
+        // worktrees have had their tmux servers killed, so attempting setenv -g
+        // against them spawns dead `tmux` processes that fail and log a warning
+        // on every debounce tick; a remote row has no tmux server at all, and
+        // its empty server name would be the same wasted `tmux` invocation
+        // every tick. `handleSetMainAreaSize` in this codebase filters the same
+        // way for the same reason.
+        let worktrees = try await db.worktrees.listLocal(status: .active)
         var attemptedServers = Set<String>()
 
         // Build the deduplicated set of servers first (single pass).

--- a/Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+AttachHandlers.swift
@@ -20,7 +20,7 @@ extension RPCRouter {
         guard let bridge = controlMode, await bridge.gateEnabled() else {
             return try RPCResponse(result: AttachRequestResult(status: "unavailable"))
         }
-        guard let worktree = try? await db.worktrees.get(id: params.worktreeID) else {
+        guard let worktree = try? await db.worktrees.getLocal(id: params.worktreeID) else {
             return RPCResponse(error: "Worktree not found")
         }
         let server = worktree.tmuxServer
@@ -169,7 +169,7 @@ extension RPCRouter {
         guard let bridge = controlMode else {
             return RPCResponse(error: "control mode not configured")
         }
-        guard let worktree = try? await db.worktrees.get(id: params.worktreeID) else {
+        guard let worktree = try? await db.worktrees.getLocal(id: params.worktreeID) else {
             return RPCResponse(error: "Worktree not found")
         }
         let server = worktree.tmuxServer
@@ -229,7 +229,7 @@ extension RPCRouter {
     func handlePaneDetach(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(PaneDetachParams.self, from: paramsData)
         if let bridge = controlMode,
-           let worktree = try? await db.worktrees.get(id: params.worktreeID) {
+           let worktree = try? await db.worktrees.getLocal(id: params.worktreeID) {
             let server = worktree.tmuxServer
             if let generation = params.generation {
                 if await bridge.supervisor.detachIfGeneration(
@@ -252,7 +252,7 @@ extension RPCRouter {
     func handlePaneResize(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(PaneResizeParams.self, from: paramsData)
         if let bridge = controlMode,
-           let worktree = try? await db.worktrees.get(id: params.worktreeID) {
+           let worktree = try? await db.worktrees.getLocal(id: params.worktreeID) {
             await bridge.resizeCoordinator.resize(
                 server: worktree.tmuxServer,
                 windowID: params.windowID,

--- a/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ContinueInCodexHandlers.swift
@@ -53,7 +53,7 @@ extension RPCRouter {
             throw ContinueInCodexHandlerError.userFacing(
                 "The selected Claude transcript is missing or unreadable: \(transcriptPath)")
         }
-        guard let worktree = try await db.worktrees.get(id: source.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: source.worktreeID) else {
             throw ContinueInCodexHandlerError.userFacing(
                 "Worktree not found for source terminal \(source.id).")
         }

--- a/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
@@ -61,7 +61,7 @@ extension RPCRouter {
             // Synthetic main worktree row points at the repo root, not a real
             // git worktree dir. No `git worktree repair` needed.
             if wt.status == .main {
-                if wt.path == oldPath {
+                if wt.localPath == oldPath {
                     do {
                         try await db.worktrees.updatePath(id: wt.id, path: newPath)
                         worktreesRepaired.append(wt.id)
@@ -73,9 +73,9 @@ extension RPCRouter {
                 continue
             }
 
-            var rewrittenPath = wt.path
-            if wt.path.hasPrefix(oldLegacyPrefix) {
-                let suffix = String(wt.path.dropFirst(oldLegacyPrefix.count))
+            var rewrittenPath = wt.localPath
+            if wt.localPath.hasPrefix(oldLegacyPrefix) {
+                let suffix = String(wt.localPath.dropFirst(oldLegacyPrefix.count))
                 rewrittenPath = newLegacyPrefix + suffix
                 do {
                     try await db.worktrees.updatePath(id: wt.id, path: rewrittenPath)

--- a/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RelocateHandler.swift
@@ -49,9 +49,12 @@ extension RPCRouter {
         try await db.repos.updatePath(id: repo.id, path: newPath)
         repo.path = newPath
 
-        // 3 + 4. Rewrite worktree paths and repair git bookkeeping.
-        let activeWorktrees = try await db.worktrees.list(repoID: repo.id, status: .active)
-        let mainWorktrees = try await db.worktrees.list(repoID: repo.id, status: .main)
+        // 3 + 4. Rewrite worktree paths and repair git bookkeeping. Local rows
+        // only: every step below rewrites a filesystem path and shells out to
+        // `git worktree repair` against it. A remote row has no checkout to
+        // move, and relocating the repo on this machine says nothing about it.
+        let activeWorktrees = try await db.worktrees.listLocal(repoID: repo.id, status: .active)
+        let mainWorktrees = try await db.worktrees.listLocal(repoID: repo.id, status: .main)
         let allWorktrees = activeWorktrees + mainWorktrees
 
         var worktreesRepaired: [UUID] = []
@@ -61,7 +64,7 @@ extension RPCRouter {
             // Synthetic main worktree row points at the repo root, not a real
             // git worktree dir. No `git worktree repair` needed.
             if wt.status == .main {
-                if wt.localPath == oldPath {
+                if wt.path == oldPath {
                     do {
                         try await db.worktrees.updatePath(id: wt.id, path: newPath)
                         worktreesRepaired.append(wt.id)
@@ -73,9 +76,9 @@ extension RPCRouter {
                 continue
             }
 
-            var rewrittenPath = wt.localPath
-            if wt.localPath.hasPrefix(oldLegacyPrefix) {
-                let suffix = String(wt.localPath.dropFirst(oldLegacyPrefix.count))
+            var rewrittenPath = wt.path
+            if wt.path.hasPrefix(oldLegacyPrefix) {
+                let suffix = String(wt.path.dropFirst(oldLegacyPrefix.count))
                 rewrittenPath = newLegacyPrefix + suffix
                 do {
                     try await db.worktrees.updatePath(id: wt.id, path: rewrittenPath)

--- a/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+RepoHandlers.swift
@@ -75,8 +75,22 @@ extension RPCRouter {
             return RPCResponse(error: "Repository not found: \(params.repoID)")
         }
 
-        // Check for active worktrees
+        // Check for active worktrees. Location-neutral on purpose: a remote
+        // lane is as much a live thing the operator would lose as a local
+        // worktree, so it blocks an unforced removal just the same and is
+        // counted in the refusal below.
         let activeWorktrees = try await db.worktrees.list(repoID: repo.id, status: .active)
+
+        // Only the local ones are cascade-archived. Archiving a remote lane
+        // means stopping its provider session, which nothing on this path can
+        // do — and `beginArchiveWorktree` resolves its row through `getLocal`,
+        // so handing it a remote id would throw `worktreeNotFound` partway
+        // through the cascade and strand the teardown half-done. A remote
+        // row is instead removed by the `deleteForRepo` in
+        // `completeRepoRemoval`, along with the repo's archived and main rows:
+        // there are no local files to reclaim and nothing on disk to leave
+        // behind.
+        let localActiveWorktrees = activeWorktrees.compactMap(LocalWorktree.init)
 
         guard !activeWorktrees.isEmpty else {
             // Nothing to archive, so nothing to wait for: the removal finishes
@@ -115,14 +129,16 @@ extension RPCRouter {
         // would grow the outcome contract for a case where the appends
         // that carried it would very likely fail too — the log was
         // unwritable one row ago.
+        // A remote lane gets no row, because no teardown of it happens here
+        // and the record may only claim acts that were attempted.
         var actuationIDs: [String] = []
-        for wt in activeWorktrees {
+        for wt in localActiveWorktrees {
             actuationIDs.append(try await beginActuation(
                 .repoRemove, actor: actor,
                 target: ActuationTarget(worktree: wt.id.uuidString)))
         }
 
-        // Cascade-archive all active worktrees. Two-phase, same split
+        // Cascade-archive all active LOCAL worktrees. Two-phase, same split
         // as `handleWorktreeArchive`: phase 1 (`beginArchiveWorktree`)
         // is the throwing part — DB status flip, session capture,
         // tmux teardown — and runs synchronously in this loop so the
@@ -133,7 +149,7 @@ extension RPCRouter {
         // it is collected here and run by the detached tail below;
         // otherwise this RPC would block on N unbounded drains.
         var pendingCompletions: [(worktree: Worktree, repo: Repo)] = []
-        for (index, wt) in activeWorktrees.enumerated() {
+        for (index, wt) in localActiveWorktrees.enumerated() {
             let worktree: Worktree
             let wtRepo: Repo
             do {

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -80,12 +80,12 @@ extension RPCRouter {
         }
 
         subscriptions.broadcast(delta: .worktreeCreated(WorktreeDelta(
-            worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.path, status: wt.status)))
+            worktreeID: wt.id, repoID: nil, name: wt.name, path: wt.localPath, status: wt.status)))
         for terminal in createdTerminals {
             subscriptions.broadcast(delta: .terminalCreated(TerminalDelta(
                 terminalID: terminal.id, worktreeID: wt.id, label: terminal.label)))
         }
-        scratchLogger.info("scratch.create: \(wt.id, privacy: .public) at \(wt.path, privacy: .public)")
+        scratchLogger.info("scratch.create: \(wt.id, privacy: .public) at \(wt.localPath, privacy: .public)")
         return try RPCResponse(result: wt)
     }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+ScratchHandlers.swift
@@ -115,7 +115,7 @@ extension RPCRouter {
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchDeleteParams.self, from: paramsData)
-        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+        guard let wt = try await db.worktrees.getLocal(id: params.worktreeID) else {
             return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
         }
         guard wt.isScratch else {
@@ -130,7 +130,7 @@ extension RPCRouter {
         let actuationID = try await beginActuation(
             .scratchDelete, actor: actor,
             target: ActuationTarget(worktree: wt.id.uuidString))
-        try await actuating(actuationID) { try await closeScratchTerminals(wt) }
+        try await actuating(actuationID) { try await closeScratchTerminals(wt.worktree) }
         await finishActuation(actuationID, .dispatched)
 
         // Move the folder to Trash — never rm -rf. Promoted rows already had
@@ -177,7 +177,7 @@ extension RPCRouter {
         _ paramsData: Data, actor: ActuationActor? = nil
     ) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchArchiveParams.self, from: paramsData)
-        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+        guard let wt = try await db.worktrees.getLocal(id: params.worktreeID) else {
             return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
         }
         guard wt.isScratch else {
@@ -189,7 +189,7 @@ extension RPCRouter {
         let actuationID = try await beginActuation(
             .scratchArchive, actor: actor,
             target: ActuationTarget(worktree: wt.id.uuidString))
-        try await actuating(actuationID) { try await closeScratchTerminals(wt) }
+        try await actuating(actuationID) { try await closeScratchTerminals(wt.worktree) }
         await finishActuation(actuationID, .dispatched)
         try await db.worktrees.archive(id: wt.id)
 
@@ -207,7 +207,7 @@ extension RPCRouter {
     /// repo-scoped revive.
     func handleScratchRevive(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchReviveParams.self, from: paramsData)
-        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+        guard let wt = try await db.worktrees.getLocal(id: params.worktreeID) else {
             return RPCResponse(error: "Scratch space not found: \(params.worktreeID)")
         }
         guard wt.isScratch else {
@@ -230,7 +230,7 @@ extension RPCRouter {
 
     func handleScratchPromote(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(ScratchPromoteParams.self, from: paramsData)
-        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+        guard let wt = try await db.worktrees.getLocal(id: params.worktreeID) else {
             return RPCResponse(error: "Scratch space not found")
         }
         guard wt.isScratch else { return RPCResponse(error: "Not a scratch space") }
@@ -303,7 +303,7 @@ extension RPCRouter {
         // addRepo just created the repo's main worktree; fetch it. Defensive
         // guard only — addRepo unconditionally calls createMain, so the else
         // branch is unreachable short of DB corruption.
-        if let mainWorktree = try await db.worktrees.list(repoID: repo.id, status: .main).first {
+        if let mainWorktree = try await db.worktrees.listLocal(repoID: repo.id, status: .main).first {
             // ALL row mutations in ONE transaction (terminals re-parented, tab
             // state migrated, main worktree inheriting the scratch tmux server
             // so the live panes stay reachable, scratch row retired with its

--- a/Sources/TBDDaemon/Server/RPCRouter+SessionHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+SessionHandlers.swift
@@ -9,7 +9,7 @@ extension RPCRouter {
     func handleSessionList(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(SessionListParams.self, from: paramsData)
 
-        guard let worktree = try await db.worktrees.get(id: params.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: params.worktreeID) else {
             return try RPCResponse(result: [SessionSummary]())
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -824,7 +824,7 @@ extension RPCRouter {
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
-            cwd: worktree.path,
+            cwd: worktree.localPath,
             shellCommand: spawnCommand,
             env: env,
             sensitiveEnv: sensitiveEnv,
@@ -1701,7 +1701,7 @@ extension RPCRouter {
         let window = try await tmux.createWindow(
             server: worktree.tmuxServer,
             session: "main",
-            cwd: worktree.path,
+            cwd: worktree.localPath,
             shellCommand: spawnCommand,
             env: env,
             sensitiveEnv: sensitiveEnv,
@@ -1784,7 +1784,7 @@ extension RPCRouter {
             try await tmux.respawnWindow(
                 server: server,
                 windowID: windowID,
-                cwd: worktree.path,
+                cwd: worktree.localPath,
                 shellCommand: spawnCommand,
                 env: env,
                 sensitiveEnv: sensitiveEnv,

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -83,7 +83,7 @@ extension RPCRouter {
         let params = try decoder.decode(TerminalCreateParams.self, from: paramsData)
 
         // Look up the worktree to get tmux server and path
-        guard let worktree = try await db.worktrees.get(id: params.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: params.worktreeID) else {
             return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
         }
 
@@ -171,7 +171,7 @@ extension RPCRouter {
 
         // Build env vars available in all TBD terminals
         var env = SystemPromptBuilder.promptLayers(
-            repo: repo, worktree: worktree, scratchInstructions: createConfig?.scratchInstructions,
+            repo: repo, worktree: worktree.worktree, scratchInstructions: createConfig?.scratchInstructions,
             scratchRenamePrompt: createConfig?.scratchRenamePrompt)
         env["TBD_WORKTREE_ID"] = params.worktreeID.uuidString
         env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
@@ -319,7 +319,7 @@ extension RPCRouter {
             claudeSessionID = sessionID
             freshSessionID = sessionID
             appendSystemPrompt = SystemPromptBuilder.build(
-                repo: repo, worktree: worktree, isResume: false,
+                repo: repo, worktree: worktree.worktree, isResume: false,
                 scratchInstructions: createConfig?.scratchInstructions,
                 scratchRenamePrompt: createConfig?.scratchRenamePrompt)
             label = isLoginSession ? TerminalLabel.login : TerminalLabel.claudeCode
@@ -350,7 +350,7 @@ extension RPCRouter {
         // reinstating the stall.
         if isClaudeType {
             await ClaudeTrustSeeder.ensureTrusted(
-                worktree: worktree,
+                worktree: worktree.worktree,
                 autoTrustNonScratch: createConfig?.autoTrustWorktrees ?? true,
                 profileConfigDir: profileConfigDir)
         }
@@ -549,7 +549,7 @@ extension RPCRouter {
             // are on and the row looks busy) while a DB failure still confirms
             // the request row before it propagates.
             let railWorktree = try await actuating(actuationID) {
-                try await db.worktrees.get(id: terminal.worktreeID)
+                try await db.worktrees.getLocal(id: terminal.worktreeID)
             }
             if let railWorktree,
                await tmux.windowExists(
@@ -578,7 +578,7 @@ extension RPCRouter {
         // Terminals). Strictly best-effort: any failure logs inside
         // captureOnClose and the close proceeds unchanged.
         let worktree = try await actuating(actuationID) {
-            try await db.worktrees.get(id: terminal.worktreeID)
+            try await db.worktrees.getLocal(id: terminal.worktreeID)
         }
         // Set when the kill itself failed. The deletion proceeds regardless
         // (pre-existing contract — the row goes and the response is the same),
@@ -646,7 +646,7 @@ extension RPCRouter {
     ) async throws -> RPCResponse {
         let params = try decoder.decode(TerminalHistoryReviveParams.self, from: paramsData)
 
-        guard let worktree = try await db.worktrees.get(id: params.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: params.worktreeID) else {
             return RPCResponse(error: "Worktree not found: \(params.worktreeID)")
         }
         // A revived terminal must land in a live worktree — an archived row's
@@ -708,7 +708,7 @@ extension RPCRouter {
             // rather than in the create-time parameter list. `reviveConfig` is a
             // `try?` read; fall back to the shipped default.
             await ClaudeTrustSeeder.ensureTrusted(
-                worktree: worktree,
+                worktree: worktree.worktree,
                 autoTrustNonScratch: reviveConfig?.autoTrustWorktrees ?? true,
                 profileConfigDir: profileConfigDir)
             await TranscriptProjectDirSync.ensureSessionResumableDetached(
@@ -751,7 +751,7 @@ extension RPCRouter {
             )
             let terminal = try await actuating(actuationID) {
                 try await spawnRevivedTerminal(
-                    worktree: worktree,
+                    worktree: worktree.worktree,
                     plannedTerminalID: plannedTerminalID,
                     spawnCommand: spawn.command,
                     env: env,
@@ -786,7 +786,7 @@ extension RPCRouter {
         ]
         let terminal = try await actuating(actuationID) {
             try await spawnRevivedTerminal(
-                worktree: worktree,
+                worktree: worktree.worktree,
                 plannedTerminalID: plannedTerminalID,
                 spawnCommand: command,
                 env: env,
@@ -894,7 +894,7 @@ extension RPCRouter {
             return RPCResponse(error: "Terminal not found: \(params.terminalID)")
         }
 
-        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
 
@@ -1121,7 +1121,7 @@ extension RPCRouter {
             return RPCResponse(error: "Terminal not found: \(params.terminalID)")
         }
 
-        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
 
@@ -1148,7 +1148,7 @@ extension RPCRouter {
             return RPCResponse(error: "No Claude session ID for terminal \(params.terminalID)")
         }
 
-        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
 
@@ -1354,7 +1354,7 @@ extension RPCRouter {
         guard let sessionID = oldTerminal.claudeSessionID else {
             return RPCResponse(error: "Terminal \(params.terminalID) is not a Claude terminal")
         }
-        guard let worktree = try await db.worktrees.get(id: oldTerminal.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: oldTerminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
 
@@ -1464,7 +1464,7 @@ extension RPCRouter {
         let plannedTerminalID = mode == .inPlace ? oldTerminal.id : UUID()
         let swapConfig = try? await db.config.get()
         var env = SystemPromptBuilder.promptLayers(
-            repo: repo, worktree: worktree, scratchInstructions: swapConfig?.scratchInstructions,
+            repo: repo, worktree: worktree.worktree, scratchInstructions: swapConfig?.scratchInstructions,
             scratchRenamePrompt: swapConfig?.scratchRenamePrompt)
         env["TBD_WORKTREE_ID"] = worktree.id.uuidString
         env["TBD_TERMINAL_ID"] = plannedTerminalID.uuidString
@@ -1556,7 +1556,7 @@ extension RPCRouter {
         // Claude-only handler. `swapConfig` is a `try?` read; fall back to the
         // shipped default.
         await ClaudeTrustSeeder.ensureTrusted(
-            worktree: worktree,
+            worktree: worktree.worktree,
             autoTrustNonScratch: swapConfig?.autoTrustWorktrees ?? true,
             profileConfigDir: configDirManager.resolveConfigDir(for: resolved))
 
@@ -1594,7 +1594,7 @@ extension RPCRouter {
         case .fresh(let newSessionID):
             logger.debug("swap: blank session — spawning fresh \(newSessionID, privacy: .public)")
             let appendPrompt = SystemPromptBuilder.build(
-                repo: repo, worktree: worktree, isResume: false,
+                repo: repo, worktree: worktree.worktree, isResume: false,
                 scratchInstructions: swapConfig?.scratchInstructions,
                 scratchRenamePrompt: swapConfig?.scratchRenamePrompt)
             spawn = ClaudeSpawnCommandBuilder.build(
@@ -1640,7 +1640,7 @@ extension RPCRouter {
             switch mode {
             case .fork:
                 response = try await forkSwapNewTab(
-                    worktree: worktree,
+                    worktree: worktree.worktree,
                     plannedTerminalID: plannedTerminalID,
                     spawnCommand: spawn.command,
                     env: env,
@@ -1655,7 +1655,7 @@ extension RPCRouter {
             case .inPlace:
                 let outcome = try await inPlaceSwapRespawn(
                     oldTerminal: oldTerminal,
-                    worktree: worktree,
+                    worktree: worktree.worktree,
                     spawnCommand: spawn.command,
                     env: env,
                     sensitiveEnv: sensitiveEnv,
@@ -1916,7 +1916,7 @@ extension RPCRouter {
         }
 
         // Look up the worktree to get the tmux server name
-        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
         }
 
@@ -2190,7 +2190,7 @@ extension RPCRouter {
         terminalID: UUID, sessionID: String?, payload: String, submit: Bool
     ) async -> ActuationOutcome {
         guard let terminal = try? await db.terminals.get(id: terminalID),
-              let worktree = try? await db.worktrees.get(id: terminal.worktreeID) else {
+              let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return .refused(.notFound)
         }
         // The kind is re-read too, not just the pane. A `recreateWindow` landing
@@ -2397,7 +2397,7 @@ extension RPCRouter {
         // tmux servers killed, so resizing windows there spawns dead `tmux
         // resize-window` processes (errors swallowed by `try?`) on every
         // resize-debounce tick during a window drag.
-        let worktrees = try await db.worktrees.list(status: .active)
+        let worktrees = try await db.worktrees.listLocal(status: .active)
         let serverByWorktree = Dictionary(uniqueKeysWithValues: worktrees.map { ($0.id, $0.tmuxServer) })
 
         logger.debug("setMainAreaSize \(params.cols, privacy: .public)x\(params.rows, privacy: .public) across \(allTerminals.count, privacy: .public) terminals")
@@ -2498,9 +2498,9 @@ extension RPCRouter {
 
             // Reconcile DB against actual git worktree list
             do {
-                let beforeCount = try await db.worktrees.list(repoID: repo.id, status: .active).count
+                let beforeCount = try await db.worktrees.listLocal(repoID: repo.id, status: .active).count
                 try await lifecycle.reconcile(repoID: repo.id, actuationLog: actuationLog)
-                let afterCount = try await db.worktrees.list(repoID: repo.id, status: .active).count
+                let afterCount = try await db.worktrees.listLocal(repoID: repo.id, status: .active).count
                 let delta = abs(beforeCount - afterCount)
                 worktreesReconciled += delta
             } catch {
@@ -2648,9 +2648,9 @@ extension RPCRouter {
             // of the promoted-to repo.
             if !accepted,
                let resolvedWorktreeID = resolved?.worktreeID,
-               let ownerWorktree = try await db.worktrees.get(id: terminal.worktreeID),
+               let ownerWorktree = try await db.worktrees.getLocal(id: terminal.worktreeID),
                let promotedRepoID = ownerWorktree.promotedToRepoID,
-               let resolvedWorktree = try await db.worktrees.get(id: resolvedWorktreeID),
+               let resolvedWorktree = try await db.worktrees.getLocal(id: resolvedWorktreeID),
                resolvedWorktree.repoID == promotedRepoID,
                resolvedWorktree.status == .main {
                 accepted = true
@@ -2750,7 +2750,7 @@ extension RPCRouter {
         if params.activityState == .idle,
            let storedPath = terminal.transcriptPath, !storedPath.isEmpty,
            FileManager.default.fileExists(atPath: storedPath),
-           let worktree = try? await db.worktrees.get(id: terminal.worktreeID) {
+           let worktree = try? await db.worktrees.getLocal(id: terminal.worktreeID) {
             let derivedDir = TranscriptProjectDirSync.derivedProjectDir(
                 worktreePath: worktree.path,
                 projectsRoot: claudeProjectsRoot(forProfileID: terminal.profileID)
@@ -2803,7 +2803,7 @@ extension RPCRouter {
             return response
         }
 
-        guard let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+        guard let worktree = try await db.worktrees.getLocal(id: terminal.worktreeID) else {
             response = RPCResponse(error: "Worktree not found for terminal: \(params.terminalID)")
             return response
         }
@@ -2862,7 +2862,7 @@ extension RPCRouter {
             return RPCResponse(error: "Terminal not found: \(params.terminalID)")
         }
         guard let sessionID = terminal.claudeSessionID,
-              let worktree = try await db.worktrees.get(id: terminal.worktreeID) else {
+              let worktree = try await db.worktrees.getLocal(id: terminal.worktreeID) else {
             return try RPCResponse(result: TerminalTranscriptItemFullBodyResult(text: "Output no longer available."))
         }
 

--- a/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+WorktreeHandlers.swift
@@ -120,7 +120,7 @@ extension RPCRouter {
                 case .ready:
                     subs.broadcast(delta: .worktreeCreated(WorktreeDelta(
                         worktreeID: pending.id, repoID: pending.repoID,
-                        name: pending.name, path: pending.path
+                        name: pending.name, path: pending.localPath
                     )))
                 case .preSessionPending:
                     // The lifecycle already broadcast `.worktreeCreated` (and
@@ -183,7 +183,7 @@ extension RPCRouter {
         // count, and enriching all archived rows made that lookup take ~19s.
         if params.status == .archived && (params.includeSessionCounts ?? true) {
             for i in worktrees.indices where worktrees[i].status == .archived {
-                if let dir = ClaudeProjectDirectory.resolve(worktreePath: worktrees[i].path) {
+                if let dir = ClaudeProjectDirectory.resolve(worktreePath: worktrees[i].localPath) {
                     worktrees[i].liveClaudeSessionCount = ClaudeSessionScanner.countSessionFiles(projectDir: dir)
                 } else {
                     worktrees[i].liveClaudeSessionCount = 0
@@ -285,7 +285,7 @@ extension RPCRouter {
 
         // Capture the path before the row is deleted so the result can report
         // the directory we deliberately left on disk.
-        let path = try await db.worktrees.get(id: params.worktreeID)?.path
+        let path = try await db.worktrees.get(id: params.worktreeID)?.localPath
 
         // Forget kills the same windows archive does, so it records the same
         // shape: one worktree-named row per call, ahead of the first kill.
@@ -347,7 +347,7 @@ extension RPCRouter {
 
         subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
             worktreeID: worktree.id, repoID: worktree.repoID,
-            name: worktree.name, path: worktree.path
+            name: worktree.name, path: worktree.localPath
         )))
 
         return try RPCResponse(result: worktree)
@@ -416,7 +416,7 @@ extension RPCRouter {
                 worktreeID: created.id,
                 repoID: created.repoID,
                 name: created.name,
-                path: created.path
+                path: created.localPath
             )))
         case .preSessionPending:
             // The lifecycle already broadcast `.worktreeCreated` alongside
@@ -444,12 +444,12 @@ extension RPCRouter {
         case .inserted:
             subscriptions.broadcast(delta: .worktreeCreated(WorktreeDelta(
                 worktreeID: worktree.id, repoID: worktree.repoID,
-                name: worktree.name, path: worktree.path
+                name: worktree.name, path: worktree.localPath
             )))
         case .revived:
             subscriptions.broadcast(delta: .worktreeRevived(WorktreeDelta(
                 worktreeID: worktree.id, repoID: worktree.repoID,
-                name: worktree.name, path: worktree.path
+                name: worktree.name, path: worktree.localPath
             )))
         case .unchanged:
             break

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -618,22 +618,33 @@ public final class RPCRouter: Sendable {
     /// by-number lookups scope to each worktree's own repo). Pulled out
     /// as a pure function (rather than inlined `.filter` in `computePRList`)
     /// so it's directly unit-testable without spinning up git/gh machinery.
+    ///
+    /// Remote rows are excluded for a second reason: everything downstream is
+    /// keyed on the worktree's path. `branchFacts` runs `git` inside it and
+    /// caches the answer under that path, and `PRStatusManager` runs `gh` there
+    /// — against a directory that does not exist on this machine. Polling a
+    /// remote lane's PR is wanted eventually and needs to key on the BRANCH
+    /// instead; until then, not polling is the only correct behavior.
     static func pollableWorktrees(_ worktrees: [Worktree]) -> [Worktree] {
-        worktrees.filter { !$0.isScratch }
+        worktrees.filter { !$0.isScratch && $0.location.isLocal }
     }
 
     private func handlePRRefresh(_ paramsData: Data) async throws -> RPCResponse {
         let params = try decoder.decode(PRRefreshParams.self, from: paramsData)
 
-        // Run targeted refresh in the worktree and try the tracked upstream branch when needed.
-        guard let wt = try await db.worktrees.get(id: params.worktreeID) else {
+        // Run targeted refresh in the worktree and try the tracked upstream
+        // branch when needed. Local rows only, for the same reason
+        // `pollableWorktrees` excludes remote ones: this runs `git` and `gh`
+        // inside the worktree's path. A remote id gets the same "nothing to
+        // report" answer as an unknown one.
+        guard let wt = try await db.worktrees.getLocal(id: params.worktreeID) else {
             return try RPCResponse(result: PRRefreshResult(status: nil))
         }
         // Read the branch facts through the SAME cache the poll uses. Reading
         // git directly here would let a user refresh attach a PR that the very
         // next poll — still inside the cache's TTL, still holding the older
         // facts — judges by a different candidate list and clears again.
-        let (upstreamBranch, pushBranch) = await branchFacts(worktreePath: wt.localPath, branch: wt.branch)
+        let (upstreamBranch, pushBranch) = await branchFacts(worktreePath: wt.path, branch: wt.branch)
         var defaultBranch: String?
         if let repoID = wt.repoID {
             defaultBranch = try await db.repos.get(id: repoID)?.defaultBranch
@@ -645,7 +656,7 @@ public final class RPCRouter: Sendable {
             upstreamBranch: upstreamBranch,
             defaultBranch: defaultBranch,
             pushBranch: pushBranch,
-            repoPath: wt.localPath,
+            repoPath: wt.path,
             prNumber: wt.prNumber
         )
         return try RPCResponse(result: PRRefreshResult(status: status))

--- a/Sources/TBDDaemon/Server/RPCRouter.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter.swift
@@ -575,14 +575,14 @@ public final class RPCRouter: Sendable {
         var infos: [PRStatusManager.PollWorktree] = []
         infos.reserveCapacity(worktrees.count)
         for wt in worktrees {
-            let (upstreamBranch, pushBranch) = await branchFacts(worktreePath: wt.path, branch: wt.branch)
+            let (upstreamBranch, pushBranch) = await branchFacts(worktreePath: wt.localPath, branch: wt.branch)
             infos.append((
                 id: wt.id,
                 branch: wt.branch,
                 upstreamBranch: upstreamBranch,
                 defaultBranch: wt.repoID.flatMap { defaultBranchByRepo[$0] },
                 pushBranch: pushBranch,
-                worktreePath: wt.path,
+                worktreePath: wt.localPath,
                 prNumber: wt.prNumber
             ))
         }
@@ -633,7 +633,7 @@ public final class RPCRouter: Sendable {
         // git directly here would let a user refresh attach a PR that the very
         // next poll — still inside the cache's TTL, still holding the older
         // facts — judges by a different candidate list and clears again.
-        let (upstreamBranch, pushBranch) = await branchFacts(worktreePath: wt.path, branch: wt.branch)
+        let (upstreamBranch, pushBranch) = await branchFacts(worktreePath: wt.localPath, branch: wt.branch)
         var defaultBranch: String?
         if let repoID = wt.repoID {
             defaultBranch = try await db.repos.get(id: repoID)?.defaultBranch
@@ -645,7 +645,7 @@ public final class RPCRouter: Sendable {
             upstreamBranch: upstreamBranch,
             defaultBranch: defaultBranch,
             pushBranch: pushBranch,
-            repoPath: wt.path,
+            repoPath: wt.localPath,
             prNumber: wt.prNumber
         )
         return try RPCResponse(result: PRRefreshResult(status: status))

--- a/Sources/TBDShared/LocalWorktree.swift
+++ b/Sources/TBDShared/LocalWorktree.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A `Worktree` proven to have files on this machine.
+///
+/// Local-only subsystems — terminal spawn, hibernation, archive, the file
+/// viewer, reconcile — take this instead of a bare `Worktree`, so a remote row
+/// cannot reach them. The guard is the compiler, not a check someone
+/// remembered to write: `WorktreeStore.listLocal` simply does not return one.
+///
+/// Reads forward to the wrapped value through `@dynamicMemberLookup`, so
+/// handler bodies keep saying `worktree.id` and `worktree.branch` unchanged.
+/// Forwarding is read-only by construction; code that MUTATES a fetched row
+/// reaches through `.worktree` explicitly.
+@dynamicMemberLookup
+public struct LocalWorktree: Equatable, Sendable {
+    /// The wrapped row. Use for mutation, or to pass a bare `Worktree` on to
+    /// location-neutral code.
+    public let worktree: Worktree
+
+    /// Non-optional: a `LocalWorktree` cannot exist without one.
+    public let path: String
+
+    /// Non-optional for the same reason as `path`. A remote row has no tmux
+    /// server, and reconcile's canonicalization loop must never see one.
+    public let tmuxServer: String
+
+    /// Fails when the worktree is remote, or when it is local but has no
+    /// directory yet (the `.creating` placeholder writes `path: ""`).
+    public init?(_ worktree: Worktree) {
+        // `worktree.path` becomes `worktree.localPath` when the stored path is
+        // renamed — both reads below move together.
+        guard worktree.location.isLocal, !worktree.path.isEmpty else { return nil }
+        self.worktree = worktree
+        self.path = worktree.path
+        self.tmuxServer = worktree.tmuxServer
+    }
+
+    public subscript<T>(dynamicMember keyPath: KeyPath<Worktree, T>) -> T {
+        worktree[keyPath: keyPath]
+    }
+}

--- a/Sources/TBDShared/LocalWorktree.swift
+++ b/Sources/TBDShared/LocalWorktree.swift
@@ -26,6 +26,11 @@ public struct LocalWorktree: Equatable, Sendable {
 
     /// Fails when the worktree is remote, or when it is local but has no
     /// directory yet (the `.creating` placeholder writes `path: ""`).
+    ///
+    /// Locality is checked FIRST and is the only thing that rejects a remote
+    /// row. A remote row's stored path is the synthetic `remote://` URI from
+    /// `WorktreeLocation.storagePath`, not an empty string, so the empty-path
+    /// arm would not catch it; that arm exists for the local placeholder alone.
     public init?(_ worktree: Worktree) {
         guard worktree.location.isLocal, !worktree.localPath.isEmpty else { return nil }
         self.worktree = worktree

--- a/Sources/TBDShared/LocalWorktree.swift
+++ b/Sources/TBDShared/LocalWorktree.swift
@@ -27,11 +27,9 @@ public struct LocalWorktree: Equatable, Sendable {
     /// Fails when the worktree is remote, or when it is local but has no
     /// directory yet (the `.creating` placeholder writes `path: ""`).
     public init?(_ worktree: Worktree) {
-        // `worktree.path` becomes `worktree.localPath` when the stored path is
-        // renamed — both reads below move together.
-        guard worktree.location.isLocal, !worktree.path.isEmpty else { return nil }
+        guard worktree.location.isLocal, !worktree.localPath.isEmpty else { return nil }
         self.worktree = worktree
-        self.path = worktree.path
+        self.path = worktree.localPath
         self.tmuxServer = worktree.tmuxServer
     }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -109,6 +109,17 @@ public enum NightwatchMode: String, Codable, Sendable, CaseIterable {
     case nightwatch
 }
 
+/// Where a worktree's files live. `.local` means a git worktree on this
+/// machine at the worktree's path. `.remote` means an agent session on a
+/// machine TBD does not manage, reached through a registered provider; there is
+/// no local checkout and no tmux server.
+public enum WorktreeLocation: Equatable, Sendable, Hashable {
+    case local
+    case remote(provider: String, sessionID: String)
+
+    public var isLocal: Bool { self == .local }
+}
+
 public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public let id: UUID
     /// nil for scratch spaces (repo-less worktrees).
@@ -181,6 +192,17 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// order — which is what lets the column ship with no backfill.
     public var pinSortOrder: Int?
 
+    /// Where this worktree's files live. Rows written before v70 decode as
+    /// `.local`, which is what they are.
+    public var location: WorktreeLocation = .local
+
+    /// The `(provider, sessionID)` pair identifying this row's provider
+    /// session, or nil when the worktree is local.
+    public var providerBinding: (provider: String, sessionID: String)? {
+        guard case let .remote(provider, sessionID) = location else { return nil }
+        return (provider, sessionID)
+    }
+
     /// A scratch space is a repo-less worktree. Derived — no separate column.
     public var isScratch: Bool { repoID == nil }
 
@@ -213,7 +235,8 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
                 prNumber: Int? = nil,
                 foreignHead: Bool = false,
                 pinnedAt: Date? = nil,
-                pinSortOrder: Int? = nil) {
+                pinSortOrder: Int? = nil,
+                location: WorktreeLocation = .local) {
         self.id = id
         self.repoID = repoID
         self.name = name
@@ -238,6 +261,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.foreignHead = foreignHead
         self.pinnedAt = pinnedAt
         self.pinSortOrder = pinSortOrder
+        self.location = location
     }
 
     enum CodingKeys: String, CodingKey {
@@ -247,6 +271,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         case liveClaudeSessionCount, parentWorktreeID, autoArchiveOnMerge
         case autoHibernateOnMerge
         case promotedToRepoID, prStatus, prNumber, foreignHead, pinnedAt, pinSortOrder
+        case locationKind, providerName, providerSessionID
     }
 
     public init(from decoder: Decoder) throws {
@@ -277,6 +302,59 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         foreignHead = try c.decodeIfPresent(Bool.self, forKey: .foreignHead) ?? false
         pinnedAt = try c.decodeIfPresent(Date.self, forKey: .pinnedAt)
         pinSortOrder = try c.decodeIfPresent(Int.self, forKey: .pinSortOrder)
+        // Absent in JSON written before v70, and unknown kinds are what a
+        // NEWER daemon will send an older app. Both land on `.local`: a
+        // pre-v70 row genuinely is local, and an unrecognized kind is safer
+        // read as local than dropped, which would fail the whole decode.
+        let kind = try c.decodeIfPresent(String.self, forKey: .locationKind) ?? "local"
+        if kind == "remote",
+           let provider = try c.decodeIfPresent(String.self, forKey: .providerName),
+           let sessionID = try c.decodeIfPresent(String.self, forKey: .providerSessionID) {
+            location = .remote(provider: provider, sessionID: sessionID)
+        } else {
+            location = .local
+        }
+    }
+
+    /// Hand-written because `location` is an enum with an associated value that
+    /// rides the wire as three flat keys, which no synthesized encoder can
+    /// produce. Every stored property is listed here: a property added to the
+    /// struct and forgotten here would silently vanish between daemon and app.
+    /// `WorktreeLocationTests.roundTripsAFullyPopulatedWorktree` is the guard.
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encodeIfPresent(repoID, forKey: .repoID)
+        try c.encode(name, forKey: .name)
+        try c.encode(displayName, forKey: .displayName)
+        try c.encode(branch, forKey: .branch)
+        try c.encode(path, forKey: .path)
+        try c.encode(status, forKey: .status)
+        try c.encode(hasConflicts, forKey: .hasConflicts)
+        try c.encode(createdAt, forKey: .createdAt)
+        try c.encodeIfPresent(archivedAt, forKey: .archivedAt)
+        try c.encode(tmuxServer, forKey: .tmuxServer)
+        try c.encodeIfPresent(archivedClaudeSessions, forKey: .archivedClaudeSessions)
+        try c.encode(sortOrder, forKey: .sortOrder)
+        try c.encodeIfPresent(archivedHeadSHA, forKey: .archivedHeadSHA)
+        try c.encodeIfPresent(liveClaudeSessionCount, forKey: .liveClaudeSessionCount)
+        try c.encodeIfPresent(parentWorktreeID, forKey: .parentWorktreeID)
+        try c.encodeIfPresent(autoArchiveOnMerge, forKey: .autoArchiveOnMerge)
+        try c.encodeIfPresent(autoHibernateOnMerge, forKey: .autoHibernateOnMerge)
+        try c.encodeIfPresent(promotedToRepoID, forKey: .promotedToRepoID)
+        try c.encodeIfPresent(prStatus, forKey: .prStatus)
+        try c.encodeIfPresent(prNumber, forKey: .prNumber)
+        try c.encode(foreignHead, forKey: .foreignHead)
+        try c.encodeIfPresent(pinnedAt, forKey: .pinnedAt)
+        try c.encodeIfPresent(pinSortOrder, forKey: .pinSortOrder)
+        switch location {
+        case .local:
+            try c.encode("local", forKey: .locationKind)
+        case let .remote(provider, sessionID):
+            try c.encode("remote", forKey: .locationKind)
+            try c.encode(provider, forKey: .providerName)
+            try c.encode(sessionID, forKey: .providerSessionID)
+        }
     }
 }
 

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -127,7 +127,12 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     public var name: String
     public var displayName: String
     public var branch: String
-    public var path: String
+    /// Absolute path to the git worktree directory on THIS machine. Named
+    /// `localPath` rather than `path` so that every read of it is visibly a
+    /// local-only assumption; code that must work for any worktree goes
+    /// through `LocalWorktree` instead. The wire key and the DB column both
+    /// stay `path`.
+    public var localPath: String
     public var status: WorktreeStatus
     public var hasConflicts: Bool = false
     public var createdAt: Date
@@ -242,7 +247,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         self.name = name
         self.displayName = displayName
         self.branch = branch
-        self.path = path
+        self.localPath = path
         self.status = status
         self.hasConflicts = hasConflicts
         self.createdAt = createdAt
@@ -281,7 +286,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         name = try c.decode(String.self, forKey: .name)
         displayName = try c.decode(String.self, forKey: .displayName)
         branch = try c.decode(String.self, forKey: .branch)
-        path = try c.decode(String.self, forKey: .path)
+        localPath = try c.decode(String.self, forKey: .path)
         status = try c.decode(WorktreeStatus.self, forKey: .status)
         hasConflicts = try c.decodeIfPresent(Bool.self, forKey: .hasConflicts) ?? false
         createdAt = try c.decode(Date.self, forKey: .createdAt)
@@ -328,7 +333,7 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
         try c.encode(name, forKey: .name)
         try c.encode(displayName, forKey: .displayName)
         try c.encode(branch, forKey: .branch)
-        try c.encode(path, forKey: .path)
+        try c.encode(localPath, forKey: .path)
         try c.encode(status, forKey: .status)
         try c.encode(hasConflicts, forKey: .hasConflicts)
         try c.encode(createdAt, forKey: .createdAt)

--- a/Sources/TBDShared/Models.swift
+++ b/Sources/TBDShared/Models.swift
@@ -118,6 +118,42 @@ public enum WorktreeLocation: Equatable, Sendable, Hashable {
     case remote(provider: String, sessionID: String)
 
     public var isLocal: Bool { self == .local }
+
+    /// The value a row of this location stores in `worktree.path`, or nil when
+    /// the caller supplies the path itself.
+    ///
+    /// nil for `.local`: a local row's path is a real directory on this disk
+    /// and only the caller knows it.
+    ///
+    /// Non-nil for `.remote`, because `worktree.path` is `NOT NULL UNIQUE` and
+    /// a remote row has no path of its own. The empty string works for exactly
+    /// one remote row — the second lane in a fan-out aborts on the constraint.
+    /// A synthetic `remote://<provider>/<sessionID>` URI is unique per session
+    /// and visibly not a filesystem path, so a row that ever leaks into
+    /// path-consuming code fails loudly rather than silently operating on the
+    /// current directory.
+    ///
+    /// Provider names and session IDs are provider-supplied strings that may
+    /// contain `/` or other delimiters, so each component is percent-encoded
+    /// against RFC 3986's unreserved set. That encoding is injective and the
+    /// separator cannot survive it, so distinct `(provider, sessionID)` pairs
+    /// always yield distinct paths.
+    public var storagePath: String? {
+        switch self {
+        case .local:
+            return nil
+        case .remote(let provider, let sessionID):
+            return "remote://\(Self.pathEscaped(provider))/\(Self.pathEscaped(sessionID))"
+        }
+    }
+
+    /// RFC 3986's unreserved set; everything else is percent-encoded.
+    private static let unreserved = CharacterSet(
+        charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+    private static func pathEscaped(_ component: String) -> String {
+        component.addingPercentEncoding(withAllowedCharacters: unreserved) ?? component
+    }
 }
 
 public struct Worktree: Codable, Sendable, Identifiable, Equatable {
@@ -132,6 +168,10 @@ public struct Worktree: Codable, Sendable, Identifiable, Equatable {
     /// local-only assumption; code that must work for any worktree goes
     /// through `LocalWorktree` instead. The wire key and the DB column both
     /// stay `path`.
+    ///
+    /// On a remote row this is not a filesystem path at all but the synthetic
+    /// `remote://` URI from `WorktreeLocation.storagePath`, which exists only
+    /// to satisfy the column's `NOT NULL UNIQUE` constraint.
     public var localPath: String
     public var status: WorktreeStatus
     public var hasConflicts: Bool = false

--- a/Tests/TBDAppTests/ArchiveTombstoneTests.swift
+++ b/Tests/TBDAppTests/ArchiveTombstoneTests.swift
@@ -228,7 +228,7 @@ final class ArchiveTombstoneTests: XCTestCase {
             worktreeID: reviveWt.id,
             repoID: reviveWt.repoID,
             name: reviveWt.name,
-            path: reviveWt.path,
+            path: reviveWt.localPath,
             status: reviveWt.status
         )
         state.handleDelta(.worktreeRevived(delta))

--- a/Tests/TBDAppTests/LocalWorktreeConversionTests.swift
+++ b/Tests/TBDAppTests/LocalWorktreeConversionTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Foundation
+@testable import TBDApp
+@testable import TBDShared
+
+/// Tier 1: the app-side end of the local/remote boundary. `selectedLocalWorktree`
+/// is what every directory-reading view binds to, so these pin that a selection
+/// with no checkout on this disk resolves to nil rather than to an empty path.
+@Suite @MainActor struct LocalWorktreeConversionTests {
+
+    private func makeWorktree(location: WorktreeLocation, path: String) -> Worktree {
+        Worktree(repoID: UUID(), name: "n", displayName: "n", branch: "b",
+                 path: path, tmuxServer: "s", location: location)
+    }
+
+    /// `UserDefaults.standard` on this unbundled executable is the developer's
+    /// real `TBDApp.plist`, so every case gets its own named suite and tears it
+    /// down.
+    private func withState(_ suiteName: String, _ body: (AppState) -> Void) {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        body(AppState(userDefaults: defaults))
+    }
+
+    @Test func selectedLocalWorktreeIsNilForARemoteSelection() {
+        withState("LocalWorktreeConversionTests.remote") { state in
+            let remote = makeWorktree(
+                location: .remote(provider: "agentbox", sessionID: "s-1"), path: "")
+            state.worktrees[remote.repoID!] = [remote]
+            state.selectedWorktreeIDs = [remote.id]
+            #expect(state.selectedLocalWorktree == nil)
+        }
+    }
+
+    /// The optimistic creation placeholder is local but has no directory yet.
+    /// It is the only empty-path row today, and it must not reach a view that
+    /// reads a directory.
+    @Test func selectedLocalWorktreeIsNilForAnEmptyPathPlaceholder() {
+        withState("LocalWorktreeConversionTests.creating") { state in
+            let placeholder = makeWorktree(location: .local, path: "")
+            state.worktrees[placeholder.repoID!] = [placeholder]
+            state.selectedWorktreeIDs = [placeholder.id]
+            #expect(state.selectedLocalWorktree == nil)
+        }
+    }
+
+    @Test func selectedLocalWorktreeWrapsALocalSelection() {
+        withState("LocalWorktreeConversionTests.local") { state in
+            let local = makeWorktree(location: .local, path: "/tmp/w")
+            state.worktrees[local.repoID!] = [local]
+            state.selectedWorktreeIDs = [local.id]
+            #expect(state.selectedLocalWorktree?.path == "/tmp/w")
+            #expect(state.selectedLocalWorktree?.worktree == local)
+        }
+    }
+
+    /// `RowActionMenu.Context.pathIsEmpty` now reads off the wrapper, so the
+    /// row menu hides the path actions for exactly the rows the wrapper
+    /// refuses.
+    @Test func rowActionContextReportsPathIsEmptyForAnEmptyPathRow() {
+        withState("LocalWorktreeConversionTests.rowMenu") { state in
+            let placeholder = makeWorktree(location: .local, path: "")
+            let actions = RowActionMenuActions(
+                appState: state, worktree: placeholder, onRename: {})
+            #expect(actions.context().pathIsEmpty)
+
+            let local = makeWorktree(location: .local, path: "/tmp/w")
+            let localActions = RowActionMenuActions(
+                appState: state, worktree: local, onRename: {})
+            #expect(!localActions.context().pathIsEmpty)
+        }
+    }
+}

--- a/Tests/TBDAppTests/StatusBarViewLocationLabelTests.swift
+++ b/Tests/TBDAppTests/StatusBarViewLocationLabelTests.swift
@@ -18,9 +18,14 @@ private func worktree(branch: String, path: String) -> Worktree {
     )
 }
 
+/// The helper takes the proven-local wrapper, so the cases below build one.
+private func localWorktree(branch: String, path: String) -> LocalWorktree? {
+    LocalWorktree(worktree(branch: branch, path: path))
+}
+
 @Test func locationLabel_abbreviatesPathAndKeepsFullValueForCopying() {
     let label = StatusBarView.locationLabel(
-        worktree(branch: "feature/x", path: "/Users/me/tbd/worktrees/acme/wt"),
+        localWorktree(branch: "feature/x", path: "/Users/me/tbd/worktrees/acme/wt"),
         home: "/Users/me"
     )
     #expect(label?.displayPath == "~/tbd/worktrees/acme/wt")
@@ -28,14 +33,20 @@ private func worktree(branch: String, path: String) -> Worktree {
     #expect(label?.branch == "feature/x")
 }
 
-@Test func locationLabel_nilWorktreeOrEmptyPath_returnsNil() {
+@Test func locationLabel_nilWorktree_returnsNil() {
     #expect(StatusBarView.locationLabel(nil, home: "/Users/me") == nil)
-    #expect(StatusBarView.locationLabel(worktree(branch: "main", path: ""), home: "/Users/me") == nil)
+}
+
+/// The empty-path rule moved into `LocalWorktree`: the label helper no longer
+/// spells it out, so this asserts it at the boundary that now owns it. Without
+/// it, a worktree with no checkout would reach the status bar as a blank path.
+@Test func locationLabel_emptyPathWorktree_doesNotConvertToLocal() {
+    #expect(localWorktree(branch: "main", path: "") == nil)
 }
 
 @Test func locationLabel_blankBranch_dropsBranchSegment() {
     let label = StatusBarView.locationLabel(
-        worktree(branch: "   ", path: "/Users/me/scratch"),
+        localWorktree(branch: "   ", path: "/Users/me/scratch"),
         home: "/Users/me"
     )
     #expect(label?.branch == nil)

--- a/Tests/TBDDaemonTests/ActuationLogTeardownWiringTests.swift
+++ b/Tests/TBDDaemonTests/ActuationLogTeardownWiringTests.swift
@@ -355,6 +355,40 @@ struct ActuationLogTeardownWiringTests {
         #expect(confirmed == Set(requests.compactMap { $0["id"] as? String }))
     }
 
+    /// A row per teardown means a row per teardown that actually happens. The
+    /// cascade cannot archive a remote lane — that means stopping its provider
+    /// session — so it does not claim to have: the lane's row is removed with
+    /// the rest of the repo's rows and no dispose row names it.
+    @Test("a forced repo.remove writes no dispose row for a remote lane it cannot tear down")
+    func repoRemoveWritesNoRowForARemoteLane() async throws {
+        let logPath = try makeLogPath()
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db: db, logPath: logPath)
+        let repo = try await db.repos.create(
+            path: "/tmp/acme-\(UUID().uuidString)", displayName: "acme", defaultBranch: "main")
+        let local = try await db.worktrees.create(
+            repoID: repo.id, name: "acme-wt", branch: "acme-branch",
+            path: "/tmp/acme-wt-\(UUID().uuidString)", tmuxServer: "tbd-acme")
+        _ = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "acme-lane", branch: "acme-lane-branch",
+            provider: "stub", sessionID: "s-1")
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: repo.id, force: true)))
+        #expect(response.success, "the cascade aborted: \(response.error ?? "no error")")
+
+        let written = try rows(at: logPath)
+        let requests = written.filter { $0["kind"] as? String != "outcome" }
+        let named = Set(requests.compactMap {
+            ($0["target"] as? [String: Any])?["worktree"] as? String
+        })
+        #expect(named == [local.id.uuidString])
+        let outcomes = written.filter { $0["kind"] as? String == "outcome" }
+        #expect(outcomes.count == 1)
+        #expect(outcomes.allSatisfy { $0["result"] as? String == "dispatched" })
+    }
+
     @Test("a repo with nothing active to tear down writes no row")
     func repoRemoveWithoutWorktreesWritesNothing() async throws {
         let logPath = try makeLogPath()

--- a/Tests/TBDDaemonTests/ArchiveScratchpadCleanupTests.swift
+++ b/Tests/TBDDaemonTests/ArchiveScratchpadCleanupTests.swift
@@ -24,12 +24,12 @@ import Testing
 
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
         let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
         try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
 
-        #expect(!FileManager.default.fileExists(atPath: wt.path))
-        #expect(await box.paths == [wt.path])
+        #expect(!FileManager.default.fileExists(atPath: wt.localPath))
+        #expect(await box.paths == [wt.localPath])
         #expect(await box.repoPaths == [repo.path], "must thread the owning repo's path alongside the worktree path")
     }
 

--- a/Tests/TBDDaemonTests/ArchivedReviveBranchRenameTests.swift
+++ b/Tests/TBDDaemonTests/ArchivedReviveBranchRenameTests.swift
@@ -22,7 +22,7 @@ import Testing
 
     // Rename the branch from inside the worktree (simulates user `git branch -m`).
     let newBranch = "renamed-\(UUID().uuidString.prefix(6))"
-    try await shell("git branch -m \(newBranch)", at: URL(fileURLWithPath: wt.path))
+    try await shell("git branch -m \(newBranch)", at: URL(fileURLWithPath: wt.localPath))
 
     // Archive — should detect the rename and persist the new branch.
     try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
@@ -44,7 +44,7 @@ import Testing
     let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
 
-    let expectedSHA = try await GitManager().headSHA(worktreePath: wt.path)
+    let expectedSHA = try await GitManager().headSHA(worktreePath: wt.localPath)
 
     try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
 
@@ -70,7 +70,7 @@ import Testing
 
     let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
     #expect(revived.status == .active)
-    #expect(FileManager.default.fileExists(atPath: revived.path))
+    #expect(FileManager.default.fileExists(atPath: revived.localPath))
 }
 
 @Test func testReviveFallsBackToSHAWhenBranchMissing() async throws {
@@ -86,7 +86,7 @@ import Testing
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
 
     // Capture SHA before archive.
-    let sha = try await GitManager().headSHA(worktreePath: wt.path)
+    let sha = try await GitManager().headSHA(worktreePath: wt.localPath)
 
     try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
 
@@ -102,10 +102,10 @@ import Testing
 
     let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
     #expect(revived.status == .active)
-    #expect(FileManager.default.fileExists(atPath: revived.path))
+    #expect(FileManager.default.fileExists(atPath: revived.localPath))
 
     // The new worktree should be on the (newly created) bogus branch, with HEAD == sha.
-    let revivedSHA = try await GitManager().headSHA(worktreePath: revived.path)
+    let revivedSHA = try await GitManager().headSHA(worktreePath: revived.localPath)
     #expect(revivedSHA == sha)
 }
 
@@ -174,7 +174,7 @@ import Testing
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
     let originalBranch = wt.branch
     let renamedBranch = "renamed-\(UUID().uuidString.prefix(6))"
-    try await shell("git branch -m \(renamedBranch)", at: URL(fileURLWithPath: wt.path))
+    try await shell("git branch -m \(renamedBranch)", at: URL(fileURLWithPath: wt.localPath))
     try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
 
     // Roll the DB row back so it has the *old* branch name. This mimics the

--- a/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
+++ b/Tests/TBDDaemonTests/ClaudeTrustSeederTests.swift
@@ -408,7 +408,7 @@ struct ClaudeTrustSeederTests {
             }
         }
 
-        let missing = worktrees.map(\.path).filter { !isTrusted($0, in: configDir) }
+        let missing = worktrees.map(\.localPath).filter { !isTrusted($0, in: configDir) }
         #expect(
             missing.isEmpty,
             // Each lost key is a worktree that will stall on the trust dialog.

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -431,7 +431,7 @@ extension TBDHomeSerialized {
             )
 
             let desk = try await manager.ensureDeskSession(mode: .nightwatch)
-            let instructions = URL(fileURLWithPath: desk.path)
+            let instructions = URL(fileURLWithPath: desk.localPath)
                 .appendingPathComponent(NightwatchDeskPrompts.judgeInstructionsFileName)
 
             // Written at spawn, before any tick fires.
@@ -492,7 +492,7 @@ extension TBDHomeSerialized {
             )
 
             let desk = try await manager.ensureDeskSession(mode: .daywatch)
-            let instructions = URL(fileURLWithPath: desk.path)
+            let instructions = URL(fileURLWithPath: desk.localPath)
                 .appendingPathComponent(NightwatchDeskPrompts.judgeInstructionsFileName)
 
             await manager.nudgeDeskSession(worktreeID: desk.id, act: false)
@@ -548,7 +548,7 @@ extension TBDHomeSerialized {
             )
 
             let desk = try await manager.ensureDeskSession(mode: .daywatch)
-            let instructions = URL(fileURLWithPath: desk.path)
+            let instructions = URL(fileURLWithPath: desk.localPath)
                 .appendingPathComponent(NightwatchDeskPrompts.judgeInstructionsFileName)
 
             // Nothing nudged yet: a judge that has read nothing must read.

--- a/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/OrphanGCDeletionQueueTests.swift
@@ -325,7 +325,7 @@ struct OrphanGCDeletionQueueTests {
         let path = try await makeInterruptedArchive(
             db: db, repo: repo, repoID: repoRow.id, name: "forgotten")
         let wtID = try #require(
-            (try await db.worktrees.list(status: .archived)).first { $0.path == path }?.id)
+            (try await db.worktrees.list(status: .archived)).first { $0.localPath == path }?.id)
 
         // Interleaved exactly where the race lives: after the candidate list
         // was built, before anything is reaped.
@@ -355,7 +355,7 @@ struct OrphanGCDeletionQueueTests {
         let path = try await makeInterruptedArchive(
             db: db, repo: repo, repoID: repoRow.id, name: "revived")
         let wtID = try #require(
-            (try await db.worktrees.list(status: .archived)).first { $0.path == path }?.id)
+            (try await db.worktrees.list(status: .archived)).first { $0.localPath == path }?.id)
 
         let gc = makeGC(db: db, beforeInterruptedArchiveReap: {
             try? await db.worktrees.updateStatus(id: wtID, status: .active)

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -1358,6 +1358,37 @@ struct PreSessionHookTests {
         #expect(try await db.terminals.list(worktreeID: wt.id).isEmpty,
                 "its terminal rows must be deleted with it")
     }
+
+    /// A daemon restart during a remote create must leave a resolvable row.
+    /// This sweep and reconcile are the only things that resolve a `.creating`
+    /// row, reconcile is fenced from remote rows, and a remote row has no
+    /// checkout to inspect — so skipping it here would spin the lane forever.
+    /// It gets the terminal state the creation flow already defines instead,
+    /// and is not deleted: a vanished row cannot be told apart from a create
+    /// that never ran.
+    @Test func recoveryMarksARemoteCreatingRowFailed() async throws {
+        let (_, cleanup) = isolateTBDHome()
+        defer { cleanup() }
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let remote = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "lane", branch: "tbd/lane",
+            provider: "agentbox", sessionID: "s-1", status: .creating)
+
+        let resumed = await lifecycle.recoverCreatingWorktrees()
+        #expect(resumed.isEmpty, "a remote row has no pre-session wait to resume")
+        let after = try #require(try await db.worktrees.get(id: remote.id))
+        #expect(after.status == .failed,
+                "a remote .creating row must reach a terminal state, not be skipped forever")
+    }
+    // The local arms are unchanged and stay covered by the tests above —
+    // `recoveryResumesOrphanedPreSessionWait` in particular proves a local
+    // `.creating` row still resumes rather than being caught by the new guard.
 }
 }
 

--- a/Tests/TBDDaemonTests/PreSessionHookTests.swift
+++ b/Tests/TBDDaemonTests/PreSessionHookTests.swift
@@ -164,7 +164,7 @@ struct PreSessionHookTests {
         let setupBody = windowCalls[1].last ?? ""
         #expect(setupBody.contains("export TBD_EVENT='setup'"))
         #expect(setupBody.contains("export TBD_WORKTREE_NAME='\(wt.name)'"))
-        #expect(setupBody.contains("export TBD_WORKTREE_PATH='\(wt.path)'"))
+        #expect(setupBody.contains("export TBD_WORKTREE_PATH='\(wt.localPath)'"))
         #expect(setupBody.contains("export TBD_REPO_PATH='\(repo.path)'"))
         #expect(setupBody.contains("export TBD_BRANCH='\(wt.branch)'"))
 
@@ -277,7 +277,7 @@ struct PreSessionHookTests {
         #expect(body.contains("export TBD_EVENT='preSession'"))
         #expect(body.contains("export TBD_WORKTREE_ID='\(createdWt.id.uuidString)'"))
         #expect(body.contains("export TBD_WORKTREE_NAME='\(createdWt.name)'"))
-        #expect(body.contains("export TBD_WORKTREE_PATH='\(createdWt.path)'"))
+        #expect(body.contains("export TBD_WORKTREE_PATH='\(createdWt.localPath)'"))
         #expect(body.contains("export TBD_REPO_PATH='\(repo.path)'"))
         #expect(body.contains("export TBD_BRANCH='\(createdWt.branch)'"))
         // The pre-session window must carry `-e DISABLE_AUTO_UPDATE=true` so
@@ -329,7 +329,7 @@ struct PreSessionHookTests {
         #expect(setupBody.contains("export TBD_EVENT='setup'"))
         #expect(setupBody.contains("export TBD_TERMINAL_ID='\(setup.id.uuidString)'"))
         #expect(setupBody.contains("export TBD_WORKTREE_NAME='\(createdWt.name)'"))
-        #expect(setupBody.contains("export TBD_WORKTREE_PATH='\(createdWt.path)'"))
+        #expect(setupBody.contains("export TBD_WORKTREE_PATH='\(createdWt.localPath)'"))
         #expect(setupBody.contains("export TBD_REPO_PATH='\(repo.path)'"))
         #expect(setupBody.contains("export TBD_BRANCH='\(createdWt.branch)'"))
     }
@@ -416,7 +416,7 @@ struct PreSessionHookTests {
         let subscriptions = StateSubscriptionManager()
         let lifecycle = makeLifecycle(db: db, subscriptions: subscriptions, timeout: 2)
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
-            worktree: worktree, repo: repo, worktreePath: worktree.path
+            worktree: worktree, repo: repo, worktreePath: worktree.localPath
         ))
         // tmux is dry-run, so the hook never really runs. Stand in for its
         // clean exit. Must come AFTER the spawn, which deletes any stale
@@ -425,7 +425,7 @@ struct PreSessionHookTests {
 
         await lifecycle.runPreSessionPhase3(
             preSession: spawn, worktree: worktree, repo: repo,
-            worktreePath: worktree.path, skipClaude: true,
+            worktreePath: worktree.localPath, skipClaude: true,
             completionAction: .markActive
         )
 
@@ -444,13 +444,13 @@ struct PreSessionHookTests {
 
         let lifecycle = makeLifecycle(db: db, timeout: 2)
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
-            worktree: worktree, repo: repo, worktreePath: worktree.path
+            worktree: worktree, repo: repo, worktreePath: worktree.localPath
         ))
         try writeMarker(worktreeID: worktree.id, exitCode: 3)
 
         await lifecycle.runPreSessionPhase3(
             preSession: spawn, worktree: worktree, repo: repo,
-            worktreePath: worktree.path, skipClaude: true,
+            worktreePath: worktree.localPath, skipClaude: true,
             completionAction: .markActive
         )
 
@@ -470,13 +470,13 @@ struct PreSessionHookTests {
 
         let lifecycle = makeLifecycle(db: db, timeout: 2)
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
-            worktree: worktree, repo: repo, worktreePath: worktree.path
+            worktree: worktree, repo: repo, worktreePath: worktree.localPath
         ))
         try writeMarker(worktreeID: worktree.id, exitCode: exitCode)
 
         await lifecycle.runPreSessionPhase3(
             preSession: spawn, worktree: worktree, repo: repo,
-            worktreePath: worktree.path, skipClaude: true,
+            worktreePath: worktree.localPath, skipClaude: true,
             completionAction: .markActive
         )
 
@@ -510,7 +510,7 @@ struct PreSessionHookTests {
 
         let lifecycle = makeLifecycle(db: db, timeout: 2)
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
-            worktree: worktree, repo: repo, worktreePath: worktree.path,
+            worktree: worktree, repo: repo, worktreePath: worktree.localPath,
             claimsFocus: false
         ))
 
@@ -537,7 +537,7 @@ struct PreSessionHookTests {
         }
         let lifecycle = makeLifecycle(db: db, subscriptions: subscriptions, timeout: 2)
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
-            worktree: worktree, repo: repo, worktreePath: worktree.path,
+            worktree: worktree, repo: repo, worktreePath: worktree.localPath,
             claimsFocus: false
         ))
 
@@ -560,7 +560,7 @@ struct PreSessionHookTests {
 
         let lifecycle = makeLifecycle(db: db, timeout: 2)
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
-            worktree: worktree, repo: repo, worktreePath: worktree.path
+            worktree: worktree, repo: repo, worktreePath: worktree.localPath
         ))
 
         let order = try await db.worktrees.getTabOrder(worktreeID: worktree.id)
@@ -579,13 +579,13 @@ struct PreSessionHookTests {
         let recorder = PreSessionRecordedCommands()
         let lifecycle = makeLifecycle(db: db, recorder: recorder, timeout: 2)
         let spawn = try #require(try await lifecycle.spawnPreSessionTerminal(
-            worktree: worktree, repo: nil, worktreePath: worktree.path
+            worktree: worktree, repo: nil, worktreePath: worktree.localPath
         ))
         #expect(try await db.terminals.get(id: spawn.terminalID) != nil)
 
         let windowCalls = recorder.snapshot().filter { $0.contains("new-window") }
         let body = windowCalls.first?.last ?? ""
-        #expect(body.contains("export TBD_REPO_PATH='\(worktree.path)'"),
+        #expect(body.contains("export TBD_REPO_PATH='\(worktree.localPath)'"),
                 "with no repo, TBD_REPO_PATH must fall back to the worktree's own path")
     }
 

--- a/Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterNightwatchLeaseTests.swift
@@ -90,7 +90,7 @@ struct RPCRouterNightwatchLeaseTests {
 
         // The capability lives under TBD_HOME, never inside the shared desk.
         #expect(result.credentialFile.hasPrefix(home.path))
-        #expect(!result.credentialFile.hasPrefix(f.desk.path))
+        #expect(!result.credentialFile.hasPrefix(f.desk.localPath))
         let mode = try FileManager.default
             .attributesOfItem(atPath: result.credentialFile)[.posixPermissions]
         #expect((mode as? NSNumber)?.intValue == 0o600)

--- a/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
@@ -4,6 +4,17 @@ import TestSupport
 @testable import TBDDaemonLib
 @testable import TBDShared
 
+/// Carries the observed state on the primary failure line (assertion-hygiene
+/// rule 4: only `Issue.record(_: some Error)` — which a thrown error becomes —
+/// survives into the CI summary).
+private struct RepoRemoveWaitTimeout: Error, CustomStringConvertible {
+    let what: String
+    let seconds: TimeInterval
+    var description: String {
+        "timed out waiting for \(what) — the row was still present after polling up to \(seconds) seconds"
+    }
+}
+
 // Repo-scoped RPC methods: repo.add, repo.list, repo.remove,
 // repo.updateInstructions, plus the unknown-method fallthrough (a
 // generic router behavior that doesn't belong with any single subsystem).
@@ -149,12 +160,34 @@ extension RPCRouterTests {
             method: RPCMethod.repoRemove,
             params: RepoRemoveParams(repoID: repo.id, force: true)))
 
+        // A forced removal answers as soon as phase 1 has archived every local
+        // worktree; the row deletions run in `handleRepoRemove`'s detached
+        // tail, so the cascade's outcome has to be waited for, not read
+        // straight after the response.
         #expect(response.success, "the cascade aborted: \(response.error ?? "no error")")
-        #expect(try await db.repos.get(id: repo.id) == nil)
+        try await waitUntilRemoved("the detached tail to delete the repo row") {
+            ((try? await db.repos.get(id: repo.id)) ?? nil) == nil
+        }
         #expect(try await db.worktrees.get(id: local.id) == nil,
                 "a local worktree row outlived its removed repo")
         #expect(try await db.worktrees.get(id: remote.id) == nil,
                 "a remote worktree row outlived its removed repo")
+    }
+
+    /// Polls `condition` until it holds or the deadline passes, then throws so
+    /// the diagnostic lands on the primary failure line (assertion-hygiene
+    /// rule 4). Mirrors `RepoRemoveCascadeTests.waitUntil`, whose error type is
+    /// file-private to that suite.
+    private func waitUntilRemoved(
+        _ what: String, timeout: TimeInterval = 10,
+        _ condition: @Sendable () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        throw RepoRemoveWaitTimeout(what: what, seconds: timeout)
     }
 
     /// Medium-2 review finding: `repo.remove` hard-deletes every worktree

--- a/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
+++ b/Tests/TBDDaemonTests/RPCRouterRepoTests.swift
@@ -102,6 +102,61 @@ extension RPCRouterTests {
         #expect(response.error?.contains("active worktree") == true)
     }
 
+    /// A remote lane still counts as something the operator would lose, so it
+    /// blocks an unforced removal exactly like a local worktree does.
+    @Test("repo.remove refuses when only a remote worktree is active, without force")
+    func repoRemoveRefusesActiveRemoteWorktree() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        _ = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote-wt", branch: "tbd/remote-wt",
+            provider: "stub", sessionID: "s-1")
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: repo.id, force: false)))
+
+        #expect(!response.success)
+        #expect(response.error?.contains("active worktree") == true)
+    }
+
+    /// The cascade must not half-complete. `archiveWorktree` resolves its row
+    /// through `getLocal`, which has nothing to return for a remote lane, so a
+    /// cascade fed every active row threw `worktreeNotFound` partway through:
+    /// the local worktree stayed torn down, the repo stayed registered, and the
+    /// caller got a not-found error naming a worktree it never asked about.
+    /// The remote row is skipped by the cascade and removed by `deleteForRepo`
+    /// with the rest — archiving a lane means stopping its provider session,
+    /// which nothing here can do.
+    @Test("repo.remove --force clears a repo owning both a local and a remote worktree")
+    func repoRemoveForceCascadesPastARemoteRow() async throws {
+        let repo = try await db.repos.create(
+            path: "/tmp/test-repo-\(UUID().uuidString)",
+            displayName: "test-repo",
+            defaultBranch: "main"
+        )
+        let local = try await db.worktrees.create(
+            repoID: repo.id, name: "local-wt", branch: "tbd/local-wt",
+            path: "/tmp/test-wt-\(UUID().uuidString)", tmuxServer: "tbd-test")
+        let remote = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote-wt", branch: "tbd/remote-wt",
+            provider: "stub", sessionID: "s-1")
+
+        let response = await router.handle(try RPCRequest(
+            method: RPCMethod.repoRemove,
+            params: RepoRemoveParams(repoID: repo.id, force: true)))
+
+        #expect(response.success, "the cascade aborted: \(response.error ?? "no error")")
+        #expect(try await db.repos.get(id: repo.id) == nil)
+        #expect(try await db.worktrees.get(id: local.id) == nil,
+                "a local worktree row outlived its removed repo")
+        #expect(try await db.worktrees.get(id: remote.id) == nil,
+                "a remote worktree row outlived its removed repo")
+    }
+
     /// Medium-2 review finding: `repo.remove` hard-deletes every worktree
     /// row for the repo (`deleteForRepo`, all statuses) with no chance for
     /// the sweep's own reconciliation to catch up afterward — the rows are

--- a/Tests/TBDDaemonTests/ReconcileRemoteRowFenceTests.swift
+++ b/Tests/TBDDaemonTests/ReconcileRemoteRowFenceTests.swift
@@ -23,16 +23,16 @@ import Foundation
 
     /// A real git repo with no extra worktrees, plus one remote row. `git
     /// worktree list` reports only the repo's own checkout, so the remote
-    /// row's (empty) path is absent from it — the exact state that made an
-    /// unfenced reconcile archive it.
+    /// row's synthetic `remote://` path is absent from it — the exact state
+    /// that made an unfenced reconcile archive it.
     private func seedRemoteRow(
         db: TBDDatabase, repoPath: String
     ) async throws -> (repo: Repo, remote: Worktree) {
         let repo = try await db.repos.create(
             path: repoPath, displayName: "acme", defaultBranch: "main")
-        let remote = try await db.worktrees.create(
-            repoID: repo.id, name: "remote", branch: "b", path: "", tmuxServer: "",
-            location: .remote(provider: "agentbox", sessionID: "s-1"))
+        let remote = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote", branch: "b",
+            provider: "agentbox", sessionID: "s-1")
         return (repo, remote)
     }
 

--- a/Tests/TBDDaemonTests/ReconcileRemoteRowFenceTests.swift
+++ b/Tests/TBDDaemonTests/ReconcileRemoteRowFenceTests.swift
@@ -68,29 +68,103 @@ import Foundation
         #expect(after.tmuxServer == "", "reconcile canonicalized a remote row's tmux server")
     }
 
-    /// Orphan GC keys on filesystem paths and snapshot refs, and a remote row
-    /// has neither, so it needs no fence of its own. This asserts that claim
-    /// rather than trusting it — with the master switch pinned ON and the
-    /// scratchpad base pointed at a temp dir, so a sweep that really runs is
-    /// what leaves the row alone.
-    @Test func orphanGCSweepLeavesARemoteRowIntact() async throws {
+    /// Orphan GC's scratchpad reconciliation maps a worktree row's stored path
+    /// to a scratchpad slug and deletes that directory once the worktree path
+    /// itself is absent from disk. A remote row's path is the synthetic
+    /// `remote://` URI, which is absent by construction — so an unfenced fetch
+    /// makes every archived remote lane a standing reap candidate on every
+    /// sweep.
+    ///
+    /// Both tests below discriminate by construction: a directory really is
+    /// planted at the remote row's slug, so an unfenced run deletes it and
+    /// records the reap. Asserting the row's own columns would prove nothing —
+    /// orphan GC never writes to the worktree table.
+    ///
+    /// Each also plants a second scratchpad behind an archived *local* row
+    /// whose directory is gone, so a run that reaped nothing at all cannot pass
+    /// by doing nothing.
+    private struct ScratchpadFixture {
+        let repoID: UUID
+        let remoteScratchpad: URL
+        let localScratchpad: URL
+    }
+
+    /// Plants `base/<slug>` for one archived remote row and one archived local
+    /// row whose worktree directory does not exist.
+    private func seedScratchpads(
+        db: TBDDatabase, repoPath: String, base: URL
+    ) async throws -> ScratchpadFixture {
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let (repo, remote) = try await seedRemoteRow(db: db, repoPath: repoPath)
+        try await db.worktrees.archive(id: remote.id)
+
+        let goneLocalPath = "/tmp/tbd-gone-wt-\(UUID().uuidString)"
+        let local = try await db.worktrees.create(
+            repoID: repo.id, name: "gone-wt", branch: "gone-wt",
+            path: goneLocalPath, tmuxServer: "tbd-test")
+        try await db.worktrees.archive(id: local.id)
+
+        let remoteDir = base.appendingPathComponent(
+            ScratchpadCollector.slug(forWorktreePath: remote.localPath))
+        let localDir = base.appendingPathComponent(
+            ScratchpadCollector.slug(forWorktreePath: goneLocalPath))
+        for dir in [remoteDir, localDir] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return ScratchpadFixture(
+            repoID: repo.id, remoteScratchpad: remoteDir, localScratchpad: localDir)
+    }
+
+    @Test func orphanGCSweepNeverReapsARemoteRowsScratchpad() async throws {
         let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         let db = try TBDDatabase(inMemory: true)
         try await db.config.setGCEnabled(true)
-        let (_, remote) = try await seedRemoteRow(db: db, repoPath: repoDir.path)
+        let base = tempDir.appendingPathComponent("scratchpads", isDirectory: true)
+        let fixture = try await seedScratchpads(db: db, repoPath: repoDir.path, base: base)
 
         let gc = OrphanGC(
-            db: db,
-            git: GitManager(),
-            broadcast: { _ in },
-            lsofProvider: { [] },
-            scratchpadBase: tempDir.appendingPathComponent("scratchpads", isDirectory: true)
-        )
-        _ = await gc.sweep(dryRun: false)
+            db: db, git: GitManager(), broadcast: { _ in },
+            lsofProvider: { [] }, scratchpadBase: base)
+        let result = await gc.sweep(dryRun: false)
 
-        let after = try #require(try await db.worktrees.get(id: remote.id))
-        #expect(after.status == .active)
+        #expect(FileManager.default.fileExists(atPath: fixture.remoteScratchpad.path),
+                "the sweep reaped a directory sitting at a remote row's scratchpad slug")
+        #expect(!FileManager.default.fileExists(atPath: fixture.localScratchpad.path),
+                "the sweep reaped nothing at all — the remote arm proves nothing")
+        #expect(result.reaped == 1)
+        #expect(!result.planned.contains { $0.contains(fixture.remoteScratchpad.path) },
+                "the remote row reached the reap-candidate plan: \(result.planned)")
+
+        let reaped = try await db.reapRecords.list(repoPath: nil).map(\.worktreePath)
+        #expect(reaped == [fixture.localScratchpad.path])
+    }
+
+    /// `repo.remove` runs the same reconciliation over EVERY row the repo owns
+    /// — every status — right before `deleteForRepo`, so it needs the same
+    /// fence as the periodic sweep.
+    @Test func repoRemovalReconciliationNeverReapsARemoteRowsScratchpad() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let base = tempDir.appendingPathComponent("scratchpads", isDirectory: true)
+        let fixture = try await seedScratchpads(db: db, repoPath: repoDir.path, base: base)
+
+        let gc = OrphanGC(
+            db: db, git: GitManager(), broadcast: { _ in },
+            lsofProvider: { [] }, scratchpadBase: base)
+        await gc.reconcileScratchpadsBeforeRepoRemoval(
+            repoID: fixture.repoID, repoPath: repoDir.path)
+
+        #expect(FileManager.default.fileExists(atPath: fixture.remoteScratchpad.path),
+                "repo-removal reconciliation reaped a remote row's scratchpad slug")
+        #expect(!FileManager.default.fileExists(atPath: fixture.localScratchpad.path),
+                "the reconciliation reaped nothing at all — the remote arm proves nothing")
+
+        let reaped = try await db.reapRecords.list(repoPath: nil).map(\.worktreePath)
+        #expect(reaped == [fixture.localScratchpad.path])
     }
 }

--- a/Tests/TBDDaemonTests/ReconcileRemoteRowFenceTests.swift
+++ b/Tests/TBDDaemonTests/ReconcileRemoteRowFenceTests.swift
@@ -1,0 +1,96 @@
+import Testing
+import TestSupport
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Reconcile archives any DB row whose path is absent from git's worktree
+/// list. A remote row's path is never in that list, so without a fence
+/// reconcile tears down every remote lane on every sweep — including killing
+/// tmux windows and deleting terminal rows. A second loop in the same function
+/// rewrites `tmuxServer` on any row whose value differs from the repo's
+/// canonical name, which an empty string always does.
+@Suite struct ReconcileRemoteRowFenceTests {
+
+    private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
+        WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver()
+        )
+    }
+
+    /// A real git repo with no extra worktrees, plus one remote row. `git
+    /// worktree list` reports only the repo's own checkout, so the remote
+    /// row's (empty) path is absent from it — the exact state that made an
+    /// unfenced reconcile archive it.
+    private func seedRemoteRow(
+        db: TBDDatabase, repoPath: String
+    ) async throws -> (repo: Repo, remote: Worktree) {
+        let repo = try await db.repos.create(
+            path: repoPath, displayName: "acme", defaultBranch: "main")
+        let remote = try await db.worktrees.create(
+            repoID: repo.id, name: "remote", branch: "b", path: "", tmuxServer: "",
+            location: .remote(provider: "agentbox", sessionID: "s-1"))
+        return (repo, remote)
+    }
+
+    @Test func reconcileLeavesARemoteRowActive() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let (repo, remote) = try await seedRemoteRow(db: db, repoPath: repoDir.path)
+
+        try await makeLifecycle(db: db).reconcile(
+            repoID: repo.id, actuationLog: makeTestActuationLog())
+
+        let after = try #require(try await db.worktrees.get(id: remote.id))
+        #expect(after.status == .active, "reconcile archived a remote row")
+        #expect(after.archivedAt == nil)
+    }
+
+    /// The canonicalization loop rewrites tmuxServer on any row whose value
+    /// differs from the repo's canonical name — which an empty string always
+    /// does. A remote row must come out untouched.
+    @Test func reconcileLeavesARemoteRowsTmuxServerEmpty() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let (repo, remote) = try await seedRemoteRow(db: db, repoPath: repoDir.path)
+
+        try await makeLifecycle(db: db).reconcile(
+            repoID: repo.id, actuationLog: makeTestActuationLog())
+
+        let after = try #require(try await db.worktrees.get(id: remote.id))
+        #expect(after.tmuxServer == "", "reconcile canonicalized a remote row's tmux server")
+    }
+
+    /// Orphan GC keys on filesystem paths and snapshot refs, and a remote row
+    /// has neither, so it needs no fence of its own. This asserts that claim
+    /// rather than trusting it — with the master switch pinned ON and the
+    /// scratchpad base pointed at a temp dir, so a sweep that really runs is
+    /// what leaves the row alone.
+    @Test func orphanGCSweepLeavesARemoteRowIntact() async throws {
+        let (tempDir, repoDir) = try await createTestRepoResolvingSymlinks()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        try await db.config.setGCEnabled(true)
+        let (_, remote) = try await seedRemoteRow(db: db, repoPath: repoDir.path)
+
+        let gc = OrphanGC(
+            db: db,
+            git: GitManager(),
+            broadcast: { _ in },
+            lsofProvider: { [] },
+            scratchpadBase: tempDir.appendingPathComponent("scratchpads", isDirectory: true)
+        )
+        _ = await gc.sweep(dryRun: false)
+
+        let after = try #require(try await db.worktrees.get(id: remote.id))
+        #expect(after.status == .active)
+    }
+}

--- a/Tests/TBDDaemonTests/RepoRemoveCascadeTests.swift
+++ b/Tests/TBDDaemonTests/RepoRemoveCascadeTests.swift
@@ -194,7 +194,7 @@ struct RepoRemoveCascadeTests {
         #expect(rowWhileParked?.status == .archived,
                 "phase 1 must have run synchronously, flipping the row before the RPC answered")
 
-        gate.open(worktree.path)
+        gate.open(worktree.localPath)
 
         try await waitUntil("the detached tail to delete the repo row") {
             ((try? await db.repos.get(id: repo.id)) ?? nil) == nil
@@ -249,7 +249,7 @@ struct RepoRemoveCascadeTests {
             observed: { "entered=\(gate.enteredPaths())" }
         ) { !gate.enteredPaths().isEmpty }
         let released = gate.enteredPaths()[0]
-        let stillParked = try #require([first, second].first { $0.path != released })
+        let stillParked = try #require([first, second].first { $0.localPath != released })
         gate.open(released)
 
         // Its completion finishes; the other is still parked, so nothing
@@ -257,7 +257,7 @@ struct RepoRemoveCascadeTests {
         try await waitUntil(
             "the second archive to reach phase 2",
             observed: { "entered=\(gate.enteredPaths())" }
-        ) { gate.enteredPaths().contains(stillParked.path) }
+        ) { gate.enteredPaths().contains(stillParked.localPath) }
 
         let reposAfterFirst = try await db.repos.list()
         #expect(reposAfterFirst.contains { $0.id == repo.id },
@@ -265,7 +265,7 @@ struct RepoRemoveCascadeTests {
         let archivedAfterFirst = try await db.worktrees.list(status: .archived)
         #expect(archivedAfterFirst.contains { $0.id == stillParked.id })
 
-        gate.open(stillParked.path)
+        gate.open(stillParked.localPath)
         try await waitUntil("the detached tail to delete the repo row") {
             ((try? await db.repos.get(id: repo.id)) ?? nil) == nil
         }

--- a/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchArchiveReviveRPCTests.swift
@@ -39,7 +39,7 @@ struct ScratchArchiveReviveRPCTests {
         let (router, deltas) = makeRouter(db: db)
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "to-archive")))
         let wt = try created.decodeResult(Worktree.self)
-        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
         let archive = await router.handle(try RPCRequest(method: RPCMethod.scratchArchive, params: ScratchArchiveParams(worktreeID: wt.id)))
         #expect(archive.success)
@@ -49,7 +49,7 @@ struct ScratchArchiveReviveRPCTests {
         #expect(reloaded?.archivedAt != nil)
 
         // Folder is left untouched on disk — unlike delete, no Trash move.
-        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
         let archived = deltas.snapshot().filter {
             if case .worktreeArchived(let d) = $0 { return d.worktreeID == wt.id }
@@ -125,7 +125,7 @@ struct ScratchArchiveReviveRPCTests {
         #expect(archive.success)
 
         // Simulate the folder disappearing out from under the archived row.
-        try FileManager.default.removeItem(atPath: wt.path)
+        try FileManager.default.removeItem(atPath: wt.localPath)
 
         let revive = await router.handle(try RPCRequest(method: RPCMethod.scratchRevive, params: ScratchReviveParams(worktreeID: wt.id)))
         #expect(!revive.success)
@@ -150,7 +150,7 @@ struct ScratchArchiveReviveRPCTests {
         let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
         #expect(del.success)
         #expect(try await db.worktrees.get(id: wt.id) == nil)
-        #expect(!FileManager.default.fileExists(atPath: wt.path))  // moved to Trash
+        #expect(!FileManager.default.fileExists(atPath: wt.localPath))  // moved to Trash
     }
 }
 }

--- a/Tests/TBDDaemonTests/ScratchCreateRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchCreateRPCTests.swift
@@ -30,8 +30,8 @@ struct ScratchCreateRPCTests {
         let wt = try response.decodeResult(Worktree.self)
         #expect(wt.repoID == nil)
         #expect(wt.isScratch)
-        #expect(wt.path.hasPrefix(TBDConstants.scratchDir.path))
-        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(wt.localPath.hasPrefix(TBDConstants.scratchDir.path))
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
         let all = try await db.worktrees.listScratch()
         #expect(all.count == 1)
     }
@@ -115,7 +115,7 @@ struct ScratchCreateRPCTests {
         // Second create with the same name must not collide on the unique path.
         let r2 = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "notes")))
         let w2 = try r2.decodeResult(Worktree.self)
-        #expect(w2.path != w1.path)
+        #expect(w2.localPath != w1.localPath)
     }
 }
 }

--- a/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchDeleteRPCTests.swift
@@ -23,12 +23,12 @@ struct ScratchDeleteRPCTests {
             tmux: TmuxManager(dryRun: true), startTime: Date(), actuationLog: makeTestActuationLog())
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "gone")))
         let wt = try created.decodeResult(Worktree.self)
-        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
         let del = await router.handle(try RPCRequest(method: RPCMethod.scratchDelete, params: ScratchDeleteParams(worktreeID: wt.id)))
         #expect(del.success)
         #expect(try await db.worktrees.get(id: wt.id) == nil)
-        #expect(!FileManager.default.fileExists(atPath: wt.path))  // moved to Trash
+        #expect(!FileManager.default.fileExists(atPath: wt.localPath))  // moved to Trash
     }
 
     @Test func closesTerminalsAndTabsBeforeDeleting() async throws {
@@ -83,7 +83,7 @@ struct ScratchDeleteRPCTests {
         #expect(!del.success)
         #expect(del.error != nil)
         #expect(try await db.worktrees.get(id: wt.id) != nil)  // row survives so a retry is possible
-        #expect(FileManager.default.fileExists(atPath: wt.path))  // folder untouched
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))  // folder untouched
     }
 
     /// Medium-1 review finding: `scratch.delete` must reclaim the scratch
@@ -108,7 +108,7 @@ struct ScratchDeleteRPCTests {
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-claude-scratchpad")))
         let wt = try created.decodeResult(Worktree.self)
 
-        let slug = ScratchpadCollector.slug(forWorktreePath: wt.path)
+        let slug = ScratchpadCollector.slug(forWorktreePath: wt.localPath)
         let claudeScratchDir = scratchpadBase.appendingPathComponent(slug)
         try FileManager.default.createDirectory(at: claudeScratchDir, withIntermediateDirectories: true)
         try "hi".write(to: claudeScratchDir.appendingPathComponent("f.txt"), atomically: true, encoding: .utf8)
@@ -145,7 +145,7 @@ struct ScratchDeleteRPCTests {
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: "with-claude-scratchpad-disabled")))
         let wt = try created.decodeResult(Worktree.self)
 
-        let slug = ScratchpadCollector.slug(forWorktreePath: wt.path)
+        let slug = ScratchpadCollector.slug(forWorktreePath: wt.localPath)
         let claudeScratchDir = scratchpadBase.appendingPathComponent(slug)
         try FileManager.default.createDirectory(at: claudeScratchDir, withIntermediateDirectories: true)
 

--- a/Tests/TBDDaemonTests/ScratchExclusionTests.swift
+++ b/Tests/TBDDaemonTests/ScratchExclusionTests.swift
@@ -27,6 +27,25 @@ struct ScratchExclusionTests {
         #expect(!pollable.contains { $0.id == scratch.id })
     }
 
+    /// The same guard, for the other kind of row the poller must not touch:
+    /// everything downstream of `pollableWorktrees` runs `git` and `gh` inside
+    /// the worktree's path and caches branch facts keyed on it, and a remote
+    /// row's path is not a directory on this machine.
+    @Test("pollableWorktrees drops remote rows and keeps local rows")
+    func pollableWorktreesDiscriminatesRemoteFromLocal() {
+        let local = Worktree(
+            repoID: UUID(), name: "l", displayName: "l", branch: "tbd/l",
+            path: "/tmp/local", tmuxServer: "tbd-l")
+        let remote = Worktree(
+            repoID: UUID(), name: "r", displayName: "r", branch: "tbd/r",
+            path: "remote://agentbox/s-1", tmuxServer: "",
+            location: .remote(provider: "agentbox", sessionID: "s-1"))
+
+        let pollable = RPCRouter.pollableWorktrees([local, remote])
+
+        #expect(pollable.map(\.id) == [local.id])
+    }
+
     @Test("pr.list never includes a scratch worktree")
     func prListExcludesScratch() async throws {
         let db = try TBDDatabase(inMemory: true)

--- a/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteMigrationTests.swift
@@ -69,7 +69,7 @@ struct ScratchPromoteMigrationTests {
         let created = await router.handle(try RPCRequest(
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
         // The scratch.create RPC now auto-spawns a default primary agent terminal;
         // clear it so this test controls its own terminal fixture.
         try await db.terminals.deleteForWorktree(worktreeID: wt.id)
@@ -129,7 +129,7 @@ struct ScratchPromoteMigrationTests {
         let created = await router.handle(try RPCRequest(
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
         // The scratch.create RPC now auto-spawns a default primary agent terminal;
         // clear it so this test controls its own terminal fixture.
         try await db.terminals.deleteForWorktree(worktreeID: wt.id)
@@ -148,9 +148,9 @@ struct ScratchPromoteMigrationTests {
         let profileRoot = home.appendingPathComponent(
             "profiles/\(profileID.uuidString.lowercased())/claude/projects", isDirectory: true)
         let oldAmbient = TranscriptProjectDirSync.derivedProjectDir(
-            worktreePath: wt.path, projectsRoot: ambientRoot)
+            worktreePath: wt.localPath, projectsRoot: ambientRoot)
         let oldProfile = TranscriptProjectDirSync.derivedProjectDir(
-            worktreePath: wt.path, projectsRoot: profileRoot)
+            worktreePath: wt.localPath, projectsRoot: profileRoot)
         try writeFile("ambient transcript", to: oldAmbient.appendingPathComponent("amb-1.jsonl"))
         try writeFile("sub", to: oldAmbient.appendingPathComponent("amb-1/subagents/agent-a.jsonl"))
         try writeFile("remember me", to: oldAmbient.appendingPathComponent("memory/MEMORY.md"))

--- a/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteRPCTests.swift
@@ -33,7 +33,7 @@ struct ScratchPromoteRPCTests {
         let router = makeRouter(db)
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
 
         let dest = home.appendingPathComponent("projects/myapp").path
         let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
@@ -41,7 +41,7 @@ struct ScratchPromoteRPCTests {
         #expect(resp.success)
         let result = try resp.decodeResult(ScratchPromoteResult.self)
         #expect(FileManager.default.fileExists(atPath: dest))
-        #expect(!FileManager.default.fileExists(atPath: wt.path))
+        #expect(!FileManager.default.fileExists(atPath: wt.localPath))
         let row = try await db.worktrees.get(id: wt.id)
         #expect(row?.promotedToRepoID == result.repoID)
         #expect(try await db.repos.get(id: result.repoID) != nil)
@@ -58,7 +58,7 @@ struct ScratchPromoteRPCTests {
         let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
             params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
         #expect(!resp.success)
-        #expect(FileManager.default.fileExists(atPath: wt.path))       // not moved
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))       // not moved
         #expect(!FileManager.default.fileExists(atPath: dest))         // dest not created
         #expect(try await db.worktrees.get(id: wt.id)?.promotedToRepoID == nil)
     }
@@ -71,7 +71,7 @@ struct ScratchPromoteRPCTests {
         var wt = try created.decodeResult(Worktree.self)
         try await db.worktrees.rename(id: wt.id, displayName: "My Cool App")  // displayName != name now
         wt = try await db.worktrees.get(id: wt.id)!
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
 
         let dest = home.appendingPathComponent("projects/folder-name").path
         let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
@@ -88,7 +88,7 @@ struct ScratchPromoteRPCTests {
         var wt = try created.decodeResult(Worktree.self)
         try await db.worktrees.rename(id: wt.id, displayName: "Renamed Scratch")
         wt = try await db.worktrees.get(id: wt.id)!
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
 
         let dest = home.appendingPathComponent("projects/folder-name").path
         let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
@@ -103,7 +103,7 @@ struct ScratchPromoteRPCTests {
         let router = makeRouter(db)
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)   // displayName == name (still default)
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
 
         let dest = home.appendingPathComponent("projects/coolfolder").path
         let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
@@ -127,7 +127,7 @@ struct ScratchPromoteRPCTests {
         #expect(!resp.success)
         #expect(!FileManager.default.fileExists(atPath: dest))
         let row = try await db.worktrees.get(id: wt.id)
-        #expect(row?.path == wt.path)
+        #expect(row?.localPath == wt.localPath)
         #expect(row?.promotedToRepoID == nil)
         #expect(try await db.repos.list().count == repoCountBefore)
     }
@@ -138,7 +138,7 @@ struct ScratchPromoteRPCTests {
         let router = makeRouter(db)
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
         let repoCountBefore = try await db.repos.list().count
 
         let dest = home.appendingPathComponent("projects/already-here").path
@@ -147,9 +147,9 @@ struct ScratchPromoteRPCTests {
         let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
             params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
         #expect(!resp.success)
-        #expect(FileManager.default.fileExists(atPath: wt.path))          // scratch folder untouched
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))          // scratch folder untouched
         let row = try await db.worktrees.get(id: wt.id)
-        #expect(row?.path == wt.path)
+        #expect(row?.localPath == wt.localPath)
         #expect(row?.promotedToRepoID == nil)
         #expect(try await db.repos.list().count == repoCountBefore)       // no repo row created
     }
@@ -163,17 +163,17 @@ struct ScratchPromoteRPCTests {
         // git init WITHOUT a commit — distinct from the no-git-at-all case,
         // exercises the hasCommits guard specifically.
         let p = Process(); p.executableURL = URL(fileURLWithPath: "/usr/bin/git")
-        p.arguments = ["-C", wt.path, "init"]; try p.run(); p.waitUntilExit()
+        p.arguments = ["-C", wt.localPath, "init"]; try p.run(); p.waitUntilExit()
         let repoCountBefore = try await db.repos.list().count
 
         let dest = home.appendingPathComponent("projects/no-commits-yet").path
         let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
             params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
         #expect(!resp.success)
-        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
         #expect(!FileManager.default.fileExists(atPath: dest))
         let row = try await db.worktrees.get(id: wt.id)
-        #expect(row?.path == wt.path)
+        #expect(row?.localPath == wt.localPath)
         #expect(row?.promotedToRepoID == nil)
         #expect(try await db.repos.list().count == repoCountBefore)
     }
@@ -184,7 +184,7 @@ struct ScratchPromoteRPCTests {
         let router = makeRouter(db)
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
         let repoCountBefore = try await db.repos.list().count
 
         // Dest is another path under the scratch base — must be rejected
@@ -193,10 +193,10 @@ struct ScratchPromoteRPCTests {
         let resp = await router.handle(try RPCRequest(method: RPCMethod.scratchPromote,
             params: ScratchPromoteParams(worktreeID: wt.id, destPath: dest, displayName: nil)))
         #expect(!resp.success)
-        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
         #expect(!FileManager.default.fileExists(atPath: dest))
         let row = try await db.worktrees.get(id: wt.id)
-        #expect(row?.path == wt.path)
+        #expect(row?.localPath == wt.localPath)
         #expect(row?.promotedToRepoID == nil)
         #expect(try await db.repos.list().count == repoCountBefore)
     }
@@ -215,7 +215,7 @@ struct ScratchPromoteRPCTests {
         let router = makeRouter(db)
         let created = await router.handle(try RPCRequest(method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
         // The scratch.create RPC now auto-spawns a default primary agent terminal;
         // clear it so this test controls its own terminal fixture.
         try await db.terminals.deleteForWorktree(worktreeID: wt.id)
@@ -238,7 +238,7 @@ struct ScratchPromoteRPCTests {
         #expect(resp.error?.contains("Moved the folder back") == true)
 
         // Folder is back home; dest is gone.
-        #expect(FileManager.default.fileExists(atPath: wt.path))
+        #expect(FileManager.default.fileExists(atPath: wt.localPath))
         #expect(!FileManager.default.fileExists(atPath: dest))
         // Scratch row still active and un-promoted — retryable.
         let row = try #require(try await db.worktrees.get(id: wt.id))

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -62,7 +62,7 @@ struct ScratchPromoteReconcileTests {
         let created = await router.handle(try RPCRequest(
             method: RPCMethod.scratchCreate, params: ScratchCreateParams(name: nil)))
         let wt = try created.decodeResult(Worktree.self)
-        try gitInitCommit(at: wt.path)
+        try gitInitCommit(at: wt.localPath)
         // The scratch.create RPC now auto-spawns a default primary agent terminal;
         // clear it so this test controls its own terminal fixture.
         try await db.terminals.deleteForWorktree(worktreeID: wt.id)

--- a/Tests/TBDDaemonTests/TerminalHistoryTests.swift
+++ b/Tests/TBDDaemonTests/TerminalHistoryTests.swift
@@ -302,8 +302,8 @@ import Testing
     @Test func shellReviveOpensFreshShellWithCapture() async throws {
         let fx = try await makeFixture(label: "sh", kind: .shell, claudeSessionID: nil)
         defer { fx.cleanup() }
-        try makeLiveDir(fx.worktree.path)
-        defer { try? FileManager.default.removeItem(atPath: fx.worktree.path) }
+        try makeLiveDir(fx.worktree.localPath)
+        defer { try? FileManager.default.removeItem(atPath: fx.worktree.localPath) }
 
         // A closed shell terminal with captured scrollback (file + row).
         let shellTerm = Terminal(
@@ -352,8 +352,8 @@ import Testing
     @Test func claudeReviveResumesSession() async throws {
         let fx = try await makeFixture(label: TerminalLabel.claudeCode, kind: .claude, claudeSessionID: "sess-xyz")
         defer { fx.cleanup() }
-        try makeLiveDir(fx.worktree.path)
-        defer { try? FileManager.default.removeItem(atPath: fx.worktree.path) }
+        try makeLiveDir(fx.worktree.localPath)
+        defer { try? FileManager.default.removeItem(atPath: fx.worktree.localPath) }
 
         await fx.db.terminalHistory.store(
             terminal: fx.terminal, text: "claude scrollback\n", closedAt: Date())
@@ -383,8 +383,8 @@ import Testing
     @Test func reviveWithMissingCaptureFileSkipsCat() async throws {
         let fx = try await makeFixture(label: "sh", kind: .shell, claudeSessionID: nil)
         defer { fx.cleanup() }
-        try makeLiveDir(fx.worktree.path)
-        defer { try? FileManager.default.removeItem(atPath: fx.worktree.path) }
+        try makeLiveDir(fx.worktree.localPath)
+        defer { try? FileManager.default.removeItem(atPath: fx.worktree.localPath) }
 
         // History row present, but the capture file is deleted underneath it.
         let shellTerm = Terminal(
@@ -430,8 +430,8 @@ import Testing
     @Test func reviveUnknownEntryErrorsWithoutTerminal() async throws {
         let fx = try await makeFixture()
         defer { fx.cleanup() }
-        try makeLiveDir(fx.worktree.path)
-        defer { try? FileManager.default.removeItem(atPath: fx.worktree.path) }
+        try makeLiveDir(fx.worktree.localPath)
+        defer { try? FileManager.default.removeItem(atPath: fx.worktree.localPath) }
         let tmux = TmuxManager(dryRun: true)
         let router = makeRouter(db: fx.db, tmux: tmux)
 

--- a/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
+++ b/Tests/TBDDaemonTests/TerminalSessionEventHandlerTests.swift
@@ -174,7 +174,7 @@ struct TerminalSessionEventHandlerTests {
     func guardAcceptsMatchingWorktreeCwd() async throws {
         let (terminal, wt) = try await makeTerminal(initialSession: "old-id")
         // A cwd nested inside the terminal's own worktree path.
-        let cwd = wt.path + "/Sources/Foo"
+        let cwd = wt.localPath + "/Sources/Foo"
         let response = await router.handle(try RPCRequest(
             method: RPCMethod.terminalSessionEvent,
             params: TerminalSessionEventParams(
@@ -197,7 +197,7 @@ struct TerminalSessionEventHandlerTests {
         let foreign = try await makeForeignWorktree()
         // Foreign teammate session inherited TBD_TERMINAL_ID but runs in a
         // different worktree's directory.
-        let cwd = foreign.path + "/subdir"
+        let cwd = foreign.localPath + "/subdir"
         let response = await router.handle(try RPCRequest(
             method: RPCMethod.terminalSessionEvent,
             params: TerminalSessionEventParams(
@@ -265,7 +265,7 @@ struct TerminalSessionEventHandlerTests {
                 sessionID: "real-session-after-heal",
                 transcriptPath: "/abs/real.jsonl",
                 source: "resume",
-                cwd: wt.path
+                cwd: wt.localPath
             )
         ))
         #expect(response.success)

--- a/Tests/TBDDaemonTests/WorktreeAdoptTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeAdoptTests.swift
@@ -26,7 +26,7 @@ import Testing
     }
 
     #expect(result.status == .active)
-    #expect(result.path == worktreePath)
+    #expect(result.localPath == worktreePath)
     #expect(result.branch == branch)
     #expect(result.name == "feature-x")
     #expect(result.repoID == repo.id)
@@ -58,7 +58,7 @@ import Testing
 
     #expect(first.id == second.id)
     let allActive = try await db.worktrees.list(repoID: repo.id, status: .active)
-    #expect(allActive.filter { $0.path == worktreePath }.count == 1)
+    #expect(allActive.filter { $0.localPath == worktreePath }.count == 1)
 }
 
 @Test func testAdoptRevivesArchivedRow() async throws {

--- a/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift
@@ -216,7 +216,7 @@ struct ArchiveHarness {
             db: db,
             git: lifecycle.git,
             repoPath: repo.path,
-            worktreePath: worktree.path,
+            worktreePath: worktree.localPath,
             worktreeID: worktree.id,
             tempDir: tempDir
         )

--- a/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeConversationCarryoverTests.swift
@@ -306,7 +306,7 @@ struct WorktreeConversationCarryoverTests {
         )
 
         let destination = TranscriptProjectDirSync.derivedProjectDir(
-            worktreePath: worktree.path,
+            worktreePath: worktree.localPath,
             projectsRoot: projectsRoot
         ).appendingPathComponent("\(sourceSessionID).jsonl")
         #expect(FileManager.default.fileExists(atPath: destination.path))

--- a/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateExistingBranchTests.swift
@@ -32,7 +32,7 @@ import Testing
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
     #expect(wt.status == .active)
     #expect(wt.branch.hasPrefix("tbd/"))
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 }
 
 @Test func testCreateWorktreeUsesExistingLocalBranch() async throws {
@@ -65,7 +65,7 @@ import Testing
     #expect(!wt.branch.hasPrefix("tbd/"))
     // Folder name is derived from the branch's local name (sanitized).
     #expect(wt.name == "existing-feature")
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
     // Verify git also reports the worktree on the existing branch.
     // Path comparison uses `hasSuffix` because macOS resolves the temp dir
@@ -126,7 +126,7 @@ import Testing
     // Stored branch is the LOCAL tracking branch name (no `origin/` prefix).
     #expect(wt.branch == "remote-feature")
     #expect(wt.name == "remote-feature")
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
     // Verify a local tracking branch was created and is what the worktree
     // is checked out on. See the path-suffix note in the local-branch test.
@@ -139,10 +139,10 @@ import Testing
 @Test func testCreateWorktreeForExistingBranchDeDupesAgainstArchivedRowPath() async throws {
     // Regression: re-opening an existing branch whose PREVIOUS worktree was
     // archived must not collide with the archived row's `path` (the
-    // `worktree.path` column is globally UNIQUE, including archived rows).
+    // `worktree.localPath` column is globally UNIQUE, including archived rows).
     // Archived worktrees keep their `path` but have no directory on disk, so
     // the old filesystem-only uniqueness check returned the base name
-    // unchanged and the insert threw `UNIQUE constraint failed: worktree.path`.
+    // unchanged and the insert threw `UNIQUE constraint failed: worktree.localPath`.
     let (tempDir, repoDir) = try await createTestRepo()
     defer { try? FileManager.default.removeItem(at: tempDir) }
 
@@ -183,8 +183,8 @@ import Testing
         useExistingBranch: true
     )
     #expect(pending.name == "existing-feature-2")
-    #expect(pending.path != archivedPath)
-    #expect(pending.path.hasSuffix("/existing-feature-2"))
+    #expect(pending.localPath != archivedPath)
+    #expect(pending.localPath.hasSuffix("/existing-feature-2"))
 
     // Drive completion and confirm the worktree goes active with a real
     // checkout at the de-duped path.
@@ -198,7 +198,7 @@ import Testing
     }
     let completed = try #require(try await db.worktrees.get(id: pending.id))
     #expect(completed.status == .active)
-    #expect(FileManager.default.fileExists(atPath: completed.path))
+    #expect(FileManager.default.fileExists(atPath: completed.localPath))
 
     let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
     #expect(listed.contains { entry in
@@ -283,7 +283,7 @@ import Testing
 
     #expect(wt.status == .active)
     #expect(wt.branch == "already-here", "should have adopted the existing branch, not renamed around it")
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
     let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
     #expect(listed.contains { $0.branch == "already-here" })

--- a/Tests/TBDDaemonTests/WorktreeForgetTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeForgetTests.swift
@@ -24,10 +24,10 @@ import Testing
 
     let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
     // Drop a gitignored-style artifact to prove forget preserves on-disk files.
-    let marker = (wt.path as NSString).appendingPathComponent("keep-me.txt")
+    let marker = (wt.localPath as NSString).appendingPathComponent("keep-me.txt")
     try "preserve".write(toFile: marker, atomically: true, encoding: .utf8)
 
     // Seed a tab override row so the tab-cleanup assertion is meaningful.
@@ -40,7 +40,7 @@ import Testing
 
     // 1. Directory (and its files) still on disk — forget did NOT run
     //    `git worktree remove`.
-    #expect(FileManager.default.fileExists(atPath: wt.path),
+    #expect(FileManager.default.fileExists(atPath: wt.localPath),
             "forget must NOT delete the worktree directory")
     #expect(FileManager.default.fileExists(atPath: marker),
             "forget must preserve files inside the worktree directory")
@@ -78,11 +78,11 @@ import Testing
 
     let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
     try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
 
-    #expect(!FileManager.default.fileExists(atPath: wt.path),
+    #expect(!FileManager.default.fileExists(atPath: wt.localPath),
             "archive must delete the worktree directory (contrast with forget)")
 }
 

--- a/Tests/TBDDaemonTests/WorktreeForgetTombstoneTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeForgetTombstoneTests.swift
@@ -41,10 +41,10 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     // Created under the repo's worktreeRoot override → an acceptable prefix
     // for reconcile's re-adopt pass.
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
     try await lifecycle.forgetWorktree(worktreeID: wt.id)
-    #expect(try await db.forgottenWorktrees.contains(path: wt.path),
+    #expect(try await db.forgottenWorktrees.contains(path: wt.localPath),
             "forget must insert a tombstone for the worktree path")
 
     // The directory is still on disk AND still registered with git — exactly
@@ -52,10 +52,10 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
-    #expect(!active.contains { $0.path == wt.path },
+    #expect(!active.contains { $0.localPath == wt.localPath },
             "reconcile must not re-adopt a tombstoned path")
     let all = try await db.worktrees.list()
-    #expect(!all.contains { $0.path == wt.path },
+    #expect(!all.contains { $0.localPath == wt.localPath },
             "no row (any status) may be re-created for a tombstoned path")
 }
 
@@ -80,7 +80,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
 
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
-    #expect(active.contains { $0.path == wtPath },
+    #expect(active.contains { $0.localPath == wtPath },
             "reconcile must still adopt untombstoned worktrees under the managed prefix")
 }
 
@@ -96,12 +96,12 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
 
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
     try await lifecycle.forgetWorktree(worktreeID: wt.id)
-    #expect(try await db.forgottenWorktrees.contains(path: wt.path))
+    #expect(try await db.forgottenWorktrees.contains(path: wt.localPath))
 
     // Adopt the same path back — the tombstone must be cleared.
-    let outcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: wt.path)
-    #expect(outcome.worktree.path == wt.path)
-    #expect(!(try await db.forgottenWorktrees.contains(path: wt.path)),
+    let outcome = try await lifecycle.adoptWorktree(repoID: repo.id, path: wt.localPath)
+    #expect(outcome.worktree.localPath == wt.localPath)
+    #expect(!(try await db.forgottenWorktrees.contains(path: wt.localPath)),
             "adopt must clear the forget tombstone for its path")
 
     // Back to normal: with the tombstone gone, reconcile re-adopts the path
@@ -110,7 +110,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     try await db.worktrees.delete(id: outcome.worktree.id)
     try await lifecycle.reconcile(repoID: repo.id, actuationLog: makeTestActuationLog())
     let active = try await db.worktrees.list(repoID: repo.id, status: .active)
-    #expect(active.contains { $0.path == wt.path },
+    #expect(active.contains { $0.localPath == wt.localPath },
             "after the tombstone is cleared, reconcile behavior is back to normal")
 }
 
@@ -134,7 +134,7 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     let wt = try await lifecycle.createWorktree(
         repoID: repo.id, folder: "reborn", skipClaude: true
     )
-    #expect(wt.path == expectedPath)
+    #expect(wt.localPath == expectedPath)
     #expect(!(try await db.forgottenWorktrees.contains(path: expectedPath)),
             "create must clear the forget tombstone for its path")
 }
@@ -152,8 +152,8 @@ private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
     try await lifecycle.forgetWorktree(worktreeID: wt.id)
     // Seed a second tombstone insert directly (same primary key).
-    try await db.forgottenWorktrees.insert(path: wt.path, repoID: repo.id)
-    #expect(try await db.forgottenWorktrees.contains(path: wt.path))
+    try await db.forgottenWorktrees.insert(path: wt.localPath, repoID: repo.id)
+    #expect(try await db.forgottenWorktrees.contains(path: wt.localPath))
 }
 
 @Suite struct MigrationForgottenWorktreeTests {

--- a/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLifecycleTests.swift
@@ -22,7 +22,7 @@ import Testing
     #expect(result.status == .active)
     #expect(result.name.contains("-"))
     #expect(result.branch.hasPrefix("tbd/"))
-    #expect(FileManager.default.fileExists(atPath: result.path))
+    #expect(FileManager.default.fileExists(atPath: result.localPath))
 
     // Verify terminals were created
     let terminals = try await db.terminals.list(worktreeID: result.id)
@@ -182,7 +182,7 @@ import Testing
     #expect(result.status == .active)
     #expect(result.name == "my-folder")
     #expect(result.branch == "feat/custom-branch")
-    #expect(result.path.hasSuffix("/my-folder"))
+    #expect(result.localPath.hasSuffix("/my-folder"))
 }
 
 @Test func testCreateWithExplicitDisplayName() async throws {
@@ -294,13 +294,13 @@ import Testing
 
     let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
     let wt = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 
     try await lifecycle.archiveWorktree(worktreeID: wt.id, force: true)
 
     let archived = try await db.worktrees.get(id: wt.id)
     #expect(archived?.status == .archived)
-    #expect(!FileManager.default.fileExists(atPath: wt.path))
+    #expect(!FileManager.default.fileExists(atPath: wt.localPath))
 
     // Verify terminals were cleaned up
     let terminals = try await db.terminals.list(worktreeID: wt.id)
@@ -340,7 +340,7 @@ import Testing
     let revived = try await lifecycle.reviveWorktree(worktreeID: wt.id, skipClaude: true)
 
     #expect(revived.status == .active)
-    #expect(FileManager.default.fileExists(atPath: revived.path))
+    #expect(FileManager.default.fileExists(atPath: revived.localPath))
 
     // Verify fresh terminals were created
     let terminals = try await db.terminals.list(worktreeID: revived.id)
@@ -388,10 +388,10 @@ import Testing
 
     // Re-create a stray directory where the worktree used to live.
     try FileManager.default.createDirectory(
-        atPath: wt.path, withIntermediateDirectories: true
+        atPath: wt.localPath, withIntermediateDirectories: true
     )
     try "stray".write(
-        toFile: (wt.path as NSString).appendingPathComponent("file.txt"),
+        toFile: (wt.localPath as NSString).appendingPathComponent("file.txt"),
         atomically: true, encoding: .utf8
     )
 
@@ -601,7 +601,7 @@ import Testing
     let secondSessionID = UUID().uuidString
     let window = try await lifecycle.tmux.createWindow(
         server: wt.tmuxServer, session: "main",
-        cwd: wt.path, shellCommand: "echo test"
+        cwd: wt.localPath, shellCommand: "echo test"
     )
     _ = try await db.terminals.create(
         worktreeID: wt.id,
@@ -710,9 +710,9 @@ import Testing
 
     // Path should be under the canonical layout (tempDir/.tbd/worktrees/<name>)
     // because makeTestRepo overrides worktreeRoot to <tempDir>/.tbd/worktrees.
-    #expect(wt.path.hasPrefix(tempDir.path))
-    #expect(wt.path.contains(".tbd/worktrees/"))
-    #expect(wt.path.contains(wt.name))
+    #expect(wt.localPath.hasPrefix(tempDir.path))
+    #expect(wt.localPath.contains(".tbd/worktrees/"))
+    #expect(wt.localPath.contains(wt.name))
 }
 
 // MARK: - Reconcile Tests
@@ -982,7 +982,7 @@ import Testing
     #expect(wt.name == wt.displayName, "name == displayName; hasDefaultDisplayName is true")
     #expect(wt.hasDefaultDisplayName, "stop-rename-check hook will fire")
     #expect(wt.branch.hasPrefix("tbd/"), "Auto-generated worktrees use tbd/* branch")
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 }
 
 @Test func testCreateWorktreeExistingBranchWithoutFolderHasDefaultDisplayName() async throws {
@@ -1026,7 +1026,7 @@ import Testing
     #expect(wt.name == wt.displayName, "Existing-branch worktrees must have name == displayName")
     #expect(wt.hasDefaultDisplayName, "Existing-branch worktrees must have hasDefaultDisplayName == true")
     #expect(wt.branch == "my-feature")
-    #expect(FileManager.default.fileExists(atPath: wt.path))
+    #expect(FileManager.default.fileExists(atPath: wt.localPath))
 }
 
 // MARK: - Helpers

--- a/Tests/TBDDaemonTests/WorktreeLocationStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeLocationStoreTests.swift
@@ -1,0 +1,31 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct WorktreeLocationStoreTests {
+
+    private func makeDB() throws -> TBDDatabase { try TBDDatabase(inMemory: true) }
+
+    @Test func existingRowsMigrateToLocal() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b",
+            path: "/tmp/r/w-\(UUID().uuidString)", tmuxServer: "s")
+        let fetched = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(fetched.location == .local)
+    }
+
+    @Test func remoteLocationRoundTripsThroughTheStore() async throws {
+        let db = try makeDB()
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let wt = try await db.worktrees.create(
+            repoID: repo.id, name: "w", branch: "b", path: "", tmuxServer: "",
+            location: .remote(provider: "agentbox", sessionID: "s-1"))
+        let fetched = try #require(try await db.worktrees.get(id: wt.id))
+        #expect(fetched.location == .remote(provider: "agentbox", sessionID: "s-1"))
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
+++ b/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
@@ -95,7 +95,7 @@ import Testing
         #expect(wt.branch == "feature-x")
         #expect(wt.prNumber == 7)
         // Worktree HEAD sits on the pull-ref commit, not on main.
-        let head = try await GitManager().headSHA(worktreePath: wt.path)
+        let head = try await GitManager().headSHA(worktreePath: wt.localPath)
         #expect(head == prSHA)
 
         let stored = try #require(try await db.worktrees.get(id: wt.id))
@@ -131,7 +131,7 @@ import Testing
         // Landed on the uniquified branch at the pull-ref commit...
         #expect(wt.branch == "feature-x-2")
         #expect(wt.prNumber == 7)
-        let head = try await GitManager().headSHA(worktreePath: wt.path)
+        let head = try await GitManager().headSHA(worktreePath: wt.localPath)
         #expect(head == prSHA)
 
         // ...and the original branch is untouched by the force refspec.
@@ -164,7 +164,7 @@ import Testing
         #expect(wt.status == .active)
         #expect(wt.branch == "feature-x")     // existing branch, not uniquified
         #expect(wt.prNumber == 9)             // still stamped for status tracking
-        let head = try await GitManager().headSHA(worktreePath: wt.path)
+        let head = try await GitManager().headSHA(worktreePath: wt.localPath)
         #expect(head == branchSHA)
         // No stray duplicate branch was created by a pull-ref fetch.
         let dupExists = try await GitManager().localBranchExists(repoPath: repoDir.path, name: "feature-x-2")

--- a/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
@@ -297,7 +297,7 @@ struct WorktreeReviveFreshTests {
         #expect(created.displayName == "stale-owl (revived)")
         #expect(created.branch == "tbd/\(created.name)")
         #expect(
-            try await GitManager().headSHA(repoPath: created.path, ref: "HEAD")
+            try await GitManager().headSHA(repoPath: created.localPath, ref: "HEAD")
                 == remoteSHA
         )
         #expect(
@@ -388,7 +388,7 @@ struct WorktreeReviveFreshTests {
 
         #expect(
             try await GitManager().headSHA(
-                repoPath: outcome.result.worktree.path, ref: "HEAD"
+                repoPath: outcome.result.worktree.localPath, ref: "HEAD"
             ) == localSHA
         )
         let warning = try #require(outcome.result.warning)
@@ -686,7 +686,7 @@ struct WorktreeReviveFreshTests {
             (try? FileManager.default.destinationOfSymbolicLink(atPath: profileRoot.path)) != nil
         )
         let derived = TranscriptProjectDirSync.derivedProjectDir(
-            worktreePath: outcome.result.worktree.path, projectsRoot: profileRoot)
+            worktreePath: outcome.result.worktree.localPath, projectsRoot: profileRoot)
         #expect(
             FileManager.default.fileExists(
                 atPath: derived.appendingPathComponent("A.jsonl").path)

--- a/Tests/TBDDaemonTests/WorktreeStoreLocalFilterTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreLocalFilterTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+@Suite struct WorktreeStoreLocalFilterTests {
+
+    private func makeDB() throws -> TBDDatabase { try TBDDatabase(inMemory: true) }
+
+    private func seed(_ db: TBDDatabase) async throws -> (repo: Repo, local: Worktree, remote: Worktree) {
+        let repo = try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+        let local = try await db.worktrees.create(
+            repoID: repo.id, name: "local", branch: "b1",
+            path: "/tmp/r/local-\(UUID().uuidString)", tmuxServer: "srv")
+        let remote = try await db.worktrees.create(
+            repoID: repo.id, name: "remote", branch: "b2", path: "", tmuxServer: "",
+            location: .remote(provider: "agentbox", sessionID: "s-1"))
+        return (repo, local, remote)
+    }
+
+    @Test func getLocalReturnsALocalRow() async throws {
+        let db = try makeDB()
+        let (_, local, _) = try await seed(db)
+        let fetched = try await db.worktrees.getLocal(id: local.id)
+        #expect(fetched?.id == local.id)
+    }
+
+    @Test func getLocalRefusesARemoteRow() async throws {
+        let db = try makeDB()
+        let (_, _, remote) = try await seed(db)
+        #expect(try await db.worktrees.getLocal(id: remote.id) == nil)
+        // The location-neutral fetch still sees it — the row is not hidden,
+        // only withheld from local-only callers.
+        #expect(try await db.worktrees.get(id: remote.id) != nil)
+    }
+
+    @Test func listLocalExcludesRemoteRows() async throws {
+        let db = try makeDB()
+        let (repo, local, _) = try await seed(db)
+        let locals = try await db.worktrees.listLocal(repoID: repo.id)
+        #expect(locals.map(\.id) == [local.id])
+        #expect(try await db.worktrees.list(repoID: repo.id).count == 2)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeStoreLocalFilterTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreLocalFilterTests.swift
@@ -13,9 +13,9 @@ import Foundation
         let local = try await db.worktrees.create(
             repoID: repo.id, name: "local", branch: "b1",
             path: "/tmp/r/local-\(UUID().uuidString)", tmuxServer: "srv")
-        let remote = try await db.worktrees.create(
-            repoID: repo.id, name: "remote", branch: "b2", path: "", tmuxServer: "",
-            location: .remote(provider: "agentbox", sessionID: "s-1"))
+        let remote = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote", branch: "b2",
+            provider: "agentbox", sessionID: "s-1")
         return (repo, local, remote)
     }
 

--- a/Tests/TBDDaemonTests/WorktreeStoreRemoteRowTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreRemoteRowTests.swift
@@ -1,0 +1,100 @@
+import Testing
+import Foundation
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// `worktree.path` is `NOT NULL UNIQUE`, so remote rows — which have no
+/// filesystem path — cannot all store the same placeholder. `create` derives a
+/// synthetic `remote://<provider>/<sessionID>` path from the location instead,
+/// which is unique per session and visibly not a filesystem path.
+@Suite struct WorktreeStoreRemoteRowTests {
+
+    private func makeDB() throws -> TBDDatabase { try TBDDatabase(inMemory: true) }
+
+    private func makeRepo(_ db: TBDDatabase) async throws -> Repo {
+        try await db.repos.create(
+            path: "/tmp/r-\(UUID().uuidString)", displayName: "r", defaultBranch: "main")
+    }
+
+    /// The headline case for the follow-up PR: an orchestrator fans out to two
+    /// remote lanes in one repo. Both rows must persist.
+    @Test func twoRemoteRowsCoexistInOneRepo() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+
+        let first = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote-1", branch: "b1",
+            provider: "agentbox", sessionID: "s-1")
+        let second = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote-2", branch: "b2",
+            provider: "agentbox", sessionID: "s-2")
+
+        let rows = try await db.worktrees.list(repoID: repo.id)
+        #expect(Set(rows.map(\.id)) == Set([first.id, second.id]))
+        #expect(first.localPath != second.localPath)
+    }
+
+    /// The stored path is the location's synthetic URI, both in the returned
+    /// value and on the row that comes back out of the database.
+    @Test func remoteRowStoresTheSyntheticPath() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+
+        let created = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote", branch: "b",
+            provider: "agentbox", sessionID: "s-1")
+
+        #expect(created.localPath == "remote://agentbox/s-1")
+        let fetched = try #require(try await db.worktrees.get(id: created.id))
+        #expect(fetched.localPath == "remote://agentbox/s-1")
+        #expect(fetched.tmuxServer == "")
+    }
+
+    /// Two sessions whose IDs differ only in a delimiter must not collapse
+    /// onto one path. Percent-encoding each component is what keeps the
+    /// mapping injective, so the UNIQUE constraint stays a real guard rather
+    /// than an accident of which characters providers happen to use.
+    @Test func sessionIDsContainingDelimitersStayDistinct() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+
+        let slashed = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "a", branch: "b1",
+            provider: "agentbox", sessionID: "team/one")
+        let flattened = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "b", branch: "b2",
+            provider: "agentbox/team", sessionID: "one")
+
+        #expect(slashed.localPath == "remote://agentbox/team%2Fone")
+        #expect(flattened.localPath == "remote://agentbox%2Fteam/one")
+        #expect(try await db.worktrees.list(repoID: repo.id).count == 2)
+    }
+
+    /// `create` derives the path from the location, so a caller that passes a
+    /// real-looking path for a remote row does not get it stored.
+    @Test func createIgnoresACallerSuppliedPathForARemoteRow() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+
+        let created = try await db.worktrees.create(
+            repoID: repo.id, name: "remote", branch: "b",
+            path: "/tmp/not-a-remote-path", tmuxServer: "",
+            location: .remote(provider: "agentbox", sessionID: "s-9"))
+
+        #expect(created.localPath == "remote://agentbox/s-9")
+    }
+
+    /// A synthetic path is still not a local checkout: local-only fetches must
+    /// keep refusing the row.
+    @Test func aSyntheticPathDoesNotMakeARowLocal() async throws {
+        let db = try makeDB()
+        let repo = try await makeRepo(db)
+
+        let created = try await db.worktrees.createRemote(
+            repoID: repo.id, name: "remote", branch: "b",
+            provider: "agentbox", sessionID: "s-1")
+
+        #expect(try await db.worktrees.getLocal(id: created.id) == nil)
+        #expect(LocalWorktree(created) == nil)
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeStoreTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeStoreTests.swift
@@ -151,7 +151,7 @@ import TBDShared
         )
         try await db.worktrees.updatePath(id: wt.id, path: "/tmp/new/w")
         let fetched = try await db.worktrees.get(id: wt.id)
-        #expect(fetched?.path == "/tmp/new/w")
+        #expect(fetched?.localPath == "/tmp/new/w")
     }
 
     @Test func worktreeStoreCanMarkFailed() async throws {

--- a/Tests/TBDSharedTests/LocalWorktreeTests.swift
+++ b/Tests/TBDSharedTests/LocalWorktreeTests.swift
@@ -1,0 +1,40 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct LocalWorktreeTests {
+
+    private func makeWorktree(
+        location: WorktreeLocation = .local, path: String = "/tmp/w"
+    ) -> Worktree {
+        Worktree(repoID: UUID(), name: "n", displayName: "dn", branch: "b",
+                 path: path, tmuxServer: "srv", location: location)
+    }
+
+    @Test func wrapsALocalWorktree() throws {
+        let wt = makeWorktree()
+        let local = try #require(LocalWorktree(wt))
+        #expect(local.path == "/tmp/w")
+        #expect(local.tmuxServer == "srv")
+    }
+
+    @Test func refusesARemoteWorktree() {
+        let wt = makeWorktree(location: .remote(provider: "agentbox", sessionID: "s-1"), path: "")
+        #expect(LocalWorktree(wt) == nil)
+    }
+
+    /// A local row with an empty path is the transient `.creating`
+    /// placeholder, which has no directory yet — it must not pass as local.
+    @Test func refusesAnEmptyPath() {
+        #expect(LocalWorktree(makeWorktree(path: "")) == nil)
+    }
+
+    @Test func forwardsOtherMembersToTheWrappedWorktree() throws {
+        let wt = makeWorktree()
+        let local = try #require(LocalWorktree(wt))
+        #expect(local.id == wt.id)
+        #expect(local.branch == "b")
+        #expect(local.displayName == "dn")
+        #expect(local.worktree == wt)
+    }
+}

--- a/Tests/TBDSharedTests/WorktreeLocationTests.swift
+++ b/Tests/TBDSharedTests/WorktreeLocationTests.swift
@@ -83,4 +83,15 @@ import Foundation
         let decoded = try JSONDecoder().decode(Worktree.self, from: JSONEncoder().encode(wt))
         #expect(decoded == wt)
     }
+
+    /// The stored path is named `localPath` in Swift but must not change the
+    /// wire format: the JSON key stays `path`, so a daemon and an app at
+    /// different versions still agree.
+    @Test func encodesLocalPathUnderThePathKey() throws {
+        let wt = makeWorktree()
+        let object = try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(wt)) as? [String: Any]
+        #expect(object?["path"] as? String == "/tmp/n")
+        #expect(object?["localPath"] == nil)
+    }
 }

--- a/Tests/TBDSharedTests/WorktreeLocationTests.swift
+++ b/Tests/TBDSharedTests/WorktreeLocationTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import Foundation
+@testable import TBDShared
+
+@Suite struct WorktreeLocationTests {
+
+    private func makeWorktree(location: WorktreeLocation = .local) -> Worktree {
+        Worktree(repoID: UUID(), name: "n", displayName: "n", branch: "b",
+                 path: "/tmp/n", tmuxServer: "s", location: location)
+    }
+
+    @Test func defaultsToLocal() {
+        #expect(makeWorktree().location == .local)
+    }
+
+    @Test func remoteCarriesProviderAndSessionID() {
+        let wt = makeWorktree(location: .remote(provider: "agentbox", sessionID: "s-1"))
+        #expect(wt.location == .remote(provider: "agentbox", sessionID: "s-1"))
+        let binding = try? #require(wt.providerBinding)
+        #expect(binding?.provider == "agentbox")
+        #expect(binding?.sessionID == "s-1")
+    }
+
+    @Test func localHasNoProviderBinding() {
+        #expect(makeWorktree().providerBinding == nil)
+    }
+
+    /// A payload written by a daemon predating v70 must still decode, as
+    /// local — the field is absent, not null.
+    @Test func decodesLegacyPayloadAsLocal() throws {
+        let json = """
+        {"id":"\(UUID().uuidString)","repoID":"\(UUID().uuidString)","name":"n",
+         "displayName":"n","branch":"b","path":"/tmp/n","status":"active",
+         "createdAt":0,"tmuxServer":"s"}
+        """
+        let decoded = try JSONDecoder().decode(Worktree.self, from: Data(json.utf8))
+        #expect(decoded.location == .local)
+    }
+
+    @Test func roundTripsRemoteThroughCodable() throws {
+        let wt = makeWorktree(location: .remote(provider: "agentbox", sessionID: "s-1"))
+        let data = try JSONEncoder().encode(wt)
+        let decoded = try JSONDecoder().decode(Worktree.self, from: data)
+        #expect(decoded.location == wt.location)
+    }
+
+    /// `Worktree` hand-writes `encode(to:)`, so a property added to the struct
+    /// but forgotten in the encoder would silently vanish off the wire between
+    /// daemon and app. Populating every field and comparing the whole decoded
+    /// value catches that, where a per-field test only catches the fields
+    /// someone remembered to write a test for.
+    @Test func roundTripsAFullyPopulatedWorktree() throws {
+        let wt = Worktree(
+            id: UUID(),
+            repoID: UUID(),
+            name: "20260810-domestic-ferret",
+            displayName: "domestic-ferret",
+            branch: "tbd/20260810-domestic-ferret",
+            path: "/tmp/wt",
+            status: .archived,
+            hasConflicts: true,
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            archivedAt: Date(timeIntervalSince1970: 1_700_000_500),
+            tmuxServer: "tbd-a1b2c3d4",
+            archivedClaudeSessions: ["sess-a", "sess-b"],
+            sortOrder: 7,
+            archivedHeadSHA: "deadbeef",
+            liveClaudeSessionCount: 3,
+            parentWorktreeID: UUID(),
+            autoArchiveOnMerge: true,
+            autoHibernateOnMerge: false,
+            promotedToRepoID: UUID(),
+            prStatus: PRStatus(number: 42, url: "https://example.invalid/pr/42",
+                               state: .mergeable, reason: "why", files: ["a.swift"],
+                               commits: 3, authorWorktreeID: UUID(),
+                               mergeQueuePosition: 1),
+            prNumber: 42,
+            foreignHead: true,
+            pinnedAt: Date(timeIntervalSince1970: 1_700_000_200),
+            pinSortOrder: 2,
+            location: .remote(provider: "agentbox", sessionID: "s-1")
+        )
+        let decoded = try JSONDecoder().decode(Worktree.self, from: JSONEncoder().encode(wt))
+        #expect(decoded == wt)
+    }
+}

--- a/Tests/TBDSharedTests/WorktreeLocationTests.swift
+++ b/Tests/TBDSharedTests/WorktreeLocationTests.swift
@@ -13,12 +13,12 @@ import Foundation
         #expect(makeWorktree().location == .local)
     }
 
-    @Test func remoteCarriesProviderAndSessionID() {
+    @Test func remoteCarriesProviderAndSessionID() throws {
         let wt = makeWorktree(location: .remote(provider: "agentbox", sessionID: "s-1"))
         #expect(wt.location == .remote(provider: "agentbox", sessionID: "s-1"))
-        let binding = try? #require(wt.providerBinding)
-        #expect(binding?.provider == "agentbox")
-        #expect(binding?.sessionID == "s-1")
+        let binding = try #require(wt.providerBinding)
+        #expect(binding.provider == "agentbox")
+        #expect(binding.sessionID == "s-1")
     }
 
     @Test func localHasNoProviderBinding() {

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -377,6 +377,23 @@ archives or dismisses it. Nothing mutates it in the background. Auto-archiving
 after the tombstone window would save one keystroke per rare event and cost a
 background mutation of persisted state, a default-off flag, and a soak.
 
+### Removing a repo that owns lanes
+
+`repo.remove` counts remote lanes among the active worktrees that block an
+unforced removal — a lane is as much a live thing to lose as a local worktree.
+Under `--force`, though, only the local worktrees are cascade-archived: stopping
+a provider session is archive's job, and the cascade has no provider to talk to.
+The lane's row is removed by the same `deleteForRepo` that clears the repo's
+archived and main rows, and no actuation row is written for it, because none of
+its sessions were torn down and the record may only claim acts that were
+attempted.
+
+The lane's provider session therefore outlives the row. That is the honest
+shape for a repo the user is unregistering: TBD is forgetting a repository, not
+promising to reach across the network on the way out — and a cascade that
+half-succeeded, tearing down local worktrees and then failing on a provider
+call, would be strictly worse than one that never claimed the provider work.
+
 ### Does not apply
 
 Hibernation, relocate, forget, scratch promote, and adopt-existing-directory
@@ -457,6 +474,9 @@ Boundary, the tests that would have caught the hazard:
 - A remote `.creating` row left behind by a daemon restart reaches `.failed`
   rather than spinning.
 - An orphan-GC sweep leaves a remote row intact.
+- `repo.remove --force` on a repo owning a local worktree and a remote lane
+  clears the repo and both rows without throwing, and writes a dispose row for
+  the local worktree only.
 
 Behavior:
 

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -201,6 +201,21 @@ viewer, the Claude trust seeder, relocate, forget, adopt-existing-directory, and
 reconcile cannot see a remote row — not because someone remembered a guard, but
 because `listLocal` does not return one.
 
+### PR polling is fenced, and has to be un-fenced by branch
+
+PR polling is the one local-only subsystem a remote lane genuinely wants back:
+a lane carries a PR badge like any other row. It is fenced anyway, because
+everything below `pollableWorktrees` is keyed on the worktree's **path** —
+`branchFacts` runs `git` inside the directory and caches its answer under that
+path, and `PRStatusManager` runs `gh` there. Pointed at a remote row, all of it
+operates on a directory that does not exist.
+
+Restoring the badge therefore means re-keying the poll on the **branch**, using
+the repo's own checkout as the working directory, not relaxing the fence. Until
+that lands, a remote lane simply carries no PR status — which is what makes
+fencing the correct move rather than a deferral: it leaves nothing that breaks
+on a remote row.
+
 ## Creation and the CLI
 
 `tbd worktree create` grows `--provider <name>` and a repeatable

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -207,12 +207,44 @@ at the CLI the model this design unifies in the database.
 
 ### Creation flow
 
-The daemon resolves parameters, calls `remote.create` with an idempotency key
-(existing machinery, including the retry-once-on-timeout path), and writes a
-`worktree` row bound to `(provider, session.id)` carrying the parent stamp, sort
-order, and display name. If the row write fails after a successful create, the
-next snapshot adopts the session: creation and adoption converge on the same
-row, so neither path can orphan a session.
+The daemon mints the worktree UUID first and writes a `.creating` row carrying
+the parent stamp, sort order, and display name. It then calls `remote.create`
+with an idempotency key (existing machinery, including the
+retry-once-on-timeout path), and on success flips the row to `.active`, bound
+to `(provider, session.id)`. A failed create marks the row `.failed` rather
+than deleting it: reconcile is fenced from remote rows, so a remote row needs
+an explicit terminal state, and a row that silently vanishes cannot be told
+apart from a create that never ran.
+
+Writing the row first is what lets the session know its own identity, below.
+
+### A remote lane knows its own worktree UUID
+
+TBD sets `TBD_WORKTREE_ID` in shells it spawns, and it never spawns a remote
+one. Without that variable, nothing running inside a remote lane can use a
+`tbd` verb keyed on ambient identity — `tbd link`, `tbd terminal send`, or any
+hook that reads it. An orchestrator's remote children would be reachable from
+the laptop but unable to act as lanes themselves.
+
+So the minted UUID travels three ways:
+
+- **Out**, on `create`'s stdin as a sibling of `params`:
+  `{"params": {…}, "idempotency_key": "…", "tbd": {"worktree_id": "…"}}`. This
+  is TBD metadata rather than a create param — it never appears in
+  `create_params`, never renders in the create sheet, and `--param` cannot set
+  or override it.
+- **Into the session**, as `TBD_WORKTREE_ID` in the agent's environment. The
+  provider's job.
+- **Back**, echoed as `meta["tbd_worktree_id"]` on the Session object.
+
+The echo is what makes the binding self-healing. If the row write fails after a
+successful create, adoption reads the echo and recreates the same row id, so
+the variable already exported on the box still resolves. Without it, adoption
+would mint a second UUID and the box would hold a dangling one.
+
+Both this and the dirty-checkout key are additive within contract v1, and a
+provider that implements neither behaves exactly as it does today: no echo
+means adoption mints a UUID as usual, and the lane simply is not self-aware.
 
 ## Default resolution
 

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -397,9 +397,18 @@ call, would be strictly worse than one that never claimed the provider work.
 ### Does not apply
 
 Hibernation, relocate, forget, scratch promote, and adopt-existing-directory
-have no remote meaning and are unreachable through `LocalWorktree`. Orphan GC
-needs no change: it keys on filesystem paths and snapshot refs, and a remote row
-has neither.
+have no remote meaning and are unreachable through `LocalWorktree`.
+
+Orphan GC's agent-worktree collector enumerates git's own worktree list and so
+never sees a remote row at all. Its scratchpad reconciliation would, and is
+fenced: both of its worktree fetches go through `listLocal`. The fence is what
+makes it safe, not the absence of a path — "the worktree's directory is gone"
+is the entire reap criterion, and a remote row's synthetic `remote://` path is
+absent from disk by construction, so a location-neutral fetch would make every
+archived lane a standing reap candidate on every sweep. The slug such a path
+produces cannot collide with a real scratchpad's, so nothing was ever at risk of
+being deleted — but a row that reaches a reaper's candidate list is one refactor
+away from being reaped, and the boundary is cheaper to hold than to re-derive.
 
 ## Sidebar
 
@@ -473,7 +482,10 @@ Boundary, the tests that would have caught the hazard:
   `worktree.path`'s UNIQUE constraint from admitting only one remote lane.
 - A remote `.creating` row left behind by a daemon restart reaches `.failed`
   rather than spinning.
-- An orphan-GC sweep leaves a remote row intact.
+- Orphan GC never reaps a directory planted at a remote row's scratchpad slug —
+  in the periodic sweep and in the repo-removal reconciliation both. Each arm
+  also plants a scratchpad behind a gone *local* row, so a run that reaped
+  nothing cannot pass by doing nothing.
 - `repo.remove --force` on a repo owning a local worktree and a remote lane
   clears the repo and both rows without throwing, and writes a dispose row for
   the local worktree only.

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -108,8 +108,25 @@ case: it archives every DB row whose `path` is absent from git's worktree list,
 capturing scrollback and killing tmux windows on the way. A remote row's path is
 never in that list, so an unguarded reconcile tears down every remote lane on
 every sweep. A second loop in the same function rewrites the `tmuxServer` of any
-row whose value differs from the repo's canonical name, which an empty string
-always does.
+row whose value differs from the repo's canonical name, which a remote row's
+empty string always does.
+
+#### What a remote row stores in the local-only columns
+
+`worktree.path` is `NOT NULL UNIQUE`, so a remote row cannot leave it empty:
+the empty string admits exactly one remote row per install, and the second lane
+of a fan-out aborts on the constraint. A remote row therefore stores a
+synthetic `remote://<provider>/<sessionID>` URI, with each component
+percent-encoded so the mapping stays injective whatever delimiters a provider
+puts in its identifiers. The value is derived inside `WorktreeStore.create`
+from the row's `location`, not passed by callers, so it cannot be forgotten at
+a new call site. It is visibly not a filesystem path, which means a remote row
+that ever reaches path-consuming code fails loudly instead of quietly operating
+on the current directory.
+
+`tmuxServer` stays empty on a remote row: there is no tmux server, the column
+is not unique, and reconcile's canonicalization loop is fenced from remote rows
+anyway.
 
 No one would think to hand-write a guard in reconcile. The boundary therefore
 has to be one the compiler enforces.
@@ -118,13 +135,15 @@ has to be one the compiler enforces.
 
 `Worktree` keeps storing a non-optional path, renamed behind the existing
 `path:` argument label and `CodingKeys` mapping. All 158 construction sites and
-the wire format stay untouched. `Worktree` exposes only:
+the wire format stay untouched. The stored property becomes:
 
 ```swift
-public var localPath: String? { ... }   // nil when remote
+public var localPath: String     // stays non-optional; wire key and column stay `path`
 ```
 
-Every current reader of `worktree.path` becomes a compile error. That is the
+Non-optional, because making it optional was rejected below on what the
+enumeration would produce. The rename alone does the work: every current reader
+of `worktree.path` becomes a compile error. That is the
 audit: the change enumerates the code that assumes a local checkout without
 churning the code that merely builds a row.
 
@@ -412,6 +431,8 @@ Boundary, the tests that would have caught the hazard:
   `tmuxServer` rewrite.
 - `getLocal`/`listLocal` exclude remote rows; the 11 neutral fetches still
   return them.
+- Two remote rows for the same repo both persist — the synthetic path keeps
+  `worktree.path`'s UNIQUE constraint from admitting only one remote lane.
 - An orphan-GC sweep leaves a remote row intact.
 
 Behavior:

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -1,7 +1,10 @@
 # Remote agent sessions as worktrees in the tree
 
 **Date:** 2026-08-10
-**Status:** Approved; not yet implemented.
+**Status:** Approved. The local/remote boundary — `WorktreeLocation`, `LocalWorktree`,
+and the `getLocal`/`listLocal` conversion — ships in PR #613. Everything downstream of it
+(remote rows in the tree, the CLI provider path, default resolution, archive semantics)
+remains unimplemented.
 **Depends on:** [`docs/remote-provider-contract.md`](../remote-provider-contract.md) (contract v1),
 [`2026-07-24-remote-agent-backends-design.md`](2026-07-24-remote-agent-backends-design.md) (mirror, RPC family, provider manager),
 [`2026-08-01-provider-desk-read-only-design.md`](2026-08-01-provider-desk-read-only-design.md) (Provider Desk).

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -111,7 +111,10 @@ every sweep. A second loop in the same function rewrites the `tmuxServer` of any
 row whose value differs from the repo's canonical name, which a remote row's
 empty string always does.
 
-#### What a remote row stores in the local-only columns
+No one would think to hand-write a guard in reconcile. The boundary therefore
+has to be one the compiler enforces.
+
+### What a remote row stores in the local-only columns
 
 `worktree.path` is `NOT NULL UNIQUE`, so a remote row cannot leave it empty:
 the empty string admits exactly one remote row per install, and the second lane
@@ -127,9 +130,6 @@ on the current directory.
 `tmuxServer` stays empty on a remote row: there is no tmux server, the column
 is not unique, and reconcile's canonicalization loop is fenced from remote rows
 anyway.
-
-No one would think to hand-write a guard in reconcile. The boundary therefore
-has to be one the compiler enforces.
 
 ### Readers break; writers do not
 
@@ -171,10 +171,16 @@ outward ripple.
 Measured against the tree at the time of writing. Fetch sites, which are what
 the change edits:
 
-- 46 of the 57 `get(` sites are local-only and move to `getLocal`
-- 11 stay location-neutral: parent resolver, notes, worktree handlers, adopt,
-  revive-fresh
-- 10 of the 31 `list(` sites live in reconcile alone
+- 45 of the 57 `get(` sites are local-only and move to `getLocal`
+- 12 `get(` sites stay location-neutral: the parent resolver, notes, worktree
+  handlers, adopt, revive-fresh, the pre-session row-existence check, and the
+  two merge coordinators
+- 18 of the 31 `list(` sites move to `listLocal`, 10 of them in reconcile alone
+- 13 `list(` sites stay location-neutral, including the two whose sets must
+  span every row on the table whatever its location — the path-reservation set
+  in create and the `.creating` path set in reconcile — and the `.creating`
+  recovery sweep, which is the only thing that resolves such a row and so must
+  see remote ones to give them an outcome
 
 Dereferences of a worktree's `path`, which are what the change mostly leaves
 alone — 161 in total:
@@ -444,10 +450,12 @@ Boundary, the tests that would have caught the hazard:
 
 - Reconcile leaves remote rows alone: no archive, no terminal teardown, no
   `tmuxServer` rewrite.
-- `getLocal`/`listLocal` exclude remote rows; the 11 neutral fetches still
+- `getLocal`/`listLocal` exclude remote rows; the 25 neutral fetches still
   return them.
 - Two remote rows for the same repo both persist — the synthetic path keeps
   `worktree.path`'s UNIQUE constraint from admitting only one remote lane.
+- A remote `.creating` row left behind by a daemon restart reaches `.failed`
+  rather than spinning.
 - An orphan-GC sweep leaves a remote row intact.
 
 Behavior:

--- a/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
+++ b/docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md
@@ -1,0 +1,442 @@
+# Remote agent sessions as worktrees in the tree
+
+**Date:** 2026-08-10
+**Status:** Approved; not yet implemented.
+**Depends on:** [`docs/remote-provider-contract.md`](../remote-provider-contract.md) (contract v1),
+[`2026-07-24-remote-agent-backends-design.md`](2026-07-24-remote-agent-backends-design.md) (mirror, RPC family, provider manager),
+[`2026-08-01-provider-desk-read-only-design.md`](2026-08-01-provider-desk-read-only-design.md) (Provider Desk).
+
+## Summary
+
+A remote agent session becomes a `Worktree` row. It nests in the sidebar tree
+under the lane that spawned it, sorts and reparents like any other row, carries
+a PR badge, and archives. `tbd worktree create --provider <name>` creates one,
+so an orchestrator lane fans out to a remote box with the command it already
+uses locally.
+
+Two facts make this cheaper than it looks. Tree placement is already UI-only —
+`--position child|sibling|root` sets `parentWorktreeID` and never affects the
+git base — so a parent edge costs nothing but a column. And the parent edge is
+TBD-side state the provider never learns about, so the contract needs no new
+verb.
+
+The work divides in two. A behavior-preserving refactor introduces
+`WorktreeLocation` and a `LocalWorktree` type that makes local-only subsystems
+structurally unable to see a remote row. On top of it, remote rows join the
+tree, the CLI grows a provider path, and archive gains a remote meaning.
+
+## Why this reverses a v1 non-goal
+
+The remote-backends design lists "making remote sessions appear as worktrees" as
+a non-goal and keeps remote sessions a parallel concept — their own model,
+their own sidebar section, their own RPC family. That was the right call for
+v1: it shipped a working transport, mirror, and attach path without paying for
+a model change whose value was speculative.
+
+The value stopped being speculative. Fanning work out across many lanes is
+TBD's central workflow, and it runs through the worktree tree and the CLI.
+A session that lives outside both can be watched but not orchestrated: it has
+no parent, no position, no `tbd worktree` verb, and no place in the hierarchy an
+agent reads to understand what it spawned. The only route to a remote box today
+transfers an already-pushed branch, which moves an existing task rather than
+starting a new lane.
+
+Parallel models also duplicate. Each worktree feature reaching remote sessions
+needs a second implementation — a second row view, a second action menu, a
+second create sheet — and the two drift. Unification pays that back once.
+
+## Model
+
+### Location on the worktree row
+
+A migration adds three columns to `worktree`, with the GRDB record and the
+`TBDShared` Codable model updated in the same commit:
+
+- `location TEXT NOT NULL DEFAULT 'local'`
+- `providerName TEXT` — null for local rows
+- `providerSessionID TEXT` — null for local rows
+
+They surface as one value:
+
+```swift
+public enum WorktreeLocation: Equatable, Sendable {
+    case local
+    case remote(provider: String, sessionID: String)
+}
+```
+
+Backfilling `'local'` is correct: every existing row is local. Because the
+default states a fact rather than a preference, no later migration has to force
+it — the trap `auto_hibernate_enabled` fell into does not apply.
+
+### Two tables, two owners
+
+The `remote_session` mirror keeps its current job unchanged: provider-owned
+liveness (`state`, `agentState`, `gone`, `missingCount`, `lastSeen`). The
+`worktree` row holds TBD-owned policy — `parentWorktreeID`, `sortOrder`,
+`pinnedAt`, `displayName`, `status`, notes — plus the
+`(providerName, providerSessionID)` binding that joins them.
+
+Authority splits by kind of fact, and neither side overrides the other. The
+party running the process owns liveness; the party the user talks to owns
+policy. So **`worktree.status` on a remote row means TBD's own lifecycle
+(`active` or `archived`) and never mirrors provider liveness.** A lane whose box
+died is `status: active` with `state: exited`. Those are different facts, and a
+row that collapses them lies about one of them.
+
+### A worktree row exists exactly when the session resolves to a local repo
+
+`RemoteRepoMatching.resolveRepoID` already maps a session's `meta["repo"]` onto
+a registered repo. That resolution decides whether a row exists at all:
+
+- A session TBD created gets a row, stamped with its parent.
+- A session created elsewhere — by hand on the box, from another laptop, or by
+  a branch transfer — gets a row on first sighting, at top level in its matched
+  repo. `tbd worktree reparent` is location-neutral, so it can move under the
+  lane that owns it afterwards.
+- A session matching no registered repo gets no row and appears only in the
+  Provider Desk.
+
+The row is created once at first sighting and never re-derived, matching how
+`resolvedRepoID` is already pinned.
+
+## The local/remote boundary
+
+Most of the daemon assumes a worktree has files on this disk. Reaching that
+code with a remote row destroys data. `WorktreeLifecycle+Reconcile` is the proof
+case: it archives every DB row whose `path` is absent from git's worktree list,
+capturing scrollback and killing tmux windows on the way. A remote row's path is
+never in that list, so an unguarded reconcile tears down every remote lane on
+every sweep. A second loop in the same function rewrites the `tmuxServer` of any
+row whose value differs from the repo's canonical name, which an empty string
+always does.
+
+No one would think to hand-write a guard in reconcile. The boundary therefore
+has to be one the compiler enforces.
+
+### Readers break; writers do not
+
+`Worktree` keeps storing a non-optional path, renamed behind the existing
+`path:` argument label and `CodingKeys` mapping. All 158 construction sites and
+the wire format stay untouched. `Worktree` exposes only:
+
+```swift
+public var localPath: String? { ... }   // nil when remote
+```
+
+Every current reader of `worktree.path` becomes a compile error. That is the
+audit: the change enumerates the code that assumes a local checkout without
+churning the code that merely builds a row.
+
+### Fix at the fetch, not at the dereference
+
+Readers are then repaired upstream, where the worktree is obtained:
+
+```swift
+db.worktrees.get(id:)   → getLocal(id:)    // returns LocalWorktree?
+db.worktrees.list(...)  → listLocal(...)   // returns [LocalWorktree]
+```
+
+`LocalWorktree` wraps a `Worktree` proven local, exposing `path` and
+`tmuxServer` non-optional and forwarding every other member to the wrapped
+value through `@dynamicMemberLookup`. Handler bodies do not change: `worktree.id`,
+`worktree.branch`, and `worktree.path` all keep compiling.
+
+This works because the daemon obtains worktrees by lookup rather than by
+parameter. Only 20 functions in `Sources/` take a `Worktree` parameter, while 57
+call sites fetch by id and 31 fetch a list. Converting at the fetch means the
+guard lands at a `guard let ... else { throw }` that already exists and already
+carries a message, and the caller's caller never learns about it. There is no
+outward ripple.
+
+Measured against the tree at the time of writing. Fetch sites, which are what
+the change edits:
+
+- 46 of the 57 `get(` sites are local-only and move to `getLocal`
+- 11 stay location-neutral: parent resolver, notes, worktree handlers, adopt,
+  revive-fresh
+- 10 of the 31 `list(` sites live in reconcile alone
+
+Dereferences of a worktree's `path`, which are what the change mostly leaves
+alone — 161 in total:
+
+- 128 in `TBDDaemon`, of which 110 sit in local-only subsystems and change
+  nothing, because those subsystems now receive a `LocalWorktree`
+- 18 daemon lines in location-neutral code, 27 in `TBDApp`, 5 in `TBDCLI`, and 1
+  in `TBDShared` are audited individually
+
+App-side sites convert at view boundaries rather than at a fetch, since SwiftUI
+views hold a worktree as a stored property. `FileViewerPanel`, `PanePlaceholder`,
+and `PinnedTerminalDock` take a `LocalWorktree` from parents that already present
+them conditionally. `RowActionMenuActions` and `StatusBarView` replace the
+`path.isEmpty` checks they already carry with a real conversion.
+
+`@dynamicMemberLookup` forwards reads but not mutation, so a handler that
+mutates a fetched row reaches through `.worktree` explicitly. That residue is
+mechanical.
+
+### What becomes unreachable
+
+Terminal spawn, hibernation, archive-as-directory-removal, scratch, the file
+viewer, the Claude trust seeder, relocate, forget, adopt-existing-directory, and
+reconcile cannot see a remote row — not because someone remembered a guard, but
+because `listLocal` does not return one.
+
+## Creation and the CLI
+
+`tbd worktree create` grows `--provider <name>` and a repeatable
+`--param key=value`. Existing flags keep working and feed the contract's
+well-known parameter names, so the orchestrator case carries no provider-specific
+syntax:
+
+```
+tbd worktree create --provider agentbox --prompt "implement the retry backoff"
+```
+
+`--position` already defaults to `child` and already resolves the parent from
+`TBD_WORKTREE_ID`, so a lane fanning out gets nested children for free.
+
+Flags that mean nothing remotely — `--claude-settings`, `--folder` — are
+**rejected by name** rather than ignored.
+
+One command serves both locations. A separate `tbd remote create` would re-fork
+at the CLI the model this design unifies in the database.
+
+`tbd worktree list` returns remote lanes alongside local ones and reports
+`location` in `--json`, which is what lets an orchestrator poll its own fan-out.
+
+### Creation flow
+
+The daemon resolves parameters, calls `remote.create` with an idempotency key
+(existing machinery, including the retry-once-on-timeout path), and writes a
+`worktree` row bound to `(provider, session.id)` carrying the parent stamp, sort
+order, and display name. If the row write fails after a successful create, the
+next snapshot adopts the session: creation and adoption converge on the same
+row, so neither path can orphan a session.
+
+## Default resolution
+
+Provider defaults exist in the contract as `create_params[].default`, but today
+only the SwiftUI create sheet applies them. A CLI calling `remote.create` would
+get none, and the two surfaces would resolve one command two ways. Resolution
+therefore moves into the `remote.create` handler, where both surfaces reach it.
+
+Most specific wins:
+
+1. **Explicit `--param`, or an edited field in the create sheet.**
+2. **The user's `defaults` map** in `~/tbd/agent-providers.json`.
+3. **TBD ambient derivation**, for the well-known names only: `repo` from the
+   lane's repo, `branch` generated, `prompt`, `title`.
+4. **The provider's `describe` default.**
+
+The registry entry grows one optional key, keeping this a user-authored file
+with no migration and no DB column:
+
+```json
+[{ "name": "agentbox",
+   "exec": "/Users/me/.local/bin/agentbox",
+   "args": ["provider"],
+   "defaults": { "permission_mode": "acceptEdits" } }]
+```
+
+A user default outranks ambient derivation. Writing `"branch": "main"` yields
+`main`, not a generated `tbd/<slug>`, because the user wrote it deliberately.
+One rule covers every field, with no per-name exceptions.
+
+The key structure admits a per-repo layer between 2 and 3 later without a
+migration. This design does not build one.
+
+## Lifecycle
+
+### Archive
+
+Archive stops the provider session, then marks the row `archived`. One action,
+two effects, on one code path whether triggered by hand, by a row action, or by
+`AutoArchiveOnMergeCoordinator` when a PR merges. Stop is idempotent per
+contract, so archiving an already-exited lane flips the row and nothing else.
+
+The contract anticipated TBD-side archival and deliberately declined to add a
+verb for it. Archive composes the two facts the contract already exposes: the
+provider's `stop`, and TBD's own row state.
+
+Archive refuses on an active lane unless forced, paralleling how local archive
+refuses on uncommitted changes. Two guards:
+
+- `agentState == .working` — do not tear down a session mid-task by accident.
+- A dirty remote checkout, reported through an optional well-known `meta` key.
+
+The second guard exists because TBD cannot see a remote working tree. Stopping a
+box session can destroy work that was never pushed, and the `working` guard does
+not help: an idle agent sitting on a dirty tree looks safe to stop. A provider
+that knows its checkout is dirty reports it; TBD then treats the lane like a
+local one with uncommitted changes. Providers that report nothing degrade to a
+warning, so the guard is inert until a provider adopts it. It is additive within
+contract v1, which lets providers add response fields at any time.
+
+`--force` overrides both.
+
+### Revive
+
+An archived remote lane has no session to return to. Revive is unsupported and
+says so. Recreating a session on the same branch and rebinding the row —
+the shape `ReviveFresh` already uses locally — is additive and needs no model
+change, so it can follow if the absence chafes.
+
+### `gone` and `archived` compose
+
+`archived` is a decision the user made. `gone` is TBD reporting that a session
+stopped being listed for two consecutive snapshots. They sit on different axes
+owned by different parties, so a row carries both independently:
+
+- **active, present** — a running lane.
+- **active, gone** — the lane vanished while being watched. This is the state
+  that wants attention, and the reason `gone` exists at all: a session that
+  simply stopped being drawn is indistinguishable from a TBD bug.
+- **archived, present** — archived, but the provider still lists it. Transient,
+  or the stop did not take.
+- **archived, gone** — the ordinary end state.
+
+The seven-day tombstone applies to the **mirror row, not the worktree row**. The
+mirror entry ages out; the lane stays in the Archived list with its branch and
+PR, exactly like an archived local worktree.
+
+A lane that goes `gone` while still `active` stays that way until the user
+archives or dismisses it. Nothing mutates it in the background. Auto-archiving
+after the tombstone window would save one keystroke per rare event and cost a
+background mutation of persisted state, a default-off flag, and a soak.
+
+### Does not apply
+
+Hibernation, relocate, forget, scratch promote, and adopt-existing-directory
+have no remote meaning and are unreachable through `LocalWorktree`. Orphan GC
+needs no change: it keys on filesystem paths and snapshot refs, and a remote row
+has neither.
+
+## Sidebar
+
+`WorktreeRowView` renders remote rows, passing `isRemote: true` — a parameter
+`RowStatusIndicator.leading` already accepts, for a `LeadingRowIndicator.remote`
+case that already exists. `WorktreeSubtreeView` needs no change: it recurses on
+`parentWorktreeID`, so nesting, indentation, the depth cap, drag reorder, and
+`sortOrder` all apply to remote children unmodified.
+
+`RepoSectionView.matchedRemoteSessions`, which appends matched sessions after a
+repo's local worktrees, retires. Remote lanes are ordinary rows in the same
+list, interleaved by `sortOrder`.
+
+### Stating uncertainty
+
+`RemoteSessionPayload.projectedForStaleSnapshot()` demotes a stale row's state to
+`unknown`, so a cached `working` value cannot keep rendering as current activity.
+In the flat Remote section that demotion reads correctly, because every
+neighbouring row is remote. In the tree it does not: a row with no suffix
+indicator already means "idle, nothing happening" to every local sibling beside
+it, and a demoted remote row would render identically while meaning the
+opposite.
+
+A new `SuffixRowIndicator` case therefore renders whenever TBD cannot vouch for
+a row's state — `agentState == .unknown`, or a stale provider snapshot. It sits
+in the attention slot deliberately: an unreachable box is worth noticing.
+
+`gone` keeps its current visual treatment — dimmed with a dismiss action, which
+parallels how archived scratch rows dim — now applied by `WorktreeRowView`.
+
+Provider health renders once at provider level, not per row. Rows say the state
+is unknown; the banner says why. This keeps `RemoteProviderStatus` the single
+source of freshness that the Provider Desk already established.
+
+### Two surfaces, not three
+
+`RemoteSectionView` retires. The Provider Desk keeps provider health, the
+two-axis status strip, and the sessions that resolve to no registered repo.
+
+Selection and attach are unchanged. `RemoteSessionDetailView`,
+`RemoteAttachTerminalView`, `RemoteReconnectPolicy`, and the session action menu
+key on `(provider, sessionID)`, which the worktree row carries.
+
+## Flag and migration
+
+**No new flag.** Everything here stays inert unless `remote_backends_enabled` is
+on and a provider is registered, and local rendering does not change — remote
+rows do not exist to render otherwise. A second flag would gate a flag.
+
+The `LocalWorktree` refactor preserves behavior and carries no flag. Its safety
+comes from the compiler and from reconcile tests, not from a toggle.
+
+**The migration adds columns and backfills nothing.** Existing mirror rows get
+their worktree rows from the adoption path on the next snapshot — code this
+design needs anyway, exercising the same path an externally created session
+takes. Backfilling in the migration would be a second implementation of adoption
+that runs once.
+
+## Testing
+
+All tests run against the existing stub provider fixture, with no network and no
+AWS, under `TBD_HOME` isolation.
+
+Boundary, the tests that would have caught the hazard:
+
+- Reconcile leaves remote rows alone: no archive, no terminal teardown, no
+  `tmuxServer` rewrite.
+- `getLocal`/`listLocal` exclude remote rows; the 11 neutral fetches still
+  return them.
+- An orphan-GC sweep leaves a remote row intact.
+
+Behavior:
+
+- Parameter resolution honors all four layers, including a user default beating
+  ambient derivation.
+- Archive stops then archives; refuses on `working`; refuses on a
+  provider-reported dirty checkout; flips an already-exited lane without error;
+  `--force` overrides both guards.
+- Adoption places an unparented session at top level in its matched repo,
+  creates no row for an unmatched session, and does not re-derive an existing
+  row.
+- `gone` and `archived` compose across all four combinations; the mirror
+  tombstone does not delete the worktree row.
+- Flag off: no remote rows, no provider processes, RPC returns disabled. Flag
+  on: the above.
+
+CLI:
+
+- `--provider` with repeated `--param`; local-only flags rejected by name;
+  `list --json` reports `location`.
+
+## Rejected alternatives
+
+**A parent edge on the mirror row, leaving remote sessions their own model.**
+Cheaper — a column on `remote_session` and a merged child list in the sidebar.
+Rejected because every worktree-keyed feature would need a second remote-aware
+path or would silently not apply, which is the duplication that motivated
+unification.
+
+**Making `path` optional.** The compiler would enumerate all 161 dereferences
+and 158 constructors. Rejected on what the enumeration produces: the honest
+handling at a local-only site is "this should never have been called", so the
+110 daemon lines in local-only subsystems would gain `guard let ... else
+{ return }` and turn a design error into a silent no-op.
+
+**Keeping `path` non-optional and guarding at runtime.** Smallest diff, and the
+codebase already does this for the short-lived `.creating` placeholder, guarded
+ad hoc in three places. Rejected because a permanent state cannot rely on a
+transient state's defenses: the guards nobody wrote stop being races never lost
+and become ordinary bugs. Reconcile is the demonstration.
+
+**Generating CLI flags from `describe`.** Nicer to type than `--param k=v`, but
+help text would vary by which providers are registered, and ArgumentParser wants
+a static command shape.
+
+**A synthetic provider node holding unmatched sessions in the tree.** Rejected
+because it puts repo-less sessions into a tree organized by repo. The Provider
+Desk already holds them.
+
+**Auto-archiving a `gone` lane after the tombstone window.** Rejected for v1:
+a background mutation of persisted state needs a default-off flag and a soak to
+save one keystroke per rare event.
+
+## Deliberate cuts
+
+No per-repo defaults layer, though the key structure admits one. No revive for
+archived remote lanes. No remote file or diff viewing, which needs a `files`
+capability the contract does not have. No change to attach, log, send, or the
+reconnect policy.


### PR DESCRIPTION
## Summary

Groundwork for [remote agent sessions as worktrees in the tree](docs/specs/2026-08-10-remote-sessions-in-worktree-tree-design.md). **Behavior-preserving — no flag, no user-visible change.** It exists so the follow-up PR can add a worktree whose files live on another machine without that row reaching code that assumes a local checkout.

- `Worktree` gains `location: WorktreeLocation` (`.local` / `.remote(provider:sessionID:)`) via migration `v70_worktree_location`.
- New `LocalWorktree` — a `Worktree` proven to have files on this machine, exposing `path`/`tmuxServer` non-optional and forwarding other reads via `@dynamicMemberLookup`.
- Local-only subsystems now fetch through `WorktreeStore.getLocal` / `listLocal`, which simply don't return a remote row.

## The hazard this fences

`WorktreeLifecycle+Reconcile` archives any DB row whose path is absent from git's worktree list — capturing scrollback, killing tmux windows, deleting terminal and tab rows on the way. A remote row's path is never in that list. A second, quieter loop rewrites `tmuxServer` on any row whose value differs from the repo's canonical name, which an empty string always does.

Both reproduce on a single sweep. Against the unmodified tree, the new fence tests fail exactly this way:

```
Expectation failed: (after.status → .archived) == .active
  reconcile archived a remote row
Expectation failed: (after.archivedAt → 2026-08-11 05:03:29 +0000) == nil
Expectation failed: (after.tmuxServer → "tbd-df8d4499") == ""
  reconcile canonicalized a remote row's tmux server
```

Nobody would have thought to hand-write a guard in reconcile. That is the argument for a compiler-enforced boundary rather than runtime checks — and the reason this is a separate PR.

## Why a wrapper rather than an optional path

Three options were weighed; rationale is in the spec's "Rejected alternatives".

Making `path` optional would have the compiler enumerate all 161 dereferences — but the honest handling at a local-only site is "this should never have been called", so ~110 sites would gain `guard let … else { return }` and turn a design error into a **silent no-op**.

Keeping `path` non-optional and guarding at runtime is what the codebase already does for the transient `.creating` placeholder (`path: ""`, guarded ad hoc in three views). That works only because the state lasts milliseconds. Made permanent, every guard nobody wrote becomes an ordinary bug.

The wrapper converts at the **fetch**, where a `guard let … else { throw }` already exists — so the caller's caller never learns about it and no ripple escapes.

## Shape of the change

- `Worktree.path` → `localPath`. The `init` label stays `path:`, the `CodingKeys` case stays `path`, and the DB column is unchanged — so all 158 construction sites and the wire format are untouched, and only *readers* break. That break is the audit.
- 45 `getLocal` + 18 `listLocal` conversions across 16 daemon files, one commit each.
- 110 of 128 daemon `path` dereferences change nothing — those subsystems now receive a `LocalWorktree`.
- App-side conversion happens at view boundaries, since SwiftUI views hold a worktree as a stored property rather than fetching one.

25 fetch sites stay location-neutral (12 of the 57 `get(`, 13 of the 31 `list(`); four of them say so in a comment. `WorktreeLifecycle+Create`'s `reserved` set and reconcile's `creatingPaths` both mirror the **global UNIQUE constraint on `worktree.path`**, where withholding a row would let a second row claim a taken path and abort the insert. Phase 3's mid-wait row check asks whether the row vanished, which is not a locality question. And the `.creating` recovery sweep is the only thing that resolves such a row, so it must see remote ones in order to give them an outcome.

## Review follow-ups

Five findings from review, one commit each on top of the original series.

- **A remote row's path is synthetic, not empty.** `worktree.path` is `NOT NULL UNIQUE`, so the empty-string convention admitted exactly one remote row per install — the second lane of a fan-out died on `UNIQUE constraint failed: worktree.path`. `WorktreeLocation.storagePath` now derives `remote://<provider>/<sessionID>` with each component percent-encoded, applied inside `WorktreeStore.create` so a call site cannot forget it. `twoRemoteRowsCoexistInOneRepo` fails against the previous code with that exact error.
- **Pre-session's mid-wait check went back to the neutral `get(id:)`.** `getLocal` answers nil for "exists but is remote", indistinguishable from deleted — and the branch it guards kills the pre-session tmux window.
- **A remote `.creating` row now reaches `.failed`.** The recovery sweep was fenced to local rows and reconcile is fenced too, so a daemon restart mid-create left a lane spinning forever. It is marked `.failed` rather than deleted, so "the create never ran" stays distinguishable from "the row vanished".
- **Three local-only subsystems the rename missed**, because they read `wt.localPath` off a bare `Worktree`: `appearance.updateColorFgBg`, `repo.relocate`, and PR polling (`pollableWorktrees` plus `pr.refresh`). PR polling is the one a remote lane wants back; re-enabling it means keying on the branch rather than the path, which the spec now records.
- **Counts in this description and the spec were recounted** from the tree and corrected.

## Reviewer notes

- **`refreshGitStatuses` unwraps to bare rows** (`.map(\.worktree)`) because it mutates array elements in place, which `@dynamicMemberLookup` cannot express. The fetch is still `listLocal`.
- **A third behavior change in reconcile** beyond the two the tests pin: `repoRows`/`scratchRows`/`globalLiveRows` moving to `listLocal` means a remote row can no longer contribute to `referencedServers` or count as a live reference keeping a tmux server alive. Correct, but unpinned by test.
- **`PanePlaceholder` taking a `LocalWorktree` rippled into `SplitLayoutView` and `TerminalContainerView`**, which the plan did not anticipate. Argued behavior-preserving: the only empty-path row today is the optimistic `.creating` placeholder, which has no terminals and no tabs, so it already took the else-branch the nil arm now routes it to.

## Test plan

- [x] `scripts/test.sh` — 5415 tests in 578 suites pass (one by-design known issue, `FlakyQuarantineSelfTests.retriesUntilPass()`)
- [x] New `ReconcileRemoteRowFenceTests` verified to **fail** against the unfenced tree and pass after — a guard test that cannot fail is not a guard test
- [x] Orphan-GC sweep characterized as leaving a remote row intact, with `setGCEnabled(true)` pinned so the assertion isn't vacuous
- [x] `getLocal`/`listLocal` exclude remote rows; location-neutral fetches still return them
- [x] Wire format pinned: a characterization test asserts the JSON key is still `path` and no `localPath` key appears, run before and after the rename
- [x] `scripts/swift-safe build` clean; `swiftlint --strict` 0 violations in 685 files
- [ ] **Visual check outstanding** — `scripts/restart.sh` confirms the daemon, terminal panes, and RPC all run from this worktree, but the UI itself was not eyeballed (screen capture is TCC-denied in the agent's shell). Sidebar rows, the file panel, the status-bar path, and the row context menu's Reveal-in-Finder / Copy-Path are the surfaces this touches and want a human glance before merge.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=D8182E8D-C247-4010-B7B5-DB34F91BAEF6)


## Deliberately deferred to PR 2

`RPCRouter+WorktreeHandlers.swift:184-191` — `handleWorktreeList`'s archived-enrichment loop gates on `status == .archived` but not on locality, so a remote row's synthetic path would flow into `ClaudeProjectDirectory.resolve`, miss both tiers, and trigger the recursive `~/.claude/projects/*` scan the comment above it warns about.

Left unfenced on purpose: the **outcome** is already correct (`liveClaudeSessionCount = 0`), an empty path would have scanned just as wastefully, and it is unreachable until remote-row creation ships. This is a performance fence for PR 2, not a correctness bug in this one. Two lines plus a test whenever it becomes reachable.
