### PR TITLE
Fix: Stop the debounce flakes by deleting the polled handshake, not resizing it

### DIFF
--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -666,9 +666,13 @@ its `advanceWhenSuspended(by:)` — parks on a continuation instead of polling
 `advance` does **no** yielding, so it never accidentally runs the resumed task's
 post-sleep code for you. Positive assertions must await the paired
 `FireRecorder.next()`; negative ones read `values` (or `hasSleeper`) and stay
-one-sided as they always were. Either clock is a legitimate choice for a new
-clock-driven test. Existing `TestClock` suites migrate on field evidence, not
-wholesale — currently `AppearanceDebounceTests` and `SearchQueryDebouncerTests`,
+one-sided as they always were. **Count each `FireRecorder.next()` in the
+`.clockDriven` tally too**: it carries its own 45 s hang guard, exactly like a
+`waitForSuspension`, so a test with 2 `advanceWhenArmed` + 2 `next()` has a
+180 s worst case against the 240 s limit. Either clock is a legitimate choice
+for a new clock-driven test. Existing `TestClock` suites migrate on field
+evidence, not wholesale — currently `AppearanceDebounceTests` and
+`SearchQueryDebouncerTests`,
 which reproduced the starvation in a full-suite soak. Design:
 `docs/specs/2026-08-11-event-driven-test-clock-design.md`.
 

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -655,6 +655,23 @@ same signature is ~180 s). When an assertion failure took far longer than an
 assertion failure should, suspect a swallowed waiter before you believe the
 message.
 
+### The event-driven alternative — `Tests/TestSupport/EventDrivenTestClock.swift`
+
+Everything above describes `TestClock` and stays true for its consumers.
+Alongside it, `EventDrivenTestClock` exists for suites whose arming handshake has
+been **observed** starving under saturation: it signals arming from inside the
+same critical section that registers the sleeper, so `advanceWhenArmed(by:)` —
+its `advanceWhenSuspended(by:)` — parks on a continuation instead of polling
+`checkSuspension()` and its megaYield. The trade to know before choosing it: its
+`advance` does **no** yielding, so it never accidentally runs the resumed task's
+post-sleep code for you. Positive assertions must await the paired
+`FireRecorder.next()`; negative ones read `values` (or `hasSleeper`) and stay
+one-sided as they always were. Either clock is a legitimate choice for a new
+clock-driven test. Existing `TestClock` suites migrate on field evidence, not
+wholesale — currently `AppearanceDebounceTests` and `SearchQueryDebouncerTests`,
+which reproduced the starvation in a full-suite soak. Design:
+`docs/specs/2026-08-11-event-driven-test-clock-design.md`.
+
 `PollerClock` is **not** this seam and must not be copied as a template — see
 its doc comment. Full rationale:
 `docs/specs/2026-07-24-test-hardening-design.md` §5.

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -666,7 +666,24 @@ its `advanceWhenSuspended(by:)` — parks on a continuation instead of polling
 `advance` does **no** yielding, so it never accidentally runs the resumed task's
 post-sleep code for you. Positive assertions must await the paired
 `FireRecorder.next()`; negative ones read `values` (or `hasSleeper`) and stay
-one-sided as they always were. **Count each `FireRecorder.next()` in the
+one-sided as they always were — and a negative of the shape "production must
+arm no timer here" belongs on `watchForSleeper(on:upTo:)` rather than
+`settle()`, because a fixed settle samples once at the end of its window and can
+miss an arming that lands late under exactly the load that makes the assertion
+worth having.
+
+**Re-arming follows from the same no-yielding property, and it is the sharper
+edge.** A task that fires and immediately re-sleeps — any poller loop — cannot
+have re-registered by the time `advance` returns, so after a fire the *next*
+advance must go through `advanceWhenArmed(by:)`. A bare `advance` moves `now`
+past a deadline that is not in the ledger yet; the re-armed sleep is then
+measured from the new `now` and never fires, and the suite desyncs permanently —
+the same hang described above for `TestClock` under load, except deterministic
+rather than probabilistic. It is the first thing to get right when migrating a
+poller suite (`GatedIntervalSleepTests`, `DaywatchRunnerTests`), where every
+advance past the first is a re-arm.
+
+**Count each `FireRecorder.next()` in the
 `.clockDriven` tally too**: it carries its own 45 s hang guard, exactly like a
 `waitForSuspension`, so a test with 2 `advanceWhenArmed` + 2 `next()` has a
 180 s worst case against the 240 s limit. Either clock is a legitimate choice

--- a/Tests/TBDAppTests/AppearanceDebounceTests.swift
+++ b/Tests/TBDAppTests/AppearanceDebounceTests.swift
@@ -1,4 +1,3 @@
-import Clocks
 import Combine
 import Foundation
 import Testing
@@ -8,30 +7,27 @@ import TestSupport
 
 /// Tier 1. Debounce contract for scheme changes before they turn into daemon RPCs.
 ///
-/// What changed and why: this suite used to *reconstruct*
-/// `AppState.setupAppearanceSubscriptions`' Combine chain inside its own body
-/// and assert against the copy, then wait on the real 200 ms
-/// `DispatchQueue.main` debounce by polling a 5 s wall-clock deadline. So the
-/// production wiring had no coverage at all, and the test failed under load
-/// (reproduced locally, 2 of 5 runs). Combine's `.debounce` takes a `Scheduler`,
-/// which can never be an `any Clock<Duration>`, so the fix was to move the
-/// timed stage out of Combine entirely — see `AppearanceBroadcastDebouncer`,
-/// which these tests now drive directly against a `TestClock`.
+/// The suite drives `AppearanceBroadcastDebouncer` — the production wiring —
+/// directly, in virtual time. That matters twice over: Combine's `.debounce`
+/// takes a `Scheduler`, which can never be an `any Clock<Duration>`, so the
+/// timed stage lives outside Combine precisely so a test clock can own it; and
+/// because every timing here is virtual, the assertions are boundary-precise
+/// rather than tolerance-windowed. There is no wall clock in the behaviour under
+/// test.
 ///
