### PR TITLE
Fix: Stop failed worktree creates from leaking a branch per attempt and hiding the real cause

### DIFF
--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -725,6 +725,18 @@ public struct GitManager: Sendable {
         _ = try await run(arguments: ["update-ref", "-d", ref], at: repoPath)
     }
 
+    /// Deletes the local branch `name`.
+    ///
+    /// `git branch -D` rather than `deleteRef`'s plumbing `update-ref -d`
+    /// deliberately: git refuses to delete a branch that is checked out in a
+    /// live worktree, and that refusal is a genuine safety net for the
+    /// failed-create cleanup path — plumbing would happily unhook a branch
+    /// somebody is working in. Run `worktreePrune` first so a stale
+    /// registration can't manufacture that refusal.
+    public func deleteLocalBranch(repoPath: String, name: String) async throws {
+        _ = try await run(arguments: ["branch", "-D", name], at: repoPath)
+    }
+
     /// Lists all ref names under `prefix` (e.g. `refs/tbd/snapshots`).
     public func listRefs(repoPath: String, prefix: String) async throws -> [String] {
         let output = try await run(

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -260,14 +260,14 @@ public struct GitManager: Sendable {
     }
 
     /// True if `refs/heads/<name>` exists locally. Used to pick a
-    /// non-clobbering local branch name before force-fetching a pull ref.
+    /// non-clobbering local branch name before fetching a pull ref into it.
     ///
     /// Fails closed, unlike the read-only `refExists`: this result gates
-    /// whether `fetchPullRequestHead`'s `+refs/pull/<n>/head:refs/heads/<name>`
-    /// force-refspec is safe to run against `name`. Only the benign "ref
-    /// missing" case (`show-ref --quiet` exits 1) is treated as absent — any
-    /// other failure (timeout, spawn failure, other exit codes) is rethrown so
-    /// a bad answer here can't let the force-fetch silently clobber a branch.
+    /// whether `fetchPullRequestHead`'s `refs/pull/<n>/head:refs/heads/<name>`
+    /// refspec is safe to run against `name`. Only the benign "ref missing"
+    /// case (`show-ref --quiet` exits 1) is treated as absent — any other
+    /// failure (timeout, spawn failure, other exit codes) is rethrown so a bad
+    /// answer here can't let the fetch move a branch it should have left alone.
     public func localBranchExists(repoPath: String, name: String) async throws -> Bool {
         do {
             _ = try await run(arguments: ["show-ref", "--verify", "--quiet", "refs/heads/\(name)"], at: repoPath)
@@ -278,12 +278,31 @@ public struct GitManager: Sendable {
     }
 
     /// Fetches a PR head (same-repo or fork — `refs/pull/<n>/head` exists for
-    /// both) into a local branch. The `+` force-updates, so callers MUST pass a
-    /// branch name verified free via `localBranchExists` / uniquification, or an
-    /// unrelated same-named branch is silently rewritten.
+    /// both) into a local branch.
+    ///
+    /// The refspec is deliberately **not** forced. Git therefore refuses to
+    /// rewrite an existing `refs/heads/<localBranch>` whose tip the pull head
+    /// does not contain: it exits 1 with `! [rejected] refs/pull/<n>/head ->
+    /// <localBranch> (non-fast-forward)` and leaves the branch where it stood.
+    /// A name that became taken after the caller's `localBranchExists` probe
+    /// then costs an attempt instead of a user's commits, and the failure
+    /// carries git's own word that this attempt did not create the branch —
+    /// which is what `WorktreeLifecycle.gitRefusedToCreateBranch` reads to keep
+    /// cleanup from deleting it.
+    ///
+    /// Two residuals, both verified against git 2.50, and both reasons callers
+    /// still pass a name verified free via `localBranchExists` /
+    /// uniquification rather than leaning on git to refuse:
+    ///
+    /// - A colliding branch the pull head *does* contain fast-forwards rather
+    ///   than being refused. No commits are lost (the old tip stays reachable
+    ///   from the new one), but the ref moves.
+    /// - A colliding branch checked out in another worktree fails differently,
+    ///   exit 128 with `fatal: refusing to fetch into branch '<ref>' checked
+    ///   out at '<path>'`, whether or not the update would fast-forward.
     public func fetchPullRequestHead(repoPath: String, number: Int, localBranch: String) async throws {
         _ = try await run(
-            arguments: ["fetch", "origin", "+refs/pull/\(number)/head:refs/heads/\(localBranch)"],
+            arguments: ["fetch", "origin", "refs/pull/\(number)/head:refs/heads/\(localBranch)"],
             at: repoPath
         )
     }

--- a/Sources/TBDDaemon/Git/GitManager.swift
+++ b/Sources/TBDDaemon/Git/GitManager.swift
@@ -779,6 +779,30 @@ public struct GitManager: Sendable {
 
     // MARK: - Private
 
+    /// The environment every git subprocess runs with: the daemon's own
+    /// environment, with the locale pinned to `C`.
+    ///
+    /// Git's stderr is the only signal several callers have for *why* a command
+    /// failed, and one of those decisions is destructive: `WorktreeLifecycle`'s
+    /// failed-create cleanup decides whether it may `branch -D` off "a branch
+    /// named … already exists". Git localizes those messages when the ambient
+    /// locale asks it to, so without this pin the matching is only as stable as
+    /// whatever `LANG` the daemon happened to launch with — and a miss there
+    /// re-opens the "delete a branch we don't own" hazard the gate exists to
+    /// close.
+    ///
+    /// It **merges onto** the inherited environment rather than replacing it: a
+    /// bare dict would drop `PATH`, `HOME`, `SSH_AUTH_SOCK` and friends from
+    /// every git call the daemon makes. (Same mistake, different subsystem:
+    /// commit 56fa912f had to restore the launch `PATH` for tmux.)
+    static func gitEnvironment(
+        inheriting base: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        // `LC_ALL` is the one git actually obeys last; `LANG` is pinned too so
+        // the child's own subprocesses don't see a mixed locale.
+        return base.merging(["LC_ALL": "C", "LANG": "C"]) { _, pinned in pinned }
+    }
+
     /// Runs a git command with the given arguments at the given directory and returns stdout.
     /// Throws `GitError` on non-zero exit.
     /// Package-internal test seam: drives `run()`'s timeout/kill wrapper against
@@ -809,6 +833,7 @@ public struct GitManager: Sendable {
             executable: executable,
             arguments: arguments,
             currentDirectory: directory,
+            environment: Self.gitEnvironment(),
             timeout: resolvedTimeout,
             clock: clock
         ) {

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -371,6 +371,14 @@ extension WorktreeLifecycle {
             let branchPreExisted: Bool? = try? await git.localBranchExists(
                 repoPath: repo.path, name: worktree.branch
             )
+            // The expected tip needs no sampling on this leg and cannot go
+            // stale: `-b <branch> <sha>` points the new ref at exactly this
+            // argument, so the archived SHA *is* what this attempt would have
+            // put there. A branch that stands at any other commit afterwards is
+            // not the one this recreate made.
+            let attempted = AttemptedBranch(
+                name: worktree.branch, preExisted: branchPreExisted, expectedTip: sha
+            )
             do {
                 try await git.worktreeAddNewBranch(
                     repoPath: repo.path,
@@ -380,12 +388,11 @@ extension WorktreeLifecycle {
                 )
             } catch {
                 // Removes the partial directory, then the branch `-b` made —
-                // the latter only if all three of the helper's gates hold.
+                // the latter only if all four of the helper's gates hold.
                 await cleanUpFailedWorktreeAdd(
                     repoPath: repo.path,
                     worktreePath: worktree.localPath,
-                    branch: worktree.branch,
-                    branchPreExisted: branchPreExisted,
+                    attempted: attempted,
                     branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
                 )
                 throw error

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Archive.swift
@@ -323,21 +323,73 @@ extension WorktreeLifecycle {
         // Re-add the git worktree. Prefer the existing branch; fall back to
         // a new branch pointing at the captured archived HEAD SHA when the
         // branch is no longer present (renamed/deleted before archive ran).
+        //
+        // Both legs can fail with a directory half-written, and the recreate
+        // leg is a `-b` call site: git creates the branch first and can fail
+        // afterwards (a failing `post-checkout` hook leaves the branch, the
+        // directory AND the worktree registration standing — verified against
+        // git 2.50), so a bare rethrow leaks all three.
         let branchExists = await git.refExists(repoPath: repo.path, ref: worktree.branch)
         if branchExists {
-            try await git.worktreeAddExisting(
-                repoPath: repo.path,
-                worktreePath: worktree.localPath,
-                branch: worktree.branch
-            )
+            do {
+                try await git.worktreeAddExisting(
+                    repoPath: repo.path,
+                    worktreePath: worktree.localPath,
+                    branch: worktree.branch
+                )
+            } catch {
+                // Directory only, and deliberately not `cleanUpFailedWorktreeAdd`.
+                // This leg runs *because* the branch is already there: it checks
+                // out a ref the user owns and creates nothing, so there is no
+                // branch of ours to withdraw and no argument that would make
+                // deleting one correct. Routing it through the shared helper —
+                // treating both legs alike — is the one mistake that turns this
+                // fix into data loss, so the branch-deleting code is not on this
+                // path at all.
+                //
+                // Git also leaves the worktree registration standing here, and
+                // removing the directory only turns it prunable (git 2.50).
+                // It is left alone: `worktree prune` is repo-wide and drops any
+                // registration whose directory is missing — including a healthy
+                // worktree on an unmounted volume — so the helper runs it only
+                // when it has a branch of ours to delete and git's refusal to
+                // touch a claimed branch forces its hand. A retry is blocked
+                // either way until the user prunes, as it was before this fix.
+                try? FileManager.default.removeItem(atPath: worktree.localPath)
+                throw error
+            }
         } else if let sha = worktree.archivedHeadSHA, !sha.isEmpty {
             archiveLogger.info("revive: branch '\(worktree.branch, privacy: .public)' missing for \(worktreeID, privacy: .public), recreating from archived SHA \(sha, privacy: .public)")
-            try await git.worktreeAddNewBranch(
-                repoPath: repo.path,
-                worktreePath: worktree.localPath,
-                branch: worktree.branch,
-                sha: sha
+            // Probed independently rather than reusing `branchExists`, even
+            // though this leg runs only when that said "absent". `refExists` is
+            // non-throwing and answers `false` for *any* failure, collapsing
+            // "the branch is gone" and "the probe itself failed" into one
+            // value — and telling those apart is the whole reason the cleanup
+            // takes a tri-state. `localBranchExists` fails closed (only git's
+            // "no such ref" exit 1 becomes `false`), so a broken probe lands on
+            // `nil` and blocks deletion instead of authorizing it.
+            let branchPreExisted: Bool? = try? await git.localBranchExists(
+                repoPath: repo.path, name: worktree.branch
             )
+            do {
+                try await git.worktreeAddNewBranch(
+                    repoPath: repo.path,
+                    worktreePath: worktree.localPath,
+                    branch: worktree.branch,
+                    sha: sha
+                )
+            } catch {
+                // Removes the partial directory, then the branch `-b` made —
+                // the latter only if all three of the helper's gates hold.
+                await cleanUpFailedWorktreeAdd(
+                    repoPath: repo.path,
+                    worktreePath: worktree.localPath,
+                    branch: worktree.branch,
+                    branchPreExisted: branchPreExisted,
+                    branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
+                )
+                throw error
+            }
         } else {
             archiveLogger.error("revive: branch '\(worktree.branch, privacy: .public)' missing for \(worktreeID, privacy: .public) and no archivedHeadSHA — cannot recover")
             throw WorktreeLifecycleError.branchMissingNoFallback(branch: worktree.branch)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -565,7 +565,8 @@ extension WorktreeLifecycle {
                 logger.warning("Failed to add worktree with base branch \(baseBranch, privacy: .public): \(String(describing: error), privacy: .public)")
                 await cleanUpFailedWorktreeAdd(
                     repoPath: repoPath, worktreePath: worktreePath,
-                    branch: branch, branchPreExisted: branchPreExisted
+                    branch: branch, branchPreExisted: branchPreExisted,
+                    branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
                 )
                 if lastKind == .repoLevel {
                     // Nothing downstream can help: not the other base, not a
@@ -582,9 +583,16 @@ extension WorktreeLifecycle {
             }
         }
 
+        // Both bases are spent. A fresh name is the only remaining move, and it
+        // is worth making only for a collision — `.baseUnresolvable` means no
+        // ref resolved, which no folder or branch name changes, so retrying
+        // would burn two more identical failures and then report the generic
+        // "after all attempts" instead of naming the bases that were tried.
+        // (`.repoLevel` never reaches here; it throws inside the loop.)
+        //
         // Explicit folders and identity-sensitive callers cannot silently
-        // switch to a different generated folder and branch.
-        if userSpecifiedFolder || !retryGeneratedNameOnCollision {
+        // switch to a different generated folder and branch either.
+        if lastKind == .baseUnresolvable || userSpecifiedFolder || !retryGeneratedNameOnCollision {
             let errorDetail = lastError.flatMap { formatErrorForMessage($0) } ?? ""
             throw WorktreeLifecycleError.createFailed(
                 "\(describeExhaustedBases(lastKind, baseBranches: baseBranches))\(errorDetail)"
@@ -606,8 +614,10 @@ extension WorktreeLifecycle {
         // collide with somebody's branch is exactly the case where deleting on
         // failure would destroy work we did not create. When the name is
         // unchanged (a user-specified branch is kept across the retry) the
-        // original probe still holds — the loop above deleted the branch only
-        // if it had created it.
+        // original probe still holds — the loop above only ever *attempted* to
+        // delete a branch it had created, so reusing the answer can leave a
+        // leaked branch standing but can never widen what is eligible for
+        // deletion.
         let retryBranchPreExisted: Bool? = retryBranch == branch
             ? branchPreExisted
             : (try? await git.localBranchExists(repoPath: repoPath, name: retryBranch))
@@ -627,7 +637,8 @@ extension WorktreeLifecycle {
                 logger.warning("Failed to add worktree with retry path and base branch \(baseBranch, privacy: .public): \(String(describing: error), privacy: .public)")
                 await cleanUpFailedWorktreeAdd(
                     repoPath: repoPath, worktreePath: retryPath,
-                    branch: retryBranch, branchPreExisted: retryBranchPreExisted
+                    branch: retryBranch, branchPreExisted: retryBranchPreExisted,
+                    branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
                 )
                 if lastKind == .repoLevel {
                     throw WorktreeLifecycleError.createFailed(
@@ -691,32 +702,77 @@ extension WorktreeLifecycle {
         return .repoLevel
     }
 
-    /// Cleans up whatever a single failed `worktreeAdd` attempt left behind.
+    /// True when git's stderr says it *refused to create* the branch because
+    /// the name was already taken ("fatal: a branch named 'x' already exists").
     ///
-    /// Three things, in order: the partially-written directory, any worktree
-    /// registration git recorded before failing, and — only when we positively
-    /// know the branch was absent beforehand and is present now — the branch
-    /// `-b` created. Git can fail *after* creating the branch (a stale
-    /// `.git/config.lock` makes the upstream-config write fail while the branch
-    /// stands), which is how a failed create used to leak a `tbd/<name>` branch
-    /// and then mask the real cause behind "a branch named … already exists" on
-    /// the next attempt.
+    /// The one question `cleanUpFailedWorktreeAdd` cannot answer from its own
+    /// bookkeeping: whether the branch standing there now is one this attempt
+    /// created. Git refusing to create it settles that — it isn't.
     ///
-    /// `branchPreExisted == nil` means the probe itself failed. Not knowing is
-    /// not the same as knowing it's absent, so nothing is deleted.
-    private func cleanUpFailedWorktreeAdd(
+    /// Matched loosely (any branch name, not just ours) on purpose. The two
+    /// ways to be wrong are not symmetric: failing to delete a branch we made
+    /// leaves a visible, recoverable `tbd/<name>`, while deleting one we did
+    /// not destroys work. So an unrecognized phrasing must land on "don't
+    /// delete", which is what a broad match buys.
+    private func gitRefusedToCreateBranch(_ error: Error) -> Bool {
+        guard let gitError = error as? GitError else { return false }
+        return gitError.stderr.lowercased().contains("a branch named")
+    }
+
+    /// Cleans up whatever a single failed `worktreeAdd` attempt left behind:
+    /// the partially-written directory always, and — only when this attempt is
+    /// the one that can have created it — the branch `-b` made. Git can fail
+    /// *after* creating the branch (a stale `.git/config.lock` makes the
+    /// upstream-config write fail while the branch stands), which is how a
+    /// failed create used to leak a `tbd/<name>` branch and then mask the real
+    /// cause behind "a branch named … already exists" on the next attempt.
+    ///
+    /// **Three independent gates stand between a failure and `branch -D`, and
+    /// deleting a branch the user owns is the worst outcome this path has, so
+    /// each one fails toward keeping it.**
+    ///
+    /// 1. `branchNameWasAlreadyTaken == false`. When git says "a branch named
+    ///    … already exists" it is telling us it *refused to create* the branch,
+    ///    which is positive evidence the branch predates this attempt — whoever
+    ///    made it. That is the gate that closes the probe→attempt window:
+    ///    `branchPreExisted` is sampled before the add, so a branch created by
+    ///    anything else in between would otherwise be indistinguishable from
+    ///    one we made, and gate 2 alone would delete it.
+    /// 2. `branchPreExisted == false`. `nil` means the probe itself failed —
+    ///    not knowing is not the same as knowing it's absent.
+    /// 3. The branch is present *now*. Nothing to do otherwise.
+    ///
+    /// Gate 1 is deliberately narrower than the `.nameCollision` classification,
+    /// which also covers an occupied worktree *path*. Those two are not
+    /// interchangeable here: verified against git 2.50, `git worktree add
+    /// <occupied-path> -b X <base>` creates `X`, *then* discovers the path is
+    /// taken and fails — leaving a branch we really did make. Widening gate 1 to
+    /// the whole `.nameCollision` case would reintroduce exactly the leak this
+    /// function exists to stop.
+    ///
+    /// `worktreePrune` runs only once all three gates hold, immediately before
+    /// the delete it exists to serve: git refuses to delete a branch checked out
+    /// in a live worktree, and a stale registration would manufacture that
+    /// refusal (see `GitManager.deleteLocalBranch`). Pruning is repo-wide and
+    /// unconditionally drops any registration whose directory is missing —
+    /// including a legitimate worktree on an unmounted volume — so it stays
+    /// scoped to the one case that needs it rather than firing on every failed
+    /// attempt.
+    func cleanUpFailedWorktreeAdd(
         repoPath: String,
         worktreePath: String,
         branch: String,
-        branchPreExisted: Bool?
+        branchPreExisted: Bool?,
+        branchNameWasAlreadyTaken: Bool
     ) async {
         try? FileManager.default.removeItem(atPath: worktreePath)
-        try? await git.worktreePrune(repoPath: repoPath)
 
+        guard !branchNameWasAlreadyTaken else { return }
         guard branchPreExisted == false else { return }
         guard (try? await git.localBranchExists(repoPath: repoPath, name: branch)) == true else {
             return
         }
+        try? await git.worktreePrune(repoPath: repoPath)
         do {
             try await git.deleteLocalBranch(repoPath: repoPath, name: branch)
             logger.info("Deleted branch \(branch, privacy: .public) left behind by a failed worktree add")

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -281,6 +281,21 @@ extension WorktreeLifecycle {
                 // get `git worktree add <path> <branch>`; remote refs get
                 // `--track -b <localName> <path> origin/<name>` to create a
                 // local tracking branch.
+                //
+                // Two of the three legs below CREATE a local branch before the
+                // step that can fail, and git fails *after* creating it in the
+                // ordinary case — a stale `.git/config.lock` makes the upstream
+                // config write fail while the branch stands (verified against
+                // git 2.50). Those two record what they made here so the `catch`
+                // can hand it to the same `cleanUpFailedWorktreeAdd` the
+                // fresh-create path uses, with the same pre-existence gates.
+                //
+                // The plain `worktreeAddExisting` leg creates NOTHING and checks
+                // out a branch the caller owns, so it leaves this nil and the
+                // catch only removes the directory. Deleting there would destroy
+                // a user's branch — the worst outcome this path has.
+                var branchCreatedByThisAttempt: String?
+                var createdBranchPreExisted: Bool?
                 do {
                     if checkoutPRHead, let prNumber = worktree.prNumber {
                         // Fork-PR checkout: the PR head has no local ref, so
@@ -297,6 +312,12 @@ extension WorktreeLifecycle {
                         let localBranch = try await uniqueLocalBranchName(
                             repoPath: repo.path, base: worktree.branch
                         )
+                        // `uniqueLocalBranchName` returns only a name whose
+                        // `refs/heads/<name>` does not exist — it throws rather
+                        // than hand back a taken one — so the fetch below is the
+                        // only thing that can have created it.
+                        branchCreatedByThisAttempt = localBranch
+                        createdBranchPreExisted = false
                         try await git.fetchPullRequestHead(
                             repoPath: repo.path, number: prNumber, localBranch: localBranch
                         )
@@ -313,6 +334,15 @@ extension WorktreeLifecycle {
                         checkedOutForeignHead = true
                         try await db.worktrees.markForeignHead(id: worktreeID)
                     } else if ref.hasPrefix("origin/") {
+                        // `--track -b <localBranch>` creates the branch. Probe
+                        // first so cleanup can tell a branch this attempt made
+                        // from one that was already standing; the tri-state is
+                        // kept (`nil` = the probe itself failed) for the same
+                        // reason the fresh-create path keeps it.
+                        createdBranchPreExisted = try? await git.localBranchExists(
+                            repoPath: repo.path, name: worktree.branch
+                        )
+                        branchCreatedByThisAttempt = worktree.branch
                         try await git.worktreeAddTrackingRemote(
                             repoPath: repo.path,
                             worktreePath: worktree.path,
@@ -328,8 +358,21 @@ extension WorktreeLifecycle {
                     }
                     resultPath = worktree.path
                 } catch {
-                    // Clean up any partially-created directory before bubbling.
-                    try? FileManager.default.removeItem(atPath: worktree.path)
+                    if let branchCreatedByThisAttempt {
+                        // Removes the partially-created directory too, then
+                        // deletes the branch only if all three gates hold.
+                        await cleanUpFailedWorktreeAdd(
+                            repoPath: repo.path,
+                            worktreePath: worktree.path,
+                            branch: branchCreatedByThisAttempt,
+                            branchPreExisted: createdBranchPreExisted,
+                            branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
+                        )
+                    } else {
+                        // Nothing was created; only the partially-written
+                        // directory needs removing.
+                        try? FileManager.default.removeItem(atPath: worktree.path)
+                    }
                     throw WorktreeLifecycleError.createFailed(
                         "git worktree add failed for existing branch '\(ref)': \(error)"
                     )
@@ -583,7 +626,24 @@ extension WorktreeLifecycle {
             }
         }
 
-        // Both bases are spent. A fresh name is the only remaining move, and it
+        // Both bases are spent. When the caller NAMED the branch, the retry
+        // below keeps that name and changes only the folder — so if the branch
+        // name is what stands in the way, the retry re-attempts the identical
+        // name against both bases, fails identically twice, and lands on the
+        // generic "after all attempts" with the real cause buried. Say what
+        // collided instead.
+        //
+        // Deliberately narrower than the whole `.nameCollision` case: an
+        // occupied worktree *path* is also a collision, and there a fresh folder
+        // is exactly the remedy.
+        if lastKind == .nameCollision, userSpecifiedBranch,
+           let lastError, gitSaysBranchNameIsTaken(lastError) {
+            throw WorktreeLifecycleError.createFailed(
+                "could not create branch '\(branch)' — the name is already taken\(formatErrorForMessage(lastError))"
+            )
+        }
+
+        // A fresh name is the only remaining move, and it
         // is worth making only for a collision — `.baseUnresolvable` means no
         // ref resolved, which no folder or branch name changes, so retrying
         // would burn two more identical failures and then report the generic
@@ -644,6 +704,11 @@ extension WorktreeLifecycle {
                     throw WorktreeLifecycleError.createFailed(
                         "git worktree add failed\(repoLevelHint(error))\(formatErrorForMessage(error))"
                     )
+                }
+                if lastKind == .nameCollision {
+                    // Base-independent here for the same reason as in the first
+                    // loop: the second base would fail identically.
+                    break
                 }
             }
         }
@@ -717,6 +782,30 @@ extension WorktreeLifecycle {
     private func gitRefusedToCreateBranch(_ error: Error) -> Bool {
         guard let gitError = error as? GitError else { return false }
         return gitError.stderr.lowercased().contains("a branch named")
+    }
+
+    /// True when git's stderr says the *branch name* is what is taken, as
+    /// opposed to the worktree path. Two phrasings mean it, both verified
+    /// against git 2.50:
+    ///
+    /// - `fatal: a branch named 'x' already exists` — the ref is there.
+    /// - `fatal: 'x' is already used by worktree at '<path>'` — the ref is
+    ///   checked out elsewhere, or a registration claims it is (an unborn
+    ///   orphan branch in the main checkout produces exactly this while
+    ///   `refs/heads/x` does not yet exist, which is why the pre-existence
+    ///   probe alone cannot answer this question).
+    ///
+    /// An occupied path says `fatal: '<path>' already exists` instead — no
+    /// overlap, so a fresh folder name stays the remedy for that one.
+    ///
+    /// Distinct from `gitRefusedToCreateBranch`, which gates branch *deletion*
+    /// and stays narrower on purpose: this one only decides whether to keep
+    /// retrying, where being wrong costs an attempt rather than a branch.
+    private func gitSaysBranchNameIsTaken(_ error: Error) -> Bool {
+        guard let gitError = error as? GitError else { return false }
+        let stderr = gitError.stderr.lowercased()
+        return stderr.contains("a branch named")
+            || stderr.contains("is already used by worktree at")
     }
 
     /// Cleans up whatever a single failed `worktreeAdd` attempt left behind:

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -611,11 +611,14 @@ extension WorktreeLifecycle {
                     branch: branch, branchPreExisted: branchPreExisted,
                     branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
                 )
-                if lastKind == .repoLevel {
-                    // Nothing downstream can help: not the other base, not a
-                    // fresh name. Surface git's own words instead of guessing.
+                if lastKind == .gitUnusable {
+                    // git returned no verdict at all, so nothing was learned
+                    // about the base or the name — and every further attempt
+                    // costs another full `GitManager.commandTimeout` (120 s).
+                    // Continuing here would make a wedged git report after
+                    // 240 s, and after 480 s once the rename retry ran too.
                     throw WorktreeLifecycleError.createFailed(
-                        "git worktree add failed\(repoLevelHint(error))\(formatErrorForMessage(error))"
+                        "git worktree add did not complete\(formatErrorForMessage(error))"
                     )
                 }
                 if lastKind == .nameCollision {
@@ -624,6 +627,24 @@ extension WorktreeLifecycle {
                     break
                 }
             }
+        }
+
+        // A repo-level cause that survived both bases. `.repoLevel` deliberately
+        // does NOT break out of the loop above, because the two bases are not
+        // interchangeable: base 1 is a remote-tracking ref, so `-b` writes
+        // upstream configuration, while base 2 is a plain local ref and writes
+        // none. Verified against git 2.50, the local base recovers from causes
+        // the remote base cannot survive — a stale `.git/config.lock` fails only
+        // the config write (and the cleanup above clears the branch it left, so
+        // the second attempt starts clean), and a local branch literally named
+        // `origin/main` makes base 1 fatal on `ambiguous object name` while base
+        // 2 resolves. A *fresh name* still cannot help, though, so this throws
+        // rather than falling through to the rename retry. Surface git's own
+        // words instead of guessing.
+        if lastKind == .repoLevel, let lastError {
+            throw WorktreeLifecycleError.createFailed(
+                "git worktree add failed\(repoLevelHint(lastError))\(formatErrorForMessage(lastError))"
+            )
         }
 
         // Both bases are spent. When the caller NAMED the branch, the retry
@@ -648,7 +669,7 @@ extension WorktreeLifecycle {
         // ref resolved, which no folder or branch name changes, so retrying
         // would burn two more identical failures and then report the generic
         // "after all attempts" instead of naming the bases that were tried.
-        // (`.repoLevel` never reaches here; it throws inside the loop.)
+        // (`.repoLevel` and `.gitUnusable` never reach here; both already threw.)
         //
         // Explicit folders and identity-sensitive callers cannot silently
         // switch to a different generated folder and branch either.
@@ -700,9 +721,12 @@ extension WorktreeLifecycle {
                     branch: retryBranch, branchPreExisted: retryBranchPreExisted,
                     branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
                 )
-                if lastKind == .repoLevel {
+                if lastKind == .gitUnusable {
+                    // Fail fast for the same reason as in the first loop: git
+                    // said nothing, and another base costs another full
+                    // subprocess timeout.
                     throw WorktreeLifecycleError.createFailed(
-                        "git worktree add failed\(repoLevelHint(error))\(formatErrorForMessage(error))"
+                        "git worktree add did not complete\(formatErrorForMessage(error))"
                     )
                 }
                 if lastKind == .nameCollision {
@@ -711,6 +735,16 @@ extension WorktreeLifecycle {
                     break
                 }
             }
+        }
+
+        // Mirrors the first loop: `.repoLevel` is worth the other base, whose
+        // plain local ref skips the upstream-config write the remote base
+        // performs, but is never worth a further name. "Spent" here means this
+        // loop's bases — the first loop already spent its own.
+        if lastKind == .repoLevel, let lastError {
+            throw WorktreeLifecycleError.createFailed(
+                "git worktree add failed\(repoLevelHint(lastError))\(formatErrorForMessage(lastError))"
+            )
         }
 
         let errorDetail = lastError.flatMap { formatErrorForMessage($0) } ?? ""
@@ -723,10 +757,10 @@ extension WorktreeLifecycle {
     /// retries above can possibly help.
     ///
     /// Classification is a whitelist of known-recoverable stderr shapes;
-    /// anything unrecognized is `.repoLevel` and fails fast. That direction is
-    /// the safe one: an unclassifiable error retried under a second base and
-    /// then a second name manufactures orphan branches, while a recoverable
-    /// error misread as fatal merely surfaces git's real message.
+    /// anything unrecognized is `.repoLevel`, which never earns a fresh name.
+    /// That direction is the safe one: an unclassifiable error retried under a
+    /// second *name* manufactures orphan branches, while a recoverable error
+    /// misread as fatal merely surfaces git's real message.
     enum WorktreeAddFailureKind {
         /// The base ref did not resolve. The *next base branch* may — this is
         /// exactly what the two-base loop exists for.
@@ -734,16 +768,25 @@ extension WorktreeLifecycle {
         /// The branch name, the folder path, or the checkout is already taken.
         /// Every base fails identically; only a *fresh name* can help.
         case nameCollision
-        /// Anything else: a stale `.git/config.lock`, a corrupt repo, a full
-        /// disk. Neither another base nor another name changes the outcome.
+        /// Anything else git reported: a stale `.git/config.lock`, a corrupt
+        /// repo, a full disk, a local branch shadowing `origin/<default>`.
+        /// No *name* changes the outcome, but the *other base* still can —
+        /// the two are not interchangeable, since only the remote-tracking one
+        /// makes `-b` write upstream configuration. So the loop continues and
+        /// this only becomes fatal once both bases are spent.
         case repoLevel
+        /// git returned no verdict at all — the subprocess timed out or could
+        /// not be spawned. Nothing was learned about the base or the name, and
+        /// unlike `.repoLevel` there is no cheap second opinion to buy: another
+        /// base costs another full `GitManager.commandTimeout`. Fails fast.
+        case gitUnusable
     }
 
     /// Classifies a `worktreeAdd` failure off `GitError.stderr`. A non-`GitError`
-    /// (spawn failure, timeout) is `.repoLevel` — it says nothing about the
-    /// base or the name.
+    /// (spawn failure, timeout) is `.gitUnusable` — git never got far enough to
+    /// say anything about the base or the name.
     private func classifyWorktreeAddFailure(_ error: Error) -> WorktreeAddFailureKind {
-        guard let gitError = error as? GitError else { return .repoLevel }
+        guard let gitError = error as? GitError else { return .gitUnusable }
         let stderr = gitError.stderr.lowercased()
 
         // "fatal: invalid reference: origin/main"
@@ -872,13 +915,17 @@ extension WorktreeLifecycle {
 
     /// Message for "both base branches were tried and none worked", worded to
     /// match what actually went wrong rather than always guessing collision.
+    ///
+    /// Only `.baseUnresolvable` and `.nameCollision` reach it; `.repoLevel` and
+    /// `.gitUnusable` throw git's own words earlier and are covered here only
+    /// for exhaustiveness.
     private func describeExhaustedBases(
         _ kind: WorktreeAddFailureKind, baseBranches: [String]
     ) -> String {
         switch kind {
         case .baseUnresolvable:
             return "git worktree add failed — no usable base branch (tried \(baseBranches.joined(separator: ", ")))"
-        case .nameCollision, .repoLevel:
+        case .nameCollision, .repoLevel, .gitUnusable:
             return "git worktree add failed — the folder or branch may already exist"
         }
     }
@@ -898,6 +945,11 @@ extension WorktreeLifecycle {
         if let gitError = error as? GitError {
             let stderr = gitError.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             detail = stderr
+        } else if let timeout = error as? GitTimeoutError {
+            // `localizedDescription` on a bare `Error` struct renders as
+            // "The operation couldn't be completed. (… error 1.)", which names
+            // neither the timeout nor the command. Its own description does.
+            detail = timeout.description
         } else {
             detail = error.localizedDescription
         }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -297,6 +297,13 @@ extension WorktreeLifecycle {
                 // catch only removes the directory. Deleting there would destroy
                 // a user's branch — the worst outcome this path has.
                 var attemptedBranch: AttemptedBranch?
+                // Set by the fork-PR leg once its checkout has succeeded: the
+                // local branch the fetch wrote, which `uniqueLocalBranchName`
+                // may have moved off the row's own branch name. Carried out of
+                // the protected scope because the DB bookkeeping it implies
+                // belongs *after* the git work, not inside the `catch` that
+                // deletes what that work produced.
+                var fetchedPullHeadBranch: String?
                 do {
                     if checkoutPRHead, let prNumber = worktree.prNumber {
                         // Fork-PR checkout: the PR head has no local ref, so
@@ -360,13 +367,7 @@ extension WorktreeLifecycle {
                             worktreePath: worktree.path,
                             branch: localBranch
                         )
-                        if localBranch != worktree.branch {
-                            try await db.worktrees.updateBranch(id: worktreeID, branch: localBranch)
-                        }
-                        // TBD made this directory but not its contents: stamp
-                        // the row so folder-trust is never pre-answered for it.
-                        checkedOutForeignHead = true
-                        try await db.worktrees.markForeignHead(id: worktreeID)
+                        fetchedPullHeadBranch = localBranch
                     } else if ref.hasPrefix("origin/") {
                         // `--track -b <localBranch>` creates the branch. Probe
                         // first so cleanup can tell a branch this attempt made
@@ -403,7 +404,6 @@ extension WorktreeLifecycle {
                             branch: worktree.branch
                         )
                     }
-                    resultPath = worktree.path
                 } catch {
                     if let attemptedBranch {
                         // Removes the partially-created directory too, then
@@ -422,6 +422,28 @@ extension WorktreeLifecycle {
                     throw WorktreeLifecycleError.createFailed(
                         "git worktree add failed for existing branch '\(ref)': \(error)"
                     )
+                }
+                // The protected scope ends at the git work's success, matching
+                // the other two legs. What follows is bookkeeping about a
+                // checkout that already exists on disk, so it must not run where
+                // `cleanUpFailedWorktreeAdd` can reach it. A successful fetch is
+                // exactly the state that clears that helper's gates — the branch
+                // was probed absent, git raised no refusal, and it now stands at
+                // the tip the fetch wrote — so a throw from either write below
+                // would hand it a correctly-fetched branch and a valid directory
+                // to destroy. Failing the create is still right (the outer catch
+                // drops the row); destroying the checkout is not.
+                resultPath = worktree.path
+                if let fetchedPullHeadBranch {
+                    if fetchedPullHeadBranch != worktree.branch {
+                        try await db.worktrees.updateBranch(
+                            id: worktreeID, branch: fetchedPullHeadBranch
+                        )
+                    }
+                    // TBD made this directory but not its contents: stamp
+                    // the row so folder-trust is never pre-answered for it.
+                    checkedOutForeignHead = true
+                    try await db.worktrees.markForeignHead(id: worktreeID)
                 }
             } else {
                 let result = try await attemptWorktreeAdd(

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -996,8 +996,11 @@ extension WorktreeLifecycle {
     /// cause behind "a branch named … already exists" on the next attempt.
     ///
     /// **Four independent gates stand between a failure and `branch -D`, and
-    /// deleting a branch the user owns is the worst outcome this path has, so
-    /// every unknown lands on keeping it.**
+    /// deleting a branch the user owns is the worst outcome this path has.
+    /// Gates 2, 3 and 4 fail closed — an answer they cannot establish keeps the
+    /// branch. Gate 1 does not: reading stderr can only ever *add* evidence, so
+    /// its `false` is an abstention rather than a finding. That asymmetry is
+    /// what gate 4 exists to cover.**
     ///
     /// 1. `branchNameWasAlreadyTaken == false`. When git says "a branch named
     ///    … already exists" — or rejects the fork-PR leg's fetch, the same
@@ -1036,7 +1039,7 @@ extension WorktreeLifecycle {
     /// the whole `.nameCollision` case would reintroduce exactly the leak this
     /// function exists to stop.
     ///
-    /// `worktreePrune` runs only once all three gates hold, immediately before
+    /// `worktreePrune` runs only once all four gates hold, immediately before
     /// the delete it exists to serve: git refuses to delete a branch checked out
     /// in a live worktree, and a stale registration would manufacture that
     /// refusal (see `GitManager.deleteLocalBranch`). Pruning is repo-wide and

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -874,18 +874,6 @@ extension WorktreeLifecycle {
         return .repoLevel
     }
 
-    /// True when git's stderr says it *refused to write the ref* because the
-    /// name was already taken. Three phrasings mean it, all verified against
-    /// git 2.50 — the first from `worktree add -b`, the other two from the
-    /// fork-PR leg's `fetch refs/pull/<n>/head:refs/heads/<name>`:
-    ///
-    /// - `fatal: a branch named 'x' already exists`
-    /// - ` ! [rejected]  refs/pull/7/head -> x  (non-fast-forward)` — a fetch
-    ///   only ever rejects a destination ref that already exists, so the line
-    ///   says the same thing the `fatal:` one does.
-    /// - `fatal: refusing to fetch into branch 'refs/heads/x' checked out at
-    ///   '<path>'` — a ref cannot be checked out unless it exists.
-    ///
     /// The branch a single create attempt is on the hook for, and everything
     /// that attempt knows about it that `cleanUpFailedWorktreeAdd` cannot
     /// reconstruct after the fact.
@@ -934,6 +922,18 @@ extension WorktreeLifecycle {
     /// answer from its own bookkeeping: whether the branch standing there now is
     /// one this attempt created. Git refusing to write it settles that — it
     /// isn't.
+    ///
+    /// Three phrasings mean that refusal, all verified against git 2.50 — the
+    /// first from `worktree add -b`, the other two from the fork-PR leg's
+    /// `fetch refs/pull/<n>/head:refs/heads/<name>`. Each of them says the
+    /// name was already taken:
+    ///
+    /// - `fatal: a branch named 'x' already exists`
+    /// - ` ! [rejected]  refs/pull/7/head -> x  (non-fast-forward)` — a fetch
+    ///   only ever rejects a destination ref that already exists, so the line
+    ///   says the same thing the `fatal:` one does.
+    /// - `fatal: refusing to fetch into branch 'refs/heads/x' checked out at
+    ///   '<path>'` — a ref cannot be checked out unless it exists.
     ///
     /// Matched loosely (any branch name, not just ours) on purpose, and the
     /// direction of that looseness is what makes widening it safe: every extra

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -822,7 +822,11 @@ extension WorktreeLifecycle {
     /// leaves a visible, recoverable `tbd/<name>`, while deleting one we did
     /// not destroys work. So an unrecognized phrasing must land on "don't
     /// delete", which is what a broad match buys.
-    private func gitRefusedToCreateBranch(_ error: Error) -> Bool {
+    ///
+    /// Not `private`: the revive path's archived-SHA recreate (`-b <branch>
+    /// <sha>` in `WorktreeLifecycle+Archive`) is the fourth `-b` call site and
+    /// feeds the same gate to the same cleanup.
+    func gitRefusedToCreateBranch(_ error: Error) -> Bool {
         guard let gitError = error as? GitError else { return false }
         return gitError.stderr.lowercased().contains("a branch named")
     }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -290,14 +290,13 @@ extension WorktreeLifecycle {
                 // config write fail while the branch stands (verified against
                 // git 2.50). Those two record what they made here so the `catch`
                 // can hand it to the same `cleanUpFailedWorktreeAdd` the
-                // fresh-create path uses, with the same pre-existence gates.
+                // fresh-create path uses, with the same gates.
                 //
                 // The plain `worktreeAddExisting` leg creates NOTHING and checks
                 // out a branch the caller owns, so it leaves this nil and the
                 // catch only removes the directory. Deleting there would destroy
                 // a user's branch — the worst outcome this path has.
-                var branchCreatedByThisAttempt: String?
-                var createdBranchPreExisted: Bool?
+                var attemptedBranch: AttemptedBranch?
                 do {
                     if checkoutPRHead, let prNumber = worktree.prNumber {
                         // Fork-PR checkout: the PR head has no local ref, so
@@ -324,19 +323,37 @@ extension WorktreeLifecycle {
                         //
                         // The probe→fetch window is not its job to close, and it
                         // cannot: a branch an external actor creates inside that
-                        // gap is invisible to a probe taken before it. That is
-                        // gate 1's job on every leg, and it works here because
-                        // `fetchPullRequestHead`'s refspec is unforced — git
-                        // rejects the update instead of rewriting the branch,
+                        // gap is invisible to a probe taken before it. Gates 1
+                        // and 4 cover that window instead, and gate 1 works here
+                        // because `fetchPullRequestHead`'s refspec is unforced —
+                        // git rejects the update instead of rewriting the branch,
                         // and `gitRefusedToCreateBranch` reads the rejection.
                         // The residual is a collision the pull head *contains*,
                         // which fast-forwards silently; see that method.
-                        createdBranchPreExisted = try? await git.localBranchExists(
+                        let prBranchPreExisted = try? await git.localBranchExists(
                             repoPath: repo.path, name: localBranch
                         )
-                        branchCreatedByThisAttempt = localBranch
+                        // Recorded before the fetch so a fetch that dies with the
+                        // ref half-written still reaches cleanup — carrying no
+                        // expected tip, which blocks the delete. That is the
+                        // right answer for this leg: the fetch is the only step
+                        // that writes the ref, so a fetch that did not report
+                        // success never created the branch standing there.
+                        attemptedBranch = AttemptedBranch(
+                            name: localBranch, preExisted: prBranchPreExisted
+                        )
                         try await git.fetchPullRequestHead(
                             repoPath: repo.path, number: prNumber, localBranch: localBranch
+                        )
+                        // Only now is there a tip to speak of, and this is the
+                        // moment it becomes meaningful: the step that can still
+                        // fail with the branch standing is the checkout below,
+                        // not the fetch. Sampling the remote's `refs/pull/<n>/head`
+                        // beforehand would cost a second network round trip to
+                        // learn what the unforced refspec has just settled —
+                        // it either wrote that tip or refused outright.
+                        attemptedBranch?.expectedTip = try? await git.headSHA(
+                            repoPath: repo.path, ref: "refs/heads/\(localBranch)"
                         )
                         try await git.worktreeAddExisting(
                             repoPath: repo.path,
@@ -356,10 +373,23 @@ extension WorktreeLifecycle {
                         // from one that was already standing; the tri-state is
                         // kept (`nil` = the probe itself failed) for the same
                         // reason the fresh-create path keeps it.
-                        createdBranchPreExisted = try? await git.localBranchExists(
+                        //
+                        // The expected tip is the remote ref's, sampled BEFORE
+                        // the add for the same reason the fresh-create legs
+                        // sample the base tip before theirs: `-b <local>
+                        // <remoteRef>` copies whatever that ref held when the add
+                        // ran, and reading it afterwards would describe a ref
+                        // another fetch may have moved in between.
+                        let trackedBranchPreExisted = try? await git.localBranchExists(
                             repoPath: repo.path, name: worktree.branch
                         )
-                        branchCreatedByThisAttempt = worktree.branch
+                        attemptedBranch = AttemptedBranch(
+                            name: worktree.branch,
+                            preExisted: trackedBranchPreExisted,
+                            expectedTip: try? await git.headSHA(
+                                repoPath: repo.path, ref: ref
+                            )
+                        )
                         try await git.worktreeAddTrackingRemote(
                             repoPath: repo.path,
                             worktreePath: worktree.path,
@@ -375,14 +405,13 @@ extension WorktreeLifecycle {
                     }
                     resultPath = worktree.path
                 } catch {
-                    if let branchCreatedByThisAttempt {
+                    if let attemptedBranch {
                         // Removes the partially-created directory too, then
-                        // deletes the branch only if all three gates hold.
+                        // deletes the branch only if all four gates hold.
                         await cleanUpFailedWorktreeAdd(
                             repoPath: repo.path,
                             worktreePath: worktree.path,
-                            branch: branchCreatedByThisAttempt,
-                            branchPreExisted: createdBranchPreExisted,
+                            attempted: attemptedBranch,
                             branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
                         )
                     } else {
@@ -611,6 +640,18 @@ extension WorktreeLifecycle {
         var lastKind: WorktreeAddFailureKind = .baseUnresolvable
 
         for baseBranch in baseBranches {
+            // Sampled per base and BEFORE the add, which is what makes it
+            // evidence: `-b <branch> <baseBranch>` points the new ref at
+            // whatever this base resolved to at that moment, so a tip read
+            // afterwards would describe a base a concurrent fetch may have
+            // moved — and would say nothing about what this attempt's own `-b`
+            // would have produced. An unresolvable base yields `nil`, which
+            // blocks the delete.
+            let attempted = AttemptedBranch(
+                name: branch,
+                preExisted: branchPreExisted,
+                expectedTip: try? await git.headSHA(repoPath: repoPath, ref: baseBranch)
+            )
             do {
                 try await git.worktreeAdd(
                     repoPath: repoPath,
@@ -625,7 +666,7 @@ extension WorktreeLifecycle {
                 logger.warning("Failed to add worktree with base branch \(baseBranch, privacy: .public): \(String(describing: error), privacy: .public)")
                 await cleanUpFailedWorktreeAdd(
                     repoPath: repoPath, worktreePath: worktreePath,
-                    branch: branch, branchPreExisted: branchPreExisted,
+                    attempted: attempted,
                     branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
                 )
                 if lastKind == .gitUnusable {
@@ -721,6 +762,12 @@ extension WorktreeLifecycle {
             : (try? await git.localBranchExists(repoPath: repoPath, name: retryBranch))
 
         for baseBranch in baseBranches {
+            // Sampled per base and before the add, exactly as in the first loop.
+            let attempted = AttemptedBranch(
+                name: retryBranch,
+                preExisted: retryBranchPreExisted,
+                expectedTip: try? await git.headSHA(repoPath: repoPath, ref: baseBranch)
+            )
             do {
                 try await git.worktreeAdd(
                     repoPath: repoPath,
@@ -735,7 +782,7 @@ extension WorktreeLifecycle {
                 logger.warning("Failed to add worktree with retry path and base branch \(baseBranch, privacy: .public): \(String(describing: error), privacy: .public)")
                 await cleanUpFailedWorktreeAdd(
                     repoPath: repoPath, worktreePath: retryPath,
-                    branch: retryBranch, branchPreExisted: retryBranchPreExisted,
+                    attempted: attempted,
                     branchNameWasAlreadyTaken: gitRefusedToCreateBranch(error)
                 )
                 if lastKind == .gitUnusable {
@@ -839,18 +886,71 @@ extension WorktreeLifecycle {
     /// - `fatal: refusing to fetch into branch 'refs/heads/x' checked out at
     ///   '<path>'` — a ref cannot be checked out unless it exists.
     ///
-    /// The one question `cleanUpFailedWorktreeAdd` cannot answer from its own
-    /// bookkeeping: whether the branch standing there now is one this attempt
-    /// created. Git refusing to write it settles that — it isn't.
+    /// The branch a single create attempt is on the hook for, and everything
+    /// that attempt knows about it that `cleanUpFailedWorktreeAdd` cannot
+    /// reconstruct after the fact.
+    ///
+    /// Both facts are measurements with an expiry, which is why they are
+    /// captured here rather than gathered inside the cleanup: read after the
+    /// failure, "was the name free?" answers about a world the attempt has
+    /// already changed, and "where does this base point?" answers about a ref
+    /// anything else may have moved since.
+    ///
+    /// The per-leg timing for `expectedTip`, which is the whole substance of
+    /// the value:
+    ///
+    /// - **Fresh create** (`worktreeAdd(… baseBranch:)`) — the resolved tip of
+    ///   the base this attempt is about to use, sampled per base, before the
+    ///   add.
+    /// - **Remote-tracking checkout** (`worktreeAddTrackingRemote`) — the tip
+    ///   of the remote ref, before the add, for the same reason.
+    /// - **Revive from an archived SHA** (`worktreeAddNewBranch(… sha:)`) — that
+    ///   SHA. It is the argument `-b` copies, so it needs no sampling and cannot
+    ///   go stale.
+    /// - **Fork-PR checkout** — the tip the unforced
+    ///   `refs/pull/<n>/head:refs/heads/<name>` refspec wrote, read once the
+    ///   fetch reports success. Left `nil` until then: the fetch is the only
+    ///   step on that leg that writes the ref, so a fetch that failed created
+    ///   nothing, and `nil` correctly refuses to authorize a delete.
+    struct AttemptedBranch: Sendable {
+        /// The local branch name this attempt aims at — which is not always the
+        /// worktree row's branch (the fork-PR leg uniquifies it).
+        let name: String
+        /// Whether `name` was already standing when this attempt started.
+        /// `nil` means the probe itself failed.
+        let preExisted: Bool?
+        /// The SHA this attempt would have pointed `name` at. `nil` means it
+        /// could not be established, which blocks the delete.
+        var expectedTip: String?
+
+        init(name: String, preExisted: Bool?, expectedTip: String? = nil) {
+            self.name = name
+            self.preExisted = preExisted
+            self.expectedTip = expectedTip
+        }
+    }
+
+    /// Positive evidence for the one question `cleanUpFailedWorktreeAdd` cannot
+    /// answer from its own bookkeeping: whether the branch standing there now is
+    /// one this attempt created. Git refusing to write it settles that — it
+    /// isn't.
     ///
     /// Matched loosely (any branch name, not just ours) on purpose, and the
     /// direction of that looseness is what makes widening it safe: every extra
     /// match returns `true`, and `true` is the answer that *keeps* the branch.
     /// The two ways to be wrong are not symmetric — failing to delete a branch
     /// we made leaves a visible, recoverable `tbd/<name>`, while deleting one
-    /// we did not destroys work. So an unrecognized phrasing must land on
-    /// "don't delete", which is what a broad match buys. A gate that instead
-    /// *authorized* deletion would have to be narrow.
+    /// we did not destroys work.
+    ///
+    /// **`false` is an abstention, not a finding.** An unrecognized phrasing —
+    /// a future git, a non-standard build, a wrapper reformatting stderr —
+    /// produces `false`, the same value a genuine "the branch is ours" failure
+    /// produces, so this gate alone cannot carry the decision. What keeps that
+    /// abstention from *authorizing* a delete is gate 4, which asks a question
+    /// no wording can garble: does the branch point where this attempt would
+    /// have put it? Read the two together — this one narrows the window
+    /// positively when git says the words, and gate 4 corroborates whenever it
+    /// does not.
     ///
     /// Not `private`: the revive path's archived-SHA recreate (`-b <branch>
     /// <sha>` in `WorktreeLifecycle+Archive`) is the fourth `-b` call site and
@@ -895,22 +995,38 @@ extension WorktreeLifecycle {
     /// failed create used to leak a `tbd/<name>` branch and then mask the real
     /// cause behind "a branch named … already exists" on the next attempt.
     ///
-    /// **Three independent gates stand between a failure and `branch -D`, and
+    /// **Four independent gates stand between a failure and `branch -D`, and
     /// deleting a branch the user owns is the worst outcome this path has, so
-    /// each one fails toward keeping it.**
+    /// every unknown lands on keeping it.**
     ///
     /// 1. `branchNameWasAlreadyTaken == false`. When git says "a branch named
     ///    … already exists" — or rejects the fork-PR leg's fetch, the same
     ///    statement in that leg's vocabulary — it is telling us it *refused to
     ///    write* the ref, which is positive evidence the branch predates this
-    ///    attempt, whoever made it. That is the gate that closes the
-    ///    probe→attempt window:
-    ///    `branchPreExisted` is sampled before the add, so a branch created by
-    ///    anything else in between would otherwise be indistinguishable from
-    ///    one we made, and gate 2 alone would delete it.
-    /// 2. `branchPreExisted == false`. `nil` means the probe itself failed —
-    ///    not knowing is not the same as knowing it's absent.
+    ///    attempt, whoever made it. Read stderr, so it can only ever *add*
+    ///    evidence: `false` means git did not say the words, which includes
+    ///    "git said them in a phrasing this build does not recognize". It
+    ///    narrows the probe→attempt window rather than closing it, and gate 4
+    ///    is what covers the abstention.
+    /// 2. `AttemptedBranch.preExisted == false`. `nil` means the probe itself
+    ///    failed — not knowing is not the same as knowing it's absent. Sampled
+    ///    before the attempt, so a branch created by anything else in between
+    ///    is invisible to it.
     /// 3. The branch is present *now*. Nothing to do otherwise.
+    /// 4. The branch points at `AttemptedBranch.expectedTip` — the SHA this
+    ///    attempt's own `-b` or fetch would have written, sampled by the caller
+    ///    (see that type for the per-leg timing). This is the gate that does not
+    ///    depend on git's wording: a branch some other actor created in the
+    ///    probe→attempt window is a branch *they* chose the starting point for,
+    ///    and it does not match. `nil`, an unreadable current tip, and a
+    ///    mismatch all block the delete — a tip we cannot establish is never a
+    ///    licence to destroy a ref.
+    ///
+    ///    Its residual, stated plainly because overclaiming here is what let
+    ///    gate 1 look sufficient: an external actor branching from the *same*
+    ///    base inside that window lands on the same SHA, so the check passes and
+    ///    their branch is deleted. This narrows the window to a coincidence of
+    ///    name *and* starting commit; it does not eliminate it.
     ///
     /// Gate 1 is deliberately narrower than the `.nameCollision` classification,
     /// which also covers an occupied worktree *path*. Those two are not
@@ -931,15 +1047,23 @@ extension WorktreeLifecycle {
     func cleanUpFailedWorktreeAdd(
         repoPath: String,
         worktreePath: String,
-        branch: String,
-        branchPreExisted: Bool?,
+        attempted: AttemptedBranch,
         branchNameWasAlreadyTaken: Bool
     ) async {
         try? FileManager.default.removeItem(atPath: worktreePath)
 
+        let branch = attempted.name
         guard !branchNameWasAlreadyTaken else { return }
-        guard branchPreExisted == false else { return }
+        guard attempted.preExisted == false else { return }
         guard (try? await git.localBranchExists(repoPath: repoPath, name: branch)) == true else {
+            return
+        }
+        guard let expectedTip = attempted.expectedTip else { return }
+        let currentTip = try? await git.headSHA(
+            repoPath: repoPath, ref: "refs/heads/\(branch)"
+        )
+        guard let currentTip, currentTip == expectedTip else {
+            logger.info("Kept branch \(branch, privacy: .public) after a failed worktree add: it does not point where this attempt would have put it (expected \(expectedTip, privacy: .public), found \(currentTip ?? "unreadable", privacy: .public))")
             return
         }
         try? await git.worktreePrune(repoPath: repoPath)

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -194,11 +194,13 @@ extension WorktreeLifecycle {
 
     /// Returns `base`, or `base-2`, `base-3`, … — the first name for which no
     /// local `refs/heads/<name>` exists. Mirrors `uniqueFolderName`'s loop but
-    /// probes git refs instead of paths: the PR-head fetch uses a `+` force
-    /// refspec, so a colliding name would silently rewrite an unrelated branch;
-    /// this picks a free name first. Caps at -1000; if every candidate through
-    /// `base-1000` is taken it THROWS rather than returning the taken `base` —
-    /// returning it would let the force refspec clobber that existing branch.
+    /// probes git refs instead of paths: the PR-head fetch writes
+    /// `refs/heads/<name>` directly, so aiming it at a colliding name either
+    /// fails the create outright or — when the pull head contains that branch —
+    /// fast-forwards someone else's ref; this picks a free name first. Caps at
+    /// -1000; if every candidate through `base-1000` is taken it THROWS rather
+    /// than returning the taken `base`, which would aim the fetch at a branch
+    /// this attempt does not own.
     private func uniqueLocalBranchName(repoPath: String, base: String) async throws -> String {
         if try await git.localBranchExists(repoPath: repoPath, name: base) == false {
             return base
@@ -210,7 +212,7 @@ extension WorktreeLifecycle {
             }
         }
         throw WorktreeLifecycleError.createFailed(
-            "no free local branch name for '\(base)' after 1000 attempts; refusing to reuse it (the force-fetch refspec would clobber the existing branch)")
+            "no free local branch name for '\(base)' after 1000 attempts; refusing to reuse it (the pull-head fetch would write over the existing branch)")
     }
 
     /// Phase 2: Async. Performs git fetch, git worktree add, tmux setup,
@@ -300,9 +302,7 @@ extension WorktreeLifecycle {
                     if checkoutPRHead, let prNumber = worktree.prNumber {
                         // Fork-PR checkout: the PR head has no local ref, so
                         // fetch refs/pull/<n>/head into a collision-free local
-                        // branch (the `+` refspec force-updates, so reusing an
-                        // existing ref name would silently rewrite an unrelated
-                        // branch), then check it out via the plain
+                        // branch, then check it out via the plain
                         // existing-branch path. No fork remote is ever added.
                         //
                         // Decorated same-repo rows (prNumber set, checkoutPRHead
@@ -315,28 +315,22 @@ extension WorktreeLifecycle {
                         // Re-probe the chosen name immediately before the fetch,
                         // and keep the tri-state, for the same reason the other
                         // legs do: cleanup must be able to tell a branch this
-                        // attempt made from one that was already standing.
-                        //
-                        // This leg needs its own probe more than they do, and
-                        // gets less out of it. A `+` refspec force-updates, so
-                        // the fetch never refuses on a collision — git can never
-                        // say "a branch named … already exists" here, and
-                        // `cleanUpFailedWorktreeAdd`'s gate 1, the one that
-                        // closes the probe→attempt window on every other leg, is
-                        // therefore dead on this one. The probe is the only gate
-                        // left.
-                        //
-                        // What it buys, stated exactly: it **narrows** the
-                        // window to the gap between this call and the fetch's
-                        // ref write rather than closing it — a branch an
-                        // external actor creates inside that gap is still
-                        // indistinguishable from one the fetch made, and no
-                        // probe can fix that while the refspec is forced. What
-                        // it does close is the two states we can observe: a
-                        // branch already standing under this name (`true`) and a
-                        // probe that did not answer (`nil`) both block the
-                        // delete. Measuring also keeps the answer honest if
+                        // attempt made from one that was already standing. It
+                        // closes the two states we can observe — a branch
+                        // already standing under this name (`true`) and a probe
+                        // that did not answer (`nil`) both block the delete —
+                        // and keeps the answer honest if
                         // `uniqueLocalBranchName`'s contract ever loosens.
+                        //
+                        // The probe→fetch window is not its job to close, and it
+                        // cannot: a branch an external actor creates inside that
+                        // gap is invisible to a probe taken before it. That is
+                        // gate 1's job on every leg, and it works here because
+                        // `fetchPullRequestHead`'s refspec is unforced — git
+                        // rejects the update instead of rewriting the branch,
+                        // and `gitRefusedToCreateBranch` reads the rejection.
+                        // The residual is a collision the pull head *contains*,
+                        // which fast-forwards silently; see that method.
                         createdBranchPreExisted = try? await git.localBranchExists(
                             repoPath: repo.path, name: localBranch
                         )
@@ -833,25 +827,40 @@ extension WorktreeLifecycle {
         return .repoLevel
     }
 
-    /// True when git's stderr says it *refused to create* the branch because
-    /// the name was already taken ("fatal: a branch named 'x' already exists").
+    /// True when git's stderr says it *refused to write the ref* because the
+    /// name was already taken. Three phrasings mean it, all verified against
+    /// git 2.50 — the first from `worktree add -b`, the other two from the
+    /// fork-PR leg's `fetch refs/pull/<n>/head:refs/heads/<name>`:
+    ///
+    /// - `fatal: a branch named 'x' already exists`
+    /// - ` ! [rejected]  refs/pull/7/head -> x  (non-fast-forward)` — a fetch
+    ///   only ever rejects a destination ref that already exists, so the line
+    ///   says the same thing the `fatal:` one does.
+    /// - `fatal: refusing to fetch into branch 'refs/heads/x' checked out at
+    ///   '<path>'` — a ref cannot be checked out unless it exists.
     ///
     /// The one question `cleanUpFailedWorktreeAdd` cannot answer from its own
     /// bookkeeping: whether the branch standing there now is one this attempt
-    /// created. Git refusing to create it settles that — it isn't.
+    /// created. Git refusing to write it settles that — it isn't.
     ///
-    /// Matched loosely (any branch name, not just ours) on purpose. The two
-    /// ways to be wrong are not symmetric: failing to delete a branch we made
-    /// leaves a visible, recoverable `tbd/<name>`, while deleting one we did
-    /// not destroys work. So an unrecognized phrasing must land on "don't
-    /// delete", which is what a broad match buys.
+    /// Matched loosely (any branch name, not just ours) on purpose, and the
+    /// direction of that looseness is what makes widening it safe: every extra
+    /// match returns `true`, and `true` is the answer that *keeps* the branch.
+    /// The two ways to be wrong are not symmetric — failing to delete a branch
+    /// we made leaves a visible, recoverable `tbd/<name>`, while deleting one
+    /// we did not destroys work. So an unrecognized phrasing must land on
+    /// "don't delete", which is what a broad match buys. A gate that instead
+    /// *authorized* deletion would have to be narrow.
     ///
     /// Not `private`: the revive path's archived-SHA recreate (`-b <branch>
     /// <sha>` in `WorktreeLifecycle+Archive`) is the fourth `-b` call site and
     /// feeds the same gate to the same cleanup.
     func gitRefusedToCreateBranch(_ error: Error) -> Bool {
         guard let gitError = error as? GitError else { return false }
-        return gitError.stderr.lowercased().contains("a branch named")
+        let stderr = gitError.stderr.lowercased()
+        return stderr.contains("a branch named")
+            || stderr.contains("[rejected]")
+            || stderr.contains("refusing to fetch into branch")
     }
 
     /// True when git's stderr says the *branch name* is what is taken, as
@@ -891,9 +900,11 @@ extension WorktreeLifecycle {
     /// each one fails toward keeping it.**
     ///
     /// 1. `branchNameWasAlreadyTaken == false`. When git says "a branch named
-    ///    … already exists" it is telling us it *refused to create* the branch,
-    ///    which is positive evidence the branch predates this attempt — whoever
-    ///    made it. That is the gate that closes the probe→attempt window:
+    ///    … already exists" — or rejects the fork-PR leg's fetch, the same
+    ///    statement in that leg's vocabulary — it is telling us it *refused to
+    ///    write* the ref, which is positive evidence the branch predates this
+    ///    attempt, whoever made it. That is the gate that closes the
+    ///    probe→attempt window:
     ///    `branchPreExisted` is sampled before the add, so a branch created by
     ///    anything else in between would otherwise be indistinguishable from
     ///    one we made, and gate 2 alone would delete it.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -522,8 +522,12 @@ extension WorktreeLifecycle {
         //
         // A failed existence probe falls through to the old path rather than
         // failing creation: not knowing is not the same as knowing it's absent.
-        let branchExistsLocally = (try? await git.localBranchExists(repoPath: repoPath, name: branch)) ?? false
-        if userSpecifiedBranch && branchExistsLocally {
+        //
+        // The tri-state is kept (rather than collapsed with `?? false`) because
+        // failure cleanup needs it: `nil` means the probe itself failed, and a
+        // branch we cannot prove was absent beforehand must never be deleted.
+        let branchPreExisted: Bool? = try? await git.localBranchExists(repoPath: repoPath, name: branch)
+        if userSpecifiedBranch && branchPreExisted == true {
             do {
                 try await git.worktreeAddExisting(
                     repoPath: repoPath,
@@ -544,6 +548,8 @@ extension WorktreeLifecycle {
             }
         }
 
+        var lastKind: WorktreeAddFailureKind = .baseUnresolvable
+
         for baseBranch in baseBranches {
             do {
                 try await git.worktreeAdd(
@@ -555,9 +561,24 @@ extension WorktreeLifecycle {
                 return (name: name, branch: branch, path: worktreePath)
             } catch {
                 lastError = error
+                lastKind = classifyWorktreeAddFailure(error)
                 logger.warning("Failed to add worktree with base branch \(baseBranch, privacy: .public): \(String(describing: error), privacy: .public)")
-                // Clean up the directory if it was partially created
-                try? FileManager.default.removeItem(atPath: worktreePath)
+                await cleanUpFailedWorktreeAdd(
+                    repoPath: repoPath, worktreePath: worktreePath,
+                    branch: branch, branchPreExisted: branchPreExisted
+                )
+                if lastKind == .repoLevel {
+                    // Nothing downstream can help: not the other base, not a
+                    // fresh name. Surface git's own words instead of guessing.
+                    throw WorktreeLifecycleError.createFailed(
+                        "git worktree add failed\(repoLevelHint(error))\(formatErrorForMessage(error))"
+                    )
+                }
+                if lastKind == .nameCollision {
+                    // The name collides regardless of base, so the second base
+                    // would fail identically. A fresh name is the only remedy.
+                    break
+                }
             }
         }
 
@@ -566,7 +587,7 @@ extension WorktreeLifecycle {
         if userSpecifiedFolder || !retryGeneratedNameOnCollision {
             let errorDetail = lastError.flatMap { formatErrorForMessage($0) } ?? ""
             throw WorktreeLifecycleError.createFailed(
-                "git worktree add failed — the folder or branch may already exist\(errorDetail)"
+                "\(describeExhaustedBases(lastKind, baseBranches: baseBranches))\(errorDetail)"
             )
         }
 
@@ -580,6 +601,17 @@ extension WorktreeLifecycle {
             withIntermediateDirectories: true
         )
 
+        // The retry leg usually uses a DIFFERENT branch name, so it needs its
+        // own pre-existence answer: a freshly generated name that happens to
+        // collide with somebody's branch is exactly the case where deleting on
+        // failure would destroy work we did not create. When the name is
+        // unchanged (a user-specified branch is kept across the retry) the
+        // original probe still holds — the loop above deleted the branch only
+        // if it had created it.
+        let retryBranchPreExisted: Bool? = retryBranch == branch
+            ? branchPreExisted
+            : (try? await git.localBranchExists(repoPath: repoPath, name: retryBranch))
+
         for baseBranch in baseBranches {
             do {
                 try await git.worktreeAdd(
@@ -591,8 +623,17 @@ extension WorktreeLifecycle {
                 return (name: retryName, branch: retryBranch, path: retryPath)
             } catch {
                 lastError = error
+                lastKind = classifyWorktreeAddFailure(error)
                 logger.warning("Failed to add worktree with retry path and base branch \(baseBranch, privacy: .public): \(String(describing: error), privacy: .public)")
-                try? FileManager.default.removeItem(atPath: retryPath)
+                await cleanUpFailedWorktreeAdd(
+                    repoPath: repoPath, worktreePath: retryPath,
+                    branch: retryBranch, branchPreExisted: retryBranchPreExisted
+                )
+                if lastKind == .repoLevel {
+                    throw WorktreeLifecycleError.createFailed(
+                        "git worktree add failed\(repoLevelHint(error))\(formatErrorForMessage(error))"
+                    )
+                }
             }
         }
 
@@ -600,6 +641,110 @@ extension WorktreeLifecycle {
         throw WorktreeLifecycleError.createFailed(
             "git worktree add failed after all attempts\(errorDetail)"
         )
+    }
+
+    /// Why a `git worktree add` failed — and therefore which of the two
+    /// retries above can possibly help.
+    ///
+    /// Classification is a whitelist of known-recoverable stderr shapes;
+    /// anything unrecognized is `.repoLevel` and fails fast. That direction is
+    /// the safe one: an unclassifiable error retried under a second base and
+    /// then a second name manufactures orphan branches, while a recoverable
+    /// error misread as fatal merely surfaces git's real message.
+    enum WorktreeAddFailureKind {
+        /// The base ref did not resolve. The *next base branch* may — this is
+        /// exactly what the two-base loop exists for.
+        case baseUnresolvable
+        /// The branch name, the folder path, or the checkout is already taken.
+        /// Every base fails identically; only a *fresh name* can help.
+        case nameCollision
+        /// Anything else: a stale `.git/config.lock`, a corrupt repo, a full
+        /// disk. Neither another base nor another name changes the outcome.
+        case repoLevel
+    }
+
+    /// Classifies a `worktreeAdd` failure off `GitError.stderr`. A non-`GitError`
+    /// (spawn failure, timeout) is `.repoLevel` — it says nothing about the
+    /// base or the name.
+    private func classifyWorktreeAddFailure(_ error: Error) -> WorktreeAddFailureKind {
+        guard let gitError = error as? GitError else { return .repoLevel }
+        let stderr = gitError.stderr.lowercased()
+
+        // "fatal: invalid reference: origin/main"
+        // "fatal: not a valid object name: 'origin/main'"
+        // "fatal: ambiguous argument 'origin/main': unknown revision or path
+        //  not in the working tree."
+        if stderr.contains("invalid reference")
+            || stderr.contains("not a valid object name")
+            || stderr.contains("unknown revision") {
+            return .baseUnresolvable
+        }
+
+        // "fatal: a branch named 'tbd/quiet-fox' already exists"
+        // "fatal: '../w3' already exists"
+        // "fatal: 'main' is already used by worktree at '/path/to/wt'"
+        if stderr.contains("already exists")
+            || stderr.contains("is already used by worktree at") {
+            return .nameCollision
+        }
+
+        return .repoLevel
+    }
+
+    /// Cleans up whatever a single failed `worktreeAdd` attempt left behind.
+    ///
+    /// Three things, in order: the partially-written directory, any worktree
+    /// registration git recorded before failing, and — only when we positively
+    /// know the branch was absent beforehand and is present now — the branch
+    /// `-b` created. Git can fail *after* creating the branch (a stale
+    /// `.git/config.lock` makes the upstream-config write fail while the branch
+    /// stands), which is how a failed create used to leak a `tbd/<name>` branch
+    /// and then mask the real cause behind "a branch named … already exists" on
+    /// the next attempt.
+    ///
+    /// `branchPreExisted == nil` means the probe itself failed. Not knowing is
+    /// not the same as knowing it's absent, so nothing is deleted.
+    private func cleanUpFailedWorktreeAdd(
+        repoPath: String,
+        worktreePath: String,
+        branch: String,
+        branchPreExisted: Bool?
+    ) async {
+        try? FileManager.default.removeItem(atPath: worktreePath)
+        try? await git.worktreePrune(repoPath: repoPath)
+
+        guard branchPreExisted == false else { return }
+        guard (try? await git.localBranchExists(repoPath: repoPath, name: branch)) == true else {
+            return
+        }
+        do {
+            try await git.deleteLocalBranch(repoPath: repoPath, name: branch)
+            logger.info("Deleted branch \(branch, privacy: .public) left behind by a failed worktree add")
+        } catch {
+            logger.warning("Failed to delete branch \(branch, privacy: .public) left behind by a failed worktree add: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    /// Message for "both base branches were tried and none worked", worded to
+    /// match what actually went wrong rather than always guessing collision.
+    private func describeExhaustedBases(
+        _ kind: WorktreeAddFailureKind, baseBranches: [String]
+    ) -> String {
+        switch kind {
+        case .baseUnresolvable:
+            return "git worktree add failed — no usable base branch (tried \(baseBranches.joined(separator: ", ")))"
+        case .nameCollision, .repoLevel:
+            return "git worktree add failed — the folder or branch may already exist"
+        }
+    }
+
+    /// A hint for the one repo-level failure a user can clear themselves.
+    private func repoLevelHint(_ error: Error) -> String {
+        guard let gitError = error as? GitError,
+              gitError.stderr.lowercased().contains("could not lock config file") else {
+            return ""
+        }
+        return " — a stale .git/config.lock in the repo can be deleted once no git process is holding it"
     }
 
     /// Formats an error for inclusion in a user-facing message, truncated to ~500 chars.

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Create.swift
@@ -312,12 +312,35 @@ extension WorktreeLifecycle {
                         let localBranch = try await uniqueLocalBranchName(
                             repoPath: repo.path, base: worktree.branch
                         )
-                        // `uniqueLocalBranchName` returns only a name whose
-                        // `refs/heads/<name>` does not exist — it throws rather
-                        // than hand back a taken one — so the fetch below is the
-                        // only thing that can have created it.
+                        // Re-probe the chosen name immediately before the fetch,
+                        // and keep the tri-state, for the same reason the other
+                        // legs do: cleanup must be able to tell a branch this
+                        // attempt made from one that was already standing.
+                        //
+                        // This leg needs its own probe more than they do, and
+                        // gets less out of it. A `+` refspec force-updates, so
+                        // the fetch never refuses on a collision — git can never
+                        // say "a branch named … already exists" here, and
+                        // `cleanUpFailedWorktreeAdd`'s gate 1, the one that
+                        // closes the probe→attempt window on every other leg, is
+                        // therefore dead on this one. The probe is the only gate
+                        // left.
+                        //
+                        // What it buys, stated exactly: it **narrows** the
+                        // window to the gap between this call and the fetch's
+                        // ref write rather than closing it — a branch an
+                        // external actor creates inside that gap is still
+                        // indistinguishable from one the fetch made, and no
+                        // probe can fix that while the refspec is forced. What
+                        // it does close is the two states we can observe: a
+                        // branch already standing under this name (`true`) and a
+                        // probe that did not answer (`nil`) both block the
+                        // delete. Measuring also keeps the answer honest if
+                        // `uniqueLocalBranchName`'s contract ever loosens.
+                        createdBranchPreExisted = try? await git.localBranchExists(
+                            repoPath: repo.path, name: localBranch
+                        )
                         branchCreatedByThisAttempt = localBranch
-                        createdBranchPreExisted = false
                         try await git.fetchPullRequestHead(
                             repoPath: repo.path, number: prNumber, localBranch: localBranch
                         )

--- a/Tests/TBDDaemonTests/GitManagerNonASCIIPathTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerNonASCIIPathTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+
+/// Resolves symlinks the way git's `worktree list --porcelain` does. Foundation's
+/// `URL.resolvingSymlinksInPath()` does NOT follow macOS's `/var` →
+/// `/private/var` symlink; C `realpath()` does, and git reports the resolved
+/// form, so fixtures must canonicalize before comparing.
+private func canonicalPath(_ path: String) -> String {
+    guard let cReal = realpath(path, nil) else { return path }
+    defer { free(cReal) }
+    return String(cString: cReal)
+}
+
+/// Tier 2 (real `git` subprocesses, real filesystem, no `~/tbd`).
+///
+/// `GitManager.run` pins `LC_ALL=C` / `LANG=C` on every git subprocess so that
+/// stderr phrasing stays stable for the destructive failed-create cleanup gate.
+/// That pin also sets `LC_CTYPE`, which raises a fair question: does it push git
+/// into octal-escaping non-ASCII bytes in the porcelain output this file's
+/// parsers consume? None of those parsers decode `\303\251`-style escapes, so an
+/// escaped path or branch name would silently become a *wrong* value rather than
+/// a failure — the orphan-GC sweep would stop recognizing its own worktrees, and
+/// the branch picker would offer names that cannot be checked out.
+///
+/// Measured answer: no. `worktree list --porcelain` and `for-each-ref` emit raw
+/// UTF-8 bytes with and without the pin; the escaping that *does* happen in
+/// `status --porcelain` is `core.quotePath` (default true), which is
+/// locale-independent and predates this pin — and neither `status` consumer
+/// parses paths out of that output anyway.
+///
+/// This suite pins that as a property instead of a transcript. Every assertion
+/// is a **round trip**: the value GitManager returns must equal the exact
+/// non-ASCII string the fixture created. Emptiness checks would pass just as
+/// happily against `caf\303\251`, so they are deliberately not what is asserted.
+///
+/// (Swift's `String` equality is Unicode canonical equivalence, so an NFC/NFD
+/// difference introduced by the filesystem compares equal — while an octal
+/// escape, being plain ASCII backslashes and digits, does not.)
+@Suite("GitManager non-ASCII paths and refs")
+struct GitManagerNonASCIIPathTests {
+    /// Directory name for the linked worktree — Latin-1 accents plus CJK.
+    static let worktreeFolder = "wt-café-日本"
+    /// Branch checked out in that worktree.
+    static let checkedOutBranch = "feature/naïve"
+    /// Branch that exists but is checked out nowhere, so `listBranches`'
+    /// in-use filter keeps it.
+    static let idleBranch = "expérience/日本"
+    /// Untracked file used to dirty the worktree.
+    static let untrackedFile = "café-日本.txt"
+
+    let tempDir: URL
+    let repoDir: URL
+    let worktreeDir: URL
+
+    init() async throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-nonascii-git-\(UUID().uuidString)")
+        repoDir = tempDir.appendingPathComponent("repo")
+        worktreeDir = tempDir.appendingPathComponent(Self.worktreeFolder)
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+
+        try await shell("git init -q -b main && git commit -q --allow-empty -m 'init'", at: repoDir)
+        try await shell(
+            "git worktree add -q -b '\(Self.checkedOutBranch)' '\(worktreeDir.path)'",
+            at: repoDir
+        )
+        try await shell("git branch '\(Self.idleBranch)'", at: repoDir)
+    }
+
+    private func cleanup() {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    // MARK: - Tests
+
+    @Test("worktreeList round-trips a non-ASCII path and branch")
+    func worktreeListRoundTripsNonASCII() async throws {
+        defer { cleanup() }
+        let expectedPath = canonicalPath(worktreeDir.path)
+
+        let entries = try await GitManager().worktreeList(repoPath: repoDir.path)
+        let entry = try #require(
+            entries.first { $0.path == expectedPath },
+            "No worktree entry matched \(expectedPath); got \(entries.map(\.path))"
+        )
+        #expect(entry.branch == Self.checkedOutBranch)
+        // An octal-escaped path or ref would be pure ASCII backslash sequences.
+        #expect(!entry.path.contains("\\"))
+        #expect(!entry.branch.contains("\\"))
+    }
+
+    @Test("worktreeListDetailed round-trips a non-ASCII path and branch")
+    func worktreeListDetailedRoundTripsNonASCII() async throws {
+        defer { cleanup() }
+        let expectedPath = canonicalPath(worktreeDir.path)
+
+        let entries = try await GitManager().worktreeListDetailed(repoPath: repoDir.path)
+        let entry = try #require(
+            entries.first { $0.path == expectedPath },
+            "No detailed entry matched \(expectedPath); got \(entries.map(\.path))"
+        )
+        #expect(entry.branch == Self.checkedOutBranch)
+        #expect(entry.headSHA.count == 40)
+        #expect(!entry.path.contains("\\"))
+    }
+
+    @Test("listBranches round-trips a non-ASCII branch name")
+    func listBranchesRoundTripsNonASCII() async throws {
+        defer { cleanup() }
+
+        let refs = try await GitManager().listBranches(repoPath: repoDir.path)
+        let names = refs.map(\.name)
+        let idle = try #require(
+            refs.first { $0.name == Self.idleBranch },
+            "Expected \(Self.idleBranch) among \(names)"
+        )
+        #expect(idle.isRemote == false)
+        #expect(idle.localName == Self.idleBranch)
+        #expect(!idle.name.contains("\\"))
+    }
+
+    /// Cross-parser round trip: `listBranches` drops branches already checked
+    /// out by comparing `for-each-ref` short names against the branch names
+    /// `worktreeList` parsed out of the porcelain. If either side escaped its
+    /// non-ASCII bytes and the other did not, the two spellings would stop
+    /// matching and the taken branch would be offered as available.
+    @Test("listBranches filters a non-ASCII branch that a worktree already holds")
+    func listBranchesFiltersNonASCIIInUseBranch() async throws {
+        defer { cleanup() }
+
+        let names = try await GitManager().listBranches(repoPath: repoDir.path).map(\.name)
+        #expect(
+            !names.contains(Self.checkedOutBranch),
+            "\(Self.checkedOutBranch) is checked out in a worktree and must be filtered; got \(names)"
+        )
+    }
+
+    /// `isDirty` and `hasUncommittedChanges` only test `status --porcelain` for
+    /// emptiness, so they cannot be sensitive to how the path inside is spelled.
+    /// What they *can* get wrong is the verdict, so both arms are asserted: a
+    /// clean worktree must read clean, and a worktree dirtied only by a
+    /// non-ASCII-named file must read dirty. (That file's name is what
+    /// `core.quotePath` octal-escapes in the output — locale-independently, with
+    /// or without the pin — which is exactly the escaping no parser here reads.)
+    @Test("dirty checks report both arms for a non-ASCII filename")
+    func dirtyChecksReportBothArmsForNonASCIIFilename() async throws {
+        defer { cleanup() }
+        let git = GitManager()
+
+        let cleanIsDirty = await git.isDirty(worktreePath: worktreeDir.path)
+        #expect(cleanIsDirty == false)
+        let cleanHasChanges = try await git.hasUncommittedChanges(repoPath: worktreeDir.path)
+        #expect(cleanHasChanges == false)
+
+        try Data("x".utf8).write(
+            to: worktreeDir.appendingPathComponent(Self.untrackedFile)
+        )
+
+        let dirtyIsDirty = await git.isDirty(worktreePath: worktreeDir.path)
+        #expect(dirtyIsDirty == true)
+        let dirtyHasChanges = try await git.hasUncommittedChanges(repoPath: worktreeDir.path)
+        #expect(dirtyHasChanges == true)
+    }
+}

--- a/Tests/TBDDaemonTests/GitManagerTests.swift
+++ b/Tests/TBDDaemonTests/GitManagerTests.swift
@@ -249,6 +249,52 @@ struct GitManagerTests {
         cleanup()
     }
 
+    // MARK: - Subprocess environment
+
+    /// Tier 2. Git's stderr is safety-critical here — `WorktreeLifecycle`'s
+    /// failed-create cleanup decides whether it may delete a branch by matching
+    /// English phrases in it — so the locale every git child runs under is
+    /// pinned rather than inherited.
+    ///
+    /// Driven through the same `run()` wrapper production calls use (via the
+    /// package-internal timeout seam, pointed at `/bin/sh` instead of git) so
+    /// this asserts what actually reaches the child process, not what a helper
+    /// returns. Asserting the inherited `HOME` in the same breath is the
+    /// load-bearing half: pinning by *replacing* the environment instead of
+    /// merging onto it would strip `HOME`, `PATH` and `SSH_AUTH_SOCK` from
+    /// every git call the daemon makes — the tmux-launch-`PATH` regression, one
+    /// subsystem over. `HOME` and not `PATH` because a POSIX shell invents a
+    /// default `PATH` when it finds none, which would mask the replacement.
+    @Test func gitSubprocessesInheritTheEnvironmentWithTheLocalePinned() async throws {
+        defer { cleanup() }
+        let inheritedHome = ProcessInfo.processInfo.environment["HOME"] ?? ""
+        let output = try await git.runForTimeoutTesting(
+            executable: "/bin/sh",
+            arguments: ["-c", #"printf '%s|%s|%s' "$LC_ALL" "$LANG" "$HOME""#],
+            at: repoDir.path
+        )
+        #expect(output == "C|C|\(inheritedHome)",
+                "git subprocess environment was not pinned-and-inherited: \(output)")
+    }
+
+    /// The composition itself, including the case the process environment
+    /// cannot produce on demand: a hostile locale already set. Both arms —
+    /// hostile values overridden, unrelated values untouched.
+    @Test func gitEnvironmentOverridesAHostileLocaleAndKeepsEverythingElse() {
+        let composed = GitManager.gitEnvironment(inheriting: [
+            "LANG": "fr_FR.UTF-8",
+            "LC_ALL": "fr_FR.UTF-8",
+            "PATH": "/opt/homebrew/bin:/usr/bin",
+            "HOME": "/Users/test",
+            "SSH_AUTH_SOCK": "/tmp/agent.sock",
+        ])
+        #expect(composed["LC_ALL"] == "C")
+        #expect(composed["LANG"] == "C")
+        #expect(composed["PATH"] == "/opt/homebrew/bin:/usr/bin")
+        #expect(composed["HOME"] == "/Users/test")
+        #expect(composed["SSH_AUTH_SOCK"] == "/tmp/agent.sock")
+    }
+
     // MARK: - Helpers
 
     func cleanup() {

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -611,7 +611,7 @@ import Testing
     }
 
     /// The fork-PR leg creates a fresh local branch of its own (the fetch's
-    /// `+refs/pull/<n>/head:refs/heads/<name>` refspec), so a failure in the
+    /// `refs/pull/<n>/head:refs/heads/<name>` refspec), so a failure in the
     /// checkout that follows leaks it just the same. The name comes from
     /// `uniqueLocalBranchName`, so it is never one the caller brought.
     @Test func failedPullRequestCheckoutLeavesNoBranchBehind() async throws {
@@ -645,9 +645,9 @@ import Testing
     }
 
     /// The same leg's pre-existence answer must be a *measurement of the name it
-    /// is about to force-fetch into*, not an inherited claim about some other
-    /// name. `uniqueLocalBranchName` hands back `pr-7-2` here because `pr-7` is
-    /// taken, and the probe that gates the delete has to follow it: aimed at
+    /// is about to fetch into*, not an inherited claim about some other name.
+    /// `uniqueLocalBranchName` hands back `pr-7-2` here because `pr-7` is taken,
+    /// and the probe that gates the delete has to follow it: aimed at
     /// `worktree.branch` instead it answers `true`, blocks the delete, and leaks
     /// the branch the fetch really did create.
     ///
@@ -657,10 +657,10 @@ import Testing
     /// `createdBranchPreExisted = true`, each leak `pr-7-2`.
     ///
     /// The caller's `pr-7` standing untouched afterwards is the other half. The
-    /// force refspec rewrote nothing here because the uniquifier steered around
-    /// it, and the cleanup deleted nothing of the caller's because the probe it
-    /// ran was about `pr-7-2`.
-    @Test func pullRequestLegProbesTheBranchItForceFetchesInto() async throws {
+    /// fetch never aimed at it because the uniquifier steered around it, and the
+    /// cleanup deleted nothing of the caller's because the probe it ran was
+    /// about `pr-7-2`.
+    @Test func pullRequestLegProbesTheBranchItFetchesInto() async throws {
         let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo(
             pullRequestHeads: [7]
         )
@@ -701,12 +701,11 @@ import Testing
     /// fetch's ref write, and `nil` needs the probe to fail in that same gap
     /// after `uniqueLocalBranchName`'s identical probe had just succeeded.
     ///
-    /// `branchNameWasAlreadyTaken` is pinned `false` in all three cases because
-    /// that is the only value this leg can produce: its `+refs/pull/<n>/head`
-    /// refspec force-updates, so git never refuses on a collision and never says
-    /// "a branch named … already exists". The probe is the whole gate here, so
-    /// all three arms are asserted — `false` must still delete, or the gate
-    /// would just be a synonym for "never clean up".
+    /// `branchNameWasAlreadyTaken` is pinned `false` in all three cases so the
+    /// probe is the only thing under test; the other gate has its own coverage
+    /// in `aRefusedPullRequestFetchKeepsTheBranchItDidNotCreate`. All three arms
+    /// are asserted — `false` must still delete, or the gate would just be a
+    /// synonym for "never clean up".
     ///
     /// Asserts preserved cleanup behavior, so it is mutation-checked: dropping
     /// the `branchPreExisted == false` guard in `cleanUpFailedWorktreeAdd`
@@ -741,6 +740,139 @@ import Testing
                 "cleanup deleted a branch whose pre-existence was unknown: \(branches)")
         #expect(!branches.contains("fetched-by-this-attempt"),
                 "cleanup left behind the branch the fetch created: \(branches)")
+    }
+
+    /// Runs `body`, expecting it to fail with a `GitError`, and hands back
+    /// git's own error. Real stderr is the point: these tests exist to pin what
+    /// `gitRefusedToCreateBranch` reads, and a hand-written string would pin
+    /// only the test author's memory of it.
+    private func gitErrorFrom(
+        _ what: String, _ body: () async throws -> Void
+    ) async throws -> GitError {
+        do {
+            try await body()
+        } catch let error as GitError {
+            return error
+        }
+        Issue.record("\(what) was expected to fail with a GitError and did not")
+        throw CancellationError()
+    }
+
+    /// Gate 1 on the fork-PR leg, which is the whole reason the fetch refspec is
+    /// unforced. A branch that appears in the window between the probe and the
+    /// fetch's ref write is invisible to the probe — `branchPreExisted` is
+    /// `false`, the arm that authorizes deletion — so git's refusal is the only
+    /// thing standing between that branch and `branch -D`.
+    ///
+    /// Red against a `+`-forced refspec twice over: the fetch succeeds, so there
+    /// is no refusal to read, and the branch is already rewritten by the time
+    /// cleanup runs.
+    @Test func aRefusedPullRequestFetchKeepsTheBranchItDidNotCreate() async throws {
+        let (parentDir, _, repoDir) = try await makeClonedTestRepo(pullRequestHeads: [7])
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let git = GitManager()
+
+        // Someone else's branch, carrying a commit the pull head does not have,
+        // standing under the name this attempt is about to fetch into.
+        try await shell(
+            "git checkout -q -b raced && git commit --allow-empty -m 'their work'"
+            + " && git checkout -q main",
+            at: repoDir
+        )
+        let originalSHA = try await git.headSHA(repoPath: repoDir.path, ref: "refs/heads/raced")
+
+        let refusal = try await gitErrorFrom("the pull-head fetch into an occupied branch name") {
+            try await git.fetchPullRequestHead(repoPath: repoDir.path, number: 7, localBranch: "raced")
+        }
+        #expect(lifecycle.gitRefusedToCreateBranch(refusal),
+                "git's refusal was not recognized as one: \(refusal.stderr)")
+
+        await lifecycle.cleanUpFailedWorktreeAdd(
+            repoPath: repoDir.path,
+            worktreePath: parentDir.appendingPathComponent("never-created").path,
+            branch: "raced",
+            branchPreExisted: false,
+            branchNameWasAlreadyTaken: lifecycle.gitRefusedToCreateBranch(refusal)
+        )
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("raced"),
+                "cleanup deleted a branch git had refused to write: \(branches)")
+        let afterSHA = try await git.headSHA(repoPath: repoDir.path, ref: "refs/heads/raced")
+        #expect(afterSHA == originalSHA,
+                "the refused fetch still moved the branch: \(originalSHA) -> \(afterSHA)")
+    }
+
+    /// Every arm of that gate, against stderr git actually produced. Three
+    /// phrasings must read as "this attempt did not write the ref", and a
+    /// failure about the *path* must not — that one leaves a branch `-b` really
+    /// did create, and answering `true` there would resurrect the leak
+    /// `cleanUpFailedWorktreeAdd` exists to stop.
+    @Test func everyPhrasingOfGitsRefusalToWriteABranchIsRecognized() async throws {
+        let (parentDir, _, repoDir) = try await makeClonedTestRepo(pullRequestHeads: [7])
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let git = GitManager()
+        let scratch = parentDir.appendingPathComponent("scratch")
+
+        // 1. `worktree add -b <taken>` — "fatal: a branch named 'x' already exists".
+        try await shell("git branch taken-branch", at: repoDir)
+        let nameTaken = try await gitErrorFrom("worktree add -b onto a taken branch name") {
+            try await git.worktreeAdd(
+                repoPath: repoDir.path, worktreePath: scratch.appendingPathComponent("a").path,
+                branch: "taken-branch", baseBranch: "main"
+            )
+        }
+        #expect(lifecycle.gitRefusedToCreateBranch(nameTaken), "unrecognized: \(nameTaken.stderr)")
+
+        // 2. The fetch's refspec rejection — "! [rejected] … (non-fast-forward)".
+        try await shell(
+            "git checkout -q -b divergent && git commit --allow-empty -m 'theirs'"
+            + " && git checkout -q main",
+            at: repoDir
+        )
+        let rejected = try await gitErrorFrom("the pull-head fetch into a divergent branch") {
+            try await git.fetchPullRequestHead(
+                repoPath: repoDir.path, number: 7, localBranch: "divergent"
+            )
+        }
+        #expect(lifecycle.gitRefusedToCreateBranch(rejected), "unrecognized: \(rejected.stderr)")
+
+        // 3. The fetch refusing a branch checked out elsewhere — a different
+        //    exit code and a different sentence, and (verified against git
+        //    2.50) raised whether or not the update would fast-forward.
+        try await shell(
+            "git worktree add -b checked-out-elsewhere '\(scratch.appendingPathComponent("b").path)' main",
+            at: repoDir
+        )
+        let checkedOut = try await gitErrorFrom("the pull-head fetch into a checked-out branch") {
+            try await git.fetchPullRequestHead(
+                repoPath: repoDir.path, number: 7, localBranch: "checked-out-elsewhere"
+            )
+        }
+        #expect(lifecycle.gitRefusedToCreateBranch(checkedOut), "unrecognized: \(checkedOut.stderr)")
+
+        // 4. The negative arm: an occupied *path*, where git creates the branch
+        //    and then fails. Recognizing this one would leak `made-by-us`.
+        let occupied = scratch.appendingPathComponent("c").path
+        try occupy(occupied)
+        let pathTaken = try await gitErrorFrom("worktree add onto an occupied path") {
+            try await git.worktreeAdd(
+                repoPath: repoDir.path, worktreePath: occupied,
+                branch: "made-by-us", baseBranch: "main"
+            )
+        }
+        #expect(!lifecycle.gitRefusedToCreateBranch(pathTaken),
+                "a failure about the path was read as a refusal to write the branch: \(pathTaken.stderr)")
+
+        // And the non-git arm: anything that isn't a `GitError` says nothing
+        // about who wrote the ref, so it cannot license a delete either.
+        #expect(!lifecycle.gitRefusedToCreateBranch(CancellationError()))
     }
 
     /// The third leg of the same `catch` creates NOTHING — it checks out a

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -644,6 +644,105 @@ import Testing
                 "the PR-head checkout leaked the branch it fetched: \(branches)")
     }
 
+    /// The same leg's pre-existence answer must be a *measurement of the name it
+    /// is about to force-fetch into*, not an inherited claim about some other
+    /// name. `uniqueLocalBranchName` hands back `pr-7-2` here because `pr-7` is
+    /// taken, and the probe that gates the delete has to follow it: aimed at
+    /// `worktree.branch` instead it answers `true`, blocks the delete, and leaks
+    /// the branch the fetch really did create.
+    ///
+    /// Asserts preserved behavior — the unfixed tree hardcodes `false`, which
+    /// cleans up here too — so it is mutation-checked twice: probing
+    /// `worktree.branch` rather than `localBranch`, and hardcoding
+    /// `createdBranchPreExisted = true`, each leak `pr-7-2`.
+    ///
+    /// The caller's `pr-7` standing untouched afterwards is the other half. The
+    /// force refspec rewrote nothing here because the uniquifier steered around
+    /// it, and the cleanup deleted nothing of the caller's because the probe it
+    /// ran was about `pr-7-2`.
+    @Test func pullRequestLegProbesTheBranchItForceFetchesInto() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo(
+            pullRequestHeads: [7]
+        )
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        // The caller's own `pr-7`, which pushes the fetch onto `pr-7-2`.
+        try await shell("git branch pr-7", at: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id, branch: "pr-7", skipClaude: true,
+            useExistingBranch: true, prNumber: 7
+        )
+        // Fail the checkout that follows the fetch, so cleanup runs with the
+        // fetched branch already created.
+        try occupy(pending.localPath)
+
+        await #expect(throws: WorktreeLifecycleError.self) {
+            _ = try await lifecycle.completeCreateWorktree(
+                worktreeID: pending.id, skipClaude: true,
+                existingBranchRef: "pr-7", checkoutPRHead: true
+            )
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(!branches.contains("pr-7-2"),
+                "the uniquified branch this attempt fetched was not cleaned up: \(branches)")
+        #expect(branches.contains("pr-7"),
+                "cleanup deleted the branch the caller brought: \(branches)")
+    }
+
+    /// The two arms of that tri-state which *block* the delete, driven at the
+    /// cleanup boundary because neither is reachable end to end on this leg:
+    /// `true` needs a branch to appear inside the gap between the probe and the
+    /// fetch's ref write, and `nil` needs the probe to fail in that same gap
+    /// after `uniqueLocalBranchName`'s identical probe had just succeeded.
+    ///
+    /// `branchNameWasAlreadyTaken` is pinned `false` in all three cases because
+    /// that is the only value this leg can produce: its `+refs/pull/<n>/head`
+    /// refspec force-updates, so git never refuses on a collision and never says
+    /// "a branch named … already exists". The probe is the whole gate here, so
+    /// all three arms are asserted — `false` must still delete, or the gate
+    /// would just be a synonym for "never clean up".
+    ///
+    /// Asserts preserved cleanup behavior, so it is mutation-checked: dropping
+    /// the `branchPreExisted == false` guard in `cleanUpFailedWorktreeAdd`
+    /// deletes both branches this test expects to survive.
+    @Test func aPullRequestBranchTheFetchDidNotCreateIsNeverDeleted() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        try await shell("git branch already-standing", at: repoDir)
+        try await shell("git branch probe-did-not-answer", at: repoDir)
+        try await shell("git branch fetched-by-this-attempt", at: repoDir)
+
+        let neverCreated = tempDir.appendingPathComponent("never-created").path
+        for (branch, preExisted) in [
+            ("already-standing", true), ("probe-did-not-answer", nil), ("fetched-by-this-attempt", false),
+        ] as [(String, Bool?)] {
+            await lifecycle.cleanUpFailedWorktreeAdd(
+                repoPath: repoDir.path,
+                worktreePath: neverCreated,
+                branch: branch,
+                branchPreExisted: preExisted,
+                branchNameWasAlreadyTaken: false
+            )
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("already-standing"),
+                "cleanup deleted a branch that was standing before the fetch: \(branches)")
+        #expect(branches.contains("probe-did-not-answer"),
+                "cleanup deleted a branch whose pre-existence was unknown: \(branches)")
+        #expect(!branches.contains("fetched-by-this-attempt"),
+                "cleanup left behind the branch the fetch created: \(branches)")
+    }
+
     /// The third leg of the same `catch` creates NOTHING — it checks out a
     /// branch the caller owns — so it must delete nothing. The hard constraint
     /// of this fix, and the one whose failure destroys a user's work.

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -703,6 +703,9 @@ import Testing
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = makeLifecycle(db: db)
         let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+        let tipsBefore = try await GitManager().refTips(repoPath: repoDir.path)
+        #expect(tipsBefore["pending"] == nil,
+                "the unborn-branch setup dissolved — `pending` is a real ref: \(tipsBefore)")
 
         do {
             _ = try await lifecycle.createWorktree(
@@ -715,7 +718,115 @@ import Testing
                     "the collision was not attributed to the branch name: \(text)")
             #expect(!text.contains("after all attempts"),
                     "the same branch name was retried under a fresh folder: \(text)")
+            // The premise of everything below: git's stderr carries ONLY the
+            // worktree-claim phrasing, which `cleanUpFailedWorktreeAdd`'s first
+            // gate deliberately does not match. Were git to say "a branch named
+            // …" here instead, that gate would block the delete and this test
+            // would be covering a different path than it claims.
+            #expect(text.contains("is already used by worktree at"),
+                    "git did not report the claim this test exists to cover: \(text)")
+            #expect(!text.lowercased().contains("a branch named"),
+                    "gate 1 matched, so the delete was blocked before its own gates: \(text)")
         }
+
+        let base = WorktreeLayout().basePath(for: repo)
+        let survivors = (try? FileManager.default.contentsOfDirectory(atPath: base)) ?? []
+        #expect(survivors.isEmpty, "failed create left worktree directories: \(survivors)")
+
+        // The branch half of the same failure, which the gates above do not
+        // guard. `-b` created `refs/heads/pending` at the base tip *before* git
+        // discovered the claim, so the ref standing afterwards is this
+        // attempt's own — never a branch someone else made. What makes that
+        // sound rather than lucky is the phrasing split asserted above:
+        // verified against git 2.50, "is already used by worktree at" is
+        // reachable only while the ref is absent, because once
+        // `refs/heads/pending` exists the same command answers "a branch named
+        // 'pending' already exists" instead.
+        //
+        // It stands rather than being cleaned up because the live main checkout
+        // holds it: `git branch -D` answers "cannot delete branch 'pending'
+        // used by worktree at …", the cleanup logs that and moves on. The
+        // sibling test covers the shape where the delete does go through.
+        let tipsAfter = try await GitManager().refTips(repoPath: repoDir.path)
+        expectPreExistingRefsSurvived(before: tipsBefore, after: tipsAfter)
+        let created = tipsAfter["pending"] ?? "absent"
+        let baseTip = tipsBefore["origin/main"] ?? "absent"
+        #expect(tipsAfter["pending"] == tipsBefore["origin/main"],
+                "`pending` is not the base-tip ref this attempt's `-b` created: \(created) vs base \(baseTip)")
+    }
+
+    /// Every ref that predates a failed create must still stand, unchanged.
+    /// The whole point of `cleanUpFailedWorktreeAdd`'s gates is that it deletes
+    /// only what the attempt itself made.
+    private func expectPreExistingRefsSurvived(
+        before: [String: String], after: [String: String]
+    ) {
+        for (name, sha) in before {
+            let observed = after[name] ?? "deleted"
+            #expect(after[name] == sha,
+                    "the failed create disturbed the pre-existing ref \(name): \(observed) (was \(sha))")
+        }
+    }
+
+    /// The same stderr split, in the shape where the branch delete is not
+    /// refused — so what the cleanup deletes, and what it leaves alone, is
+    /// directly observable.
+    ///
+    /// A *stale* registration claims the unborn `pending` (a linked worktree
+    /// moved onto an orphan branch, then its directory removed), so `git
+    /// worktree add … -b pending origin/main` still fails with "'pending' is
+    /// already used by worktree at …" while `refs/heads/pending` does not
+    /// exist. All three of `cleanUpFailedWorktreeAdd`'s gates therefore hold,
+    /// the prune drops the dead registration, and `git branch -D` succeeds on
+    /// the branch `-b` had just created.
+    ///
+    /// Mutation-checked: widening gate 1 to match "is already used by worktree
+    /// at" as well makes the cleanup return early and leaks `pending`.
+    @Test func anUnbornBranchClaimDeletesOnlyTheBranchTheAttemptCreated() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        // A branch off the base tip, so "left alone" is provable against a SHA
+        // the failed attempt could not have produced.
+        try await shell(
+            "git checkout -b keepsake && git commit --allow-empty -m keepsake"
+            + " && git checkout main",
+            at: repoDir
+        )
+
+        let claimer = parentDir.appendingPathComponent("claimer")
+        try await shell("git worktree add -b claimed '\(claimer.path)' main", at: repoDir)
+        try await shell("git checkout --orphan pending", at: claimer)
+        try await shell("git branch -D claimed", at: repoDir)
+        // Directory gone, registration kept: git still honours the claim, and
+        // the cleanup's prune is what clears it.
+        try FileManager.default.removeItem(at: claimer)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+        let tipsBefore = try await GitManager().refTips(repoPath: repoDir.path)
+        #expect(tipsBefore["pending"] == nil,
+                "the unborn-branch setup dissolved — `pending` is a real ref: \(tipsBefore)")
+
+        do {
+            _ = try await lifecycle.createWorktree(
+                repoID: repo.id, branch: "pending", skipClaude: true
+            )
+            Issue.record("expected a claimed branch name to fail the create")
+        } catch {
+            let text = String(describing: error)
+            #expect(text.contains("is already used by worktree at"),
+                    "git did not report the claim this test exists to cover: \(text)")
+            #expect(!text.lowercased().contains("a branch named"),
+                    "gate 1 matched, so the delete was blocked before its own gates: \(text)")
+        }
+
+        let tipsAfter = try await GitManager().refTips(repoPath: repoDir.path)
+        let leaked = tipsAfter["pending"] ?? "absent"
+        #expect(tipsAfter["pending"] == nil,
+                "the branch this attempt's `-b` created leaked: pending → \(leaked)")
+        expectPreExistingRefsSurvived(before: tipsBefore, after: tipsAfter)
 
         let base = WorktreeLayout().basePath(for: repo)
         let survivors = (try? FileManager.default.contentsOfDirectory(atPath: base)) ?? []

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -111,6 +111,14 @@ import Testing
         )
     }
 
+    /// The SHA a local branch currently points at — what a caller hands the
+    /// cleanup as the attempt's `expectedTip` when some *other* gate is what
+    /// the test means to put under load. Passing the branch's own tip makes
+    /// gate 4 hold, so it neither masks nor manufactures the outcome.
+    private func tip(of branch: String, in repoDir: URL) async throws -> String {
+        try await GitManager().headSHA(repoPath: repoDir.path, ref: "refs/heads/\(branch)")
+    }
+
     // MARK: - Bug 1: a failed create must not leak the branch it just made
 
     /// Jammed for BOTH bases: a lock that stops only the remote base is now
@@ -452,18 +460,27 @@ import Testing
         try await shell("git branch appeared-mid-flight", at: repoDir)
         try await shell("git branch ours-to-clean-up", at: repoDir)
 
+        // Both branches were cut from the same commit this attempt's `-b` would
+        // have used, so gate 4 holds for both and git's refusal is the only
+        // thing telling them apart. (The case where it does NOT hold — an
+        // interloper cut from somewhere else — is
+        // `aBranchAtADifferentSHAIsKeptEvenWhenGitsRefusalGoesUnrecognized`.)
         await lifecycle.cleanUpFailedWorktreeAdd(
             repoPath: repoDir.path,
             worktreePath: tempDir.appendingPathComponent("never-created").path,
-            branch: "appeared-mid-flight",
-            branchPreExisted: false,
+            attempted: .init(
+                name: "appeared-mid-flight", preExisted: false,
+                expectedTip: try await tip(of: "appeared-mid-flight", in: repoDir)
+            ),
             branchNameWasAlreadyTaken: true
         )
         await lifecycle.cleanUpFailedWorktreeAdd(
             repoPath: repoDir.path,
             worktreePath: tempDir.appendingPathComponent("never-created").path,
-            branch: "ours-to-clean-up",
-            branchPreExisted: false,
+            attempted: .init(
+                name: "ours-to-clean-up", preExisted: false,
+                expectedTip: try await tip(of: "ours-to-clean-up", in: repoDir)
+            ),
             branchNameWasAlreadyTaken: false
         )
 
@@ -472,6 +489,141 @@ import Testing
                 "cleanup deleted a branch git had refused to create: \(branches)")
         #expect(!branches.contains("ours-to-clean-up"),
                 "cleanup left behind a branch it did create: \(branches)")
+    }
+
+    // MARK: - Gate 4: the branch must point where this attempt would have put it
+
+    /// The gate that does not read git's stderr, and the one case that needs
+    /// it. Every other signal here is either sampled before the attempt
+    /// (`preExisted`) or a phrase match (`branchNameWasAlreadyTaken`), so a
+    /// branch that appears in the probe→attempt window under a refusal this
+    /// build does not recognize — a future git, a non-standard build, a wrapper
+    /// reformatting stderr — arrives at the cleanup looking exactly like a
+    /// branch we made. Where it *points* is what tells them apart: an
+    /// interloper chose its own starting commit.
+    ///
+    /// Both arms, because a gate that only ever blocks is a synonym for "never
+    /// clean up": the branch cut from this attempt's own base is still deleted.
+    ///
+    /// Red against the tree before gate 4 existed, on the surviving arm:
+    ///   ✘ Expectation failed: (branches → ["main"]).contains("theirs-from-elsewhere")
+    @Test func aBranchAtADifferentSHAIsKeptEvenWhenGitsRefusalGoesUnrecognized() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let baseTip = try await tip(of: "main", in: repoDir)
+
+        // What this attempt's `-b <branch> main` would have produced.
+        try await shell("git branch ours-from-the-base", at: repoDir)
+        // Somebody else's, carrying a commit the base does not have.
+        try await shell(
+            "git checkout -q -b theirs-from-elsewhere && git commit -q --allow-empty -m theirs"
+            + " && git checkout -q main",
+            at: repoDir
+        )
+
+        let neverCreated = tempDir.appendingPathComponent("never-created").path
+        for branch in ["theirs-from-elsewhere", "ours-from-the-base"] {
+            await lifecycle.cleanUpFailedWorktreeAdd(
+                repoPath: repoDir.path,
+                worktreePath: neverCreated,
+                attempted: .init(name: branch, preExisted: false, expectedTip: baseTip),
+                // The whole premise: git's refusal went unrecognized, so gate 1
+                // abstains and every other gate reads as "this attempt made it".
+                branchNameWasAlreadyTaken: false
+            )
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("theirs-from-elsewhere"),
+                "cleanup deleted a branch that does not point where this attempt would have put it: \(branches)")
+        #expect(!branches.contains("ours-from-the-base"),
+                "cleanup left behind the branch this attempt's own base produced: \(branches)")
+    }
+
+    /// The unresolvable arm. A base ref that does not resolve, a `rev-parse`
+    /// that could not run — the attempt cannot say where it would have put the
+    /// branch, and an answer we do not have is never a licence to delete a ref.
+    ///
+    /// Red against the tree before gate 4 existed:
+    ///   ✘ Expectation failed: (branches → ["main"]).contains("expected-tip-unknown")
+    @Test func anUnresolvableExpectedTipNeverDeletes() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        try await shell("git branch expected-tip-unknown", at: repoDir)
+
+        await lifecycle.cleanUpFailedWorktreeAdd(
+            repoPath: repoDir.path,
+            worktreePath: tempDir.appendingPathComponent("never-created").path,
+            // Every other gate says "delete"; only the missing tip stands in
+            // the way.
+            attempted: .init(
+                name: "expected-tip-unknown", preExisted: false, expectedTip: nil
+            ),
+            branchNameWasAlreadyTaken: false
+        )
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("expected-tip-unknown"),
+                "cleanup deleted a branch with no expected tip to compare against: \(branches)")
+    }
+
+    /// The unreadable arm: git cannot produce a tip it will vouch for. Driven
+    /// with a ref whose file names an object that is not in the repository —
+    /// what a truncated fetch or a hand-edited ref leaves — so `show-ref
+    /// --verify` answers `fatal: bad ref` (exit 128, which `localBranchExists`
+    /// rethrows rather than reading as "absent") while `rev-parse` cheerfully
+    /// echoes the recorded SHA back.
+    ///
+    /// It pins gates 3 and 4 together rather than gate 4 alone, and that is a
+    /// property of git, not a shortcut: the two reads see the same refs through
+    /// the same launcher, and no repository state satisfies one while failing
+    /// the other (both directions were tried against git 2.50 — a dangling ref
+    /// fails only `show-ref`, a dangling symref fails both). What *is* worth
+    /// asserting is the property they share: an answer git could not give never
+    /// authorizes a delete.
+    ///
+    /// Deliberately not driven by a wedged git (a 1 ms subprocess timeout, as
+    /// the timeout test above uses). That fixture proves nothing here, because
+    /// the `branch -D` at the end of this path is a git subprocess too — it
+    /// would fail whether or not the gates blocked, and the test would pass
+    /// against any implementation at all.
+    ///
+    /// Asserts preserved behavior, so it is mutation-checked: making the
+    /// unknowns in the read path permissive (`!= false` on the existence probe,
+    /// `?? expectedTip` on the tip read) deletes `unvouched-ref` — `git branch
+    /// -D` removes a dangling ref quite happily, which is what keeps this
+    /// fixture honest.
+    @Test func aRefGitCannotVouchForIsNeverDeleted() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+
+        // A syntactically valid object name that no object answers to.
+        let absentObject = "0000000000000000000000000000000000000001"
+        let refPath = repoDir.appendingPathComponent(".git/refs/heads/unvouched-ref").path
+        try Data("\(absentObject)\n".utf8).write(to: URL(fileURLWithPath: refPath))
+
+        await lifecycle.cleanUpFailedWorktreeAdd(
+            repoPath: repoDir.path,
+            worktreePath: tempDir.appendingPathComponent("never-created").path,
+            // The SHA the ref records, so a cleanup that trusted what it could
+            // read would find a match and delete.
+            attempted: .init(
+                name: "unvouched-ref", preExisted: false, expectedTip: absentObject
+            ),
+            branchNameWasAlreadyTaken: false
+        )
+
+        #expect(FileManager.default.fileExists(atPath: refPath),
+                "cleanup deleted a ref git would not vouch for: \(refPath)")
     }
 
     /// A failed probe (`nil`) is not the same answer as "absent", so it must
@@ -488,8 +640,10 @@ import Testing
         await lifecycle.cleanUpFailedWorktreeAdd(
             repoPath: repoDir.path,
             worktreePath: tempDir.appendingPathComponent("never-created").path,
-            branch: "probe-failed",
-            branchPreExisted: nil,
+            attempted: .init(
+                name: "probe-failed", preExisted: nil,
+                expectedTip: try await tip(of: "probe-failed", in: repoDir)
+            ),
             branchNameWasAlreadyTaken: false
         )
 
@@ -727,8 +881,12 @@ import Testing
             await lifecycle.cleanUpFailedWorktreeAdd(
                 repoPath: repoDir.path,
                 worktreePath: neverCreated,
-                branch: branch,
-                branchPreExisted: preExisted,
+                // Each branch's own tip, so gate 4 holds and the probe is the
+                // only thing under test.
+                attempted: .init(
+                    name: branch, preExisted: preExisted,
+                    expectedTip: try await tip(of: branch, in: repoDir)
+                ),
                 branchNameWasAlreadyTaken: false
             )
         }
@@ -793,8 +951,11 @@ import Testing
         await lifecycle.cleanUpFailedWorktreeAdd(
             repoPath: repoDir.path,
             worktreePath: parentDir.appendingPathComponent("never-created").path,
-            branch: "raced",
-            branchPreExisted: false,
+            // The branch's own tip, so gate 4 would permit and git's refusal is
+            // the only thing keeping `raced` alive.
+            attempted: .init(
+                name: "raced", preExisted: false, expectedTip: originalSHA
+            ),
             branchNameWasAlreadyTaken: lifecycle.gitRefusedToCreateBranch(refusal)
         )
 

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -157,13 +157,157 @@ import Testing
         #expect(survivors.isEmpty, "second name left a directory: \(survivors)")
     }
 
+    /// An unresolvable base is not fixable by a fresh name either, so it must
+    /// fail fast the same way a repo-level cause does, and say which bases it
+    /// tried. Without the `lastKind == .baseUnresolvable` arm the create falls
+    /// through to the name-retry leg, burns two more identical failures, and
+    /// reports the generic "after all attempts" — the mutation this asserts
+    /// against.
+    @Test func unresolvableBaseFailsFastNamingTheBasesTried() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // No `origin`, and a default branch that does not exist locally either,
+        // so BOTH bases are unresolvable rather than just the remote one.
+        let db = try TBDDatabase(inMemory: true)
+        let created = try await db.repos.create(
+            path: repoDir.path, displayName: "test", defaultBranch: "no-such-base"
+        )
+        try await db.repos.updateWorktreeRoot(
+            id: created.id, path: tempDir.appendingPathComponent(".tbd/worktrees").path
+        )
+        let repo = try #require(try await db.repos.get(id: created.id))
+        let lifecycle = makeLifecycle(db: db)
+
+        do {
+            _ = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+            Issue.record("expected an unresolvable base to fail the create")
+        } catch {
+            let text = String(describing: error)
+            #expect(text.contains("no usable base branch"),
+                    "unresolvable base reported as something else: \(text)")
+            #expect(text.contains("origin/no-such-base") && text.contains("no-such-base"),
+                    "the bases tried are not named: \(text)")
+            #expect(!text.contains("after all attempts"),
+                    "a second name was attempted for an unresolvable base: \(text)")
+        }
+
+        let base = WorktreeLayout().basePath(for: repo)
+        let survivors = (try? FileManager.default.contentsOfDirectory(atPath: base)) ?? []
+        #expect(survivors.isEmpty, "failed create left worktree directories: \(survivors)")
+    }
+
     // MARK: - Branches we did NOT create are never deleted
+
+    /// An occupied worktree *path* is the case that keeps the deletion gate
+    /// honest in the other direction: git creates the branch, then discovers the
+    /// path is taken and fails — so this failure really does leak a branch we
+    /// made, even though its stderr says "already exists" like a branch
+    /// collision does. Widening the gate from "git refused to create the branch"
+    /// to the whole `.nameCollision` classification passes every other test in
+    /// this file and reintroduces the leak here.
+    @Test func occupiedPathLeaksNoBranchEvenThoughItLooksLikeACollision() async throws {
+        // A cloned repo, so `origin/main` resolves and the FIRST attempt is the
+        // one that trips over the path. Against an origin-less repo the base
+        // fallback gets there first, and its cleanup deletes the planted
+        // directory before any branch exists — the leak never forms.
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        // Reserve the name, then occupy its path so the FIRST attempt fails
+        // with "fatal: '<path>' already exists" after having created the branch.
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        try FileManager.default.createDirectory(
+            atPath: pending.localPath, withIntermediateDirectories: true
+        )
+        try Data("occupied".utf8).write(
+            to: URL(fileURLWithPath: pending.localPath).appendingPathComponent("stray.txt")
+        )
+
+        let completion = try await lifecycle.completeCreateWorktree(
+            worktreeID: pending.id, skipClaude: true
+        )
+        if case .preSessionPending(let phase3) = completion {
+            await phase3.value
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(!branches.contains(pending.branch),
+                "an occupied path leaked the branch git created: \(branches)")
+    }
+
+    /// The probe→attempt window, driven directly because no test can reliably
+    /// win a race against a subprocess spawn: a branch that appeared after the
+    /// probe answered "absent" is indistinguishable from one we created by
+    /// bookkeeping alone, and only git's own "a branch named … already exists"
+    /// tells the two apart. Both arms asserted — the same inputs with that
+    /// signal absent must still delete, or the gate would just be a synonym for
+    /// "never clean up".
+    @Test func branchTakenBetweenProbeAndAddIsNeverDeleted() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        try await shell("git branch appeared-mid-flight", at: repoDir)
+        try await shell("git branch ours-to-clean-up", at: repoDir)
+
+        await lifecycle.cleanUpFailedWorktreeAdd(
+            repoPath: repoDir.path,
+            worktreePath: tempDir.appendingPathComponent("never-created").path,
+            branch: "appeared-mid-flight",
+            branchPreExisted: false,
+            branchNameWasAlreadyTaken: true
+        )
+        await lifecycle.cleanUpFailedWorktreeAdd(
+            repoPath: repoDir.path,
+            worktreePath: tempDir.appendingPathComponent("never-created").path,
+            branch: "ours-to-clean-up",
+            branchPreExisted: false,
+            branchNameWasAlreadyTaken: false
+        )
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("appeared-mid-flight"),
+                "cleanup deleted a branch git had refused to create: \(branches)")
+        #expect(!branches.contains("ours-to-clean-up"),
+                "cleanup left behind a branch it did create: \(branches)")
+    }
+
+    /// A failed probe (`nil`) is not the same answer as "absent", so it must
+    /// keep the branch — the third arm of the pre-existence tri-state, which the
+    /// other tests only reach as `false` or `true`.
+    @Test func unknownPreExistenceNeverDeletes() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        try await shell("git branch probe-failed", at: repoDir)
+
+        await lifecycle.cleanUpFailedWorktreeAdd(
+            repoPath: repoDir.path,
+            worktreePath: tempDir.appendingPathComponent("never-created").path,
+            branch: "probe-failed",
+            branchPreExisted: nil,
+            branchNameWasAlreadyTaken: false
+        )
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("probe-failed"),
+                "cleanup deleted a branch whose pre-existence was unknown: \(branches)")
+    }
 
     /// The `worktreeAddExisting` leg creates no branch and must therefore never
     /// delete one. Not red against the unfixed tree — which deletes no branches
     /// anywhere — so it is mutation-checked instead: routing that leg's `catch`
-    /// through `cleanUpFailedWorktreeAdd(branchPreExisted: false)`, the obvious
-    /// over-eager version of this fix, makes it fail.
+    /// through `cleanUpFailedWorktreeAdd(branchPreExisted: false,
+    /// branchNameWasAlreadyTaken: false)`, the obvious over-eager version of
+    /// this fix, makes it fail.
     @Test func preExistingBranchSurvivesAFailedCheckout() async throws {
         let (tempDir, repoDir) = try await createTestRepo()
         defer { try? FileManager.default.removeItem(at: tempDir) }

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -79,7 +79,20 @@ import Testing
     /// Jams the repo so `git worktree add -b … origin/main` fails *after*
     /// creating the branch. No process holds this lock; it is exactly the
     /// residue a crashed git leaves.
-    private func jamConfigLock(_ repoDir: URL) throws {
+    ///
+    /// It jams only the *remote* base by default, and that asymmetry is the
+    /// point: `-b <new> origin/main` writes upstream tracking configuration,
+    /// while `-b <new> main` writes none and therefore never touches
+    /// `.git/config`. Pass `includingTheLocalBase: true` to set
+    /// `branch.autoSetupMerge = always`, which makes a local base configure
+    /// upstream too — the way to build one cause that both bases hit. Both
+    /// halves verified against git 2.50.
+    private func jamConfigLock(
+        _ repoDir: URL, includingTheLocalBase: Bool = false
+    ) async throws {
+        if includingTheLocalBase {
+            try await shell("git config branch.autoSetupMerge always", at: repoDir)
+        }
         try Data().write(to: repoDir.appendingPathComponent(".git/config.lock"))
     }
 
@@ -100,10 +113,13 @@ import Testing
 
     // MARK: - Bug 1: a failed create must not leak the branch it just made
 
+    /// Jammed for BOTH bases: a lock that stops only the remote base is now
+    /// recovered by the local one (see `remoteBaseFailureRecoversOnTheLocalBase`),
+    /// so making the create fail at all takes a cause neither base escapes.
     @Test func failedCreateLeavesNothingBehind() async throws {
         let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
         defer { try? FileManager.default.removeItem(at: parentDir) }
-        try jamConfigLock(repoDir)
+        try await jamConfigLock(repoDir, includingTheLocalBase: true)
 
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = makeLifecycle(db: db)
@@ -132,12 +148,82 @@ import Testing
         #expect(survivors.isEmpty, "failed create left worktree directories: \(survivors)")
     }
 
-    // MARK: - Bug 2: a repo-level failure must fail fast, with git's own words
+    // MARK: - Bug 2: a repo-level failure earns the other base, but never a name
 
-    @Test func repoLevelFailureSurfacesGitStderr() async throws {
+    /// The two bases are not interchangeable, so a repo-level failure on the
+    /// remote one is not the end of the road: `origin/main` makes `-b` write
+    /// upstream configuration, and a stale `.git/config.lock` fails exactly that
+    /// write, while the plain local `main` writes no configuration at all and
+    /// succeeds with the lock still sitting there.
+    ///
+    /// What makes continuing safe is the branch cleanup this suite's first test
+    /// covers: attempt 1 leaves `tbd/<name>` standing, cleanup removes it, and
+    /// attempt 2 finds the name free. Failing fast here spent that cleanup for
+    /// nothing.
+    @Test func remoteBaseFailureRecoversOnTheLocalBase() async throws {
         let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
         defer { try? FileManager.default.removeItem(at: parentDir) }
-        try jamConfigLock(repoDir)
+        try await jamConfigLock(repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        let created = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+        #expect(listed.contains { $0.branch == created.branch },
+                "the local base did not recover the create: \(listed)")
+        #expect(FileManager.default.fileExists(atPath: created.localPath),
+                "the create reported success without a checkout at \(created.localPath)")
+
+        // Exactly the branch the create started with — a fresh name would show
+        // up here as a second `tbd/…`, and an uncleaned attempt 1 as a leftover.
+        let branches = try await localBranches(repoDir)
+        #expect(branches.filter { $0.hasPrefix("tbd/") } == [created.branch],
+                "the recovery burned a second name or leaked a branch: \(branches)")
+    }
+
+    /// The second verified shape of the same thing, and the one that regressed
+    /// outright: a local branch literally named `origin/main` makes base 1 fatal
+    /// on `fatal: ambiguous object name: 'origin/main'` — creating nothing at
+    /// all, so there is not even a branch to clean up — while base 2 resolves
+    /// the unambiguous local `main` and succeeds.
+    ///
+    /// Distinct from the config-lock shape above because its stderr is a
+    /// *reference* complaint that the base-unresolvable whitelist deliberately
+    /// does not match ("ambiguous object name" is not "not a valid object
+    /// name"), so it lands in `.repoLevel` and depends on that case continuing.
+    @Test func aShadowingLocalBranchStillResolvesOnTheLocalBase() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+        try await shell("git branch origin/main", at: repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        let created = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+
+        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+        #expect(listed.contains { $0.branch == created.branch },
+                "the local base did not resolve past the shadowing branch: \(listed)")
+        let branches = try await localBranches(repoDir)
+        #expect(branches.filter { $0.hasPrefix("tbd/") } == [created.branch],
+                "the recovery burned a second name or leaked a branch: \(branches)")
+    }
+
+    /// Once BOTH bases hit the same repo-level cause the create is over: git's
+    /// own words reach the user, with the one hint they can act on.
+    ///
+    /// Asserts preserved behavior, so it is mutation-checked: deleting the
+    /// `.repoLevel` fast-exit from both loops drops the create through to the
+    /// generic "after all attempts" message, which carries no
+    /// `.git/config.lock` hint.
+    @Test func repoLevelFailureOnBothBasesSurfacesGitStderr() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+        try await jamConfigLock(repoDir, includingTheLocalBase: true)
 
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = makeLifecycle(db: db)
@@ -160,20 +246,53 @@ import Testing
         }
     }
 
-    @Test func repoLevelFailureDoesNotGenerateASecondName() async throws {
+    /// A fresh name genuinely cannot help a repo-level cause, so spending the
+    /// other base must not turn into spending a second name too.
+    ///
+    /// The read-only worktree base is chosen over a jammed config lock because
+    /// it makes the answer *directly* observable: git names the path it could
+    /// not create, so the surfaced message says which folder the create died
+    /// on. A jammed lock cannot settle this — its stderr names no folder, and
+    /// the retry leg's own `.repoLevel` exit produces a byte-identical message,
+    /// so both outcomes read the same.
+    ///
+    /// Preserved behavior, so it is mutation-checked: deleting the FIRST loop's
+    /// post-loop `.repoLevel` throw makes the create generate a second folder
+    /// and branch, and the reported path becomes that second folder's.
+    @Test func repoLevelFailureOnBothBasesKeepsTheOriginalName() async throws {
         let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
         defer { try? FileManager.default.removeItem(at: parentDir) }
-        try jamConfigLock(repoDir)
 
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = makeLifecycle(db: db)
         let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
 
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        let base = WorktreeLayout().basePath(for: repo)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o555], ofItemAtPath: base
+        )
+        // Registered after the temp-dir cleanup above, so it runs BEFORE it —
+        // a read-only directory cannot be emptied.
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: base
+            )
+        }
+
         do {
-            _ = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
-            Issue.record("expected the jammed config lock to fail the create")
+            _ = try await lifecycle.completeCreateWorktree(
+                worktreeID: pending.id, skipClaude: true
+            )
+            Issue.record("expected the read-only worktree base to fail the create")
         } catch {
             let text = String(describing: error)
+            #expect(text.contains("could not create leading directories"),
+                    "the real cause was masked: \(text)")
+            // The folder git died on is the one the create started with. A
+            // fresh name would put a different folder in this message.
+            #expect(text.contains("/\(pending.name)/.git"),
+                    "a second folder name was generated: \(text)")
             // "after all attempts" is produced ONLY by the name-retry leg, so
             // its absence is direct evidence that no second folder/branch name
             // was generated for a cause no name can fix.
@@ -183,11 +302,56 @@ import Testing
                     "a second name was attempted and collided: \(text)")
         }
 
+        // Both attempts created `tbd/<name>` before dying on the mkdir, and both
+        // were cleaned up.
         let branches = try await localBranches(repoDir)
-        #expect(branches.filter { $0.hasPrefix("tbd/") }.isEmpty)
-        let base = WorktreeLayout().basePath(for: repo)
+        #expect(branches.filter { $0.hasPrefix("tbd/") }.isEmpty,
+                "a repo-level failure leaked branches: \(branches)")
         let survivors = (try? FileManager.default.contentsOfDirectory(atPath: base)) ?? []
         #expect(survivors.isEmpty, "second name left a directory: \(survivors)")
+    }
+
+    /// The other side of that split. A failure git never reported — the
+    /// subprocess timed out or could not be spawned — says nothing about the
+    /// base, and buying a second opinion costs another full
+    /// `GitManager.commandTimeout` (120 s in production), so it fails fast where
+    /// `.repoLevel` continues.
+    ///
+    /// Driven end to end through a real killed `git worktree add`: the
+    /// lifecycle's own `GitManager` carries a 1 ms subprocess timeout, which no
+    /// fork+exec of git survives. The message is what discriminates the branch —
+    /// only the `.gitUnusable` arm says "did not complete", while every
+    /// `.repoLevel` exit says "git worktree add failed" — so classifying a
+    /// non-`GitError` as `.repoLevel` again fails this test.
+    @Test func aTimedOutGitFailsFastInsteadOfSpendingTheOtherBase() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(subprocessTimeout: .milliseconds(1)),
+            tmux: TmuxManager(dryRun: true),
+            hooks: HookResolver()
+        )
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        do {
+            _ = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+            Issue.record("expected a timed-out git subprocess to fail the create")
+        } catch {
+            let text = String(describing: error)
+            #expect(text.contains("did not complete"),
+                    "a timeout was reported as an ordinary git failure: \(text)")
+            #expect(text.contains("timed out after"),
+                    "the timeout's own words did not reach the user: \(text)")
+            #expect(!text.contains("after all attempts"),
+                    "a second name was attempted for a wedged git: \(text)")
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.filter { $0.hasPrefix("tbd/") }.isEmpty,
+                "a timed-out attempt leaked a branch: \(branches)")
     }
 
     /// An unresolvable base is not fixable by a fresh name either, so it must
@@ -428,7 +592,7 @@ import Testing
             remoteOnlyBranches: ["feature"]
         )
         defer { try? FileManager.default.removeItem(at: parentDir) }
-        try jamConfigLock(repoDir)
+        try await jamConfigLock(repoDir)
 
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = makeLifecycle(db: db)
@@ -595,14 +759,16 @@ import Testing
 
     /// Every other test here jams the repo before the FIRST attempt, so the
     /// first loop always throws and the retry leg's copy of the `.repoLevel`
-    /// guard never runs. This one reaches it: the canonical folder is occupied
-    /// (attempt 1 → collision → out of the first loop) and the worktree base
-    /// directory is read-only, so the retry's fresh folder gets past the
-    /// existence check and dies creating its directory.
+    /// handling never runs. This one reaches it: the canonical folder is
+    /// occupied (attempt 1 → collision → out of the first loop) and the worktree
+    /// base directory is read-only, so the retry's fresh folder gets past the
+    /// existence check and dies creating its directory — on both of the retry
+    /// leg's own bases, since a read-only parent is not something a base ref
+    /// changes.
     ///
     /// Asserts preserved behavior rather than a fix, so it is mutation-checked:
-    /// deleting the retry loop's `.repoLevel` throw makes it report the generic
-    /// "after all attempts" instead of git's own words.
+    /// deleting the retry loop's post-loop `.repoLevel` throw makes it report
+    /// the generic "after all attempts" instead of git's own words.
     @Test func repoLevelFailureInsideTheRetryLegAlsoFailsFast() async throws {
         let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
         defer { try? FileManager.default.removeItem(at: parentDir) }
@@ -638,7 +804,7 @@ import Testing
             #expect(text.contains("could not create leading directories"),
                     "the retry leg's real cause was not surfaced: \(text)")
             #expect(!text.contains("after all attempts"),
-                    "the retry leg burned a second base on a repo-level cause: \(text)")
+                    "the retry leg fell through to the generic message: \(text)")
         }
 
         let branches = try await localBranches(repoDir)

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -849,6 +849,111 @@ import Testing
                 "cleanup deleted the branch the caller brought: \(branches)")
     }
 
+    /// Writes a `post-checkout` hook that parks inside `git worktree add` until
+    /// the test releases it. Git runs that hook as part of `worktree add`
+    /// (verified against git 2.50), which is what makes the interlock below
+    /// exact instead of a sleep race: while it is parked, the fetch and the
+    /// checkout have both succeeded and nothing after them has run yet.
+    ///
+    /// Capped at ~60 s so a test that never releases it fails inside
+    /// `GitManager.commandTimeout` rather than wedging the run.
+    private func installCheckoutBarrier(
+        in repoDir: URL, marker: URL, release: URL
+    ) throws {
+        let script = """
+        #!/bin/sh
+        : > '\(marker.path)'
+        i=0
+        while [ ! -e '\(release.path)' ] && [ "$i" -lt 600 ]; do
+            sleep 0.1
+            i=$((i + 1))
+        done
+        exit 0
+        """
+        let hook = repoDir.appendingPathComponent(".git/hooks/post-checkout")
+        try script.write(to: hook, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: hook.path
+        )
+    }
+
+    /// Bounded poll for a file the code under test creates, with the observed
+    /// state in the diagnostic (assertion-hygiene rule 4).
+    private func waitForFile(_ url: URL, _ what: String) async {
+        let deadline = 300
+        for _ in 0..<deadline {
+            if FileManager.default.fileExists(atPath: url.path) { return }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        Issue.record("\(what): \(url.path) never appeared after polling 30 seconds")
+    }
+
+    /// The failure this leg's cleanup must NOT answer: one that arrives *after*
+    /// the git work succeeded. The fetch wrote `pr-7-2` and the checkout stands
+    /// on disk, so nothing is left over to withdraw — but a successful fetch is
+    /// also exactly the state that clears all four of
+    /// `cleanUpFailedWorktreeAdd`'s gates, so routing a later failure through it
+    /// deletes a correct branch and a correct checkout.
+    ///
+    /// The failure is induced by deleting the worktree row while the checkout is
+    /// parked in a `post-checkout` hook, which is the real shape rather than a
+    /// contrivance: `forgetWorktree` deletes that row over RPC with no interlock
+    /// against an in-flight create, and `updateBranch` throws on a row that is
+    /// gone.
+    ///
+    /// The create must still fail — the row it was building is gone — but it
+    /// must fail leaving the repo exactly as the git work left it.
+    @Test func aFailureAfterThePullHeadCheckoutKeepsTheBranchAndTheDirectory() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo(
+            pullRequestHeads: [7]
+        )
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        // The caller's own `pr-7` pushes the fetch onto `pr-7-2`, which is what
+        // makes the create reach the `updateBranch` write that records it.
+        try await shell("git branch pr-7", at: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id, branch: "pr-7", skipClaude: true,
+            useExistingBranch: true, prNumber: 7
+        )
+
+        let marker = parentDir.appendingPathComponent("checkout-parked")
+        let release = parentDir.appendingPathComponent("resume-checkout")
+        try installCheckoutBarrier(in: repoDir, marker: marker, release: release)
+
+        let forget = Task {
+            await self.waitForFile(marker, "the post-checkout barrier never armed")
+            try? await db.worktrees.delete(id: pending.id)
+            FileManager.default.createFile(atPath: release.path, contents: nil)
+        }
+
+        var thrown: Error?
+        do {
+            _ = try await lifecycle.completeCreateWorktree(
+                worktreeID: pending.id, skipClaude: true,
+                existingBranchRef: "pr-7", checkoutPRHead: true
+            )
+        } catch {
+            thrown = error
+        }
+        await forget.value
+
+        #expect(thrown != nil,
+                "the create reported success after its own row was deleted")
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("pr-7-2"),
+                "a failure after the checkout deleted the branch the fetch correctly created: \(branches)")
+        #expect(branches.contains("pr-7"),
+                "the caller's own branch did not survive: \(branches)")
+        #expect(FileManager.default.fileExists(atPath: pending.localPath),
+                "a failure after the checkout deleted the working tree at \(pending.localPath)")
+    }
+
     /// The two arms of that tri-state which *block* the delete, driven at the
     /// cleanup boundary because neither is reachable end to end on this leg:
     /// `true` needs a branch to appear inside the gap between the probe and the

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 (real git subprocesses, real filesystem, no tmux — `dryRun: true`).
+///
+/// Covers what a *failed* `git worktree add` leaves behind, and how the create
+/// path decides whether retrying can help.
+///
+/// The failure is induced with a stale `.git/config.lock`, which is a faithful
+/// reproduction rather than a contrivance: `git worktree add -b <branch>
+/// origin/<default>` creates the branch, then writes upstream tracking
+/// configuration, and a lock file left by a crashed git makes only the second
+/// half fail. Git rolls back the directory and the worktree registration but
+/// keeps the branch — so the create fails with a `tbd/<name>` branch standing.
+/// `GitManager` is a concrete struct, so real git is also the only way to drive
+/// these paths.
+@Suite struct WorktreeCreateFailureCleanupTests {
+
+    /// A bare remote plus a clone with `main` pushed, so `origin/main` resolves
+    /// and the upstream-config write is actually attempted. Returns the clone's
+    /// host directory (the caller's `tempDir`) and the clone itself.
+    private func makeClonedTestRepo() async throws -> (parentDir: URL, hostDir: URL, repoDir: URL) {
+        let parentDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-create-failure-\(UUID().uuidString)")
+        let remoteDir = parentDir.appendingPathComponent("remote.git")
+        let hostDir = parentDir.appendingPathComponent("clone-host")
+        let repoDir = hostDir.appendingPathComponent("repo")
+        try FileManager.default.createDirectory(at: remoteDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: hostDir, withIntermediateDirectories: true)
+
+        try await shell("git init --bare -b main", at: remoteDir)
+
+        let sourceDir = parentDir.appendingPathComponent("source")
+        try FileManager.default.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        try await shell("git init -b main && git commit --allow-empty -m 'init'", at: sourceDir)
+        try await shell("git remote add origin '\(remoteDir.path)'", at: sourceDir)
+        try await shell("git push origin main", at: sourceDir)
+
+        try await shell("git clone '\(remoteDir.path)' '\(repoDir.path)'", at: hostDir)
+        return (parentDir, hostDir, repoDir)
+    }
+
+    /// Jams the repo so `git worktree add -b … origin/main` fails *after*
+    /// creating the branch. No process holds this lock; it is exactly the
+    /// residue a crashed git leaves.
+    private func jamConfigLock(_ repoDir: URL) throws {
+        try Data().write(to: repoDir.appendingPathComponent(".git/config.lock"))
+    }
+
+    /// Every local branch. Deliberately not `listBranches`, which filters out
+    /// branches that are checked out in a worktree — exactly the ones these
+    /// tests need to see.
+    private func localBranches(_ repoDir: URL) async throws -> [String] {
+        try await GitManager()
+            .listRefs(repoPath: repoDir.path, prefix: "refs/heads")
+            .map { String($0.dropFirst("refs/heads/".count)) }
+    }
+
+    private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
+        WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+        )
+    }
+
+    // MARK: - Bug 1: a failed create must not leak the branch it just made
+
+    @Test func failedCreateLeavesNothingBehind() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+        try jamConfigLock(repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        await #expect(throws: WorktreeLifecycleError.self) {
+            _ = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+        }
+
+        // The whole point: git created `tbd/<name>` before failing, and nothing
+        // cleaned it up. Against the unfixed tree this listed one branch per
+        // generated name — e.g. ["tbd/…-thirsty-marmoset", "tbd/…-underlying-vole"].
+        let branches = try await localBranches(repoDir)
+        let leaked = branches.filter { $0.hasPrefix("tbd/") }
+        #expect(leaked.isEmpty, "failed create leaked branches: \(leaked)")
+
+        // Registration and directory, checked in the same run so the sweep is
+        // whole. Git rolls both back by itself for this particular failure, so
+        // these two are a guard against a future failure mode that doesn't —
+        // which is why `worktreePrune` is part of the cleanup.
+        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+        #expect(listed.count == 1, "stray worktree registrations: \(listed.map(\.path))")
+
+        let base = WorktreeLayout().basePath(for: repo)
+        let survivors = (try? FileManager.default.contentsOfDirectory(atPath: base)) ?? []
+        #expect(survivors.isEmpty, "failed create left worktree directories: \(survivors)")
+    }
+
+    // MARK: - Bug 2: a repo-level failure must fail fast, with git's own words
+
+    @Test func repoLevelFailureSurfacesGitStderr() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+        try jamConfigLock(repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        do {
+            _ = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+            Issue.record("expected the jammed config lock to fail the create")
+        } catch {
+            let text = String(describing: error)
+            // Before the fix, the surfaced stderr came from the LAST attempt —
+            // "a branch named 'tbd/…' already exists", an artifact of the leak
+            // in bug 1 — and the real cause never reached the user.
+            #expect(text.contains("could not lock config file"),
+                    "the real cause was masked: \(text)")
+            #expect(!text.contains("the folder or branch may already exist"),
+                    "repo-level failure reported as a collision guess: \(text)")
+            #expect(text.contains(".git/config.lock"),
+                    "no actionable hint for a stale lock: \(text)")
+        }
+    }
+
+    @Test func repoLevelFailureDoesNotGenerateASecondName() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+        try jamConfigLock(repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        do {
+            _ = try await lifecycle.createWorktree(repoID: repo.id, skipClaude: true)
+            Issue.record("expected the jammed config lock to fail the create")
+        } catch {
+            let text = String(describing: error)
+            // "after all attempts" is produced ONLY by the name-retry leg, so
+            // its absence is direct evidence that no second folder/branch name
+            // was generated for a cause no name can fix.
+            #expect(!text.contains("after all attempts"),
+                    "a second name was attempted for a repo-level failure: \(text)")
+            #expect(!text.contains("already exists"),
+                    "a second name was attempted and collided: \(text)")
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.filter { $0.hasPrefix("tbd/") }.isEmpty)
+        let base = WorktreeLayout().basePath(for: repo)
+        let survivors = (try? FileManager.default.contentsOfDirectory(atPath: base)) ?? []
+        #expect(survivors.isEmpty, "second name left a directory: \(survivors)")
+    }
+
+    // MARK: - Branches we did NOT create are never deleted
+
+    /// The `worktreeAddExisting` leg creates no branch and must therefore never
+    /// delete one. Not red against the unfixed tree — which deletes no branches
+    /// anywhere — so it is mutation-checked instead: routing that leg's `catch`
+    /// through `cleanUpFailedWorktreeAdd(branchPreExisted: false)`, the obvious
+    /// over-eager version of this fix, makes it fail.
+    @Test func preExistingBranchSurvivesAFailedCheckout() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        try await shell("git branch owned-by-caller", at: repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Fail the checkout by occupying the reserved path. Deliberately NOT by
+        // checking the branch out in a second worktree: git refuses to delete a
+        // checked-out branch all by itself, which would mask an over-eager
+        // cleanup instead of exposing it. Here nothing holds `owned-by-caller`,
+        // so only the pre-existence gate keeps it alive.
+        let pending = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id, branch: "owned-by-caller", skipClaude: true
+        )
+        try FileManager.default.createDirectory(
+            atPath: pending.localPath, withIntermediateDirectories: true
+        )
+        try Data("occupied".utf8).write(
+            to: URL(fileURLWithPath: pending.localPath).appendingPathComponent("stray.txt")
+        )
+
+        await #expect(throws: WorktreeLifecycleError.self) {
+            _ = try await lifecycle.completeCreateWorktree(
+                worktreeID: pending.id, skipClaude: true, userSpecifiedBranch: true
+            )
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("owned-by-caller"),
+                "cleanup deleted a branch the caller brought: \(branches)")
+    }
+
+    /// The name-collision retry must keep working — otherwise the new
+    /// classification could silently turn retrying off. Doubles as the second
+    /// half of the deletion guard: the colliding branch belongs to somebody
+    /// else and must survive the attempt that tripped over it.
+    ///
+    /// Also not red against the unfixed tree — it asserts preserved behavior —
+    /// so it is mutation-checked twice: classifying `already exists` as
+    /// `.repoLevel` makes the create throw instead of retrying, and dropping
+    /// the `branchPreExisted == false` guard in `cleanUpFailedWorktreeAdd`
+    /// makes the cleanup delete the colliding branch.
+    @Test func nameCollisionStillRetriesUnderAFreshName() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        // Reserve the name first, then plant a branch on it — the only way to
+        // collide with an auto-generated `tbd/<name>` whose name nobody knows
+        // until it is generated.
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        try await shell("git branch '\(pending.branch)'", at: repoDir)
+
+        let completion = try await lifecycle.completeCreateWorktree(
+            worktreeID: pending.id, skipClaude: true
+        )
+        if case .preSessionPending(let phase3) = completion {
+            await phase3.value
+        }
+
+        // A fresh name was generated and the worktree exists on it.
+        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+        let created = listed.filter { $0.branch.hasPrefix("tbd/") }
+        #expect(created.count == 1, "expected exactly one tbd/ worktree: \(listed)")
+        #expect(created.first?.branch != pending.branch,
+                "retry reused the colliding branch name")
+
+        // And the branch that caused the collision is untouched.
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains(pending.branch),
+                "cleanup deleted the pre-existing colliding branch: \(branches)")
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -22,7 +22,16 @@ import Testing
     /// A bare remote plus a clone with `main` pushed, so `origin/main` resolves
     /// and the upstream-config write is actually attempted. Returns the clone's
     /// host directory (the caller's `tempDir`) and the clone itself.
-    private func makeClonedTestRepo() async throws -> (parentDir: URL, hostDir: URL, repoDir: URL) {
+    ///
+    /// `remoteOnlyBranches` are pushed to the remote and then deleted from the
+    /// source, so the clone sees `origin/<name>` with no local counterpart —
+    /// the shape that makes `--track -b <name>` create a branch.
+    /// `pullRequestHeads` plant `refs/pull/<n>/head` on the remote, which is
+    /// what a fork-PR checkout fetches.
+    private func makeClonedTestRepo(
+        remoteOnlyBranches: [String] = [],
+        pullRequestHeads: [Int] = []
+    ) async throws -> (parentDir: URL, hostDir: URL, repoDir: URL) {
         let parentDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-create-failure-\(UUID().uuidString)")
         let remoteDir = parentDir.appendingPathComponent("remote.git")
@@ -39,8 +48,32 @@ import Testing
         try await shell("git remote add origin '\(remoteDir.path)'", at: sourceDir)
         try await shell("git push origin main", at: sourceDir)
 
+        for branch in remoteOnlyBranches {
+            try await shell(
+                "git checkout -b '\(branch)' && git commit --allow-empty -m '\(branch)'"
+                + " && git push origin '\(branch)' && git checkout main",
+                at: sourceDir
+            )
+        }
+        for number in pullRequestHeads {
+            try await shell(
+                "git update-ref refs/pull/\(number)/head refs/heads/main", at: remoteDir
+            )
+        }
+
         try await shell("git clone '\(remoteDir.path)' '\(repoDir.path)'", at: hostDir)
         return (parentDir, hostDir, repoDir)
+    }
+
+    /// Occupies `path` with a stray file, so the next `git worktree add`
+    /// targeting it fails with `fatal: '<path>' already exists`.
+    private func occupy(_ path: String) throws {
+        try FileManager.default.createDirectory(
+            atPath: path, withIntermediateDirectories: true
+        )
+        try Data("occupied".utf8).write(
+            to: URL(fileURLWithPath: path).appendingPathComponent("stray.txt")
+        )
     }
 
     /// Jams the repo so `git worktree add -b … origin/main` fails *after*
@@ -186,7 +219,11 @@ import Testing
             let text = String(describing: error)
             #expect(text.contains("no usable base branch"),
                     "unresolvable base reported as something else: \(text)")
-            #expect(text.contains("origin/no-such-base") && text.contains("no-such-base"),
+            // Both bases, in the order they were tried. Asserting the joined
+            // list rather than each name separately: "origin/no-such-base"
+            // contains "no-such-base", so a per-name check would pass on a
+            // message that named only the remote one.
+            #expect(text.contains("tried origin/no-such-base, no-such-base"),
                     "the bases tried are not named: \(text)")
             #expect(!text.contains("after all attempts"),
                     "a second name was attempted for an unresolvable base: \(text)")
