### PR TITLE
Fix: The last five flakes were all lying tests, not slow ones

### DIFF
--- a/Sources/TBDApp/Panes/Transcript/Renderer/TranscriptImageService.swift
+++ b/Sources/TBDApp/Panes/Transcript/Renderer/TranscriptImageService.swift
@@ -51,7 +51,8 @@ struct TranscriptImageMetadata: Equatable {
 /// cache below means a scrolled row pays it once.
 ///
 /// `@unchecked Sendable` is justified by the state: `NSCache` is documented
-/// thread-safe, and every other stored property is a `let` of a Sendable type.
+/// thread-safe, every other stored property is a `let` of a Sendable type, and
+/// the one `var` (`onThumbnailRequest`, a test seam) is `@MainActor`-isolated.
 final class TranscriptImageService: @unchecked Sendable {
     static let shared = TranscriptImageService()
 
@@ -107,6 +108,7 @@ final class TranscriptImageService: @unchecked Sendable {
         maxPixelSize: Int,
         completion: @escaping @MainActor (NSImage?) -> Void
     ) {
+        onThumbnailRequest?(path, maxPixelSize)
         guard let stamp = Self.fileStamp(path) else {
             completion(nil)
             return
@@ -128,6 +130,24 @@ final class TranscriptImageService: @unchecked Sendable {
             DispatchQueue.main.async { MainActor.assumeIsolated { completion(image) } }
         }
     }
+
+    /// Test seam: fired on every thumbnail REQUEST, with the requested path and
+    /// `maxPixelSize`, BEFORE the cache is consulted — so it observes the fetch
+    /// itself rather than the entry the fetch eventually lands in.
+    ///
+    /// That distinction is the point. A test that asserts through
+    /// `hasCachedThumbnail` is asserting on `thumbnailCache`, which is an
+    /// `NSCache` under a `countLimit` and an eviction policy of its own: the
+    /// entry may not have landed yet (the decode is asynchronous and its
+    /// scheduling latency is unbounded under load) and, once landed, may be
+    /// evicted by any concurrently running suite that decodes 64 other images.
+    /// The request is synchronous, ordered, and nobody else's to evict.
+    ///
+    /// `@MainActor`-isolated, like `thumbnail(forPath:maxPixelSize:completion:)`
+    /// which fires it, so the seam needs no synchronization of its own and does
+    /// not weaken the class's `@unchecked Sendable` justification. Production
+    /// never sets it.
+    @MainActor var onThumbnailRequest: ((String, Int) -> Void)?
 
     /// Test seam: drops every probe and thumbnail so a test can observe a cold
     /// path. Production never calls it — the caches are self-bounding.

--- a/Sources/TBDApp/Terminal/ChildReaper.swift
+++ b/Sources/TBDApp/Terminal/ChildReaper.swift
@@ -135,6 +135,30 @@ enum ChildReaper {
         }
     }
 
+    /// Test seam: runs `done` once every reap enqueued *before this call*
+    /// has finished. Never used by production code — nothing here waits on a
+    /// reap, deliberately (see `reap`).
+    ///
+    /// Why this exists. `queue` is concurrent and `reap(pid:unless:)` enqueues
+    /// its block **synchronously**, so a barrier submitted after a teardown has
+    /// returned is ordered behind every reap that teardown enqueued. That turns
+    /// "has the reap happened yet?" from a window a test must poll into an
+    /// event it can await — and, unlike polling, it tells the two failures
+    /// apart: once `done` runs, the reap block has *finished*, so a child that
+    /// still exists means the reap did not reap it, not that libdispatch had
+    /// not got round to scheduling it yet. Polling cannot make that distinction
+    /// at all, which is why a polling test can only ever report "still there
+    /// after N tries".
+    ///
+    /// **Caveat: the barrier is process-wide, not per-pid.** It also waits on
+    /// reaps enqueued by any concurrently running test, and each reap parks
+    /// until *its* child exits. That is bounded — every child in these suites
+    /// exits within a second — but it is not free, and a caller that spawned a
+    /// long-lived child elsewhere in the process pays for it here.
+    static func drainPendingReaps(_ done: @escaping @Sendable () -> Void) {
+        queue.async(flags: .barrier, execute: done)
+    }
+
     /// Blocking `waitpid` for `pid`. Returns `waitpid`'s result: the reaped pid,
     /// or `-1` when there was nothing to reap (`ECHILD`).
     ///

--- a/Tests/TBDAppTests/ChildReapDrainSupport.swift
+++ b/Tests/TBDAppTests/ChildReapDrainSupport.swift
@@ -1,0 +1,168 @@
+import Darwin
+import Foundation
+
+@testable import TBDApp
+
+// Shared by the two suites that observe background reaps —
+// `ChildReaperTests` and `TerminalTeardownReapTests`.
+
+/// How long a barrier wait may take before it is reported as a stuck reap.
+///
+/// The honest cost of the barrier is the longest-lived child in the process:
+/// every child these suites spawn is either `/bin/sleep 0`–`0.4` or a `sleep
+/// 120` that teardown SIGTERMs, so a healthy drain returns in well under a
+/// second. 30 s is ~30x that, and it must land inside the two suites' shared
+/// `.timeLimit(.minutes(1))` with room for the disposal and assertions that
+/// follow it — which it does with 2x to spare. It is a hang guard, not a timing
+/// assertion: a passing run never spends any of it.
+let reapDrainHangGuard: Duration = .seconds(30)
+
+/// How a bounded wait for `ChildReaper`'s queue barrier ended.
+enum ReapDrainOutcome {
+    /// The barrier fired: every reap enqueued before the wait has run to
+    /// completion, so a child that still exists is a reap that did not reap.
+    case drained(waited: Duration)
+    /// The barrier did not fire inside the hang guard. Some reap is parked in
+    /// `waitpid` on a child that has not exited.
+    case stalled(waited: Duration)
+    /// The surrounding task was cancelled — the suite time limit fired, or the
+    /// run is tearing down.
+    case cancelled(waited: Duration)
+
+    /// The diagnostic for a barrier that did not fire — `nil` when it did.
+    /// `observedState` is a closure so the caller's `waitid`/`kill` probe runs
+    /// only on the failing path.
+    func diagnostic(pid: pid_t, observedState: () -> String) -> (any Error)? {
+        switch self {
+        case .drained:
+            return nil
+        case .stalled(let waited):
+            return ReapDrainStalled(pid: pid, observedState: observedState(), waited: waited)
+        case .cancelled(let waited):
+            return ReapDrainWaitCancelled(pid: pid, observedState: observedState(), waited: waited)
+        }
+    }
+}
+
+struct ReapDrainStalled: Error, CustomStringConvertible {
+    let pid: pid_t
+    let observedState: String
+    let waited: Duration
+
+    var description: String {
+        "ChildReaper's queue barrier did not fire within \(waited) — a reap is parked in waitpid "
+            + "on a child that has not exited (the unbounded wait ChildReaper's doc comment "
+            + "declares). pid \(pid) was observed \(observedState); this test ended and reaped it "
+            + "before failing. Nothing here says teardown is broken — it says a reap is stuck."
+    }
+}
+
+struct ReapDrainWaitCancelled: Error, CustomStringConvertible {
+    let pid: pid_t
+    let observedState: String
+    let waited: Duration
+
+    var description: String {
+        "waiting for ChildReaper's queue barrier was CANCELLED after \(waited) — the suite time "
+            + "limit fired, or the run is tearing down. pid \(pid) was observed \(observedState); "
+            + "this test ended and reaped it before failing. This says nothing about whether "
+            + "teardown reaps."
+    }
+}
+
+/// Suspends until every reap `ChildReaper` had already enqueued has run to
+/// completion — or until `budget` elapses, or the task is cancelled.
+///
+/// **The fast path is the point, and it is an event, not a window.**
+/// `ChildReaper.drainPendingReaps` puts a barrier on the reaper's own concurrent
+/// queue, so when it fires every reap enqueued before this call has *finished*.
+/// A child that still exists after that is a contract failure, not a scheduling
+/// delay — which is the distinction polling cannot make (it can only ever report
+/// "still there after N tries"). Suspending rather than blocking also keeps the
+/// main queue draining, which the teardown suite needs.
+///
+/// **Why the wait is nevertheless bounded.** The barrier is ordered behind
+/// `waitpid` calls that `ChildReaper` itself documents as unbounded: a child
+/// that ignores `SIGHUP` never exits and its reaper thread parks forever. No
+/// suite `.timeLimit` can rescue that — a `withCheckedContinuation` awaiting a
+/// callback that never runs is not cancellable, and Swift Testing cannot cancel
+/// a thread parked in a synchronous `waitpid` either — so an unbounded barrier
+/// wait would wedge the whole run instead of reddening one test. The hang guard
+/// converts that back into a red test with a named diagnostic, and the caller
+/// SIGKILLs its own child on that path so the stall cannot poison siblings.
+///
+/// **Two properties of the barrier the caller has to know.** It is *process-
+/// wide*, so it also waits on reaps enqueued by any concurrently running test.
+/// And a barrier on a *concurrent* queue also blocks every block submitted
+/// after it, which is precisely the serialization
+/// `ChildReaper.queue`'s `.concurrent` attribute exists to avoid: while one reap
+/// is parked, later reaps still run (they were submitted before this barrier),
+/// but every *subsequent* barrier queues behind this one. So a single stuck reap
+/// costs each later test one bounded `budget` and a named failure — degraded,
+/// attributable, and finite — instead of a wedge.
+///
+/// The guard task is cancelled on the fast path, and cancellation of the caller
+/// resolves the wait immediately rather than waiting the budget out.
+func drainPendingReaps(within budget: Duration = reapDrainHangGuard) async -> ReapDrainOutcome {
+    let started = ContinuousClock.now
+    let signal = DrainSignal()
+    ChildReaper.drainPendingReaps { signal.resolve(.drained) }
+    let hangGuard = Task {
+        // A cancelled sleep means the barrier already won — say nothing.
+        do { try await Task.sleep(for: budget) } catch { return }
+        signal.resolve(.stalled)
+    }
+    defer { hangGuard.cancel() }
+
+    let reason = await withTaskCancellationHandler {
+        await signal.wait()
+    } onCancel: {
+        signal.resolve(.cancelled)
+    }
+    let waited = ContinuousClock.now - started
+    switch reason {
+    case .drained: return .drained(waited: waited)
+    case .stalled: return .stalled(waited: waited)
+    case .cancelled: return .cancelled(waited: waited)
+    }
+}
+
+/// One-shot resolution box: whoever gets there first decides, and the losers —
+/// including the barrier callback that fires minutes later — are no-ops.
+///
+/// It exists because the three racers cannot be raced with a task group: the
+/// barrier arm is exactly the one that may never complete, and a task group
+/// awaits *every* child at scope exit, so `cancelAll()` would not release it.
+/// The two losing arms here are a cancellable `Task.sleep` and a callback that
+/// simply lands in an already-settled box, so nothing is left to wait on.
+private final class DrainSignal: @unchecked Sendable {
+    enum Reason: Sendable { case drained, stalled, cancelled }
+
+    private let lock = NSLock()
+    private var settled: Reason?
+    private var waiter: CheckedContinuation<Reason, Never>?
+
+    func resolve(_ reason: Reason) {
+        lock.lock()
+        guard settled == nil else { lock.unlock(); return }
+        settled = reason
+        let waiter = self.waiter
+        self.waiter = nil
+        lock.unlock()
+        waiter?.resume(returning: reason)
+    }
+
+    /// Single-consumer by construction: one call per `drainPendingReaps`.
+    func wait() async -> Reason {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Reason, Never>) in
+            lock.lock()
+            if let settled {
+                lock.unlock()
+                continuation.resume(returning: settled)
+            } else {
+                waiter = continuation
+                lock.unlock()
+            }
+        }
+    }
+}

--- a/Tests/TBDAppTests/ChildReaperTests.swift
+++ b/Tests/TBDAppTests/ChildReaperTests.swift
@@ -15,20 +15,32 @@ import Testing
 /// TBDApp. `ChildReaper` is the guaranteed `waitpid`; a non-blocking (`WNOHANG`)
 /// or event-source implementation fails `reapsAChildThatIsStillRunning` below.
 ///
+/// HOW THESE TESTS WAIT. The background-reap tests await an **event**, not a
+/// window: `ChildReaper.drainPendingReaps` puts a barrier on the reaper's own
+/// concurrent queue, so when it fires every reap already enqueued has *run to
+/// completion*. A child that still exists after that is a reap that did not
+/// reap — a contract failure, not a scheduling delay. The single remaining
+/// bounded poll, `waitUntilZombie`, waits for a child to **exit**, which is not
+/// an in-process event and therefore has nothing to be ordered behind; it is
+/// documented as a hang guard at its definition.
+///
 /// WHY AN EXPLICIT `.timeLimit(.minutes(1))` AND NOT `.clockDriven`. Following
 /// the precedent of `SubprocessTimeoutTests`, which states its reason rather
 /// than inheriting the shared trait: `.clockDriven`'s four minutes is sized for
 /// suites that arm a `TestClock` handshake in the ~4500-test parallel pass, and
-/// nothing here is clock-driven — the longest child lives 0.3 s and the polls
-/// below are capped at 5 s of their own. A limit an order of magnitude above
-/// the work is a hang-catcher; four minutes of a shared box is not free.
+/// nothing here is clock-driven. What the limit has to afford is the barrier
+/// wait, whose worst case is the longest-lived child in the process (0.3 s
+/// here) plus scheduling, and one `waitUntilZombie` hang-guard budget. Both are
+/// seconds against a sixty-second limit — a hang-catcher an order of magnitude
+/// above the work, which is what this trait is for. Four minutes of a shared
+/// box is not free.
 ///
 /// The limit's known blind spot, stated rather than glossed: Swift Testing
 /// cannot cancel a thread parked in a synchronous `waitpid`, so it would not
 /// rescue a test that waits on a child that never exits. None can — every child
 /// spawned here is `/bin/sleep` with a bounded argument, which always exits, and
