### PR TITLE
feat(scripts): --release flag for restart.sh, and stop calling a release daemon 'skew'

### DIFF
--- a/Sources/TBDApp/Helpers/DaemonBuildSkew.swift
+++ b/Sources/TBDApp/Helpers/DaemonBuildSkew.swift
@@ -11,6 +11,11 @@ import Foundation
 /// legitimately be paired with makes the skew visible. Visibility only — the
 /// app never kills or restarts a mismatched daemon.
 enum DaemonBuildSkew {
+    /// SwiftPM build configurations `scripts/restart.sh` can launch a daemon
+    /// from. A release-built daemon from this app's own worktree is a
+    /// deliberate `--release` restart, not cross-build skew.
+    static let buildConfigurations = ["debug", "release"]
+
     /// Human-readable warning when the daemon binary doesn't belong to this
     /// app's build; nil when it matches or when identity can't be established
     /// (older daemon without the field, unbundled app with no source path).
@@ -18,9 +23,11 @@ enum DaemonBuildSkew {
     /// Acceptable daemon locations for this app:
     /// - `appSiblingDaemonPath`: TBDDaemon next to the app executable — the
     ///   binary `startDaemonAndConnect()` itself would spawn.
-    /// - `<sourceWorktreePath>/.build/debug/TBDDaemon`: the binary
-    ///   `scripts/restart.sh` of the worktree that built this app launches
-    ///   (the app itself runs from /Applications, not from that worktree).
+    /// - `<sourceWorktreePath>/.build/<config>/TBDDaemon` for each build
+    ///   configuration `scripts/restart.sh` can launch — `debug` by default,
+    ///   `release` under its `--release` flag. Both belong to the worktree
+    ///   that built this app (the app itself runs from /Applications, not
+    ///   from that worktree), so neither is skew.
     ///
     /// `resolvePath` is an injection seam so tests can exercise both branches
     /// with fabricated paths; production uses `defaultResolvePath`.
@@ -39,7 +46,9 @@ enum DaemonBuildSkew {
             candidates.append(sibling)
         }
         if let worktree = sourceWorktreePath, !worktree.isEmpty {
-            candidates.append(worktree + "/.build/debug/TBDDaemon")
+            for config in buildConfigurations {
+                candidates.append(worktree + "/.build/\(config)/TBDDaemon")
+            }
         }
         guard !candidates.isEmpty else { return nil }
         let resolvedDaemon = resolvePath(daemonPath)

--- a/Sources/TBDApp/Helpers/DaemonCandidateFinder.swift
+++ b/Sources/TBDApp/Helpers/DaemonCandidateFinder.swift
@@ -8,7 +8,16 @@ enum DaemonCandidateFinder {
     ///
     /// Candidates include:
     /// 1. The app executable's sibling directory (the .app bundle's MacOS/)
-    /// 2. The source worktree's `.build/debug/TBDDaemon` (if known)
+    /// 2. The source worktree's `.build/<config>/TBDDaemon` (if known), trying
+    ///    THIS app's own build configuration first and the other second.
+    ///
+    /// The configuration order matters. This list previously named only
+    /// `debug`, so a release app that auto-spawned its daemon — which is what
+    /// happens after a reboot, when the app launches with no daemon running —
+    /// silently paired a release app with a DEBUG daemon. Preferring the
+    /// matching configuration keeps a `--release` install release end-to-end,
+    /// while the fallback means a developer who has only ever built one
+    /// configuration still gets a daemon rather than an error.
     ///
     /// Paths are returned as absolute strings for immediate filesystem checks;
     /// they are NOT yet resolved for symlinks. The caller is responsible for
@@ -36,12 +45,28 @@ enum DaemonCandidateFinder {
             candidates.append(siblingPath)
         }
 
-        // Second candidate: daemon in the source worktree's build directory
+        // Next candidates: the source worktree's build directories, this app's
+        // own configuration first (see the note above).
         if let worktreePath = sourceWorktreePath, !worktreePath.isEmpty {
-            let worktreeDaemonPath = worktreePath + "/.build/debug/TBDDaemon"
-            candidates.append(worktreeDaemonPath)
+            for config in buildConfigurationSearchOrder {
+                candidates.append(worktreePath + "/.build/\(config)/TBDDaemon")
+            }
         }
 
         return candidates
+    }
+
+    /// Build configurations to search, matching this app's own first.
+    ///
+    /// `#if DEBUG` is the only thing the running app knows about how it was
+    /// compiled; SwiftPM sets it for `-c debug` and not for `-c release`.
+    /// Exposed (rather than inlined) so the ordering is assertable in tests,
+    /// which can only observe the configuration they themselves run under.
+    static var buildConfigurationSearchOrder: [String] {
+        #if DEBUG
+        ["debug", "release"]
+        #else
+        ["release", "debug"]
+        #endif
     }
 }

--- a/Tests/TBDAppTests/DaemonBuildSkewTests.swift
+++ b/Tests/TBDAppTests/DaemonBuildSkewTests.swift
@@ -19,6 +19,32 @@ private let identity: @Sendable (String) -> String = { $0 }
     #expect(message == nil)
 }
 