@@ -221,12 +258,7 @@ import Testing
         // Reserve the name, then occupy its path so the FIRST attempt fails
         // with "fatal: '<path>' already exists" after having created the branch.
         let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
-        try FileManager.default.createDirectory(
-            atPath: pending.localPath, withIntermediateDirectories: true
-        )
-        try Data("occupied".utf8).write(
-            to: URL(fileURLWithPath: pending.localPath).appendingPathComponent("stray.txt")
-        )
+        try occupy(pending.localPath)
 
         let completion = try await lifecycle.completeCreateWorktree(
             worktreeID: pending.id, skipClaude: true
@@ -326,12 +358,7 @@ import Testing
         let pending = try await lifecycle.beginCreateWorktree(
             repoID: repo.id, branch: "owned-by-caller", skipClaude: true
         )
-        try FileManager.default.createDirectory(
-            atPath: pending.localPath, withIntermediateDirectories: true
-        )
-        try Data("occupied".utf8).write(
-            to: URL(fileURLWithPath: pending.localPath).appendingPathComponent("stray.txt")
-        )
+        try occupy(pending.localPath)
 
         await #expect(throws: WorktreeLifecycleError.self) {
             _ = try await lifecycle.completeCreateWorktree(
@@ -386,5 +413,236 @@ import Testing
         let branches = try await localBranches(repoDir)
         #expect(branches.contains(pending.branch),
                 "cleanup deleted the pre-existing colliding branch: \(branches)")
+    }
+
+    // MARK: - The existing-branch flow leaks the same way
+
+    /// `--track -b <local> <path> origin/<name>` has the same shape as the
+    /// fresh-create path: git creates the local branch, then writes upstream
+    /// tracking configuration, and a jammed `.git/config.lock` fails only the
+    /// second half. Reproduced by hand against git 2.50:
+    /// `git worktree add --track -b tracked ../wt origin/tracked` leaves
+    /// `tracked` standing and creates no directory.
+    @Test func failedTrackingCheckoutLeavesNoBranchBehind() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo(
+            remoteOnlyBranches: ["feature"]
+        )
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+        try jamConfigLock(repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        await #expect(throws: WorktreeLifecycleError.self) {
+            _ = try await lifecycle.createWorktree(
+                repoID: repo.id, branch: "origin/feature", skipClaude: true,
+                useExistingBranch: true
+            )
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(!branches.contains("feature"),
+                "the tracking checkout leaked the branch it created: \(branches)")
+    }
+
+    /// The fork-PR leg creates a fresh local branch of its own (the fetch's
+    /// `+refs/pull/<n>/head:refs/heads/<name>` refspec), so a failure in the
+    /// checkout that follows leaks it just the same. The name comes from
+    /// `uniqueLocalBranchName`, so it is never one the caller brought.
+    @Test func failedPullRequestCheckoutLeavesNoBranchBehind() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo(
+            pullRequestHeads: [7]
+        )
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id, branch: "pr-7", skipClaude: true,
+            useExistingBranch: true, prNumber: 7
+        )
+        // Fail the checkout that follows the fetch, so the failure lands with
+        // the fetched branch already created.
+        try occupy(pending.localPath)
+
+        await #expect(throws: WorktreeLifecycleError.self) {
+            _ = try await lifecycle.completeCreateWorktree(
+                worktreeID: pending.id, skipClaude: true,
+                existingBranchRef: "pr-7", checkoutPRHead: true
+            )
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(!branches.contains("pr-7"),
+                "the PR-head checkout leaked the branch it fetched: \(branches)")
+    }
+
+    /// The third leg of the same `catch` creates NOTHING — it checks out a
+    /// branch the caller owns — so it must delete nothing. The hard constraint
+    /// of this fix, and the one whose failure destroys a user's work.
+    ///
+    /// Not red against the unfixed tree, which deletes no branches on this path
+    /// at all; it is mutation-checked instead: routing this leg's failure
+    /// through `cleanUpFailedWorktreeAdd(branchPreExisted: false,
+    /// branchNameWasAlreadyTaken: false)` — treating all three legs alike —
+    /// makes it fail.
+    @Test func failedExistingBranchCheckoutKeepsTheCallersBranch() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        try await shell("git branch owned-by-caller", at: repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id, branch: "owned-by-caller", skipClaude: true,
+            useExistingBranch: true
+        )
+        try occupy(pending.localPath)
+
+        await #expect(throws: WorktreeLifecycleError.self) {
+            _ = try await lifecycle.completeCreateWorktree(
+                worktreeID: pending.id, skipClaude: true,
+                existingBranchRef: "owned-by-caller"
+            )
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains("owned-by-caller"),
+                "the existing-branch checkout deleted the caller's branch: \(branches)")
+    }
+
+    // MARK: - Bug 2, continued: don't retry what the retry keeps
+
+    /// A user-specified branch is carried across the folder-rename retry
+    /// unchanged, so when the BRANCH NAME is what stands in the way the retry
+    /// re-attempts it against both bases and fails identically twice, ending on
+    /// the generic "after all attempts".
+    ///
+    /// Reached without a race by putting the main checkout on an unborn orphan
+    /// branch: `refs/heads/pending` does not exist — so the pre-existence probe
+    /// answers "absent" and the check-out-the-existing-branch path is skipped —
+    /// while git still reports the name as used by that worktree. Verified
+    /// against git 2.50: attempt 1 says "'pending' is already used by worktree
+    /// at …", and every later attempt says "a branch named 'pending' already
+    /// exists".
+    @Test func aTakenBranchNameFailsFastInsteadOfRetryingTheSameName() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+        try await shell("git checkout --orphan pending", at: repoDir)
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        do {
+            _ = try await lifecycle.createWorktree(
+                repoID: repo.id, branch: "pending", skipClaude: true
+            )
+            Issue.record("expected a taken branch name to fail the create")
+        } catch {
+            let text = String(describing: error)
+            #expect(text.contains("could not create branch 'pending'"),
+                    "the collision was not attributed to the branch name: \(text)")
+            #expect(!text.contains("after all attempts"),
+                    "the same branch name was retried under a fresh folder: \(text)")
+        }
+
+        let base = WorktreeLayout().basePath(for: repo)
+        let survivors = (try? FileManager.default.contentsOfDirectory(atPath: base)) ?? []
+        #expect(survivors.isEmpty, "failed create left worktree directories: \(survivors)")
+    }
+
+    /// The other arm of that gate: when the FOLDER is what collided, a fresh
+    /// folder is exactly the remedy — even though git reports it as an
+    /// "already exists" collision too. Widening the fast-fail to the whole
+    /// `.nameCollision` classification passes the test above and breaks this
+    /// one, which is the mutation it is here to catch.
+    @Test func aTakenFolderStillRetriesKeepingTheCallersBranch() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        // A cloned repo so `origin/main` resolves and the FIRST attempt is the
+        // one that trips over the occupied path (see the occupied-path test
+        // above for why an origin-less repo dissolves the setup).
+        let pending = try await lifecycle.beginCreateWorktree(
+            repoID: repo.id, branch: "mine", skipClaude: true
+        )
+        try occupy(pending.localPath)
+
+        let completion = try await lifecycle.completeCreateWorktree(
+            worktreeID: pending.id, skipClaude: true, userSpecifiedBranch: true
+        )
+        if case .preSessionPending(let phase3) = completion {
+            await phase3.value
+        }
+
+        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+        #expect(listed.contains { $0.branch == "mine" },
+                "the retry never happened for an occupied folder: \(listed)")
+    }
+
+    // MARK: - The retry leg's own fail-fast guard
+
+    /// Every other test here jams the repo before the FIRST attempt, so the
+    /// first loop always throws and the retry leg's copy of the `.repoLevel`
+    /// guard never runs. This one reaches it: the canonical folder is occupied
+    /// (attempt 1 → collision → out of the first loop) and the worktree base
+    /// directory is read-only, so the retry's fresh folder gets past the
+    /// existence check and dies creating its directory.
+    ///
+    /// Asserts preserved behavior rather than a fix, so it is mutation-checked:
+    /// deleting the retry loop's `.repoLevel` throw makes it report the generic
+    /// "after all attempts" instead of git's own words.
+    @Test func repoLevelFailureInsideTheRetryLegAlsoFailsFast() async throws {
+        let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
+        defer { try? FileManager.default.removeItem(at: parentDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: hostDir, repoDir: repoDir)
+
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        try occupy(pending.localPath)
+
+        let base = WorktreeLayout().basePath(for: repo)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o555], ofItemAtPath: base
+        )
+        // Registered after the temp-dir cleanup above, so it runs BEFORE it —
+        // a read-only directory cannot be emptied.
+        defer {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o755], ofItemAtPath: base
+            )
+        }
+
+        do {
+            _ = try await lifecycle.completeCreateWorktree(
+                worktreeID: pending.id, skipClaude: true
+            )
+            Issue.record("expected the read-only worktree base to fail the create")
+        } catch {
+            let text = String(describing: error)
+            // Only the retry leg can produce this: attempt 1's path exists, so
+            // it fails on the existence check long before any mkdir.
+            #expect(text.contains("could not create leading directories"),
+                    "the retry leg's real cause was not surfaced: \(text)")
+            #expect(!text.contains("after all attempts"),
+                    "the retry leg burned a second base on a repo-level cause: \(text)")
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.filter { $0.hasPrefix("tbd/") }.isEmpty,
+                "the retry leg leaked a branch: \(branches)")
     }
 }

