### PR TITLE
Fix: First message to a peer fails, because the docs say to use a bare name

### DIFF
--- a/Sources/TBDShared/TBDSkillContent.swift
+++ b/Sources/TBDShared/TBDSkillContent.swift
@@ -107,11 +107,15 @@ Two channels reach another TBD session.
 If `ListAgents` and `SendMessage` are among your tools, sibling sessions on this
 machine should show up in `ListAgents` — registration is best-effort, so a
 running session can be missing — and `SendMessage` hands one plain text,
-delivered between the recipient's turns. Rows are labelled with the
-worktree display name, which is **not** unique: several terminals in one
-worktree share it, and so can worktrees in different repos. `ListAgents` prints
-a short `[ref]` on each row; address a peer by that `[ref]` whenever more than
-one row shares a name. If those tools aren't there, use `tbd terminal send`.
+delivered between the recipient's turns. Each row carries the
+worktree display name plus a short `[ref]`. Address a peer you
+have not messaged before as `name [ref]`: a bare name may be refused with an
+error naming the ref you need, even when only one row answers to it, and the
+ref is also how you pick when several rows share a name (several terminals in
+one worktree do, and so can worktrees in different repos). Once a message to
+that peer has gone through, its bare name works. Refs belong to live sessions —
+re-read `ListAgents` instead of reusing an old listing. If those tools aren't
+there, use `tbd terminal send`.
 
 `tbd terminal send` / `tbd terminal output` (above) is the daemon-mediated
 channel: it works from any harness, and it can also drive input into a

--- a/Tests/TBDSharedTests/TBDSkillContentTests.swift
+++ b/Tests/TBDSharedTests/TBDSkillContentTests.swift
@@ -46,10 +46,14 @@ import Foundation
     #expect(body.contains("worktree display name"))
     #expect(body.contains("tbd terminal send"))
     #expect(body.contains("tbd terminal output"))
-    // Display names are not unique — several terminals share one worktree's,
-    // and worktrees in different repos can share one too — so the text must
-    // point at the per-row `[ref]` as the address.
-    #expect(body.contains("[ref]"))
+    // The `[ref]` is the address, not merely a tiebreak for ambiguous names:
+    // a peer that has not been messaged before must be addressed `name [ref]`,
+    // and a bare name is refused even where exactly one row answers to it.
+    // Pin the addressing form and the refusal together — text that described
+    // the ref as only-for-collisions would satisfy neither.
+    #expect(body.contains("name [ref]"))
+    #expect(body.contains("a bare name may be refused"))
+    #expect(body.contains("have not messaged before"))
     // Missing tools have several causes (four env killswitches, and the
     // non-Claude harnesses this same body is fed to), so the text must not
     // name one. It states the fallback instead.

--- a/docs/cross-session-messaging.md
+++ b/docs/cross-session-messaging.md
@@ -59,10 +59,32 @@ session's **next respawn or resume**; until then the running session
 still answers to its spawn-time name. Nothing breaks in the meantime —
 the listing tells the two apart, as described next.
 
-## Addressing a peer when names collide
+## Addressing a peer
 
-A name is a label, not a unique address. Two things make one name answer
-for several sessions:
+Addressing starts at the listing. Run `/list-agents` — or call the
+`ListAgents` tool — and each row carries the session's name and a short
+`[ref]`, an identifier unique to that live session, alongside its working
+directory and status.
+
+**Address a peer you have not messaged before as `name [ref]`.** A bare
+name may be refused even when exactly one row answers to it, and nothing
+is delivered when it is:
+
+```
+'acme-worker' is not an agent in this conversation. Re-send with the ref
+to confirm you mean: acme-worker [<ref>] — Claude session, on this
+machine, active 11h ago
+```
+
+The refusal names the ref you need, so a bare-name send costs a round
+trip rather than failing silently: re-send addressed as
+`acme-worker [<ref>]` and it lands. Sending with the ref up front skips
+that round trip. Once a message to that peer has gone through, the bare
+name works for it for the rest of the conversation.
+
+**The ref is also how you pick when a name is ambiguous.** A name is a
+label, not a unique address, and TBD makes one name answering for several
+sessions ordinary:
 
 - **One worktree, several Claude terminals.** Every Claude session spawned
   in a worktree gets that worktree's display name, so a worktree running
@@ -70,17 +92,12 @@ for several sessions:
 - **Two worktrees, one name.** Display names are yours to choose and
   nothing stops you reusing one.
 
-`/list-agents` handles this. Each row carries a short `[ref]` — an
-identifier unique to that live session — alongside the name, working
-directory, and status. Read the listing first, then:
-
-- if exactly one row answers to the name you want, address it by name;
-- if more than one does, address the one you want by its `[ref]`. The
-  working directory and status in the row are how you tell which is
-  which.
+The working directory and status in the row are how you tell which is
+which; the `[ref]` is how you say which one you meant.
 
 Pull a fresh listing rather than reusing one from earlier in a long
-conversation — the pool changes as sessions spawn, respawn, and exit.
+conversation — refs belong to live sessions, and the pool changes as
+sessions spawn, respawn, and exit.
 
 ## Reach
 