-/// the skip-branch test reaps its own deliberately-unreaped child before
-/// returning.
+/// the skip-branch test disposes of its own deliberately-unreaped child before
+/// it asserts anything.
 @Suite("ChildReaper", .timeLimit(.minutes(1)))
 struct ChildReaperTests {
 
@@ -45,10 +57,37 @@ struct ChildReaperTests {
 
     private struct StillZombie: Error, CustomStringConvertible {
         let pid: pid_t
-        let polls: Int
+        let state: String
         var description: String {
-            "pid \(pid) was still a live-or-zombie process after \(polls) polls "
-                + "(expected ESRCH once ChildReaper reaped it)"
+            "pid \(pid) still existed after ChildReaper's queue drained — observed \(state). "
+                + "The barrier means the reap block already ran to completion, so this is a "
+                + "reap that did not reap, not a reap that has not been scheduled yet."
+        }
+    }
+
+    /// Why the outcome is an enum rather than a thrown error at the point of
+    /// failure: the caller has a child to dispose of before it may fail, so
+    /// `waitUntilZombie` reports and the caller decides when to throw.
+    private enum ZombieWaitOutcome {
+        case becameZombie
+        case budgetExhausted(polls: Int)
+        /// The surrounding task was cancelled — in this suite that means the
+        /// suite `.timeLimit` fired. Named separately because the alternative
+        /// is a lie: a swallowed `CancellationError` makes every remaining
+        /// `Task.sleep` return instantly, the loop burns its whole budget in
+        /// microseconds, and the resulting "never became a zombie after N
+        /// polls" points at production for a harness event.
+        case cancelled(polls: Int)
+
+        func diagnostic(pid: pid_t) -> (any Error)? {
+            switch self {
+            case .becameZombie:
+                return nil
+            case .budgetExhausted(let polls):
+                return NeverExited(pid: pid, polls: polls)
+            case .cancelled(let polls):
+                return WaitCancelled(pid: pid, polls: polls)
+            }
         }
     }
 
@@ -56,8 +95,17 @@ struct ChildReaperTests {
         let pid: pid_t
         let polls: Int
         var description: String {
-            "pid \(pid) never became a reapable zombie after \(polls) polls "
+            "pid \(pid) never became a reapable zombie within \(polls) polls "
                 + "(it exited and something else reaped it, or it never exited)"
+        }
+    }
+
+    private struct WaitCancelled: Error, CustomStringConvertible {
+        let pid: pid_t
+        let polls: Int
+        var description: String {
+            "waiting for pid \(pid) to exit was CANCELLED after \(polls) polls — the suite "
+                + "time limit fired. This says nothing about whether ChildReaper is correct."
         }
     }
 
@@ -89,6 +137,13 @@ struct ChildReaperTests {
         return waitid(P_PID, id_t(pid), &info, WEXITED | WNOWAIT | WNOHANG) == 0 && info.si_pid == pid
     }
 
+    /// Describes what `pid` currently is, for a diagnostic. `WNOWAIT` keeps
+    /// this a probe: it leaves the child in exactly the state it found it.
+    private func describeState(_ pid: pid_t) -> String {
+        if isUnreapedZombie(pid) { return "an unreaped zombie (exited, still waitable)" }
+        return processExists(pid) ? "a live process (never exited)" : "gone"
+    }
+
     /// Runs the blocking reap off the cooperative pool. Parking a concurrency
     /// worker for the child's lifetime would tax every other suite in this
     /// process (Swift Testing runs them all in one).
@@ -100,13 +155,66 @@ struct ChildReaperTests {
         }
     }
 
-    private func waitUntilZombie(_ pid: pid_t) async throws {
-        var polls = 0
-        while !isUnreapedZombie(pid), polls < 50 {
-            polls += 1
-            try await Task.sleep(for: .milliseconds(100))
+    /// Suspends until every reap `ChildReaper` had already enqueued has run to
+    /// completion. See `ChildReaper.drainPendingReaps` for what the barrier
+    /// does and does not cover — notably that it is process-wide.
+    private func drainPendingReaps() async {
+        await withCheckedContinuation { continuation in
+            ChildReaper.drainPendingReaps { continuation.resume() }
         }
-        guard isUnreapedZombie(pid) else { throw NeverExited(pid: pid, polls: polls) }
+    }
+
+    /// Ends and reaps a child this test deliberately left unreaped, given the
+    /// state that was just observed for it.
+    ///
+    /// Two hazards this navigates. A pid that was already reaped must not be
+    /// signalled — it is free and the OS may have recycled it. And a child that
+    /// never exited must be SIGKILLed first, or the `waitpid` parks forever on
+    /// a thread Swift Testing cannot cancel.
+    ///
+    /// **Call only after `drainPendingReaps()`.** Committing a `waitpid` while
+    /// one of `ChildReaper`'s own blocks may still be parked on the same pid is
+    /// the two-waiter pid-recycling hazard its doc comment forbids; the barrier
+    /// is what guarantees the reaper is no longer a waiter.
+    private func disposeChild(_ pid: pid_t, observedZombie: Bool) async {
+        if observedZombie {
+            _ = await reapOffPool(pid)  // already exited; returns at once
+        } else if processExists(pid) {
+            kill(pid, SIGKILL)
+            _ = await reapOffPool(pid)
+        }
+    }
+
+    /// A child *exiting* is not an in-process event: no queue drains and no
+    /// barrier can be ordered behind it, so there is nothing to await and
+    /// bounded polling is the honest instrument (assertion-hygiene rule 3).
+    ///
+    /// The budget is a **hang guard, not a timing assertion**. Every child
+    /// waited on here is `/bin/sleep 0`, which exits in milliseconds, so a run
+    /// that consumes any material part of the budget has already found a bug.
+    /// It is deliberately *not* described as a wall-clock cap: `Task.sleep` is
+    /// a floor, not a ceiling, so `pollBudget × pollInterval` (≈5 s) is the
+    /// nominal figure and the real elapsed time is larger under load. The
+    /// suite's `.timeLimit` is the outer bound; this budget only keeps a wedged
+    /// child from consuming all of it.
+    private static let pollBudget = 50
+    private static let pollInterval = Duration.milliseconds(100)
+
+    private func waitUntilZombie(_ pid: pid_t) async -> ZombieWaitOutcome {
+        var polls = 0
+        while !isUnreapedZombie(pid) {
+            if polls >= Self.pollBudget { return .budgetExhausted(polls: polls) }
+            if Task.isCancelled { return .cancelled(polls: polls) }
+            polls += 1
+            do {
+                try await Task.sleep(for: Self.pollInterval)
+            } catch {
+                // Cancellation, propagated rather than swallowed — see
+                // `ZombieWaitOutcome.cancelled`.
+                return .cancelled(polls: polls)
+            }
+        }
+        return .becameZombie
     }
 
     // MARK: - The teardown decision
@@ -180,13 +288,19 @@ struct ChildReaperTests {
         let pid = try spawn("/bin/sleep", ["0"])
         ChildReaper.reap(pid: pid, unless: ChildExitObservation())
 
-        var polls = 0
-        while processExists(pid), polls < 50 {
-            polls += 1
-            try await Task.sleep(for: .milliseconds(100))
-        }
-        if processExists(pid) {
-            Issue.record(StillZombie(pid: pid, polls: polls))
+        // The barrier, not a poll: when this returns the reap block has run to
+        // completion, so the assertion below is a contract check with no
+        // scheduling window in it.
+        await drainPendingReaps()
+
+        let survived = processExists(pid)
+        if survived {
+            let state = describeState(pid)
+            // Dispose before recording, so a failing run cannot leave the child
+            // behind. Safe to commit our own waitpid: the barrier above already
+            // guarantees ChildReaper is no longer a waiter for this pid.
+            await disposeChild(pid, observedZombie: isUnreapedZombie(pid))
+            Issue.record(StillZombie(pid: pid, state: state))
         }
     }
 
@@ -200,13 +314,24 @@ struct ChildReaperTests {
 
         // Let the child actually exit, so "still waitable" means "nobody
         // reaped it" rather than "it had not exited yet".
-        try await waitUntilZombie(pid)
-        try await Task.sleep(for: .milliseconds(200))
-        #expect(isUnreapedZombie(pid),
-                "an observed child must be left for its real waiter, not reaped here")
+        let outcome = await waitUntilZombie(pid)
 
-        // This test owns the zombie it deliberately kept; don't leak it.
-        _ = await reapOffPool(pid)
+        // `reap` should have early-returned without enqueuing anything, so this
+        // normally fires at once. It is here because a regression that enqueued
+        // the block anyway would otherwise be *racing* the assertion below —
+        // and because it makes this test the sole waiter for the disposal.
+        await drainPendingReaps()
+
+        let survived = isUnreapedZombie(pid)
+
+        // This test owns the zombie it deliberately kept. Disposed before
+        // anything can throw or fail: a `defer` registered after a throwing
+        // statement never runs at all, which is how a probe escapes to launchd.
+        await disposeChild(pid, observedZombie: survived)
+
+        if let diagnostic = outcome.diagnostic(pid: pid) { throw diagnostic }
+        #expect(survived,
+                "an observed child must be left for its real waiter, not reaped here")
     }
 
     // MARK: - What is deliberately NOT tested here

--- a/Tests/TBDAppTests/ChildReaperTests.swift
+++ b/Tests/TBDAppTests/ChildReaperTests.swift
@@ -24,23 +24,32 @@ import Testing
 /// an in-process event and therefore has nothing to be ordered behind; it is
 /// documented as a hang guard at its definition.
 ///
+/// Both waits carry their own bounded hang guard, and that is deliberate:
+/// **neither one can be rescued by the suite `.timeLimit`.** Swift Testing
+/// cannot cancel a thread parked in a synchronous `waitpid`, nor a
+/// `withCheckedContinuation` awaiting a barrier callback that never runs — a
+/// child that ignored its signals would wedge the whole run rather than redden
+/// one test. `drainPendingReaps(within:)` (see `ChildReapDrainSupport.swift`)
+/// and `waitUntilZombie` each convert that into a named failure, and each
+/// disposes of its child on that path so a stuck reap cannot poison the tests
+/// that follow.
+///
 /// WHY AN EXPLICIT `.timeLimit(.minutes(1))` AND NOT `.clockDriven`. Following
 /// the precedent of `SubprocessTimeoutTests`, which states its reason rather
 /// than inheriting the shared trait: `.clockDriven`'s four minutes is sized for
 /// suites that arm a `TestClock` handshake in the ~4500-test parallel pass, and
-/// nothing here is clock-driven. What the limit has to afford is the barrier
-/// wait, whose worst case is the longest-lived child in the process (0.3 s
-/// here) plus scheduling, and one `waitUntilZombie` hang-guard budget. Both are
-/// seconds against a sixty-second limit — a hang-catcher an order of magnitude
-/// above the work, which is what this trait is for. Four minutes of a shared
-/// box is not free.
+/// nothing here is clock-driven. What the limit has to afford is a test that
+/// fails through its own guards and still gets to report: the 30 s barrier hang
+/// guard plus the ~5 s `waitUntilZombie` budget plus the disposal that follows
+/// — 35 s against a sixty-second limit, so the diagnostic lands rather than
+/// being truncated. The honest path meanwhile finishes in under a second (the
+/// longest-lived child in the process is 0.3 s), which is the order-of-magnitude
+/// margin this trait is for. Four minutes of a shared box is not free.
 ///
-/// The limit's known blind spot, stated rather than glossed: Swift Testing
-/// cannot cancel a thread parked in a synchronous `waitpid`, so it would not
-/// rescue a test that waits on a child that never exits. None can — every child
-/// spawned here is `/bin/sleep` with a bounded argument, which always exits, and
-/// the skip-branch test disposes of its own deliberately-unreaped child before
-/// it asserts anything.
+/// What the limit therefore is, stated rather than glossed: a coarse outer
+/// backstop for the ordinary case where a test is merely slow. The two waits
+/// above are what actually catch a stuck reap, and both are sized to fire —
+/// with their diagnostic — inside this limit rather than be truncated by it.
 @Suite("ChildReaper", .timeLimit(.minutes(1)))
 struct ChildReaperTests {
 
@@ -155,15 +164,6 @@ struct ChildReaperTests {
         }
     }
 
-    /// Suspends until every reap `ChildReaper` had already enqueued has run to
-    /// completion. See `ChildReaper.drainPendingReaps` for what the barrier
-    /// does and does not cover — notably that it is process-wide.
-    private func drainPendingReaps() async {
-        await withCheckedContinuation { continuation in
-            ChildReaper.drainPendingReaps { continuation.resume() }
-        }
-    }
-
     /// Ends and reaps a child this test deliberately left unreaped, given the
     /// state that was just observed for it.
     ///
@@ -172,10 +172,20 @@ struct ChildReaperTests {
     /// never exited must be SIGKILLed first, or the `waitpid` parks forever on
     /// a thread Swift Testing cannot cancel.
     ///
-    /// **Call only after `drainPendingReaps()`.** Committing a `waitpid` while
-    /// one of `ChildReaper`'s own blocks may still be parked on the same pid is
-    /// the two-waiter pid-recycling hazard its doc comment forbids; the barrier
-    /// is what guarantees the reaper is no longer a waiter.
+    /// **Call only after a `drainPendingReaps` that returned `.drained`.**
+    /// Committing a `waitpid` while one of `ChildReaper`'s own blocks may still
+    /// be parked on the same pid is the two-waiter pid-recycling hazard its doc
+    /// comment forbids; the barrier is what guarantees the reaper is no longer
+    /// a waiter.
+    ///
+    /// The one exception is the stalled-barrier path, where there is no such
+    /// guarantee and disposing anyway is still right: the alternative is
+    /// leaving a live child and an unreaped pid for the rest of the run. The
+    /// `SIGKILL` keeps our own `waitpid` bounded there (an exiting child either
+    /// gets reaped by us or returns `ECHILD` at once), and the residual — both
+    /// waiters returning inside the microseconds it takes to recycle a pid into
+    /// a *new* child of this process — is the coincidence-on-top-of-a-race
+    /// `ChildReaper` already accepts.
     private func disposeChild(_ pid: pid_t, observedZombie: Bool) async {
         if observedZombie {
             _ = await reapOffPool(pid)  // already exited; returns at once
@@ -290,8 +300,13 @@ struct ChildReaperTests {
 
         // The barrier, not a poll: when this returns the reap block has run to
         // completion, so the assertion below is a contract check with no
-        // scheduling window in it.
-        await drainPendingReaps()
+        // scheduling window in it. Bounded, so a reap parked on a child that
+        // never exits reds this test instead of wedging the run.
+        let drain = await drainPendingReaps()
+        if let diagnostic = drain.diagnostic(pid: pid, observedState: { describeState(pid) }) {
+            await disposeChild(pid, observedZombie: isUnreapedZombie(pid))
+            throw diagnostic
+        }
 
         let survived = processExists(pid)
         if survived {
@@ -320,7 +335,7 @@ struct ChildReaperTests {
         // normally fires at once. It is here because a regression that enqueued
         // the block anyway would otherwise be *racing* the assertion below —
         // and because it makes this test the sole waiter for the disposal.
-        await drainPendingReaps()
+        let drain = await drainPendingReaps()
 
         let survived = isUnreapedZombie(pid)
 
@@ -330,6 +345,12 @@ struct ChildReaperTests {
         await disposeChild(pid, observedZombie: survived)
 
         if let diagnostic = outcome.diagnostic(pid: pid) { throw diagnostic }
+        // Reported after the wait's own outcome (which happened first) and
+        // before the assertion, which a stalled barrier would make unsound:
+        // an enqueued reap could still be pending.
+        if let diagnostic = drain.diagnostic(pid: pid, observedState: { "already disposed" }) {
+            throw diagnostic
+        }
         #expect(survived,
                 "an observed child must be left for its real waiter, not reaped here")
     }

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -51,11 +51,23 @@ import Testing
 /// The barrier's own cost is bounded by the longest-lived child in the
 /// process — see `ChildReaper.drainPendingReaps` for the process-wide caveat.
 ///
-/// **Why `.timeLimit(.minutes(1))`.** A hang-catcher for the one thing the
-/// barrier cannot bound: a reap parked on a child that never exits. Nothing
-/// here waits on wall time otherwise, and the honest path completes in
-/// well under a second, so a minute is the order-of-magnitude margin such a
-/// guard wants without spending four minutes of a shared box.
+/// **The barrier wait is itself bounded, and by its own guard rather than by
+/// the suite limit.** It is ordered behind `waitpid` calls `ChildReaper`
+/// documents as unbounded, and neither a parked `waitpid` nor a
+/// `withCheckedContinuation` awaiting a callback that never runs can be
+/// cancelled by Swift Testing — so an unguarded wait would wedge the run
+/// instead of reddening one test, and (a barrier on a concurrent queue blocking
+/// everything submitted after it) would take the sibling tests down with it.
+/// `drainPendingReaps(within:)` in `ChildReapDrainSupport.swift` races the
+/// barrier against a 30 s guard, reports a stuck reap with its observed state,
+/// and each call site SIGKILLs and reaps its own child on that path.
+///
+/// **Why `.timeLimit(.minutes(1))`.** A coarse outer backstop for the ordinary
+/// case of a merely slow test — not the guard that catches a stuck reap, which
+/// it cannot do (above). Nothing here waits on wall time otherwise, and the
+/// honest path completes in well under a second, so a minute leaves the 30 s
+/// hang guard room to fire with its diagnostic rather than be truncated, and
+/// still spends less than four minutes of a shared box.
 ///
 /// **Probe children are disposed of before anything can fail.** Assertions run
 /// last, after every child this suite spawned has been ended and reaped,
@@ -108,22 +120,18 @@ struct TerminalTeardownReapTests {
         return processExists(pid) ? "a live process (never exited)" : "gone"
     }
 
-    /// Suspends until every reap `ChildReaper` had already enqueued has run to
-    /// completion. Suspending (rather than blocking) also keeps the main queue
-    /// draining — see the suite comment.
-    private func drainPendingReaps() async {
-        await withCheckedContinuation { continuation in
-            ChildReaper.drainPendingReaps { continuation.resume() }
-        }
-    }
-
     /// Ends and reaps a child that outlived teardown, given the state that was
     /// just observed for it. Only ever called on a failure path: on success the
     /// pid is already freed and signalling it could reach a recycled process.
     ///
-    /// **Call only after `drainPendingReaps()`** — committing a `waitpid` while
-    /// one of `ChildReaper`'s blocks may still be parked on the same pid is the
-    /// two-waiter recycling hazard `ChildReaper`'s doc comment forbids.
+    /// **Call only after a `drainPendingReaps` that returned `.drained`** —
+    /// committing a `waitpid` while one of `ChildReaper`'s blocks may still be
+    /// parked on the same pid is the two-waiter recycling hazard
+    /// `ChildReaper`'s doc comment forbids. The stalled-barrier path is the one
+    /// exception and is disposed of anyway: the `SIGKILL` keeps this `waitpid`
+    /// bounded (an exiting child is either reaped here or returns `ECHILD` at
+    /// once), and leaving a live `sleep` plus an unreaped pid behind for the
+    /// rest of the run is the worse outcome.
     private func disposeSurvivor(_ pid: pid_t) {
         guard pid > 0 else { return }
         kill(pid, SIGKILL)
@@ -183,8 +191,30 @@ struct TerminalTeardownReapTests {
         }
         try #require(pid > 0, "forkpty must have produced a child pid")
 
-        await drainPendingReaps()
+        try await requireDrainedAndReaped(pid)
+    }
+
+    /// Awaits the barrier, then asserts the child is gone. A barrier that did
+    /// not fire is its own named failure — reported instead of the reap
+    /// assertion, which it would make unsound: with a reap still parked, "the
+    /// child is gone" has not been decided yet either way.
+    private func requireDrainedAndReaped(_ pid: pid_t) async throws {
+        try requireDrained(await drainPendingReaps(), teardownChild: pid)
         try requireReaped(pid)
+    }
+
+    /// Throws when the barrier did not fire, disposing of the teardown child
+    /// first. Reported ahead of every other assertion in the test, because with
+    /// a reap still parked "the child is gone" has not been decided either way
+    /// — and a stalled barrier is a harness fact, not a verdict on `cleanup()`.
+    private func requireDrained(_ drain: ReapDrainOutcome, teardownChild pid: pid_t) throws {
+        guard let diagnostic = drain.diagnostic(pid: pid, observedState: { describeState(pid) })
+        else { return }
+        // End our own child even though the barrier is wedged: whatever is
+        // stuck may never reap it, and a live `sleep` plus an unreaped pid
+        // would outlive this test. See `disposeSurvivor`.
+        if processExists(pid) { disposeSurvivor(pid) }
+        throw diagnostic
     }
 
     /// Asserts the child is gone, disposing of it first if it is not. Disposal
@@ -230,8 +260,7 @@ struct TerminalTeardownReapTests {
         }
         try #require(pid > 0, "forkpty must have produced a child pid")
 
-        await drainPendingReaps()
-        try requireReaped(pid)
+        try await requireDrainedAndReaped(pid)
     }
 
     // MARK: - cleanup() is one-shot
@@ -270,9 +299,10 @@ struct TerminalTeardownReapTests {
         // Observe, then dispose, then assert — in that order, with nothing that
         // can throw in between. See the suite comment: a `defer` registered
         // after a throwing `#require` never runs, and the probe is a `sleep 120`.
-        await drainPendingReaps()
+        let drain = await drainPendingReaps()
         let probeAlive = processExists(run.probe)
         disposeProbe(pid: run.probe) { coordinator.localProcess = nil }
+        try requireDrained(drain, teardownChild: run.first)
 
         try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
         #expect(run.stillHeld,
@@ -299,9 +329,10 @@ struct TerminalTeardownReapTests {
             return OneShotRun(first: first, probe: probe, stillHeld: coordinator.localProcess != nil)
         }
         // Observe, then dispose, then assert — see the sibling test above.
-        await drainPendingReaps()
+        let drain = await drainPendingReaps()
         let probeAlive = processExists(run.probe)
         disposeProbe(pid: run.probe) { coordinator.localProcess = nil }
+        try requireDrained(drain, teardownChild: run.first)
 
         try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
         // Sharper here than on the panel path: without the guard this second

--- a/Tests/TBDAppTests/TerminalTeardownReapTests.swift
+++ b/Tests/TBDAppTests/TerminalTeardownReapTests.swift
@@ -40,9 +40,36 @@ import Testing
 /// thing to keep small — and never wait for main-queue work while occupying
 /// the main queue.
 ///
-/// Bounded by construction: each test polls against a 5 s cap and force-kills
-/// its child in a `defer`, so nothing can park on a `waitpid` that never
-/// returns. (`cleanup()` also appends a line to `/tmp/tbd-bridge.log` via the
+/// **How these tests wait: an event, not a window.** `cleanup()` enqueues its
+/// reap synchronously onto `ChildReaper`'s concurrent queue, so a barrier
+/// submitted after `cleanup()` returns is ordered behind it —
+/// `ChildReaper.drainPendingReaps` is that barrier. When it fires, the reap
+/// block has *run to completion*, so "the child still exists" means the reap
+/// did not reap, full stop. There is no poll anywhere in this suite and
+/// therefore no scheduling window to mistake for a bug (nor a bug to mistake
+/// for scheduling: a polling test can only report "still there after N tries").
+/// The barrier's own cost is bounded by the longest-lived child in the
+/// process — see `ChildReaper.drainPendingReaps` for the process-wide caveat.
+///
+/// **Why `.timeLimit(.minutes(1))`.** A hang-catcher for the one thing the
+/// barrier cannot bound: a reap parked on a child that never exits. Nothing
+/// here waits on wall time otherwise, and the honest path completes in
+/// well under a second, so a minute is the order-of-magnitude margin such a
+/// guard wants without spending four minutes of a shared box.
+///
+/// **Probe children are disposed of before anything can fail.** Assertions run
+/// last, after every child this suite spawned has been ended and reaped,
+/// because a `defer` registered *after* a throwing `#require` never runs at
+/// all — and the probes are `sleep 120` that no production path under test
+/// ends. Be precise about what that costs, since the sloppy version of this
+/// claim is "they orphan to launchd" and they measurably do not: every child
+/// here is on a PTY this process owns, and closing the master fd SIGHUPs it
+/// (measured directly — the child goes to `Z` within half a second), so
+/// process exit collects them all. What a mis-ordered disposal actually leaves
+/// is a live `sleep 120` and an unreaped pid for the *rest of the run*, on
+/// every failing iteration, in a process that already runs ~4500 tests. That
+/// is worth ordering correctly on its own; it is not the launchd-orphan story.
+/// (`cleanup()` also appends a line to `/tmp/tbd-bridge.log` via the
 /// production `debugLog`; no TBD-owned store is touched.)
 @Suite("Terminal teardown reaps its PTY child", .timeLimit(.minutes(1)))
 struct TerminalTeardownReapTests {
@@ -56,11 +83,12 @@ struct TerminalTeardownReapTests {
 
     private struct ChildSurvivedTeardown: Error, CustomStringConvertible {
         let pid: pid_t
-        let polls: Int
         let state: String
         var description: String {
-            "PTY child \(pid) still existed \(polls) polls after cleanup() — observed \(state). "
-                + "Teardown must reap it; an unreaped child is the <defunct> leak this fixes."
+            "PTY child \(pid) still existed after cleanup() and after ChildReaper's queue "
+                + "drained — observed \(state). The barrier means the reap block already ran to "
+                + "completion, so teardown either enqueued no reap or reaped nothing; an "
+                + "unreaped child is the <defunct> leak this fixes."
         }
     }
 
@@ -80,19 +108,26 @@ struct TerminalTeardownReapTests {
         return processExists(pid) ? "a live process (never exited)" : "gone"
     }
 
-    /// Polls for the child to disappear entirely. Suspends between checks so
-    /// the main queue keeps draining — see the suite comment.
-    private func waitForChildToVanish(_ pid: pid_t) async -> Bool {
-        var polls = 0
-        while processExists(pid), polls < 50 {
-            polls += 1
-            try? await Task.sleep(for: .milliseconds(100))
+    /// Suspends until every reap `ChildReaper` had already enqueued has run to
+    /// completion. Suspending (rather than blocking) also keeps the main queue
+    /// draining — see the suite comment.
+    private func drainPendingReaps() async {
+        await withCheckedContinuation { continuation in
+            ChildReaper.drainPendingReaps { continuation.resume() }
         }
-        if processExists(pid) {
-            Issue.record(ChildSurvivedTeardown(pid: pid, polls: polls, state: describeState(pid)))
-            return false
-        }
-        return true
+    }
+
+    /// Ends and reaps a child that outlived teardown, given the state that was
+    /// just observed for it. Only ever called on a failure path: on success the
+    /// pid is already freed and signalling it could reach a recycled process.
+    ///
+    /// **Call only after `drainPendingReaps()`** — committing a `waitpid` while
+    /// one of `ChildReaper`'s blocks may still be parked on the same pid is the
+    /// two-waiter recycling hazard `ChildReaper`'s doc comment forbids.
+    private func disposeSurvivor(_ pid: pid_t) {
+        guard pid > 0 else { return }
+        kill(pid, SIGKILL)
+        ChildReaper.reapBlocking(pid: pid)
     }
 
     /// Starts a child on a real `LocalProcess` owned solely by `assign`, and
@@ -148,26 +183,32 @@ struct TerminalTeardownReapTests {
         }
         try #require(pid > 0, "forkpty must have produced a child pid")
 
-        var reaped = false
-        defer {
-            // Safety net for the failure path only: on success the pid is
-            // already freed and signalling it could reach a recycled process.
-            if !reaped {
-                kill(pid, SIGKILL)
-                ChildReaper.reapBlocking(pid: pid)
-            }
-        }
+        await drainPendingReaps()
+        try requireReaped(pid)
+    }
 
-        reaped = await waitForChildToVanish(pid)
-        #expect(reaped)
+    /// Asserts the child is gone, disposing of it first if it is not. Disposal
+    /// precedes the throw for the reason the suite comment gives: on a failure
+    /// path there is a live child to account for, and nothing that can throw
+    /// may sit between observing it and ending it.
+    private func requireReaped(_ pid: pid_t) throws {
+        guard processExists(pid) else { return }
+        let state = describeState(pid)
+        disposeSurvivor(pid)
+        throw ChildSurvivedTeardown(pid: pid, state: state)
     }
 
     /// Drops the coordinator's reference to a probe child's `LocalProcess`
     /// (whose deinit cancels its exit monitor, making us the sole waiter), then
-    /// kills and reaps it. Probe children outlive their test by design, so
-    /// every test that starts one must call this.
+    /// kills and reaps it. Probe children are `sleep 120` and nothing in the
+    /// production path under test ends them, so every test that starts one must
+    /// call this — before any assertion that could throw first.
+    ///
+    /// The `pid > 0` guard is load-bearing, not defensive: `kill(0, SIGKILL)`
+    /// signals the caller's entire process group, i.e. the whole test process.
     private func disposeProbe(pid: pid_t, release: () -> Void) {
         release()
+        guard pid > 0 else { return }
         kill(pid, SIGKILL)
         ChildReaper.reapBlocking(pid: pid)
     }
@@ -189,16 +230,8 @@ struct TerminalTeardownReapTests {
         }
         try #require(pid > 0, "forkpty must have produced a child pid")
 
-        var reaped = false
-        defer {
-            if !reaped {
-                kill(pid, SIGKILL)
-                ChildReaper.reapBlocking(pid: pid)
-            }
-        }
-
-        reaped = await waitForChildToVanish(pid)
-        #expect(reaped)
+        await drainPendingReaps()
+        try requireReaped(pid)
     }
 
     // MARK: - cleanup() is one-shot
@@ -234,16 +267,21 @@ struct TerminalTeardownReapTests {
             coordinator.cleanup()
             return OneShotRun(first: first, probe: probe, stillHeld: coordinator.localProcess != nil)
         }
-        try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
-        defer { disposeProbe(pid: run.probe) { coordinator.localProcess = nil } }
+        // Observe, then dispose, then assert — in that order, with nothing that
+        // can throw in between. See the suite comment: a `defer` registered
+        // after a throwing `#require` never runs, and the probe is a `sleep 120`.
+        await drainPendingReaps()
+        let probeAlive = processExists(run.probe)
+        disposeProbe(pid: run.probe) { coordinator.localProcess = nil }
 
+        try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
         #expect(run.stillHeld,
                 "a second cleanup() must not release state it never set up")
-        #expect(processExists(run.probe),
+        #expect(probeAlive,
                 "a second cleanup() must not reap or signal anything")
 
-        let firstReaped = await waitForChildToVanish(run.first)
-        #expect(firstReaped, "the real teardown must still have reaped its own child")
+        // The real teardown must still have reaped its own child.
+        try requireReaped(run.first)
     }
 
     @Test("a second LocalPTYTerminalRepresentable cleanup() tears nothing down")
@@ -260,18 +298,21 @@ struct TerminalTeardownReapTests {
             coordinator.cleanup()
             return OneShotRun(first: first, probe: probe, stillHeld: coordinator.localProcess != nil)
         }
-        try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
-        defer { disposeProbe(pid: run.probe) { coordinator.localProcess = nil } }
+        // Observe, then dispose, then assert — see the sibling test above.
+        await drainPendingReaps()
+        let probeAlive = processExists(run.probe)
+        disposeProbe(pid: run.probe) { coordinator.localProcess = nil }
 
+        try #require(run.first > 0 && run.probe > 0, "forkpty must have produced both pids")
         // Sharper here than on the panel path: without the guard this second
         // call reaches `localProcess?.terminate()`, so the probe would be
         // SIGTERMed as well as released.
         #expect(run.stillHeld,
                 "a second cleanup() must not release state it never set up")
-        #expect(processExists(run.probe),
+        #expect(probeAlive,
                 "a second cleanup() must not terminate a process it never started")
 
-        let firstReaped = await waitForChildToVanish(run.first)
-        #expect(firstReaped, "the real teardown must still have killed and reaped its own child")
+        // The real teardown must still have killed and reaped its own child.
+        try requireReaped(run.first)
     }
 }

--- a/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
@@ -542,18 +542,43 @@ struct TranscriptImageAttachmentTests {
     ///
     /// What is observable headlessly is the FETCH, not the pixels: SwiftUI content
     /// is not captured by `cacheDisplay` or `CALayer.render` in this unbundled test
-    /// process, so the drawn image cannot be read back. The fetch is a sound proxy
-    /// — `load()` requests a thumbnail only when it holds no image, so a request
-    /// for the second attachment can only come from a view that dropped the first.
+    /// process, so the drawn image cannot be read back. The fetch is a sound proxy:
+    /// a view draws only what it fetched, so a request for the second attachment is
+    /// what proves the recycled cell is not still showing the first one's picture.
     ///
     /// Both fixtures are the same pixel size, so `maxPixelSize` is identical for
-    /// both and a cache hit cannot be confused for the wrong file.
+    /// both and a request cannot be confused for the wrong file.
+    ///
+    /// This covers the COMPOSITE — call site plus view. Which of the two mechanisms
+    /// delivered the re-fetch is deliberately not pinned here, and today it is the
+    /// call site's path-keyed segment identity rather than the view's `.onChange`.
+    /// `attachmentChangeRefetchesWhenTheViewIdentityIsStable` below is the one that
+    /// pins the view's own guard; keep both, since either mechanism regressing
+    /// alone leaves a real hazard the other happens to be covering.
+    ///
+    /// It watches `onThumbnailRequest` rather than `hasCachedThumbnail`, and that
+    /// is what makes it deterministic. The cache is the wrong instrument twice
+    /// over: the entry appears only after an asynchronous decode whose scheduling
+    /// latency is unbounded (this file's own fifo probe parks a global-queue
+    /// thread for up to 5 s; daemon suites park more), and `thumbnailCache` is an
+    /// `NSCache` with `countLimit` 64, so once landed the entry can be evicted by
+    /// any concurrent suite that decodes images of its own. The request is
+    /// synchronous with `load()`, so waiting on it measures the view's behavior
+    /// instead of the machine's weather.
     @Test func recycledHostingViewFetchesTheNewAttachmentsThumbnail() async throws {
         let scratch = Scratch()
+        // The fixtures must outlive every wait below: `Scratch.deinit` deletes
+        // the directory, and `load()` never requests a thumbnail for a file whose
+        // header probe comes back `.missing`.
+        defer { withExtendedLifetime(scratch) {} }
         TranscriptImageService.shared.clearCaches()
         let first = try writePNG(scratch, name: "first.png", width: 160, height: 160, color: .red)
         let second = try writePNG(scratch, name: "second.png", width: 160, height: 160, color: .blue)
         let maxPixel = Self.hostedMaxPixelSize(forPath: first)
+
+        let requests = ThumbnailRequestLog()
+        TranscriptImageService.shared.onThumbnailRequest = { requests.record(path: $0, maxPixelSize: $1) }
+        defer { TranscriptImageService.shared.onThumbnailRequest = nil }
 
         let host = NSHostingView(rootView: AnyView(Self.bubble(marker: marker(first))))
         host.frame = NSRect(x: 0, y: 0, width: 420, height: 260)
@@ -561,18 +586,169 @@ struct TranscriptImageAttachmentTests {
             contentRect: host.frame, styleMask: [.borderless], backing: .buffered, defer: false)
         window.contentView = host
 
-        await pump(host) { TranscriptImageService.shared.hasCachedThumbnail(forPath: first, maxPixelSize: maxPixel) }
-        #expect(TranscriptImageService.shared.hasCachedThumbnail(forPath: first, maxPixelSize: maxPixel),
-                "precondition: the hosted view must fetch its own attachment at all")
-        #expect(!TranscriptImageService.shared.hasCachedThumbnail(forPath: second, maxPixelSize: maxPixel),
+        try await awaitRequest(
+            for: first, maxPixelSize: maxPixel, in: requests, drivingLayoutOf: host,
+            what: "precondition: the hosted view must fetch its own attachment at all")
+        #expect(!requests.contains(path: second, maxPixelSize: maxPixel),
                 "precondition: nothing has asked for the second attachment yet")
 
         // Recycle the cell onto a different message carrying a different image.
         host.rootView = AnyView(Self.bubble(marker: marker(second)))
-        await pump(host) { TranscriptImageService.shared.hasCachedThumbnail(forPath: second, maxPixelSize: maxPixel) }
-        #expect(TranscriptImageService.shared.hasCachedThumbnail(forPath: second, maxPixelSize: maxPixel),
-                Comment(rawValue: "the recycled hosting view never fetched the new attachment, so "
-                    + "it is still drawing the previous message's thumbnail"))
+        try await awaitRequest(
+            for: second, maxPixelSize: maxPixel, in: requests, drivingLayoutOf: host,
+            what: "the recycled hosting view never fetched the new attachment, so it is still "
+                + "drawing the previous message's thumbnail")
+    }
+
+    /// The view's OWN staleness guard, isolated from the call site that currently
+    /// masks it.
+    ///
+    /// `recycledHostingViewFetchesTheNewAttachmentsThumbnail` above goes through
+    /// `ChatBubbleView`, whose `ForEach` keys image segments by path
+    /// (`MarkdownSegments.Segment.id` → `"i:<path>"`). Swapping the marker
+    /// therefore changes the segment's identity, SwiftUI discards the old
+    /// `TranscriptImageAttachmentView` along with its `@State`, and the fresh one
+    /// fetches on `onAppear` — with or without `.onChange(of: attachment)`. That
+    /// makes the composite test a real regression test for the composite (the
+    /// picture is never stale end to end) but blind to the view's own guard:
+    /// deleting `.onChange` leaves it passing.
+    ///
+    /// This test removes the mask. The host's root view is one concrete type with
+    /// no `ForEach` and no `.id`, so replacing `rootView` is an in-place UPDATE:
+    /// structural identity is stable, `@State image` survives, and `onAppear` does
+    /// not fire a second time. `.onChange` is then the only thing that can make the
+    /// view re-fetch — which is exactly the invariant its comment claims to own,
+    /// and what would keep the previous message's picture on screen if the call
+    /// site ever stopped keying identity by path.
+    ///
+    /// The first thumbnail is decoded UP FRONT so the cache serves the hosted
+    /// view's request synchronously (the documented cache-hit contract, pinned by
+    /// `thumbnailDecodesOffMainAndIsThenServedFromCache`). That makes `image`
+    /// non-nil at the swap without polling for a decode, so the test exercises the
+    /// stale-picture case rather than the never-loaded one. If a concurrent suite
+    /// evicts that entry first the test still holds — it just proves the weaker
+    /// arm — so eviction can never redden it.
+    @Test func attachmentChangeRefetchesWhenTheViewIdentityIsStable() async throws {
+        let scratch = Scratch()
+        defer { withExtendedLifetime(scratch) {} }
+        TranscriptImageService.shared.clearCaches()
+        let first = try writePNG(scratch, name: "first.png", width: 160, height: 160, color: .red)
+        let second = try writePNG(scratch, name: "second.png", width: 160, height: 160, color: .blue)
+        let maxPixel = Self.hostedMaxPixelSize(forPath: first)
+
+        // Warm `first` before the hook is installed, so the pre-warm decode is not
+        // itself recorded as one of the view's requests.
+        _ = await withCheckedContinuation { continuation in
+            TranscriptImageService.shared.thumbnail(forPath: first, maxPixelSize: maxPixel) {
+                continuation.resume(returning: $0)
+            }
+        }
+
+        let requests = ThumbnailRequestLog()
+        TranscriptImageService.shared.onThumbnailRequest = { requests.record(path: $0, maxPixelSize: $1) }
+        defer { TranscriptImageService.shared.onThumbnailRequest = nil }
+
+        let host = NSHostingView(rootView: StableIdentityAttachmentHost(path: first))
+        host.frame = NSRect(x: 0, y: 0, width: 420, height: 260)
+        let window = NSWindow(
+            contentRect: host.frame, styleMask: [.borderless], backing: .buffered, defer: false)
+        window.contentView = host
+
+        try await awaitRequest(
+            for: first, maxPixelSize: maxPixel, in: requests, drivingLayoutOf: host,
+            what: "precondition: the hosted view must fetch its own attachment at all")
+        #expect(!requests.contains(path: second, maxPixelSize: maxPixel),
+                "precondition: nothing has asked for the second attachment yet")
+
+        // Point the SAME view at a different attachment. No identity change, so
+        // `onAppear` cannot save it — only `.onChange(of: attachment)` can.
+        host.rootView = StableIdentityAttachmentHost(path: second)
+        try await awaitRequest(
+            for: second, maxPixelSize: maxPixel, in: requests, drivingLayoutOf: host,
+            what: "the view did not re-fetch when its attachment changed under a stable "
+                + "identity, so it is still drawing the previous attachment's thumbnail")
+    }
+
+    /// One attachment view under a stable structural identity — no `ForEach`, no
+    /// `.id`, one concrete root type — so `NSHostingView.rootView =` updates it in
+    /// place instead of rebuilding it.
+    private struct StableIdentityAttachmentHost: View {
+        let path: String
+        var body: some View {
+            TranscriptImageAttachmentView(attachment: TranscriptImageAttachment(path: path))
+        }
+    }
+
+    /// Ordered record of every `TranscriptImageService` thumbnail request, in the
+    /// order the views made them.
+    @MainActor
+    private final class ThumbnailRequestLog {
+        private(set) var requests: [(path: String, maxPixelSize: Int)] = []
+
+        func record(path: String, maxPixelSize: Int) {
+            requests.append((path: path, maxPixelSize: maxPixelSize))
+        }
+
+        func contains(path: String, maxPixelSize: Int) -> Bool {
+            requests.contains { $0.path == path && $0.maxPixelSize == maxPixelSize }
+        }
+
+        /// Every request as `<file>@<maxPixelSize>` — file names only, so the
+        /// diagnostic stays readable and never prints a temp path.
+        var summary: String {
+            requests.isEmpty
+                ? "none"
+                : requests.map { "\(($0.path as NSString).lastPathComponent)@\($0.maxPixelSize)" }
+                    .joined(separator: ", ")
+        }
+    }
+
+    /// A bounded wait that ran out with no matching request. Thrown rather than
+    /// `#expect`-ed: only a thrown error puts the observed state on the PRIMARY
+    /// failure line, which is the line CI summaries keep (`Tests/CLAUDE.md`,
+    /// assertion-hygiene rule 4). The bare `#expect` this replaced reported
+    /// `condition(value → false)` and could not distinguish "the view never
+    /// re-fetched" from "the cache entry was evicted underneath us".
+    private struct ThumbnailRequestNotObserved: Error, CustomStringConvertible {
+        let what: String
+        let expected: String
+        let maxPixelSize: Int
+        let observed: String
+        let waited: Duration
+
+        var description: String {
+            "\(what) — no thumbnail request for \(expected) at maxPixelSize=\(maxPixelSize) "
+                + "after polling up to \(waited); observed requests: \(observed)"
+        }
+    }
+
+    /// Drives `view`'s layout and yields the main actor until the service has been
+    /// asked for `path` at `maxPixelSize`, or the deadline passes.
+    ///
+    /// It YIELDS rather than spinning a nested `RunLoop.run`: SwiftUI delivers
+    /// `onAppear` / `onChange` through the main queue, and suspending is what lets
+    /// that queue run. A nested run loop could not — this body is itself a block on
+    /// that serial queue, so the delivery would sit there until the body ended and
+    /// then land inside some other test.
+    ///
+    /// The budget is generous because it bounds a hang, not a measurement: what is
+    /// being waited on is a main-queue delivery, not a decode, so a healthy run
+    /// satisfies it in milliseconds and a saturated one still has room.
+    private func awaitRequest(
+        for path: String, maxPixelSize: Int, in log: ThumbnailRequestLog,
+        drivingLayoutOf view: NSView, what: String,
+        within budget: Duration = .seconds(30)
+    ) async throws {
+        let deadline = ContinuousClock.now + budget
+        while true {
+            view.layoutSubtreeIfNeeded()
+            if log.contains(path: path, maxPixelSize: maxPixelSize) { return }
+            guard ContinuousClock.now < deadline else { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        throw ThumbnailRequestNotObserved(
+            what: what, expected: (path as NSString).lastPathComponent,
+            maxPixelSize: maxPixelSize, observed: log.summary, waited: budget)
     }
 
     /// The hosted shape the reuse pool actually renders: a chat bubble whose text
@@ -592,24 +768,6 @@ struct TranscriptImageAttachmentTests {
             bodyWidth: TranscriptImageGeometry.maxEdge)
         let scale = NSScreen.main?.backingScaleFactor ?? 2
         return Int((max(display.width, display.height) * scale).rounded(.up))
-    }
-
-    /// Lays out, then yields the main actor until `done` or ~1s has passed.
-    ///
-    /// It YIELDS rather than spinning a nested `RunLoop.run`: the decode's
-    /// completion arrives via `DispatchQueue.main.async`, and suspending is what
-    /// lets the main queue deliver it. A nested run loop could not — this body is
-    /// itself a block on that serial queue, so the completion would sit there
-    /// until the body ended and then land inside some other test.
-    ///
-    /// Bounded on purpose: a decode that never arrives must fail the assertion
-    /// below rather than hang the suite.
-    private func pump(_ view: NSView, until done: () -> Bool) async {
-        for _ in 0..<50 {
-            view.layoutSubtreeIfNeeded()
-            if done() { return }
-            try? await Task.sleep(for: .milliseconds(20))
-        }
     }
 
     /// Every string actually drawn by `view`'s subtree.

--- a/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
+++ b/Tests/TBDAppTests/TranscriptImageAttachmentTests.swift
@@ -679,6 +679,36 @@ struct TranscriptImageAttachmentTests {
         }
     }
 