--- a/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeCreateFailureCleanupTests.swift
@@ -331,6 +331,26 @@ import Testing
     /// only the `.gitUnusable` arm says "did not complete", while every
     /// `.repoLevel` exit says "git worktree add failed" — so classifying a
     /// non-`GitError` as `.repoLevel` again fails this test.
+    ///
+    /// **The classification is all this fixture can establish, so it is all it
+    /// asserts.** The 1 ms ceiling is an instance property of the `GitManager`,
+    /// so it governs *every* git subprocess the lifecycle runs — cleanup's own
+    /// existence probe, tip read, prune and `branch -D` included — and
+    /// `runBoundedProcess` reports `.timedOut` whenever real elapsed time
+    /// reached the deadline, even for a child that ran to completion. So
+    /// `cleanUpFailedWorktreeAdd`'s probes can never answer here, its gates fail
+    /// closed, and **keeping the branch is the correct outcome rather than a
+    /// leak**. Whether there is a branch to keep is a wall-clock race with no
+    /// guaranteed winner: `-b` writes the ref early in `worktree add`, so on a
+    /// loaded runner git reaches it before the deadline elapses and on an idle
+    /// one it does not. An assertion that no `tbd/` branch survives therefore
+    /// asserts that race, not the design — it held locally and went red in CI on
+    /// `["tbd/…-impressed-rook"]`. The directory is no better a subject: cleanup
+    /// removes it in-process before any probe, but the child only gets SIGTERM
+    /// (SIGKILL 500 ms later) and can still be writing into the path after the
+    /// removal. Nor does observation fix it — a second `GitManager` on an
+    /// ordinary timeout would read the tree reliably, but what it reads is the
+    /// nondeterministic part.
     @Test func aTimedOutGitFailsFastInsteadOfSpendingTheOtherBase() async throws {
         let (parentDir, hostDir, repoDir) = try await makeClonedTestRepo()
         defer { try? FileManager.default.removeItem(at: parentDir) }
@@ -356,10 +376,6 @@ import Testing
             #expect(!text.contains("after all attempts"),
                     "a second name was attempted for a wedged git: \(text)")
         }