+@Test func warningMessage_daemonMatchesSourceWorktreeReleaseBuild_returnsNil() {
+    // `scripts/restart.sh --release` topology: same worktree, optimized
+    // build. Only the .build subdirectory differs from the debug case, so
+    // this is a deliberate configuration choice and NOT cross-build skew.
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: "/Users/me/proj/tbd/.build/release/TBDDaemon",
+        appSiblingDaemonPath: "/Applications/TBD.app/Contents/MacOS/TBDDaemon",
+        sourceWorktreePath: "/Users/me/proj/tbd",
+        resolvePath: identity
+    )
+    #expect(message == nil)
+}
+
+@Test func warningMessage_releaseDaemonFromOtherWorktree_stillWarns() {
+    // Widening to release must not blunt the real signal: a release daemon
+    // from a DIFFERENT worktree is still skew.
+    let otherBuild = "/Users/me/proj/tbd/.claude/worktrees/other-wt/.build/release/TBDDaemon"
+    let message = DaemonBuildSkew.warningMessage(
+        daemonExecutablePath: otherBuild,
+        appSiblingDaemonPath: "/Applications/TBD.app/Contents/MacOS/TBDDaemon",
+        sourceWorktreePath: "/Users/me/proj/tbd",
+        resolvePath: identity
+    )
+    #expect(message?.contains(otherBuild) == true)
+}
+
 @Test func warningMessage_daemonMatchesAppSibling_returnsNil() {
     // App-spawned daemon: TBDDaemon sits next to the app executable.
     let message = DaemonBuildSkew.warningMessage(

--- a/Tests/TBDAppTests/DaemonBuildSkewTests.swift
+++ b/Tests/TBDAppTests/DaemonBuildSkewTests.swift
@@ -120,3 +120,46 @@ private let identity: @Sendable (String) -> String = { $0 }
     let resolved = DaemonBuildSkew.defaultResolvePath("/Users/me/proj/tbd/./.build/debug/TBDDaemon")
     #expect(resolved == "/Users/me/proj/tbd/.build/debug/TBDDaemon")
 }
+
+// MARK: - Cross-source consistency
+
+/// `DaemonBuildSkew.buildConfigurations` hand-mirrors the configurations
+/// `scripts/restart.sh` can launch a daemon from. Nothing in the compiler ties
+/// those two lists together, so a future third `build_config` value in the
+/// script would silently reintroduce the false-positive skew warning this
+/// check exists to prevent. This test is that tie: it reads the script and
+/// fails if the script grows a configuration the Swift list does not know.
+@Test func buildConfigurations_matchesEveryConfigurationRestartScriptCanLaunch() throws {
+    // Walk up from this source file to the repo root (the dir holding `scripts/`).
+    var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    while !FileManager.default.fileExists(atPath: dir.appendingPathComponent("scripts/restart.sh").path) {
+        let parent = dir.deletingLastPathComponent()
+        // Reached the filesystem root without finding it — skip rather than
+        // fail, so a packaged/sandboxed test run doesn't red for the wrong reason.
+        guard parent.path != dir.path else { return }
+        dir = parent
+    }
+    let script = try String(contentsOf: dir.appendingPathComponent("scripts/restart.sh"), encoding: .utf8)
+
+    // Every literal assigned to build_config, e.g. `build_config=debug` and
+    // `--release) build_config=release ;;`.
+    var found: Set<String> = []
+    let pattern = try NSRegularExpression(pattern: #"build_config=([A-Za-z0-9_]+)"#)
+    let ns = script as NSString
+    for m in pattern.matches(in: script, range: NSRange(location: 0, length: ns.length)) {
+        found.insert(ns.substring(with: m.range(at: 1)))
+    }
+
+    #expect(!found.isEmpty, "found no build_config assignments — did restart.sh change shape?")
+    let known = Set(DaemonBuildSkew.buildConfigurations)
+    let unknown = found.subtracting(known)
+    #expect(
+        unknown.isEmpty,
+        """
+        restart.sh can launch build configuration(s) \(unknown.sorted()) that \
+        DaemonBuildSkew.buildConfigurations does not list \(known.sorted()). \
+        A daemon launched in that configuration would be misreported as \
+        cross-build skew. Add it to buildConfigurations.
+        """
+    )
+}

--- a/Tests/TBDAppTests/DaemonCandidateFinderTests.swift
+++ b/Tests/TBDAppTests/DaemonCandidateFinderTests.swift
@@ -2,15 +2,22 @@ import Testing
 import Foundation
 @testable import TBDApp
 
-@Test func daemonCandidatePaths_withBothInputs_returnsBothCandidates() {
+// The worktree candidates follow this app's OWN build configuration first, so
+// these tests derive the expected order rather than hardcoding "debug" — the
+// suite compiles in whichever configuration the run uses, and hardcoding would
+// make it pass in one and fail in the other for no real reason.
+private let configOrder = DaemonCandidateFinder.buildConfigurationSearchOrder
+private func worktreeCandidates(_ worktree: String) -> [String] {
+    configOrder.map { worktree + "/.build/\($0)/TBDDaemon" }
+}
+
+@Test func daemonCandidatePaths_withBothInputs_returnsSiblingThenEachConfiguration() {
     let candidates = DaemonCandidateFinder.daemonCandidatePaths(
         appExecutablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
         sourceWorktreePath: "/Users/me/tbd/worktrees/mywork"
     )
-    #expect(candidates == [
-        "/Applications/TBD.app/Contents/MacOS/TBDDaemon",
-        "/Users/me/tbd/worktrees/mywork/.build/debug/TBDDaemon"
-    ])
+    #expect(candidates == ["/Applications/TBD.app/Contents/MacOS/TBDDaemon"]
+        + worktreeCandidates("/Users/me/tbd/worktrees/mywork"))
 }
 
 @Test func daemonCandidatePaths_withOnlyAppPath_returnsSiblingCandidate() {
@@ -21,12 +28,12 @@ import Foundation
     #expect(candidates == ["/some/path/TBDDaemon"])
 }
 