+    /// The harness's own guard, pinned because its failure mode is invisible in
+    /// the suite it protects: a swallowed cancellation makes every subsequent
+    /// `Task.sleep` return instantly, so `awaitRequest` busy-spins
+    /// `layoutSubtreeIfNeeded` plus a cache scan ON THE MAIN ACTOR for the whole
+    /// 30 s budget, starving every other main-isolated test in the process —
+    /// and then blames production ("the view never re-fetched") for a harness
+    /// event. Deterministic: the wait observes the cancellation on its first
+    /// iteration, so this costs milliseconds.
+    @Test func awaitRequestEndsOnCancellationInsteadOfSpinning() async throws {
+        let requests = ThumbnailRequestLog()
+        let view = NSView(frame: NSRect(x: 0, y: 0, width: 10, height: 10))
+        let started = ContinuousClock.now
+
+        let waiter = Task { [self] in
+            try await awaitRequest(
+                for: "/nonexistent/never-requested.png", maxPixelSize: 64, in: requests,
+                drivingLayoutOf: view, what: "cancellation probe", within: .seconds(30))
+        }
+        waiter.cancel()
+
+        var thrown: (any Error)?
+        do { try await waiter.value } catch { thrown = error }
+        let elapsed = ContinuousClock.now - started
+
+        #expect(thrown is ThumbnailWaitCancelled,
+                "cancellation must end the wait as itself, not as a never-observed request: \(String(describing: thrown))")
+        #expect(elapsed < .seconds(5),
+                "a cancelled wait must return at once, not spin out its budget (took \(elapsed))")
+    }
+
     /// Ordered record of every `TranscriptImageService` thumbnail request, in the
     /// order the views made them.
     @MainActor