-
-        let branches = try await localBranches(repoDir)
-        #expect(branches.filter { $0.hasPrefix("tbd/") }.isEmpty,
-                "a timed-out attempt leaked a branch: \(branches)")
     }
 
     /// An unresolvable base is not fixable by a fresh name either, so it must

--- a/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
+++ b/Tests/TBDDaemonTests/WorktreePRCheckoutTests.swift
@@ -6,8 +6,8 @@ import Testing
 
 /// Task 2: PR-head checkout. Covers the GitManager primitive
 /// (`fetchPullRequestHead` / `localBranchExists`) plus the lifecycle PR-create
-/// dispatch, including the collision-safety guard that the `+` force refspec
-/// must never clobber an unrelated pre-existing local branch of the same name.
+/// dispatch, including the collision-safety guard that a pull-head fetch must
+/// never rewrite an unrelated pre-existing local branch of the same name.
 @Suite struct WorktreePRCheckoutTests {
 
     /// Builds a bare "origin" carrying `refs/pull/<number>/head` at a commit
@@ -42,7 +42,7 @@ import Testing
         return (cloneTempDir, cloneRepoDir, prSHA)
     }
 
-    /// `localBranchExists` gates the force-refspec in `fetchPullRequestHead`,
+    /// `localBranchExists` gates which name `fetchPullRequestHead` writes,
     /// so it must fail CLOSED: only the benign "ref missing" exit-1 case may
     /// return `false`. A non-exit-1 failure (here: `show-ref` run inside a
     /// plain, non-git directory exits 128 with "fatal: not a git repository")