-@Test func daemonCandidatePaths_withOnlyWorktreePath_returnsWorktreeCandidate() {
+@Test func daemonCandidatePaths_withOnlyWorktreePath_returnsWorktreeCandidates() {
     let candidates = DaemonCandidateFinder.daemonCandidatePaths(
         appExecutablePath: nil,
         sourceWorktreePath: "/Users/me/tbd/worktrees/mywork"
     )
-    #expect(candidates == ["/Users/me/tbd/worktrees/mywork/.build/debug/TBDDaemon"])
+    #expect(candidates == worktreeCandidates("/Users/me/tbd/worktrees/mywork"))
 }
 
 @Test func daemonCandidatePaths_withNeitherInput_returnsEmpty() {
@@ -46,12 +53,34 @@ import Foundation
 }
 
 @Test func daemonCandidatePaths_returnsSiblingFirst() {
-    // Verify ordering: sibling should come before worktree
     let candidates = DaemonCandidateFinder.daemonCandidatePaths(
         appExecutablePath: "/Applications/TBD.app/Contents/MacOS/TBDApp",
         sourceWorktreePath: "/Users/me/tbd/worktrees/mywork"
     )
-    #expect(candidates.count == 2)
-    #expect(candidates[0].contains("Contents/MacOS/TBDDaemon"))
-    #expect(candidates[1].contains(".build/debug/TBDDaemon"))
+    #expect(candidates.first?.contains("Contents/MacOS/TBDDaemon") == true)
+}
+
+@Test func daemonCandidatePaths_offersBothConfigurations() {
+    // The regression this guards: the list once named only `debug`, so a
+    // release app that auto-spawned its daemon (what happens after a reboot,
+    // with no daemon running) paired a release app with a DEBUG daemon.
+    let candidates = DaemonCandidateFinder.daemonCandidatePaths(
+        appExecutablePath: nil,
+        sourceWorktreePath: "/w"
+    )
+    #expect(candidates.contains("/w/.build/release/TBDDaemon"))
+    #expect(candidates.contains("/w/.build/debug/TBDDaemon"))
+}
+
+@Test func buildConfigurationSearchOrder_prefersThisAppsOwnConfiguration() {
+    // A test binary is compiled `-c debug`, so DEBUG is defined here and the
+    // matching-first rule must put "debug" ahead of "release". In a release
+    // build the same rule yields the reverse; asserting the invariant through
+    // `#if DEBUG` keeps the test honest in both.
+    #if DEBUG
+    #expect(configOrder == ["debug", "release"])
+    #else
+    #expect(configOrder == ["release", "debug"])
+    #endif
+    #expect(Set(configOrder) == ["debug", "release"])
 }

--- a/scripts/restart-guard-lib.sh
+++ b/scripts/restart-guard-lib.sh
@@ -102,7 +102,10 @@ warn_wip_build() {
     local installed_path
     installed_path=$(get_installed_worktree_path)
 
-    cat >&2 << 'EOF'
+    # Unquoted heredoc so ${build_config} expands: restart.sh sets it before
+    # calling, and this banner must name the configuration the app WILL
+    # launch from. The body has no other $ or backticks, so nothing else expands.
+    cat >&2 << EOF
 
 ===============================================================================
 WARNING: NOT INSTALL-READY — WIP WORKTREE GUARD ACTIVE
@@ -111,7 +114,7 @@ WARNING: NOT INSTALL-READY — WIP WORKTREE GUARD ACTIVE
 This worktree is on a feature branch or has uncommitted/untracked changes. To
 prevent accidental takeover of the shared daemon and /Applications/TBD.app, the
 full install is SKIPPED. Instead, the app will build and launch from this
-worktree's own .build/debug/TBD.app.
+worktree's own .build/${build_config:-debug}/TBD.app.
 
 CONSEQUENCES:
   • Deep links (tbd://) will NOT route to this app (they'll route to the

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -11,6 +11,7 @@ set -e
 #   scripts/restart.sh --quick  # skip rebuild, restart everything
 #   scripts/restart.sh --dry-run # print install-ready/not-install-ready decision, touch nothing
 #   scripts/restart.sh --wip    # force install even if on a WIP branch
+#   scripts/restart.sh --release # build/launch optimized (-c release) instead of debug
 #   TBD_INSTALL_WIP=1 scripts/restart.sh # same as --wip
 
 SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
@@ -27,13 +28,13 @@ source "$SCRIPT_DIR/restart-environment-lib.sh"
 require_restart_path "${PATH-}"
 
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BUILD_DIR="$REPO_ROOT/.build/debug"
 
 app_only=false
 daemon_only=false
 skip_build=false
 dry_run=false
 force_wip=false
+build_config=debug
 
 for arg in "$@"; do
     case "$arg" in
@@ -42,8 +43,14 @@ for arg in "$@"; do
         --quick) skip_build=true ;;
         --dry-run) dry_run=true ;;
         --wip) force_wip=true ;;
