### PR TITLE
Fix: Root-cause the flake cluster that made "rerun once" standard advice

### DIFF
--- a/Tests/TBDAppTests/MarkdownStylesheetTests.swift
+++ b/Tests/TBDAppTests/MarkdownStylesheetTests.swift
@@ -1,9 +1,13 @@
+import Clocks
 import Foundation
 import Testing
 @testable import TBDApp
+import TestSupport
 
 /// Tier 1, except for `themesDirectoryWatchSeesAStylesheetCreatedLater`, which
-/// is tier 2 (real filesystem, real dispatch source, bounded polling).
+/// is tier 2: a real filesystem and a real dispatch source deliver the *event*,
+/// while the debounce *timer* is virtual — the same split `FileWatcherTests`
+/// documents.
 ///
 /// Every test supplies its own tmp themes directory and its own
 /// `UserDefaults(suiteName:)`. Neither `~/tbd` nor `UserDefaults.standard` is
@@ -285,9 +289,27 @@ struct MarkdownStylesheetTests {
     /// That is the only way the viewer can notice a stylesheet that did not
     /// exist when it opened — there is no inode for a file watcher to open.
     ///
-    /// Tier 2 by construction (real dispatch source), so it uses the production
-    /// clock and bounded polling rather than a `TestClock`.
-    @Test("a watch on the themes directory sees a stylesheet created later")
+    /// Tier 2, split the way `FileWatcherTests` splits: a real dispatch source
+    /// delivers the *event*, while the debounce *timer* is virtual — production
+    /// takes `clock: any Clock<Duration>`, so the 150 ms window is crossed by
+    /// advancing a `TestClock` instead of being waited out on a loaded runner.
+    /// Waiting out a real debounce plus `AsyncStream` delivery under one 8 s
+    /// bound is exactly what starved here when the process carried >5000 tests.
+    ///
+    /// The bounded polls that remain wait only on legs that are genuinely
+    /// real-time — the dispatch source delivering an event and production
+    /// reaching `clock.sleep` (observed through `armed`), and the consuming
+    /// `Task` receiving an `AsyncStream` element — never on the debounce
+    /// interval itself. Each is a hang guard whose healthy path exits on its
+    /// first probe, and each timeout travels as a thrown `Failure` carrying the
+    /// observed counts (Tests/CLAUDE.md rule 4).
+    ///
+    /// One-sidedness worth naming: this watches a *directory*, so the events
+    /// are not attributable to a particular entry. A straggler probe event
+    /// could in principle supply the phase-2 arm or notification. The final
+    /// `resolve()` assertion is what pins the actual content — a watcher that
+    /// never saw `later.css` cannot make it read `body{color:teal}`.
+    @Test("a watch on the themes directory sees a stylesheet created later", .clockDriven)
     func themesDirectoryWatchSeesAStylesheetCreatedLater() async throws {
         let dir = try tempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
@@ -300,45 +322,73 @@ struct MarkdownStylesheetTests {
             ) == bundledMarker)
         }
 
+        let clock = TestClock<Swift.Duration>()
+        let armed = Counter()
         let notified = Counter()
-        let watcher = FileWatcher()
+        let watcher = FileWatcher(clock: RecordingClock(base: clock, armed: armed))
         let stream = watcher.changes(for: dir.path)
         let consumer = Task { for await _ in stream { notified.record() } }
         defer { consumer.cancel() }
 