@@ -74,6 +74,72 @@ import Testing
         #expect(existsAfter == true)
         let sha = try await git.headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/pr-7")
         #expect(sha == prSHA)
+    }
+
+    /// The refspec is unforced, so a local branch already standing under the
+    /// destination name and carrying commits the pull head does not contain is
+    /// REFUSED — it keeps its own tip, and the create fails instead.
+    ///
+    /// `uniqueLocalBranchName` normally steers around that name; this is the
+    /// backstop for the window between that probe and the fetch's ref write,
+    /// which no probe can close. Red against the `+`-forced refspec, which
+    /// succeeds and moves the branch to the pull head.
+    @Test func fetchPullRequestHeadRefusesToRewriteADivergentBranch() async throws {
+        let (tempDir, cloneRepoDir, prSHA) = try await makePRFixture(number: 7)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // A branch under the name the fetch aims at, carrying a commit the pull
+        // head does not contain — the shape a forced refspec silently ate.
+        try await shell(
+            "git checkout -q -b pr-7 && git commit --allow-empty -m 'only this branch has it'"
+            + " && git checkout -q main",
+            at: cloneRepoDir
+        )
+        let git = GitManager()
+        let originalSHA = try await git.headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/pr-7")
+        #expect(originalSHA != prSHA)
+
+        var refusal: GitError?
+        do {
+            try await git.fetchPullRequestHead(repoPath: cloneRepoDir.path, number: 7, localBranch: "pr-7")
+        } catch let error as GitError {
+            refusal = error
+        }
+        let error = try #require(
+            refusal, "the fetch did not refuse; it wrote over a branch it did not create"
+        )
+        // The wording `gitRefusedToCreateBranch` reads to keep cleanup off this
+        // branch — pinned here because that gate depends on it.
+        #expect(error.stderr.contains("[rejected]"),
+                "git's refusal did not name a rejected ref update: \(error.stderr)")
+
+        let afterSHA = try await git.headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/pr-7")
+        #expect(afterSHA == originalSHA,
+                "the refused fetch still moved the branch: \(originalSHA) -> \(afterSHA)")
+    }
+
+    /// The residual the unforced refspec does NOT cover, pinned so nobody reads
+    /// the test above as "collisions are impossible now": a colliding branch the
+    /// pull head already *contains* fast-forwards rather than being refused. No
+    /// commits are lost — the old tip stays reachable from the new one — but the
+    /// ref moves, which is why `uniqueLocalBranchName` still runs first.
+    ///
+    /// Characterization, not a fix: it behaves the same either side of dropping
+    /// the `+`.
+    @Test func aBranchThePullHeadAlreadyContainsStillFastForwards() async throws {
+        let (tempDir, cloneRepoDir, prSHA) = try await makePRFixture(number: 7)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // `main` is an ancestor of the pull head in this fixture.
+        try await shell("git branch pr-7 main", at: cloneRepoDir)
+        let git = GitManager()
+        let originalSHA = try await git.headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/pr-7")
+        #expect(originalSHA != prSHA)
+
+        try await git.fetchPullRequestHead(repoPath: cloneRepoDir.path, number: 7, localBranch: "pr-7")
+
+        let afterSHA = try await git.headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/pr-7")
+        #expect(afterSHA == prSHA)
     }
 
     @Test func createFromPRChecksOutPullHeadAndStampsNumber() async throws {
@@ -111,8 +177,8 @@ import Testing
         defer { try? FileManager.default.removeItem(at: tempDir) }
 
         // Pre-existing, unrelated local branch sharing the PR head name. The
-        // `+refs/pull/7/head:refs/heads/feature-x` refspec would force-rewrite
-        // it — the lifecycle must uniquify the local branch name first.
+        // `refs/pull/7/head:refs/heads/feature-x` refspec would write over it —
+        // the lifecycle must uniquify the local branch name first.
         try await shell("git branch feature-x", at: cloneRepoDir)
         let originalSHA = try await GitManager().headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/feature-x")
         #expect(originalSHA != prSHA)
@@ -134,7 +200,7 @@ import Testing
         let head = try await GitManager().headSHA(worktreePath: wt.localPath)
         #expect(head == prSHA)
 
-        // ...and the original branch is untouched by the force refspec.
+        // ...and the original branch is untouched by the fetch.
         let afterSHA = try await GitManager().headSHA(repoPath: cloneRepoDir.path, ref: "refs/heads/feature-x")
         #expect(afterSHA == originalSHA)
     }