-/// Consequence: there is no wall clock anywhere below. Every timing is virtual
-/// and exact, so the assertions are boundary-precise rather than
-/// tolerance-windowed. The old doc comment's `DispatchQueue.main` vs
-/// `RunLoop.main` reasoning no longer applies — no Combine scheduler is
-/// involved.
-/// `.serialized` is load-bearing, not tidiness. Every test here drives a
-/// `TestClock`, and each probe/advance costs a `Task.megaYield()` — 20
-/// serially-awaited background-QoS detached tasks. Run in parallel, seven such
-/// tests flood the pool with exactly the low-priority work they are each
-/// waiting on, and they starve *each other*: measured in the full 1332-test
-/// target, the unserialized suite failed 4 of 6 runs on the arming handshake
-/// while taking ~12.6 s even when it passed. Serialized, the suite stops being
-/// its own contention source. This narrows one suite, not the target — other
-/// suites still run in parallel around it.
+/// The clock is `EventDrivenTestClock`, not `TestClock`. Its arming handshake is
+/// a signal emitted from inside the same critical section that registers the
+/// sleeper, so `advanceWhenArmed` cannot be starved by a saturated process the
+/// way a megaYield-driven probe can — the failure this suite reproduced under
+/// full-suite load. Its `advance` does no yielding at all, which is why every
+/// *positive* assertion below awaits `fired.next()` instead of reading the
+/// recorder synchronously: `advance` returning means the continuation was
+/// resumed, not that the resumed task has run. Design:
+/// `docs/specs/2026-08-11-event-driven-test-clock-design.md`.
+///
+/// `.serialized` is retained as cheap isolation between seven tests that each
+/// mint a `UserDefaults` suite and a debouncer; it is no longer load-bearing for
+/// the handshake.
 @MainActor
 @Suite("AppState appearance debounce", .clockDriven, .serialized)
 struct AppearanceDebounceTests {
@@ -45,12 +41,10 @@ struct AppearanceDebounceTests {
         let suiteName: String
         let defaults: UserDefaults
         let appearance: AppearanceSettings
-        let clock = TestClock()
+        let clock = EventDrivenTestClock()
         let debouncer: AppearanceBroadcastDebouncer
-        let fired = Box()
+        let fired = FireRecorder<String>()
         var subscription: AnyCancellable?
-
-        final class Box { var values: [String] = [] }
 
         init() {
             suiteName = "TBDAppTests.AppearanceDebounce.\(UUID().uuidString)"
@@ -72,7 +66,7 @@ struct AppearanceDebounceTests {
 
         func subscribe() {
             subscription = debouncer.start(observing: appearance) { [fired] value in
-                fired.values.append(value)
+                fired.record(value)
             }
         }
 
@@ -82,8 +76,8 @@ struct AppearanceDebounceTests {
         }
     }
 
-    /// A `Clock<Duration>` that delegates to a `TestClock` and then cancels the
-    /// sleeping task the instant its sleep resumes.
+    /// A `Clock<Duration>` that delegates to an `EventDrivenTestClock` and then
+    /// cancels the sleeping task the instant its sleep resumes.
     ///
     /// This reproduces the one window a `try? await clock.sleep(...)` cannot
     /// see: cancellation that arrives *after* the sleep completed, which cannot
@@ -97,20 +91,31 @@ struct AppearanceDebounceTests {
     /// `nonisolated` protocol requirement, so it runs on the generic executor
     /// even when the calling task is `@MainActor`.)
     ///
-    /// Delegating rather than reimplementing keeps virtual time exact —
-    /// `TestClock` still owns every suspension, so `advanceWhenSuspended` on the
-    /// base clock behaves normally.
+    /// Delegating rather than reimplementing keeps virtual time exact — the base
+    /// clock still owns every suspension, so `advanceWhenArmed` on it behaves
+    /// normally.
     fileprivate struct CancelOnResumeClock: Clock {
-        let base: TestClock<Swift.Duration>
+        let base: EventDrivenTestClock
 
-        var now: TestClock<Swift.Duration>.Instant { base.now }
+        var now: EventDrivenTestClock.Instant { base.now }
         var minimumResolution: Swift.Duration { base.minimumResolution }
 
-        func sleep(until deadline: TestClock<Swift.Duration>.Instant,
+        func sleep(until deadline: EventDrivenTestClock.Instant,
                    tolerance: Swift.Duration?) async throws {
             try await base.sleep(until: deadline, tolerance: tolerance)
             withUnsafeCurrentTask { $0?.cancel() }
         }
+    }
+
+    /// Hands the main actor back for a few real turns, so a fire that *would*
+    /// land gets the chance to before a negative assertion reads the recorder.
+    ///
+    /// Negative assertions are one-sided by nature — a pathologically late fire
+    /// can make one false-*pass*, never false-fail — and that was equally true
+    /// when `TestClock.advance`'s trailing megaYield supplied the same settling
+    /// incidentally. This makes the settle explicit and bounded instead.
+    private static func settle() async {
+        for _ in 0..<3 { try? await Task.sleep(for: .milliseconds(10)) }
     }
 
     @MainActor
@@ -133,7 +138,8 @@ struct AppearanceDebounceTests {
             h.appearance.schemeID = "scheme-b"
             h.appearance.schemeID = "scheme-c"
 
-            await h.clock.advanceWhenSuspended(by: Self.interval)
+            await h.clock.advanceWhenArmed(by: Self.interval)
+            #expect(await h.fired.next() == "scheme-c")
             #expect(h.fired.values == ["scheme-c"])
         }
     }
@@ -144,11 +150,12 @@ struct AppearanceDebounceTests {
         await Self.withHarness { h in
             h.appearance.schemeID = "scheme-a"
 
-            await h.clock.advanceWhenSuspended(by: Self.interval - .milliseconds(1))
+            await h.clock.advanceWhenArmed(by: Self.interval - .milliseconds(1))
+            await Self.settle()
             #expect(h.fired.values.isEmpty, "one millisecond short of the window must not fire")
 
             await h.clock.advance(by: .milliseconds(1))
-            #expect(h.fired.values == ["scheme-a"])
+            #expect(await h.fired.next() == "scheme-a")
         }
     }
 
@@ -157,23 +164,23 @@ struct AppearanceDebounceTests {
     func lateChangeRestartsWindow() async {
         await Self.withHarness { h in
             h.appearance.schemeID = "scheme-a"
-            await h.clock.advanceWhenSuspended(by: .milliseconds(150))
+            await h.clock.advanceWhenArmed(by: .milliseconds(150))
+            await Self.settle()
             #expect(h.fired.values.isEmpty)
 
             // Restarts the window: the first sleeper is cancelled, a fresh
-            // 200 ms one is armed. Note what the wait below can and cannot
-            // promise — `checkSuspension()` only asks "is anything suspended",
-            // so it can in principle be satisfied by the superseded sleeper
-            // whose entry is still being cleaned up, rather than by the new one.
-            // `advance(to:)` megaYields before touching `suspensions`, which is
-            // why the cleanup and the re-arm land first in practice. A
-            // "wait for a sleeper at/after deadline X" helper would make it a
-            // guarantee; that is a shared-helper change, not a C1 change.
+            // 200 ms one is armed. The wait below is unambiguous about which of
+            // the two it is satisfied by — cancelling the superseded task runs
+            // the clock's cancellation handler synchronously, which removes its
+            // ledger entry before `schedule` returns, so the only registration
+            // left to signal is the new sleeper's.
             h.appearance.schemeID = "scheme-b"
-            await h.clock.advanceWhenSuspended(by: .milliseconds(150))
+            await h.clock.advanceWhenArmed(by: .milliseconds(150))
+            await Self.settle()
             #expect(h.fired.values.isEmpty, "only 150ms since the restart — must not fire yet")
 
             await h.clock.advance(by: .milliseconds(50))
+            #expect(await h.fired.next() == "scheme-b")
             #expect(h.fired.values == ["scheme-b"])
         }
     }
@@ -183,11 +190,12 @@ struct AppearanceDebounceTests {
     func separatedChangesFireTwice() async {
         await Self.withHarness { h in
             h.appearance.schemeID = "scheme-a"
-            await h.clock.advanceWhenSuspended(by: Self.interval)
-            #expect(h.fired.values == ["scheme-a"])
+            await h.clock.advanceWhenArmed(by: Self.interval)
+            #expect(await h.fired.next() == "scheme-a")
 
             h.appearance.schemeID = "scheme-b"
-            await h.clock.advanceWhenSuspended(by: Self.interval)
+            await h.clock.advanceWhenArmed(by: Self.interval)
+            #expect(await h.fired.next() == "scheme-b")
             #expect(h.fired.values == ["scheme-a", "scheme-b"])
         }
     }
@@ -200,20 +208,27 @@ struct AppearanceDebounceTests {
             // subscription time in `subscribe()`. Assert on the SLEEPER, not on
             // `fired`: with no advance yet, `fired` is empty either way, so
             // checking it would pass just as happily with `dropFirst()` deleted
-            // from production. `checkSuspension()` throws when a sleeper is
-            // registered, so "does not throw" is the real assertion — the
-            // subscriber-time replay never armed a timer at all.
-            await #expect(throws: Never.self) { try await h.clock.checkSuspension() }
+            // from production. The settle is what makes the negative worth
+            // anything — the timer a missing `dropFirst()` would arm needs a
+            // scheduling turn to appear, so give it several before looking. It
+            // is a weaker proof than the old "a registered sleeper makes
+            // `checkSuspension()` throw", and one-sided like every negative
+            // here: it can only ever false-pass.
+            await Self.settle()
+            #expect(h.clock.hasSleeper == false,
+                    "the subscriber-time replay must not arm a timer at all")
             #expect(h.fired.values.isEmpty)
 
             // `removeDuplicates`: the second assignment is not a distinct value,
             // so it never reaches the timer and cannot restart the window.
             h.appearance.schemeID = "scheme-a"
-            await h.clock.advanceWhenSuspended(by: .milliseconds(100))
+            await h.clock.advanceWhenArmed(by: .milliseconds(100))
             h.appearance.schemeID = "scheme-a"
             await h.clock.advance(by: .milliseconds(100))
 
-            #expect(h.fired.values == ["scheme-a"], "a repeated value must neither fire twice nor restart the window")
+            #expect(await h.fired.next() == "scheme-a")
+            #expect(h.fired.values == ["scheme-a"],
+                    "a repeated value must neither fire twice nor restart the window")
         }
     }
 
@@ -224,7 +239,7 @@ struct AppearanceDebounceTests {
     /// The other cancellation test below cancels while the timer is still
     /// asleep, which the thrown-error path already handles — delete the
     /// `Task.isCancelled` guard in production and that test stays green. This
-    /// one goes red, because `PostResumeCancelClock` lands the cancel in
+    /// one goes red, because `CancelOnResumeClock` lands the cancel in
     /// exactly the window the guard exists for.
     @Test("a cancel landing after the sleep resumes still suppresses the fire")
     func cancelAfterSleepResumesSuppressesFire() async {
@@ -237,19 +252,20 @@ struct AppearanceDebounceTests {
                 .appendingPathComponent("TBDAppTests.AppearanceDebounce.\(UUID().uuidString)")
         )
 
-        let base = TestClock()
+        let base = EventDrivenTestClock()
         let debouncer = AppearanceBroadcastDebouncer(
             interval: Self.interval,
             clock: CancelOnResumeClock(base: base)
         )
-        let fired = Harness.Box()
+        let fired = FireRecorder<String>()
         let subscription = debouncer.start(observing: appearance) { [fired] value in
-            fired.values.append(value)
+            fired.record(value)
         }
         defer { subscription.cancel() }
 
         appearance.schemeID = "scheme-a"
-        await base.advanceWhenSuspended(by: Self.interval)
+        await base.advanceWhenArmed(by: Self.interval)
+        await Self.settle()
         #expect(fired.values.isEmpty, "a fire cancelled after its sleep resumed must not land")
     }
 
@@ -258,10 +274,11 @@ struct AppearanceDebounceTests {
     func cancelSuppressesPendingFire() async {
         await Self.withHarness { h in
             h.appearance.schemeID = "scheme-a"
-            await h.clock.advanceWhenSuspended(by: .milliseconds(100))
+            await h.clock.advanceWhenArmed(by: .milliseconds(100))
 
             h.debouncer.cancel()
             await h.clock.advance(by: Self.interval)
+            await Self.settle()
             #expect(h.fired.values.isEmpty)
         }
     }

--- a/Tests/TBDAppTests/AppearanceDebounceTests.swift
+++ b/Tests/TBDAppTests/AppearanceDebounceTests.swift
@@ -107,17 +107,6 @@ struct AppearanceDebounceTests {
         }
     }
 
-    /// Hands the main actor back for a few real turns, so a fire that *would*
-    /// land gets the chance to before a negative assertion reads the recorder.
-    ///
-    /// Negative assertions are one-sided by nature — a pathologically late fire
-    /// can make one false-*pass*, never false-fail — and that was equally true
-    /// when `TestClock.advance`'s trailing megaYield supplied the same settling
-    /// incidentally. This makes the settle explicit and bounded instead.
-    private static func settle() async {
-        for _ in 0..<3 { try? await Task.sleep(for: .milliseconds(10)) }
-    }
-
     @MainActor
     private static func withHarness(_ body: (Harness) async -> Void) async {
         let harness = Harness()
@@ -151,11 +140,12 @@ struct AppearanceDebounceTests {
             h.appearance.schemeID = "scheme-a"
 
             await h.clock.advanceWhenArmed(by: Self.interval - .milliseconds(1))
-            await Self.settle()
+            await settle()
             #expect(h.fired.values.isEmpty, "one millisecond short of the window must not fire")
 
             await h.clock.advance(by: .milliseconds(1))
             #expect(await h.fired.next() == "scheme-a")
+            #expect(h.fired.values == ["scheme-a"], "the boundary must fire once, not twice")
         }
     }
 
@@ -165,7 +155,7 @@ struct AppearanceDebounceTests {
         await Self.withHarness { h in
             h.appearance.schemeID = "scheme-a"
             await h.clock.advanceWhenArmed(by: .milliseconds(150))
-            await Self.settle()
+            await settle()
             #expect(h.fired.values.isEmpty)
 
             // Restarts the window: the first sleeper is cancelled, a fresh
@@ -176,7 +166,7 @@ struct AppearanceDebounceTests {
             // left to signal is the new sleeper's.
             h.appearance.schemeID = "scheme-b"
             await h.clock.advanceWhenArmed(by: .milliseconds(150))
-            await Self.settle()
+            await settle()
             #expect(h.fired.values.isEmpty, "only 150ms since the restart — must not fire yet")
 
             await h.clock.advance(by: .milliseconds(50))
@@ -214,7 +204,7 @@ struct AppearanceDebounceTests {
             // is a weaker proof than the old "a registered sleeper makes
             // `checkSuspension()` throw", and one-sided like every negative
             // here: it can only ever false-pass.
-            await Self.settle()
+            await settle()
             #expect(h.clock.hasSleeper == false,
                     "the subscriber-time replay must not arm a timer at all")
             #expect(h.fired.values.isEmpty)
@@ -265,7 +255,7 @@ struct AppearanceDebounceTests {
 
         appearance.schemeID = "scheme-a"
         await base.advanceWhenArmed(by: Self.interval)
-        await Self.settle()
+        await settle()
         #expect(fired.values.isEmpty, "a fire cancelled after its sleep resumed must not land")
     }
 
@@ -278,7 +268,7 @@ struct AppearanceDebounceTests {
 
             h.debouncer.cancel()
             await h.clock.advance(by: Self.interval)
-            await Self.settle()
+            await settle()
             #expect(h.fired.values.isEmpty)
         }
     }

--- a/Tests/TBDAppTests/AppearanceDebounceTests.swift
+++ b/Tests/TBDAppTests/AppearanceDebounceTests.swift
@@ -198,14 +198,14 @@ struct AppearanceDebounceTests {
             // subscription time in `subscribe()`. Assert on the SLEEPER, not on
             // `fired`: with no advance yet, `fired` is empty either way, so
             // checking it would pass just as happily with `dropFirst()` deleted
-            // from production. The settle is what makes the negative worth
-            // anything — the timer a missing `dropFirst()` would arm needs a
-            // scheduling turn to appear, so give it several before looking. It
-            // is a weaker proof than the old "a registered sleeper makes
-            // `checkSuspension()` throw", and one-sided like every negative
-            // here: it can only ever false-pass.
-            await settle()
-            #expect(h.clock.hasSleeper == false,
+            // from production. And *watch* rather than settle: the timer a
+            // missing `dropFirst()` arms needs a scheduling turn to appear, so
+            // a fixed settle buys its whole proof at one instant and can miss
+            // the arming entirely under saturation — the one condition where a
+            // mutation most needs catching. The watch keeps looking for a
+            // second and returns the moment a sleeper shows up. One-sided as
+            // ever: absence holds only up to the window.
+            #expect(await watchForSleeper(on: h.clock) == false,
                     "the subscriber-time replay must not arm a timer at all")
             #expect(h.fired.values.isEmpty)
 

--- a/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
+++ b/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
@@ -1,4 +1,3 @@
-import Clocks
 import Foundation
 import Testing
 @testable import TBDApp
@@ -320,74 +319,89 @@ struct ArchivedRefreshPlanTests {
 /// keystrokes must cost one RPC, not one per character. Entirely virtual time —
 /// see `Tests/CLAUDE.md` "Clock and date seams".
 ///
-/// `.serialized` for the same reason as `AppearanceDebounceTests`: every test
-/// here drives a `TestClock`, and each advance costs a `Task.megaYield()`; run
-/// in parallel these starve each other on the arming handshake.
+/// The clock is `EventDrivenTestClock`, whose arming signal is emitted from
+/// inside the same critical section that registers the sleeper, so
+/// `advanceWhenArmed` is not a megaYield-driven probe that a saturated process
+/// can starve — the failure this suite reproduced under full-suite load. Its
+/// `advance` does no yielding, so every *positive* assertion awaits
+/// `fired.next()`: advancing resumes the sleeper's continuation, it does not
+/// run the resumed task's next statement. Design:
+/// `docs/specs/2026-08-11-event-driven-test-clock-design.md`.
+///
+/// `.serialized` is retained as cheap isolation between four tests that each
+/// build their own debouncer; it is no longer load-bearing for the handshake.
 @MainActor
 @Suite("Archived search debounce", .clockDriven, .serialized)
 struct SearchQueryDebouncerTests {
     private static let interval = Duration.milliseconds(250)
 
-    @MainActor
-    private final class Box {
-        var values: [String] = []
+    /// Hands the main actor back for a few real turns so a fire that *would*
+    /// land gets the chance to before a negative assertion reads the recorder.
+    /// One-sided by nature: it can only ever false-pass, exactly as the old
+    /// synchronous read after a megaYielding `advance` could.
+    private static func settle() async {
+        for _ in 0..<3 { try? await Task.sleep(for: .milliseconds(10)) }
     }
 
     @Test("a burst within one window collapses to a single fire with the last value")
     func burstCollapsesToLastValue() async {
-        let clock = TestClock()
+        let clock = EventDrivenTestClock()
         let debouncer = SearchQueryDebouncer(interval: Self.interval, clock: clock)
-        let fired = Box()
+        let fired = FireRecorder<String>()
 
-        debouncer.schedule("w") { [fired] in fired.values.append($0) }
-        debouncer.schedule("wo") { [fired] in fired.values.append($0) }
-        debouncer.schedule("wolv") { [fired] in fired.values.append($0) }
+        debouncer.schedule("w") { [fired] in fired.record($0) }
+        debouncer.schedule("wo") { [fired] in fired.record($0) }
+        debouncer.schedule("wolv") { [fired] in fired.record($0) }
 
-        await clock.advanceWhenSuspended(by: Self.interval)
+        await clock.advanceWhenArmed(by: Self.interval)
+        #expect(await fired.next() == "wolv")
         #expect(fired.values == ["wolv"])
     }
 
     @Test("nothing fires until the full interval has elapsed")
     func firesOnTheBoundary() async {
-        let clock = TestClock()
+        let clock = EventDrivenTestClock()
         let debouncer = SearchQueryDebouncer(interval: Self.interval, clock: clock)
-        let fired = Box()
+        let fired = FireRecorder<String>()
 
-        debouncer.schedule("wolv") { [fired] in fired.values.append($0) }
+        debouncer.schedule("wolv") { [fired] in fired.record($0) }
 
-        await clock.advanceWhenSuspended(by: Self.interval - .milliseconds(1))
+        await clock.advanceWhenArmed(by: Self.interval - .milliseconds(1))
+        await Self.settle()
         #expect(fired.values.isEmpty, "one millisecond short of the window must not fire")
 
         await clock.advance(by: .milliseconds(1))
-        #expect(fired.values == ["wolv"])
+        #expect(await fired.next() == "wolv")
     }
 
     @Test("cancel() drops a pending fire")
     func cancelDropsPendingFire() async {
-        let clock = TestClock()
+        let clock = EventDrivenTestClock()
         let debouncer = SearchQueryDebouncer(interval: Self.interval, clock: clock)
-        let fired = Box()
+        let fired = FireRecorder<String>()
 
-        debouncer.schedule("wolv") { [fired] in fired.values.append($0) }
-        await clock.advanceWhenSuspended(by: .milliseconds(100))
+        debouncer.schedule("wolv") { [fired] in fired.record($0) }
+        await clock.advanceWhenArmed(by: .milliseconds(100))
 
         debouncer.cancel()
         await clock.advance(by: Self.interval)
+        await Self.settle()
         #expect(fired.values.isEmpty, "a cancelled query must never reach the daemon")
     }
 
     @Test("queries separated by a full window fire twice, in order")
     func separatedQueriesFireTwice() async {
-        let clock = TestClock()
+        let clock = EventDrivenTestClock()
         let debouncer = SearchQueryDebouncer(interval: Self.interval, clock: clock)
-        let fired = Box()
+        let fired = FireRecorder<String>()
 
-        debouncer.schedule("wolv") { [fired] in fired.values.append($0) }
-        await clock.advanceWhenSuspended(by: Self.interval)
-        #expect(fired.values == ["wolv"])
+        debouncer.schedule("wolv") { [fired] in fired.record($0) }
+        await clock.advanceWhenArmed(by: Self.interval)
+        #expect(await fired.next() == "wolv")
 
-        debouncer.schedule("otter") { [fired] in fired.values.append($0) }
-        await clock.advanceWhenSuspended(by: Self.interval)
+        debouncer.schedule("otter") { [fired] in fired.record($0) }
+        await clock.advanceWhenArmed(by: Self.interval)
+        #expect(await fired.next() == "otter")
         #expect(fired.values == ["wolv", "otter"])
     }
 }

--- a/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
+++ b/Tests/TBDAppTests/ArchivedWorktreeSearchTests.swift
@@ -335,14 +335,6 @@ struct ArchivedRefreshPlanTests {
 struct SearchQueryDebouncerTests {
     private static let interval = Duration.milliseconds(250)
 
-    /// Hands the main actor back for a few real turns so a fire that *would*
-    /// land gets the chance to before a negative assertion reads the recorder.
-    /// One-sided by nature: it can only ever false-pass, exactly as the old
-    /// synchronous read after a megaYielding `advance` could.
-    private static func settle() async {
-        for _ in 0..<3 { try? await Task.sleep(for: .milliseconds(10)) }
-    }
-
     @Test("a burst within one window collapses to a single fire with the last value")
     func burstCollapsesToLastValue() async {
         let clock = EventDrivenTestClock()
@@ -367,11 +359,12 @@ struct SearchQueryDebouncerTests {
         debouncer.schedule("wolv") { [fired] in fired.record($0) }
 
         await clock.advanceWhenArmed(by: Self.interval - .milliseconds(1))
-        await Self.settle()
+        await settle()
         #expect(fired.values.isEmpty, "one millisecond short of the window must not fire")
 
         await clock.advance(by: .milliseconds(1))
         #expect(await fired.next() == "wolv")
+        #expect(fired.values == ["wolv"], "the boundary must fire once, not twice")
     }
 
     @Test("cancel() drops a pending fire")
@@ -385,7 +378,7 @@ struct SearchQueryDebouncerTests {
 
         debouncer.cancel()
         await clock.advance(by: Self.interval)
-        await Self.settle()
+        await settle()
         #expect(fired.values.isEmpty, "a cancelled query must never reach the daemon")
     }
 

--- a/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
+++ b/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
@@ -129,6 +129,46 @@ struct EventDrivenTestClockSelfTests {
                 "a stranded waiter must be deregistered, or a later signal resumes a dead continuation")
     }
 
+    /// The hang guard and the waiter it guards are two child tasks in one
+    /// group, and their order is not fixed: the guard can run its whole body
+    /// *before* the waiter reaches its park. A guard that only ever rescued an
+    /// already-parked waiter then resumed nobody, and the waiter parked on a
+    /// continuation nothing was watching — a hang until the suite time limit
+    /// rather than the named diagnostic.
+    ///
+    /// Reproducing that ordering takes both halves of the shape below, and a
+    /// mutation check paid for the second. A zero timeout alone is not enough:
+    /// with waits issued one at a time the waiter child reliably reached its
+    /// park first, and a clock with the fix deleted still passed. A **burst**
+    /// of concurrent waits is what puts enough waiter children behind the
+    /// executor for some guard to expire first, and against the same weakened
+    /// clock it hangs every time.
+    ///
+    /// The second half of the test is the second half of the fix: whatever the
+    /// guard left behind must be cleaned up, so the *next* wait on the same
+    /// clock still parks and is still released by a real registration.
+    @Test("sleeperArmed survives a hang guard that expires before the waiter parks")
+    func armedSurvivesGuardExpiringBeforePark() async {
+        let clock = EventDrivenTestClock()
+        await withKnownIssue("no sleeper ever registers, so every wait must give up",
+                             isIntermittent: false) {
+            await withTaskGroup(of: Void.self) { group in
+                for _ in 0..<32 { group.addTask { await clock.sleeperArmed(timeout: .zero) } }
+            }
+        }
+        #expect(clock.hasParkedArmingWaiter == false)
+
+        let recorder = FireRecorder<String>()
+        let sleeper = Task { [clock] in
+            try? await clock.sleep(for: .seconds(1))
+            recorder.record("woke")
+        }
+        await clock.advanceWhenArmed(by: .seconds(1))
+        #expect(await recorder.next() == "woke",
+                "an expired waiter must not poison the ledger for later waits")
+        _ = await sleeper.value
+    }
+
     // MARK: Cancellation
 
     /// Pre-cancellation must be invisible to the clock: no ledger entry, and no
@@ -320,5 +360,39 @@ struct EventDrivenTestClockSelfTests {
         recorder.record("after")
         #expect(recorder.values == ["after"])
         #expect(await recorder.next() == "after")
+    }
+
+    /// The recorder's half of `armedSurvivesGuardExpiringBeforePark`: the hang
+    /// guard can finish before the consumer installs itself, and "no consumer
+    /// is parked" reads identically to "the consumer already settled". A guard
+    /// that resumed nobody in that case left the consumer parked forever.
+    ///
+    /// Same burst-of-concurrent-waits shape, and for the same measured reason —
+    /// see that test. **One recorder each**, though: a `FireRecorder` holds a
+    /// single consumer slot and documents that callers await sequentially, so
+    /// 32 consumers sharing one recorder would be testing a contract violation
+    /// rather than this bug. The burst is only there to load the executor.
+    ///
+    /// Each recorder then takes a real record/consume pair, so a leftover
+    /// expiry marker cannot pass unnoticed: it would swallow the `next()` that
+    /// should have delivered.
+    @Test("next() survives a hang guard that expires before the consumer parks")
+    func recorderSurvivesGuardExpiringBeforePark() async {
+        let recorders = (0..<32).map { _ in FireRecorder<String>() }
+        await withKnownIssue("nothing is ever recorded, so every wait must give up",
+                             isIntermittent: false) {
+            await withTaskGroup(of: Void.self) { group in
+                for recorder in recorders {
+                    group.addTask { #expect(await recorder.next(timeout: .zero) == nil) }
+                }
+            }
+        }
+
+        for recorder in recorders {
+            recorder.record("after")
+            #expect(await recorder.next() == "after",
+                    "an expired consumer must not poison the recorder for later waits")
+            #expect(recorder.values == ["after"])
+        }
     }
 }

--- a/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
+++ b/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
@@ -1,0 +1,324 @@
+import Foundation
+import TestSupport
+import Testing
+
+/// Tier 1 — proof that the shared clock machinery in
+/// `Tests/TestSupport/EventDrivenTestClock.swift` does what the suites relying
+/// on it assume. In-process state only: no filesystem, no subprocess, no
+/// `~/tbd`, and the only real sleeps are the scheduling handshake itself
+/// (bounded polling, `Tests/CLAUDE.md` assertion-hygiene rule 3) plus the
+/// deliberately tiny hang-guard timeouts two tests drive to their diagnostic.
+///
+/// Why a self-test suite exists at all: this clock's whole value is that its
+/// arming signal is emitted **after** the sleeper is registered, and that its
+/// `advance` resumes due sleepers without relying on a megaYield to do it. Both
+/// are invisible properties — a clock that silently stopped signalling would
+/// look identical to a working one until some unrelated suite started timing
+/// out at 45 s. Same reasoning as `FlakyQuarantineSelfTests`, which lives here
+/// for the same reason (`TestSupport` machinery, proven in the daemon target).
+///
+/// Design: `docs/specs/2026-08-11-event-driven-test-clock-design.md`.
+@Suite("EventDrivenTestClock self-tests", .clockDriven)
+struct EventDrivenTestClockSelfTests {
+    // MARK: Helpers
+
+    /// Bounded poll on an in-process condition, for the handshake only.
+    ///
+    /// Real `Task.sleep` rather than `Task.yield()`: yielding keeps this task
+    /// runnable and re-queues it behind the very task it is waiting for (see
+    /// `ClockTestSupport.waitForSuspension`'s long note). Non-throwing with a
+    /// named diagnostic on timeout, so a wedged handshake is attributed here
+    /// instead of hanging.
+    private static func waitUntil(_ what: String,
+                                  timeout: Swift.Duration = .seconds(30),
+                                  sourceLocation: SourceLocation = #_sourceLocation,
+                                  _ condition: () -> Bool) async {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if condition() { return }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        Issue.record(
+            HandshakeTimeout(what: what, timeout: timeout),
+            sourceLocation: sourceLocation
+        )
+    }
+
+    private struct HandshakeTimeout: Error, CustomStringConvertible {
+        let what: String
+        let timeout: Swift.Duration
+
+        var description: String {
+            "EventDrivenTestClock self-test: still not true after \(timeout) — observed: \(what)"
+        }
+    }
+
+    /// A task that reaches `clock.sleep` only *after* it has been cancelled.
+    ///
+    /// Cancelling a freshly created `Task` races its first execution, so a test
+    /// that just called `cancel()` cannot know whether the sleep saw the
+    /// cancellation. Spinning on `Task.isCancelled` first removes the race: the
+    /// sleep is guaranteed to be entered by an already-cancelled task.
+    private static func sleepAfterCancellation(
+        on clock: EventDrivenTestClock,
+        for duration: Swift.Duration
+    ) -> Task<String, Never> {
+        Task {
+            while !Task.isCancelled { try? await Task.sleep(for: .milliseconds(2)) }
+            do {
+                try await clock.sleep(for: duration)
+                return "returned"
+            } catch is CancellationError {
+                return "cancelled"
+            } catch {
+                return "other: \(error)"
+            }
+        }
+    }
+
+    // MARK: Arming
+
+    /// The property the whole design turns on: a waiter that parked *before* any
+    /// sleeper existed is released by the registration itself, not by a probe.
+    /// The wait for `hasParkedArmingWaiter` is what makes this a real test —
+    /// without it the sleeper could register first and the fast path would pass
+    /// the test with the signal deleted.
+    @Test("a waiter parked before any sleep is resumed by a later registration")
+    func parkedWaiterIsResumedByRegistration() async {
+        let clock = EventDrivenTestClock()
+        let recorder = FireRecorder<String>()
+
+        async let armed: Void = clock.sleeperArmed()
+        await Self.waitUntil("an arming waiter is parked") { clock.hasParkedArmingWaiter }
+
+        let sleeper = Task { [clock] in
+            try? await clock.sleep(for: .seconds(1))
+            recorder.record("woke")
+        }
+        await armed
+
+        #expect(clock.hasSleeper, "the signal must not arrive before the ledger append")
+        await clock.advance(by: .seconds(1))
+        #expect(await recorder.next() == "woke")
+        _ = await sleeper.value
+    }
+
+    @Test("sleeperArmed returns immediately when a sleeper already exists")
+    func armedReturnsImmediatelyWhenSleeperExists() async {
+        let clock = EventDrivenTestClock()
+        let sleeper = Task { [clock] in try? await clock.sleep(for: .seconds(1)) }
+        await Self.waitUntil("a sleeper is registered") { clock.hasSleeper }
+
+        // A 50 ms hang guard: if this parked instead of taking the fast path it
+        // would record a diagnostic and this test would go red.
+        await clock.sleeperArmed(timeout: .milliseconds(50))
+
+        await clock.advance(by: .seconds(1))
+        _ = await sleeper.value
+    }
+
+    /// The hang guard has to be able to fire, and it has to say what it saw.
+    /// Driven at 50 ms rather than the 45 s default so the proof is cheap.
+    @Test("sleeperArmed records a named diagnostic when nothing ever arms")
+    func armedRecordsDiagnosticOnTimeout() async {
+        let clock = EventDrivenTestClock()
+        await withKnownIssue("no sleeper ever registers, so the hang guard must fire") {
+            await clock.sleeperArmed(timeout: .milliseconds(50))
+        }
+        #expect(clock.hasParkedArmingWaiter == false,
+                "a stranded waiter must be deregistered, or a later signal resumes a dead continuation")
+    }
+
+    // MARK: Cancellation
+
+    /// Pre-cancellation must be invisible to the clock: no ledger entry, and no
+    /// arming signal to a waiter — otherwise a test could advance past a sleeper
+    /// that will never fire.
+    @Test("a pre-cancelled task's sleep never registers and never signals")
+    func preCancelledSleepNeverRegisters() async {
+        let clock = EventDrivenTestClock()
+        let task = Self.sleepAfterCancellation(on: clock, for: .seconds(1))
+        task.cancel()
+
+        await withKnownIssue("the cancelled sleep must leave the arming waiter stranded") {
+            // Parked inside the block so the child task inherits the
+            // known-issue scope: an `async let` created outside it would report
+            // its issue from a task tree the suppression does not cover.
+            async let armed: Void = clock.sleeperArmed(timeout: .milliseconds(300))
+            _ = await task.value
+            await armed
+        }
+
+        #expect(await task.value == "cancelled")
+        #expect(clock.hasSleeper == false)
+    }
+
+    /// `checkCancellation()` at the top of `sleep` is the *only* thing enforcing
+    /// cancellation on the already-elapsed-deadline path, which returns before
+    /// any cancellation handler is installed. A sleep that returned normally in
+    /// a cancelled task is exactly how a cancel-and-replace debouncer fires a
+    /// superseded value.
+    @Test("a cancelled task's sleep throws even when the deadline has already passed")
+    func cancelledSleepThrowsOnElapsedDeadline() async {
+        let clock = EventDrivenTestClock()
+        let task = Self.sleepAfterCancellation(on: clock, for: .zero)
+        task.cancel()
+
+        #expect(await task.value == "cancelled")
+        #expect(clock.hasSleeper == false)
+    }
+
+    @Test("cancelling a suspended sleeper removes its ledger entry and throws")
+    func cancelWhileSuspendedRemovesEntry() async {
+        let clock = EventDrivenTestClock()
+        let task = Task { [clock] () -> String in
+            do {
+                try await clock.sleep(for: .seconds(1))
+                return "returned"
+            } catch is CancellationError {
+                return "cancelled"
+            } catch {
+                return "other: \(error)"
+            }
+        }
+        await Self.waitUntil("a sleeper is registered") { clock.hasSleeper }
+
+        task.cancel()
+        #expect(await task.value == "cancelled")
+        #expect(clock.hasSleeper == false, "a cancelled sleeper must not leave a ledger entry behind")
+
+        // And the vacated deadline must not fire anything.
+        await clock.advance(by: .seconds(1))
+        #expect(clock.now.offset == .seconds(1))
+    }
+
+    // MARK: Advancing
+
+    @Test("advance fires sleepers in deadline order and moves now exactly")
+    func advanceFiresInDeadlineOrder() async {
+        let clock = EventDrivenTestClock()
+        let recorder = FireRecorder<String>()
+        let sleepers = [("a", 10), ("b", 20), ("c", 30)].map { name, ms in
+            Task { [clock] in
+                try? await clock.sleep(for: .milliseconds(ms))
+                recorder.record(name)
+            }
+        }
+        await Self.waitUntil("all three sleepers are registered") { clock.sleeperCount == 3 }
+
+        // Stepping deadline by deadline is what makes the ordering claim
+        // deterministic: three tasks resumed by one advance would then race each
+        // other to `record`, and their arrival order is not a contract.
+        await clock.advance(by: .milliseconds(10))
+        #expect(await recorder.next() == "a")
+        #expect(clock.now.offset == .milliseconds(10))
+        #expect(clock.sleeperCount == 2)
+
+        await clock.advance(by: .milliseconds(10))
+        #expect(await recorder.next() == "b")
+        #expect(clock.now.offset == .milliseconds(20))
+
+        await clock.advance(by: .milliseconds(10))
+        #expect(await recorder.next() == "c")
+        #expect(clock.now.offset == .milliseconds(30))
+        #expect(clock.sleeperCount == 0)
+
+        for sleeper in sleepers { _ = await sleeper.value }
+    }
+
+    @Test("one advance past several deadlines fires each sleeper exactly once")
+    func advancePastMultipleDeadlinesFiresEachOnce() async {
+        let clock = EventDrivenTestClock()
+        let recorder = FireRecorder<String>()
+        let sleepers = [("a", 10), ("b", 20), ("c", 30)].map { name, ms in
+            Task { [clock] in
+                try? await clock.sleep(for: .milliseconds(ms))
+                recorder.record(name)
+            }
+        }
+        await Self.waitUntil("all three sleepers are registered") { clock.sleeperCount == 3 }
+
+        await clock.advance(by: .milliseconds(30))
+        for _ in 0..<3 { _ = await recorder.next() }
+        for sleeper in sleepers { _ = await sleeper.value }
+
+        // Membership, not order: one advance resumes three tasks that then race
+        // to `record`, so their arrival order is an incident rather than a
+        // contract (`Tests/CLAUDE.md` assertion-hygiene rule 1).
+        #expect(Set(recorder.values) == ["a", "b", "c"])
+        #expect(recorder.values.count == 3, "a sleeper fired twice, or a stale entry survived")
+        #expect(clock.now.offset == .milliseconds(30))
+        #expect(clock.sleeperCount == 0)
+    }
+
+    @Test("advancing short of a deadline moves now without firing")
+    func advanceShortOfDeadlineDoesNotFire() async {
+        let clock = EventDrivenTestClock()
+        let recorder = FireRecorder<String>()
+        let sleeper = Task { [clock] in
+            try? await clock.sleep(for: .milliseconds(250))
+            recorder.record("fired")
+        }
+        await Self.waitUntil("a sleeper is registered") { clock.hasSleeper }
+
+        await clock.advance(by: .milliseconds(249))
+        #expect(clock.now.offset == .milliseconds(249))
+        #expect(clock.hasSleeper, "one millisecond short of the deadline must not fire")
+        #expect(recorder.values.isEmpty)
+
+        await clock.advance(by: .milliseconds(1))
+        #expect(await recorder.next() == "fired")
+        _ = await sleeper.value
+    }
+
+    @Test("a sleep whose deadline has already passed returns without registering")
+    func elapsedDeadlineReturnsImmediately() async {
+        let clock = EventDrivenTestClock()
+        await clock.advance(by: .seconds(5))
+        let clockRef = clock
+        await Task { try? await clockRef.sleep(for: .zero) }.value
+        #expect(clock.hasSleeper == false)
+    }
+
+    // MARK: FireRecorder
+
+    @Test("next() hands back buffered values in order without draining values")
+    func recorderReturnsBufferedValuesInOrder() async {
+        let recorder = FireRecorder<String>()
+        recorder.record("first")
+        recorder.record("second")
+
+        #expect(await recorder.next() == "first")
+        #expect(await recorder.next() == "second")
+        #expect(recorder.values == ["first", "second"],
+                "`values` is a history snapshot, not a queue next() drains")
+    }
+
+    @Test("a parked next() is resumed by a later record()")
+    func recorderParksUntilRecorded() async {
+        let recorder = FireRecorder<String>()
+        async let value = recorder.next()
+        // No observable "is parked" on the recorder, so settle briefly to make
+        // the parked path the one under test rather than the buffered path.
+        try? await Task.sleep(for: .milliseconds(20))
+        recorder.record("late")
+        #expect(await value == "late")
+        #expect(recorder.values == ["late"])
+    }
+
+    @Test("next() records a named diagnostic and returns nil when nothing fires")
+    func recorderRecordsDiagnosticOnTimeout() async {
+        let recorder = FireRecorder<String>()
+        var observed: String? = "unset"
+        await withKnownIssue("nothing is ever recorded, so the hang guard must fire") {
+            observed = await recorder.next(timeout: .milliseconds(50))
+        }
+        #expect(observed == nil)
+
+        // A stranded consumer must be deregistered: a later record() has to
+        // buffer rather than resume a dead continuation.
+        recorder.record("after")
+        #expect(recorder.values == ["after"])
+        #expect(await recorder.next() == "after")
+    }
+}

--- a/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
+++ b/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
@@ -390,14 +390,25 @@ struct EventDrivenTestClockSelfTests {
     @Test("next() survives a hang guard that expires before the consumer parks")
     func recorderSurvivesGuardExpiringBeforePark() async {
         let recorders = (0..<32).map { _ in FireRecorder<String>() }
+        // Results are hoisted out of the block and asserted after it: a
+        // matcher-less `withKnownIssue` suppresses *every* issue recorded
+        // inside, an `#expect` failure among them, so an assertion written in
+        // there could never go red (`Tests/CLAUDE.md`, assertion hygiene).
+        var results: [String?] = []
         await withKnownIssue("nothing is ever recorded, so every wait must give up",
                              isIntermittent: false) {
-            await withTaskGroup(of: Void.self) { group in
+            results = await withTaskGroup(of: String?.self, returning: [String?].self) { group in
                 for recorder in recorders {
-                    group.addTask { #expect(await recorder.next(timeout: .zero) == nil) }
+                    group.addTask { await recorder.next(timeout: .zero) }
                 }
+                var settled: [String?] = []
+                while let value = await group.next() { settled.append(value) }
+                return settled
             }
         }
+        #expect(results.count == recorders.count)
+        #expect(results.allSatisfy { $0 == nil },
+                "an expired wait must return nil, not a value nobody recorded")
 
         for recorder in recorders {
             recorder.record("after")
@@ -423,10 +434,19 @@ struct EventDrivenTestClockSelfTests {
     /// Neither call sits out its guard on a healthy run — the displaced one
     /// returns immediately and the `record` releases the survivor — so a
     /// regression shows up as this test hanging, not as a slow pass.
+    ///
+    /// Those same generous guards are what the matcher below polices. The
+    /// displaced wait returns in milliseconds, so a hang-guard diagnostic from
+    /// it would be pure fabrication — a "no value was recorded within 10 s" on
+    /// a call that never waited ten seconds, sending a reader after a fire
+    /// nobody owed. The matcher therefore accepts **only** the contract issue:
+    /// any timeout issue reaching it is unmatched, which `withKnownIssue`
+    /// surfaces as a real failure.
     @Test("two concurrent next() calls report the single-consumer contract instead of hanging")
     func recorderReportsConcurrentConsumers() async {
         let recorder = FireRecorder<String>()
         let sawContractIssue = Latch()
+        let sawTimeoutIssue = Latch()
         var results: [String?] = []
 
         await withKnownIssue("a second next() displaces the first, which the contract forbids",
@@ -444,12 +464,16 @@ struct EventDrivenTestClockSelfTests {
             }
         } matching: { issue in
             let text = (issue.error.map { String(describing: $0) } ?? "") + issue.description
-            if text.contains("single-consumer slot") { sawContractIssue.latch() }
-            return true
+            let isContract = text.contains("single-consumer slot")
+            if isContract { sawContractIssue.latch() }
+            if text.contains("no value was recorded within") { sawTimeoutIssue.latch() }
+            return isContract
         }
 
         #expect(sawContractIssue.isLatched,
                 "displacing a parked consumer must name the contract, not pass in silence")
+        #expect(sawTimeoutIssue.isLatched == false,
+                "the displaced wait returned promptly — it must not also report a hang guard it never sat out")
         #expect(results.count == 2)
         #expect(results.contains(nil), "the displaced next() must return nil rather than park forever")
         #expect(results.contains("after-displacement"), "the surviving consumer must still be served")

--- a/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
+++ b/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
@@ -44,6 +44,17 @@ struct EventDrivenTestClockSelfTests {
         )
     }
 
+    /// Lock-guarded latch for observing a specific issue from
+    /// `withKnownIssue`'s matcher, which runs outside the test body and is not
+    /// a place to mutate a captured `var`.
+    private final class Latch: @unchecked Sendable {
+        private let lock = NSLock()
+        private var latched = false
+
+        func latch() { lock.withLock { latched = true } }
+        var isLatched: Bool { lock.withLock { latched } }
+    }
+
     private struct HandshakeTimeout: Error, CustomStringConvertible {
         let what: String
         let timeout: Swift.Duration
@@ -394,5 +405,59 @@ struct EventDrivenTestClockSelfTests {
                     "an expired consumer must not poison the recorder for later waits")
             #expect(recorder.values == ["after"])
         }
+    }
+
+    /// A `FireRecorder` holds a single consumer slot and *documents* that its
+    /// callers await sequentially — but documented is not enforced, and this is
+    /// the enforcement. A second `next()` used to overwrite the slot in
+    /// silence, orphaning the first continuation: the displaced call's own hang
+    /// guard recognises a parked consumer by id, finds the newcomer's instead,
+    /// and so resumes nobody. The displaced `next()` then never returns at all —
+    /// a diagnostic-free hang, the worst failure shape available. It now
+    /// reports the contract and releases the displaced consumer with `nil`.
+    ///
+    /// The deliberately generous 10 s guards are what make the displacement
+    /// deterministic instead of a race against expiry: with nothing recorded,
+    /// whichever call parks first is still parked when the second arrives, so
+    /// exactly one displacement happens whichever order the executor picks.
+    /// Neither call sits out its guard on a healthy run — the displaced one
+    /// returns immediately and the `record` releases the survivor — so a
+    /// regression shows up as this test hanging, not as a slow pass.
+    @Test("two concurrent next() calls report the single-consumer contract instead of hanging")
+    func recorderReportsConcurrentConsumers() async {
+        let recorder = FireRecorder<String>()
+        let sawContractIssue = Latch()
+        var results: [String?] = []
+
+        await withKnownIssue("a second next() displaces the first, which the contract forbids",
+                             isIntermittent: false) {
+            results = await withTaskGroup(of: String?.self, returning: [String?].self) { group in
+                group.addTask { await recorder.next(timeout: .seconds(10)) }
+                group.addTask { await recorder.next(timeout: .seconds(10)) }
+                var settled: [String?] = []
+                if let displaced = await group.next() { settled.append(displaced) }
+                // The displaced call is back, so the survivor is the one parked
+                // in the slot: recording releases it.
+                recorder.record("after-displacement")
+                while let remaining = await group.next() { settled.append(remaining) }
+                return settled
+            }
+        } matching: { issue in
+            let text = (issue.error.map { String(describing: $0) } ?? "") + issue.description
+            if text.contains("single-consumer slot") { sawContractIssue.latch() }
+            return true
+        }
+
+        #expect(sawContractIssue.isLatched,
+                "displacing a parked consumer must name the contract, not pass in silence")
+        #expect(results.count == 2)
+        #expect(results.contains(nil), "the displaced next() must return nil rather than park forever")
+        #expect(results.contains("after-displacement"), "the surviving consumer must still be served")
+
+        // And the recorder is intact afterwards: the breach cost one wait, not
+        // the recorder.
+        recorder.record("after")
+        #expect(await recorder.next() == "after")
+        #expect(recorder.values == ["after-displacement", "after"])
     }
 }

--- a/Tests/TestSupport/EventDrivenTestClock.swift
+++ b/Tests/TestSupport/EventDrivenTestClock.swift
@@ -434,6 +434,19 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     /// until the effect actually lands. A *negative* assertion ("nothing fired
     /// yet") reads the snapshot directly and stays one-sided, as it always was.
     ///
+    /// **Re-arming has the same consequence, and it bites harder.** A task that
+    /// fires and immediately sleeps again — a poller loop — cannot possibly have
+    /// re-registered by the time `advance` returns, because `advance` never
+    /// yields it the chance. So after a fire, the **next** advance must go
+    /// through ``advanceWhenArmed(by:sourceLocation:)``: a bare `advance` moves
+    /// `now` past a deadline that is not in the ledger yet, and the sleep that
+    /// registers afterwards is measured from the new `now` and never fires —
+    /// permanent desync, the hang `Tests/CLAUDE.md` documents for `TestClock`
+    /// under load, except here it is deterministic rather than probabilistic.
+    /// This is the rule to carry into any future poller-suite migration
+    /// (`GatedIntervalSleepTests`, `DaywatchRunnerTests`), where every advance
+    /// after the first is a re-arm.
+    ///
     /// A deadline in the past is a no-op: virtual time never moves backwards.
     public func advance(to deadline: Instant) async {
         // Scoped locking only: `NSLock.lock()`/`unlock()` are unavailable from
@@ -517,20 +530,32 @@ private struct NoSleeperArmed: Error, CustomStringConvertible {
 /// Lock-guarded rather than an actor, because ``record(_:)`` is called from a
 /// synchronous callback (`@MainActor (String) -> Void`) that cannot await.
 public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
+    /// How a parked `next()` was settled. Three verdicts rather than two,
+    /// because "returned nil" is not one situation: a *displaced* consumer was
+    /// released deliberately by the code that already recorded
+    /// ``ConcurrentConsumers`` naming the breach, so adding a fabricated
+    /// "no value was recorded within 10 s" on a call that returned in
+    /// milliseconds would misdescribe what happened and point the reader at a
+    /// timeout that never elapsed.
+    private enum ConsumerOutcome {
+        case value(Value)
+        case timedOut
+        case displaced
+    }
+
     /// A parked `next()`. Like the clock's arming waiter, the continuation
-    /// carries the verdict — a value, or "the hang guard gave up" — so the
-    /// consumer's own result is authoritative regardless of which task the
-    /// group sees finish first.
+    /// carries the verdict, so the consumer's own result is authoritative
+    /// regardless of which task the group sees finish first.
     private struct Consumer {
         let id: UUID
-        let continuation: CheckedContinuation<(value: Value?, timedOut: Bool), Never>
+        let continuation: CheckedContinuation<ConsumerOutcome, Never>
     }
 
     /// One outcome of `next()`'s two-task race, tagged by its producer. Only
     /// the consumer's verdict is authoritative; the hang guard's is not, since
     /// it cannot see a value `record(_:)` delivered a moment earlier.
     private enum ConsumerRace {
-        case consumer(value: Value?, timedOut: Bool)
+        case consumer(ConsumerOutcome)
         case hangGuard
     }
 
@@ -559,7 +584,7 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
         consumer = nil
         if waiting != nil { consumed += 1 }
         lock.unlock()
-        waiting?.continuation.resume(returning: (value, false))
+        waiting?.continuation.resume(returning: .value(value))
     }
 
     /// A snapshot of every value recorded so far, in order. Never drained by
@@ -578,26 +603,28 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
     ///   cancellation the wait ends without a diagnostic**: the consumer is
     ///   still released and `nil` returned, but the failure belongs to whatever
     ///   cancelled the test rather than to this call site.
-    /// - Returns: the value, or `nil` after recording a diagnostic on timeout.
+    /// - Returns: the value, or `nil` after recording a diagnostic on timeout —
+    ///   or, for a wait displaced by a second concurrent `next()`, `nil` with
+    ///   only the ``ConcurrentConsumers`` breach already recorded against it.
     ///   Returning an optional rather than continuing silently means a test that
     ///   asserts on the result gets a comparison against `nil` *after* the real
     ///   diagnostic has already been recorded, never instead of it.
     public func next(timeout: Swift.Duration = .seconds(45),
                      sourceLocation: SourceLocation = #_sourceLocation) async -> Value? {
         let consumerID = UUID()
-        let outcome: (value: Value?, timedOut: Bool) = await withTaskGroup(
+        let outcome: ConsumerOutcome = await withTaskGroup(
             of: ConsumerRace.self,
-            returning: (value: Value?, timedOut: Bool).self
+            returning: ConsumerOutcome.self
         ) { group in
             group.addTask { [self] in
                 let settled = await withCheckedContinuation {
-                    (continuation: CheckedContinuation<(value: Value?, timedOut: Bool), Never>) in
+                    (continuation: CheckedContinuation<ConsumerOutcome, Never>) in
                     lock.lock()
                     if consumed < recorded.count {
                         let buffered = recorded[consumed]
                         consumed += 1
                         lock.unlock()
-                        continuation.resume(returning: (buffered, false))
+                        continuation.resume(returning: .value(buffered))
                         return
                     }
                     if expiredConsumers.remove(consumerID) != nil {
@@ -605,7 +632,7 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
                         // not parked yet: settle here rather than park on a
                         // continuation nothing is watching.
                         lock.unlock()
-                        continuation.resume(returning: (nil, true))
+                        continuation.resume(returning: .timedOut)
                         return
                     }
                     // A consumer already parked here means two `next()` calls
@@ -616,9 +643,12 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
                     // the displaced `next()` never returns. Report the contract
                     // breach and release the displaced consumer instead: a
                     // diagnostic beats a hang. The displaced call returns `nil`
-                    // and, like any unsatisfied wait, records its own hang-guard
-                    // diagnostic on the way out — two issues for one breach,
-                    // both naming the offending test.
+                    // carrying the `.displaced` verdict — **one** issue for one
+                    // breach. It must not also report a hang guard it never sat
+                    // out: that wait returned in milliseconds, so a "no value
+                    // was recorded within 45 s" beside it would describe an
+                    // elapsed timeout that never happened and send the reader
+                    // hunting a fire nobody owed.
                     let displaced = consumer
                     consumer = Consumer(id: consumerID, continuation: continuation)
                     lock.unlock()
@@ -627,10 +657,10 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
                             ConcurrentConsumers(),
                             sourceLocation: sourceLocation
                         )
-                        displaced.continuation.resume(returning: (nil, true))
+                        displaced.continuation.resume(returning: .displaced)
                     }
                 }
-                return .consumer(value: settled.value, timedOut: settled.timedOut)
+                return .consumer(settled)
             }
             group.addTask { [self] in
                 try? await Task.sleep(for: timeout)
@@ -646,17 +676,17 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
                     consumer = nil
                     return waiting
                 }
-                stranded?.continuation.resume(returning: (nil, true))
+                stranded?.continuation.resume(returning: .timedOut)
                 return .hangGuard
             }
             // The consumer's verdict is the authoritative one. Reading whichever
             // result arrived first would let the guard both report a spurious
             // timeout and *discard* a value `record(_:)` had already handed over
             // — with `consumed` already advanced, so the value is gone for good.
-            var verdict: (value: Value?, timedOut: Bool) = (nil, true)
+            var verdict: ConsumerOutcome = .timedOut
             while let raced = await group.next() {
-                if case .consumer(let value, let timedOut) = raced {
-                    verdict = (value, timedOut)
+                if case .consumer(let settled) = raced {
+                    verdict = settled
                     break
                 }
             }
@@ -667,19 +697,31 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
         // marker the guard left for a consumer that had already settled.
         lock.withLock { _ = expiredConsumers.remove(consumerID) }
 
-        // Same rule as the clock's arming guard: a cancelled enclosing task
-        // cancels this hang guard's sleep, which releases the consumer with
-        // `timedOut == true` for a fire that was never given its chance. The
-        // wait still ends — `nil` is returned, so an assertion on the result
-        // still fails — but the "within 45 s" diagnostic would name an innocent
-        // call site for someone else's cancellation, so it is suppressed.
-        if outcome.timedOut && !Task.isCancelled {
-            Issue.record(
-                NoValueRecorded(timeout: timeout, observed: values),
-                sourceLocation: sourceLocation
-            )
+        switch outcome {
+        case .value(let value):
+            return value
+        case .displaced:
+            // The breach was already reported at the moment of displacement, by
+            // the call that did the displacing. Reporting again here would
+            // manufacture a timeout diagnostic for a wait that returned
+            // promptly.
+            return nil
+        case .timedOut:
+            // Same rule as the clock's arming guard: a cancelled enclosing task
+            // cancels this hang guard's sleep, which releases the consumer as
+            // timed out for a fire that was never given its chance. The wait
+            // still ends — `nil` is returned, so an assertion on the result
+            // still fails — but the "within 45 s" diagnostic would name an
+            // innocent call site for someone else's cancellation, so it is
+            // suppressed.
+            if !Task.isCancelled {
+                Issue.record(
+                    NoValueRecorded(timeout: timeout, observed: values),
+                    sourceLocation: sourceLocation
+                )
+            }
+            return nil
         }
-        return outcome.value
     }
 }
 
@@ -736,4 +778,40 @@ private struct NoValueRecorded<Value: Sendable>: Error, CustomStringConvertible 
 /// effect instead of hoping it arrived.
 public func settle() async {
     for _ in 0..<3 { try? await Task.sleep(for: .milliseconds(10)) }
+}
+
+/// Watches for a sleeper to appear on `clock`, for a **negative** assertion of
+/// the shape "the code under test must arm no timer at all".
+///
+/// Why this rather than ``settle()`` there. Arming takes a scheduling turn, so
+/// the thing being ruled out cannot appear instantly — and a fixed settle
+/// window buys its whole proof at one instant at the end of that window. Under
+/// saturation the turn can land later than the window, and the negative passes
+/// against production that *did* arm a timer: the assertion stops
+/// discriminating exactly when the machine is busy, which is when it matters.
+/// Watching instead keeps looking, so the window is a patience budget rather
+/// than a single sample, and a regression is caught the moment it shows up
+/// instead of only if it happens to show up early.
+///
+/// **Still one-sided, in the same direction as everything else here.** Absence
+/// is proven only up to `window` — a pathologically late arming can make this
+/// false-*pass*, never false-fail. Presence, by contrast, is detected the
+/// instant it happens, which is what makes the failing direction prompt: the
+/// caller learns within one poll interval rather than after the full window.
+///
+/// - Parameters:
+///   - clock: the clock whose ledger is watched.
+///   - window: how long to keep watching before concluding absence. A second is
+///     ~100× the scheduling turn being ruled out, and a passing test pays it
+///     only when the code under test is behaving.
+/// - Returns: `true` if a sleeper appeared (assert `false` on this), `false` if
+///   none appeared within `window`.
+public func watchForSleeper(on clock: EventDrivenTestClock,
+                            upTo window: Swift.Duration = .seconds(1)) async -> Bool {
+    let deadline = ContinuousClock.now.advanced(by: window)
+    repeat {
+        if clock.hasSleeper { return true }
+        try? await Task.sleep(for: .milliseconds(10))
+    } while ContinuousClock.now < deadline
+    return clock.hasSleeper
 }

--- a/Tests/TestSupport/EventDrivenTestClock.swift
+++ b/Tests/TestSupport/EventDrivenTestClock.swift
@@ -127,11 +127,19 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
 
     /// A parked `sleeperArmed` waiter. The continuation carries *why* it was
     /// resumed — `true` for "a sleeper registered", `false` for "the hang guard
-    /// stranded you" — so the waiter reports the same verdict as the timeout
-    /// task no matter which of the two the task group observes finishing first.
+    /// gave up" — which is what lets the waiter's own result be the
+    /// authoritative verdict no matter which task the group sees finish first.
     private struct ArmingWaiter {
         let id: UUID
         let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    /// One outcome of `sleeperArmed`'s two-task race, tagged by which task
+    /// produced it. Only the waiter's verdict is authoritative: the hang guard
+    /// finishing first says nothing about how the waiter settled.
+    private enum ArmingRace {
+        case waiter(timedOut: Bool)
+        case hangGuard
     }
 
     /// Virtual time has no resolution floor: a test may advance by any duration.
@@ -141,6 +149,12 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     private var currentNow: Instant
     private var suspensions: [Suspension] = []
     private var armingWaiters: [ArmingWaiter] = []
+    /// Waiter ids whose hang guard expired *before* the waiter reached its park.
+    /// Without this, the guard would resume nobody and the waiter would then
+    /// park on a continuation no one is watching any more — a hang, not a
+    /// diagnostic. Each id is consumed by its own park, and every call removes
+    /// its id on the way out, so the set never grows across calls.
+    private var expiredArmingWaiters: Set<UUID> = []
 
     /// - Parameter now: starting instant, offset zero by default.
     public init(now: Instant = .init()) {
@@ -292,7 +306,7 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
         if hasSleeper { return }
 
         let waiterID = UUID()
-        let timedOut = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+        let timedOut = await withTaskGroup(of: ArmingRace.self, returning: Bool.self) { group in
             group.addTask { [self] in
                 let armed = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
                     lock.lock()
@@ -303,28 +317,57 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
                         continuation.resume(returning: true)
                         return
                     }
+                    if expiredArmingWaiters.remove(waiterID) != nil {
+                        // The hang guard already gave up on a waiter that had
+                        // not parked yet, so nothing is left watching for this
+                        // continuation. Settle here instead of parking forever.
+                        lock.unlock()
+                        continuation.resume(returning: false)
+                        return
+                    }
                     armingWaiters.append(ArmingWaiter(id: waiterID, continuation: continuation))
                     lock.unlock()
                 }
-                return !armed
+                return .waiter(timedOut: !armed)
             }
             group.addTask { [self] in
                 try? await Task.sleep(for: timeout)
                 // Deregistering is what makes this safe: whoever removes the
                 // waiter owns resuming it, so a signal arriving after the
-                // timeout finds nothing to resume, and a timeout arriving after
-                // the signal reports nothing.
+                // timeout finds nothing to resume. Three cases here, and the
+                // last is why the expiry marker exists: the waiter is parked
+                // (strand it), the waiter already settled (nothing owed), or
+                // the waiter has not reached its park yet — where an unmarked
+                // give-up would leave it to park on a dead continuation.
                 let stranded: ArmingWaiter? = lock.withLock {
-                    guard let index = armingWaiters.firstIndex(where: { $0.id == waiterID }) else { return nil }
+                    guard let index = armingWaiters.firstIndex(where: { $0.id == waiterID }) else {
+                        expiredArmingWaiters.insert(waiterID)
+                        return nil
+                    }
                     return armingWaiters.remove(at: index)
                 }
                 stranded?.continuation.resume(returning: false)
-                return stranded != nil
+                return .hangGuard
             }
-            let first = await group.next() ?? false
+            // Consume results until the waiter's, which is the only
+            // authoritative one — the guard can finish first without knowing
+            // how the waiter settled. Defaulting to "timed out" keeps an
+            // impossible group (a waiter that never returns) loud rather than
+            // silently green.
+            var verdict = true
+            while let outcome = await group.next() {
+                if case .waiter(let waiterTimedOut) = outcome {
+                    verdict = waiterTimedOut
+                    break
+                }
+            }
             group.cancelAll()
-            return first
+            return verdict
         }
+        // The guard may have marked an id whose waiter had already settled. The
+        // group has awaited both children by now, so this is the last word: no
+        // call leaves an entry behind for the next one to trip over.
+        lock.withLock { _ = expiredArmingWaiters.remove(waiterID) }
 
         if timedOut {
             Issue.record(
@@ -384,7 +427,10 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
                 currentNow = deadline
                 return .finished
             }
-            currentNow = next.deadline
+            // Virtual time is monotonic: a sleeper whose deadline is already in
+            // the past (its task read `now` before an interleaved advance)
+            // fires here without rewinding the clock under everyone else.
+            currentNow = max(currentNow, next.deadline)
             suspensions.removeFirst()
             guard !next.box.isSettled else { return .fired(nil) }
             next.box.isSettled = true
@@ -451,9 +497,21 @@ private struct NoSleeperArmed: Error, CustomStringConvertible {
 /// Lock-guarded rather than an actor, because ``record(_:)`` is called from a
 /// synchronous callback (`@MainActor (String) -> Void`) that cannot await.
 public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
+    /// A parked `next()`. Like the clock's arming waiter, the continuation
+    /// carries the verdict — a value, or "the hang guard gave up" — so the
+    /// consumer's own result is authoritative regardless of which task the
+    /// group sees finish first.
     private struct Consumer {
         let id: UUID
-        let continuation: CheckedContinuation<Value?, Never>
+        let continuation: CheckedContinuation<(value: Value?, timedOut: Bool), Never>
+    }
+
+    /// One outcome of `next()`'s two-task race, tagged by its producer. Only
+    /// the consumer's verdict is authoritative; the hang guard's is not, since
+    /// it cannot see a value `record(_:)` delivered a moment earlier.
+    private enum ConsumerRace {
+        case consumer(value: Value?, timedOut: Bool)
+        case hangGuard
     }
 
     private let lock = NSLock()
@@ -464,6 +522,10 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
     private var consumed = 0
     /// At most one consumer parks at a time: these tests await sequentially.
     private var consumer: Consumer?
+    /// Consumer ids whose hang guard expired *before* the consumer reached its
+    /// park — the same hazard, and the same remedy, as the clock's
+    /// `expiredArmingWaiters`. Each `next()` removes its id on the way out.
+    private var expiredConsumers: Set<UUID> = []
 
     public init() {}
 
@@ -477,7 +539,7 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
         consumer = nil
         if waiting != nil { consumed += 1 }
         lock.unlock()
-        waiting?.continuation.resume(returning: value)
+        waiting?.continuation.resume(returning: (value, false))
     }
 
     /// A snapshot of every value recorded so far, in order. Never drained by
@@ -500,47 +562,76 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
     public func next(timeout: Swift.Duration = .seconds(45),
                      sourceLocation: SourceLocation = #_sourceLocation) async -> Value? {
         let consumerID = UUID()
-        let value: Value? = await withTaskGroup(of: (Bool, Value?).self,
-                                                returning: Value?.self) { group in
+        let outcome: (value: Value?, timedOut: Bool) = await withTaskGroup(
+            of: ConsumerRace.self,
+            returning: (value: Value?, timedOut: Bool).self
+        ) { group in
             group.addTask { [self] in
-                let value = await withCheckedContinuation { (continuation: CheckedContinuation<Value?, Never>) in
+                let settled = await withCheckedContinuation {
+                    (continuation: CheckedContinuation<(value: Value?, timedOut: Bool), Never>) in
                     lock.lock()
                     if consumed < recorded.count {
                         let buffered = recorded[consumed]
                         consumed += 1
                         lock.unlock()
-                        continuation.resume(returning: buffered)
+                        continuation.resume(returning: (buffered, false))
+                        return
+                    }
+                    if expiredConsumers.remove(consumerID) != nil {
+                        // The hang guard already gave up on a consumer that had
+                        // not parked yet: settle here rather than park on a
+                        // continuation nothing is watching.
+                        lock.unlock()
+                        continuation.resume(returning: (nil, true))
                         return
                     }
                     consumer = Consumer(id: consumerID, continuation: continuation)
                     lock.unlock()
                 }
-                return (false, value)
+                return .consumer(value: settled.value, timedOut: settled.timedOut)
             }
             group.addTask { [self] in
                 try? await Task.sleep(for: timeout)
-                // Same ownership rule as the clock's arming waiter: whoever
-                // removes the parked consumer owns resuming it.
+                // Same ownership rule, and same three cases, as the clock's
+                // arming waiter: whoever removes the parked consumer owns
+                // resuming it, and a consumer that has not parked yet is marked
+                // expired so its own park can settle itself.
                 let stranded: Consumer? = lock.withLock {
-                    guard let waiting = consumer, waiting.id == consumerID else { return nil }
+                    guard let waiting = consumer, waiting.id == consumerID else {
+                        expiredConsumers.insert(consumerID)
+                        return nil
+                    }
                     consumer = nil
                     return waiting
                 }
-                stranded?.continuation.resume(returning: nil)
-                return (stranded != nil, nil)
+                stranded?.continuation.resume(returning: (nil, true))
+                return .hangGuard
             }
-            let (timedOut, value) = await group.next() ?? (false, nil)
+            // The consumer's verdict is the authoritative one. Reading whichever
+            // result arrived first would let the guard both report a spurious
+            // timeout and *discard* a value `record(_:)` had already handed over
+            // — with `consumed` already advanced, so the value is gone for good.
+            var verdict: (value: Value?, timedOut: Bool) = (nil, true)
+            while let raced = await group.next() {
+                if case .consumer(let value, let timedOut) = raced {
+                    verdict = (value, timedOut)
+                    break
+                }
+            }
             group.cancelAll()
-            return timedOut ? nil : value
+            return verdict
         }
+        // Both children have been awaited by now, so this is the last word on a
+        // marker the guard left for a consumer that had already settled.
+        lock.withLock { _ = expiredConsumers.remove(consumerID) }
 
-        if value == nil {
+        if outcome.timedOut {
             Issue.record(
                 NoValueRecorded(timeout: timeout, observed: values),
                 sourceLocation: sourceLocation
             )
         }
-        return value
+        return outcome.value
     }
 }
 

--- a/Tests/TestSupport/EventDrivenTestClock.swift
+++ b/Tests/TestSupport/EventDrivenTestClock.swift
@@ -1,0 +1,562 @@
+import Foundation
+import Testing
+
+// A megaYield-free virtual clock, plus the awaitable recorder that goes with it.
+//
+// Design and rationale:
+// `docs/specs/2026-08-11-event-driven-test-clock-design.md`.
+//
+// The short version, because it explains every API choice below. `TestClock`
+// (swift-clocks) makes a clock-driven suite load-*tolerant*, not
+// load-*independent*, and both halves of its test<->clock handshake are the
+// reason:
+//
+// - **Arming is polled.** The only way to observe "a sleeper is registered" on
+//   a `TestClock` is `checkSuspension()`, which opens with `Task.megaYield()` —
+//   20 serially-awaited background-QoS detached tasks per probe. Under
+//   process-global saturation macOS starves background QoS, so the probe both
+//   fails to see the arming *and* floods the pool with more of exactly the work
+//   that is starving. Field signature: `Issue recorded` at the
+//   `advanceWhenSuspended` call site, then an empty fired-values array.
+// - **Firing is asserted synchronously.** `TestClock.advance(to:)` megaYields
+//   after finishing a sleeper's continuation, which is the only thing that
+//   *usually* lets the resumed task run its post-sleep code before `advance`
+//   returns. That is a scheduling accident, not a guarantee.
+//
+// This file makes both directions event-driven. `EventDrivenTestClock` signals
+// arming from inside the same critical section that registers the sleeper, and
+// `FireRecorder` turns "the effect happened" into something a test can await
+// instead of guess at. Under arbitrary load a green test here gets slower,
+// never red.
+//
+// This is an *addition*, not a replacement: `TestClock` and
+// `ClockTestSupport`'s `advanceWhenSuspended` / `waitForSuspension` stay for
+// their existing consumers, and suites migrate on field evidence rather than
+// wholesale.
+
+// MARK: - EventDrivenTestClock
+
+/// A deterministic virtual clock whose arming handshake is a signal, not a poll.
+///
+/// Drop-in for `TestClock` in a tier-1 suite: it conforms to
+/// `Clock` with `Duration == Swift.Duration`, so it satisfies the production
+/// `clock: any Clock<Duration>` seam unchanged. The differences are the two that
+/// matter under load:
+///
+/// - `advanceWhenArmed(by:)` replaces `advanceWhenSuspended(by:)`. It parks on a
+///   continuation that the *clock itself* resumes when a sleeper registers, so
+///   there is no probe, no megaYield and no busy budget to exhaust.
+/// - `advance(by:)` performs **no** yielding of any kind. It moves virtual time
+///   and resumes due sleepers, and that is all — so a test must await
+///   ``FireRecorder/next(timeout:sourceLocation:)`` for any *positive*
+///   assertion about what a resumed task did. See `advance(to:)`.
+///
+/// The correctness property worth stating explicitly, because it is why this is
+/// a clock rather than a wrapper around `TestClock`: the arming signal is
+/// emitted **after** the suspension has been appended to the ledger, under the
+/// same lock. A waiter can therefore never be released into a world where the
+/// sleeper it was told about is not yet registered — which is exactly the gap
+/// that makes a signalling *wrapper* around `TestClock` unsound, since that
+/// registration happens inside `TestClock`'s own lock where no wrapper can
+/// interpose.
+///
+/// Usage:
+///
+/// ```swift
+/// let clock = EventDrivenTestClock()
+/// let fired = FireRecorder<String>()
+/// let debouncer = SearchQueryDebouncer(interval: .milliseconds(250), clock: clock)
+///
+/// debouncer.schedule("wolv") { fired.record($0) }
+/// await clock.advanceWhenArmed(by: .milliseconds(250))
+/// #expect(await fired.next() == "wolv")
+/// ```
+///
+/// Full rationale: `docs/specs/2026-08-11-event-driven-test-clock-design.md`.
+public final class EventDrivenTestClock: Clock, @unchecked Sendable {
+    /// Offset-based virtual instant, mirroring `TestClock.Instant`.
+    ///
+    /// Virtual time starts at offset zero and only ever moves where a test
+    /// moves it, so failure output reads as exact durations from the start of
+    /// the test rather than as wall-clock noise.
+    public struct Instant: InstantProtocol {
+        /// Distance from the clock's origin. Exposed because assertions and
+        /// diagnostics read better as an offset than as an opaque instant.
+        public let offset: Swift.Duration
+
+        public init(offset: Swift.Duration = .zero) {
+            self.offset = offset
+        }
+
+        public func advanced(by duration: Swift.Duration) -> Self {
+            .init(offset: offset + duration)
+        }
+
+        public func duration(to other: Self) -> Swift.Duration {
+            other.offset - offset
+        }
+
+        public static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs.offset < rhs.offset
+        }
+    }
+
+    /// Per-sleep state shared by the sleeping task's continuation body and its
+    /// cancellation handler, which can run concurrently and in either order.
+    ///
+    /// It is a class so both closures see the same box without a clock-wide
+    /// registry keyed by id — a registry would have to remember every id that
+    /// ever settled in order to recognise a late cancellation, and would grow
+    /// for the life of the test. Every field is guarded by the clock's lock.
+    private final class SleepBox: @unchecked Sendable {
+        /// Non-nil exactly while the sleeper is parked and unsettled.
+        var continuation: CheckedContinuation<Void, any Error>?
+        /// Set once the sleeper has been resumed (fired or cancelled). Guards
+        /// the resume-exactly-once invariant.
+        var isSettled = false
+        /// Set when cancellation arrives *before* the continuation is installed.
+        /// The continuation body consumes it and throws instead of registering.
+        var isCancelledEarly = false
+    }
+
+    private struct Suspension {
+        let id: UUID
+        let deadline: Instant
+        let box: SleepBox
+    }
+
+    /// A parked `sleeperArmed` waiter. The continuation carries *why* it was
+    /// resumed — `true` for "a sleeper registered", `false` for "the hang guard
+    /// stranded you" — so the waiter reports the same verdict as the timeout
+    /// task no matter which of the two the task group observes finishing first.
+    private struct ArmingWaiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    /// Virtual time has no resolution floor: a test may advance by any duration.
+    public let minimumResolution: Swift.Duration = .zero
+
+    private let lock = NSLock()
+    private var currentNow: Instant
+    private var suspensions: [Suspension] = []
+    private var armingWaiters: [ArmingWaiter] = []
+
+    /// - Parameter now: starting instant, offset zero by default.
+    public init(now: Instant = .init()) {
+        currentNow = now
+    }
+
+    public var now: Instant {
+        lock.withLock { currentNow }
+    }
+
+    /// Whether at least one task is currently suspended on this clock.
+    ///
+    /// The negative direction is the useful one — "the code under test armed no
+    /// timer at all" — and it is the reason this exists as a property rather
+    /// than as `TestClock`'s throwing `checkSuspension()`. Reading it is a
+    /// synchronous snapshot with no megaYield, so a *negative* assertion on it
+    /// is one-sided in the usual way: it proves nothing was armed *by the time
+    /// you looked*. Pair it with a short real settle when the thing you are
+    /// ruling out would need a scheduling turn to appear.
+    public var hasSleeper: Bool {
+        sleeperCount > 0
+    }
+
+    /// How many tasks are currently suspended on this clock.
+    ///
+    /// Needed when a test has to get *several* sleepers registered before
+    /// advancing — `sleeperArmed` is satisfied by the first one, so it cannot
+    /// express "all three are armed". Same one-sidedness as ``hasSleeper``.
+    public var sleeperCount: Int {
+        lock.withLock { suspensions.count }
+    }
+
+    /// Whether a `sleeperArmed` waiter is currently parked.
+    ///
+    /// Exists for the clock's own self-tests, which have to get a waiter parked
+    /// *before* the first sleep registers in order to prove that the
+    /// registration is what releases it. Production tests should not need this.
+    public var hasParkedArmingWaiter: Bool {
+        lock.withLock { !armingWaiters.isEmpty }
+    }
+
+    // MARK: Clock
+
+    /// Suspends until virtual time reaches `deadline`, or throws
+    /// `CancellationError`.
+    ///
+    /// Semantics mirror `TestClock.sleep(until:tolerance:)`, and two of them are
+    /// load-bearing rather than incidental:
+    ///
+    /// - **`Task.checkCancellation()` comes first.** A task cancelled before it
+    ///   ever ran must not register a sleeper, and must throw rather than
+    ///   return normally. Cancel-and-replace debouncers depend on this: a burst
+    ///   of keystrokes cancels tasks that have not started, and a sleep that
+    ///   returned *successfully* in one of them would fire a superseded value.
+    ///   It is also the only enforcement on the already-elapsed-deadline path
+    ///   below, which returns without consulting cancellation at all.
+    /// - **The arming signal follows the ledger append**, inside the same
+    ///   critical section discipline: waiters are collected under the lock after
+    ///   the suspension is appended, and resumed once the lock is released. No
+    ///   waiter can observe "armed" while the sleeper is unregistered, and no
+    ///   continuation is resumed with the lock held.
+    ///
+    /// A deadline at or before `now` returns immediately without registering and
+    /// without signalling — there is nothing to wait for, and signalling would
+    /// tell a waiter about a sleeper that does not exist.
+    public func sleep(until deadline: Instant, tolerance: Swift.Duration? = nil) async throws {
+        try Task.checkCancellation()
+        if lock.withLock({ deadline <= currentNow }) { return }
+
+        let id = UUID()
+        let box = SleepBox()
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                lock.lock()
+                if box.isCancelledEarly {
+                    // Cancellation beat us to the lock: settle here, register
+                    // nothing, signal nobody.
+                    box.isSettled = true
+                    lock.unlock()
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                box.continuation = continuation
+                suspensions.append(Suspension(id: id, deadline: deadline, box: box))
+                let waiters = armingWaiters
+                armingWaiters.removeAll()
+                lock.unlock()
+                // Outside the lock: a waiter resumes into arbitrary user code.
+                // Draining the ledger and resuming what was drained are one
+                // obligation — a waiter removed here but not resumed parks
+                // forever, and its own timeout task cannot rescue it because
+                // that task recognises a stranded waiter by finding it still in
+                // the ledger.
+                for waiter in waiters { waiter.continuation.resume(returning: true) }
+            }
+        } onCancel: {
+            lock.lock()
+            guard !box.isSettled else {
+                lock.unlock()
+                return
+            }
+            guard let continuation = box.continuation else {
+                // The continuation is not installed yet — hand the decision to
+                // the body, which runs next and will throw instead of
+                // registering.
+                box.isCancelledEarly = true
+                lock.unlock()
+                return
+            }
+            box.isSettled = true
+            box.continuation = nil
+            suspensions.removeAll { $0.id == id }
+            lock.unlock()
+            continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    // MARK: Arming
+
+    /// Waits until at least one task is suspended on this clock.
+    ///
+    /// Returns immediately if a sleeper is already registered; otherwise parks
+    /// on a continuation that ``sleep(until:tolerance:)`` resumes the moment it
+    /// appends its suspension. There is no probe loop, so a healthy handshake
+    /// costs one scheduling hop and a loaded machine costs a slower hop — never
+    /// a red test.
+    ///
+    /// - Parameters:
+    ///   - timeout: hang guard **only**. It exists so a timer that genuinely
+    ///     never arms fails with a named diagnostic instead of parking until the
+    ///     suite time limit reports an uninformative "wedged". It is implemented
+    ///     as a race against a single real `Task.sleep` that never fires on a
+    ///     healthy path, so a passing run pays nothing for it. 45 s carries over
+    ///     from `waitForSuspension`, whose derivation against `.clockDriven`'s
+    ///     240 s limit is documented in `ClockTestSupport.swift` and
+    ///     `Tests/CLAUDE.md` ("Population is the scheduler"); the value is kept
+    ///     so that a chain of these still tallies the same way.
+    ///   - sourceLocation: reported location of the diagnostic, so it lands on
+    ///     the caller's line rather than in this file.
+    ///
+    /// Non-throwing, like the helpers it replaces: a missing sleeper is an
+    /// `Issue.record` at the caller's location and execution continues, so call
+    /// sites stay free of `try` noise. That is safe only because it returns
+    /// nothing — see `Tests/CLAUDE.md` on non-throwing waiters that *do* return
+    /// a value.
+    public func sleeperArmed(timeout: Swift.Duration = .seconds(45),
+                             sourceLocation: SourceLocation = #_sourceLocation) async {
+        if hasSleeper { return }
+
+        let waiterID = UUID()
+        let timedOut = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+            group.addTask { [self] in
+                let armed = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                    lock.lock()
+                    // Re-check under the lock: a sleeper may have registered
+                    // between the fast path above and this park.
+                    if !suspensions.isEmpty {
+                        lock.unlock()
+                        continuation.resume(returning: true)
+                        return
+                    }
+                    armingWaiters.append(ArmingWaiter(id: waiterID, continuation: continuation))
+                    lock.unlock()
+                }
+                return !armed
+            }
+            group.addTask { [self] in
+                try? await Task.sleep(for: timeout)
+                // Deregistering is what makes this safe: whoever removes the
+                // waiter owns resuming it, so a signal arriving after the
+                // timeout finds nothing to resume, and a timeout arriving after
+                // the signal reports nothing.
+                let stranded: ArmingWaiter? = lock.withLock {
+                    guard let index = armingWaiters.firstIndex(where: { $0.id == waiterID }) else { return nil }
+                    return armingWaiters.remove(at: index)
+                }
+                stranded?.continuation.resume(returning: false)
+                return stranded != nil
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+
+        if timedOut {
+            Issue.record(
+                NoSleeperArmed(timeout: timeout, virtualNow: now),
+                sourceLocation: sourceLocation
+            )
+        }
+    }
+
+    /// ``sleeperArmed(timeout:sourceLocation:)`` followed by
+    /// ``advance(by:)`` — the drop-in replacement for
+    /// `TestClock.advanceWhenSuspended(by:)`.
+    ///
+    /// Same convention as its predecessor: **put the advance next to the
+    /// assertion it unblocks**, never in a setup block far away. And remember
+    /// what advancing does not promise — for a positive assertion, follow it
+    /// with `await recorder.next()`.
+    public func advanceWhenArmed(by duration: Swift.Duration,
+                                 sourceLocation: SourceLocation = #_sourceLocation) async {
+        await sleeperArmed(sourceLocation: sourceLocation)
+        await advance(by: duration)
+    }
+
+    // MARK: Advancing
+
+    /// Advances virtual time by `duration`, firing every sleeper it passes.
+    public func advance(by duration: Swift.Duration = .zero) async {
+        await advance(to: lock.withLock { currentNow.advanced(by: duration) })
+    }
+
+    /// Advances virtual time to `deadline`, stepping `now` through each due
+    /// sleeper's deadline in order and resuming it.
+    ///
+    /// **This does not yield, megaYield, or sleep.** Sleepers are resumed
+    /// outside the lock and that is the end of the method's obligations, so
+    /// `advance` returning means *"virtual time moved and the due continuations
+    /// were resumed"* — it does **not** mean the resumed tasks have run their
+    /// post-sleep code. `TestClock` appears to promise the stronger thing only
+    /// because it megaYields on the way out, which is a scheduling accident that
+    /// stops holding under exactly the load this clock exists for.
+    ///
+    /// So: pair every *positive* assertion with
+    /// ``FireRecorder/next(timeout:sourceLocation:)``, which suspends the test
+    /// until the effect actually lands. A *negative* assertion ("nothing fired
+    /// yet") reads the snapshot directly and stays one-sided, as it always was.
+    ///
+    /// A deadline in the past is a no-op: virtual time never moves backwards.
+    public func advance(to deadline: Instant) async {
+        // Scoped locking only: `NSLock.lock()`/`unlock()` are unavailable from
+        // an async context. Each turn of the loop takes the lock once, decides,
+        // and hands back at most one continuation to resume *after* the lock is
+        // released — a continuation must never be resumed while holding it.
+        while case .fired(let due) = lock.withLock({ () -> AdvanceStep in
+            guard currentNow <= deadline else { return .finished }
+            suspensions.sort { $0.deadline < $1.deadline }
+            guard let next = suspensions.first, next.deadline <= deadline else {
+                currentNow = deadline
+                return .finished
+            }
+            currentNow = next.deadline
+            suspensions.removeFirst()
+            guard !next.box.isSettled else { return .fired(nil) }
+            next.box.isSettled = true
+            let continuation = next.box.continuation
+            next.box.continuation = nil
+            return .fired(continuation)
+        }) {
+            due?.resume()
+        }
+    }
+
+    /// One turn of `advance(to:)`: either virtual time reached the target, or a
+    /// sleeper came due and its continuation is owed a resume outside the lock.
+    private enum AdvanceStep {
+        case finished
+        case fired(CheckedContinuation<Void, any Error>?)
+    }
+}
+
+/// Diagnostic for `sleeperArmed`'s hang guard.
+///
+/// Thrown-`Error` shape on purpose: only `Issue.record(_: some Error)` puts the
+/// text on the **primary** failure line, where a CI summary will show it
+/// (`Tests/CLAUDE.md` assertion-hygiene rule 4). It reports *observed* state —
+/// what virtual time actually said when the wait gave up — rather than
+/// restating the expectation.
+private struct NoSleeperArmed: Error, CustomStringConvertible {
+    let timeout: Swift.Duration
+    let virtualNow: EventDrivenTestClock.Instant
+
+    var description: String {
+        """
+        EventDrivenTestClock: no task suspended on the clock within \(timeout) — observed \
+        zero registered sleepers, virtual now = \(virtualNow.offset). The code under test \
+        never reached its sleep: did you start the task, cancel it first, or advance past \
+        the point where it would have armed?
+        """
+    }
+}
+
+// MARK: - FireRecorder
+
+/// An awaitable record of the values a debounced/delayed callback produced.
+///
+/// Replaces the hand-rolled `Box { var values: [String] }` that clock-driven
+/// suites used to assert against immediately after `advance`. That assertion was
+/// safe only because `TestClock.advance` megaYielded on the way out; with
+/// ``EventDrivenTestClock`` there is no such accident, and there should not be —
+/// a positive assertion should *wait* for the effect rather than hope it beat
+/// the next statement.
+///
+/// Two reads, and they are not interchangeable:
+///
+/// - ``next(timeout:sourceLocation:)`` — awaits the next value not yet handed
+///   out, returning a buffered one immediately if it has already arrived. This
+///   is what a positive assertion uses.
+/// - ``values`` — a synchronous snapshot of everything recorded so far, for
+///   order and collapse assertions (`["a", "b"]`) and for negative assertions
+///   ("nothing fired yet"). **Negative assertions here are one-sided**: a fire
+///   that is pathologically late can make one false-*pass*, never false-fail.
+///   That is unchanged from the hand-rolled boxes, and it is the reason the
+///   positive half of every test must go through `next()`.
+///
+/// Lock-guarded rather than an actor, because ``record(_:)`` is called from a
+/// synchronous callback (`@MainActor (String) -> Void`) that cannot await.
+public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
+    private struct Consumer {
+        let id: UUID
+        let continuation: CheckedContinuation<Value?, Never>
+    }
+
+    private let lock = NSLock()
+    private var recorded: [Value] = []
+    /// How many recorded values `next()` has already handed out. Kept as an
+    /// index rather than draining `recorded`, so `values` stays a full history
+    /// no matter how many times `next()` was called.
+    private var consumed = 0
+    /// At most one consumer parks at a time: these tests await sequentially.
+    private var consumer: Consumer?
+
+    public init() {}
+
+    /// Records a value from the code under test. Synchronous, callable from any
+    /// context, and resumes a parked ``next(timeout:sourceLocation:)`` if one is
+    /// waiting.
+    public func record(_ value: Value) {
+        lock.lock()
+        recorded.append(value)
+        let waiting = consumer
+        consumer = nil
+        if waiting != nil { consumed += 1 }
+        lock.unlock()
+        waiting?.continuation.resume(returning: value)
+    }
+
+    /// A snapshot of every value recorded so far, in order. Never drained by
+    /// ``next(timeout:sourceLocation:)``.
+    public var values: [Value] {
+        lock.withLock { recorded }
+    }
+
+    /// The next value not yet returned by a previous `next()`, awaiting one if
+    /// it has not arrived.
+    ///
+    /// - Parameter timeout: hang guard only, in the same family as
+    ///   ``EventDrivenTestClock/sleeperArmed(timeout:sourceLocation:)`` — it
+    ///   turns "the effect never landed" into a named failure instead of a park
+    ///   until the suite time limit. Never reached on a healthy path.
+    /// - Returns: the value, or `nil` after recording a diagnostic on timeout.
+    ///   Returning an optional rather than continuing silently means a test that
+    ///   asserts on the result gets a comparison against `nil` *after* the real
+    ///   diagnostic has already been recorded, never instead of it.
+    public func next(timeout: Swift.Duration = .seconds(45),
+                     sourceLocation: SourceLocation = #_sourceLocation) async -> Value? {
+        let consumerID = UUID()
+        let value: Value? = await withTaskGroup(of: (Bool, Value?).self,
+                                                returning: Value?.self) { group in
+            group.addTask { [self] in
+                let value = await withCheckedContinuation { (continuation: CheckedContinuation<Value?, Never>) in
+                    lock.lock()
+                    if consumed < recorded.count {
+                        let buffered = recorded[consumed]
+                        consumed += 1
+                        lock.unlock()
+                        continuation.resume(returning: buffered)
+                        return
+                    }
+                    consumer = Consumer(id: consumerID, continuation: continuation)
+                    lock.unlock()
+                }
+                return (false, value)
+            }
+            group.addTask { [self] in
+                try? await Task.sleep(for: timeout)
+                // Same ownership rule as the clock's arming waiter: whoever
+                // removes the parked consumer owns resuming it.
+                let stranded: Consumer? = lock.withLock {
+                    guard let waiting = consumer, waiting.id == consumerID else { return nil }
+                    consumer = nil
+                    return waiting
+                }
+                stranded?.continuation.resume(returning: nil)
+                return (stranded != nil, nil)
+            }
+            let (timedOut, value) = await group.next() ?? (false, nil)
+            group.cancelAll()
+            return timedOut ? nil : value
+        }
+
+        if value == nil {
+            Issue.record(
+                NoValueRecorded(timeout: timeout, observed: values),
+                sourceLocation: sourceLocation
+            )
+        }
+        return value
+    }
+}
+
+/// Diagnostic for `FireRecorder.next`'s hang guard. Thrown-`Error` shape for the
+/// same reason as ``NoSleeperArmed``, and it reports what was actually in the
+/// recorder — the most useful fact when a debounce fired the wrong number of
+/// times rather than not at all.
+private struct NoValueRecorded<Value: Sendable>: Error, CustomStringConvertible {
+    let timeout: Swift.Duration
+    let observed: [Value]
+
+    var description: String {
+        """
+        FireRecorder: no value was recorded within \(timeout) — observed \(observed.count) \
+        value(s) so far: \(observed.map { String(describing: $0) }). Either the code under \
+        test never fired, or virtual time was never advanced past its deadline.
+        """
+    }
+}

--- a/Tests/TestSupport/EventDrivenTestClock.swift
+++ b/Tests/TestSupport/EventDrivenTestClock.swift
@@ -292,7 +292,10 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     ///     from `waitForSuspension`, whose derivation against `.clockDriven`'s
     ///     240 s limit is documented in `ClockTestSupport.swift` and
     ///     `Tests/CLAUDE.md` ("Population is the scheduler"); the value is kept
-    ///     so that a chain of these still tallies the same way.
+    ///     so that a chain of these still tallies the same way. **On task
+    ///     cancellation the wait ends without a diagnostic**: the waiter is
+    ///     still released, but the failure belongs to whatever cancelled the
+    ///     test, not to this call site.
     ///   - sourceLocation: reported location of the diagnostic, so it lands on
     ///     the caller's line rather than in this file.
     ///
@@ -331,6 +334,13 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
                 return .waiter(timedOut: !armed)
             }
             group.addTask { [self] in
+                // `try?`, so a *cancelled* guard still runs the rescue below: a
+                // waiter parked on a continuation nobody is watching hangs, and
+                // that stays true when the reason the guard woke early is
+                // cancellation rather than expiry. Whether the wait *reports*
+                // anything is decided by the caller, which can tell the two
+                // apart; this child cannot, because the group's own
+                // `cancelAll()` cancels it on the healthy path too.
                 try? await Task.sleep(for: timeout)
                 // Deregistering is what makes this safe: whoever removes the
                 // waiter owns resuming it, so a signal arriving after the
@@ -369,7 +379,17 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
         // call leaves an entry behind for the next one to trip over.
         lock.withLock { _ = expiredArmingWaiters.remove(waiterID) }
 
-        if timedOut {
+        // Cancellation is not expiry. A cancelled enclosing task — `.clockDriven`'s
+        // time limit firing, a sibling's `cancelAll()` — cancels the hang guard's
+        // sleep, so the waiter is released early and `timedOut` says `true` for a
+        // timer that may well have been about to arm. Reporting that would put a
+        // fabricated "within 45 s" on an innocent call site and hide the real
+        // cause, so the diagnostic is suppressed and the attribution left to
+        // whatever did the cancelling. The check belongs *here* rather than in
+        // the guard child: cancellation is monotonic, so the enclosing task's
+        // flag is unambiguous, while the child cannot distinguish its parent's
+        // cancellation from the group's own `cancelAll()` on the healthy path.
+        if timedOut && !Task.isCancelled {
             Issue.record(
                 NoSleeperArmed(timeout: timeout, virtualNow: now),
                 sourceLocation: sourceLocation
@@ -554,7 +574,10 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
     /// - Parameter timeout: hang guard only, in the same family as
     ///   ``EventDrivenTestClock/sleeperArmed(timeout:sourceLocation:)`` — it
     ///   turns "the effect never landed" into a named failure instead of a park
-    ///   until the suite time limit. Never reached on a healthy path.
+    ///   until the suite time limit. Never reached on a healthy path. **On task
+    ///   cancellation the wait ends without a diagnostic**: the consumer is
+    ///   still released and `nil` returned, but the failure belongs to whatever
+    ///   cancelled the test rather than to this call site.
     /// - Returns: the value, or `nil` after recording a diagnostic on timeout.
     ///   Returning an optional rather than continuing silently means a test that
     ///   asserts on the result gets a comparison against `nil` *after* the real
@@ -585,8 +608,27 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
                         continuation.resume(returning: (nil, true))
                         return
                     }
+                    // A consumer already parked here means two `next()` calls
+                    // are in flight on one recorder, which the single-consumer
+                    // contract forbids. Overwriting the slot silently would
+                    // orphan that continuation — its own hang guard looks for
+                    // its own id and finds this one, so it resumes nobody and
+                    // the displaced `next()` never returns. Report the contract
+                    // breach and release the displaced consumer instead: a
+                    // diagnostic beats a hang. The displaced call returns `nil`
+                    // and, like any unsatisfied wait, records its own hang-guard
+                    // diagnostic on the way out — two issues for one breach,
+                    // both naming the offending test.
+                    let displaced = consumer
                     consumer = Consumer(id: consumerID, continuation: continuation)
                     lock.unlock()
+                    if let displaced {
+                        Issue.record(
+                            ConcurrentConsumers(),
+                            sourceLocation: sourceLocation
+                        )
+                        displaced.continuation.resume(returning: (nil, true))
+                    }
                 }
                 return .consumer(value: settled.value, timedOut: settled.timedOut)
             }
@@ -625,13 +667,35 @@ public final class FireRecorder<Value: Sendable>: @unchecked Sendable {
         // marker the guard left for a consumer that had already settled.
         lock.withLock { _ = expiredConsumers.remove(consumerID) }
 
-        if outcome.timedOut {
+        // Same rule as the clock's arming guard: a cancelled enclosing task
+        // cancels this hang guard's sleep, which releases the consumer with
+        // `timedOut == true` for a fire that was never given its chance. The
+        // wait still ends — `nil` is returned, so an assertion on the result
+        // still fails — but the "within 45 s" diagnostic would name an innocent
+        // call site for someone else's cancellation, so it is suppressed.
+        if outcome.timedOut && !Task.isCancelled {
             Issue.record(
                 NoValueRecorded(timeout: timeout, observed: values),
                 sourceLocation: sourceLocation
             )
         }
         return outcome.value
+    }
+}
+
+/// Diagnostic for two `next()` calls racing on one recorder. Thrown-`Error`
+/// shape for the same reason as ``NoSleeperArmed``: the text has to reach the
+/// primary failure line, because the symptom it explains (a `next()` that
+/// returned `nil` for no visible reason) is otherwise unattributable.
+private struct ConcurrentConsumers: Error, CustomStringConvertible {
+    var description: String {
+        """
+        FireRecorder: a second next() parked while one was already waiting — this \
+        recorder holds a single-consumer slot and its callers must await \
+        sequentially. The displaced wait was released with nil so it does not \
+        hang; await one next() at a time, or give each concurrent waiter its own \
+        FireRecorder.
+        """
     }
 }
 
@@ -650,4 +714,26 @@ private struct NoValueRecorded<Value: Sendable>: Error, CustomStringConvertible 
         test never fired, or virtual time was never advanced past its deadline.
         """
     }
+}
+
+// MARK: - Settling
+
+/// Hands the current executor back for a few real turns, so a fire that *would*
+/// land gets the chance to before a **negative** assertion reads the recorder.
+///
+/// Shared by the suites on ``EventDrivenTestClock`` because its ``advance`` does
+/// no yielding: where `TestClock.advance`'s trailing megaYield supplied this
+/// settling incidentally, here it is explicit and bounded. From a `@MainActor`
+/// test body this is what returns the main queue, which is the only way the
+/// deferred work becomes observable at all (`Tests/CLAUDE.md`, "`@MainActor`
+/// tests: suspend to drain, never pump").
+///
+/// **One-sided, and only ever worth this much:** it proves absence up to the
+/// settle window and no further, so a pathologically late fire can make a
+/// negative assertion false-*pass*, never false-fail. That is unchanged from
+/// the synchronous read it replaces. Every *positive* assertion must still go
+/// through ``FireRecorder/next(timeout:sourceLocation:)``, which waits for the
+/// effect instead of hoping it arrived.
+public func settle() async {
+    for _ in 0..<3 { try? await Task.sleep(for: .milliseconds(10)) }
 }

--- a/docs/specs/2026-08-11-event-driven-test-clock-design.md
+++ b/docs/specs/2026-08-11-event-driven-test-clock-design.md
@@ -1,0 +1,211 @@
+# Event-driven test clock — design
+
+## The problem
+
+Clock-driven tier-1 suites drive virtual time so their assertions are exact and
+independent of how loaded the machine is. `TestClock` (swift-clocks) delivers
+most of that, but it makes those suites load-**tolerant** rather than
+load-**independent**, and the intolerance is structural rather than a matter of
+tuning. Both halves of the test↔clock handshake are the reason.
+
+- **Arming is polled, and every probe costs a yield storm.** The only way to
+  observe "a sleeper is registered" on a `TestClock` is `checkSuspension()`,
+  which opens with `Task.megaYield()` — 20 serially-awaited background-QoS
+  detached tasks per probe. `waitForSuspension`
+  (`Tests/TestSupport/ClockTestSupport.swift`) polls it against a 45 s deadline.
+  Under process-global saturation macOS starves background QoS, so the code
+  under test cannot reach its `sleep` inside the guard, and the guard itself
+  floods the pool with more of exactly the work that is starving.
+- **Asserting straight after `advance` is safe only by accident.**
+  `TestClock.advance(to:)` megaYields after finishing a sleeper's continuation,
+  and that is the only thing which usually lets the resumed task run its
+  post-sleep code before `advance` returns. It is a scheduling accident, not a
+  guarantee — and it stops holding under precisely the load that matters.
+
+The field evidence: in a full-suite soak on a loaded development box (2 of 3
+runs, failing at ~131 s and ~228 s), `AppearanceDebounceTests` and
+`SearchQueryDebouncerTests` reported `Issue recorded` at the
+`advanceWhenSuspended` call site, followed by an empty fired-values array. No
+logic assertion failed — the arming handshake did.
+
+Every suite-local remedy is already measured and refuted (`Tests/CLAUDE.md`,
+"Population is the scheduler"): both suites already carry `.serialized` and
+failed anyway, since the contention is process-global; `TASK_MEGA_YIELD_COUNT=1`
+measured as noise; blanket retry is banned in every tier. `ClockTestSupport`
+names the real fix and defers it — "a megaYield-free virtual clock replacing
+`TestClock` … a shared-contract change". This is that change.
+
+## Goal
+
+Make both directions of the handshake **event-driven**: no polling, no yield
+storms, no wall-clock guard on any healthy path.
+
+- **Arming** — the clock signals when a sleeper registers; the test parks on a
+  continuation instead of probing.
+- **Firing** — the test observes the effect through an awaitable recorder
+  instead of reading state synchronously after `advance` returns.
+
+The property to hold: under arbitrary load a green test gets slower, never red.
+Diagnostics-only timeouts remain, because a timer that genuinely never arms must
+fail with a named message rather than park until the suite time limit, and they
+are reached only on runs that are already failing.
+
+## Design
+
+Both types live in `Tests/TestSupport/EventDrivenTestClock.swift` and are
+`public`, since `TestSupport` is imported across test targets.
+
+### `EventDrivenTestClock`
+
+A `final class` conforming to `Clock` with `Duration == Swift.Duration` and its
+own offset-based `Instant`, so it satisfies the production
+`clock: any Clock<Duration>` seam with no change to any production type. State
+is one `NSLock`-guarded group: current virtual `now`, the suspension ledger, and
+the ledger of parked arming waiters — the same storage shape as `TestClock` plus
+the waiter ledger that makes arming observable.
+
+- **`sleep(until:tolerance:)`** opens with `try Task.checkCancellation()`,
+  mirroring `TestClock`. A task cancelled before it ever ran must not register a
+  sleeper and must throw rather than return normally: cancel-and-replace
+  debouncers depend on it, since a burst of keystrokes cancels tasks that have
+  never started and a sleep returning *successfully* in one of them fires a
+  superseded value. It is also the only enforcement on the already-elapsed
+  deadline path, which returns without consulting cancellation at all. A
+  deadline at or before `now` returns immediately, registering nothing and
+  signalling nobody. Otherwise the suspension is appended to the ledger under
+  the lock, parked arming waiters are collected in the same critical section,
+  and they are resumed after the lock is released.
+- **Signal-after-append is the whole correctness story.** There is no window in
+  which a waiter proceeds while the sleeper it was told about is unregistered.
+  That ordering is also why this is a clock and not a wrapper: `TestClock`
+  registers inside its own lock, where nothing outside can interpose, so any
+  wrapper's signal necessarily precedes the registration it claims to announce.
+- **Cancellation while suspended** removes the entry under the lock and resumes
+  the continuation throwing `CancellationError`, matching `TestClock`. The
+  handler and the continuation body can run in either order, so they share a
+  per-sleep box that records whether the sleeper has settled and whether
+  cancellation arrived before the continuation was installed; whoever gets the
+  lock first owns the outcome, and the sleeper is resumed exactly once.
+- **`sleeperArmed(timeout:sourceLocation:)`** returns immediately when a sleeper
+  is registered and otherwise parks a continuation that the next registration
+  resumes. The timeout is a hang guard only: it races a single real
+  `Task.sleep` that never fires on a healthy path, and on expiry it deregisters
+  the waiter — so a later signal cannot resume a dead continuation — then
+  records an `Issue` carrying observed state. 45 s carries over from
+  `waitForSuspension` so that existing tallies of chained waits against
+  `.clockDriven`'s 240 s limit stay valid.
+- **`advanceWhenArmed(by:)`** is `sleeperArmed()` followed by `advance(by:)` —
+  the drop-in replacement for `advanceWhenSuspended(by:)`.
+- **`advance(by:)` / `advance(to:)`** step `now` through each due deadline in
+  order and resume those sleepers outside the lock. **No megaYield and no
+  yields at all.** The consequence is documented on the method and is the one
+  thing a migrating test must internalize: `advance` returning means the
+  continuations were resumed, *not* that the resumed tasks have run their
+  post-sleep code. Positive assertions pair with `FireRecorder.next()`.
+- **`hasSleeper` / `sleeperCount`** are synchronous snapshots, for the negative
+  assertion "the code under test armed no timer at all" and for waiting until
+  several sleepers are registered before advancing.
+
+### `FireRecorder<Value: Sendable>`
+
+A lock-guarded buffer plus at most one parked consumer, replacing the
+hand-rolled `Box { var values: [String] }` that these suites asserted against
+immediately after `advance`.
+
+- **`record(_:)`** is synchronous and callable from any context, because the
+  code under test calls it from a non-async callback. It resumes a parked
+  consumer if there is one.
+- **`next(timeout:sourceLocation:)`** returns the next value not yet handed out,
+  awaiting it if it has not arrived, and returns `nil` after recording a
+  diagnostic on timeout. Returning an optional rather than continuing silently
+  means a test asserting on the result compares against `nil` *after* the real
+  diagnostic was recorded, never instead of it.
+- **`values`** is a full-history snapshot, never drained by `next()`, for order
+  and collapse assertions and for negative assertions. Negative assertions here
+  stay **one-sided**: a pathologically late fire can make one false-*pass*,
+  never false-fail. That is unchanged from the hand-rolled boxes, and it is
+  exactly why the positive half of every test goes through `next()`.
+
+Both diagnostics are thrown-`Error` shapes passed to `Issue.record`, since only
+that form puts the message on the primary failure line where a CI summary shows
+it (`Tests/CLAUDE.md` assertion-hygiene rule 4), and both report observed state
+rather than restating the expectation.
+
+### First consumers
+
+`AppearanceDebounceTests` and `SearchQueryDebouncerTests` migrate wholesale —
+they are small, each shares one harness, and a mixed-clock suite would be harder
+to read than either pure form. The pattern per positive test is: schedule the
+work, `await clock.advanceWhenArmed(by:)`, `let value = await fired.next()`,
+assert on that value and on `fired.values`. Boundary and cancellation tests keep
+their exact-virtual-time structure. `CancelOnResumeClock`, the delegating
+wrapper that reproduces cancellation landing after a sleep resumes, ports
+unchanged onto the new base clock.
+
+Two consequences worth naming, because they are the cost side of the trade:
+
+- **Negative assertions need an explicit settle.** Where a megaYielding
+  `advance` used to supply incidental scheduling turns, these suites now hand
+  the main actor back for a few short real sleeps before reading `values`. Same
+  one-sidedness as before, made explicit and bounded rather than inherited from
+  a library's internals.
+- **One negative got weaker on purpose.** `dropFirstAndRemoveDuplicates` proved
+  "the subscriber-time replay armed no timer" by asserting that
+  `checkSuspension()` did *not* throw. Its replacement settles briefly and then
+  asserts `hasSleeper == false`. The timer a missing `dropFirst()` would arm
+  needs a scheduling turn to appear and the settle gives it several, but this is
+  a weaker proof than the original and, like every negative here, can only ever
+  false-pass.
+
+### Self-tests
+
+The clock's own properties are invisible in normal use — a clock that silently
+stopped signalling would look identical to a working one until some unrelated
+suite began timing out at 45 s. `Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift`
+covers them, alongside `FlakyQuarantineSelfTests`, which lives there for the
+same reason: a waiter parked before any sleep is released by the later
+registration; `sleeperArmed` takes the fast path when a sleeper already exists;
+a pre-cancelled task's sleep neither registers nor signals; a cancelled task's
+sleep throws even when the deadline has already elapsed; cancelling a suspended
+sleeper removes its ledger entry and throws; `advance` fires in deadline order
+and moves `now` exactly; one advance past several deadlines fires each sleeper
+once; both hang guards reach their diagnostic when driven at a tiny timeout, and
+deregister the stranded waiter afterwards.
+
+## Non-goals
+
+- **Migrating the other clock-driven suites.** `FileWatcherTests`,
+  `GatedIntervalSleepTests`, `DaywatchRunnerTests`, `PaneRepairCoordinatorTests`
+  and the rest stay on `TestClock` and move on field evidence, one at a time —
+  the Built/Enabled ratchet applied to test infrastructure.
+- **Removing `TestClock`, `advanceWhenSuspended` or `waitForSuspension`.** They
+  remain correct for their existing consumers, and their documented derivation
+  against `.clockDriven`'s limit stays load-bearing.
+- **Touching the production clock seam.** `clock: any Clock<Duration>` as the
+  last defaulted initializer parameter is unchanged; the new type simply
+  conforms to it.
+
+## Rejected alternatives
+
+- **Raise the 45 s arming guard.** It does not converge — at a load average in
+  the hundreds no finite number holds. It also violates the rule that
+  `ciSafeDeadline`, `waitForSuspension` and `.clockDriven` are derived together,
+  and it taxes every genuinely wedged test with a longer wait before the failure
+  is attributed.
+- **Wrap `TestClock` in a signalling decorator.** Unsound. Registration happens
+  inside `TestClock`'s own lock, so a wrapper can only signal before or after
+  that critical section, never within it. Signalling before leaves a window in
+  which the waiter advances past an unregistered sleeper — which moves `now`
+  with nothing to fire, so the sleep that lands afterwards is scheduled against
+  the new `now` and never fires. That is the permanent-desync hang, not a red
+  test.
+- **`TASK_MEGA_YIELD_COUNT=1`.** Measured across interleaved runs with
+  population held constant: p90 26.5 s / 31.2 s → 26.0 s / 29.4 s, p99 26.6 s →
+  27.0 s. Noise. The megaYield is a real but secondary contributor; the dominant
+  term is the number of runnable tasks in the process.
+- **`.serialized` on the affected suites.** Already applied to both, and both
+  still failed. It narrows a suite that starves *itself*; it cannot shrink the
+  process-global queue its waiter sits behind.
+- **Blanket retry.** Banned in every tier: a retry nobody named hides a
+  regression, because a test that started failing when someone broke the code is
+  indistinguishable from one that was always flaky.


### PR DESCRIPTION
## What's broken

Two tier-1 debounce tests — `AppearanceDebounceTests` "rapid scheme changes within one window collapse to a single fire" and `SearchQueryDebouncerTests` "a burst within one window collapses to a single fire with the last value" — fail under machine load and pass on rerun. They are already fully virtual-time and already `.serialized`, so neither the usual "raise the deadline" nor "stop the suite contending with itself" applies. The failure signature is always the same pair: `Issue recorded` at the `advanceWhenSuspended` call site, then `fired.values → []`.

This is the remainder of the cluster from #618, which fixed the four tests whose defects were deadline derivations and one transient-state assertion. These two were deliberately left out of that PR because their fix is a shared-infrastructure change, and `Tests/CLAUDE.md` required a human decision before reshaping shared test infrastructure.

## Why it happens

`TestClock`'s test↔clock handshake is polled in both directions, and both halves degrade under exactly the load this repo runs at.

- **Arming is polled.** The only way to observe "a sleeper is registered" on a `TestClock` is `checkSuspension()`, which opens with `Task.megaYield()` — 20 serially-awaited background-QoS detached tasks per probe. macOS starves background QoS first under saturation, so the probe both fails to see the arming and floods the pool with more of the very work that is starving. `waitForSuspension` then burns its 45s guard and records its Issue; the debounce never fired because the code under test never got a turn to reach its `sleep`.
- **Firing is asserted synchronously.** `TestClock.advance(to:)` megaYields after finishing a sleeper's continuation, and that is the only reason the resumed task's post-sleep code usually runs before `advance` returns. It is a scheduling accident, not a guarantee.

`ClockTestSupport.swift` documents both, names the remedy, and defers it: *"Making this load-independent means a megaYield-free virtual clock replacing `TestClock`, which is a shared-contract change and deliberately not bundled here."* This PR is that change.

## Why this one holds when four earlier attempts did not

TBD's worktree archive shows at least four prior runs at this cluster — a ThemeStore flake fix, two rounds of deadline-starvation/CI-flake hardening, and an earlier appearance-debounce fix. Every one of them tuned a *number* or a *scheduling knob*: bigger deadlines, `.serialized`, megaYield count. `Tests/CLAUDE.md` now records the measured refutation of each for this failure class — `.serialized` was already applied to both suites and they still failed; `TASK_MEGA_YIELD_COUNT=1` measured as noise; blanket retry is banned.

This PR does not resize the handshake. It **removes the polling from both directions**:

- The clock signals arming from inside the same critical section that registers the sleeper, so a waiter can never be released into a world where the sleeper it was told about is not yet registered. A test parks on a continuation instead of probing.
- `FireRecorder` makes "the effect landed" awaitable, so a positive assertion waits for the fire instead of racing it.

The consequence is the property the earlier attempts could not buy at any parameter value: **under arbitrary load a green test here gets slower, never red.** The remaining 45s guards fire only when a timer genuinely never arms, and they exist to turn a hang into a named diagnostic — not to bound a healthy path.

That is also the claim to check if this PR ever stops holding: if these tests go red again with a hang-guard diagnostic, the failure is a timer that truly never armed, not a starved observer.

## What this PR does

- Adds `EventDrivenTestClock` and `FireRecorder` to `Tests/TestSupport`, with `settle()` and `watchForSleeper(on:upTo:)` as the two documented helpers for negative assertions.
- Migrates `AppearanceDebounceTests` and `SearchQueryDebouncerTests` to them. `CancelOnResumeClock` ports unchanged in shape.
- Adds `EventDrivenTestClockSelfTests` covering the clock's own contracts: arming-signal ordering, pre-cancelled sleeps, cancel-while-suspended, deadline-ordered advance, both hang guards, recorder buffering/parking, and the two burst regressions described below.
- Documents the design in `docs/specs/2026-08-11-event-driven-test-clock-design.md` and adds a short `Tests/CLAUDE.md` section pointing at it.

`TestClock`, `waitForSuspension` and `advanceWhenSuspended` are untouched and stay for their existing consumers. No production file changes: the new clock satisfies the existing `any Clock<Duration>` seam as-is. Other suites migrate on field evidence, not wholesale — named candidates below.

## Assumptions

- Assumes at most one consumer awaits a given `FireRecorder` at a time. This is now enforced rather than trusted: a displaced consumer is rescued and the contract breach is recorded as an Issue, so violating it fails loudly instead of hanging.
- Assumes a migrated suite advances through `advanceWhenArmed` after any fire. Because `advance` never yields, a task that fires and immediately re-sleeps cannot re-register before `advance` returns, so a bare second `advance` would desync permanently. This is documented on `advance(to:)` and in `Tests/CLAUDE.md`, and it is the first thing to get right when migrating the poller suites.

## Evidence & verification

**The failure, reproduced.** Three full-suite runs (5411 tests) on a loaded box before this change: the two burst tests failed in 2 of 3 runs with the signature above, at ~131s and ~228s reported duration.

**The fix, demonstrated under the same condition.** Three more full-suite runs (5555 tests) with load induced deliberately — 12 spinners, load average climbing 5.9 → 24.6 across the run — put both tests **3 of 3 green**, at 62s, 63s and 100s reported duration. That is the whole claim in one line: they sat in the same starved regime that used to fail them, took a long time about it, and stayed green. The `EventDrivenTestClock` self-tests passed in all three runs too (~21s each).

Two unrelated tests reddened during that soak, neither in this diff and both already known members of the wider cluster: `ChildReaperTests` "background reap: fire-and-forget clears the zombie" (run 1) and `TranscriptImageAttachmentTests.recycledHostingViewFetchesTheNewAttachmentsThumbnail` (run 2, the shared `TranscriptImageService.shared` cache that `Tests/CLAUDE.md` documents as the escaping-`Task` cross-test corruption shape). Listed as follow-ups rather than quietly fixed here.

**Adversarial review.** Three fresh-context review rounds found and fixed 14 findings in the new clock, several of which were real concurrency defects that the happy-path tests did not catch:

- two park-forever races where a hang guard that outran the waiter's park left it on a continuation nothing would resume — a diagnostic-free hang, the worst failure shape in this repo's taxonomy
- a verdict path that could both fabricate a timeout diagnostic and silently drop a just-recorded value
- virtual time able to step backwards past a stale-deadline sleeper
- both hang guards reporting a fabricated "nothing happened in 45s" when the real cause was the enclosing test being cancelled
- a displaced second consumer parking forever with no diagnostic

**Mutation checks**, each observed red then restored: deleting the arming signal (guard diagnostic reds); advancing without resuming due sleepers (recorder guard reds); deleting `Task.checkCancellation()` from `sleep` (burst test reds); removing the displaced-consumer rescue (hangs past 420s — the exact defect the fix prevents); resuming a displaced consumer as timed-out (fabricated 10s diagnostic on a call that returned in 0.002s); removing the cancellation gate (fabricated 30s diagnostic in 0.020s); and deleting `.dropFirst()` from `AppearanceBroadcastDebouncer` (the strengthened negative reds in 0.020s, where the previous fixed 30ms settle could have missed it under saturation).

One finding worth recording because it changes how these are tested: **a sequential zero-timeout loop does not discriminate** the guard-first races — the waiter child reliably parks first. Only a 32-wide concurrent burst forces the ordering, and against the weakened clock that burst hangs every time. Both regression tests are written that way.

## Follow-ups, not in scope

- `ControlModeInputHealthTests` "fail then success fires one failing and one recovery transition" — same family, a 100s wall-clock wait on an event-driven fact, surfaced in another PR's CI.
- `ReplayLiveIntegrationMatrixTests` firehose-overflow and the `TerminalTeardownReapTests` / `ChildReaperTests` PTY-reap suites — observed flaking during the #618 soak.
- `GatedIntervalSleepTests` and `DaywatchRunnerTests` — poller loops, the migration where the re-arm rule above matters most.

- `ChildReaperTests` background reap and `TranscriptImageAttachmentTests` thumbnail recycling — observed reddening during this PR's own soak, above.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9EEB84BC-BF9D-408C-ACA1-4543A64AAA7C)