-        // Same dispatch-source registration race `FileWatcherTests` documents:
-        // `resume()` is asynchronous, so the first create can land before the
-        // source is listening. Retry, waiting out three full debounce windows
-        // per attempt.
-        let url = dir.appendingPathComponent("later.css")
-        for attempt in 0..<4 {
+        // Phase 1 — prove the source is registered and delivering.
+        //
+        // Same dispatch-source registration race `FileWatcherTests.writeUntilArmed`
+        // documents: `resume()` registers its kqueue filter asynchronously, so a
+        // create issued right after `changes(for:)` returns can be lost forever.
+        // Retrying is legitimate ONLY for that first-write race; every wait after
+        // this one treats a missing event as event loss, not as something to
+        // retry.
+        let attempts = 4
+        let attemptWindow: Duration = .seconds(2)
+        var registered = false
+        for attempt in 0..<attempts {
             try "body{color:teal}".write(
                 to: dir.appendingPathComponent("probe-\(attempt).css"),
                 atomically: true, encoding: .utf8
             )
-            let deadline = ContinuousClock.now.advanced(by: FileWatcher.debounceInterval * 3)
-            while notified.count == 0, ContinuousClock.now < deadline {
-                try? await Task.sleep(for: .milliseconds(10))
+            if await Self.waitUntil(attemptWindow, { armed.count > 0 }) {
+                registered = true
+                break
             }
-            if notified.count > 0 { break }
         }
-        guard notified.count > 0 else {
+        guard registered else {
             throw Failure("""
-                a FileWatcher on a directory never reported an entry being created — \
-                observed \(notified.count) notifications after \
-                4 attempts of \(FileWatcher.debounceInterval * 3) each
+                a FileWatcher on a directory armed no debounce timer for an entry being \
+                created — observed armed=\(armed.count) after \(attempts) attempts of \
+                \(attemptWindow) each
                 """)
         }
 
-        // The event the viewer actually cares about: the selected stylesheet
-        // appearing. After it, resolution must stop returning the bundled sheet.
-        let before = notified.count
-        try "body{color:teal}".write(to: url, atomically: true, encoding: .utf8)
-        let deadline = ContinuousClock.now.advanced(by: .seconds(8))
-        while notified.count == before, ContinuousClock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(10))
+        // The timer is virtual, so crossing the window costs no wall time. The
+        // poll after it is the real leg: `AsyncStream` delivery into the
+        // consuming `Task`, on the same 8 s budget `FileWatcherTests.poll` uses.
+        await clock.advanceWhenSuspended(by: FileWatcher.debounceInterval)
+        guard await Self.waitUntil(.seconds(8), { notified.count > 0 }) else {
+            throw Failure("""
+                the debounce window elapsed but no notification reached the consumer — \
+                observed \(notified.count) after polling up to 8 seconds
+                """)
         }
-        guard notified.count > before else {
+
+        // Phase 2 — the event the viewer actually cares about: the selected
+        // stylesheet appearing. After it, resolution must stop returning the
+        // bundled sheet.
+        let before = notified.count
+        let armedBefore = armed.count
+        let url = dir.appendingPathComponent("later.css")
+        try "body{color:teal}".write(to: url, atomically: true, encoding: .utf8)
+        // No retry here: the source has already delivered once, so a missing arm
+        // is event loss. This waits only for kernel event -> GCD handler ->
+        // production reaching `clock.sleep`, the leg `writeUntilArmed`'s 8 s
+        // budget covers.
+        guard await Self.waitUntil(.seconds(8), { armed.count > armedBefore }) else {
+            throw Failure("""
+                creating the selected stylesheet armed no new debounce timer — observed \
+                armed=\(armed.count) (baseline \(armedBefore)) after polling up to 8 seconds
+                """)
+        }
+        await clock.advanceWhenSuspended(by: FileWatcher.debounceInterval)
+        guard await Self.waitUntil(.seconds(8), { notified.count > before }) else {
             throw Failure("""
                 creating the selected stylesheet produced no directory notification — \
                 observed \(notified.count) (baseline \(before)) after polling up to 8 seconds
@@ -355,6 +405,25 @@ struct MarkdownStylesheetTests {
         consumer.cancel()
         _ = await consumer.value
     }
+
+    /// Bounded poll on a fact produced by **real** scheduling — a dispatch
+    /// source delivering an event, or `AsyncStream` handing an element to its
+    /// consumer.
+    ///
+    /// `timeout` is a hang guard, never a tolerance window: the healthy path
+    /// returns on the first probe. It returns a `Bool` rather than recording an
+    /// issue itself so each call site can throw a `Failure` naming what it
+    /// observed (Tests/CLAUDE.md rule 4) — only a thrown error lands on the
+    /// primary failure line that CI summaries quote.
+    private static func waitUntil(_ timeout: Duration,
+                                  pollInterval: Duration = .milliseconds(25),
+                                  _ condition: () -> Bool) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: pollInterval)
+        }
+        return condition()
+    }
 }
 
 // MARK: - Local helpers
@@ -364,6 +433,30 @@ struct MarkdownStylesheetTests {
 private struct Failure: Error, CustomStringConvertible {
     let description: String
     init(_ description: String) { self.description = description }
+}
+
+/// A `Clock` that delegates to a `TestClock` and counts every armed sleep.
+///
+/// Mirrors `FileWatcherTests.RecordingClock`, for the same reason: arming is
+/// the only *positive, pollable* fact that the FS event was delivered and
+/// production reached its timer. `TestClock.checkSuspension()` can answer only
+/// "is anything suspended", so it cannot distinguish a superseded debounce
+/// still being torn down from the fresh one a later write just armed.
+///
+/// Delegating rather than reimplementing keeps virtual time exactly
+/// `TestClock`'s, so `advanceWhenSuspended` on the base clock behaves normally.
+private struct RecordingClock: Clock {
+    let base: TestClock<Swift.Duration>
+    let armed: Counter
+
+    var now: TestClock<Swift.Duration>.Instant { base.now }
+    var minimumResolution: Swift.Duration { base.minimumResolution }
+
+    func sleep(until deadline: TestClock<Swift.Duration>.Instant,
+               tolerance: Swift.Duration?) async throws {
+        armed.record()
+        try await base.sleep(until: deadline, tolerance: tolerance)
+    }
 }
 
 private final class Counter: @unchecked Sendable {

--- a/Tests/TBDAppTests/ThemeStoreTests.swift
+++ b/Tests/TBDAppTests/ThemeStoreTests.swift
@@ -180,6 +180,7 @@ struct ThemeStoreTests {
 
         let store = ThemeStore(themesDirectory: themesDir)
         store.startWatching()
+        defer { store.stopWatching() }
         store.reloadFromDisk()
         #expect(store.userThemes.isEmpty)
 
@@ -192,25 +193,47 @@ struct ThemeStoreTests {
         try JSONEncoder().encode(theme)
             .write(to: themesDir.appendingPathComponent("ext.json"))
 
-        // Generous positive-wait deadline that only elapses on failure. Both
-        // this polling loop and the FSEvents callback's `Task { @MainActor in
-        // ... }` bounce must acquire a turn on the single serial MainActor
-        // executor (bound to the process's one main thread); under a
-        // full-suite `swift test --parallel -j 2` run, hundreds of other
-        // @MainActor suites queue for that same executor and can stretch
-        // delivery well past a 5s window (reproduced locally: reload landed
-        // at ~12s wall-clock). Same root cause as the cooperative-pool
-        // starvation documented for `ciSafeDeadline` in
+        // Hang guard, not a tolerance window. This is a positive wait: it breaks
+        // on the first satisfying probe (~0.1s on the healthy path), so only a
+        // genuinely failing run ever pays the deadline.
+        //
+        // Why it has to be generous at all: both this polling loop and the
+        // FSEvents callback's `Task { @MainActor in ... }` bounce must acquire a
+        // turn on the single serial MainActor executor (bound to the process's
+        // one main thread), and every @MainActor suite in the process queues for
+        // that same executor. Same root cause as the cooperative-pool starvation
+        // documented for `ciSafeDeadline` in
         // Tests/TBDDaemonTests/ControlModeTestSupport.swift (PR #379).
-        // Passing runs still complete in ~0.1s.
-        let deadline = Date().addingTimeInterval(30)
+        //
+        // 90s is anchored to that same population-derived figure rather than
+        // tuned here. The predecessor 30s was sized (PR #441) against a
+        // ~3000-test process where the reproduced delay was ~12s; the population
+        // is now 5417, and this test failed at 30s on a loaded multi-agent dev
+        // box during a full in-process run. Re-derive if the population moves
+        // materially again — see Tests/CLAUDE.md, "Population is the scheduler".
+        let timeout: TimeInterval = 90
+        let deadline = Date().addingTimeInterval(timeout)
         while store.userThemes.isEmpty && Date() < deadline {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
+        guard !store.userThemes.isEmpty else {
+            // Thrown, not `#expect(..., "message")`: only `Issue.record(_: some
+            // Error)` puts the diagnostic on the primary failure line CI
+            // summaries quote (Tests/CLAUDE.md rule 4). The three observations
+            // discriminate the failure modes: `loadErrors` separates "reload ran
+            // but decode failed" from "reload never ran", and the directory
+            // listing separates "the file never landed" (a test bug) from "the
+            // watcher never fired".
+            throw Failure("""
+                the themes-directory watcher never reloaded after an external add — \
+                after \(timeout)s, userThemes=\(store.userThemes.map(\.id)), \
+                loadErrors=\(store.loadErrors), \
+                directory contents=\(String(describing: try? FileManager.default
+                    .contentsOfDirectory(atPath: themesDir.path)))
+                """)
+        }
         #expect(store.userThemes.count == 1)
         #expect(store.userThemes.first?.id == "ext")
-
-        store.stopWatching()
     }
 
     @Test("saveAs rejects display names that slugify to empty")
@@ -301,4 +324,13 @@ struct ThemeStoreTests {
         #expect(appearance.schemeID == ColorSchemes.defaultScheme.id)
         #expect(appearance.draftSchemeOverride == nil)
     }
+}
+
+// MARK: - Local helpers
+
+/// Timeout diagnostics travel as a thrown `Error` so they land on the primary
+/// failure line and survive into the CI summary (Tests/CLAUDE.md, rule 4).
+private struct Failure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
 }

--- a/Tests/TBDDaemonLiveTests/ProviderEventsSupervisorTests.swift
+++ b/Tests/TBDDaemonLiveTests/ProviderEventsSupervisorTests.swift
@@ -7,14 +7,62 @@ import Foundation
 // polling against explicit deadlines per Tests/CLAUDE.md — no bare
 // Task.sleep as a synchronization primitive, and timeout failures report
 // the observed state, not just what was expected.
-@Suite("ProviderEventsSupervisor (live)")
+//
+// The deadlines below (`saturatedWaitDeadline`, `reapDeadline`) are hang
+// guards sized against the *process population*, not against how long the
+// supervisor ought to take: in CI this target runs in the quiet serial pass
+// where healthy waits are milliseconds, but a full local `scripts/test.sh`
+// puts all 5417 tests in one process, and per-test scheduling latency scales
+// with that total (Tests/CLAUDE.md, "Population is the scheduler"). See each
+// constant for its derivation.
+//
+// The suite time limit is a hang catcher, pinned per the tier-3 convention
+// (Tests/CLAUDE.md: tier-3 suites pin their own limit rather than inheriting
+// `.clockDriven`, whose value is sized for the fast parallel pass). It is NOT
+// a regression detector here — unlike `SubprocessTimeoutTests`, nothing in
+// this suite proves anything by outliving it. Its job is to stop a regressed
+// `stop()` that never returns from wedging a whole local run, since nothing
+// else bounds that. Sized so the first named diagnostic (a 90s bounded wait's
+// thrown failure) always lands well inside it, and above the worst-case
+// failing chain (~90x3 + 30 + stop ~= 310s).
+@Suite("ProviderEventsSupervisor (live)", .timeLimit(.minutes(6)))
 struct ProviderEventsSupervisorTests {
+    /// Hang guard for the bounded waits on supervisor progress (spawn, snapshot
+    /// application, respawn, resync).
+    ///
+    /// Positive waits, all of them: each breaks on its first satisfying probe,
+    /// so raising the guard costs a passing run nothing and only a genuinely
+    /// failing one pays it. 15s was the previous value and produced reds on a
+    /// loaded multi-agent dev box that went green on a targeted rerun — the
+    /// signature of scheduling latency, not of a supervisor defect (mined p50
+    /// per-test duration is ~1/3 of total wall time). 90s matches the
+    /// `ciSafeDeadline` re-derivation for this same contention class; that
+    /// constant lives in `Tests/TBDDaemonTests` and is not importable from this
+    /// target, hence the local literal rather than a shared symbol.
+    private static let saturatedWaitDeadline: TimeInterval = 90
+
+    /// Hang guard for the "no leaked children" waits, which are cheaper than
+    /// the ones above but not free: SIGKILL delivery is kernel-immediate, yet
+    /// `kill(pid, 0)` keeps succeeding on a **zombie** until Foundation's
+    /// termination machinery (or launchd, for an orphan) reaps it — and that
+    /// reaping needs queue turns, which starve under the same contention.
+    private static let reapDeadline: TimeInterval = 30
+
     /// Stub emits hello+snapshot then hangs; killing its process tree must
     /// trigger a restart whose snapshot is REAPPLIED (resync-by-reconnect —
     /// the contract has no cursors, so a fresh connection is the whole
     /// recovery story). Each invocation announces a run-specific session id,
-    /// so the post-restart assertion can only pass if run 2's snapshot
-    /// actually reached the mirror.
+    /// so the post-restart assertion can only pass if a snapshot from a
+    /// connection established *after* the kill reached the mirror.
+    ///
+    /// The stub goes silent after its snapshot and `silenceLimit` is 5, so the
+    /// supervisor's own watchdog legitimately kills and respawns it every few
+    /// seconds of test time. Respawns are therefore expected background
+    /// behaviour, especially on a starved run, and the assertions below are
+    /// written against the contract ("a dead or silent events process is
+    /// replaced, and the replacement resyncs by reconnecting") rather than
+    /// against particular run indices, which are a transient a starved observer
+    /// can miss entirely.
     @Test func snapshotAppliedAndRestartResyncs() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("events-supervisor-\(UUID().uuidString)")
@@ -71,7 +119,7 @@ struct ProviderEventsSupervisorTests {
         let pid = Int32((try? String(contentsOf: pidFile, encoding: .utf8))?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? "") ?? 0
         var alive = true
-        let leakDeadline = Date().addingTimeInterval(5)
+        let leakDeadline = Date().addingTimeInterval(Self.reapDeadline)
         while Date() < leakDeadline {
             alive = pid > 0 && kill(-pid, 0) == 0
             if !alive { break }
@@ -116,7 +164,7 @@ struct ProviderEventsSupervisorTests {
 
         // Bounded wait for the child to exist before stopping it.
         var pid: Int32 = 0
-        let spawnDeadline = Date().addingTimeInterval(15)
+        let spawnDeadline = Date().addingTimeInterval(Self.saturatedWaitDeadline)
         while Date() < spawnDeadline {
             pid = Int32((try? String(contentsOf: pidFile, encoding: .utf8))?
                 .trimmingCharacters(in: .whitespacesAndNewlines) ?? "") ?? 0
@@ -128,9 +176,16 @@ struct ProviderEventsSupervisorTests {
         let started = Date()
         await supervisor.stop()
         let elapsed = Date().timeIntervalSince(started)
-        #expect(elapsed < 10, "stop() took \(elapsed)s — it must not wait on a TERM-immune child")
+        // The bound discriminates "stop() returned promptly after one ~0.5s kill
+        // grace" from "stop() waited on the TERM-immune child" — and that second
+        // case is UNBOUNDED, because the child ignores TERM forever. So the
+        // number only has to sit far above the worst-case scheduling latency of
+        // stop()'s several actor/task hops under saturation, and far below
+        // "never". 10s failed the first half: it is inside observed per-test
+        // scheduling noise (p90 ~= 26s for trivial tests at population 4536).
+        #expect(elapsed < 60, "stop() took \(elapsed)s — it must not wait on a TERM-immune child")
         var alive = true
-        let leakDeadline = Date().addingTimeInterval(5)
+        let leakDeadline = Date().addingTimeInterval(Self.reapDeadline)
         while Date() < leakDeadline {
             alive = pid > 0 && kill(-pid, 0) == 0
             if !alive { break }
@@ -140,46 +195,122 @@ struct ProviderEventsSupervisorTests {
         try? FileManager.default.removeItem(at: dir)
     }
 
+    /// Three bounded waits, written against the contract rather than against a
+    /// particular run index.
+    ///
+    /// Why that distinction matters: the stub goes silent after its snapshot
+    /// and `silenceLimit` is 5, so the supervisor's watchdog kills and respawns
+    /// it every few seconds *on its own*. Each respawn bumps the counter file
+    /// and replaces the mirror rows with `{live-a, run-N}` for the new N, so
+    /// `{live-a, run-1}` is a **transient** state — an observer starved past it
+    /// would never see it again while N marched upward, and demanding that
+    /// exact set turned a slow run into a red one reporting
+    /// `rows=["live-a", "run-2"]`. Each wait below therefore asserts the
+    /// property it cares about: that *a* snapshot was applied, that the process
+    /// was replaced, and that a snapshot from a connection established after
+    /// the kill reached the mirror.
     private func runAssertions(db: TBDDatabase, countFile: URL, pidFile: URL) async throws {
-        // Bounded wait (15s deadline, tier-3 discipline): run 1's snapshot lands.
+        // Wait 1: a snapshot has been applied — `live-a` plus whichever `run-N`
+        // is current. Records the highest N seen, which is the baseline the
+        // resync wait below is measured against.
         var rows: [RemoteSessionRow] = []
-        let deadline = Date().addingTimeInterval(15)
+        var maxRunAtKill: Int?
+        let deadline = Date().addingTimeInterval(Self.saturatedWaitDeadline)
         while Date() < deadline {
             rows = (try? await db.remoteSessions.list()) ?? []
-            if Set(rows.map(\.sessionID)) == ["live-a", "run-1"] { break }
+            let ids = rows.map(\.sessionID)
+            if ids.contains("live-a"), let highest = Self.highestRunIndex(ids) {
+                maxRunAtKill = highest
+                break
+            }
             try await Task.sleep(for: .milliseconds(100))
         }
-        #expect(Set(rows.map(\.sessionID)) == ["live-a", "run-1"],
-                "run 1's snapshot not applied within 15s; observed rows=\(rows.map(\.sessionID))")
+        guard let maxRunAtKill else {
+            throw Failure("""
+                no snapshot was applied within \(Self.saturatedWaitDeadline)s — the mirror needs \
+                "live-a" and some "run-<n>"; observed rows=\(rows.map(\.sessionID))
+                """)
+        }
+
+        // Read the invocation count immediately before the kill, so the respawn
+        // wait below is relative to what had already happened rather than to a
+        // fixed `>= 2`.
+        let countAtKill = Self.invocationCount(countFile)
 
         // Kill the whole stub process group (SIGKILL can't be trapped, so the
-        // backgrounded sleep has to be taken out with it) and require a
-        // respawn: only a real second exec can bump the counter file.
+        // backgrounded sleep has to be taken out with it).
+        //
+        // The pid may already be stale — the watchdog may have cycled the
+        // process first, in which case this no-ops on ESRCH and the watchdog's
+        // own respawn satisfies the waits below. That is fine: the contract
+        // under test is "the supervisor replaces a dead or silent events process
+        // and resyncs by reconnecting", not "our kill specifically caused it".
         let pid = try #require(Int32(
             String(contentsOf: pidFile, encoding: .utf8)
                 .trimmingCharacters(in: .whitespacesAndNewlines)))
         kill(-pid, SIGKILL)
-        var count = 0
-        let restartDeadline = Date().addingTimeInterval(15)
+
+        // Wait 2: a replacement process really ran. Only a fresh exec bumps the
+        // counter file.
+        var count = countAtKill
+        let restartDeadline = Date().addingTimeInterval(Self.saturatedWaitDeadline)
         while Date() < restartDeadline {
-            count = Int((try? String(contentsOf: countFile, encoding: .utf8))?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? "0") ?? 0
-            if count >= 2 { break }
+            count = Self.invocationCount(countFile)
+            if count > countAtKill { break }
             try await Task.sleep(for: .milliseconds(200))
         }
-        #expect(count >= 2,
-                "supervisor did not restart the events process within 15s; observed invocation count=\(count)")
+        guard count > countAtKill else {
+            throw Failure("""
+                supervisor did not restart the events process within \
+                \(Self.saturatedWaitDeadline)s; observed invocation count=\(count), \
+                was \(countAtKill) at the kill
+                """)
+        }
 
-        // Reconnect-and-resnapshot IS the resync mechanism, so run 2's
-        // snapshot must reach the mirror. `run-2` exists nowhere else — if the
-        // second connection's hello+snapshot were dropped, this fails.
-        let resyncDeadline = Date().addingTimeInterval(15)
+        // Wait 3: reconnect-and-resnapshot IS the resync mechanism, so a
+        // snapshot from a connection established AFTER the kill must reach the
+        // mirror. `run-M` for M > maxRunAtKill exists nowhere else — no earlier
+        // connection could have produced it — which preserves the original
+        // test's "only a real second connection can pass this" property without
+        // pinning a specific index.
+        var highest: Int?
+        let resyncDeadline = Date().addingTimeInterval(Self.saturatedWaitDeadline)
         while Date() < resyncDeadline {
             rows = (try? await db.remoteSessions.list()) ?? []
-            if rows.contains(where: { $0.sessionID == "run-2" }) { break }
+            highest = Self.highestRunIndex(rows.map(\.sessionID))
+            if let highest, highest > maxRunAtKill { break }
             try await Task.sleep(for: .milliseconds(100))
         }
-        #expect(rows.contains { $0.sessionID == "run-2" },
-                "reconnect snapshot did not resync the mirror; observed rows=\(rows.map(\.sessionID))")
+        guard let highest, highest > maxRunAtKill else {
+            throw Failure("""
+                reconnect snapshot did not resync the mirror within \
+                \(Self.saturatedWaitDeadline)s — no run index above \(maxRunAtKill) reached it; \
+                observed rows=\(rows.map(\.sessionID))
+                """)
+        }
     }
+
+    /// Highest `n` across ids shaped `run-<n>`, or `nil` if the mirror carries
+    /// none. The stub announces one per invocation, so this is "which
+    /// connection's snapshot is currently applied".
+    private static func highestRunIndex(_ ids: some Sequence<String>) -> Int? {
+        ids.compactMap { id -> Int? in
+            guard id.hasPrefix("run-") else { return nil }
+            return Int(id.dropFirst("run-".count))
+        }.max()
+    }
+
+    /// The stub's invocation counter, or 0 if the file is missing or unparsable
+    /// (which is indistinguishable from "not yet written" and treated the same).
+    private static func invocationCount(_ countFile: URL) -> Int {
+        Int((try? String(contentsOf: countFile, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? "0") ?? 0
+    }
+}
+
+/// Timeout diagnostics travel as a thrown `Error` so they land on the primary
+/// failure line and survive into the CI summary (Tests/CLAUDE.md, rule 4).
+private struct Failure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
 }


### PR DESCRIPTION
## What's broken

A recurring cluster of tests fails under machine load and passes on targeted rerun: both `ProviderEventsSupervisorTests`, the `MarkdownStylesheetTests` directory-watch test, the `ThemeStoreTests` watcher-reload test, and (analyzed but not changed here, see below) the `AppearanceDebounceTests`/`SearchQueryDebouncerTests` burst tests. Across four full runs on a loaded dev machine, every run had at least one of these red; each went green on rerun. The standing advice calcified into "rerun once", which taxes every branch and trains people to wave past red suites.

## Why it happens

Swift Testing runs every non-serialized test in one process with no concurrency cap, so per-test scheduling latency scales with the total population (now 5417 tests) plus external machine load — mined runs put p50 per-test reported duration at ~1/3 of total wall time (`Tests/CLAUDE.md`, "Population is the scheduler"). Each flaking test waited on that real scheduling behind a wall-clock bound sized for a smaller population or a quieter environment. Per-test root causes, each traced through the production pipeline (none is a race in the code under test):

- **`ProviderEventsSupervisorTests` (tier 3)** — 15s bounded-poll deadlines were sized for CI's quiet serial pass; a loaded parallel local run starves the supervision task past them (observed: pid file never read in 15s; mirror rows still empty at 15s). On top of that, one assertion had a genuine logic race: `snapshotAppliedAndRestartResyncs` demanded the *exact transient* set `{live-a, run-1}`, but the stub goes silent after its snapshot and `silenceLimit` is 5, so the supervisor's own watchdog legitimately kills and respawns it every few seconds, replacing `run-1` with `run-2` — an observer starved past the first cycle could never match, at any deadline.
- **`MarkdownStylesheetTests` watch test (tier 2)** — waited out a real 150ms `FileWatcher` debounce plus `AsyncStream` delivery under one 8s bound. `FileWatcher` already takes an injected clock, and the sibling `FileWatcherTests` already proves the real-dispatch-source + `TestClock` pattern; this test predated it.
- **`ThemeStoreTests` watcher test (tier 2)** — FSEvents cannot be virtualized (the 0.1s is a stream latency parameter, not a sleep; events are journaled by fseventsd, so none can be lost) and bounded polling is the sanctioned shape; the 30s bound predated the population re-derivation that took the shared guards to 45s/90s. Its wait rides the single MainActor executor that every `@MainActor` suite queues on.

## When it broke

Not one regression commit: each bound was correct for the population it was derived against (the ThemeStore 30s in #441 against ~3000 tests; the supervisor 15s with #514 assuming the quiet tier-3 pass). Population growth to 5417 plus multi-agent load on the dev box moved the environment out from under them. The `run-1` transient-set race has been latent since #514 — it needs a >5s observation delay to bite, so only load exposed it.

## What this PR does

- **`MarkdownStylesheetTests`**: rewrites the watch test onto the `FileWatcherTests` idiom — real dispatch source delivers the *event*, the debounce *timer* is virtual (`FileWatcher(clock: TestClock)` via an arm-counting delegating clock). No wall bound covers the debounce any more; the remaining bounded polls guard only genuinely real-time legs (kqueue registration/arming, `AsyncStream` delivery) and throw named diagnostics.
- **`ProviderEventsSupervisorTests`**: rewrites `runAssertions` against the contract instead of run indices — *a* snapshot applied (`live-a` + any `run-N`), invocation count strictly above its value at the kill, then some `run-M` with `M > maxRunAtKill` (a snapshot only a post-kill connection can produce). Re-derives deadlines with the reasoning inline: bounded-poll guards 15→90s (anchoring to the `ciSafeDeadline` figure for the same contention class), zombie-reap guards 5→30s, the `stop()` promptness bound 10→60s, and pins a 6-minute suite hang limit so a regressed `stop()` cannot wedge a whole local run.
- **`ThemeStoreTests`**: re-derives the reload hang guard 30→90s (same anchor), and upgrades the timeout to a thrown diagnostic reporting `userThemes`, `loadErrors`, and the actual directory listing — discriminating "watcher never fired" from "reload ran but decode failed" from "file never landed".

On the raised numbers, explicitly rather than quietly: every one is a **positive wait** that breaks on its first satisfying probe — healthy runs pay ~0.1s, only a genuinely failing run pays the deadline — and each carries its derivation in a comment so the next re-derivation has an anchor. This is the repo's established hang-guard doctrine (`Tests/CLAUDE.md`), not tolerance-window inflation; the transient-state fix above is the part no deadline could have fixed.

**Deliberately not changed:** the `AppearanceDebounceTests`/`SearchQueryDebouncerTests` burst tests. They are already fully virtual-time and `.serialized`; their failure is the arming handshake starving inside shared machinery (`TestClock.checkSuspension`'s background-QoS megaYield under process-global saturation), and every suite-local remedy is already measured-and-refuted in `Tests/CLAUDE.md`. The real fix is the megaYield-free virtual clock that `ClockTestSupport` names as a deliberate shared-contract non-goal — that reshapes shared test infrastructure, so it needs a human decision first rather than being bundled here. Also checked per the burn-down list: all five production types in the cluster already carry the clock seam; no `no_raw_task_sleep` suppressions are involved.

## Evidence & verification

Mutation checks (each applied to `Sources/`, observed red with its named diagnostic, restored, re-observed green):

- `FileWatcher` eventMask minus `.write`/`.extend` → `a FileWatcher on a directory armed no debounce timer for an entry being created — observed armed=0 after 4 attempts of 2.0 seconds each`
- `ThemeStore.startWatching()` without `w.start(directory:)` → thrown diagnostic at 90s whose directory listing shows `ext.json` present, pinning "watcher never fired"
- Supervisor restart loop removed → `supervisor did not restart the events process within 90.0s; observed invocation count=1, was 1 at the kill`
- SIGKILL escalation removed from `killTree` → red via the leak check at the 30s reap guard (`stop()` returned promptly; the child survived)

Targeted suites green before and after: 32 tests across the three files (the rewritten markdown watch test now runs in ~0.1s instead of riding a real debounce). `scripts/swift-safe build` clean, `swiftlint --strict` clean. Full-suite under-load soak runs are executing on the loaded dev box now; results will follow as a PR comment.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9EEB84BC-BF9D-408C-ACA1-4543A64AAA7C)