--- a/Tests/TBDDaemonTests/WorktreeReviveFailureCleanupTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveFailureCleanupTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import TestSupport
+import Testing
+@testable import TBDDaemonLib
+@testable import TBDShared
+
+/// Tier 2 (real git subprocesses, real filesystem, no tmux — `dryRun: true`).
+///
+/// Covers what a *failed* revive leaves behind. Revive re-adds the git worktree
+/// two ways, and only one of them creates a branch:
+///
+/// - the branch still exists → `git worktree add <path> <branch>` checks out a
+///   branch the user owns, so nothing there is ours to delete;
+/// - the branch is gone → `git worktree add -b <branch> <path> <sha>` recreates
+///   it from the archived HEAD, the fourth `-b` call site in the lifecycle and
+///   the same create-then-fail-later shape the create path had to be fixed for.
+///
+/// The failure is induced with a `post-checkout` hook that exits 1 — a real
+/// repo-level thing (LFS, direnv, and friends install one) and, verified
+/// against git 2.50, the shape that leaks the most: git creates the branch,
+/// writes the directory, registers the worktree, runs the hook, and exits 1
+/// with all three standing. It is also what makes the cleanup's
+/// `worktree prune` load-bearing here — `git branch -D` refuses a branch a live
+/// registration claims ("cannot delete branch 'x' used by worktree at …").
+@Suite struct WorktreeReviveFailureCleanupTests {
+
+    /// Makes every `git worktree add` in `repoDir` fail *after* git has created
+    /// the branch, the directory and the registration.
+    private func installFailingPostCheckoutHook(_ repoDir: URL) throws {
+        let hook = repoDir.appendingPathComponent(".git/hooks/post-checkout")
+        try "#!/bin/sh\necho 'post-checkout veto' >&2\nexit 1\n"
+            .write(to: hook, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: hook.path
+        )
+    }
+
+    /// Every local branch. Deliberately not `listBranches`, which filters out
+    /// branches checked out in a worktree — exactly the ones these tests need
+    /// to see.
+    private func localBranches(_ repoDir: URL) async throws -> [String] {
+        try await GitManager()
+            .listRefs(repoPath: repoDir.path, prefix: "refs/heads")
+            .map { String($0.dropFirst("refs/heads/".count)) }
+    }
+
+    private func makeLifecycle(db: TBDDatabase) -> WorktreeLifecycle {
+        WorktreeLifecycle(
+            db: db, git: GitManager(), tmux: TmuxManager(dryRun: true), hooks: HookResolver()
+        )
+    }
+
+    /// A created-then-archived worktree, which is how a row acquires the
+    /// `archivedHeadSHA` the recreate leg needs.
+    private func makeArchivedWorktree(
+        lifecycle: WorktreeLifecycle, repoID: UUID
+    ) async throws -> Worktree {
+        let worktree = try await lifecycle.createWorktree(repoID: repoID, skipClaude: true)
+        try await lifecycle.archiveWorktree(worktreeID: worktree.id, force: true)
+        return worktree
+    }
+
+    // MARK: - The archived-SHA recreate leg
+
+    /// The bug: `worktreeAddNewBranch` creates `<branch>` and a failure after
+    /// that used to leak the branch, the directory and the registration, with no
+    /// cleanup at any layer — strictly worse than a failed *create*, which at
+    /// least removed the directory.
+    ///
+    /// Red against the unfixed tree, on all three:
+    ///   ✘ the failed recreate leaked the branch it made: ["main", "tbd/…"]
+    ///   ✘ the failed recreate left a directory at …/tbd/worktrees/…/…
+    ///   ✘ stray worktree registrations: ["…/repo", "…/tbd/worktrees/…"]
+    @Test func failedRecreateFromArchivedSHALeavesNothingBehind() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let archived = try await makeArchivedWorktree(lifecycle: lifecycle, repoID: repo.id)
+
+        // Point the row at a branch git does not have, so the revive takes the
+        // archived-SHA leg. The same shape as a branch renamed or deleted
+        // between archive and revive, without racing the archive's own capture.
+        let missingBranch = "tbd/deleted-before-revive"
+        try await db.worktrees.updateBranch(id: archived.id, branch: missingBranch)
+        try installFailingPostCheckoutHook(repoDir)
+
+        do {
+            _ = try await lifecycle.reviveWorktree(worktreeID: archived.id, skipClaude: true)
+            Issue.record("expected the post-checkout veto to fail the revive")
+        } catch {
+            #expect(String(describing: error).contains("post-checkout veto"),
+                    "the revive failed for an unexpected reason: \(error)")
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(!branches.contains(missingBranch),
+                "the failed recreate leaked the branch it made: \(branches)")
+        #expect(!FileManager.default.fileExists(atPath: archived.localPath),
+                "the failed recreate left a directory at \(archived.localPath)")
+        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+        #expect(listed.count == 1, "stray worktree registrations: \(listed.map(\.path))")
+    }
+
+    /// The success arm of the same conditional: a recreate that works keeps the
+    /// branch it just made and the checkout it just wrote.
+    ///
+    /// Asserts preserved behavior, so it is mutation-checked: running
+    /// `cleanUpFailedWorktreeAdd` unconditionally after the recreate (rather
+    /// than only from its `catch`) deletes the fresh branch and the directory,
+    /// and this fails on both.
+    @Test func successfulRecreateFromArchivedSHAKeepsItsNewBranch() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        let archived = try await makeArchivedWorktree(lifecycle: lifecycle, repoID: repo.id)
+
+        let missingBranch = "tbd/deleted-before-revive"
+        try await db.worktrees.updateBranch(id: archived.id, branch: missingBranch)
+
+        let revived = try await lifecycle.reviveWorktree(
+            worktreeID: archived.id, skipClaude: true
+        )
+
+        #expect(revived.status == .active)
+        #expect(FileManager.default.fileExists(atPath: revived.localPath),
+                "the revive reported success without a checkout at \(revived.localPath)")
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains(missingBranch),
+                "the successful recreate lost the branch it made: \(branches)")
+    }
+
+    // MARK: - The existing-branch leg
+
+    /// The hard constraint: this leg checks out a branch the user owns and
+    /// creates nothing, so a failure must delete nothing — while still removing
+    /// the directory git left, which is the half nobody was doing.
+    ///
+    /// Half red against the unfixed tree, half mutation-checked. Red half:
+    ///   ✘ the failed checkout left a directory at …/tbd/worktrees/…/…
+    /// The branch half asserts preserved behavior — the unfixed tree deletes no
+    /// branches on this path at all — so it is mutation-checked instead:
+    /// routing this leg's `catch` through `cleanUpFailedWorktreeAdd(
+    /// branchPreExisted: false, branchNameWasAlreadyTaken: false)`, the obvious
+    /// treat-both-legs-alike version of this fix, makes it fail.
+    @Test func failedCheckoutOfAnExistingBranchKeepsTheUsersBranch() async throws {
+        let (tempDir, repoDir) = try await createTestRepo()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let db = try TBDDatabase(inMemory: true)
+        let lifecycle = makeLifecycle(db: db)
+        let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
+        // Archiving leaves the branch standing, which is what routes the revive
+        // through `worktreeAddExisting`.
+        let archived = try await makeArchivedWorktree(lifecycle: lifecycle, repoID: repo.id)
+        #expect(try await localBranches(repoDir).contains(archived.branch),
+                "fixture: the archive was expected to leave the branch behind")
+        try installFailingPostCheckoutHook(repoDir)
+
+        do {
+            _ = try await lifecycle.reviveWorktree(worktreeID: archived.id, skipClaude: true)
+            Issue.record("expected the post-checkout veto to fail the revive")
+        } catch {
+            #expect(String(describing: error).contains("post-checkout veto"),
+                    "the revive failed for an unexpected reason: \(error)")
+        }
+
+        let branches = try await localBranches(repoDir)
+        #expect(branches.contains(archived.branch),
+                "the failed checkout deleted the user's branch: \(branches)")
+        #expect(!FileManager.default.fileExists(atPath: archived.localPath),
+                "the failed checkout left a directory at \(archived.localPath)")
+    }
+}