@@ -718,7 +748,29 @@ struct TranscriptImageAttachmentTests {
 
         var description: String {
             "\(what) — no thumbnail request for \(expected) at maxPixelSize=\(maxPixelSize) "
-                + "after polling up to \(waited); observed requests: \(observed)"
+                + "after polling for \(waited); observed requests: \(observed)"
+        }
+    }
+
+    /// The surrounding task was cancelled while waiting — the suite time limit
+    /// fired, or the run is tearing down. Named separately for the reason
+    /// `ChildReaperTests.ZombieWaitOutcome.cancelled` is: a swallowed
+    /// `CancellationError` makes every subsequent `Task.sleep` return instantly,
+    /// so the loop burns its whole budget in microseconds and reports "the view
+    /// never re-fetched" — production blamed for a harness event. Worse here
+    /// than there, because this suite is `@MainActor`: the busy-spin runs
+    /// `layoutSubtreeIfNeeded` plus a cache scan **on the main actor**, starving
+    /// every other main-isolated test in the process until the deadline.
+    private struct ThumbnailWaitCancelled: Error, CustomStringConvertible {
+        let what: String
+        let expected: String
+        let observed: String
+        let waited: Duration
+
+        var description: String {
+            "\(what) — waiting for a thumbnail request for \(expected) was CANCELLED after "
+                + "\(waited); observed requests: \(observed). This says nothing about whether "
+                + "the view re-fetched."
         }
     }
 
@@ -734,21 +786,38 @@ struct TranscriptImageAttachmentTests {
     /// The budget is generous because it bounds a hang, not a measurement: what is
     /// being waited on is a main-queue delivery, not a decode, so a healthy run
     /// satisfies it in milliseconds and a saturated one still has room.
+    ///
+    /// **Cancellation ends the wait; it is never swallowed** — see
+    /// `ThumbnailWaitCancelled`. And the diagnostics report ELAPSED time, not the
+    /// budget: on the cancelled path those differ by three orders of magnitude,
+    /// and "after polling for 30 seconds" would be a fabrication.
     private func awaitRequest(
         for path: String, maxPixelSize: Int, in log: ThumbnailRequestLog,
         drivingLayoutOf view: NSView, what: String,
         within budget: Duration = .seconds(30)
     ) async throws {
-        let deadline = ContinuousClock.now + budget
+        let started = ContinuousClock.now
+        let deadline = started + budget
+        var elapsed: Duration { ContinuousClock.now - started }
+        func cancelled() -> ThumbnailWaitCancelled {
+            ThumbnailWaitCancelled(
+                what: what, expected: (path as NSString).lastPathComponent,
+                observed: log.summary, waited: elapsed)
+        }
         while true {
             view.layoutSubtreeIfNeeded()
             if log.contains(path: path, maxPixelSize: maxPixelSize) { return }
+            if Task.isCancelled { throw cancelled() }
             guard ContinuousClock.now < deadline else { break }
-            try? await Task.sleep(for: .milliseconds(20))
+            do {
+                try await Task.sleep(for: .milliseconds(20))
+            } catch {
+                throw cancelled()
+            }
         }
         throw ThumbnailRequestNotObserved(
             what: what, expected: (path as NSString).lastPathComponent,
-            maxPixelSize: maxPixelSize, observed: log.summary, waited: budget)
+            maxPixelSize: maxPixelSize, observed: log.summary, waited: elapsed)
     }
 
     /// The hosted shape the reuse pool actually renders: a chat bubble whose text