+        --release) build_config=release ;;
     esac
 done
+
+# Everything downstream (bundle assembly, daemon launch, pgrep patterns)
+# derives from BUILD_DIR, so pointing it at the release layout is the whole
+# of --release. Set after arg parsing since the flag decides it.
+BUILD_DIR="$REPO_ROOT/.build/$build_config"
 
 # Check TBD_INSTALL_WIP env var as well
 if [ -n "${TBD_INSTALL_WIP:-}" ]; then
@@ -82,7 +89,7 @@ if [ "$dry_run" = true ]; then
             echo "Would install to /Applications and restart daemon (--wip override)."
         else
             echo "Would SKIP /Applications install and daemon restart."
-            echo "Would launch app from .build/debug/TBD.app instead."
+            echo "Would launch app from .build/$build_config/TBD.app instead."
         fi
     fi
     exit 0
@@ -151,7 +158,7 @@ MODULE_CACHE_FLAGS=(
 if [ "$skip_build" = false ]; then
     echo "Building..."
     t0=$SECONDS
-    (cd "$REPO_ROOT" && scripts/swift-safe build "${MODULE_CACHE_FLAGS[@]}") 2>&1 | tail -3
+    (cd "$REPO_ROOT" && scripts/swift-safe build -c "$build_config" "${MODULE_CACHE_FLAGS[@]}") 2>&1 | tail -3
     echo "  Build: $((SECONDS - t0))s"
 fi
 
@@ -363,7 +370,7 @@ if [ "$daemon_only" = false ]; then
         if [ "$install_to_applications" = true ]; then
             echo "  App launched from /Applications (PID $APP_PID) — logs: /tmp/tbdapp.log"
         else
-            echo "  App launched from .build/debug (PID $APP_PID) — logs: /tmp/tbdapp.log"
+            echo "  App launched from .build/$build_config (PID $APP_PID) — logs: /tmp/tbdapp.log"
         fi
     else
         echo "  ERROR: App failed to launch. Last lines of /tmp/tbdapp.log:"

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -158,8 +158,42 @@ MODULE_CACHE_FLAGS=(
 if [ "$skip_build" = false ]; then
     echo "Building..."
     t0=$SECONDS
-    (cd "$REPO_ROOT" && scripts/swift-safe build -c "$build_config" "${MODULE_CACHE_FLAGS[@]}") 2>&1 | tail -3
+    # Build the two PRODUCTS rather than the whole package.
+    #
+    # A whole-package build compiles the test targets too, and
+    # Tests/TestSupport does `@testable import TBDDaemonLib`, which needs
+    # testability enabled. Debug builds enable it by default; release builds
+    # do NOT, so `swift build -c release` always fails with
+    # ModuleNotTestable — after having already linked both products. That
+    # made --release look like it worked (correct binaries on disk) while
+    # reporting failure, and it is why the exit code below could not be
+    # checked before this change.
+    #
+    # SwiftPM honors only the LAST --product, so these are two invocations.
+    # Restarting needs exactly these two products; the test targets are
+    # scripts/test.sh's job, not the restart path's.
+    build_ok=true
+    for product in TBDDaemon TBDApp; do
+        # Capture the status, THEN print. Piping the build straight into
+        # `tail` would make the pipeline's status `tail`'s (always 0) — the
+        # very status-discarding bug this block exists to fix.
+        if ! build_out=$( (cd "$REPO_ROOT" && scripts/swift-safe build \
+                -c "$build_config" --product "$product" \
+                "${MODULE_CACHE_FLAGS[@]}") 2>&1 ); then
+            build_ok=false
+        fi
+        printf '%s\n' "$build_out" | tail -3
+    done
     echo "  Build: $((SECONDS - t0))s"
+
+    # Stop on a failed build. Previously the build was piped straight to
+    # `tail`, discarding its status, so a broken build fell through to the
+    # bundle assembly and daemon restart and silently relaunched the STALE
+    # binary — a failed build that looked like a successful restart.
+    if [ "$build_ok" = false ]; then
+        echo "ERROR: build failed — not restarting. The running daemon/app are unchanged." >&2
+        exit 1
+    fi
 fi
 
 # MARK: - Assemble TBD.app bundle


### PR DESCRIPTION
## Why

TBD's app and daemon are normally run from a debug build, which leaves Swift at `-Onone`. That is measurably expensive in SwiftTerm's render path.

Profiling `TBDApp` (5s `sample`, debug build) shows `TerminalView.draw` → `drawTerminalContents` → `buildAttributedString` → `getAttributes` dominated by a single `Dictionary` lookup whose equality resolves through an **unspecialized protocol witness** for `Attribute.==` (`CharData.swift:117`):

```
getAttributes  →  Dictionary._Variant.lookup  →  __RawDictionaryStorage.find
  →  protocol witness for static Equatable.== in conformance Attribute
    →  Attribute.== infix        CharData.swift:117/119
```

42 of 46 samples inside `buildAttributedString` were in `getAttributes`; 40 of those in that lookup. That is one un-inlined dynamic dispatch **per character cell, per redraw**.

The same profile against a release build has **zero** samples in those frames — the optimizer inlines the comparison and the witness dispatch ceases to exist. What remains is `+[NSAttributeDictionary newWithDictionary:]` / `_SwiftDeferredNSDictionary.bridgeKeys()`, i.e. AppKit's own Swift→ObjC bridging. The bottleneck moves out of our code and into the framework.

There was no way to ask `restart.sh` for that build.

## What changed

**1. `scripts/restart.sh --release`** — builds and launches `-c release`. Everything downstream of `BUILD_DIR` (bundle assembly, daemon launch, pgrep patterns) already derived from it, so the flag is just repointing it at `.build/release` and passing `-c` to `swift-safe`. Default behavior unchanged.

**2. `DaemonBuildSkew` no longer false-positives on a release daemon.** The check accepted exactly one worktree path, `.build/debug/TBDDaemon`, so `--release` produced *"Daemon is from a different build"* even with app and daemon from the same worktree at the same commit. Widened to every configuration `restart.sh` can launch.

The real signal is preserved, and asserted: `warningMessage_releaseDaemonFromOtherWorktree_stillWarns` pins that a release daemon from a *different* worktree still warns, so a later widening can't silently blunt the check.

## Testing

`scripts/test.sh --filter DaemonBuildSkew` — 10/10 pass, including both new cases.

Verified end to end on macOS 26.1: release build launched via `scripts/restart.sh --release --wip`, one daemon and one app both from the release path, banner gone, installed binary 36.4 MB vs 58.4 MB debug.

## No spec

Per CLAUDE.md's "say so in the PR description": (1) is a dev-script flag with no product surface and no new runtime behavior; (2) restores the skew check's intended behavior rather than revising it. Neither revises the system's theory.

## Not in scope

Whether release should become the *default* for daily use is a real question this raises but does not answer — it changes what every developer runs and deserves its own spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for launching and restarting the app in Release configuration.
  * Daemon discovery now supports both Debug and Release builds, prioritizing the app’s active configuration.
  * Restart and warning messages now identify the selected build configuration.

* **Bug Fixes**
  * Prevented false daemon mismatch warnings for valid Release builds from the same source worktree.
  * Restart operations now stop if required builds fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->