--- a/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
@@ -202,6 +202,19 @@ struct WorktreeReviveFreshTests {
         #expect(createdPaths.isEmpty)
     }
 
+    /// An ordinary create whose generated `tbd/<name>` collides still lands,
+    /// under a fresh name — the collision safety net the revive path above
+    /// relies on.
+    ///
+    /// The collision is real: the name is reserved first, then a branch is
+    /// planted on it, so git answers `fatal: a branch named 'tbd/…' already
+    /// exists`. It used to be simulated with the `reference-transaction` hook
+    /// the revive test still uses, which declines the first two
+    /// `refs/heads/tbd/` updates. That stands in for a collision only while
+    /// *every* git failure is retried blindly — the behavior that manufactured
+    /// orphan branches. A hook decline is a repo-level policy that no second
+    /// base and no second name can satisfy, so the create now fails fast on it
+    /// and surfaces git's own words.
     @Test func ordinaryCreateStillRetriesGeneratedNameCollision() async throws {
         let (tempDir, repoDir) = try await createTestRepo()
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -210,27 +223,34 @@ struct WorktreeReviveFreshTests {
         try await shell("git init --bare -b main", at: remoteDir)
         try await shell("git remote add origin '\(remoteDir.path)'", at: repoDir)
         try await shell("git push -u origin main", at: repoDir)
-        let rejectionCount = try installGeneratedBranchCollisionHook(
-            repoDir: repoDir,
-            rejections: 2
-        )
 
         let db = try TBDDatabase(inMemory: true)
         let lifecycle = makeReviveFreshLifecycle(db: db)
         let repo = try await makeTestRepo(db: db, tempDir: tempDir, repoDir: repoDir)
 
-        let created = try await lifecycle.createWorktree(
-            repoID: repo.id,
-            skipClaude: true
-        )
+        let pending = try await lifecycle.beginCreateWorktree(repoID: repo.id, skipClaude: true)
+        try await shell("git branch '\(pending.branch)'", at: repoDir)
 
-        #expect(created.status == .active)
-        #expect(
-            try String(contentsOf: rejectionCount, encoding: .utf8)
-                .trimmingCharacters(in: .whitespacesAndNewlines) == "2"
+        let completion = try await lifecycle.completeCreateWorktree(
+            worktreeID: pending.id, skipClaude: true
         )
+        if case .preSessionPending(let phase3) = completion {
+            await phase3.value
+        }
+
+        let created = try #require(try await db.worktrees.get(id: pending.id))
+        #expect(created.status == .active)
         let worktreeRoot = try #require(repo.worktreeRoot)
         #expect(try FileManager.default.contentsOfDirectory(atPath: worktreeRoot).count == 1)
+
+        // Checked out on a DIFFERENT generated branch, and the branch that
+        // caused the collision is untouched.
+        let listed = try await GitManager().worktreeList(repoPath: repoDir.path)
+        let tbdWorktrees = listed.filter { $0.branch.hasPrefix("tbd/") }
+        #expect(tbdWorktrees.count == 1)
+        #expect(tbdWorktrees.first?.branch != pending.branch)
+        let refs = try await GitManager().listRefs(repoPath: repoDir.path, prefix: "refs/heads")
+        #expect(refs.contains("refs/heads/\(pending.branch)"))
     }
 
     @Test func successfulFetchCarriesOnlySelectedConversationAndSeedsProvenance() async throws {

--- a/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
+++ b/Tests/TBDDaemonTests/WorktreeReviveFreshTests.swift
@@ -909,6 +909,19 @@ struct WorktreeReviveFreshTests {
             .write(to: source, atomically: true, encoding: .utf8)
     }
 
+    /// Declines the first `rejections` updates to a `refs/heads/tbd/` ref, and
+    /// declines them *in git's own collision vocabulary*.
+    ///
+    /// The echoed line is what makes this a collision rather than an arbitrary
+    /// hook veto: `worktreeAdd` failures are classified off `GitError.stderr`,
+    /// and a hook's stderr is git's stderr, so this reaches the classifier as
+    /// `.nameCollision` — the failure kind whose only remedy is a fresh name.
+    /// Without it the decline reads as a repo-level veto that fails fast, the
+    /// caller never reaches its `retryGeneratedNameOnCollision` decision, and a
+    /// test asserting that decision passes no matter which way the flag is set.
+    /// (Measured: flipping `WorktreeLifecycle+ReviveFresh`'s
+    /// `retryGeneratedNameOnCollision` to `true` left the veto-only version of
+    /// this suite green.)
     private func installGeneratedBranchCollisionHook(
         repoDir: URL,
         rejections: Int
@@ -927,6 +940,7 @@ struct WorktreeReviveFreshTests {
             if [ "$count" -lt \(rejections) ]; then
                 count=$((count + 1))
                 echo "$count" > "\(rejectionCount.path)"
+                echo "fatal: a branch named 'tbd/simulated-collision' already exists" >&2
                 exit 1
             fi
         fi

--- a/docs/specs/2026-08-14-worktree-add-failure-cleanup-design.md
+++ b/docs/specs/2026-08-14-worktree-add-failure-cleanup-design.md
@@ -1,0 +1,164 @@
+# Worktree-add failure classification and gated branch cleanup
+
+`git worktree add -b <branch> <path> <base>` creates the branch before it
+finishes its work, so any failure after that point leaves the branch standing.
+This document records how TBD decides whether such a failure is worth retrying,
+and how it withdraws a branch its own failed attempt created.
+
+Both mechanisms live in `WorktreeLifecycle`, and both are reached only from an
+explicit user gesture — an RPC-triggered create or revive. Neither runs from a
+sweep, a timer, or any background pass.
+
+## Why this exists
+
+A stale `.git/config.lock` made every `git worktree add` in one repo fail after
+git had created the branch. Each attempt left a `tbd/<name>` behind, and the
+leak then masked its own cause: the next attempt reused the same name, failed on
+the collision the first attempt had just manufactured, and reported *that* as
+the error. The user saw "the folder or branch may already exist" for a stuck
+lock file.
+
+Two properties were missing. A failed operation did not withdraw what it
+created, and the retry logic could not tell a cause a retry might fix from one
+it could not.
+
+## Failure classification
+
+`WorktreeAddFailureKind` sorts a failed `worktree add` into what could still
+help:
+
+- **`baseUnresolvable`** — the base ref did not resolve. The *other* base branch
+  may; the two-base loop exists for exactly this.
+- **`nameCollision`** — the branch name, the path, or the checkout is taken.
+  Base-independent, so further bases are pointless and only a fresh name helps.
+- **`repoLevel`** — a stale lock, a corrupt repo, no disk. A fresh name cannot
+  help, so that leg is skipped. The *other base* is still tried: the two are not
+  interchangeable, because `origin/<default>` is a remote-tracking ref whose
+  `-b` triggers an upstream-config write while a plain local ref writes none.
+  With a jammed config lock, the remote base fails and the local base succeeds.
+- **`gitUnusable`** — a timeout or spawn failure, i.e. not a `GitError` at all.
+  Fails immediately. This is the one cause where a further attempt has a real
+  cost — another full `GitManager.commandTimeout` — rather than a real chance.
+
+### Unknown means stop, not retry
+
+Recognized-recoverable stderr shapes are a narrow whitelist; everything else is
+`repoLevel` and fails fast carrying git's own words.
+
+The justification is an asymmetry. Misreading a recoverable cause as fatal costs
+one attempt and surfaces a true error message. Misreading a fatal cause as
+recoverable costs a leaked branch *per attempt* and buries the real error under
+a collision of our own making — which is the bug this design exists to remove.
+
+A consequence worth stating, because it is what makes the design safe to leave
+alone: a future git version, or a phrasing nobody catalogued, can only ever
+narrow what we retry. It cannot silently re-enable blind retrying.
+
+The classifier reads `GitError.stderr`, so every git subprocess runs under
+`LC_ALL=C`/`LANG=C` merged onto the inherited environment. Merged rather than
+replaced — a bare dictionary would strip `PATH`, `HOME` and `SSH_AUTH_SOCK` from
+every git call the daemon makes.
+
+## Gated branch cleanup
+
+A failed attempt removes its directory, prunes any worktree registration git
+recorded, and deletes the branch it created. This is the first code in TBD that
+deletes a local branch.
+
+Deletion is governed by four gates. **Each closes a distinct way of being
+wrong**, and that is the rule for changing the set: a fifth gate must name a
+fifth failure mode, and a gate that cannot name one is decoration.
+
+1. **Pre-existence.** A probe taken before the attempt positively answered
+   "absent". Kept as a tri-state, so a probe that *failed* blocks deletion — not
+   knowing is not the same as knowing it was absent.
+2. **Git's own refusal.** Git said it refused because the name was taken. This
+   is what closes the window between the probe and the attempt, where something
+   else could have created the branch.
+3. **Existence now.** The branch is actually there to delete.
+4. **Tip match.** It points at the SHA this attempt would have written. Each
+   call site knows that value: the base tip sampled *before* the attempt for the
+   fresh-create legs, the remote ref's tip for a tracking checkout, the archived
+   SHA for a revive, and for the fork-PR leg the fetched tip read once the fetch
+   reports success.
+
+Gates 1, 3 and 4 fail toward keeping the branch: a probe that did not answer, an
+unresolvable expected SHA, an unreadable current tip and a mismatched one each
+return before `branch -D`, and the reason is logged. Gate 2 is the exception,
+covered below.
+
+Beneath the gates, deletion uses `git branch -D` rather than plumbing
+`update-ref -d`, because git itself refuses to delete a branch a live worktree
+has checked out. Plumbing would not.
+
+Legs that check out a branch the *caller* owns create nothing and delete
+nothing. There the deleting helper is kept structurally off the code path rather
+than called with a safe argument, so no single edit sits between the code and
+data loss.
+
+### The abstention, and why it needed a fourth gate
+
+Gate 2 answers `false` both when git did not refuse and when its wording was not
+recognized. `false` permits deletion, so an unrecognized refusal is an
+**abstention, not a finding** — the one place in the design where an unknown
+does not by itself mean "keep". Gate 4 exists to cover that: it depends on ref
+content rather than message text, so a phrasing nobody catalogued cannot on its
+own authorize a deletion.
+
+## Rejected: surface leaked branches for manual cleanup
+
+TBD could refuse to delete anything and instead report leaked branches for a
+human to remove.
+
+This is close to what we already had. The leaked branches were visible in `git
+branch` the entire time, and one repo still reached 2,804 local branches against
+109 live worktrees — a 374 KB `.git/config` rewritten in full on every `worktree
+add`, which is what made the original lock failure plausible. Reporting a leak
+more loudly does not fix a leak nobody acts on, and it would ship the bug while
+adding a reporting surface to maintain.
+
+Auto-deletion also restores an ordinary property rather than adding a capability:
+the create either produces a worktree or leaves the repo as it found it.
+
+## What would show this is wrong
+
+Two triggers, and the second matters more than it looks.
+
+1. **A branch deleted that TBD did not create.** Any such report flips
+   auto-deletion to surface-only. The gates are designed so this should be
+   unreachable without an external actor inside a sub-second window.
+2. **The keep-reason log firing routinely in normal use.** That would mean the
+   gates are abstaining on ordinary cleanups — the leak quietly returned while
+   the code looks safe *precisely because* it never deletes anything. This is
+   the failure that resembles success, and it is invisible without watching for
+   it.
+
+## Residual risk
+
+An external actor that creates a branch of the same name from the *same base*
+inside the probe-to-attempt window produces a tip identical to ours, so gate 4
+passes. The window is narrowed, not eliminated. `RepoSerializer` rules out any
+concurrent TBD-initiated race, so this requires a human or another tool acting
+directly on the repo at that moment.
+
+On the fork-PR leg the branch is created by fetching `refs/pull/<n>/head` rather
+than by `-b`. That refspec is deliberately unforced, so git refuses a colliding
+update instead of overwriting it and gate 2 has a refusal to read. A colliding
+branch the pull head *already contains* still fast-forwards rather than being
+refused: no commits are lost, but the ref moves, which is why a free name is
+chosen before the fetch rather than relying on git to refuse.
+
+## Why no flag
+
+Per `CLAUDE.md`, large or risky new behavior ships behind a default-off flag,
+and "deletes or mutates persisted state" is an independently-sufficient trigger.
+
+The rule targets behavior that acts on its own — a sweep, a timer, anything
+"auto-". This deletion is neither autonomous nor a capability a user gains: it
+is the withdrawal half of an operation TBD already performs, reached only from
+an explicit create or revive. Default-off would ship the leak still open, since
+the flag's "off" state is the bug.
+
+The hazard a soak would surface is also the status quo: every gate but the
+abstention in gate 2 fails toward keeping the branch, and keeping it reproduces
+today's visible, recoverable leak.

--- a/docs/specs/2026-08-14-worktree-add-failure-cleanup-design.md
+++ b/docs/specs/2026-08-14-worktree-add-failure-cleanup-design.md
@@ -137,9 +137,23 @@ Two triggers, and the second matters more than it looks.
 
 An external actor that creates a branch of the same name from the *same base*
 inside the probe-to-attempt window produces a tip identical to ours, so gate 4
-passes. The window is narrowed, not eliminated. `RepoSerializer` rules out any
-concurrent TBD-initiated race, so this requires a human or another tool acting
-directly on the repo at that moment.
+passes. The window is narrowed, not eliminated.
+
+`RepoSerializer` narrows who can be inside that window, but it covers two of the
+three entry points rather than all of them. `handleWorktreeCreate` and
+`handleWorktreeReviveConversationFresh` run their lifecycle calls inside
+`repoSerializer.submit(repoID:)`, so for those two no second TBD-initiated
+attempt on the same repo can be in flight. `handleWorktreeRevive` calls
+`beginReviveWorktree` directly and unserialized — deliberately, so an RPC
+connection is never held for the length of a `preSession` hook — and that path
+reaches the same gated deletion. **The gates, not serialization, are what
+constrain the delete.** On the revive path the possible occupants of the window
+therefore include another TBD create in the same repo, alongside a human or
+another tool acting on the repo directly.
+
+Serializing that handler too is a known follow-up. It would change the
+concurrency behavior of a path whose non-blocking shape is load-bearing, so it
+belongs to a change of its own rather than to the gates described here.
 
 On the fork-PR leg the branch is created by fetching `refs/pull/<n>/head` rather
 than by `-b`. That refspec is deliberately unforced, so git refuses a colliding


### PR DESCRIPTION
## What's broken

Creating a worktree stopped working in one repo, and left a mess behind while it failed.

A stale `.git/config.lock` — orphaned, no process holding it — made every `git worktree add` fail. Each attempt created the branch, then died writing the upstream tracking config; TBD cleaned up the directory and moved on, so every try left a `tbd/<name>` branch standing. Six orphan branches accumulated before anyone noticed creation was broken at all.

The error named the wrong thing entirely: `git worktree add failed — the folder or branch may already exist`. The real cause, `could not lock config file .git/config: File exists`, never reached the user — by the time the message was composed it had been overwritten by a second, self-inflicted error.

The lock was plausible because that repo's `.git/config` is 374 KB — 2,804 local branches against 109 live worktrees — and it is rewritten in full on every `worktree add`. TBD never deletes a local branch anywhere, so this leak contributes to that pile.

## Why it happens

**A failed create kept the branch it had just made.** `git worktree add -b <branch> <path> <base>` creates the branch *before* it finishes writing config, so a failure after that point leaves it behind permanently. Every failure path cleaned up the directory and nothing else.

That leak then poisoned the next attempt. The path tries two bases — `origin/main`, then local `main` — under the same name, so attempt 2 failed with `a branch named 'tbd/x' already exists`, caused entirely by attempt 1's leak. That became `lastError`, and it is what produced the misleading "folder or branch may already exist" text.

**Retrying under a fresh name cannot help when the cause is repo-level.** With both bases spent, the path generated a new name and tried again — right for a name collision, which is why it exists. For a stuck lock, a corrupt repo, or a full disk the name was never the problem, and the retry just manufactured another orphan per attempt.

The same shape sat at every other branch-creating call site: the existing-branch create path (`--track -b`) leaked identically, and so did the revive path's archived-SHA recreate (`-b <branch> <sha>`), which was worse — no cleanup at any layer, not even the directory. Not a regression; the directory-only cleanup dates to the original lifecycle orchestrator.

## Spec

The branch-leak fix itself is a bug fix and needs no spec. Two things built on top of it are authored policy a reasonable team could decide differently, so they are written down in [`docs/specs/2026-08-14-worktree-add-failure-cleanup-design.md`](docs/specs/2026-08-14-worktree-add-failure-cleanup-design.md): the four-way failure taxonomy with its per-kind retry policy, and the four gates governing the first branch deletion TBD has ever performed.

The spec records the governing principles rather than the mechanics the diff already shows — unknown failures stop rather than retry, and gates are one-per-failure-mode — plus what the code cannot record: the rejected alternative (surface leaked branches for manual cleanup), and what would show the design wrong.

## Why no flag

This is the first code in TBD that deletes a local branch, and CLAUDE.md lists "deletes or mutates persisted state" as an independently-sufficient trigger for a default-off flag. That bullet deserves a direct answer.

A flag would defeat the fix rather than de-risk it. The rule protects against *new behavior acting on its own* — a sweep, a timer, anything "auto-". This deletion is neither autonomous nor a capability a user gains: it is the withdrawal half of an operation TBD already performs. `git worktree add -b` creates a branch; when that same call fails, the branch is a half-finished side effect, and removing it makes the operation atomic. Default-off would ship the leak still open.

Scope is narrow by construction, and every unknown lands on "don't delete": a probe error, an expected tip that would not resolve, a current tip git would not vouch for, a tip that disagrees. Each reproduces today's leak — visible and recoverable — so the soak a flag would buy protects against a hazard whose realization is the status quo.

One of the four gates is an abstention rather than a finding, and that is why it is not alone. The stderr match answers `false` both when a failure genuinely left our own branch standing and when a future git, a non-standard build or a wrapper rewords the refusal — so wording alone would leave one axis fail-open. The tip check is AND-ed alongside it because it asks a question no phrasing can garble. Beneath the gates, deletion uses `git branch -D` rather than plumbing `update-ref -d`, so git itself refuses to delete a branch any live worktree has checked out.

## What this PR does

**Cleans up what each failed attempt created.** The directory as before, plus `git worktree prune`, plus the branch — behind four AND-ed gates:

- a pre-attempt probe positively answered "absent", kept as a tri-state so a *failed* probe (`nil`) blocks deletion.
- git's own stderr does **not** say it refused because the name was taken.
- the branch exists now.
- the branch points at the SHA this attempt would have put it at: the resolved base tip for the two fresh-create legs and the remote-tracking checkout, sampled per attempt *before* the add; the archived SHA for the revive recreate, which is the argument `-b` copies; the tip the unforced pull-head fetch wrote, read once that fetch reports success. An unresolvable tip, an unreadable one, and a disagreement all block the delete.

That last gate is the one that does not read English. The stderr gate narrows the probe→attempt window but cannot close it: an unrecognized phrasing answers `false`, the same value a genuine "this branch is ours" failure answers, so alone it would let an unknown *authorize* a delete. Where the branch points does not depend on wording.

A branch the caller brought is never touched. The legs that check out an existing branch create nothing and delete nothing — and there the deleting helper is kept structurally off the code path rather than called with a safe argument, so no single edit sits between the code and data loss.

All five branch-creating mechanisms are covered: the four `-b` sites (two in the fresh-create loop, the remote-tracking checkout, the revive path's archived-SHA recreate) plus the fork-PR leg, which creates its branch by fetching `refs/pull/<n>/head` into it. `GC/ReapSnapshot`'s `worktree add` creates none.

**Unforces the fork-PR leg's fetch.** `+refs/pull/<n>/head:refs/heads/<name>` force-updated, so a branch appearing between the probe and the fetch was silently rewritten — and a forced fetch never refuses, so the stderr gate was structurally dead on that leg. Dropping the `+` fixes both halves: git rejects the update, the colliding branch keeps its own commits, and the refusal is the evidence the gate wants. The gate learns the two phrasings that refusal takes (git 2.50) — `! [rejected] … (non-fast-forward)`, and `refusing to fetch into branch '<ref>' checked out at '<path>'` when a live worktree holds it.

**Classifies the failure instead of retrying blindly.** Git's stderr decides which remedy can work:

- *base unresolvable* (`invalid reference`) — the other base may resolve. Try it.
- *name collision* (`already exists`, `is already used by worktree at`) — base-independent; go straight to a fresh name.
- *repo-level* (anything else) — no name helps, so that leg is skipped and git's real words surface, with a hint naming `.git/config.lock` for a stale lock.
- *git unusable* (a timeout or spawn failure — not a `GitError`) — fail immediately; a second attempt costs another full 120 s timeout.

The patterns are a narrow whitelist, each commented with the message it matches; anything unrecognized falls into fail-fast, because an unclassifiable error retried under a second name is exactly what manufactured the orphans.

Counterintuitive but deliberate: a repo-level failure still tries the **other base**. The two are not interchangeable — `origin/<default>` is remote-tracking, so `-b` triggers the upstream-config write; plain local `<default>` writes none. With the lock jammed, base 1 fails and base 2 **succeeds**, so for the motivating scenario the outcome is a worktree rather than a better error message. The added cleanup is what makes continuing safe, deleting base 1's leaked branch before base 2 reuses the name.

**Pins the git subprocess locale.** Since two gates read English phrases in stderr, every git child runs with `LC_ALL=C`/`LANG=C` merged onto the inherited environment — merged, not replaced, since a bare dict would strip `PATH`, `HOME` and `SSH_AUTH_SOCK` from every git call the daemon makes.

## Assumptions

- **Git's failure messages are the ones matched.** Verified against git 2.50; the locale pin removes the translation variable, but not a non-standard build or a wrapper that reformats stderr. A rewording makes that gate abstain, not err — the delete then rests on the tip check, which is why the two are AND-ed.
- **A same-base coincidence is not detected.** The tip check narrows the probe→attempt window to a collision of name *and* starting commit: an external actor branching from the very base this attempt used lands on the same SHA, the check passes, and their branch is deleted. Substantially narrowed, not closed.
- **Git refuses only what it cannot fast-forward.** So one collision shape on the fork-PR leg still moves a ref this attempt did not create — a branch the pull head already *contains*. No commits are lost, the uniquifier steers around the name first, and a test pins the behavior.

## Evidence & verification

**The repro**, reduced to a fixture reproducing the field failure:

```
git init --bare -b main remote.git && git clone remote.git repo
cd repo && git commit --allow-empty -m init && git push origin main
touch .git/config.lock
git worktree add ../wt -b tbd/leaky origin/main
# exit 255 — "could not lock config file .git/config: File exists"
# tbd/leaky stands; git rolled back the directory itself
```

**Discriminating tests.** 26 in a new `WorktreeCreateFailureCleanupTests`, 3 in `WorktreeReviveFailureCleanupTests`, 2 in `GitManagerTests`, 2 re-fixtured in `WorktreeReviveFreshTests`. Each was shown red before its fix; those asserting *preserved* behavior are mutation-checked instead, with the mutation named in the docstring:

- `failedCreateLeavesNothingBehind` — `(leaked → ["tbd/…-thirsty-marmoset", "tbd/…-underlying-vole"]).isEmpty → false`: two leaked branches, also proof a second name was generated.
- `aBranchAtADifferentSHAIsKeptEvenWhenGitsRefusalGoesUnrecognized` — the tip gate's own case, red without it: `(branches → ["main"]).contains("theirs-from-elsewhere")` — someone else's branch, deleted because the stderr gate abstained. Its sibling arm, a branch cut from this attempt's own base, is still deleted, so the gate is not a synonym for "never clean up".
- `anUnresolvableExpectedTipNeverDeletes` — red without the gate: `(branches → ["main"]).contains("expected-tip-unknown")`.
- `preExistingBranchSurvivesAFailedCheckout` — mutation: route the caller-owned leg through cleanup as if it had created the branch. Red: `(branches → ["main"]).contains("owned-by-caller")` — the user's branch destroyed.

**The thinnest gate, measured.** For `worktree add` the stderr gate matches only `a branch named 'x' already exists`, leaving one shape where it does not fire — an unborn branch claimed by another worktree, which reports `fatal: 'x' is already used by worktree at '<path>'` instead. Measured (git 2.50.1): the phrasing turns on whether the ref exists, so that wording is reachable *only while the ref is absent* — only when git itself just created it, at the base tip. Two tests pin it.

Three coverage limits, stated rather than papered over. The retry loop's `.nameCollision` break has no discriminating test — reaching it needs the generated name to also collide, and both arms look the same to the user. The timeout test discriminates on message text rather than an attempt count, because `GitManager` is a concrete struct with no counting seam. And no fixture separates "the branch is present" from "its tip is readable": both reads go through the same git, and no repo state satisfies one while failing the other (both directions tried against 2.50), so `aRefGitCannotVouchForIsNeverDeleted` pins the property they share — an answer git could not give never authorizes a delete.

**Suite:** 2751 tests in 279 suites pass (the `FlakyQuarantineSelfTests` fixture is the expected known issue). `swiftlint --strict` clean across 695 files. The locale pin touches every git call in the daemon, so the full pass is load-bearing.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7AA4EBE5-B63C-49BA-A2E2-91B349DBDDD9)