--- a/Tests/TBDDaemonLiveTests/ReplayLiveIntegrationMatrixTests.swift
+++ b/Tests/TBDDaemonLiveTests/ReplayLiveIntegrationMatrixTests.swift
@@ -129,20 +129,31 @@ struct ReplayLiveIntegrationMatrixTests {
     /// precisely because a non-zero value there means the overflow was seen and
     /// dropped rather than repaired.
     ///
-    /// **The completion signal is a DELTA against `baseline`, never an absolute
-    /// count — that distinction is the difference between this test proving
-    /// something and passing vacuously.** `repairs` is cumulative on the sink,
-    /// and the phases before this window read the pipe against a full-blast pane
-    /// for up to 30 s; a sink that overflowed and completed a repair in *that*
-    /// window would satisfy an absolute `repairs >= 1` on this gate's very first
-    /// poll. The deliberate no-reader window would then close instantly without
-    /// inducing anything, and phase 3's guard and assertions — cumulative too —
-    /// would be satisfied by that same stale repair, so the whole scenario could
-    /// go green having never exercised an overflow. `repairing` needs no delta:
-    /// `enqueueLocked` is the only thing that sets it, and only on an overflow
-    /// entry, so it cannot be a stale free lunch the way a counter can. It is
-    /// still cleared on completion, which is why the completion delta is checked
-    /// alongside it rather than instead of it.
+    /// **Neither signal means anything unless the window opens on a QUIESCENT
+    /// sink, and that is the difference between this test proving something and
+    /// passing vacuously.** Both are properties of a repair *cycle*, and a cycle
+    /// that was already running when the baseline was taken satisfies both of
+    /// them for free:
+    ///
+    ///  - `repairs` is cumulative, so a repair that completes after the baseline
+    ///    but STARTED before it clears every `repairs > baseline.repairs` delta
+    ///    in this test — this gate's, phase 3's drain guard, and assertion (a).
+    ///  - `repairing` is not a per-poll edge either. `enqueueLocked` sets it on
+    ///    overflow entry (`PaneFanout.swift`) and only `endRepair`/`abortRepair`
+    ///    clear it, so it stays set for the whole cycle. An in-flight repair
+    ///    therefore makes this gate return `nil` on its very FIRST poll.
+    ///
+    /// Both are live risks, not hypotheticals: the phases before this window read
+    /// the pipe against a full-blast pane for up to 30 s, which is exactly the
+    /// shape that overflows. So the window is required to open on a sink that is
+    /// neither repairing nor about to be credited with a repair it did not
+    /// induce. Phase 1 reads until `repairing` is clear before snapshotting the
+    /// baseline — a repair in flight there completes, because phase 1 is still
+    /// reading and reader catch-up is what the repair is waiting for — and this
+    /// gate REFUSES a `repairing` baseline outright rather than measuring against
+    /// a poisoned one. Refusing is deliberate: with `baseline.repairing` set,
+    /// there is no weaker gate left to fall back to, since the in-flight cycle
+    /// satisfies the completion delta too.
     ///
     /// On expiry it RETURNS the error rather than throwing it, and the caller
     /// throws only after tearing the supervisor down. That is not ceremony: on
@@ -164,15 +175,24 @@ struct ReplayLiveIntegrationMatrixTests {
         fanout: PaneFanout, key: PaneKey, baseline: PaneFlowStats,
         within budget: Duration = .seconds(30)
     ) async -> MatrixError? {
-        let deadline = ContinuousClock.now + budget
+        guard !baseline.repairing else {
+            return .overflowWindowOpenedMidRepair(baseline: baseline)
+        }
+        let started = ContinuousClock.now
+        let deadline = started + budget
         while true {
             let stats = fanout.flowStats(key: key)
             if stats?.repairing == true { return nil }
             if let stats, stats.repairs > baseline.repairs { return nil }
             guard ContinuousClock.now < deadline else {
+                // MEASURED elapsed, never `budget`: the loop's own poll slices
+                // overshoot the deadline under load, and reporting the budget
+                // would print "no repair cycle after 30 seconds" for a wait that
+                // actually ran far longer — the fabrication `waitFor`'s
+                // diagnostic and `awaitImageRequest`'s already refuse to print.
                 return .overflowRepairNeverEntered(
                     stats: stats, baseline: baseline, queueCap: PaneFanout.queueCap,
-                    waited: budget)
+                    waited: ContinuousClock.now - started)
             }
             try? await Task.sleep(for: .milliseconds(50))
         }
@@ -699,19 +719,32 @@ struct ReplayLiveIntegrationMatrixTests {
         }
 
         // Phase 1: read concurrently while the attach runs (its replay write
-        // needs the reader), until the attach outcome lands.
+        // needs the reader), until the attach outcome lands AND the sink is
+        // quiescent.
+        //
+        // The quiescence half is what makes the baseline below mean anything.
+        // This pane is a full-blast firehose and phase 1 can run for up to 30 s
+        // against it, so it can itself overflow and enter a repair; a baseline
+        // snapshotted mid-cycle would credit that repair to the deliberate
+        // window (see `overflowRepairEntryFailure`). Waiting for `repairing` to
+        // clear is safe precisely BECAUSE this phase is still reading — reader
+        // catch-up is what the repair cycle parks on, so an in-flight repair
+        // completes here rather than deadlocking.
+        let key = PaneKey(server: server, paneID: paneID)
+        let fanout = supervisor.fanout
         let attachDone = FlagBox()
-        async let phase1 = drain(fd: readFD, deadline: .seconds(30)) { _ in attachDone.get() }
+        async let phase1 = drain(fd: readFD, deadline: .seconds(30)) { _ in
+            attachDone.get() && fanout.flowStats(key: key)?.repairing != true
+        }
         let outcome = try await orchestrator.performAttachReady(server: server, paneID: paneID)
         #expect(outcome == .ready)
         attachDone.set()
         var accumulated = await phase1
 
         // The baseline for everything below. Every "a repair happened" check in
-        // this test is a DELTA against it — see `overflowRepairEntryFailure` for
-        // why an absolute count is a vacuous pass here.
-        let key = PaneKey(server: server, paneID: paneID)
-        let fanout = supervisor.fanout
+        // this test is a DELTA against it, and the gate below additionally
+        // refuses a baseline taken mid-repair — see `overflowRepairEntryFailure`
+        // for why either alone is a vacuous pass here.
         guard let baseline = fanout.flowStats(key: key) else {
             // Stop the supervisor BEFORE unwinding: the pane is still blasting,
             // and the `defer` above closes the read end of the pipe it writes to.
@@ -803,6 +836,10 @@ private enum MatrixError: Error, CustomStringConvertible {
     /// sink itself was gone.
     case overflowRepairNeverEntered(
         stats: PaneFlowStats?, baseline: PaneFlowStats, queueCap: Int, waited: Duration)
+    /// The no-reader window opened on a sink that was ALREADY mid-repair, so
+    /// neither the entry signal nor any `repairs` delta after it can be
+    /// attributed to the window.
+    case overflowWindowOpenedMidRepair(baseline: PaneFlowStats)
 
     var description: String {
         switch self {
@@ -831,6 +868,14 @@ private enum MatrixError: Error, CustomStringConvertible {
                 ? "the queue DID overflow and the sink dropped instead of repairing — production"
                 : "the queue never reached the cap, so the setup never induced an overflow — harness"
             return "no repair cycle after \(waited) of firehose with no reader: \(verdict). \(facts)"
+        case .overflowWindowOpenedMidRepair(let baseline):
+            return "the no-reader window opened on a sink that was ALREADY repairing "
+                + "(repairs=\(baseline.repairs), queuedHighWater=\(baseline.queuedHighWater), "
+                + "overflowEvents=\(baseline.overflowEvents)), so nothing downstream is "
+                + "attributable to the window: the in-flight cycle sets the entry signal and, "
+                + "on completion, satisfies every repairs delta. Phase 1 reads until the sink "
+                + "is quiescent, so reaching here means the pane out-ran the reader in the "
+                + "instant between that wait and this snapshot — harness/load, not production"
         }
     }
 }

--- a/Tests/TBDDaemonLiveTests/ReplayLiveIntegrationMatrixTests.swift
+++ b/Tests/TBDDaemonLiveTests/ReplayLiveIntegrationMatrixTests.swift
@@ -129,6 +129,21 @@ struct ReplayLiveIntegrationMatrixTests {
     /// precisely because a non-zero value there means the overflow was seen and
     /// dropped rather than repaired.
     ///
+    /// **The completion signal is a DELTA against `baseline`, never an absolute
+    /// count — that distinction is the difference between this test proving
+    /// something and passing vacuously.** `repairs` is cumulative on the sink,
+    /// and the phases before this window read the pipe against a full-blast pane
+    /// for up to 30 s; a sink that overflowed and completed a repair in *that*
+    /// window would satisfy an absolute `repairs >= 1` on this gate's very first
+    /// poll. The deliberate no-reader window would then close instantly without
+    /// inducing anything, and phase 3's guard and assertions — cumulative too —
+    /// would be satisfied by that same stale repair, so the whole scenario could
+    /// go green having never exercised an overflow. `repairing` needs no delta:
+    /// `enqueueLocked` is the only thing that sets it, and only on an overflow
+    /// entry, so it cannot be a stale free lunch the way a counter can. It is
+    /// still cleared on completion, which is why the completion delta is checked
+    /// alongside it rather than instead of it.
+    ///
     /// On expiry it RETURNS the error rather than throwing it, and the caller
     /// throws only after tearing the supervisor down. That is not ceremony: on
     /// expiry the pane is still blasting into the vended pipe, so unwinding
@@ -146,15 +161,18 @@ struct ReplayLiveIntegrationMatrixTests {
     /// repair started" (a production problem), which the previous fixed sleep
     /// collapsed into a misleading `(stats.repairs → 0) >= 1`.
     private func overflowRepairEntryFailure(
-        fanout: PaneFanout, key: PaneKey, within budget: Duration = .seconds(30)
+        fanout: PaneFanout, key: PaneKey, baseline: PaneFlowStats,
+        within budget: Duration = .seconds(30)
     ) async -> MatrixError? {
         let deadline = ContinuousClock.now + budget
         while true {
             let stats = fanout.flowStats(key: key)
-            if stats?.repairing == true || (stats?.repairs ?? 0) >= 1 { return nil }
+            if stats?.repairing == true { return nil }
+            if let stats, stats.repairs > baseline.repairs { return nil }
             guard ContinuousClock.now < deadline else {
                 return .overflowRepairNeverEntered(
-                    stats: stats, queueCap: PaneFanout.queueCap, waited: budget)
+                    stats: stats, baseline: baseline, queueCap: PaneFanout.queueCap,
+                    waited: budget)
             }
             try? await Task.sleep(for: .milliseconds(50))
         }
@@ -689,6 +707,18 @@ struct ReplayLiveIntegrationMatrixTests {
         attachDone.set()
         var accumulated = await phase1
 
+        // The baseline for everything below. Every "a repair happened" check in
+        // this test is a DELTA against it — see `overflowRepairEntryFailure` for
+        // why an absolute count is a vacuous pass here.
+        let key = PaneKey(server: server, paneID: paneID)
+        let fanout = supervisor.fanout
+        guard let baseline = fanout.flowStats(key: key) else {
+            // Stop the supervisor BEFORE unwinding: the pane is still blasting,
+            // and the `defer` above closes the read end of the pipe it writes to.
+            await supervisor.stopAll()
+            throw MatrixError.sinkVanished("before the overflow window opened")
+        }
+
         // Phase 2: deliberately do NOT read — the overflow window. The repair
         // fires, pauses the pane, and parks in its reader-catch-up wait until
         // phase 3 starts reading.
@@ -704,20 +734,22 @@ struct ReplayLiveIntegrationMatrixTests {
         // `stats.repairs >= 1` as though production had failed to repair. Waiting
         // for the stall itself makes the setup's postcondition true by
         // construction, so every assertion downstream is about the repair.
-        let key = PaneKey(server: server, paneID: paneID)
-        let fanout = supervisor.fanout
-        if let failure = await overflowRepairEntryFailure(fanout: fanout, key: key) {
+        if let failure = await overflowRepairEntryFailure(
+            fanout: fanout, key: key, baseline: baseline) {
             // Stop the supervisor BEFORE unwinding: the pane is still blasting,
             // and the `defer` above closes the read end of the pipe it writes to.
             await supervisor.stopAll()
             throw failure
         }
 
-        // Phase 3: read continuously until at least one repair completed and
-        // the healed stream carries enough post-repair tokens to judge.
+        // Phase 3: read continuously until a repair completed AFTER the window
+        // opened and the healed stream carries enough post-repair tokens to
+        // judge. The delta is the same guard as the entry gate's, for the same
+        // reason: `>= 1` here would be satisfied by a pre-window repair.
         let phase1Prefix = accumulated
         accumulated += await drain(fd: readFD, deadline: .seconds(45)) { [self] data in
-            guard (fanout.flowStats(key: key)?.repairs ?? 0) >= 1 else { return false }
+            guard let stats = fanout.flowStats(key: key),
+                  stats.repairs > baseline.repairs else { return false }
             let text = String(decoding: phase1Prefix + data, as: UTF8.self)
             guard let last = text.range(of: ReplayWriter.resetPrelude, options: .backwards)
             else { return false }
@@ -725,15 +757,27 @@ struct ReplayLiveIntegrationMatrixTests {
             return tokens(in: healed, label: "SEQ").count >= 30
         }
         let text = String(decoding: accumulated, as: UTF8.self)
+        let observed = fanout.flowStats(key: key)
+        // Stop the supervisor BEFORE the assertions, not after: the pane is
+        // still blasting, and a `try #require` that fails below would unwind
+        // past the `defer` that closes the read end of the pipe it writes to —
+        // the next fanout write then raises SIGPIPE and kills the whole test
+        // process (measured: `Exited with unexpected signal code 13`, with no
+        // diagnostic at all). The counters are snapshotted above so tearing the
+        // supervisor down first costs nothing.
+        await supervisor.stopAll()
 
-        // (a) At least one repair completed — both in the counters and as a
-        // second reset prelude in the byte stream (attach replay + repair
-        // replay each begin with one).
-        let stats = try #require(fanout.flowStats(key: key), "sink vanished mid-test")
-        #expect(stats.repairs >= 1, "the overflow never triggered a completed repair")
+        // (a) A repair completed DURING the overflow window — both in the
+        // counters and as one more reset prelude in the byte stream than the
+        // window opened with (the attach replay contributed the first).
+        let stats = try #require(observed, "sink vanished mid-test")
+        #expect(stats.repairs > baseline.repairs,
+                "the overflow window never triggered a completed repair (repairs \(stats.repairs), baseline \(baseline.repairs))")
         let preludeCount = text.components(separatedBy: ReplayWriter.resetPrelude).count - 1
-        #expect(preludeCount >= 2,
-                "expected the repair's reset prelude in the stream (found \(preludeCount))")
+        let baselinePreludes = String(decoding: phase1Prefix, as: UTF8.self)
+            .components(separatedBy: ReplayWriter.resetPrelude).count - 1
+        #expect(preludeCount > baselinePreludes,
+                "expected the repair's reset prelude in the stream (found \(preludeCount), of which \(baselinePreludes) were already present when the window opened)")
 
         // (b) The heal proof: after the LAST reset prelude — the final repair
         // replay — SEQ tokens are gapless and monotonic through the end of
@@ -745,18 +789,20 @@ struct ReplayLiveIntegrationMatrixTests {
         let violations = sequenceViolations(healed).joined(separator: "; ")
         #expect(violations.isEmpty,
                 "LOSS/DUP after the repair replay — the overflow hole was not healed: \(violations)")
-
-        await supervisor.stopAll()
     }
 }
 
 private enum MatrixError: Error, CustomStringConvertible {
     case clientNeverReady
     case pollDeadline(String)
+    /// The pane's sink was gone when the test needed to read its counters.
+    case sinkVanished(String)
     /// The overflow window closed without the sink entering the repair cycle.
-    /// Carries the counters observed at the deadline — `nil` stats mean the sink
-    /// itself was gone.
-    case overflowRepairNeverEntered(stats: PaneFlowStats?, queueCap: Int, waited: Duration)
+    /// Carries the counters observed at the deadline AND the baseline the window
+    /// opened with, since every verdict here is a delta — `nil` stats mean the
+    /// sink itself was gone.
+    case overflowRepairNeverEntered(
+        stats: PaneFlowStats?, baseline: PaneFlowStats, queueCap: Int, waited: Duration)
 
     var description: String {
         switch self {
@@ -764,16 +810,24 @@ private enum MatrixError: Error, CustomStringConvertible {
             return "the tmux control-mode command client never became ready"
         case .pollDeadline(let what):
             return "timed out polling for: \(what)"
-        case .overflowRepairNeverEntered(let stats, let queueCap, let waited):
+        case .sinkVanished(let when):
+            return "the pane's fanout sink was gone \(when) (detached or superseded), "
+                + "so nothing was routing"
+        case .overflowRepairNeverEntered(let stats, let baseline, let queueCap, let waited):
             guard let stats else {
                 return "no repair cycle after \(waited) of firehose with no reader — "
                     + "the sink had vanished (detached or superseded), so nothing was routing"
             }
+            // Every counter is shown against the value the window opened with:
+            // the question this error answers is what happened DURING the
+            // window, and the absolute totals include everything before it.
             let facts = "queuedHighWater=\(stats.queuedHighWater) of queueCap=\(queueCap), "
-                + "queuedBytes=\(stats.queuedBytes), overflowEvents=\(stats.overflowEvents), "
-                + "droppedBytes=\(stats.droppedBytes), repairing=\(stats.repairing), "
-                + "repairs=\(stats.repairs)"
-            let verdict = stats.overflowEvents > 0
+                + "queuedBytes=\(stats.queuedBytes), "
+                + "overflowEvents=\(stats.overflowEvents) (baseline \(baseline.overflowEvents)), "
+                + "droppedBytes=\(stats.droppedBytes) (baseline \(baseline.droppedBytes)), "
+                + "repairing=\(stats.repairing), "
+                + "repairs=\(stats.repairs) (baseline \(baseline.repairs))"
+            let verdict = stats.overflowEvents > baseline.overflowEvents
                 ? "the queue DID overflow and the sink dropped instead of repairing — production"
                 : "the queue never reached the cap, so the setup never induced an overflow — harness"
             return "no repair cycle after \(waited) of firehose with no reader: \(verdict). \(facts)"

--- a/Tests/TBDDaemonLiveTests/ReplayLiveIntegrationMatrixTests.swift
+++ b/Tests/TBDDaemonLiveTests/ReplayLiveIntegrationMatrixTests.swift
@@ -117,6 +117,49 @@ struct ReplayLiveIntegrationMatrixTests {
         throw MatrixError.clientNeverReady
     }
 
+    /// Wait — WITHOUT reading the pane's pipe — until its sink has provably
+    /// overflowed and entered the M3 repair cycle.
+    ///
+    /// `repairing` is the entry signal and `repairs` the completion signal; both
+    /// are accepted so a repair that somehow completed between two polls does not
+    /// look like one that never started. Note that `overflowEvents` is NOT an
+    /// entry signal: `enqueueLocked` increments it only on the fenced /
+    /// already-repairing DROP branch, so on the steady-state path the counter
+    /// stays at zero while the repair runs. It is reported in the diagnostic
+    /// precisely because a non-zero value there means the overflow was seen and
+    /// dropped rather than repaired.
+    ///
+    /// On expiry it RETURNS the error rather than throwing it, and the caller
+    /// throws only after tearing the supervisor down. That is not ceremony: on
+    /// expiry the pane is still blasting into the vended pipe, so unwinding
+    /// straight past the test's `defer { Darwin.close(readFD) }` makes the next
+    /// fanout write raise SIGPIPE and kill the whole test process. Measured — an
+    /// early throw reported `error: Exited with unexpected signal code 13` and no
+    /// diagnostic at all. An error is only worth composing if it survives to be
+    /// read.
+    ///
+    /// It is an error rather than an `#expect` for the other half of the same
+    /// reason: only a thrown error puts the observed counters on the primary
+    /// failure line CI summaries keep (`Tests/CLAUDE.md`, assertion-hygiene rule
+    /// 4). The message separates "the firehose never filled the queue" (a harness
+    /// problem — the test's own setup did not hold) from "it overflowed and no
+    /// repair started" (a production problem), which the previous fixed sleep
+    /// collapsed into a misleading `(stats.repairs → 0) >= 1`.
+    private func overflowRepairEntryFailure(
+        fanout: PaneFanout, key: PaneKey, within budget: Duration = .seconds(30)
+    ) async -> MatrixError? {
+        let deadline = ContinuousClock.now + budget
+        while true {
+            let stats = fanout.flowStats(key: key)
+            if stats?.repairing == true || (stats?.repairs ?? 0) >= 1 { return nil }
+            guard ContinuousClock.now < deadline else {
+                return .overflowRepairNeverEntered(
+                    stats: stats, queueCap: PaneFanout.queueCap, waited: budget)
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+    }
+
     // MARK: - Vended-fd reading
 
     private func makeNonblocking(_ fd: Int32) {
@@ -646,15 +689,32 @@ struct ReplayLiveIntegrationMatrixTests {
         attachDone.set()
         var accumulated = await phase1
 
-        // Phase 2: deliberately do NOT read for ~2 s — the overflow window.
-        // The repair fires, pauses the pane, and parks in its reader-catch-up
-        // wait until phase 3 starts reading.
-        try await Task.sleep(for: .seconds(2))
+        // Phase 2: deliberately do NOT read — the overflow window. The repair
+        // fires, pauses the pane, and parks in its reader-catch-up wait until
+        // phase 3 starts reading.
+        //
+        // The end of this window is an OBSERVED event, not a wall-clock guess.
+        // Overflow is a byte threshold the test does not itself produce: the
+        // queue only grows once the ~64 KB pipe fills and `route()` starts
+        // taking EAGAIN, so ~192 KB has to arrive from the pane before
+        // `enqueueLocked` crosses `PaneFanout.queueCap`. A fixed sleep makes
+        // that a race against an external producer — this pane emits 700 KB–1 MB
+        // per 2 s on an idle box, but a run that dragged 28x slower delivered
+        // ~25–39 KB in the same window, never overflowed, and reddened
+        // `stats.repairs >= 1` as though production had failed to repair. Waiting
+        // for the stall itself makes the setup's postcondition true by
+        // construction, so every assertion downstream is about the repair.
+        let key = PaneKey(server: server, paneID: paneID)
+        let fanout = supervisor.fanout
+        if let failure = await overflowRepairEntryFailure(fanout: fanout, key: key) {
+            // Stop the supervisor BEFORE unwinding: the pane is still blasting,
+            // and the `defer` above closes the read end of the pipe it writes to.
+            await supervisor.stopAll()
+            throw failure
+        }
 
         // Phase 3: read continuously until at least one repair completed and
         // the healed stream carries enough post-repair tokens to judge.
-        let key = PaneKey(server: server, paneID: paneID)
-        let fanout = supervisor.fanout
         let phase1Prefix = accumulated
         accumulated += await drain(fd: readFD, deadline: .seconds(45)) { [self] data in
             guard (fanout.flowStats(key: key)?.repairs ?? 0) >= 1 else { return false }
@@ -690,7 +750,33 @@ struct ReplayLiveIntegrationMatrixTests {
     }
 }
 
-private enum MatrixError: Error {
+private enum MatrixError: Error, CustomStringConvertible {
     case clientNeverReady
     case pollDeadline(String)
+    /// The overflow window closed without the sink entering the repair cycle.
+    /// Carries the counters observed at the deadline — `nil` stats mean the sink
+    /// itself was gone.
+    case overflowRepairNeverEntered(stats: PaneFlowStats?, queueCap: Int, waited: Duration)
+
+    var description: String {
+        switch self {
+        case .clientNeverReady:
+            return "the tmux control-mode command client never became ready"
+        case .pollDeadline(let what):
+            return "timed out polling for: \(what)"
+        case .overflowRepairNeverEntered(let stats, let queueCap, let waited):
+            guard let stats else {
+                return "no repair cycle after \(waited) of firehose with no reader — "
+                    + "the sink had vanished (detached or superseded), so nothing was routing"
+            }
+            let facts = "queuedHighWater=\(stats.queuedHighWater) of queueCap=\(queueCap), "
+                + "queuedBytes=\(stats.queuedBytes), overflowEvents=\(stats.overflowEvents), "
+                + "droppedBytes=\(stats.droppedBytes), repairing=\(stats.repairing), "
+                + "repairs=\(stats.repairs)"
+            let verdict = stats.overflowEvents > 0
+                ? "the queue DID overflow and the sink dropped instead of repairing — production"
+                : "the queue never reached the cap, so the setup never induced an overflow — harness"
+            return "no repair cycle after \(waited) of firehose with no reader: \(verdict). \(facts)"
+        }
+    }
 }

--- a/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputHealthTests.swift
@@ -27,60 +27,63 @@ struct ControlModeInputHealthTests {
         }
     }
 
-    private final class ClientHolder: @unchecked Sendable {
-        weak var client: TmuxControlCommandClient?
-    }
-
     /// Poll until `recorder` has at least `count` health events (shared
     /// `waitFor`, which keeps the post-deadline re-check this suite needed
-    /// under parallel-suite load).
+    /// under parallel-suite load). Reports the events actually observed: the
+    /// bare count this waits on says nothing about what arrived, and it is the
+    /// finding when it times out.
     private func waitForEvents(_ recorder: HealthRecorder, count: Int,
                                sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
-        try await waitFor("\(count) health events", sourceLocation: sourceLocation) {
+        try await waitFor("\(count) health events",
+                          observed: { Self.describe(recorder.events) },
+                          sourceLocation: sourceLocation) {
             recorder.events.count >= count
         }
     }
 
     private func waitForWrites(_ recorder: LineRecorder, count: Int,
                                sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
-        try await waitFor("\(count) stream writes", sourceLocation: sourceLocation) {
+        try await waitFor("\(count) stream writes",
+                          observed: { "\(recorder.writes.count): \(recorder.writes)" },
+                          sourceLocation: sourceLocation) {
             recorder.writes.count >= count
         }
     }
 
+    /// Renders health events for a timeout diagnostic — `1: [%0 failing gen=42]`.
+    private static func describe(
+        _ events: [(worktreeID: UUID, paneID: String, healthy: Bool, generation: UInt64?)]
+    ) -> String {
+        let rendered = events.map { event in
+            "\(event.paneID) \(event.healthy ? "healthy" : "failing") "
+                + "gen=\(event.generation.map(String.init) ?? "nil")"
+        }
+        return "\(events.count): [\(rendered.joined(separator: ", "))]"
+    }
+
     /// A router whose client replies to every command: `%error` when
-    /// `shouldFail(commandText)` says so, `%end` otherwise. Replies are fed
-    /// back one per command in FIFO order, so completion order matches write
-    /// order and health transitions are deterministic.
+    /// `shouldFail(commandText)` says so, `%end` otherwise.
+    ///
+    /// The replies go through a shared `ReplyFeed`, whose single long-lived
+    /// consumer makes completion order equal write order **by construction** —
+    /// the invariant the correlator's order-based matching depends on and that
+    /// production gets from `TmuxControlSupervisor`'s one drain loop. The
+    /// per-write `Task { … }` this replaced only *looked* FIFO on an idle box;
+    /// under load its verdicts landed on the wrong commands and stranded these
+    /// edge-triggered assertions (#494). See `ReplyFeed` for the full account.
+    ///
+    /// The returned feed is also the quiescence signal: `waitForDeliveries(n)`
+    /// proves the first `n` verdicts were recorded, which a fixed settle cannot.
     private func makeRouter(shouldFail: @escaping @Sendable (String) -> Bool)
-        -> (ControlModeInputRouter, LineRecorder, HealthRecorder) {
-        let recorder = LineRecorder()
+        -> (ControlModeInputRouter, LineRecorder, HealthRecorder, ReplyFeed) {
         let health = HealthRecorder()
-        let holder = ClientHolder()
-        let client = TmuxControlCommandClient(
-            writeLine: { line in
-                recorder.record(line)
-                let commands = line.split(separator: "\n", omittingEmptySubsequences: false)
-                Task {
-                    for command in commands {
-                        if shouldFail(String(command)) {
-                            await holder.client?.handle(
-                                .commandFailed(number: 0, fromClient: true, lines: ["no pane"]))
-                        } else {
-                            await holder.client?.handle(
-                                .commandSucceeded(number: 0, fromClient: true, lines: []))
-                        }
-                    }
-                }
-            },
-            onFatalError: {})
-        holder.client = client
+        let (client, recorder, feed) = makeRespondingClient(shouldFail: shouldFail)
         let router = ControlModeInputRouter(
             commandProvider: { server in server == "srv" ? client : nil },
             onHealthChange: { worktreeID, paneID, healthy, generation in
                 health.record(worktreeID, paneID, healthy, generation)
             })
-        return (router, recorder, health)
+        return (router, recorder, health, feed)
     }
 
     /// The sentinel byte 0xFF marks a keystroke the fake client should ACCEPT;
@@ -92,7 +95,7 @@ struct ControlModeInputHealthTests {
     @Test("repeated send-keys failures fire exactly ONE failing transition")
     func repeatedFailuresFireOnce() async throws {
         let worktreeID = UUID()
-        let (router, _, health) = makeRouter(shouldFail: Self.failUnlessFF)
+        let (router, _, health, feed) = makeRouter(shouldFail: Self.failUnlessFF)
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
@@ -103,6 +106,7 @@ struct ControlModeInputHealthTests {
         router.enqueue(header: header, bytes: Data([0xff]))
 
         try #require(await waitForEvents(health, count: 2))
+        try #require(await feed.waitForDeliveries(4))
         let events = health.events
         #expect(events.count == 2)
         #expect(events[0].healthy == false)
@@ -110,12 +114,13 @@ struct ControlModeInputHealthTests {
         #expect(events[0].paneID == "%0")
         #expect(events[1].healthy == true)
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("fail then success fires one failing and one recovery transition")
     func failThenRecoveryFiresOnce() async throws {
         let worktreeID = UUID()
-        let (router, _, health) = makeRouter(shouldFail: Self.failUnlessFF)
+        let (router, _, health, feed) = makeRouter(shouldFail: Self.failUnlessFF)
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
@@ -124,51 +129,66 @@ struct ControlModeInputHealthTests {
         router.enqueue(header: header, bytes: Data([0xff]))   // steady healthy: no event
 
         try #require(await waitForEvents(health, count: 2))
-        // Give the third completion time to land, then confirm no third event.
-        try await Task.sleep(for: .milliseconds(50))
+        // The third verdict is RECORDED, not merely waited out: `reportDelivery`
+        // runs inside `client.handle`, so three deliveries means the steady
+        // success was processed and stayed silent.
+        try #require(await feed.waitForDeliveries(3))
         #expect(health.events.map(\.healthy) == [false, true])
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("successful deliveries alone never fire a transition")
     func successOnlyIsSilent() async throws {
         let worktreeID = UUID()
-        let (router, recorder, health) = makeRouter(shouldFail: { _ in false })
+        let (router, recorder, health, feed) = makeRouter(shouldFail: { _ in false })
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
         for i in 0..<5 { router.enqueue(header: header, bytes: Data([UInt8(i)])) }
 
         try #require(await waitForWrites(recorder, count: 5))
-        try await Task.sleep(for: .milliseconds(50))   // let completions drain
+        try #require(await feed.waitForDeliveries(5))   // all five verdicts recorded
         #expect(health.events.isEmpty)
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("input for an unregistered pane does NOT trip failing health")
     func unregisteredPaneDropIsNotFailure() async throws {
         let worktreeID = UUID()
-        let (router, recorder, health) = makeRouter(shouldFail: { _ in false })
+        let (router, recorder, health, feed) = makeRouter(shouldFail: { _ in false })
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
 
         // Unregistered pane first; a registered success after it proves the
-        // drop was processed by the time we assert.
+        // drop was processed by the time we assert — the router's consumer is
+        // strictly sequential, so the second item's verdict cannot be recorded
+        // before the first item was handled.
         router.enqueue(header: SidecarInputHeader(worktreeID: worktreeID, paneID: "%9"),
                        bytes: Data([0x41]))
         router.enqueue(header: SidecarInputHeader(worktreeID: worktreeID, paneID: "%0"),
                        bytes: Data([0x42]))
 
         try #require(await waitForWrites(recorder, count: 1))
-        try await Task.sleep(for: .milliseconds(50))
+        try #require(await feed.waitForDeliveries(1))
         #expect(health.events.isEmpty)
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("a missing command client (server down) trips failing health")
     func missingCommandClientTripsFailing() async throws {
         let health = HealthRecorder()
+        // There is no client here, so no reply feed either; the lookups
+        // themselves are the quiescence signal. The router's consumer is
+        // strictly sequential, so the Nth lookup starting proves item N-1 was
+        // fully delivered — including its `reportDelivery`.
+        let lookups = LineRecorder()
         let router = ControlModeInputRouter(
-            commandProvider: { _ in nil },   // server connection is down
+            commandProvider: { server in   // server connection is down
+                lookups.record(server)
+                return nil
+            },
             onHealthChange: { worktreeID, paneID, healthy, generation in
                 health.record(worktreeID, paneID, healthy, generation)
             })
@@ -178,9 +198,13 @@ struct ControlModeInputHealthTests {
 
         router.enqueue(header: header, bytes: Data([0x41]))
         router.enqueue(header: header, bytes: Data([0x42]))   // steady failing: no 2nd event
+        router.enqueue(header: header, bytes: Data([0x43]))   // probe: its lookup fences the two above
 
         try #require(await waitForEvents(health, count: 1))
-        try await Task.sleep(for: .milliseconds(50))
+        try #require(await waitFor("3 command-client lookups",
+                                   observed: { "\(lookups.writes.count)" }) {
+            lookups.writes.count >= 3
+        })
         #expect(health.events.map(\.healthy) == [false])
         router.shutdown()
     }
@@ -190,7 +214,7 @@ struct ControlModeInputHealthTests {
         // paste-buffer replies %error; everything else (load-buffer,
         // delete-buffer, send-keys) succeeds — same shape as the router
         // suite's pasteFailureDoesNotStall.
-        let (router, _, health) = makeRouter(shouldFail: { $0.hasPrefix("paste-buffer") })
+        let (router, _, health, feed) = makeRouter(shouldFail: { $0.hasPrefix("paste-buffer") })
         let worktreeID = UUID()
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
@@ -201,12 +225,13 @@ struct ControlModeInputHealthTests {
         try #require(await waitForEvents(health, count: 2))
         #expect(health.events.map(\.healthy) == [false, true])
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("unregister clears health state: a re-attach that fails fires failing again")
     func unregisterResetsHealthState() async throws {
         let worktreeID = UUID()
-        let (router, _, health) = makeRouter(shouldFail: Self.failUnlessFF)
+        let (router, _, health, feed) = makeRouter(shouldFail: Self.failUnlessFF)
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
@@ -221,12 +246,13 @@ struct ControlModeInputHealthTests {
         try #require(await waitForEvents(health, count: 2))
         #expect(health.events.map(\.healthy) == [false, false])
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("health events carry the attach generation registered with the route (R6-M7)")
     func healthEventsCarryRegisteredGeneration() async throws {
         let worktreeID = UUID()
-        let (router, _, health) = makeRouter(shouldFail: Self.failUnlessFF)
+        let (router, _, health, feed) = makeRouter(shouldFail: Self.failUnlessFF)
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv", generation: 42)
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
@@ -245,12 +271,13 @@ struct ControlModeInputHealthTests {
         try #require(await waitForEvents(health, count: 3))
         #expect(health.events.last?.generation == 43)
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("a route registered without a generation stamps nil (back-compat)")
     func generationlessRouteStampsNil() async throws {
         let worktreeID = UUID()
-        let (router, _, health) = makeRouter(shouldFail: Self.failUnlessFF)
+        let (router, _, health, feed) = makeRouter(shouldFail: Self.failUnlessFF)
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
@@ -258,12 +285,13 @@ struct ControlModeInputHealthTests {
         try #require(await waitForEvents(health, count: 1))
         #expect(health.events.map(\.generation) == [nil])
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("register alone resets health state: a lost detach cannot leak a stale failing flag into a re-attach")
     func registerResetsHealthStateWithoutUnregister() async throws {
         let worktreeID = UUID()
-        let (router, _, health) = makeRouter(shouldFail: Self.failUnlessFF)
+        let (router, _, health, feed) = makeRouter(shouldFail: Self.failUnlessFF)
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
@@ -279,5 +307,6 @@ struct ControlModeInputHealthTests {
         try #require(await waitForEvents(health, count: 2))
         #expect(health.events.map(\.healthy) == [false, false])
         router.shutdown()
+        await feed.finish()
     }
 }

--- a/Tests/TBDDaemonTests/ControlModeInputRouterTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeInputRouterTests.swift
@@ -29,7 +29,9 @@ struct ControlModeInputRouterTests {
     @discardableResult
     private func waitForWrites(_ recorder: LineRecorder, count: Int,
                                sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
-        try await waitFor("\(count) stream writes", sourceLocation: sourceLocation) {
+        try await waitFor("\(count) stream writes",
+                          observed: { "\(recorder.writes.count): \(recorder.writes)" },
+                          sourceLocation: sourceLocation) {
             recorder.writes.count >= count
         }
     }
@@ -43,7 +45,7 @@ struct ControlModeInputRouterTests {
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
         for i in 0..<50 { router.enqueue(header: header, bytes: Data([UInt8(i)])) }
 
-        try await waitForWrites(recorder, count: 50)
+        try #require(await waitForWrites(recorder, count: 50))
         let expected = (0..<50).map { "send-keys -H -t %0 " + String(format: "%02x", UInt8($0)) }
         #expect(recorder.writes == expected)
         router.shutdown()
@@ -62,7 +64,7 @@ struct ControlModeInputRouterTests {
         router.enqueue(header: SidecarInputHeader(worktreeID: worktreeID, paneID: "%0"),
                        bytes: Data([0x42]))
 
-        try await waitForWrites(recorder, count: 1)
+        try #require(await waitForWrites(recorder, count: 1))
         #expect(recorder.writes == ["send-keys -H -t %0 42"])
         router.shutdown()
     }
@@ -77,50 +79,36 @@ struct ControlModeInputRouterTests {
         router.enqueue(header: header, bytes: Data())      // no command
         router.enqueue(header: header, bytes: Data([0x5a]))
 
-        try await waitForWrites(recorder, count: 1)
+        try #require(await waitForWrites(recorder, count: 1))
         #expect(recorder.writes == ["send-keys -H -t %0 5a"])
         router.shutdown()
-    }
-
-    /// Holds a weak ref to the client so the `writeLine` closure (created before
-    /// the client) can feed replies back into it.
-    private final class ClientHolder: @unchecked Sendable {
-        weak var client: TmuxControlCommandClient?
     }
 
     /// A router whose client AUTO-COMPLETES every written command with a success
     /// reply — required because `PasteExecutor` awaits `client.send(...)` (the
     /// keystroke path uses fire-and-forget `sendList`, but paste does not), so
-    /// without a reply feed the consumer would hang on the first paste. Each
-    /// written stream line (a command list is one `\n`-joined write) is answered
-    /// with one `%end` per contained command, preserving FIFO order.
+    /// without a reply feed the consumer would hang on the first paste.
+    ///
+    /// Replies go through the shared `ReplyFeed`: one long-lived consumer hands
+    /// them to the correlator in write order, which is the invariant its
+    /// order-based matching assumes and that production gets from
+    /// `TmuxControlSupervisor`'s single drain loop. Uniform verdicts make the
+    /// difference latent here, but a per-write `Task { … }` is the shape that
+    /// stranded `ControlModeInputHealthTests` under load (#494) — don't
+    /// reintroduce it in either suite.
     private func makeSelfRespondingRouter(chunkSize: Int = 330)
-        -> (ControlModeInputRouter, LineRecorder) {
-        let recorder = LineRecorder()
-        let holder = ClientHolder()
-        let client = TmuxControlCommandClient(
-            writeLine: { line in
-                recorder.record(line)
-                let commandCount = line.split(separator: "\n", omittingEmptySubsequences: false).count
-                Task {
-                    for _ in 0..<commandCount {
-                        await holder.client?.handle(
-                            .commandSucceeded(number: 0, fromClient: true, lines: []))
-                    }
-                }
-            },
-            onFatalError: {})
-        holder.client = client
+        -> (ControlModeInputRouter, LineRecorder, ReplyFeed) {
+        let (client, recorder, feed) = makeRespondingClient()
         let router = ControlModeInputRouter(
             commandProvider: { server in server == "srv" ? client : nil },
             chunkSize: chunkSize)
-        return (router, recorder)
+        return (router, recorder, feed)
     }
 
     @Test("a paste enqueued between two keystrokes writes load/paste-buffer BETWEEN the send-keys")
     func pasteOrderedBetweenKeystrokes() async throws {
         let worktreeID = UUID()
-        let (router, recorder) = makeSelfRespondingRouter()
+        let (router, recorder, feed) = makeSelfRespondingRouter()
         router.register(worktreeID: worktreeID, paneID: "%0", server: "srv")
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
 
@@ -139,30 +127,21 @@ struct ControlModeInputRouterTests {
         #expect(writes[2].hasSuffix("-t %0"))
         #expect(writes[3] == "send-keys -H -t %0 42")
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("a paste failure does not stall the stream: a following keystroke still lands")
     func pasteFailureDoesNotStall() async throws {
-        // Client whose paste-buffer command FAILS (%error, tolerated). The
-        // keystroke after the paste must still be written — deliverPaste logs
-        // the failure and tears nothing down.
-        let recorder = LineRecorder()
-        let holder = ClientHolder()
-        let client = TmuxControlCommandClient(
-            writeLine: { line in
-                recorder.record(line)
-                let isPasteBuffer = line.hasPrefix("paste-buffer")
-                Task {
-                    // paste-buffer → %error (tolerated); everything else → %end.
-                    if isPasteBuffer {
-                        await holder.client?.handle(.commandFailed(number: 0, fromClient: true, lines: ["no pane"]))
-                    } else {
-                        await holder.client?.handle(.commandSucceeded(number: 0, fromClient: true, lines: []))
-                    }
-                }
-            },
-            onFatalError: {})
-        holder.client = client
+        // Client whose paste-buffer command FAILS (%error, tolerated); every
+        // other command succeeds. The keystroke after the paste must still be
+        // written — deliverPaste logs the failure and tears nothing down.
+        //
+        // These are MIXED verdicts, so the ordered feed is load-bearing rather
+        // than latent: a per-write `Task { … }` could hand the `%error` to the
+        // wrong queue entry. Sequential `PasteExecutor` sends happened to keep
+        // that from biting here; the feed makes it structural.
+        let (client, recorder, feed) = makeRespondingClient(
+            shouldFail: { $0.hasPrefix("paste-buffer") })
         let router = ControlModeInputRouter(
             commandProvider: { server in server == "srv" ? client : nil })
 
@@ -178,10 +157,12 @@ struct ControlModeInputRouterTests {
         // LAST write: the failure-cleanup `delete-buffer` and the keystroke are
         // order-independent (buffer GC vs a keypress), so `.last` couples the
         // test to an incidental ordering. Wait for the keystroke itself.
-        try await waitFor("the post-paste keystroke reaches the stream") {
+        try #require(await waitFor("the post-paste keystroke reaches the stream",
+                                   observed: { "\(recorder.writes.count): \(recorder.writes)" }) {
             recorder.writes.contains("send-keys -H -t %0 5a")
-        }
+        })
         router.shutdown()
+        await feed.finish()
     }
 
     @Test("each delivered event records exactly one latency sample")
@@ -196,7 +177,7 @@ struct ControlModeInputRouterTests {
         let header = SidecarInputHeader(worktreeID: worktreeID, paneID: "%0")
         for i in 0..<50 { router.enqueue(header: header, bytes: Data([UInt8(i)])) }
 
-        try await waitForWrites(recorder, count: 50)
+        try #require(await waitForWrites(recorder, count: 50))
         #expect(latency.summarizeAndReset()?.count == 50)
         router.shutdown()
     }

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -126,10 +126,31 @@ func makeFakeClient() -> (TmuxControlCommandClient, LineRecorder) {
     return (client, recorder)
 }
 
+/// Carries a bounded wait's OBSERVED state on the primary failure line
+/// (assertion-hygiene rule 4: `#expect(cond, "…")` and `Issue.record(String)`
+/// both demote the message to a trailing `↳` line that CI summaries drop; only
+/// `Issue.record(_: some Error)` survives). `observed` is nil when the caller
+/// supplied no reporter — the text then matches the pre-#494 wording exactly.
+struct ControlModeWaitTimeout: Error, CustomStringConvertible {
+    let what: String
+    let observed: String?
+    let deadline: Duration
+
+    var description: String {
+        let seen = observed.map { " — observed \($0)" } ?? ""
+        return "timed out waiting for \(what)\(seen) after polling up to \(deadline)"
+    }
+}
+
 /// Poll every 10 ms until `condition`, recording an Issue at the caller's
 /// source location after `deadline`. A final post-deadline re-check absorbs
 /// sleep slices that overshoot the deadline AFTER the condition became true
 /// (observed live as `timedOut(got: N, want: N)` at loadavg ~40).
+///
+/// `observed` renders what the waiter actually saw at the moment it gave up; it
+/// is evaluated only on the failing path. Supply it for any wait whose
+/// condition is uninformative on its own ("2 health events" says nothing about
+/// how many arrived).
 ///
 /// Returns whether the condition was met (false on timeout) so callers that
 /// index into results afterwards can abort via `#require` instead of trapping
@@ -137,6 +158,7 @@ func makeFakeClient() -> (TmuxControlCommandClient, LineRecorder) {
 @discardableResult
 func waitFor(
     _ what: String, deadline: Duration = ciSafeDeadline,
+    observed: (@Sendable () async -> String)? = nil,
     sourceLocation: SourceLocation = #_sourceLocation,
     _ condition: @Sendable () async -> Bool
 ) async throws -> Bool {
@@ -146,6 +168,151 @@ func waitFor(
         try await Task.sleep(for: .milliseconds(10))
     }
     if await condition() { return true }
-    Issue.record("timed out waiting for \(what)", sourceLocation: sourceLocation)
+    Issue.record(
+        ControlModeWaitTimeout(what: what, observed: await observed?(), deadline: deadline),
+        sourceLocation: sourceLocation)
     return false
+}
+
+// MARK: - Ordered reply feed
+
+/// Thread-safe weak box letting a `writeLine` closure (built before the client
+/// exists) feed reply blocks back into that client.
+final class ClientBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private weak var _client: TmuxControlCommandClient?
+    var client: TmuxControlCommandClient? {
+        get { lock.lock(); defer { lock.unlock() }; return _client }
+        set { lock.lock(); _client = newValue; lock.unlock() }
+    }
+}
+
+/// Monotone count of reply blocks fully handed to the correlator. Held
+/// separately from `ReplyFeed` so the drain task can own it without capturing
+/// (and thus retaining) the feed.
+private final class ReplyDeliveryCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _count = 0
+    func increment() { lock.lock(); _count += 1; lock.unlock() }
+    var count: Int { lock.lock(); defer { lock.unlock() }; return _count }
+}
+
+/// A SINGLE-CONSUMER reply feed for the fake control-mode clients — the harness
+/// half of `TmuxControlCommandClient`'s order-based correlation.
+///
+/// **Why this exists (#494).** The correlator matches reply blocks to commands
+/// **by order**: `complete` pops `pending.removeFirst()`, trusting tmux's
+/// protocol invariant that exactly one reply block arrives per command, in
+/// command order. Production upholds that because `TmuxControlSupervisor.drain`
+/// feeds every event from ONE loop — `for await event in connection.events {
+/// … await client.handle(event) }` — so blocks reach the actor strictly in
+/// stream order.
+///
+/// A fake `writeLine` that spawns a fresh unstructured `Task { await
+/// client.handle(…) }` per write does **not** model that. Those tasks race each
+/// other into the actor; their arrival order is a scheduling artifact that
+/// matches creation order on an idle box and stops doing so under load. Because
+/// `deliverInput` awaits only `sendList` — which returns after the stream
+/// **write**, not the reply — several keystrokes are routinely in flight at
+/// once, so their verdicts could be permuted onto the wrong commands. With
+/// verdicts {fail, ok, ok} arriving as {ok, ok, fail}, the edge-triggered health
+/// tracker fires ONE event instead of two and the waiter burns its full
+/// `ciSafeDeadline`. That manufactured race — not the router — was the flake.
+///
+/// `ReplyFeed` restores the production shape. `enqueue` pushes **synchronously**,
+/// in write order, into an unbounded `AsyncStream`; one long-lived task awaits
+/// `client.handle(...)` for each in turn. Completion order therefore equals
+/// write order by construction, at any load — the same single-consumer shape
+/// `ControlModeInputRouter` itself uses, for the same reason.
+///
+/// It also provides the quiescence signal that replaces "sleep 50 ms and hope":
+/// `waitForDeliveries(n)` is a real happens-before, because `reportDelivery`
+/// runs synchronously inside `client.handle`, so `delivered >= n` means the
+/// first `n` verdicts have already been recorded.
+final class ReplyFeed: @unchecked Sendable {
+    private let box = ClientBox()
+    private let counter = ReplyDeliveryCounter()
+    private let continuation: AsyncStream<TmuxControlEvent>.Continuation
+    private let drain: Task<Void, Never>
+
+    init() {
+        var escaped: AsyncStream<TmuxControlEvent>.Continuation!
+        let stream = AsyncStream<TmuxControlEvent>(bufferingPolicy: .unbounded) { escaped = $0 }
+        self.continuation = escaped
+        // Captures the box and counter, never `self` — so the feed can
+        // deallocate, and its `deinit` can end this loop, without a cycle.
+        let box = self.box
+        let counter = self.counter
+        self.drain = Task {
+            for await event in stream {
+                await box.client?.handle(event)
+                counter.increment()
+            }
+        }
+    }
+
+    /// Backstop teardown: a feed that goes out of scope without `finish()` (an
+    /// early `#require` abort, say) must not leave its drain task running.
+    deinit {
+        continuation.finish()
+        drain.cancel()
+    }
+
+    /// Point the feed at the client whose `writeLine` fills it. Weak, so the
+    /// client (which retains this feed through its `writeLine` closure) is not
+    /// kept alive by it.
+    func attach(_ client: TmuxControlCommandClient) { box.client = client }
+
+    /// Queue one reply block. Synchronous and ordered: the caller's write order
+    /// IS the delivery order.
+    func enqueue(_ event: TmuxControlEvent) { continuation.yield(event) }
+
+    /// Reply blocks fully processed by the correlator so far.
+    var delivered: Int { counter.count }
+
+    /// Wait until at least `count` reply blocks have been fully processed. The
+    /// quiescence signal for "…and nothing further happened" assertions: a
+    /// fixed settle samples once and can only produce false greens.
+    @discardableResult
+    func waitForDeliveries(_ count: Int,
+                           sourceLocation: SourceLocation = #_sourceLocation) async throws -> Bool {
+        try await waitFor("\(count) reply blocks delivered",
+                          observed: { "\(self.delivered)" },
+                          sourceLocation: sourceLocation) {
+            self.delivered >= count
+        }
+    }
+
+    /// End the feed and await the drain task, so no reply delivery outlives the
+    /// test that created it.
+    func finish() async {
+        continuation.finish()
+        drain.cancel()
+        await drain.value
+    }
+}
+
+/// A fake correlator client that answers every command it is written with the
+/// verdict `shouldFail(commandText)` chooses — `%error` when true, `%end`
+/// otherwise — through an ORDERED single-consumer `ReplyFeed`.
+///
+/// One stream write may carry several `\n`-joined commands (`sendList`); each
+/// gets its own reply block, enqueued in command order. Callers must
+/// `await feed.finish()` when done.
+func makeRespondingClient(shouldFail: @escaping @Sendable (String) -> Bool = { _ in false })
+    -> (TmuxControlCommandClient, LineRecorder, ReplyFeed) {
+    let recorder = LineRecorder()
+    let feed = ReplyFeed()
+    let client = TmuxControlCommandClient(
+        writeLine: { line in
+            recorder.record(line)
+            for command in line.split(separator: "\n", omittingEmptySubsequences: false) {
+                feed.enqueue(shouldFail(String(command))
+                    ? .commandFailed(number: 0, fromClient: true, lines: ["no pane"])
+                    : .commandSucceeded(number: 0, fromClient: true, lines: []))
+            }
+        },
+        onFatalError: {})
+    feed.attach(client)
+    return (client, recorder, feed)
 }

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -302,22 +302,27 @@ final class ReplyFeed: @unchecked Sendable {
     /// End the feed and await the drain task, so no reply delivery outlives the
     /// test that created it.
     ///
-    /// **Awaiting `drain.value` is the load-bearing half.** It is what makes
-    /// "`finish()` returned" mean "every block enqueued before it has been
-    /// handed to the correlator" — the happens-before the callers' post-test
-    /// assertions rest on. Callers reach here with blocks in flight by
-    /// construction: `writeLine` records the stream write and enqueues its reply
-    /// synchronously, so a wait that returns on the WRITE
-    /// (`pasteFailureDoesNotStall` waits for `send-keys … 5a` to be recorded)
-    /// returns before those replies are handled.
+    /// **Awaiting `drain.value` is the load-bearing half, and its guarantee has
+    /// one precondition worth stating exactly.** It makes "`finish()` returned"
+    /// mean "every block ALREADY YIELDED into the stream has been handed to the
+    /// correlator". It can do nothing for a block that has not been yielded yet:
+    /// `continuation.finish()` runs first, and a `yield` onto a finished
+    /// continuation is silently discarded. So the happens-before callers rest on
+    /// is a joint property of this method and `makeRespondingClient`, which
+    /// enqueues each reply BEFORE recording the write that a waiter can observe
+    /// (see its doc comment). Given that order, a caller that reaches here on a
+    /// recorded write — `pasteFailureDoesNotStall` waits for `send-keys … 5a` —
+    /// necessarily has its replies in the buffer, and awaiting the drain is what
+    /// delivers them. Reverse the two statements there and no amount of draining
+    /// here recovers the reply.
     ///
     /// **`cancel()` does not truncate that buffer** — measured, not assumed,
     /// because the opposite is the natural assumption and it is wrong.
     /// `AsyncStream` implements task cancellation as `finish()`, and a finished
     /// stream still yields everything already buffered before `next()` returns
     /// nil; the loop body's only suspension is an actor hop, which ignores
-    /// cancellation. With a deliberate backlog of 2,395–5,312 blocks in flight
-    /// at the call, all 20,000 were still delivered
+    /// cancellation. With a deliberate backlog of all 20,000 blocks in flight
+    /// at the call, every one was still delivered
     /// (`ControlModeTestSupportTests.finishDeliversBufferedReplies`, run against
     /// this exact code). So the reply to a `send(…)`-shaped command — the
     /// PasteExecutor load-buffer / paste-buffer / delete-buffer shape, whose
@@ -337,18 +342,31 @@ final class ReplyFeed: @unchecked Sendable {
 /// One stream write may carry several `\n`-joined commands (`sendList`); each
 /// gets its own reply block, enqueued in command order. Callers must
 /// `await feed.finish()` when done.
+///
+/// **The replies are enqueued BEFORE the write is recorded, and that order is
+/// load-bearing** — it is what `ReplyFeed.finish()`'s happens-before rests on.
+/// Tests routinely wait on the recorded WRITE (`pasteFailureDoesNotStall` polls
+/// `recorder.writes.contains("send-keys -H -t %0 5a")` every 10 ms) and then
+/// tear down. With the recording first, a waiter that observes the write in the
+/// gap between the two statements — one preemption of this executor thread is
+/// enough — can reach `finish()` before the reply is in the buffer, so
+/// `continuation.finish()` lands first and the `yield` that follows is silently
+/// dropped. Enqueuing first makes "the write is visible" imply "the reply is
+/// buffered", which is precisely the premise `await drain.value` needs: it
+/// drains what is already enqueued, and can do nothing for a block that has not
+/// been yielded yet.
 func makeRespondingClient(shouldFail: @escaping @Sendable (String) -> Bool = { _ in false })
     -> (TmuxControlCommandClient, LineRecorder, ReplyFeed) {
     let recorder = LineRecorder()
     let feed = ReplyFeed()
     let client = TmuxControlCommandClient(
         writeLine: { line in
-            recorder.record(line)
             for command in line.split(separator: "\n", omittingEmptySubsequences: false) {
                 feed.enqueue(shouldFail(String(command))
                     ? .commandFailed(number: 0, fromClient: true, lines: ["no pane"])
                     : .commandSucceeded(number: 0, fromClient: true, lines: []))
             }
+            recorder.record(line)
         },
         onFatalError: {})
     feed.attach(client)

--- a/Tests/TBDDaemonTests/ControlModeTestSupport.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupport.swift
@@ -152,6 +152,19 @@ struct ControlModeWaitTimeout: Error, CustomStringConvertible {
 /// condition is uninformative on its own ("2 health events" says nothing about
 /// how many arrived).
 ///
+/// **The diagnostic reports the state that decided the failure, not the state
+/// at report time** (assertion-hygiene rule 4 — the
+/// `fileBytesMismatch(expected: 6150, actual: 6150)` shape). `observed` and
+/// `condition` are two closures over the same growing state, so reading
+/// `observed` *after* the last `condition()` lets an event that lands in the
+/// gap print the self-contradictory `timed out waiting for 2 health events —
+/// observed 2`. The order below closes that: `observed` is captured first, and
+/// the condition is then re-checked once more, so anything that arrived while
+/// the diagnostic was being composed makes this a PASS rather than a
+/// contradictory failure. The counters these waits watch are monotone, so a
+/// condition that is false after the capture was false at the capture too —
+/// the reported state and the verdict are consistent by construction.
+///
 /// Returns whether the condition was met (false on timeout) so callers that
 /// index into results afterwards can abort via `#require` instead of trapping
 /// out of range; count/equality-checking callers may ignore the result.
@@ -168,8 +181,11 @@ func waitFor(
         try await Task.sleep(for: .milliseconds(10))
     }
     if await condition() { return true }
+    // Capture BEFORE deciding to fail, then re-check: see the doc comment.
+    let seen = await observed?()
+    if await condition() { return true }
     Issue.record(
-        ControlModeWaitTimeout(what: what, observed: await observed?(), deadline: deadline),
+        ControlModeWaitTimeout(what: what, observed: seen, deadline: deadline),
         sourceLocation: sourceLocation)
     return false
 }
@@ -285,6 +301,28 @@ final class ReplyFeed: @unchecked Sendable {
 
     /// End the feed and await the drain task, so no reply delivery outlives the
     /// test that created it.
+    ///
+    /// **Awaiting `drain.value` is the load-bearing half.** It is what makes
+    /// "`finish()` returned" mean "every block enqueued before it has been
+    /// handed to the correlator" — the happens-before the callers' post-test
+    /// assertions rest on. Callers reach here with blocks in flight by
+    /// construction: `writeLine` records the stream write and enqueues its reply
+    /// synchronously, so a wait that returns on the WRITE
+    /// (`pasteFailureDoesNotStall` waits for `send-keys … 5a` to be recorded)
+    /// returns before those replies are handled.
+    ///
+    /// **`cancel()` does not truncate that buffer** — measured, not assumed,
+    /// because the opposite is the natural assumption and it is wrong.
+    /// `AsyncStream` implements task cancellation as `finish()`, and a finished
+    /// stream still yields everything already buffered before `next()` returns
+    /// nil; the loop body's only suspension is an actor hop, which ignores
+    /// cancellation. With a deliberate backlog of 2,395–5,312 blocks in flight
+    /// at the call, all 20,000 were still delivered
+    /// (`ControlModeTestSupportTests.finishDeliversBufferedReplies`, run against
+    /// this exact code). So the reply to a `send(…)`-shaped command — the
+    /// PasteExecutor load-buffer / paste-buffer / delete-buffer shape, whose
+    /// loss would strand a `withCheckedThrowingContinuation` forever — is not at
+    /// risk here. Delete `await drain.value` and it would be.
     func finish() async {
         continuation.finish()
         drain.cancel()

--- a/Tests/TBDDaemonTests/ControlModeTestSupportTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupportTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+
+@testable import TBDDaemonLib
+
+/// Tier 1: the control-mode suites' own harness, driven directly.
+///
+/// Two properties that every suite consuming `ControlModeTestSupport` depends
+/// on, and that nothing else would notice regressing — a harness defect shows
+/// up as a *sibling* suite flaking under load, weeks later and attributed to
+/// production. Both tests below are deterministic and take milliseconds.
+@Suite("Control-mode test support")
+struct ControlModeTestSupportTests {
+
+    /// A state box whose "event" lands the moment the diagnostic reads it —
+    /// the exact race that produced `timed out waiting for 2 health events —
+    /// observed 2`, made deterministic.
+    private final class ArrivesWhenObserved: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+        private var reads = 0
+
+        /// Reading the observed state IS the arrival, so the value the
+        /// diagnostic would print always disagrees with the verdict that was
+        /// taken before it.
+        func read() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            reads += 1
+            count = 1
+            return count
+        }
+
+        var current: Int { lock.lock(); defer { lock.unlock() }; return count }
+        var observedReads: Int { lock.lock(); defer { lock.unlock() }; return reads }
+    }
+
+    @Test("waitFor's diagnostic can never contradict the verdict that produced it")
+    func waitForDiagnosticIsConsistentWithItsVerdict() async throws {
+        let state = ArrivesWhenObserved()
+
+        // Deadline in the past by construction: the loop body never runs, so
+        // this exercises exactly the post-deadline decision path.
+        let met = try await waitFor("1 event", deadline: .zero,
+                                    observed: { "\(state.read())" }) {
+            state.current >= 1
+        }
+
+        // The event arrived while the diagnostic was being composed, so this is
+        // a PASS. Under the pre-fix ordering the timeout was already recorded by
+        // then and the run carried the self-contradictory "timed out waiting for
+        // 1 event — observed 1" (assertion-hygiene rule 4's
+        // `expected: 6150, actual: 6150` shape).
+        #expect(met, "an event that landed during the diagnostic must be a pass, not a contradiction")
+        #expect(state.observedReads == 1, "the observed state must be read exactly once, on the failing path")
+    }
+
+    /// `finish()` is a happens-before, not a best effort: when it returns, every
+    /// block enqueued before it has reached the correlator. Callers depend on
+    /// that because they routinely reach `finish()` with replies in flight — a
+    /// wait that returns on a stream WRITE returns before that write's reply is
+    /// handled — and a `send(…)`-shaped command whose reply is never handed over
+    /// leaves a `withCheckedThrowingContinuation` suspended for the rest of the
+    /// run.
+    ///
+    /// The count is large enough to guarantee a real backlog at the call
+    /// (measured: 2,395–5,312 blocks still queued), so this is a drain
+    /// assertion rather than a formality.
+    @Test("ReplyFeed.finish() delivers every enqueued reply, backlog and all")
+    func finishDeliversBufferedReplies() async throws {
+        let (client, _, feed) = makeRespondingClient()
+        let blocks = 20_000
+        for _ in 0..<blocks {
+            feed.enqueue(.commandSucceeded(number: 0, fromClient: true, lines: []))
+        }
+
+        await feed.finish()
+
+        #expect(feed.delivered == blocks,
+                "finish() must not return before the buffer is drained (delivered \(feed.delivered) of \(blocks))")
+        // The feed holds the client weakly; keeping it alive here is what makes
+        // the deliveries above go through a real correlator.
+        withExtendedLifetime(client) {}
+    }
+}

--- a/Tests/TBDDaemonTests/ControlModeTestSupportTests.swift
+++ b/Tests/TBDDaemonTests/ControlModeTestSupportTests.swift
@@ -63,23 +63,65 @@ struct ControlModeTestSupportTests {
     /// leaves a `withCheckedThrowingContinuation` suspended for the rest of the
     /// run.
     ///
-    /// The count is large enough to guarantee a real backlog at the call
-    /// (measured: 2,395–5,312 blocks still queued), so this is a drain
-    /// assertion rather than a formality.
+    /// **The backlog is built by real commands, not by hand-fed reply blocks.**
+    /// `TmuxControlCommandClient.complete` pops `pending.removeFirst()`, so a
+    /// reply arriving against an EMPTY queue is a protocol violation: it takes
+    /// the teardown branch (`closed = true`, `onFatalError()`, one `logger.error`
+    /// each) and never correlates with anything. Enqueuing 20,000 bare
+    /// `.commandSucceeded` blocks would exercise only that desync path — a drain
+    /// assertion still, but with the correlator's actual job never once
+    /// performed, and 20,000 error-level log entries emitted per run. Writing
+    /// the commands first is what makes the sentence above true: each reply pops
+    /// its own command, in order, and every completion fires with `.success`.
+    ///
+    /// One `sendList` is deliberate rather than 20,000 `send(…)` calls: it
+    /// appends all 20,000 to `pending` and writes them as ONE stream write, and
+    /// `makeRespondingClient`'s `writeLine` splits that write back into 20,000
+    /// ordered replies — so the whole backlog is yielded inside a single actor
+    /// hop that `handle` cannot interleave with. That is what guarantees a real
+    /// backlog at the `finish()` call rather than a hoped-for one, and it shows
+    /// in the measurement: all 20,000 blocks are still queued at the call, on
+    /// every run (3/3 measured), where hand-fed blocks left an
+    /// already-partly-drained 2,395–5,312. Completions are plain closures, so
+    /// nothing here depends on a continuation resuming. The whole test takes
+    /// ~0.2 s.
     @Test("ReplyFeed.finish() delivers every enqueued reply, backlog and all")
     func finishDeliversBufferedReplies() async throws {
         let (client, _, feed) = makeRespondingClient()
         let blocks = 20_000
-        for _ in 0..<blocks {
-            feed.enqueue(.commandSucceeded(number: 0, fromClient: true, lines: []))
-        }
+        let succeeded = SuccessCounter()
+        await client.sendList((0..<blocks).map { index in
+            TmuxCommand(text: "display-message -p drain-\(index)") { result in
+                if case .success = result { succeeded.increment() }
+            }
+        })
 
+        // Measured before the drain gets a turn: this is the backlog the
+        // assertion below is actually about. Zero would make `delivered ==
+        // blocks` true by arithmetic rather than by draining, and the
+        // delete-`await drain.value` mutation would stop reddening.
+        let queuedAtFinish = blocks - feed.delivered
         await feed.finish()
 
+        #expect(queuedAtFinish > 0,
+                "no backlog at the call — this test would pass without draining anything")
         #expect(feed.delivered == blocks,
-                "finish() must not return before the buffer is drained (delivered \(feed.delivered) of \(blocks))")
+                "finish() must not return before the buffer is drained (delivered \(feed.delivered) of \(blocks), backlog at the call \(queuedAtFinish))")
+        // Every reply popped its own pending command and completed it: had they
+        // hit `complete`'s empty-queue teardown branch instead, no completion
+        // would have fired at all.
+        #expect(succeeded.count == blocks,
+                "replies must correlate to commands in order (\(succeeded.count) of \(blocks) completed with success)")
         // The feed holds the client weakly; keeping it alive here is what makes
         // the deliveries above go through a real correlator.
         withExtendedLifetime(client) {}
+    }
+
+    /// Thread-safe tally of command completions that resolved successfully.
+    private final class SuccessCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _count = 0
+        func increment() { lock.lock(); _count += 1; lock.unlock() }
+        var count: Int { lock.lock(); defer { lock.unlock() }; return _count }
     }
 }


### PR DESCRIPTION
## What's broken

Five tests fail under machine load and pass on rerun: both PTY-reap suites (`ChildReaperTests`, `TerminalTeardownReapTests`), `ControlModeInputHealthTests`, `TranscriptImageAttachmentTests.recycledHostingViewFetchesTheNewAttachmentsThumbnail`, and `ReplayLiveIntegrationMatrixTests`' firehose-overflow test. They are the remainder of the cluster from #618 and #622, and they are the reason "rerun once" is still standing advice — a tax every branch pays, and a habit that trains people past red suites.

## Why it happens

**All five are harness defects. None is a race in the code under test.** In two cases the tests' own surviving assertions actively exonerate production. Four distinct mechanisms:

- **A bound that existed only in a doc comment.** Both reap suites polled `while processExists(pid), polls < 50` with a 100 ms sleep — bounded in *iterations*, not wall time, since `Task.sleep` is a floor. Both suite headers claimed a "5 s cap", and the suite time limit was sized against that fiction. Meanwhile production reaps on a `.utility` queue *precisely because nothing waits on the result* — and the tests waited on it. There is no path where the reap block runs and fails; the only variable is when libdispatch schedules it. Late, never wrong.
- **A harness inventing concurrency production does not have.** `ControlModeInputHealthTests` spawned a fresh unstructured `Task` per tmux reply, so replies raced into a correlator that matches them to commands purely by order. Production drains from a single loop and cannot produce that interleaving. With verdicts `{fail, success, success}`, the `S,S,F` permutation means the second health transition is **never emitted at all** — the wait was not slow, it was waiting for something that would never arrive, and burned its full 90 s deadline. The comment asserting FIFO order was false.
- **An assertion racing a fire-and-forget effect through an evictable proxy.** The transcript test drove a SwiftUI decode with no completion signal and polled a process-shared 64-slot `NSCache` against a silent ~1 s budget — losable to a delayed decode *or* to eviction by an unserialized sibling suite.
- **A precondition load can silently prevent.** The firehose test needed ~192 KB delivered inside a fixed 2 s window; load compresses the external producer ~28×, delivering ~25–39 KB. The overflow never happened, so the repair correctly never triggered — and the failure read as a production defect.

## What this PR does

- **Reap suites** — `ChildReaper.drainPendingReaps` submits a barrier to the existing concurrent queue, so its completion means every reap that teardown enqueued has *finished*. That is an event, and unlike polling it distinguishes "not yet scheduled" from "reap failed". The barrier races a bounded guard so a reap parked on a child that never exits reds with a named diagnostic and still cleans the child up, rather than wedging the run.
- **Control mode** — a shared `ReplyFeed` enqueues replies synchronously in write order and one consumer awaits each `handle()` in turn, so completion order equals write order by construction. Fixed 50 ms settles become real quiescence signals.
- **Transcript** — `TranscriptImageService.onThumbnailRequest` fires on the decode *request*: synchronous, ordered, and nobody else's to evict. The test asserts the fetch its own docstring names.
- **Firehose** — the fixed stall becomes an observed one: keep not reading until `flowStats` shows the sink actually entered repair, with a diagnostic that separates "never overflowed" (harness) from "overflowed but never repaired" (production).

Also fixed along the way, none of which was the flake: a diagnostic that blamed production for a harness timeout (`try?` swallowed `CancellationError`, so the loop burned to poll 50 in microseconds and reported whatever it saw); probe `defer`s registered *after* their `#require`; and a failure path that could `waitpid` a pid the production reaper was already parked on.

**Two production changes, both additive test seams, and the only things here worth close review:** `ChildReaper.drainPendingReaps` and `TranscriptImageService.onThumbnailRequest`. Both are documented with their caveats — the barrier is process-wide and blocks blocks submitted after it; the callback is `@MainActor`-isolated on an already-`@MainActor` method.

**One deliberate tradeoff to disagree with if you want:** the overflow gate now *refuses* to run against a mid-repair baseline, with a named error, rather than measuring against poisoned state. That trades a rare false red for eliminating the vacuous-green class. It should be unreachable given phase-1 quiescence (it needs ~192 KB of unread bytes inside a sub-millisecond gap), and if it ever fires the message says plainly that it is load, not production.

## Evidence & verification

**Under the failure condition.** Three full-suite passes with load induced deliberately (10 spinners; load average peaked at **116**): **3/3 green**, 5797 tests each. The tier-3 live target passed serially (66 tests in 21 suites). Zero spinners and zero tmux servers survived. Targeted suites: 59 tests green across 5 consecutive loops at ~0.5 s; the live matrix 3/3 at ~1.8 s, down from 3.4–4.2 s now that its fixed 2 s stall is gone. Worst-case reap test time went from ~5 s to 0.49 s.

**Mutation-checked, each observed red then restored.** Deleting the production reap call reds in **0.004 s** — that speed *is* the proof the wait is an event rather than a window. `WNOHANG` on the reap reds 7 tests. A stuck reap (`trap '' HUP TERM`) reds 5 tests with the named `ReapDrainStalled` diagnostic and leaves **zero orphaned pids**. For control mode, a deterministic A/B: with the old per-write tasks plus a forced reply delay, **exactly the three tests whose replies can differ mid-flight fail and the other seven pass** — matching the CI signature on demand, where natural reproduction needs heavy load and hits ~1 in 10 — while the ordered feed passes all 16 under the same perturbation. Three production-mutation arms confirm those tests still discriminate rather than passing vacuously.

**The vacuous-pass class, found twice and closed twice.** The hardened firehose gate first read a *cumulative* repair counter, so a repair completed during phase 1 satisfied it on the first poll and the test could go green having induced nothing. Delta-gating fixed one of the gate's two accept conditions; the other, `repairing`, is a persistent flag and reopened the same hole. Both scenarios were constructed against a real `PaneFanout` and demonstrated in both directions — old gate accepts, new gate rejects.

**A coverage hole exposed by insisting on proof.** The transcript mutation came back *green*: reverting the `.onChange` staleness guard could not redden the test, because segment identity is keyed by image path, so swapping attachments rebuilds the view and `onAppear` refetches regardless. The old cache-based test was equally blind. `attachmentChangeRefetchesWhenTheViewIdentityIsStable` hosts the view under a stable identity and reds deterministically.

**Five briefed claims were disproved rather than implemented,** each by measurement: the green-run leak (traced to `SubprocessTimeoutTests`/`GitManagerTimeoutTests`' deliberately self-limiting grandchildren, not these suites — argv distinguishes them); the reap suites' ability to orphan at all (children sit on a PTY this process owns, so closing the master fd SIGHUPs them — measured `Z` within 0.5 s); `overflowEvents` as an overflow signal (incremented only on the *drop* branch, so gating on it would have hung every green run); the `.onChange` mutation above; and `ReplyFeed.finish()`'s supposed dropped replies (`AsyncStream` cancellation *is* `finish()`, and a 2,395–5,312-block backlog still delivered 20,000/20,000).

**Review coverage, stated exactly.** Two fresh-context adversarial rounds produced nine findings: eight fixed, one disproved by measurement. A third round stalled twice on the loaded box without producing findings, so it is not counted. `claude-review` on this PR is the independent third pass.

## Follow-ups, not in scope

- `GatedIntervalSleepTests` and `DaywatchRunnerTests` — poller loops, the migration where #622's re-arm rule matters most.
- The `no calls to throwing functions occur within 'try'` warnings in `TranscriptImageAttachmentTests` and the non-`Sendable` `NSString` capture in `TranscriptImageService` are pre-existing and deliberately untouched here.

Independent of #622 (event-driven test clock), which is approved and awaiting merge; this branch is cut from `main` and shares no files.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9EEB84BC-BF9D-408C-ACA1-4543A64AAA7C)