--- a/docs/specs/2026-08-09-cross-session-messaging-design.md
+++ b/docs/specs/2026-08-09-cross-session-messaging-design.md
@@ -102,9 +102,12 @@ one and exists even when every name is current.
 
 Disambiguation therefore belongs at the addressing layer, not the naming
 one. `ListAgents` prints a short `[ref]` beside each row, unique per
-live session; a sender uses that ref whenever more than one row answers
-to the name it wants, and may use the plain name only when exactly one
-does. Keeping `--name` as the unadorned display name is what makes the
+live session, and a sender addresses a peer it has not messaged before
+as `name [ref]` — a bare name may be refused with an error naming the
+ref, measured even where exactly one row answered to that name, and the
+ref is likewise how a sender picks between rows sharing a name. Once a
+message to that peer has gone through, its bare name works. Keeping
+`--name` as the unadorned display name is what makes the
 listing legible against the app sidebar — a human reading either surface
 sees the same words — while the ref is what makes a row addressable.
 Decorating the name to force uniqueness would trade the first property


### PR DESCRIPTION
## What's broken

The cross-session messaging guidance shipped in #605 tells a reader to address a peer by its bare name when only one row answers to it, and to reach for the `[ref]` only when several rows share a name.

Follow that and your first message to any peer fails. The send is refused, nothing is delivered, and you have burned a round trip being told the opposite of what happens.

It is wrong in both places #605 put it: the user-facing page, and the skill text that loads into spawned sessions — so it misleads humans and agents alike.

## Why it happens

The `[ref]` is not a tiebreak for ambiguous names. It is how you confirm you mean a session outside your own conversation.

Measured against Claude Code 2.1.227 / 2.1.228, on **two independent peers**, each with a name unique in the listing:

```
'acme-worker' is not an agent in this conversation.
Re-send with the ref to confirm you mean:
  acme-worker [<ref>] — Claude session, on this machine, active 11h ago
```

Uniqueness does not help — the refusal names a single candidate and fires anyway. After a message to that peer has gone through, its bare name resolves.

The wrong text came from reading the tool's description rather than exercising it.

## When it broke

#605, which introduced the guidance. It has never been correct.

## What this PR does

Rewrites the addressing guidance on all three surfaces to describe what a reader should do and what they will see:

- **`docs/cross-session-messaging.md`** — section retitled from "Addressing a peer when names collide" to "Addressing a peer", since collisions are only half of it. Read the listing, address an unmessaged peer as `name [ref]`, expect the refusal (quoted verbatim), know the bare name works afterwards. The collision case is kept, with the ref as the picker. The fresh-listing caution is now motivated: refs belong to live sessions.
- **`Sources/TBDShared/TBDSkillContent.swift`** — same rule, compressed, since this loads into every spawned session. Net +3 lines.
- **`docs/specs/2026-08-09-cross-session-messaging-design.md`** — one paragraph of "The name is a label; the ref is the address" corrected. The section's core claim was already right; only the sentence scoping the ref to multi-row cases was wrong.

Deliberately **operational, not mechanistic**. The wording says what to do and what you will see; it does not assert that Claude Code keeps a per-peer handshake. An earlier draft of this fix claimed exactly that, on a single before/after observation — which could not distinguish a handshake from the name merely having been ambiguous at first. A peer session challenged the inference, the falsification test above settled it, and the docs now state only what a reader can act on and this repo can maintain.

## Assumptions

- **The refusal text is not a contract.** It was measured, not documented. If Claude Code changes the message, our quoted example goes stale — but the instruction to address first contact as `name [ref]` still holds, which is why the guidance leads with the action rather than the error string.

## Evidence & verification

- **Discriminating test**: the skill-content assertions now pin `name [ref]`, `a bare name may be refused`, and `have not messaged before` together. **Mutation-checked** — restoring #605's wording turns all three red, one issue per assertion; collision-only text satisfies none of them. The previous single `#expect(body.contains("[ref]"))` passed against the wrong text, which is why it did not catch this.
- **Field evidence**: two independent peers, both refused on a unique bare name, both reachable with `name [ref]`; one confirmed to accept its bare name on a later send. A refused send delivers nothing, so establishing this cost no peer any context.
- `scripts/test.sh` → 5591 tests in 590 suites **passed** (1 known issue: the `FlakyQuarantineSelfTests` fixture that fails-then-passes by design).
- `scripts/swift-safe build` clean; `swiftlint --strict` → 0 violations in 695 files.

Two unrelated live-subprocess flakes appeared in earlier full runs, a different one each time (`CodexUsageFetcherLifecycleTests.virtualTimeoutReturnsTimedOutAndKillsChild`, `ChildReaperTests` background reap), and the final run was clean. Neither is plausibly reachable from a string-only change; both belong to the load-sensitive cluster being addressed separately.

### Note for future edits here

The skill-content assertions pin phrases that must stay contiguous in the Swift multi-line string literal. A cosmetic rewrap of that paragraph broke `worktree display name` and `have not messaged before` across line breaks and reddened the suite legitimately. The final wrapping keeps every pinned phrase on one line at ≤80 columns.

[💬 Cross-Session Messaging](https://cheapsteak.github.io/tbd/open/?worktree=C575707C-5617-4EB3-A294-1F00D11CB93B)
