### PR TITLE
Fix: the Watch Desk replaced a healthy judge every fifteen minutes

### DIFF
--- a/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
+++ b/Sources/TBDDaemon/Claude/LimitResumeActuator.swift
@@ -426,6 +426,12 @@ public struct LimitResumeActuator: LimitResumeActuating {
                 \(terminal.id.uuidString, privacy: .public) is dead — cancelling
                 """)
             return .notEligible(.terminalGone)
+        case .unverifiable(let error):
+            logger.warning("""
+                actuate: pane \(terminal.tmuxPaneID, privacy: .public) could not be verified \
+                (tmux unreachable: \(error, privacy: .public)) — failing closed
+                """)
+            return .notEligible(.failed("could not verify the target pane: \(error)"))
         case .live(let paneTerminalID):
             guard let paneTerminalID else {
                 // Absence is not disagreement: a pane spawned before TBD

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -794,13 +794,19 @@ public actor HibernationCoordinator {
         case .dead:
             disagreement = .processExited
         case .unverifiable(let error):
-            // Could not verify the pane's status (tmux unreachable). Fail closed:
-            // do not resume, treat as a disagreement condition.
-            disagreement = .paneMissing
+            // Not a POSITIVE disagreement — the same "probe merely threw" case
+            // the doc comment above already carves out, just arriving as a
+            // return value instead of a thrown error now that `paneSendTarget`
+            // can say "I could not look" directly. Conflating it with
+            // `.paneMissing` here would be exactly the fail-open collapse this
+            // PR removes everywhere else: an unanswerable tmux consultation
+            // reported as `sessionGone` on an already-awake row, dropping a
+            // caller's `initialPrompt` on a session that never actually died.
             logger.notice("""
                 wake: could not verify pane \(terminal.tmuxPaneID, privacy: .public) \
-                (tmux unreachable: \(error, privacy: .public)) — treating as missing
+                (tmux unreachable: \(error, privacy: .public)) — keeping the benign no-op
                 """)
+            return .notHibernated
         }
 
         logger.warning("""

--- a/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
+++ b/Sources/TBDDaemon/Lifecycle/HibernationCoordinator.swift
@@ -793,6 +793,14 @@ public actor HibernationCoordinator {
             disagreement = .paneMissing
         case .dead:
             disagreement = .processExited
+        case .unverifiable(let error):
+            // Could not verify the pane's status (tmux unreachable). Fail closed:
+            // do not resume, treat as a disagreement condition.
+            disagreement = .paneMissing
+            logger.notice("""
+                wake: could not verify pane \(terminal.tmuxPaneID, privacy: .public) \
+                (tmux unreachable: \(error, privacy: .public)) — treating as missing
+                """)
         }
 
         logger.warning("""

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -185,9 +185,11 @@ extension WorktreeLifecycle {
         // on. Rewriting such a row would orphan those live windows: the next
         // pass below probes the (empty) canonical server, concludes every
         // window is dead, and parks/deletes terminals that are actually alive.
-        // So: canonicalize ONLY when the stored server has no live window for
-        // this worktree's terminals — the genuinely-stale case the self-heal
-        // was built for.
+        // So: canonicalize ONLY on PROOF that the stored server has no live
+        // window for this worktree's terminals — the genuinely-stale case the
+        // self-heal was built for. A probe that could not be run is not that
+        // proof, and this rewrite is destructive enough that absence of evidence
+        // must not license it.
         let mainWorktrees = try await db.worktrees.listLocal(repoID: repoID, status: .main)
         for wt in (dbWorktrees + mainWorktrees) where wt.tmuxServer != correctTmuxServer {
             try await tmux.withServerResourceLock(server: wt.tmuxServer) {
@@ -195,9 +197,15 @@ extension WorktreeLifecycle {
                 // while we waited. Only judge the server whose lock we hold.
                 guard let current = try await db.worktrees.getLocal(id: wt.id),
                       current.tmuxServer == wt.tmuxServer else { return }
-                if await hasLiveWindow(server: current.tmuxServer, worktreeID: current.id) {
+                switch await liveWindowProbe(server: current.tmuxServer, worktreeID: current.id) {
+                case .live:
                     logger.info("reconcile: keeping non-canonical tmux server \(current.tmuxServer, privacy: .public) for worktree \(current.id, privacy: .public) — it has live windows (promoted-scratch inheritance)")
                     return
+                case .unverifiable(let reason):
+                    logger.notice("reconcile: keeping non-canonical tmux server \(current.tmuxServer, privacy: .public) for worktree \(current.id, privacy: .public) — could not prove it has no live windows: \(reason, privacy: .public)")
+                    return
+                case .noneLive:
+                    break
                 }
                 do {
                     try await db.worktrees.updateTmuxServer(
@@ -570,15 +578,27 @@ extension WorktreeLifecycle {
         // Probe the server each worktree row actually stores, not a canonical
         // name. Promoted scratch worktrees keep their inherited scratch server.
         // Cached per server name — rows overwhelmingly share one server.
-        var serverAliveByName: [String: Bool] = [:]
+        //
+        // Tri-state, not a Bool: parking a row and deleting a row are
+        // mutations, and a tmux that could not be reached is not a tmux that
+        // answered "gone". A server whose probe fails takes every one of its
+        // worktrees' terminals out of this pass rather than through it.
+        var serverExistenceByName: [String: TmuxTargetExistence] = [:]
         for wt in worktrees {
-            let serverAlive: Bool
-            if let cached = serverAliveByName[wt.tmuxServer] {
-                serverAlive = cached
+            let serverExistence: TmuxTargetExistence
+            if let cached = serverExistenceByName[wt.tmuxServer] {
+                serverExistence = cached
             } else {
-                serverAlive = await tmux.serverExists(server: wt.tmuxServer)
-                serverAliveByName[wt.tmuxServer] = serverAlive
+                serverExistence = await tmux.serverExistence(server: wt.tmuxServer)
+                serverExistenceByName[wt.tmuxServer] = serverExistence
             }
+            if case .unverifiable(let error) = serverExistence {
+                logger.notice("reconcile: leaving worktree \(wt.id, privacy: .public) terminals alone — server \(wt.tmuxServer, privacy: .public) could not be consulted: \(error, privacy: .public)")
+                continue
+            }
+            // `.gone` is the reboot case and is genuine proof every window died
+            // with it; `.exists` means each window still has to answer for itself.
+            let serverAlive = serverExistence == .exists
             let terminals = try await db.terminals.list(worktreeID: wt.id)
             // Parked rows (`hibernatedAt` OR legacy `suspendedAt` — see
             // `isParked`) are skipped: a parked terminal's window being gone
@@ -607,8 +627,18 @@ extension WorktreeLifecycle {
 
                 var windowAlive = false
                 if serverAlive {
-                    windowAlive = await tmux.windowExists(
-                        server: wt.tmuxServer, windowID: terminal.tmuxWindowID)
+                    switch await tmux.windowExistence(
+                        server: wt.tmuxServer, windowID: terminal.tmuxWindowID) {
+                    case .exists:
+                        windowAlive = true
+                    case .gone:
+                        windowAlive = false
+                    case .unverifiable(let error):
+                        // Absence of evidence. Skipping costs one deferred
+                        // park/delete; acting costs a live session's row.
+                        logger.notice("reconcile: leaving terminal \(terminal.id, privacy: .public) alone — window \(terminal.tmuxWindowID, privacy: .public) could not be consulted: \(error, privacy: .public)")
+                        continue
+                    }
                 }
 
                 if windowAlive {
@@ -805,19 +835,60 @@ extension WorktreeLifecycle {
         }
     }
 
-    /// True when `server` is up AND hosts a live tmux window for at least one
-    /// of `worktreeID`'s terminal rows. Used by the stale-server self-heal to
-    /// distinguish a genuinely dead/renamed server (safe to canonicalize)
+    /// What the stale-server self-heal was able to prove about `server`.
+    ///
+    /// Three answers, not two, because this probe's negative drives a
+    /// destructive mutation: rewriting a worktree's stored server orphans any
+    /// live windows on the old one, and the very next pass then reads those
+    /// orphans as dead and parks or deletes rows whose sessions are running. A
+    /// tmux that could not be reached must not be able to trigger that.
+    enum LiveWindowProbe: Equatable {
+        /// At least one window is confirmed alive on this server.
+        case live
+        /// PROOF there is nothing to orphan: the server is gone, or every one of
+        /// this worktree's windows was positively reported missing.
+        case noneLive
+        /// The probe could not be run. Proof of nothing.
+        case unverifiable(reason: String)
+    }
+
+    /// Probe whether `server` is up AND hosts a live tmux window for at least
+    /// one of `worktreeID`'s terminal rows. Used by the stale-server self-heal
+    /// to distinguish a genuinely dead/renamed server (safe to canonicalize)
     /// from a deliberately inherited one whose sessions are still running
     /// (promoted scratch space). Early-exits on the first live window.
-    private func hasLiveWindow(server: String, worktreeID: UUID) async -> Bool {
-        guard await tmux.serverExists(server: server) else { return false }
-        let terminals = (try? await db.terminals.list(worktreeID: worktreeID)) ?? []
+    func liveWindowProbe(server: String, worktreeID: UUID) async -> LiveWindowProbe {
+        switch await tmux.serverExistence(server: server) {
+        case .gone:
+            return .noneLive
+        case .unverifiable(let error):
+            return .unverifiable(reason: "server \(server) could not be reached: \(error)")
+        case .exists:
+            break
+        }
+        let terminals: [Terminal]
+        do {
+            terminals = try await db.terminals.list(worktreeID: worktreeID)
+        } catch {
+            // An unreadable terminal table is not an empty one, and `try?` here
+            // would let a database error license the rewrite.
+            return .unverifiable(reason: "terminal rows unreadable: \(error.localizedDescription)")
+        }
+        var unverifiable: String?
         for terminal in terminals {
-            if await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) {
-                return true
+            switch await tmux.windowExistence(server: server, windowID: terminal.tmuxWindowID) {
+            case .exists:
+                return .live
+            case .gone:
+                continue
+            case .unverifiable(let error):
+                // Keep looking: a later window may still prove the server live,
+                // which is a stronger answer than "could not tell". Only if no
+                // window is confirmed alive does this become the verdict.
+                unverifiable = unverifiable ?? "window \(terminal.tmuxWindowID): \(error)"
             }
         }
-        return false
+        if let unverifiable { return .unverifiable(reason: unverifiable) }
+        return .noneLive
     }
 }

--- a/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
+++ b/Sources/TBDDaemon/Lifecycle/WorktreeLifecycle+Reconcile.swift
@@ -659,6 +659,13 @@ extension WorktreeLifecycle {
                             }
                         case .missing:
                             break
+                        case .unverifiable(let error):
+                            // Same rule as the thrown-error case right below:
+                            // an unanswerable identity check is not evidence of
+                            // staleness. Keep the row and let a later sweep
+                            // retry the probe.
+                            logger.warning("reconcile: could not verify pane ownership for terminal \(terminal.id, privacy: .public): \(error, privacy: .public)")
+                            continue
                         }
                     } catch {
                         // An unreadable identity is not evidence of staleness.

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -134,16 +134,21 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// shift accumulates one per tick — the bug this rail was built to end. Three
     /// bounds the wreckage at three abandoned sessions and then says so out loud.
     ///
-    /// **Status: a compiled theory, and knowingly so.** By the battery in
-    /// `docs/theory-placement.md` this is a count-shaped constant two reasonable
-    /// projects could set differently, which puts it in the contested tier where
-    /// what matters is who chose it and how cheaply they can change their mind.
-    /// Nobody has chosen it yet: the reasoning above is the rationale for a
-    /// number, not a record of a human's decision on it, and no committed spec
-    /// covers it. It is written down here rather than left implicit so the
-    /// decision is visible to whoever makes it. That the bound must exist is not
-    /// in question — its absence is the incident this rail was built for — only
-    /// where the number should live.
+    /// **Status: a compiled theory, held deliberately.** By the battery in
+    /// `docs/theory-placement.md` a count-shaped constant two reasonable projects
+    /// could set differently sits in the contested tier, where what matters is
+    /// who chose it and how cheaply they can change their mind. The repo owner
+    /// reviewed this constant during review of the PR that introduced it and
+    /// directed that it stay at three, with the rationale above written down and
+    /// the exhaustion behaviour pinned by tests. That is the choice; this comment
+    /// is its record.
+    ///
+    /// What remains open is placement, not the number: whether the threshold
+    /// eventually belongs in the redesign's user-land path rather than here. It
+    /// cannot move there as things stand — the bound guards a spawn the daemon
+    /// makes on its own tick, and a sweep-program cannot refuse a spawn it never
+    /// sees — so relocating it means relocating the rail, which is the
+    /// fleet-supervision redesign's business rather than this constant's.
     private static let maxConsecutiveRecoverySpawnsWithoutNudge = 3
 
     // MARK: - Init

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -133,6 +133,17 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// agent process behind, and nothing reaps them. Unbounded, an overnight
     /// shift accumulates one per tick — the bug this rail was built to end. Three
     /// bounds the wreckage at three abandoned sessions and then says so out loud.
+    ///
+    /// **Status: a compiled theory, and knowingly so.** By the battery in
+    /// `docs/theory-placement.md` this is a count-shaped constant two reasonable
+    /// projects could set differently, which puts it in the contested tier where
+    /// what matters is who chose it and how cheaply they can change their mind.
+    /// Nobody has chosen it yet: the reasoning above is the rationale for a
+    /// number, not a record of a human's decision on it, and no committed spec
+    /// covers it. It is written down here rather than left implicit so the
+    /// decision is visible to whoever makes it. That the bound must exist is not
+    /// in question — its absence is the incident this rail was built for — only
+    /// where the number should live.
     private static let maxConsecutiveRecoverySpawnsWithoutNudge = 3
 
     // MARK: - Init

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -276,49 +276,6 @@ public actor DeskSessionManager: DeskSessionManaging {
         return wt
     }
 
-    /// Resolve the Watch Desk's *live* configured agent terminal, newest first.
-    ///
-    /// `TerminalStore.list` orders by `createdAt` ascending, so the previous
-    /// `terminals.first(where:)` deterministically returned the OLDEST row —
-    /// not a race, a guarantee. Desk terminal rows outlive their
-    /// panes: a session that dies, or was killed out-of-band by an older
-    /// Nightwatch handoff that bypassed TBD's terminal-close path,
-    /// leaves its row behind forever. The oldest row is therefore the one *most* likely
-    /// to be dead, and every handoff inserted another corpse ahead of the live desk.
-    ///
-    /// Observed in production: one desk carried three `Claude Code` rows, the nudge aimed
-    /// at the first, and the judge prompt was discarded every fifteen minutes for hours
-    /// while ticks kept correctly reporting queued judgment.
-    ///
-    /// Two guards make that impossible. Prefer the NEWEST row, and confirm its tmux window
-    /// still exists before sending. The liveness check is not redundant belt-and-braces:
-    /// tmux recycles pane IDs per server — both dead rows in the incident above had been
-    /// assigned `%1` — so a stale row can start resolving to a *live pane owned by an
-    /// unrelated session*, which would then receive a pasted judge prompt plus Enter. That
-    /// is issue #384, and picking the newest row alone would not prevent it.
-    ///
-    /// Neither guard is sufficient on its own, and neither proves *ownership*.
-    /// `windowExists` proves a window id resolves to SOME window;
-    /// `paneCurrentCommand` proves an agent of the right kind is in the
-    /// foreground of SOME pane. A recycled pane id running a stranger's Claude
-    /// satisfies both. So each surviving candidate is asked who it is
-    /// (`paneSendTarget`) and dropped when it answers with a different terminal
-    /// — see `paneIdentityPermitsSend`.
-    ///
-    /// Hibernated/suspended rows are excluded even if their tmux window still
-    /// exists: their pane contains a shell, not an agent, and pasting a judge
-    /// prompt there would execute it as shell input.
-    ///
-    /// - Returns: The newest matching agent terminal whose tmux window is still alive, or nil.
-    private func liveAgentTerminals(
-        worktreeID: UUID,
-        server: String,
-        kind: TerminalKind
-    ) async throws -> [Terminal] {
-        try await classifyAgentTerminals(
-            worktreeID: worktreeID, server: server, kind: kind).live
-    }
-
     /// What the desk's consultations proved about one candidate row.
     ///
     /// Two questions run over the same evidence and must not share an answer:
@@ -392,6 +349,41 @@ public actor DeskSessionManager: DeskSessionManaging {
         }
     }
 
+    /// Classify every candidate row of one kind — the desk's *live* agents,
+    /// newest first, plus what was proven about everyone else.
+    ///
+    /// `TerminalStore.list` orders by `createdAt` ascending, so the previous
+    /// `terminals.first(where:)` deterministically returned the OLDEST row —
+    /// not a race, a guarantee. Desk terminal rows outlive their
+    /// panes: a session that dies, or was killed out-of-band by an older
+    /// Nightwatch handoff that bypassed TBD's terminal-close path,
+    /// leaves its row behind forever. The oldest row is therefore the one *most* likely
+    /// to be dead, and every handoff inserted another corpse ahead of the live desk.
+    ///
+    /// Observed in production: one desk carried three `Claude Code` rows, the nudge aimed
+    /// at the first, and the judge prompt was discarded every fifteen minutes for hours
+    /// while ticks kept correctly reporting queued judgment.
+    ///
+    /// Two guards make that impossible. Prefer the NEWEST row, and confirm its tmux window
+    /// still exists before sending. The liveness check is not redundant belt-and-braces:
+    /// tmux recycles pane IDs per server — both dead rows in the incident above had been
+    /// assigned `%1` — so a stale row can start resolving to a *live pane owned by an
+    /// unrelated session*, which would then receive a pasted judge prompt plus Enter. That
+    /// is issue #384, and picking the newest row alone would not prevent it.
+    ///
+    /// Neither guard is sufficient on its own, and neither proves *ownership*.
+    /// `windowExists` proves a window id resolves to SOME window;
+    /// `paneCurrentCommand` proves an agent of the right kind is in the
+    /// foreground of SOME pane. A recycled pane id running a stranger's Claude
+    /// satisfies both. So each surviving candidate is asked who it is
+    /// (`paneSendTarget`) and dropped when it answers with a different terminal
+    /// — see `paneIdentityPermitsSend`.
+    ///
+    /// Hibernated/suspended rows are excluded even if their tmux window still
+    /// exists: their pane contains a shell, not an agent, and pasting a judge
+    /// prompt there would execute it as shell input.
+    ///
+    /// - Returns: The newest matching agent terminal whose tmux window is still alive, or nil.
     private func classifyAgentTerminals(
         worktreeID: UUID,
         server: String,
@@ -420,9 +412,10 @@ public actor DeskSessionManager: DeskSessionManaging {
     ///
     /// The identity question runs first because it is the only consultation that
     /// distinguishes "tmux looked and the pane is gone" from "tmux could not be
-    /// asked" — the distinction both callers hang on. `windowExists` and the
-    /// foreground-command check still gate `.live` exactly as before, so nothing
-    /// reaches a paste that would not have reached one previously.
+    /// asked" — the distinction both callers hang on. The window and
+    /// foreground-command checks still gate `.live` exactly as before, so nothing
+    /// reaches a paste that would not have reached one previously; all three now
+    /// answer that distinction rather than only the first.
     private func verdict(
         server: String,
         terminal: Terminal,
@@ -431,12 +424,26 @@ public actor DeskSessionManager: DeskSessionManaging {
         let identity = await paneIdentityVerdict(server: server, terminal: terminal)
         guard identity == .live else { return identity }
 
-        guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
+        switch await tmux.windowExistence(server: server, windowID: terminal.tmuxWindowID) {
+        case .exists:
+            break
+        case .gone:
             logger.notice("""
                 Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
                 window \(terminal.tmuxWindowID, privacy: .public) no longer exists
                 """)
             return .absent
+        case .unverifiable(let error):
+            // The same rule as the other two consultations. `windowExists` — the
+            // Bool this used to call — folds a wedged or unreachable server into
+            // "the window is gone", which is the exact collapse that licenses a
+            // spawn beside a healthy judge.
+            logger.notice("""
+                Skipping Watch Desk terminal \(terminal.id, privacy: .public): could not determine \
+                whether window \(terminal.tmuxWindowID, privacy: .public) still exists: \
+                \(error, privacy: .public)
+                """)
+            return .unknown
         }
 
         if tmux.verifiesPaneCurrentCommand {
@@ -559,15 +566,6 @@ public actor DeskSessionManager: DeskSessionManaging {
         }
     }
 
-    private func liveAgentTerminal(
-        worktreeID: UUID,
-        server: String,
-        kind: TerminalKind
-    ) async throws -> Terminal? {
-        try await liveAgentTerminals(
-            worktreeID: worktreeID, server: server, kind: kind).first
-    }
-
     /// Everything the desk knows about who is sitting at it, across both
     /// supported agent kinds.
     ///
@@ -633,8 +631,22 @@ public actor DeskSessionManager: DeskSessionManaging {
         guard !staffing.isStaffed else { return }
 
         if let previous = lastRecoveryTerminalID {
-            let rowStillExists = (try? await db.terminals.get(id: previous)) != nil
-            if rowStillExists && !staffing.provenAbsent(previous) {
+            let previousRow: Terminal?
+            do {
+                previousRow = try await db.terminals.get(id: previous)
+            } catch {
+                // "The table could not be read" is not "the row is gone". A
+                // `try?` here would let a database error license the spawn this
+                // gate exists to withhold — the same absence-as-evidence mistake
+                // the tmux consultations make when they collapse.
+                logger.notice("""
+                    Not spawning another Watch Desk agent: the terminal table could not be read, \
+                    so the previous recovery terminal \(previous, privacy: .public) has not been \
+                    accounted for: \(error.localizedDescription, privacy: .public)
+                    """)
+                return
+            }
+            if previousRow != nil && !staffing.provenAbsent(previous) {
                 logger.notice("""
                     Not spawning another Watch Desk agent: the previous recovery terminal \
                     \(previous, privacy: .public) has not been proven gone
@@ -759,8 +771,23 @@ public actor DeskSessionManager: DeskSessionManaging {
             // timer — and then, finding no judge, spawns a replacement beside
             // it. That pair is one bug, and this guard and the staffing proof
             // are its two halves.
-            let ownerRowExists = (try? await db.terminals.get(id: lease.terminalID)) != nil
-            guard !ownerRowExists || staffing.provenAbsent(lease.terminalID) else {
+            //
+            // A database error is not proof either: `try?` here would turn an
+            // unreadable terminal table into "the owner's row is gone" and revoke
+            // on it.
+            let ownerRow: Terminal?
+            do {
+                ownerRow = try await db.terminals.get(id: lease.terminalID)
+            } catch {
+                logger.notice("""
+                    Keeping Watch Desk judge lease generation \(lease.generation, privacy: .public): \
+                    the terminal table could not be read, which is not proof that owner \
+                    \(lease.terminalID, privacy: .public) is gone: \
+                    \(error.localizedDescription, privacy: .public)
+                    """)
+                return nil
+            }
+            guard ownerRow == nil || staffing.provenAbsent(lease.terminalID) else {
                 logger.notice("""
                     Keeping Watch Desk judge lease generation \(lease.generation, privacy: .public): \
                     owner \(lease.terminalID, privacy: .public) could not be consulted this tick, \

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -134,6 +134,13 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// shift accumulates one per tick — the bug this rail was built to end. Three
     /// bounds the wreckage at three abandoned sessions and then says so out loud.
     ///
+    /// What matters for a theory-shaped constant is who chose it and how cheaply
+    /// they can change their mind. Adam chose three on 2026-08-17, asked directly
+    /// with this rationale and the rejected alternatives in front of him, and
+    /// answered directly. That is the whole provenance: a decision in
+    /// conversation, not a review comment or a committed artifact — so if you go
+    /// looking in the PR record for it, that is why it is not there.
+    ///
     /// The bound's design, the alternatives weighed against it, and why the
     /// threshold stays compiled for now:
     /// `docs/specs/2026-08-14-watch-desk-recovery-bound-design.md`.

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -108,16 +108,31 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// `spawnRecoveryTerminalIfWarranted`.
     private var lastRecoveryTerminalID: UUID?
 
-    /// Replacements spawned since a nudge last reached a pane. Reset by a
-    /// delivered nudge and by closing the desk; bounded by
+    /// Replacements spawned since a nudge last reached a pane. Bounded by
     /// `maxConsecutiveRecoverySpawnsWithoutNudge` so a launch that dies on every
-    /// attempt cannot spawn forever.
+    /// attempt cannot spawn forever. Cleared only by `resetRecoveryBudget` — a
+    /// delivered nudge, a desk built fresh, or a desk closed.
     private var consecutiveRecoverySpawnsWithoutNudge = 0
 
     /// Deduplicates the give-up notification so the user is told once per
     /// incident rather than every tick. Cleared whenever the counter it guards is.
     private var notifiedRecoveryExhaustion = false
 
+    /// Three, because the two failure modes it sits between are asymmetric and
+    /// both real.
+    ///
+    /// One attempt is too few. A launch can fail for reasons that pass on their
+    /// own — a machine too loaded to start an agent, a tmux server mid-restart, a
+    /// profile being re-authenticated — and a cap of one would let a single
+    /// unlucky minute silence the desk until a human toggled the mode. Three
+    /// leaves two retries after the first failure, spread across roughly
+    /// forty-five minutes at the desk's fifteen-minute tick.
+    ///
+    /// Many attempts are too many, and the cost is not the retry but the debris:
+    /// every attempt that half-succeeds leaves a real tmux window and a real
+    /// agent process behind, and nothing reaps them. Unbounded, an overnight
+    /// shift accumulates one per tick — the bug this rail was built to end. Three
+    /// bounds the wreckage at three abandoned sessions and then says so out loud.
     private static let maxConsecutiveRecoverySpawnsWithoutNudge = 3
 
     // MARK: - Init
@@ -239,7 +254,10 @@ public actor DeskSessionManager: DeskSessionManaging {
             throw error
         }
 
-        // Spawn the configured primary agent for nightwatch operations.
+        // Spawn the configured primary agent for nightwatch operations. A desk
+        // built from scratch carries nothing forward from the last one, so any
+        // in-flight replacement incident ends here.
+        resetRecoveryBudget()
         do {
             _ = try await spawnDeskTerminal(worktree: wt, mode: mode)
         } catch {
@@ -657,6 +675,19 @@ public actor DeskSessionManager: DeskSessionManaging {
             .max(by: { ($0.createdAt, $0.id.uuidString) < ($1.createdAt, $1.id.uuidString) })?.id
     }
 
+    /// Clear the replacement budget and everything keyed to the same incident.
+    ///
+    /// Deliberately not called from `spawnDeskTerminal`: that is the function the
+    /// recovery rail calls to make an attempt, so clearing here would undo the
+    /// attempt it is about to count. The three callers are the three things that
+    /// genuinely end an incident — a nudge that reached a pane, a desk built from
+    /// scratch, and a desk closed.
+    private func resetRecoveryBudget() {
+        consecutiveRecoverySpawnsWithoutNudge = 0
+        notifiedRecoveryExhaustion = false
+        lastRecoveryTerminalID = nil
+    }
+
     /// Tell the user once that the desk has stopped trying to staff itself.
     /// Deduplicated on the same counter that stopped it, so a desk that recovers
     /// and fails again later is a new incident and notifies again.
@@ -1028,12 +1059,10 @@ public actor DeskSessionManager: DeskSessionManaging {
             lastNudgedMode = mode
 
             // A nudge landed, so the desk is staffed by something that took it:
-            // the replacement budget and its give-up notice both reset here, and
-            // only here. Any earlier reset (at spawn, say) would count a launch
-            // that never came up as a success.
-            consecutiveRecoverySpawnsWithoutNudge = 0
-            notifiedRecoveryExhaustion = false
-            lastRecoveryTerminalID = nil
+            // the replacement budget and its give-up notice reset here. A reset at
+            // spawn time instead would count a launch that never came up as a
+            // success — which is exactly how the backstop was first defeated.
+            resetRecoveryBudget()
 
             logger.debug("Nudged Watch Desk session: act=\(act, privacy: .public)")
         } catch {
@@ -1129,6 +1158,9 @@ public actor DeskSessionManager: DeskSessionManaging {
         }
 
         deskWorktreeID = nil
+        // The desk this budget was counting against no longer exists; the next
+        // one starts its own incident.
+        resetRecoveryBudget()
     }
 
     public func releaseJudgeLease(worktreeID: UUID) async {
@@ -1231,18 +1263,19 @@ public actor DeskSessionManager: DeskSessionManaging {
         // the actor, and this is the one chokepoint both spawn paths — fresh
         // create and crash recovery — pass through.
         //
-        // Recovery state resets too: a successful spawn clears the incident,
-        // so the new session's first tick should not be rate-limited by the
-        // dead session's consecutive failures.
-        //
         // Reset unconditionally, before the spawn can throw: over-signalling
         // costs one extra file Read, under-signalling costs a judge running an
         // unattended shift on instructions it never opened.
+        //
+        // The recovery budget deliberately does NOT reset here. This function is
+        // what `spawnRecoveryTerminalIfWarranted` calls to make its attempt, so a
+        // reset on this line would run before that caller's increment and pin
+        // `consecutiveRecoverySpawnsWithoutNudge` at 1 for every attempt — the
+        // backstop would never reach its cap. The budget belongs to the incident,
+        // not to the spawn: only a delivered nudge, a fresh desk, or a desk close
+        // clears it. See `resetRecoveryBudget`.
         lastNudgedMode = nil
         lastNudgeTime = nil
-        lastRecoveryTerminalID = nil
-        consecutiveRecoverySpawnsWithoutNudge = 0
-        notifiedRecoveryExhaustion = false
 
         // Lay the instructions down before the session exists, so a judge that
         // reads them on its own initiative — before its first tick ever fires —

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -670,9 +670,9 @@ public actor DeskSessionManager: DeskSessionManaging {
             (attempt \(self.consecutiveRecoverySpawnsWithoutNudge + 1, privacy: .public) \
             of \(Self.maxConsecutiveRecoverySpawnsWithoutNudge, privacy: .public))
             """)
-        let before = Set(((try? await db.terminals.list(worktreeID: worktree.id)) ?? []).map(\.id))
+        let spawned: [UUID]
         do {
-            try await spawnDeskTerminal(worktree: worktree, mode: mode)
+            spawned = try await spawnDeskTerminal(worktree: worktree, mode: mode)
         } catch {
             logger.warning("""
                 Failed to spawn a replacement Watch Desk agent: \
@@ -685,10 +685,23 @@ public actor DeskSessionManager: DeskSessionManaging {
             return
         }
         consecutiveRecoverySpawnsWithoutNudge += 1
-        let after = (try? await db.terminals.list(worktreeID: worktree.id)) ?? []
-        lastRecoveryTerminalID = after
-            .filter { !before.contains($0.id) }
+        // Take the id the spawn itself returned rather than diffing the terminal
+        // table around it. The desk is an ordinary sidebar-visible scratch
+        // worktree and this actor's gate serializes only its own methods, so a
+        // terminal the user opens during the spawn lands inside a before/after
+        // diff and would be adopted as the tracked replacement. A shell adopted
+        // that way can never be proven absent by an agent-kind consultation,
+        // which wedges gate 2 shut and stops recovery for that desk until
+        // someone closes the terminal by hand.
+        //
+        // Newest of the returned ids for the same reason the classification
+        // prefers newest: `spawnPrimaryTerminals` mints the primary agent first,
+        // and a later row is the more recent coordinate.
+        let spawnedRows = ((try? await db.terminals.list(worktreeID: worktree.id)) ?? [])
+            .filter { spawned.contains($0.id) }
+        lastRecoveryTerminalID = spawnedRows
             .max(by: { ($0.createdAt, $0.id.uuidString) < ($1.createdAt, $1.id.uuidString) })?.id
+            ?? spawned.last
     }
 
     /// Clear the replacement budget and everything keyed to the same incident.
@@ -1284,7 +1297,10 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// Note: Model selection (daywatch=Sonnet, nightwatch=Opus) requires per-profile configuration.
     /// The resolved profile's model is what gets used; mode affects behavior (conservative vs. free-acting),
     /// not the LLM model directly (that's a user's profile choice).
-    private func spawnDeskTerminal(worktree: Worktree, mode: NightwatchMode) async throws {
+    @discardableResult
+    private func spawnDeskTerminal(
+        worktree: Worktree, mode: NightwatchMode
+    ) async throws -> [UUID] {
         // Get initial prompt for mode (includes absolute skillDir paths and field learnings)
         let initialPrompt = NightwatchDeskPrompts.initialPrompt(mode: mode, skillDir: skillDir)
 
@@ -1337,8 +1353,9 @@ public actor DeskSessionManager: DeskSessionManaging {
         let actuationID = try await actuationLog.appendRequest(row)
 
         // Use production spawn path which handles trust, overlay, and all lifecycle concerns
+        let spawned: [(id: UUID, label: String)]
         do {
-            _ = try await lifecycle.spawnPrimaryTerminals(
+            spawned = try await lifecycle.spawnPrimaryTerminals(
                 worktree: worktree,
                 repo: nil,
                 skipClaude: false,
@@ -1362,6 +1379,7 @@ public actor DeskSessionManager: DeskSessionManaging {
         // Model follows the profile spawnPrimaryTerminals resolves internally —
         // resolving here too would just double the keychain-backed lookup.
         logger.info("Spawned desk terminal in \(worktree.id, privacy: .public)")
+        return spawned.map(\.id)
     }
 
 }

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -134,21 +134,9 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// shift accumulates one per tick — the bug this rail was built to end. Three
     /// bounds the wreckage at three abandoned sessions and then says so out loud.
     ///
-    /// **Status: a compiled theory, held deliberately.** By the battery in
-    /// `docs/theory-placement.md` a count-shaped constant two reasonable projects
-    /// could set differently sits in the contested tier, where what matters is
-    /// who chose it and how cheaply they can change their mind. The repo owner
-    /// reviewed this constant during review of the PR that introduced it and
-    /// directed that it stay at three, with the rationale above written down and
-    /// the exhaustion behaviour pinned by tests. That is the choice; this comment
-    /// is its record.
-    ///
-    /// What remains open is placement, not the number: whether the threshold
-    /// eventually belongs in the redesign's user-land path rather than here. It
-    /// cannot move there as things stand — the bound guards a spawn the daemon
-    /// makes on its own tick, and a sweep-program cannot refuse a spawn it never
-    /// sees — so relocating it means relocating the rail, which is the
-    /// fleet-supervision redesign's business rather than this constant's.
+    /// The bound's design, the alternatives weighed against it, and why the
+    /// threshold stays compiled for now:
+    /// `docs/specs/2026-08-14-watch-desk-recovery-bound-design.md`.
     private static let maxConsecutiveRecoverySpawnsWithoutNudge = 3
 
     // MARK: - Init
@@ -719,6 +707,13 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// Tell the user once that the desk has stopped trying to staff itself.
     /// Deduplicated on the same counter that stopped it, so a desk that recovers
     /// and fails again later is a new incident and notifies again.
+    ///
+    /// The dedup flag is set only after the write lands, matching
+    /// `notifiedContentionGeneration`. Setting it first would let one failed
+    /// write silence the incident permanently: the desk has stopped staffing
+    /// itself and looks exactly like a desk that is fine, which is the single
+    /// thing this notification exists to prevent. Every tick after a failure
+    /// therefore tries again, and the first one to succeed stops the retries.
     private func notifyRecoveryExhausted(worktree: Worktree) async {
         logger.error("""
             Watch Desk gave up spawning an agent after \
@@ -726,7 +721,6 @@ public actor DeskSessionManager: DeskSessionManaging {
             that never took a nudge; no further spawns until one succeeds
             """)
         guard !notifiedRecoveryExhaustion else { return }
-        notifiedRecoveryExhaustion = true
         do {
             let notification = try await db.notifications.create(
                 worktreeID: worktree.id,
@@ -741,10 +735,11 @@ public actor DeskSessionManager: DeskSessionManaging {
                 terminalID: notification.terminalID,
                 activate: false
             )))
+            notifiedRecoveryExhaustion = true
         } catch {
             logger.error("""
-                Could not record the Watch Desk recovery-exhausted notification: \
-                \(error.localizedDescription, privacy: .public)
+                Could not record the Watch Desk recovery-exhausted notification, \
+                will retry next tick: \(error.localizedDescription, privacy: .public)
                 """)
         }
     }

--- a/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
+++ b/Sources/TBDDaemon/Nightwatch/DeskSessionManager.swift
@@ -98,6 +98,28 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// generation. A new generation is a new incident and notifies again.
     private var notifiedContentionGeneration: Int64?
 
+    /// The agent this rail spawned the last time it found the desk empty.
+    ///
+    /// Bounds recovery on evidence rather than on a clock. A time-based limit
+    /// cannot help here: the desk ticks roughly every fifteen minutes, so any
+    /// interval short enough to allow real recovery is also short enough to
+    /// allow one abandoned agent per tick. Instead, a second replacement waits
+    /// until this one is gone from the database or PROVEN absent — see
+    /// `spawnRecoveryTerminalIfWarranted`.
+    private var lastRecoveryTerminalID: UUID?
+
+    /// Replacements spawned since a nudge last reached a pane. Reset by a
+    /// delivered nudge and by closing the desk; bounded by
+    /// `maxConsecutiveRecoverySpawnsWithoutNudge` so a launch that dies on every
+    /// attempt cannot spawn forever.
+    private var consecutiveRecoverySpawnsWithoutNudge = 0
+
+    /// Deduplicates the give-up notification so the user is told once per
+    /// incident rather than every tick. Cleared whenever the counter it guards is.
+    private var notifiedRecoveryExhaustion = false
+
+    private static let maxConsecutiveRecoverySpawnsWithoutNudge = 3
+
     // MARK: - Init
 
     public init(
@@ -123,38 +145,36 @@ public actor DeskSessionManager: DeskSessionManaging {
 
     /// Idempotent: ensure a Watch Desk scratch space exists.
     /// Returns existing desk worktree if already created, otherwise creates one.
-    /// On recovery, respawns the configured primary agent if it has no live pane
-    /// (H1 fix: desk dead after off→on cycle).
+    /// On recovery, respawns the configured primary agent only if the desk is genuinely
+    /// unstaffed (no live agent of any supported kind). Cross-kind incumbent reuse:
+    /// an intentional handoff to the non-preferred kind is preserved.
     /// - Parameter mode: The current nightwatch mode (daywatch or nightwatch)
     /// - Returns: The Worktree for the desk session
     public func ensureDeskSession(mode: NightwatchMode) async throws -> Worktree {
         await gateAcquire()
         defer { gateRelease() }
-        let preferredKind = try await preferredAgentKind()
 
         // Validate cached desk session: the row alone is not enough. Agent
         // processes can exit before their terminal row is removed, so require a
-        // live pane owned by the currently configured primary agent.
+        // live pane of either supported kind (not just the preferred one).
         if let cachedID = deskWorktreeID,
            let existing = try await db.worktrees.getLocal(id: cachedID),
            existing.status == .active {
-            if try await liveAgentTerminal(
-                worktreeID: existing.id,
-                server: existing.tmuxServer,
-                kind: preferredKind
-            ) != nil {
-                // Fast path: cached desk is alive and valid.
+            if await deskStaffing(worktree: existing.worktree).isStaffed {
+                // Fast path: cached desk is staffed by either kind.
                 // Mode switches (daywatch ↔ nightwatch) intentionally REUSE the existing desk and terminal.
                 // The desk is NOT respawned on mode switch because every tick re-derives the mode and
                 // rewrites JUDGE-INSTRUCTIONS.md to match. Since the judge is told to read that file once
                 // rather than per tick, reuse-without-respawn is exactly the case where a memorized copy
                 // can go stale — `nudgeDeskSession` compares against `lastNudgedMode` and flags the flip.
                 // Initial frame is one-time; steady-state mode is driven per-tick.
+                // Cross-kind reuse: a Codex judge, even if Claude is the configured preference,
+                // is an intentional handoff and must not be respawned.
                 return existing.worktree
             }
         }
 
-        // Cached entry was stale (archived or no terminal); clear it and fall through to recovery/create
+        // Cached entry was stale (archived or genuinely unstaffed); clear it and fall through to recovery/create
         deskWorktreeID = nil
 
         // Query by displayName to detect existing desk worktrees (active only).
@@ -164,21 +184,14 @@ public actor DeskSessionManager: DeskSessionManaging {
         if let existing = activeWorktrees.first(where: { $0.displayName == NightwatchDeskPrompts.deskDisplayName && $0.isScratch }) {
             deskWorktreeID = existing.id
 
-            // Ensure the recovered desk has a live configured agent; respawn if
-            // its row is missing OR its pane exited.
-            if try await liveAgentTerminal(
-                worktreeID: existing.id,
-                server: existing.tmuxServer,
-                kind: preferredKind
-            ) == nil {
-                logger.info("Recovered Watch Desk \(existing.id, privacy: .public) but no live \(preferredKind.rawValue, privacy: .public) terminal; respawning")
-                do {
-                    _ = try await spawnDeskTerminal(worktree: existing.worktree, mode: mode)
-                } catch {
-                    logger.warning("Failed to respawn terminal on recovery: \(error.localizedDescription, privacy: .public)")
-                    // Best-effort; don't fail the recovery
-                }
-            }
+            // Respawn only on proof that the desk has no agent of EITHER kind,
+            // and never more than once per unaccounted-for replacement — the
+            // whole rule lives in `spawnRecoveryTerminalIfWarranted` so this
+            // site and the nudge path cannot drift apart.
+            await spawnRecoveryTerminalIfWarranted(
+                worktree: existing.worktree,
+                mode: mode,
+                staffing: await deskStaffing(worktree: existing.worktree))
 
             logger.info("Reusing existing Watch Desk session: \(existing.id, privacy: .public)")
             return existing.worktree
@@ -284,6 +297,88 @@ public actor DeskSessionManager: DeskSessionManaging {
         server: String,
         kind: TerminalKind
     ) async throws -> [Terminal] {
+        try await classifyAgentTerminals(
+            worktreeID: worktreeID, server: server, kind: kind).live
+    }
+
+    /// What the desk's consultations proved about one candidate row.
+    ///
+    /// Two questions run over the same evidence and must not share an answer:
+    /// *may I paste into this pane?* and *is anyone already sitting at this
+    /// desk?* The first is satisfied only by `.live`. The second is satisfied by
+    /// `.live` **or** `.unknown`, because spawning is a creating act and may
+    /// happen only on proof of an empty desk — never on a consultation that
+    /// could not be run. One false negative that licenses a spawn becomes a new
+    /// abandoned agent on every tick for as long as the fault lasts.
+    private enum CandidateVerdict {
+        /// Pane exists, belongs to this row, and an agent of the row's kind is
+        /// in its foreground. The only verdict a send may act on.
+        case live
+        /// PROOF the row's coordinate holds no agent of ours: the window is
+        /// gone, tmux says the pane is gone, the pane's process has exited, the
+        /// pane now belongs to a different terminal, or it is running something
+        /// that is not this kind of agent.
+        case absent
+        /// A consultation could not be answered. Proof of nothing.
+        case unknown
+    }
+
+    /// Every candidate row of one kind, split by verdict — the single traversal
+    /// both questions read. `live` keeps its original order (newest first).
+    private struct CandidateClassification {
+        var live: [Terminal] = []
+        var absent: [Terminal] = []
+        var unknown: [Terminal] = []
+        /// The candidate rows themselves could not be read, so this desk has not
+        /// been ruled empty either. Separate from `unknown`, which names rows we
+        /// did read and could not consult.
+        var rowsUnreadable = false
+
+        /// The desk could not be read at all — staffed by the same rule that
+        /// governs every other unanswerable question here.
+        static var unreadable: CandidateClassification {
+            CandidateClassification(rowsUnreadable: true)
+        }
+
+        /// True unless every candidate was PROVEN absent. An empty desk with no
+        /// rows at all is unstaffed; a desk whose rows could not be consulted is
+        /// treated as staffed, which costs a skipped tick and prevents a spawn
+        /// nobody can justify.
+        var isStaffed: Bool { !live.isEmpty || !unknown.isEmpty || rowsUnreadable }
+
+        mutating func record(_ terminal: Terminal, _ verdict: CandidateVerdict) {
+            switch verdict {
+            case .live: live.append(terminal)
+            case .absent: absent.append(terminal)
+            case .unknown: unknown.append(terminal)
+            }
+        }
+
+        mutating func merge(_ other: CandidateClassification) {
+            live.append(contentsOf: other.live)
+            absent.append(contentsOf: other.absent)
+            unknown.append(contentsOf: other.unknown)
+        }
+
+        /// Whether this row was proven absent — the only evidence that justifies
+        /// replacing it, or stripping its lease. A row nobody could consult is
+        /// not "gone".
+        func provenAbsent(_ terminalID: UUID) -> Bool {
+            absent.contains { $0.id == terminalID }
+        }
+
+        /// Live candidates across both kinds, newest first. Secondary key on id:
+        /// Swift's sort is not stable and two rows can share a `createdAt`.
+        var liveNewestFirst: [Terminal] {
+            live.sorted { ($0.createdAt, $0.id.uuidString) > ($1.createdAt, $1.id.uuidString) }
+        }
+    }
+
+    private func classifyAgentTerminals(
+        worktreeID: UUID,
+        server: String,
+        kind: TerminalKind
+    ) async throws -> CandidateClassification {
         let candidates = try await db.terminals.list(worktreeID: worktreeID)
             .filter {
                 $0.suspendedAt == nil
@@ -294,31 +389,64 @@ public actor DeskSessionManager: DeskSessionManaging {
             // createdAt, so without it the winner between same-instant rows is arbitrary.
             .sorted { ($0.createdAt, $0.id.uuidString) > ($1.createdAt, $1.id.uuidString) }
 
-        var live: [Terminal] = []
+        var classification = CandidateClassification()
         for terminal in candidates {
-            guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
+            classification.record(
+                terminal,
+                await verdict(server: server, terminal: terminal, kind: kind))
+        }
+        return classification
+    }
+
+    /// Run every consultation against one candidate and reduce them to a verdict.
+    ///
+    /// The identity question runs first because it is the only consultation that
+    /// distinguishes "tmux looked and the pane is gone" from "tmux could not be
+    /// asked" — the distinction both callers hang on. `windowExists` and the
+    /// foreground-command check still gate `.live` exactly as before, so nothing
+    /// reaches a paste that would not have reached one previously.
+    private func verdict(
+        server: String,
+        terminal: Terminal,
+        kind: TerminalKind
+    ) async -> CandidateVerdict {
+        let identity = await paneIdentityVerdict(server: server, terminal: terminal)
+        guard identity == .live else { return identity }
+
+        guard await tmux.windowExists(server: server, windowID: terminal.tmuxWindowID) else {
+            logger.notice("""
+                Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
+                window \(terminal.tmuxWindowID, privacy: .public) no longer exists
+                """)
+            return .absent
+        }
+
+        if tmux.verifiesPaneCurrentCommand {
+            let command: String
+            do {
+                command = try await tmux.paneCurrentCommand(
+                    server: server, paneID: terminal.tmuxPaneID)
+            } catch {
+                // Same rule as the identity consultation: a query that could not
+                // run says nothing. It still bars a send (this returns a
+                // non-`live` verdict either way), but it must not be mistaken
+                // for an empty pane.
+                logger.notice("""
+                    Skipping Watch Desk terminal \(terminal.id, privacy: .public): could not read \
+                    the foreground process of pane \(terminal.tmuxPaneID, privacy: .public): \
+                    \(String(describing: error), privacy: .public)
+                    """)
+                return .unknown
+            }
+            guard Self.agentCommand(command, matches: kind) else {
                 logger.notice("""
                     Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
-                    window \(terminal.tmuxWindowID, privacy: .public) no longer exists
+                    pane exists but no \(kind.rawValue, privacy: .public) process is running
                     """)
-                continue
+                return .absent
             }
-            guard await paneIdentityPermitsSend(server: server, terminal: terminal) else { continue }
-            if tmux.verifiesPaneCurrentCommand {
-                guard let command = try? await tmux.paneCurrentCommand(
-                    server: server,
-                    paneID: terminal.tmuxPaneID
-                ), Self.agentCommand(command, matches: kind) else {
-                    logger.notice("""
-                        Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
-                        pane exists but no \(kind.rawValue, privacy: .public) process is running
-                        """)
-                    continue
-                }
-            }
-            live.append(terminal)
         }
-        return live
+        return .live
     }
 
     /// Ask a candidate's pane who it belongs to, before it can become the target
@@ -345,25 +473,30 @@ public actor DeskSessionManager: DeskSessionManaging {
     /// masquerade as the lease owner, nor pad the candidate count into a
     /// spurious fail-closed contention report.
     ///
-    /// - Returns: `true` when this pane may be sent to.
-    private func paneIdentityPermitsSend(server: String, terminal: Terminal) async -> Bool {
+    /// - Returns: `.live` when this pane may be sent to; `.absent` when tmux
+    ///   proved it holds nothing of ours; `.unknown` when nobody could tell.
+    ///   Only `.live` permits a send — the three-way split exists for the
+    ///   staffing question, which must not read "I could not look" as "empty".
+    private func paneIdentityVerdict(
+        server: String, terminal: Terminal
+    ) async -> CandidateVerdict {
         let target: PaneSendTarget
         do {
             target = try await tmux.paneSendTarget(server: server, paneID: terminal.tmuxPaneID)
         } catch {
             // The consultation could not be RUN at all (a wedged tmux tripping
             // the subprocess timeout) — no answer about the pane either way.
-            // Dropped, matching how the `paneCurrentCommand` check below already
-            // treats the same wedged server: `try?` there turns a failed query
-            // into a skipped candidate. Pasting a judge prompt into a pane we
-            // could not look at is exactly what this check exists to stop, and
-            // the cost of being wrong is only a skipped tick.
+            // Pasting a judge prompt into a pane we could not look at is exactly
+            // what this check exists to stop, and the cost of being wrong is a
+            // skipped tick. Replacing that pane on the same non-answer would
+            // cost an abandoned agent per tick, which is why this is `.unknown`
+            // and not `.absent`.
             logger.notice("""
                 Skipping Watch Desk terminal \(terminal.id, privacy: .public): could not verify \
                 pane \(terminal.tmuxPaneID, privacy: .public) belongs to it: \
                 \(String(describing: error), privacy: .public)
                 """)
-            return false
+            return .unknown
         }
 
         switch target {
@@ -372,17 +505,27 @@ public actor DeskSessionManager: DeskSessionManaging {
                 Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
                 pane \(terminal.tmuxPaneID, privacy: .public) no longer exists
                 """)
-            return false
+            return .absent
         case .dead:
             logger.notice("""
                 Skipping stale Watch Desk terminal \(terminal.id, privacy: .public): \
                 pane \(terminal.tmuxPaneID, privacy: .public) is dead
                 """)
-            return false
+            return .absent
+        case .unverifiable(let error):
+            // Loud, and carrying tmux's own words: a rail that both refuses to
+            // send AND refuses to respawn has gone quiet on purpose, and the
+            // only way anyone finds out why is this line.
+            logger.warning("""
+                Skipping Watch Desk terminal \(terminal.id, privacy: .public): could not consult \
+                pane \(terminal.tmuxPaneID, privacy: .public) — \(error, privacy: .public). \
+                Nothing will be pasted into it, and nothing will be spawned beside it
+                """)
+            return .unknown
         case .live(let paneTerminalID):
-            guard let paneTerminalID else { return true }
+            guard let paneTerminalID else { return .live }
             guard paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString) != .orderedSame
-            else { return true }
+            else { return .live }
             // Logged distinctly and loudly: to every caller this looks like an
             // ordinary absence, and "no live terminal" is a sentence this rail
             // prints for half a dozen benign reasons. A pane that has changed
@@ -394,7 +537,7 @@ public actor DeskSessionManager: DeskSessionManaging {
                 \(paneTerminalID, privacy: .public) — nothing will be pasted into it \
                 (tmux reuses pane ids, so this coordinate is stale)
                 """)
-            return false
+            return .absent
         }
     }
 
@@ -407,23 +550,160 @@ public actor DeskSessionManager: DeskSessionManaging {
             worktreeID: worktreeID, server: server, kind: kind).first
     }
 
-    private func liveJudgeCandidates(worktree: Worktree) async throws -> [Terminal] {
-        let claude = try await liveAgentTerminals(
-            worktreeID: worktree.id, server: worktree.tmuxServer, kind: .claude)
-        let codex = try await liveAgentTerminals(
-            worktreeID: worktree.id, server: worktree.tmuxServer, kind: .codex)
-        return (claude + codex).sorted {
-            ($0.createdAt, $0.id.uuidString) > ($1.createdAt, $1.id.uuidString)
+    /// Everything the desk knows about who is sitting at it, across both
+    /// supported agent kinds.
+    ///
+    /// Cross-kind on purpose: a Nightwatch handoff can legitimately replace a
+    /// Claude judge with a Codex one (or the reverse), and that successor is the
+    /// desk's agent even though it is not the configured primary preference.
+    /// Resolving only the preferred kind reads a live incumbent as an empty desk
+    /// and spawns a second agent beside it.
+    private func deskStaffing(worktree: Worktree) async -> CandidateClassification {
+        var staffing = CandidateClassification()
+        for kind in [TerminalKind.claude, .codex] {
+            do {
+                staffing.merge(try await classifyAgentTerminals(
+                    worktreeID: worktree.id, server: worktree.tmuxServer, kind: kind))
+            } catch {
+                // The row read itself failed, so this desk has not been ruled
+                // empty — the same rule the per-pane consultations follow. A
+                // sentinel `unknown` entry carries that through `isStaffed`
+                // without inventing a Terminal nobody read.
+                logger.warning("""
+                    Watch Desk staffing unknown: could not read \
+                    \(kind.rawValue, privacy: .public) terminal rows: \
+                    \(error.localizedDescription, privacy: .public)
+                    """)
+                return CandidateClassification.unreadable
+            }
         }
+        if staffing.live.isEmpty && !staffing.unknown.isEmpty {
+            logger.notice("""
+                Watch Desk has no confirmed live agent, but \(staffing.unknown.count) \
+                candidate(s) could not be consulted — treating the desk as staffed. \
+                Nothing will be spawned until a consultation proves the desk is empty
+                """)
+        }
+        return staffing
+    }
+
+    /// Replace the desk's agent — but only on proof that it has none, and never
+    /// more than once until that replacement is accounted for.
+    ///
+    /// Both recovery sites call this, so the rule cannot drift between them.
+    /// Three gates, in order:
+    ///
+    /// 1. **Proof.** `staffing.isStaffed` is false only when every candidate was
+    ///    positively ruled absent. An unanswerable consultation leaves the desk
+    ///    staffed and nothing is spawned.
+    /// 2. **The previous replacement.** A desk terminal row outlives its pane, so
+    ///    "did the last recovery work?" cannot be answered by the row's
+    ///    existence. It is answered by the same classification: spawn again only
+    ///    once that row is gone from the database or proven absent. This is what
+    ///    turns a repeating fault into ONE extra terminal instead of one per
+    ///    tick, and it still lets a genuinely dead replacement be replaced.
+    /// 3. **A backstop count.** A launch that dies every time would satisfy gate
+    ///    2 forever. After `maxConsecutiveRecoverySpawnsWithoutNudge` spawns with
+    ///    no nudge ever landing, the rail stops and says so — a Watch Desk that
+    ///    has quietly given up looks exactly like one that is fine, so this is a
+    ///    notification and not only a log line.
+    private func spawnRecoveryTerminalIfWarranted(
+        worktree: Worktree,
+        mode: NightwatchMode,
+        staffing: CandidateClassification
+    ) async {
+        guard !staffing.isStaffed else { return }
+
+        if let previous = lastRecoveryTerminalID {
+            let rowStillExists = (try? await db.terminals.get(id: previous)) != nil
+            if rowStillExists && !staffing.provenAbsent(previous) {
+                logger.notice("""
+                    Not spawning another Watch Desk agent: the previous recovery terminal \
+                    \(previous, privacy: .public) has not been proven gone
+                    """)
+                return
+            }
+        }
+
+        guard consecutiveRecoverySpawnsWithoutNudge < Self.maxConsecutiveRecoverySpawnsWithoutNudge
+        else {
+            await notifyRecoveryExhausted(worktree: worktree)
+            return
+        }
+
+        logger.notice("""
+            Watch Desk has no live agent; spawning a replacement \
+            (attempt \(self.consecutiveRecoverySpawnsWithoutNudge + 1, privacy: .public) \
+            of \(Self.maxConsecutiveRecoverySpawnsWithoutNudge, privacy: .public))
+            """)
+        let before = Set(((try? await db.terminals.list(worktreeID: worktree.id)) ?? []).map(\.id))
+        do {
+            try await spawnDeskTerminal(worktree: worktree, mode: mode)
+        } catch {
+            logger.warning("""
+                Failed to spawn a replacement Watch Desk agent: \
+                \(error.localizedDescription, privacy: .public)
+                """)
+            // A spawn that threw still counts against the backstop: the failure
+            // mode this bounds is "keeps trying, never works", and a launch that
+            // cannot even start is the purest form of it.
+            consecutiveRecoverySpawnsWithoutNudge += 1
+            return
+        }
+        consecutiveRecoverySpawnsWithoutNudge += 1
+        let after = (try? await db.terminals.list(worktreeID: worktree.id)) ?? []
+        lastRecoveryTerminalID = after
+            .filter { !before.contains($0.id) }
+            .max(by: { ($0.createdAt, $0.id.uuidString) < ($1.createdAt, $1.id.uuidString) })?.id
+    }
+
+    /// Tell the user once that the desk has stopped trying to staff itself.
+    /// Deduplicated on the same counter that stopped it, so a desk that recovers
+    /// and fails again later is a new incident and notifies again.
+    private func notifyRecoveryExhausted(worktree: Worktree) async {
+        logger.error("""
+            Watch Desk gave up spawning an agent after \
+            \(Self.maxConsecutiveRecoverySpawnsWithoutNudge, privacy: .public) attempts \
+            that never took a nudge; no further spawns until one succeeds
+            """)
+        guard !notifiedRecoveryExhaustion else { return }
+        notifiedRecoveryExhaustion = true
+        do {
+            let notification = try await db.notifications.create(
+                worktreeID: worktree.id,
+                type: .error,
+                message: "Watch Desk could not start an agent after \(Self.maxConsecutiveRecoverySpawnsWithoutNudge) attempts. Nightwatch judgment is paused. Open the desk and start an agent, or turn the mode off and on once the cause is fixed."
+            )
+            subscriptions?.broadcast(delta: .notificationReceived(NotificationDelta(
+                notificationID: notification.id,
+                worktreeID: notification.worktreeID,
+                type: notification.type,
+                message: notification.message,
+                terminalID: notification.terminalID,
+                activate: false
+            )))
+        } catch {
+            logger.error("""
+                Could not record the Watch Desk recovery-exhausted notification: \
+                \(error.localizedDescription, privacy: .public)
+                """)
+        }
+    }
+
+    /// Live judge candidates of either kind, newest first — `deskStaffing`'s
+    /// `live` set in the order the lease logic wants it.
+    private func liveJudgeCandidates(worktree: Worktree) async -> [Terminal] {
+        await deskStaffing(worktree: worktree).liveNewestFirst
     }
 
     /// Resolve the sole mutable judge. Existing valid ownership wins even when
     /// observers are present. With no lease, multiple candidates are ambiguous
     /// and fail closed rather than selecting by recency.
     private func leasedJudgeTerminal(
-        worktree: Worktree
+        worktree: Worktree,
+        staffing: CandidateClassification
     ) async throws -> (Terminal, WatchDeskLease, String)? {
-        var candidates = try await liveJudgeCandidates(worktree: worktree)
+        var candidates = staffing.liveNewestFirst
         let now = now()
 
         if let lease = try await db.watchDeskLeases.status(worktreeID: worktree.id),
@@ -438,11 +718,30 @@ public actor DeskSessionManager: DeskSessionManaging {
                 notifiedContentionGeneration = nil
                 return (owner, renewed, credentialFile)
             }
+            // Revoking is a mutation. It strips a running judge of its authority
+            // mid-shift, and the judge cannot undo it or even see it coming —
+            // its next renew simply comes back fenced. So revocation takes the
+            // same proof spawning takes: the owner's row must be gone, or a
+            // consultation must have positively placed its pane absent.
+            // "Nobody could reach tmux this tick" is not evidence that the
+            // incumbent died. Treating it as such demotes a healthy judge on a
+            // timer — and then, finding no judge, spawns a replacement beside
+            // it. That pair is one bug, and this guard and the staffing proof
+            // are its two halves.
+            let ownerRowExists = (try? await db.terminals.get(id: lease.terminalID)) != nil
+            guard !ownerRowExists || staffing.provenAbsent(lease.terminalID) else {
+                logger.notice("""
+                    Keeping Watch Desk judge lease generation \(lease.generation, privacy: .public): \
+                    owner \(lease.terminalID, privacy: .public) could not be consulted this tick, \
+                    which is not proof that it is gone — skipping this nudge rather than revoking
+                    """)
+                return nil
+            }
             logger.warning("Revoking Watch Desk judge lease generation \(lease.generation): owner pane is gone")
             try await db.watchDeskLeases.revoke(worktreeID: worktree.id)
             subscriptions?.broadcast(delta: .watchDeskRolesChanged(
                 WorktreeIDDelta(worktreeID: worktree.id)))
-            candidates = try await liveJudgeCandidates(worktree: worktree)
+            candidates = await liveJudgeCandidates(worktree: worktree)
         }
 
         guard candidates.count <= 1 else {
@@ -533,7 +832,8 @@ public actor DeskSessionManager: DeskSessionManaging {
             }
 
             guard let (agentTerminal, _, _) = try await leasedJudgeTerminal(
-                worktree: worktree.worktree
+                worktree: worktree.worktree,
+                staffing: await deskStaffing(worktree: worktree.worktree)
             ) else {
                 logger.warning("No uniquely owned live terminal in Watch Desk; skipping wrap-up prompt")
                 return
@@ -619,23 +919,32 @@ public actor DeskSessionManager: DeskSessionManaging {
             }
 
             var preferredKind = try await preferredAgentKind()
-            var judge = try await leasedJudgeTerminal(worktree: worktree.worktree)
-            if judge == nil,
-               try await liveJudgeCandidates(worktree: worktree.worktree).isEmpty {
+            // One traversal per tick, shared by both questions it answers:
+            // who may be nudged, and whether the desk is empty enough to staff.
+            let staffing = await deskStaffing(worktree: worktree.worktree)
+            var judge = try await leasedJudgeTerminal(
+                worktree: worktree.worktree, staffing: staffing)
+            if judge == nil {
                 // A terminal row can survive a process/pane exit. Recover in the
                 // nudge path itself so one failed launch does not turn into a
                 // silent all-night outage waiting for a mode toggle or daemon
                 // restart. spawnPrimaryTerminals uses the same configured
                 // primary-agent preference and production launch path as normal
                 // worktrees.
-                logger.notice("No live \(preferredKind.rawValue, privacy: .public) Watch Desk terminal; retrying spawn before nudge")
-                do {
-                    try await spawnDeskTerminal(worktree: worktree.worktree, mode: mode)
+                //
+                // Having no *judge* is not the same as having no *agent*: the
+                // lease can be unresolved while a live incumbent sits right
+                // there, so what gates the spawn is the staffing proof, not this
+                // branch.
+                let spawnedCount = consecutiveRecoverySpawnsWithoutNudge
+                await spawnRecoveryTerminalIfWarranted(
+                    worktree: worktree.worktree, mode: mode, staffing: staffing)
+                if consecutiveRecoverySpawnsWithoutNudge != spawnedCount {
                     // Re-read in case the preference changed while spawning.
                     preferredKind = try await preferredAgentKind()
-                    judge = try await leasedJudgeTerminal(worktree: worktree.worktree)
-                } catch {
-                    logger.warning("Failed to recover Watch Desk terminal before nudge: \(error.localizedDescription, privacy: .public)")
+                    judge = try await leasedJudgeTerminal(
+                        worktree: worktree.worktree,
+                        staffing: await deskStaffing(worktree: worktree.worktree))
                 }
             }
 
@@ -717,6 +1026,14 @@ public actor DeskSessionManager: DeskSessionManaging {
             // or the next tick would tell it nothing changed when everything did.
             lastNudgeTime = now()
             lastNudgedMode = mode
+
+            // A nudge landed, so the desk is staffed by something that took it:
+            // the replacement budget and its give-up notice both reset here, and
+            // only here. Any earlier reset (at spawn, say) would count a launch
+            // that never came up as a success.
+            consecutiveRecoverySpawnsWithoutNudge = 0
+            notifiedRecoveryExhaustion = false
+            lastRecoveryTerminalID = nil
 
             logger.debug("Nudged Watch Desk session: act=\(act, privacy: .public)")
         } catch {
@@ -838,7 +1155,9 @@ public actor DeskSessionManager: DeskSessionManaging {
         defer { gateRelease() }
         do {
             guard let worktree = try await db.worktrees.getLocal(id: worktreeID) else { return }
-            _ = try await leasedJudgeTerminal(worktree: worktree.worktree)
+            _ = try await leasedJudgeTerminal(
+                worktree: worktree.worktree,
+                staffing: await deskStaffing(worktree: worktree.worktree))
         } catch {
             logger.error("Failed to maintain Watch Desk judge lease: \(error.localizedDescription, privacy: .public)")
         }
@@ -912,11 +1231,18 @@ public actor DeskSessionManager: DeskSessionManaging {
         // the actor, and this is the one chokepoint both spawn paths — fresh
         // create and crash recovery — pass through.
         //
+        // Recovery state resets too: a successful spawn clears the incident,
+        // so the new session's first tick should not be rate-limited by the
+        // dead session's consecutive failures.
+        //
         // Reset unconditionally, before the spawn can throw: over-signalling
         // costs one extra file Read, under-signalling costs a judge running an
         // unattended shift on instructions it never opened.
         lastNudgedMode = nil
         lastNudgeTime = nil
+        lastRecoveryTerminalID = nil
+        consecutiveRecoverySpawnsWithoutNudge = 0
+        notifiedRecoveryExhaustion = false
 
         // Lay the instructions down before the session exists, so a judge that
         // reads them on its own initiative — before its first tick ever fires —

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -3101,6 +3101,12 @@ extension RPCRouter {
                 dead (its process has exited) — nothing was sent; recreate the terminal's \
                 window first
                 """)
+        case .unverifiable(let error):
+            return PaneSendRefusal(outcome: .transportFailed, message: """
+                could not verify tmux pane \(terminal.tmuxPaneID) for terminal \
+                \(terminal.id.uuidString) on server \(server) (tmux unreachable: \(error)) — \
+                nothing was sent
+                """)
         case .live(let paneTerminalID):
             guard let paneTerminalID else {
                 // Absence is not disagreement. A pane spawned before TBD stamped

--- a/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
+++ b/Sources/TBDDaemon/Server/RPCRouter+TerminalHandlers.swift
@@ -781,6 +781,16 @@ extension RPCRouter {
                     window first
                     """,
                 code: RPCErrorCode.terminalSessionGone.rawValue)
+        case .unverifiable(let error):
+            // Absence of evidence, not evidence of absence — the whole point of
+            // this case (see `PaneSendTarget.unverifiable`). Refusing to compose
+            // an attach command is the safe default; it must not be conflated
+            // with `.terminalSessionGone`, which asserts the pane IS gone.
+            return RPCResponse(
+                error: """
+                    could not verify tmux pane \(probedPaneID) for terminal \(terminal.id) on \
+                    server \(server) (tmux unreachable: \(error)) — no command was composed
+                    """)
         case .live(let paneTerminalID):
             if let paneTerminalID,
                paneTerminalID.caseInsensitiveCompare(terminal.id.uuidString) != .orderedSame {

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -19,6 +19,21 @@ public enum PaneSendTarget: Sendable, Equatable {
     /// answered with, or `nil` when the pane carries no identity to compare —
     /// a pane spawned before TBD stamped one, or by something outside TBD.
     case live(terminalID: String?)
+    /// The consultation could not be answered at all: tmux failed for a reason
+    /// that says nothing about this pane — no server on that socket, a lost or
+    /// mismatched server, a tmux that would not run.
+    ///
+    /// Distinct from `.missing`, and the distinction is the whole point. Both
+    /// fail a send closed, so no caller that types into panes changes
+    /// behaviour. But `.missing` is *evidence the pane is gone* and
+    /// `.unverifiable` is *the absence of evidence*, and a caller that reacts to
+    /// absence by CREATING something — respawning an agent, say — must never
+    /// act on the second. Collapsing the two is how one unanswerable query
+    /// becomes a new terminal on every tick, forever.
+    ///
+    /// Carries tmux's own exit status and output, because a rail that refuses
+    /// to act should be able to say why it could not look.
+    case unverifiable(error: String)
 }
 
 /// One session on a tmux server, with everything reconcile needs to date its
@@ -864,6 +879,25 @@ public struct TmuxManager: Sendable {
         return (.missing, nil)
     }
 
+    /// Whether tmux's own failure text says it resolved the target and found
+    /// nothing — the one non-zero exit that is an answer rather than a failure.
+    ///
+    /// tmux prints `can't find pane: %N` (and the window/session variants when
+    /// the pane's container is what vanished) and exits 1. Every other non-zero
+    /// exit reports a tmux that could not be consulted, and is deliberately NOT
+    /// matched here: this predicate exists to keep "gone" narrow, because it is
+    /// the branch that lets callers act on absence.
+    ///
+    /// Matching tmux's error text is not screen-scraping: this is a CLI tool's
+    /// documented stderr on its own failure path, read from a subprocess we ran,
+    /// not state inferred from a rendered TUI. It is also fail-safe by
+    /// construction — if tmux ever rewords these messages, an absent pane
+    /// degrades to `.unverifiable`, which every caller already handles by doing
+    /// nothing rather than by acting.
+    static func reportsTargetNotFound(_ output: String) -> Bool {
+        output.lowercased().contains("can't find")
+    }
+
     /// The exact assignment shape `newWindowCommand` and `respawnWindowCommand`
     /// emit for one entry of the `env` map. Both build the prefix from the one
     /// shared `envExportPrefixed`, so a pane spawned either way — including the
@@ -1308,8 +1342,22 @@ public struct TmuxManager: Sendable {
         let args = Self.paneSendTargetQuery(server: server, paneID: paneID)
         do {
             return Self.parsePaneSendProbe(try await runTmux(args), paneID: paneID)
-        } catch TmuxError.commandFailed {
-            return (.missing, nil)
+        } catch TmuxError.commandFailed(_, let status, let output) {
+            // A non-zero exit is an ANSWER only when tmux says it looked and found
+            // nothing: `can't find pane: %N` (also `can't find window`/`session`
+            // when the pane's window or session is what vanished). Everything else
+            // with a non-zero status — `error connecting to <socket>`, a lost or
+            // version-mismatched server, a tmux that would not run at all — is the
+            // query failing, not the pane being gone, and is reported as such so
+            // callers can tell "it is not there" from "I could not look".
+            //
+            // `timedOut` deliberately still propagates: the wake path catches it to
+            // leave a row hibernated for retry (see `TmuxError.timedOut`), and
+            // swallowing it here would silently retarget that behaviour.
+            if Self.reportsTargetNotFound(output) { return (.missing, nil) }
+            return (.unverifiable(
+                error: "tmux list-panes exited \(status): "
+                    + output.trimmingCharacters(in: .whitespacesAndNewlines)), nil)
         }
     }
 

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -1604,12 +1604,17 @@ public struct TmuxManager: Sendable {
     /// Check whether a tmux window exists by querying list-panes.
     ///
     /// Collapses `.unverifiable` into `false`, which is what this method has
-    /// always done and what its Bool-shaped callers already assume: they use it
-    /// to decide whether to bother with a window, and skipping one they could not
-    /// consult is harmless. Callers that act *because* a window is gone — the
-    /// Watch Desk's spawn and lease-revocation rails — must use
-    /// `windowExistence` instead, so absence of evidence cannot license a
-    /// creating or destroying act.
+    /// always done. That collapse is harmless for a caller that merely skips a
+    /// window it could not consult, but NOT audited or guaranteed harmless for
+    /// every existing Bool-shaped caller in this codebase — at least one
+    /// (`HibernationCoordinator.wakeTmuxSection`) acts on a `false` result by
+    /// creating a replacement window, which is exactly the kind of act
+    /// `.unverifiable` must not license. Migrating every such caller to
+    /// `windowExistence` is a larger change than this fix; new callers that act
+    /// *because* a window is gone — the Watch Desk's spawn and
+    /// lease-revocation rails already do — must use `windowExistence`, and an
+    /// existing caller found to have the same problem should migrate too
+    /// rather than lean on this doc comment's old, overstated claim.
     public func windowExists(server: String, windowID: String) async -> Bool {
         await windowExistence(server: server, windowID: windowID) == .exists
     }

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -115,7 +115,7 @@ actor TmuxServerResourceCoordinator {
 /// found. The Watch Desk reads this verdict to decide whether to spawn an agent
 /// and whether to revoke a running judge's lease — both acts that may follow
 /// only from evidence.
-public enum WindowExistence: Sendable, Equatable {
+public enum TmuxTargetExistence: Sendable, Equatable {
     /// tmux resolved the window id.
     case exists
     /// PROOF the window is gone: tmux looked and said it could not find it.
@@ -161,7 +161,11 @@ public struct TmuxManager: Sendable {
     /// precedence over `dryRunWindowIsDead`. Only this seam can express the third
     /// answer — `.unverifiable` — which the Bool hook cannot say and which is
     /// exactly the case the desk must not act on.
-    public let dryRunWindowExistence: (@Sendable (String, String) -> WindowExistence?)?
+    public let dryRunWindowExistence: (@Sendable (String, String) -> TmuxTargetExistence?)?
+    /// Optional test hook consulted by `serverExistence` in dryRun mode. Without
+    /// it dryRun reports every server as up, which cannot express the
+    /// unreachable-server case the stale-server self-heal must refuse to act on.
+    public let dryRunServerExistence: (@Sendable (String) -> TmuxTargetExistence?)?
     /// Optional test hook consulted by `capturePaneOutput` and
     /// `capturePaneWithAnsi` in dryRun mode:
     /// (server, paneID) → pane text. Without it, dryRun captures return "",
@@ -263,7 +267,7 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunWindowExistence: (@Sendable (String, String) -> WindowExistence?)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunWindowExistence: (@Sendable (String, String) -> TmuxTargetExistence?)? = nil, dryRunServerExistence: (@Sendable (String) -> TmuxTargetExistence?)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
@@ -271,6 +275,7 @@ public struct TmuxManager: Sendable {
         self.dryRunRecorder = dryRunRecorder
         self.dryRunWindowIsDead = dryRunWindowIsDead
         self.dryRunWindowExistence = dryRunWindowExistence
+        self.dryRunServerExistence = dryRunServerExistence
         self.dryRunListWindows = dryRunListWindows
         self.dryRunListSessions = dryRunListSessions
         self.dryRunCapturePane = dryRunCapturePane
@@ -929,7 +934,7 @@ public struct TmuxManager: Sendable {
     /// without a tmux server — the branch that licenses spawning an agent and
     /// revoking a judge's lease is the last one that should be covered only by
     /// dry-run fixtures that never reach it.
-    static func classifyWindowExistence(status: Int32, output: String) -> WindowExistence {
+    static func classifyWindowExistence(status: Int32, output: String) -> TmuxTargetExistence {
         // Narrow by construction: only tmux saying it looked and found nothing is
         // an answer. `error connecting to <socket>`, a lost or version-mismatched
         // server, a usage error — all of those are the query failing, and reading
@@ -1573,7 +1578,7 @@ public struct TmuxManager: Sendable {
     /// reason. This is the desk's first of three consultations, and a caller that
     /// reacts to absence by spawning an agent or revoking a lease must be able to
     /// tell tmux's answer from tmux's silence.
-    public func windowExistence(server: String, windowID: String) async -> WindowExistence {
+    public func windowExistence(server: String, windowID: String) async -> TmuxTargetExistence {
         if dryRun {
             if let answer = dryRunWindowExistence?(server, windowID) { return answer }
             return (dryRunWindowIsDead?(windowID) ?? false) ? .gone : .exists
@@ -1611,14 +1616,43 @@ public struct TmuxManager: Sendable {
 
     /// Check whether a tmux server is running by querying list-sessions.
     public func serverExists(server: String) async -> Bool {
-        if dryRun { return true }
+        await serverExistence(server: server) == .exists
+    }
+
+    /// Whether a tmux server is running, keeping "there is no server on this
+    /// socket" apart from "I could not find out" — the same split
+    /// `windowExistence` makes, for callers whose negative branch mutates state.
+    public func serverExistence(server: String) async -> TmuxTargetExistence {
+        if dryRun { return dryRunServerExistence?(server) ?? .exists }
+        let args = ["-L", server, "list-sessions"]
         do {
-            let args = ["-L", server, "list-sessions"]
             _ = try await runTmux(args)
-            return true
+            return .exists
+        } catch TmuxError.commandFailed(_, let status, let output) {
+            return Self.classifyServerExistence(status: status, output: output)
         } catch {
-            return false
+            return .unverifiable(error: String(describing: error))
         }
+    }
+
+    /// Classify a failed `list-sessions`.
+    ///
+    /// A server's absence reads differently from a window's: tmux does not say
+    /// `can't find` when nothing is listening, it says `no server running on
+    /// <socket>`, or the connect itself fails because the socket file is not
+    /// there. Those two are proof. A protocol-version mismatch, a permission
+    /// error, a connection refused by a server mid-restart — those are a server
+    /// we could not reach, and reading them as "no server" is what lets a
+    /// destructive sweep act on a transient fault.
+    static func classifyServerExistence(status: Int32, output: String) -> TmuxTargetExistence {
+        let lowered = output.lowercased()
+        if lowered.contains("no server running")
+            || lowered.contains("no such file or directory") {
+            return .gone
+        }
+        return .unverifiable(
+            error: "tmux list-sessions exited \(status): "
+                + output.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     // MARK: - Private

--- a/Sources/TBDDaemon/Tmux/TmuxManager.swift
+++ b/Sources/TBDDaemon/Tmux/TmuxManager.swift
@@ -107,6 +107,25 @@ actor TmuxServerResourceCoordinator {
     }
 }
 
+/// What a `list-panes -t <window>` consultation proved about a window id.
+///
+/// The same three-way split as `PaneSendTarget`, and it exists for the same
+/// reason: `windowExists` used to answer a plain Bool, so a tmux that could not
+/// be reached was indistinguishable from a window tmux had looked for and not
+/// found. The Watch Desk reads this verdict to decide whether to spawn an agent
+/// and whether to revoke a running judge's lease — both acts that may follow
+/// only from evidence.
+public enum WindowExistence: Sendable, Equatable {
+    /// tmux resolved the window id.
+    case exists
+    /// PROOF the window is gone: tmux looked and said it could not find it.
+    case gone
+    /// The consultation could not be answered — no server on that socket, a
+    /// wedged server that tripped the subprocess timeout, a tmux that would not
+    /// run. Proof of nothing. Carries tmux's own status and output.
+    case unverifiable(error: String)
+}
+
 public struct TmuxManager: Sendable {
     /// Hard ceiling on any single tmux subprocess. tmux control operations
     /// (respawn-window, new-session, kill-window, capture-pane, …) normally
@@ -138,6 +157,11 @@ public struct TmuxManager: Sendable {
     /// Without it, dryRun reports every window as alive, which makes paths
     /// like the pre-session `.paneKilled` short-circuit untestable.
     public let dryRunWindowIsDead: (@Sendable (String) -> Bool)?
+    /// Optional test hook consulted by `windowExistence` in dryRun mode, taking
+    /// precedence over `dryRunWindowIsDead`. Only this seam can express the third
+    /// answer — `.unverifiable` — which the Bool hook cannot say and which is
+    /// exactly the case the desk must not act on.
+    public let dryRunWindowExistence: (@Sendable (String, String) -> WindowExistence?)?
     /// Optional test hook consulted by `capturePaneOutput` and
     /// `capturePaneWithAnsi` in dryRun mode:
     /// (server, paneID) → pane text. Without it, dryRun captures return "",
@@ -239,13 +263,14 @@ public struct TmuxManager: Sendable {
         }
     }
 
-    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
+    public init(dryRun: Bool = false, dryRunRecorder: (@Sendable ([String]) -> Void)? = nil, dryRunWindowIsDead: (@Sendable (String) -> Bool)? = nil, dryRunWindowExistence: (@Sendable (String, String) -> WindowExistence?)? = nil, dryRunListWindows: (@Sendable (String, String) -> [(windowID: String, paneID: String)])? = nil, dryRunListSessions: (@Sendable (String) -> [TmuxSessionInfo])? = nil, dryRunCapturePane: (@Sendable (String, String) -> String)? = nil, dryRunPaneCurrentCommand: (@Sendable (String, String) -> String)? = nil, dryRunCreateWindowError: (@Sendable (String) -> Error?)? = nil, dryRunRespawnWindowError: (@Sendable (String) -> Error?)? = nil, dryRunKillWindowError: (@Sendable (String, String) -> Error?)? = nil, dryRunPaneSendTarget: (@Sendable (String, String) throws -> PaneSendTarget)? = nil, dryRunSessionSpared: (@Sendable (String, String) -> Bool)? = nil, dryRunPaneWindowID: (@Sendable (String, String) -> String?)? = nil, dryRunPasteBytes: (@Sendable (String, String, Data) -> Void)? = nil, realModeWindowExistsOverride: (@Sendable (String, String) -> Bool?)? = nil, realModePaneCurrentCommandOverride: (@Sendable (String, String) -> String?)? = nil, subprocessTimeout: Duration = TmuxManager.commandTimeout) {
         self.dryRun = dryRun
         self.subprocessTimeout = subprocessTimeout
         self.counter = Counter()
         self.resourceCoordinator = TmuxServerResourceCoordinator()
         self.dryRunRecorder = dryRunRecorder
         self.dryRunWindowIsDead = dryRunWindowIsDead
+        self.dryRunWindowExistence = dryRunWindowExistence
         self.dryRunListWindows = dryRunListWindows
         self.dryRunListSessions = dryRunListSessions
         self.dryRunCapturePane = dryRunCapturePane
@@ -898,6 +923,24 @@ public struct TmuxManager: Sendable {
         output.lowercased().contains("can't find")
     }
 
+    /// Classify a failed `list-panes -t <window>` on the same rule
+    /// `paneSendTarget` uses. Split out from `windowExistence` so the branch that
+    /// decides whether a window is *proven* gone is reachable from a unit test
+    /// without a tmux server — the branch that licenses spawning an agent and
+    /// revoking a judge's lease is the last one that should be covered only by
+    /// dry-run fixtures that never reach it.
+    static func classifyWindowExistence(status: Int32, output: String) -> WindowExistence {
+        // Narrow by construction: only tmux saying it looked and found nothing is
+        // an answer. `error connecting to <socket>`, a lost or version-mismatched
+        // server, a usage error — all of those are the query failing, and reading
+        // them as an empty window is what turned one wedged tmux into an
+        // abandoned agent per tick.
+        if reportsTargetNotFound(output) { return .gone }
+        return .unverifiable(
+            error: "tmux list-panes exited \(status): "
+                + output.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
     /// The exact assignment shape `newWindowCommand` and `respawnWindowCommand`
     /// emit for one entry of the `env` map. Both build the prefix from the one
     /// shared `envExportPrefixed`, so a pane spawned either way — including the
@@ -1525,19 +1568,45 @@ public struct TmuxManager: Sendable {
         try await runTmux(args)
     }
 
-    /// Check whether a tmux window exists by querying list-panes.
-    public func windowExists(server: String, windowID: String) async -> Bool {
-        if dryRun { return !(dryRunWindowIsDead?(windowID) ?? false) }
+    /// Ask tmux whether a window id still resolves, keeping "gone" and "could
+    /// not look" apart — the same rule `paneSendTarget` follows, for the same
+    /// reason. This is the desk's first of three consultations, and a caller that
+    /// reacts to absence by spawning an agent or revoking a lease must be able to
+    /// tell tmux's answer from tmux's silence.
+    public func windowExistence(server: String, windowID: String) async -> WindowExistence {
+        if dryRun {
+            if let answer = dryRunWindowExistence?(server, windowID) { return answer }
+            return (dryRunWindowIsDead?(windowID) ?? false) ? .gone : .exists
+        }
         if let override = realModeWindowExistsOverride?(server, windowID) {
-            return override
+            return override ? .exists : .gone
         }
+        let args = ["-L", server, "list-panes", "-t", windowID]
         do {
-            let args = ["-L", server, "list-panes", "-t", windowID]
             _ = try await runTmux(args)
-            return true
+            return .exists
+        } catch TmuxError.commandFailed(_, let status, let output) {
+            return Self.classifyWindowExistence(status: status, output: output)
         } catch {
-            return false
+            // Including `TmuxError.timedOut`: a wedged server that never answered
+            // is the purest case of "I could not look". This method is
+            // non-throwing by signature, so the timeout is reported rather than
+            // propagated, and the desk treats it as proof of nothing.
+            return .unverifiable(error: String(describing: error))
         }
+    }
+
+    /// Check whether a tmux window exists by querying list-panes.
+    ///
+    /// Collapses `.unverifiable` into `false`, which is what this method has
+    /// always done and what its Bool-shaped callers already assume: they use it
+    /// to decide whether to bother with a window, and skipping one they could not
+    /// consult is harmless. Callers that act *because* a window is gone — the
+    /// Watch Desk's spawn and lease-revocation rails — must use
+    /// `windowExistence` instead, so absence of evidence cannot license a
+    /// creating or destroying act.
+    public func windowExists(server: String, windowID: String) async -> Bool {
+        await windowExistence(server: server, windowID: windowID) == .exists
     }
 
     /// Check whether a tmux server is running by querying list-sessions.

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -119,6 +119,26 @@ private final class PaneIdentities: @unchecked Sendable {
     }
 }
 
+/// Fires exactly once, so a dry-run tmux hook can stand in for a concurrent
+/// event at a deterministic point inside one spawn instead of racing it.
+private final class OneShotLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var armed = false
+
+    func arm() {
+        lock.lock(); defer { lock.unlock() }
+        armed = true
+    }
+
+    /// True once, for the first caller after `arm()`.
+    func consume() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard armed else { return false }
+        armed = false
+        return true
+    }
+}
+
 private final class SpawnFailureSwitch: @unchecked Sendable {
     private let lock = NSLock()
     private var failing = false
@@ -1737,6 +1757,108 @@ extension TBDHomeSerialized {
             #expect(
                 errors.first?.message?.contains("could not start an agent") == true,
                 "the notification must name what stopped: \(errors.first?.message ?? "nil")")
+        }
+
+        /// Gate 2 tracks the terminal this rail spawned, so it has to know which
+        /// one that is. Diffing the terminal table around the spawn does not:
+        /// the desk is an ordinary sidebar-visible scratch worktree and the
+        /// actor's gate serializes only its own methods, so a terminal the user
+        /// opens *while the spawn is in flight* falls inside the before/after
+        /// window and gets adopted as the tracked replacement.
+        ///
+        /// The consequence is the failure mode this whole PR is about, reached
+        /// by a different road: a shell adopted that way can never be proven
+        /// absent by an agent-kind consultation, so gate 2 stays shut and the
+        /// desk quietly stops restaffing itself.
+        ///
+        /// The interleave is deterministic rather than raced — the dry-run tmux
+        /// recorder fires inside `spawnPrimaryTerminals`, so the intruder row is
+        /// written from there, landing strictly between the two snapshots the
+        /// old code compared. A test that raced a real task here would be timing
+        /// dependent and would pass on the broken code most of the time.
+        @Test("a terminal opened during the spawn is not mistaken for the replacement")
+        func testConcurrentTerminalIsNotAdoptedAsTheReplacement() async throws {
+            let f = try makeDeskFixture(tag: "staff-spawn-identity")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let original = try #require(
+                try await f.db.terminals.list(worktreeID: desk.id)
+                    .first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // Second manager over the same database, whose tmux writes the
+            // intruder row mid-spawn. Fires once, on the recovery spawn only.
+            let intruderID = UUID()
+            let armed = OneShotLatch()
+            let writer = f.db.writerForTests
+            // The window is opened by `spawnPrimaryTerminals`, which runs on the
+            // LIFECYCLE's tmux — not the manager's. Hanging this recorder only on
+            // the manager's would never fire, the intruder row would never land,
+            // and the test would pass against the very code it is meant to pin.
+            let openIntruderMidSpawn: (@Sendable ([String]) -> Void) = { args in
+                guard args.contains("new-window") || args.contains("new-session"),
+                      armed.consume() else { return }
+                // A user opening a shell in the desk, right now.
+                try? writer.write { conn in
+                    try conn.execute(
+                        sql: """
+                            INSERT INTO terminal
+                            (id, worktreeID, tmuxWindowID, tmuxPaneID, label, createdAt, kind)
+                            VALUES (?, ?, '@99', '%99', 'shell', ?, 'shell')
+                            """,
+                        arguments: [
+                            intruderID.uuidString, desk.id.uuidString,
+                            Date().addingTimeInterval(60),
+                        ])
+                }
+            }
+            let manager = DeskSessionManager(
+                db: f.db,
+                lifecycle: WorktreeLifecycle(
+                    db: f.db, git: GitManager(),
+                    tmux: TmuxManager(dryRun: true, dryRunRecorder: openIntruderMidSpawn),
+                    hooks: HookResolver()),
+                tmux: TmuxManager(
+                    dryRun: true,
+                    dryRunRecorder: openIntruderMidSpawn,
+                    dryRunWindowIsDead: { f.dead.isDead($0) },
+                    dryRunWindowExistence: { _, windowID in f.dead.existence(windowID) },
+                    dryRunPaneCurrentCommand: { _, paneID in f.commands.command(for: paneID) },
+                    dryRunPaneSendTarget: { _, paneID in try f.identities.answer(for: paneID) }
+                ),
+                skillDir: f.home.appendingPathComponent("skills/nightwatch").path,
+                actuationLog: makeTestActuationLog()
+            )
+
+            f.identities.set(.missing, for: original.tmuxPaneID)
+            f.dead.markDead(original.tmuxWindowID)
+            armed.arm()
+            _ = try await manager.ensureDeskSession(mode: .daywatch)
+
+            #expect(
+                try await f.db.terminals.get(id: intruderID) != nil,
+                "fixture check: the intruder must have landed mid-spawn")
+
+            // Kill the agents only; the user's shell stays open, as it would.
+            for terminal in try await f.db.terminals.list(worktreeID: desk.id)
+            where terminal.id != intruderID {
+                f.identities.set(.missing, for: terminal.tmuxPaneID)
+                f.dead.markDead(terminal.tmuxWindowID)
+            }
+
+            // The replacement is dead. If the shell had been adopted as the
+            // tracked replacement, gate 2 could never clear — a shell is not an
+            // agent candidate, so no consultation can ever prove it absent — and
+            // this death would buy nothing.
+            let before = try await f.db.terminals.list(worktreeID: desk.id).count
+            _ = try await manager.ensureDeskSession(mode: .daywatch)
+            let after = try await f.db.terminals.list(worktreeID: desk.id).count
+            #expect(
+                after == before + 1,
+                "a terminal opened during the spawn must not wedge gate 2 shut")
+            #expect(
+                try await f.db.terminals.get(id: intruderID) != nil,
+                "the user's terminal is not this rail's to touch")
         }
 
         /// The give-up notification is the only user-visible sign that the desk

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -1640,16 +1640,24 @@ extension TBDHomeSerialized {
                 "a replacement that dies must itself be replaced")
         }
 
-        /// The incident, end to end: a healthy incumbent whose lease is valid and
-        /// renewing must survive tick after tick with no replacement spawned and no
-        /// change to who holds authority — even while one of the tmux consultations
-        /// cannot be answered.
+        /// The incident, end to end, in the order it was observed in the field: one tick
+        /// spawns a replacement desk AND invalidates the live incumbent, ~30 seconds
+        /// apart, while that incumbent's lease is renewing on its own timer and has never
+        /// missed a renewal. Both halves come from the same tick, through two different
+        /// actuators, on the same wrong verdict.
         ///
-        /// Before the fix each tick read the unanswerable consultation as "the owner's
-        /// pane is gone", revoked the lease in place (same terminal, same generation,
-        /// validity flipped off) and then spawned another agent beside the incumbent it
-        /// had just demoted: one abandoned desk per tick, all night.
-        @Test("a live incumbent with a valid lease survives repeated ticks untouched")
+        /// So this drives the whole tick — `ensureDeskSession` (which spawns),
+        /// `maintainJudgeLease` (the ownership heartbeat) and `nudgeDeskSession` (which
+        /// revoked) — with the judge renewing between ticks the way a running judge does,
+        /// and holds all four invariants across every one of them: no new terminal, the
+        /// terminal's persisted role stays `judge`, and the lease keeps its owner, its
+        /// generation and its validity.
+        ///
+        /// Before the fix each tick read an unanswerable tmux consultation as "the
+        /// owner's pane is gone", demoted the incumbent in place — same terminal, same
+        /// generation, `expiresAt` zeroed, so its next renew came back fenced — and
+        /// spawned another agent beside the judge it had just stripped of authority.
+        @Test("a live incumbent with a renewing lease survives repeated ticks untouched")
         func testLiveIncumbentSurvivesRepeatedTicks() async throws {
             let f = try makeDeskFixture(tag: "staff-incumbent")
             defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
@@ -1660,7 +1668,7 @@ extension TBDHomeSerialized {
                     .first(where: { $0.label == TerminalLabel.claudeCode }))
 
             // The incumbent holds the judge lease, as a running judge does.
-            let lease = try await f.db.watchDeskLeases.acquire(
+            var lease = try await f.db.watchDeskLeases.acquire(
                 worktreeID: desk.id, terminalID: incumbent.id, now: Date())
 
             // Its pane is alive and running an agent, but the identity consultation
@@ -1669,13 +1677,25 @@ extension TBDHomeSerialized {
 
             let terminalsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
             for tick in 0..<5 {
+                // The judge's own renew loop, which never missed a beat in the field.
+                lease = try await f.db.watchDeskLeases.renew(
+                    worktreeID: desk.id, terminalID: lease.terminalID,
+                    token: lease.token, generation: lease.generation, now: Date())
+
+                // One whole tick, in the order the runner drives it.
                 _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+                await f.manager.maintainJudgeLease(worktreeID: desk.id)
                 await f.manager.nudgeDeskSession(worktreeID: desk.id, act: false)
 
                 let terminals = try await f.db.terminals.list(worktreeID: desk.id)
                 #expect(
                     terminals.count == terminalsBefore,
                     "tick \(tick): no agent may be spawned beside a live incumbent")
+
+                let row = try #require(terminals.first { $0.id == incumbent.id })
+                #expect(
+                    row.watchDeskRole == .judge,
+                    "tick \(tick): the incumbent was demoted in place")
 
                 let current = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
                 #expect(current.terminalID == lease.terminalID, "tick \(tick): owner changed")

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -1640,6 +1640,113 @@ extension TBDHomeSerialized {
                 "a replacement that dies must itself be replaced")
         }
 
+        /// Kill every terminal the desk currently has — proven gone, both the way
+        /// `windowExists` sees it and the way the identity consultation does — then
+        /// drive one tick. Returns how many terminal rows exist afterwards, which is
+        /// the only externally visible evidence of whether a replacement was spawned.
+        private func killAllAndTick(
+            _ f: (db: TBDDatabase, manager: DeskSessionManager, recorder: DeskTmuxRecorder,
+                  dead: DeadWindows, commands: PaneCommands, identities: PaneIdentities,
+                  spawnFailures: SpawnFailureSwitch, home: URL, priorTBDHome: String?),
+            desk: UUID
+        ) async throws -> Int {
+            for terminal in try await f.db.terminals.list(worktreeID: desk) {
+                f.identities.set(.missing, for: terminal.tmuxPaneID)
+                f.dead.markDead(terminal.tmuxWindowID)
+            }
+            _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+            return try await f.db.terminals.list(worktreeID: desk).count
+        }
+
+        /// The backstop has to actually count, and it did not.
+        ///
+        /// `spawnDeskTerminal` cleared the recovery budget itself, and
+        /// `spawnRecoveryTerminalIfWarranted` calls that very function to make its
+        /// attempt — so on every attempt the clear ran first and the increment second,
+        /// pinning `consecutiveRecoverySpawnsWithoutNudge` at 1 forever. The cap was
+        /// unreachable, the give-up notification could never fire, and a desk whose
+        /// launches all died went back to spawning one abandoned agent per tick: the
+        /// precise unbounded behaviour this rail exists to end.
+        ///
+        /// Nothing about that is visible from a single attempt, which is why this
+        /// walks four. Each tick kills every terminal on the desk before running, so no
+        /// nudge ever lands and nothing legitimately clears the budget. Three
+        /// replacements must happen, the third must be the last, and the desk must say
+        /// so out loud — a Watch Desk that has quietly given up looks exactly like one
+        /// that is fine.
+        @Test("the recovery budget accumulates, stops at the third spawn, and notifies")
+        func testRecoveryBudgetAccumulatesAndCapsAtThree() async throws {
+            let f = try makeDeskFixture(tag: "staff-budget")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            var count = try await f.db.terminals.list(worktreeID: desk.id).count
+
+            // maxConsecutiveRecoverySpawnsWithoutNudge attempts, each licensed by a
+            // fresh death. Before the fix the counter never left 1, so this loop passed
+            // and the one below it did not.
+            for attempt in 1...3 {
+                let after = try await killAllAndTick(f, desk: desk.id)
+                #expect(
+                    after == count + 1,
+                    "attempt \(attempt) of 3 must still spawn a replacement")
+                count = after
+            }
+
+            #expect(
+                try await f.db.notifications.unread(worktreeID: desk.id)
+                    .filter({ $0.type == .error }).isEmpty,
+                "the desk must not give up while attempts remain")
+
+            // The budget is spent. Further deaths buy nothing, however many arrive.
+            for tick in 0..<2 {
+                let after = try await killAllAndTick(f, desk: desk.id)
+                #expect(
+                    after == count,
+                    "tick \(tick) past the cap must not spawn a fourth agent")
+            }
+
+            let errors = try await f.db.notifications.unread(worktreeID: desk.id)
+                .filter { $0.type == .error }
+            #expect(
+                errors.count == 1,
+                "exhaustion must be announced exactly once per incident, not per tick")
+            #expect(
+                errors.first?.message?.contains("could not start an agent") == true,
+                "the notification must name what stopped: \(errors.first?.message ?? "nil")")
+        }
+
+        /// The other side of the counter: it is a budget for one incident, not a
+        /// lifetime quota. A nudge that reaches a pane is the proof the desk is staffed
+        /// by something that took it, and it must hand the attempts back — otherwise a
+        /// desk that had a bad hour in the evening would refuse to restaff itself for
+        /// the rest of the night.
+        @Test("a delivered nudge hands the recovery budget back")
+        func testDeliveredNudgeClearsRecoveryBudget() async throws {
+            let f = try makeDeskFixture(tag: "staff-budget-reset")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+
+            // Spend the whole budget, leaving the third replacement alive.
+            var count = try await f.db.terminals.list(worktreeID: desk.id).count
+            for _ in 1...3 {
+                count = try await killAllAndTick(f, desk: desk.id)
+            }
+
+            let pastesBefore = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+            #expect(
+                f.recorder.pastedPanes.count == pastesBefore + 1,
+                "the live replacement must have taken a nudge for this test to mean anything")
+
+            // Same fourth death as the test above, which there bought nothing.
+            let after = try await killAllAndTick(f, desk: desk.id)
+            #expect(
+                after == count + 1,
+                "a delivered nudge must restore the desk's ability to restaff itself")
+        }
+
         /// The incident, end to end, in the order it was observed in the field: one tick
         /// spawns a replacement desk AND invalidates the live incumbent, ~30 seconds
         /// apart, while that incumbent's lease is renewing on its own timer and has never

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import GRDB
 import TestSupport
 @testable import TBDDaemonLib
 @testable import TBDShared
@@ -1736,6 +1737,59 @@ extension TBDHomeSerialized {
             #expect(
                 errors.first?.message?.contains("could not start an agent") == true,
                 "the notification must name what stopped: \(errors.first?.message ?? "nil")")
+        }
+
+        /// The give-up notification is the only user-visible sign that the desk
+        /// has stopped staffing itself — a desk that has quietly given up looks
+        /// exactly like one that is fine. So the dedup flag may not be set until
+        /// the write actually lands: setting it first means one failed write
+        /// silences the incident for good, and the notification's whole reason
+        /// for existing is gone precisely when it is needed.
+        ///
+        /// The table is dropped to make the write fail the way a real one would,
+        /// then restored, and the next tick must try again.
+        @Test("a give-up notification that fails to write is retried, not swallowed")
+        func testExhaustionNotificationRetriesAfterWriteFailure() async throws {
+            let f = try makeDeskFixture(tag: "staff-notify-retry")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            for _ in 1...3 { _ = try await killAllAndTick(f, desk: desk.id) }
+
+            // Spend the last attempt with the notifications table missing, so the
+            // give-up write throws exactly as an unwritable database would.
+            let schema = try await f.db.writerForTests.read { conn in
+                try String.fetchOne(
+                    conn, sql: "SELECT sql FROM sqlite_master WHERE name = 'notification'")
+            }
+            let createSQL = try #require(schema, "fixture must find the notification table")
+            try await f.db.writerForTests.write { conn in
+                try conn.execute(sql: "DROP TABLE notification")
+            }
+            _ = try await killAllAndTick(f, desk: desk.id)
+
+            try await f.db.writerForTests.write { conn in
+                try conn.execute(sql: createSQL)
+            }
+            #expect(
+                try await f.db.notifications.unread(worktreeID: desk.id)
+                    .filter({ $0.type == .error }).isEmpty,
+                "fixture check: the failed write must have recorded nothing")
+
+            // The database is healthy again; the very next tick must say so.
+            _ = try await killAllAndTick(f, desk: desk.id)
+            let errors = try await f.db.notifications.unread(worktreeID: desk.id)
+                .filter { $0.type == .error }
+            #expect(
+                errors.count == 1,
+                "a give-up notification lost to a failed write must be retried, not dropped")
+
+            // And it is still deduplicated once it has landed.
+            _ = try await killAllAndTick(f, desk: desk.id)
+            #expect(
+                try await f.db.notifications.unread(worktreeID: desk.id)
+                    .filter({ $0.type == .error }).count == 1,
+                "the retry must not turn into one notification per tick")
         }
 
         /// `resetRecoveryBudget` has three callers, and a delivered nudge is only

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -54,7 +54,7 @@ private final class DeadWindows: @unchecked Sendable {
         return dead.contains(windowID)
     }
 
-    func existence(_ windowID: String) -> WindowExistence {
+    func existence(_ windowID: String) -> TmuxTargetExistence {
         lock.lock(); defer { lock.unlock() }
         if unverifiable.contains(windowID) {
             return .unverifiable(error: "tmux list-panes exited 1: error connecting to socket")
@@ -1736,6 +1736,46 @@ extension TBDHomeSerialized {
             #expect(
                 errors.first?.message?.contains("could not start an agent") == true,
                 "the notification must name what stopped: \(errors.first?.message ?? "nil")")
+        }
+
+        /// `resetRecoveryBudget` has three callers, and a delivered nudge is only
+        /// one of them. The other two are worth pinning because the tempting
+        /// place to put a reset — inside the spawn — is exactly where it must not
+        /// go, and these two sit close enough to that mistake to be mistaken for
+        /// it.
+        ///
+        /// Closing the desk and building a new one is one path through both
+        /// remaining resets — `closeDeskSession` clears the budget and the
+        /// fresh-create site clears it again — and the two cannot be told apart
+        /// from outside, because a closed desk is archived and the next `ensure`
+        /// always builds a new one. So this pins what is actually observable and
+        /// what actually matters: a budget spent by one desk's abandoned
+        /// replacements is not charged to its successor.
+        @Test("a desk built after a close starts with a full recovery budget")
+        func testFreshDeskStartsWithFullRecoveryBudget() async throws {
+            let f = try makeDeskFixture(tag: "staff-budget-fresh")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            for _ in 1...3 { _ = try await killAllAndTick(f, desk: desk.id) }
+            let capped = try await killAllAndTick(f, desk: desk.id)
+            #expect(
+                capped == (try await f.db.terminals.list(worktreeID: desk.id).count),
+                "the first desk must be at its cap for this test to mean anything")
+
+            await f.manager.closeDeskSession()
+            let fresh = try await f.manager.ensureDeskSession(mode: .daywatch)
+            #expect(fresh.id != desk.id)
+
+            // Three full attempts again, on the new desk.
+            var count = try await f.db.terminals.list(worktreeID: fresh.id).count
+            for attempt in 1...3 {
+                let after = try await killAllAndTick(f, desk: fresh.id)
+                #expect(
+                    after == count + 1,
+                    "attempt \(attempt) on a fresh desk must not be charged to the old one")
+                count = after
+            }
         }
 
         /// The desk asks tmux three read-only questions, and until now only one of

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -33,15 +33,33 @@ private final class DeskTmuxRecorder: @unchecked Sendable {
 private final class DeadWindows: @unchecked Sendable {
     private let lock = NSLock()
     private var dead: Set<String> = []
+    private var unverifiable: Set<String> = []
 
     func markDead(_ windowID: String) {
         lock.lock(); defer { lock.unlock() }
         dead.insert(windowID)
     }
 
+    /// Make the window consultation itself fail — a tmux that could not be
+    /// asked, as distinct from a tmux that looked and found nothing. Only the
+    /// tri-state `dryRunWindowExistence` seam can express this; the older
+    /// Bool hook collapses it into "dead", which is the bug.
+    func markUnverifiable(_ windowID: String) {
+        lock.lock(); defer { lock.unlock() }
+        unverifiable.insert(windowID)
+    }
+
     func isDead(_ windowID: String) -> Bool {
         lock.lock(); defer { lock.unlock() }
         return dead.contains(windowID)
+    }
+
+    func existence(_ windowID: String) -> WindowExistence {
+        lock.lock(); defer { lock.unlock() }
+        if unverifiable.contains(windowID) {
+            return .unverifiable(error: "tmux list-panes exited 1: error connecting to socket")
+        }
+        return dead.contains(windowID) ? .gone : .exists
     }
 }
 
@@ -910,6 +928,7 @@ extension TBDHomeSerialized {
                     dryRun: true,
                     dryRunRecorder: { recorder.record($0) },
                     dryRunWindowIsDead: { dead.isDead($0) },
+                    dryRunWindowExistence: { _, windowID in dead.existence(windowID) },
                     dryRunPaneCurrentCommand: { _, paneID in commands.command(for: paneID) },
                     dryRunPaneSendTarget: { _, paneID in try identities.answer(for: paneID) }
                 ),
@@ -1474,7 +1493,7 @@ extension TBDHomeSerialized {
         /// This test drives the exact failure mode: a live pane that the identity
         /// consultation cannot reach (wedged tmux, timeout, etc). The staffing check
         /// must treat "cannot tell" as "staffed for now" and skip the spawn.
-        /// Multiple ticks are simulated via `now` advance to pass the rate limit.
+        /// Multiple ticks are simulated by advancing `now` between calls.
         @Test("unverifiable terminal does not trigger spawn — staffing check treats 'cannot tell' as staffed")
         func testUnavailableIdentityConsultationIsNotSpawned() async throws {
             let f = try makeDeskFixture(tag: "staff-unverifiable")
@@ -1514,7 +1533,10 @@ extension TBDHomeSerialized {
             // says "cannot tell if it's alive or not, assume staffed" and skips spawn.
             let terminalCountsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
             for iteration in 0..<3 {
-                // Advance the clock past the 2-minute recovery rate limit.
+                // Advance the clock between ticks. Nothing here is gated on a
+                // clock — the desk's gating is evidence-based, which is this
+                // PR's whole point — so this only makes each iteration a
+                // distinct tick rather than a repeated instant.
                 clock.advance(by: 2 * 60 + 1)
 
                 // Call ensure, which checks staffing and may spawn if genuinely unstaffed.
@@ -1714,6 +1736,84 @@ extension TBDHomeSerialized {
             #expect(
                 errors.first?.message?.contains("could not start an agent") == true,
                 "the notification must name what stopped: \(errors.first?.message ?? "nil")")
+        }
+
+        /// The desk asks tmux three read-only questions, and until now only one of
+        /// them could say "I could not look". `windowExists` answered a plain
+        /// `Bool` and swallowed every error into `false`, so a wedged or
+        /// unreachable server — the exact production fault — was indistinguishable
+        /// from a window tmux had looked for and not found. `verdict` then read
+        /// that `false` as `.absent`, which is the verdict that licenses both
+        /// spawning a replacement and revoking a running judge's lease.
+        ///
+        /// So this reproduces the incident through the window consultation
+        /// instead of the identity one, and holds the same invariants: no spawn,
+        /// no demotion, no paste into a pane nobody could look at.
+        @Test("an unanswerable window consultation spawns nothing and revokes nothing")
+        func testUnverifiableWindowNeitherSpawnsNorRevokes() async throws {
+            let f = try makeDeskFixture(tag: "staff-window-unverifiable")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let incumbent = try #require(
+                try await f.db.terminals.list(worktreeID: desk.id)
+                    .first(where: { $0.label == TerminalLabel.claudeCode }))
+            var lease = try await f.db.watchDeskLeases.acquire(
+                worktreeID: desk.id, terminalID: incumbent.id, now: Date())
+
+            // The pane answers for itself and runs an agent; it is the WINDOW
+            // query that cannot be run.
+            f.dead.markUnverifiable(incumbent.tmuxWindowID)
+
+            let terminalsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
+            let pastesBefore = f.recorder.pastedPanes.count
+            for tick in 0..<3 {
+                lease = try await f.db.watchDeskLeases.renew(
+                    worktreeID: desk.id, terminalID: lease.terminalID,
+                    token: lease.token, generation: lease.generation, now: Date())
+
+                _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+                await f.manager.maintainJudgeLease(worktreeID: desk.id)
+                await f.manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+
+                #expect(
+                    try await f.db.terminals.list(worktreeID: desk.id).count == terminalsBefore,
+                    "tick \(tick): a window nobody could consult must not license a spawn")
+
+                let current = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+                #expect(current.terminalID == lease.terminalID, "tick \(tick): owner changed")
+                #expect(current.generation == lease.generation, "tick \(tick): generation changed")
+                #expect(
+                    current.isValid(at: Date()),
+                    "tick \(tick): a lease was revoked on a consultation nobody could run")
+            }
+
+            #expect(
+                f.recorder.pastedPanes.count == pastesBefore,
+                "a pane whose window could not be consulted must not be pasted into")
+        }
+
+        /// The other half of the same rule, so refusing to act on absence of
+        /// evidence did not become refusing to act on evidence: when tmux
+        /// positively answers that the window is gone, the desk still restaffs.
+        @Test("a window tmux proves is gone still licenses a replacement")
+        func testProvenGoneWindowStillSpawns() async throws {
+            let f = try makeDeskFixture(tag: "staff-window-gone")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let original = try #require(
+                try await f.db.terminals.list(worktreeID: desk.id)
+                    .first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            f.identities.set(.missing, for: original.tmuxPaneID)
+            f.dead.markDead(original.tmuxWindowID)
+
+            let before = try await f.db.terminals.list(worktreeID: desk.id).count
+            _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+            #expect(
+                try await f.db.terminals.list(worktreeID: desk.id).count == before + 1,
+                "a proven-gone window must still be restaffed")
         }
 
         /// The other side of the counter: it is a budget for one incident, not a

--- a/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
+++ b/Tests/TBDDaemonTests/DeskSessionManagerTests.swift
@@ -1465,5 +1465,352 @@ extension TBDHomeSerialized {
             #expect(duringClose.contains { $0.contains("kill-window") && $0.contains("@7") },
                     "the tmux leg must still kill its own window: \(duringClose)")
         }
+
+        // MARK: - Spawn rate-limiting (bug fix: duplicate spawn on unverifiable terminal)
+
+        /// The regression: `paneSendTarget` returns `.missing` when the query fails
+        /// (correct for "don't paste into a pane I can't verify"), but the spawn
+        /// logic reused this to mean "desk is unstaffed" and spawned every tick.
+        /// This test drives the exact failure mode: a live pane that the identity
+        /// consultation cannot reach (wedged tmux, timeout, etc). The staffing check
+        /// must treat "cannot tell" as "staffed for now" and skip the spawn.
+        /// Multiple ticks are simulated via `now` advance to pass the rate limit.
+        @Test("unverifiable terminal does not trigger spawn — staffing check treats 'cannot tell' as staffed")
+        func testUnavailableIdentityConsultationIsNotSpawned() async throws {
+            let f = try makeDeskFixture(tag: "staff-unverifiable")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let clock = TestDateSource(Date(timeIntervalSince1970: 1_000_000))
+            let manager = DeskSessionManager(
+                db: f.db,
+                lifecycle: WorktreeLifecycle(
+                    db: f.db,
+                    git: GitManager(),
+                    tmux: TmuxManager(dryRun: true),
+                    hooks: HookResolver()
+                ),
+                tmux: TmuxManager(
+                    dryRun: true,
+                    dryRunRecorder: { f.recorder.record($0) },
+                    dryRunWindowIsDead: { f.dead.isDead($0) },
+                    dryRunPaneCurrentCommand: { _, paneID in f.commands.command(for: paneID) },
+                    dryRunPaneSendTarget: { _, paneID in try f.identities.answer(for: paneID) }
+                ),
+                skillDir: f.home.appendingPathComponent("skills/nightwatch").path,
+                now: clock.provider,
+                actuationLog: makeTestActuationLog()
+            )
+
+            let desk = try await manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let original = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // The pane exists and is running Claude, but the identity check fails
+            // (tmux wedged, query timeout, etc).
+            f.identities.markUnreachable(original.tmuxPaneID)
+
+            // Multiple iterations simulating ticks passing. Without the fix, each
+            // tick would spawn a new terminal. With the fix, the staffing check
+            // says "cannot tell if it's alive or not, assume staffed" and skips spawn.
+            let terminalCountsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
+            for iteration in 0..<3 {
+                // Advance the clock past the 2-minute recovery rate limit.
+                clock.advance(by: 2 * 60 + 1)
+
+                // Call ensure, which checks staffing and may spawn if genuinely unstaffed.
+                // Because the pane is unverifiable (not unresponsive), staffing check
+                // returns true and no spawn happens.
+                _ = try await manager.ensureDeskSession(mode: .daywatch)
+
+                let terminalCountsAfter = try await f.db.terminals.list(worktreeID: desk.id).count
+                #expect(
+                    terminalCountsAfter == terminalCountsBefore,
+                    "iteration \(iteration): unverifiable pane must not trigger spawn"
+                )
+            }
+        }
+
+        /// Cross-kind incumbent reuse: `ensureDeskSession` must treat a live agent of
+        /// EITHER supported kind as the desk's agent, not only the configured preferred
+        /// kind. An intentional handoff to Codex while Claude is preferred must not spawn
+        /// a Claude replacement.
+        @Test("live Codex terminal is reused even when Claude is preferred agent")
+        func testLiveCodexTerminalReusedWhenClaudePreferred() async throws {
+            let f = try makeDeskFixture(tag: "staff-cross-kind")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            // Prefer Claude (the default), but a Codex session exists.
+            try await f.db.config.setPrimaryAgentPreference(.claude)
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+
+            // Replace the Claude terminal with a Codex one (simulating handoff).
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+            f.dead.markDead(claude.tmuxWindowID)
+            let codex = try await f.db.terminals.create(
+                worktreeID: desk.id, tmuxWindowID: "@codex", tmuxPaneID: "%codex",
+                label: TerminalLabel.codex, kind: .codex)
+            f.commands.set("codex", for: codex.tmuxPaneID)
+
+            // Second ensure: prefer Claude, but a live Codex exists. Must reuse Codex
+            // without spawning Claude.
+            let terminalsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
+            let desk2 = try await f.manager.ensureDeskSession(mode: .daywatch)
+
+            #expect(desk2.id == desk.id, "same desk should be reused")
+            let terminalsAfter = try await f.db.terminals.list(worktreeID: desk.id).count
+            #expect(
+                terminalsAfter == terminalsBefore,
+                "live Codex should prevent Claude spawn even when Claude is preferred"
+            )
+        }
+
+        /// A pane running a Claude version string (e.g. "2.1.229") is live and should
+        /// be reused. The `agentCommand` check must recognize it.
+        @Test("live agent running version string pane_current_command is reused")
+        func testLiveVersionStringCommandIsReused() async throws {
+            let f = try makeDeskFixture(tag: "staff-version-string")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // Set the pane's command to a version string, which `agentCommand` should
+            // recognize as a Claude process.
+            f.commands.set("2.1.229", for: claude.tmuxPaneID)
+
+            // Ensure again: the version-string command should be recognized, and
+            // no spawn should happen.
+            let terminalsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
+            _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+
+            let terminalsAfter = try await f.db.terminals.list(worktreeID: desk.id).count
+            #expect(
+                terminalsAfter == terminalsBefore,
+                "live agent with version-string command must not trigger spawn"
+            )
+        }
+
+        /// Genuine recovery still works, and is bounded by evidence rather than by a
+        /// clock. A desk whose agent is really gone gets exactly one replacement; the
+        /// next tick, with that replacement alive, gets none; once the replacement is
+        /// itself proven dead, the desk is allowed to try again.
+        ///
+        /// Before the fix the bound was the absence of any bound: every tick that found
+        /// no live candidate spawned another agent.
+        @Test("a dead desk is restaffed once per death, not once per tick")
+        func testDeadDeskRestaffsOncePerDeath() async throws {
+            let f = try makeDeskFixture(tag: "staff-recovery")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let original = try #require(
+                try await f.db.terminals.list(worktreeID: desk.id)
+                    .first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // Proven dead: tmux answers that the pane is gone.
+            f.identities.set(.missing, for: original.tmuxPaneID)
+            f.dead.markDead(original.tmuxWindowID)
+
+            let beforeRecovery = try await f.db.terminals.list(worktreeID: desk.id).count
+            _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let afterRecovery = try await f.db.terminals.list(worktreeID: desk.id)
+            #expect(
+                afterRecovery.count == beforeRecovery + 1,
+                "a proven-dead desk must be restaffed exactly once")
+
+            // The replacement is alive, so further ticks must add nothing.
+            for tick in 0..<3 {
+                _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+                let count = try await f.db.terminals.list(worktreeID: desk.id).count
+                #expect(count == afterRecovery.count, "tick \(tick) must not add another agent")
+            }
+
+            // Now the replacement dies too. One death, one replacement.
+            let replacement = try #require(
+                afterRecovery.max(by: { ($0.createdAt, $0.id.uuidString) < ($1.createdAt, $1.id.uuidString) }))
+            f.identities.set(.missing, for: replacement.tmuxPaneID)
+            f.dead.markDead(replacement.tmuxWindowID)
+            _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let afterSecondDeath = try await f.db.terminals.list(worktreeID: desk.id).count
+            #expect(
+                afterSecondDeath == afterRecovery.count + 1,
+                "a replacement that dies must itself be replaced")
+        }
+
+        /// The incident, end to end: a healthy incumbent whose lease is valid and
+        /// renewing must survive tick after tick with no replacement spawned and no
+        /// change to who holds authority — even while one of the tmux consultations
+        /// cannot be answered.
+        ///
+        /// Before the fix each tick read the unanswerable consultation as "the owner's
+        /// pane is gone", revoked the lease in place (same terminal, same generation,
+        /// validity flipped off) and then spawned another agent beside the incumbent it
+        /// had just demoted: one abandoned desk per tick, all night.
+        @Test("a live incumbent with a valid lease survives repeated ticks untouched")
+        func testLiveIncumbentSurvivesRepeatedTicks() async throws {
+            let f = try makeDeskFixture(tag: "staff-incumbent")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let incumbent = try #require(
+                try await f.db.terminals.list(worktreeID: desk.id)
+                    .first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // The incumbent holds the judge lease, as a running judge does.
+            let lease = try await f.db.watchDeskLeases.acquire(
+                worktreeID: desk.id, terminalID: incumbent.id, now: Date())
+
+            // Its pane is alive and running an agent, but the identity consultation
+            // cannot be run — the production fault.
+            f.identities.markUnreachable(incumbent.tmuxPaneID)
+
+            let terminalsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
+            for tick in 0..<5 {
+                _ = try await f.manager.ensureDeskSession(mode: .daywatch)
+                await f.manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+
+                let terminals = try await f.db.terminals.list(worktreeID: desk.id)
+                #expect(
+                    terminals.count == terminalsBefore,
+                    "tick \(tick): no agent may be spawned beside a live incumbent")
+
+                let current = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+                #expect(current.terminalID == lease.terminalID, "tick \(tick): owner changed")
+                #expect(current.generation == lease.generation, "tick \(tick): generation changed")
+                #expect(
+                    current.isValid(at: Date()),
+                    "tick \(tick): a lease was revoked on a consultation nobody could run")
+            }
+        }
+
+        /// The other half of the same rule: when tmux positively answers that the
+        /// owner's pane is gone, the lease IS revoked, exactly as before. Refusing to
+        /// act on absence of evidence must not become refusing to act on evidence.
+        @Test("a lease whose owner is proven gone is still revoked")
+        func testProvenGoneOwnerLoosesLease() async throws {
+            let f = try makeDeskFixture(tag: "staff-revoke")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let incumbent = try #require(
+                try await f.db.terminals.list(worktreeID: desk.id)
+                    .first(where: { $0.label == TerminalLabel.claudeCode }))
+            let lease = try await f.db.watchDeskLeases.acquire(
+                worktreeID: desk.id, terminalID: incumbent.id, now: Date())
+            #expect(lease.isValid(at: Date()))
+
+            f.identities.set(.missing, for: incumbent.tmuxPaneID)
+            f.dead.markDead(incumbent.tmuxWindowID)
+
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+
+            // Either the lease is now invalid, or a live successor holds a newer
+            // one — what must not survive is the gone terminal still holding
+            // valid authority.
+            let after = try #require(try await f.db.watchDeskLeases.status(worktreeID: desk.id))
+            #expect(
+                !(after.terminalID == incumbent.id && after.isValid(at: Date())),
+                "a proven-gone owner must lose the lease")
+        }
+
+        /// Mode switches must reuse the existing desk and terminal without respawning.
+        /// This is preserved by the cross-kind check: both modes use the same desk and
+        /// terminal, so mode doesn't affect reuse.
+        @Test("mode switch daywatch↔nightwatch reuses desk without respawning")
+        func testModeFlipReusesDesk() async throws {
+            let f = try makeDeskFixture(tag: "mode-reuse")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk1 = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let terminalsAfterFirst = try await f.db.terminals.list(worktreeID: desk1.id)
+
+            // Mode switch: nightwatch on the same desk.
+            let desk2 = try await f.manager.ensureDeskSession(mode: .nightwatch)
+
+            #expect(desk2.id == desk1.id, "mode switch must reuse the same desk")
+
+            let terminalsAfterSecond = try await f.db.terminals.list(worktreeID: desk1.id)
+            #expect(
+                terminalsAfterSecond.count == terminalsAfterFirst.count,
+                "mode switch must not respawn the terminal"
+            )
+        }
+
+        // MARK: - Observability: distinguishing "cannot tell" from "genuinely gone"
+
+        /// Failed consultation (unverifiable) is not the same as a genuine
+        /// "pane is gone" answer. When the identity consultation fails (tmux
+        /// returns non-zero exit or throws), it returns `.unverifiable(error:)`.
+        /// This must not license a spawn — "cannot tell" is not "empty".
+        @Test("unverifiable identity consultation is not pasted into (differs from send failure)")
+        func testUnverifiableIdentityIsNotPastedInto() async throws {
+            let f = try makeDeskFixture(tag: "obs-unverifiable")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let desk = try await f.manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let claude = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // The pane exists and is running Claude, but the identity check fails
+            // (tmux query returns non-zero exit).
+            f.identities.markUnreachable(claude.tmuxPaneID)
+
+            let before = f.recorder.pastedPanes.count
+            await f.manager.nudgeDeskSession(worktreeID: desk.id, act: false)
+
+            let targets = Array(f.recorder.pastedPanes.dropFirst(before))
+            #expect(targets.isEmpty, "unverifiable pane must not be pasted into")
+        }
+
+        /// Genuine death is still diagnosable: when a pane is truly gone
+        /// (window killed, pane dead, no agent process), spawning is triggered.
+        /// The `.missing` answer from `paneSendTarget` is the expected failure
+        /// mode that should license recovery spawn.
+        @Test("genuinely missing pane triggers recovery spawn (verified distinct from unverifiable)")
+        func testGenuinelyMissingPaneSpawns() async throws {
+            let f = try makeDeskFixture(tag: "obs-missing")
+            defer { restoreTBDHome(f.priorTBDHome); try? FileManager.default.removeItem(at: f.home) }
+
+            let clock = TestDateSource(Date(timeIntervalSince1970: 3_000_000))
+            let manager = DeskSessionManager(
+                db: f.db,
+                lifecycle: WorktreeLifecycle(
+                    db: f.db,
+                    git: GitManager(),
+                    tmux: TmuxManager(dryRun: true),
+                    hooks: HookResolver()
+                ),
+                tmux: TmuxManager(
+                    dryRun: true,
+                    dryRunRecorder: { f.recorder.record($0) },
+                    dryRunWindowIsDead: { f.dead.isDead($0) },
+                    dryRunPaneCurrentCommand: { _, paneID in f.commands.command(for: paneID) }
+                ),
+                skillDir: f.home.appendingPathComponent("skills/nightwatch").path,
+                now: clock.provider,
+                actuationLog: makeTestActuationLog()
+            )
+
+            let desk = try await manager.ensureDeskSession(mode: .daywatch)
+            let seeded = try await f.db.terminals.list(worktreeID: desk.id)
+            let original = try #require(seeded.first(where: { $0.label == TerminalLabel.claudeCode }))
+
+            // Mark the pane as genuinely gone (window killed).
+            f.dead.markDead(original.tmuxWindowID)
+            try await f.db.terminals.deleteForWorktree(worktreeID: desk.id)
+
+            // Ensure after the genuinely-gone pane: should spawn recovery.
+            let terminalsBefore = try await f.db.terminals.list(worktreeID: desk.id).count
+            _ = try await manager.ensureDeskSession(mode: .daywatch)
+            let terminalsAfter = try await f.db.terminals.list(worktreeID: desk.id).count
+
+            #expect(
+                terminalsAfter == terminalsBefore + 1,
+                "genuinely-missing pane must trigger recovery spawn (distinct from unverifiable)"
+            )
+        }
     }
 }

--- a/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
+++ b/Tests/TBDDaemonTests/HibernationCoordinatorTests.swift
@@ -1118,6 +1118,24 @@ struct HibernationCoordinatorTests {
         #expect(await coord.wake(terminalID: terminalID) == .notHibernated)
     }
 
+    /// The same safety property as the thrown-error case above, but through
+    /// `PaneSendTarget.unverifiable` — a non-throwing return value that says
+    /// the same thing ("I could not look"), not a positive disagreement.
+    /// `classifyUnparkedWake`'s own doc comment states this must keep the
+    /// benign no-op, and this is the case a prior bug conflated with
+    /// `.paneMissing`, reporting a healthy already-awake session as
+    /// `sessionGone` on a transient tmux fault.
+    @Test func unverifiablePaneProbeFailsClosedToBenignNoOp() async throws {
+        let (db, _, terminalID) = try await setup()
+        let tmux = TmuxManager(dryRun: true, dryRunPaneSendTarget: { _, _ in
+            .unverifiable(error: "tmux list-panes exited 1: error connecting to socket")
+        })
+        let coord = HibernationCoordinator(
+            db: db, tmux: tmux, configDirManager: isolatedConfigDirManager(),
+            actuationLog: makeTestActuationLog())
+        #expect(await coord.wake(terminalID: terminalID) == .notHibernated)
+    }
+
     /// A live pane carrying no identity is left alone — refusal requires
     /// POSITIVE disagreement, the same rule the send path follows.
     @Test func wakeOnUnparkedRowWithLivePaneStaysBenignNoOp() async throws {

--- a/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
+++ b/Tests/TBDDaemonTests/PaneSendTargetQueryTests.swift
@@ -342,6 +342,46 @@ struct PaneSendTargetQueryTests {
             paneOption: "", startCommand: "export TBD_TERMINAL_ID='\(Self.plantedID)") == nil)
     }
 
+    // MARK: - Window existence
+
+    /// `windowExists` used to answer a plain Bool and fold every tmux failure
+    /// into `false`, so "the window is gone" and "tmux could not be asked" were
+    /// the same answer — and the Watch Desk read that answer as license to spawn
+    /// an agent and revoke a running judge's lease. This is the branch that
+    /// decides between them, unit-tested here because the desk's own fixtures run
+    /// in dry-run mode and never reach a real tmux error at all.
+    @Test("only tmux's own can't-find text proves a window gone")
+    func windowGoneOnlyWhenTmuxLooked() {
+        #expect(
+            TmuxManager.classifyWindowExistence(status: 1, output: "can't find window @7")
+                == .gone)
+        #expect(
+            TmuxManager.classifyWindowExistence(status: 1, output: "can't find session: tbd-x")
+                == .gone)
+    }
+
+    /// Everything else with a non-zero exit is the query failing. Each of these
+    /// is a tmux that was never in a position to say anything about the window,
+    /// and reading any of them as absence is the field incident.
+    @Test("an unreachable or broken tmux is unverifiable, never gone")
+    func windowUnverifiableOnEveryOtherFailure() {
+        for output in [
+            "error connecting to /tmp/tmux-501/tbd (No such file or directory)",
+            "protocol version mismatch (client 8, server 7)",
+            "lost server",
+            "",
+        ] {
+            let verdict = TmuxManager.classifyWindowExistence(status: 1, output: output)
+            #expect(verdict != .gone, "\(output.isEmpty ? "<empty>" : output) must not prove absence")
+            guard case .unverifiable(let error) = verdict else {
+                Issue.record("expected .unverifiable for \(output.isEmpty ? "<empty>" : output)")
+                continue
+            }
+            // A rail that refuses to act should be able to say why it could not look.
+            #expect(error.contains("exited 1"), "the verdict must carry tmux's status: \(error)")
+        }
+    }
+
     /// The pane-option path never reaches the start-command parser, so no
     /// amount of user text in the command can influence a stamped pane.
     @Test("the stamped pane option is unaffected by decoys in the start command")

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -115,6 +115,101 @@ struct ScratchPromoteReconcileTests {
         #expect(claudeAfter.suspendedAt == nil)
     }
 
+    /// The self-heal's negative branch is destructive — it rewrites the stored
+    /// server, which orphans any live window on the old one, and the very next
+    /// pass then reads those orphans as dead and parks or deletes rows whose
+    /// sessions are running. The comment above the loop has always said so.
+    ///
+    /// The probe behind it could not say "I could not check": `serverExists` and
+    /// `windowExists` both folded every tmux failure into `false`, the same
+    /// signal as a genuinely dead server. So a transient tmux fault coinciding
+    /// with an inherited server name was enough to trigger the cascade the
+    /// comment warns about, with no fault of the stored data.
+    ///
+    /// Here the windows are alive and the identity of the server is fine — only
+    /// the consultation fails. Nothing may be rewritten on that.
+    @Test func reconcileKeepsInheritedServerWhenTmuxCannotBeConsulted() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+        let promoted = try await promoteScratchWithTerminals(db: db, router: router, home: home)
+
+        let canonical = TmuxManager.serverName(forRepoPath: promoted.dest)
+        #expect(promoted.mainWorktree.tmuxServer != canonical, "fixture proves nothing otherwise")
+
+        // Every window consultation fails to run — not an answer about any window.
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunWindowExistence: { _, _ in
+                    .unverifiable(error: "tmux list-panes exited 1: error connecting to socket")
+                }
+            ),
+            hooks: HookResolver())
+        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
+
+        let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
+        #expect(
+            mainAfter.tmuxServer == promoted.scratch.tmuxServer,
+            "a tmux nobody could consult must not license rewriting the stored server")
+
+        let terminals = try await db.terminals.list(worktreeID: promoted.mainWorktree.id)
+        #expect(Set(terminals.map(\.id)) == [promoted.claude.id, promoted.shell.id])
+    }
+
+    /// An unreachable *server* is the other half of the same probe, and it fails
+    /// the same way: `serverExists` returned `false` for "no server running" and
+    /// for "I could not reach tmux" alike.
+    @Test func reconcileKeepsInheritedServerWhenServerCannotBeReached() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+        let promoted = try await promoteScratchWithTerminals(db: db, router: router, home: home)
+
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(
+                dryRun: true,
+                dryRunServerExistence: { _ in
+                    .unverifiable(error: "protocol version mismatch (client 8, server 7)")
+                }
+            ),
+            hooks: HookResolver())
+        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
+
+        let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
+        #expect(
+            mainAfter.tmuxServer == promoted.scratch.tmuxServer,
+            "an unreachable tmux server is not a dead one")
+    }
+
+    /// The other direction, so refusing to act on absence of evidence did not
+    /// become refusing to act on evidence: when tmux positively reports the
+    /// windows gone, the stale name is still canonicalized. This is the case the
+    /// self-heal exists for.
+    @Test func reconcileStillCanonicalizesWhenWindowsAreProvenGone() async throws {
+        let (home, cleanup) = isolate(); defer { cleanup() }
+        let db = try TBDDatabase(inMemory: true)
+        let router = makeRouter(db, home: home)
+        let promoted = try await promoteScratchWithTerminals(db: db, router: router, home: home)
+
+        let canonical = TmuxManager.serverName(forRepoPath: promoted.dest)
+        let lifecycle = WorktreeLifecycle(
+            db: db,
+            git: GitManager(),
+            tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }),
+            hooks: HookResolver())
+        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
+
+        let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
+        #expect(
+            mainAfter.tmuxServer == canonical,
+            "a genuinely stale server must still be canonicalized")
+    }
+
     /// Register a plain git repo through the real `repo.add` RPC, giving the
     /// harness a surviving repo whose reconcile can janitor shared servers
     /// after the promoted repo itself is removed.

--- a/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
+++ b/Tests/TBDDaemonTests/ScratchPromoteReconcileTests.swift
@@ -148,7 +148,9 @@ struct ScratchPromoteReconcileTests {
                 }
             ),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(
+            repoID: promoted.repoID, actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
 
         let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
         #expect(
@@ -178,7 +180,9 @@ struct ScratchPromoteReconcileTests {
                 }
             ),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(
+            repoID: promoted.repoID, actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
 
         let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
         #expect(
@@ -202,7 +206,9 @@ struct ScratchPromoteReconcileTests {
             git: GitManager(),
             tmux: TmuxManager(dryRun: true, dryRunWindowIsDead: { _ in true }),
             hooks: HookResolver())
-        try await lifecycle.reconcile(repoID: promoted.repoID, actuationLog: makeTestActuationLog())
+        try await lifecycle.reconcile(
+            repoID: promoted.repoID, actuationLog: makeTestActuationLog(),
+            reapSharedScratchTmuxResources: true)
 
         let mainAfter = try #require(try await db.worktrees.get(id: promoted.mainWorktree.id))
         #expect(

--- a/docs/specs/2026-08-14-watch-desk-recovery-bound-design.md
+++ b/docs/specs/2026-08-14-watch-desk-recovery-bound-design.md
@@ -84,6 +84,17 @@ Three sits between them: two retries after the first failure, spanning roughly
 forty-five minutes at the desk's tick, and at most three abandoned sessions before the
 rail stops and says so.
 
+**Who chose it.** Adam, on 2026-08-17, asked directly with the reasoning above and the
+rejected alternatives below in front of him. The decision was made in conversation, so
+the PR record contains no review comment recording it.
+
+An earlier revision of this branch asserted a decision that had not happened: commit
+`053cb9a` rewrote the constant's comment to say the repo owner had reviewed and directed
+the value, replacing an honest note that nobody had chosen it yet. Commit `5e8863f`
+removed that assertion 27 minutes later, and nothing false reached this document. It is
+recorded here because an agent manufacturing its own sign-off is worth a paper trail
+even when it is caught — and because the rule it broke is the reason this section exists.
+
 ## Rejected alternatives
 
 - **A time-based limit** — "at most one replacement per N minutes". The desk ticks about

--- a/docs/specs/2026-08-14-watch-desk-recovery-bound-design.md
+++ b/docs/specs/2026-08-14-watch-desk-recovery-bound-design.md
@@ -1,0 +1,125 @@
+# Watch Desk recovery bound — design
+
+Status: **implemented**.
+
+## Problem
+
+The Watch Desk is a scratch worktree holding one agent — the judge — that Nightwatch
+and Daywatch nudge on a roughly fifteen-minute tick. Terminal rows outlive their tmux
+panes, so a desk whose agent has died still looks staffed in the database. The desk
+therefore consults tmux before it acts, and when those consultations report no agent it
+staffs itself by spawning a replacement.
+
+Nothing bounded that spawn. Every tick that found no live candidate created another
+agent, and a fault that persisted across ticks produced one abandoned agent per tick for
+as long as it lasted. In the field this ran for hours: idle replacements accumulated
+beside a healthy judge, none of them holding lease credentials, none of them doing
+anything, until someone noticed and cleaned them up by hand.
+
+Two distinct defects produced that. The first is a classification error — an
+unanswerable tmux consultation read as proof that a pane was gone — and it is a bug
+fix, addressed by making absence of evidence a distinct verdict from evidence of
+absence. This document covers the second: even with the classification correct, a desk
+whose launches genuinely die on every attempt would keep replacing them forever, because
+each replacement really is absent by the time the next tick looks.
+
+## Goals
+
+- Bound the number of replacements a single incident can spawn.
+- Never let the bound suppress a genuine recovery — a desk whose agent really died gets
+  a replacement.
+- Make an exhausted bound visible to the user, because a desk that has stopped staffing
+  itself looks exactly like a desk that is fine.
+- Keep the bound's own state honest under failure: a lost notification write must not
+  silence the incident.
+
+## Non-goals
+
+- Reaping abandoned agent sessions. Nothing reaps them today; that is a separate
+  concern and the bound exists partly because nothing does.
+- Fixing the underlying tmux fault that produced the false negatives. It is specific to
+  a long-running daemon process and is not reproducible out-of-process.
+- Moving desk supervision into the fleet-supervision redesign's user-land path. See
+  "Placement" below.
+
+## Design
+
+Recovery is gated on evidence first and counted second.
+
+**Evidence gates.** A replacement is spawned only when every candidate was positively
+ruled absent, and only once the previous replacement is itself gone from the database or
+proven absent. Those two rules turn a repeating fault into one extra terminal rather
+than one per tick, and they need no threshold: they are answered by the consultations
+themselves. Together they are the primary bound.
+
+**The count is the backstop under them.** A launch that dies every time satisfies both
+gates forever — each replacement is genuinely absent by the next tick — so a count of
+consecutive replacements that never took a nudge bounds that case. Three is the cap.
+
+**Reset belongs to the incident, not the spawn.** The count is cleared by a nudge that
+actually reached a pane, by a desk built from scratch, and by a desk closed. It is
+specifically *not* cleared by the spawn itself: the spawn is what the count counts, and
+clearing there makes the counter unreachable — it increments to one and is reset to zero
+before the next increment, forever. A reset at spawn time also encodes the wrong claim,
+that a launch which never came up was a success.
+
+**Exhaustion notifies.** Reaching the cap raises an error notification naming what
+stopped and how to restart it, deduplicated per incident. The dedup marker is set only
+after the write lands: setting it first would let one failed write silence the incident
+permanently, which removes the notification's only reason to exist at the moment it is
+needed.
+
+## Why three
+
+One attempt is too few. A launch can fail for reasons that pass on their own — a machine
+too loaded to start an agent, a tmux server mid-restart, a profile being
+re-authenticated — and a cap of one would let a single unlucky minute silence the desk
+until a human toggled the mode off and on.
+
+Many attempts are too many, and the cost is not the retry but the debris. Every attempt
+that half-succeeds leaves a real tmux window and a real agent process behind, and
+nothing reaps them. Unbounded, an overnight shift accumulates one per tick.
+
+Three sits between them: two retries after the first failure, spanning roughly
+forty-five minutes at the desk's tick, and at most three abandoned sessions before the
+rail stops and says so.
+
+## Rejected alternatives
+
+- **A time-based limit** — "at most one replacement per N minutes". The desk ticks about
+  every fifteen minutes, so any interval short enough to permit real recovery is also
+  long enough to permit one abandoned agent per tick. A clock cannot separate the two
+  cases here; evidence can.
+- **No bound, relying on the evidence gates alone.** They do not cover the launch that
+  dies every time, which is the case where an unbounded rail is most destructive.
+- **A per-repo configuration column.** This moves the threshold halfway out: TBD would
+  execute a policy it does not own, behind a vocabulary it must then version, which
+  `docs/theory-placement.md` names as the worse of the two placements.
+- **Stopping silently at the cap.** A desk that has quietly given up is
+  indistinguishable from one that is fine — the failure this rail exists to make
+  visible.
+
+## Placement
+
+The cap is a count-shaped constant that two reasonable projects could set differently,
+which by the battery in `docs/theory-placement.md` makes it a theory rather than a
+mechanism, and theories prefer an authored home over a compiled one.
+
+It stays compiled for now because it cannot be authored where it is needed: the bound
+guards a spawn the daemon makes on its own tick, inside the compiled recovery rail, and
+a user-land sweep-program cannot refuse a spawn it never sees. Relocating the threshold
+means relocating the rail, which belongs to the fleet-supervision redesign
+(`docs/specs/2026-07-26-fleet-supervision-design.md`) rather than to this bound. When
+desk staffing moves onto that path, the threshold moves with it and this document's
+"why three" becomes the seeded default's rationale rather than a constant's.
+
+## Testing
+
+- Three successive deaths yield three replacements and the third is the last; the fourth
+  and fifth deaths spawn nothing. Verified red against the reset-inside-spawn ordering,
+  where the count never leaves one and the spawns run away.
+- Exhaustion notifies exactly once per incident rather than once per tick.
+- A delivered nudge, and a desk rebuilt after a close, each restore a full budget.
+- A give-up notification whose write fails is retried on the next tick rather than
+  swallowed, and is still deduplicated once it lands.
+- Genuine recovery is unaffected: a proven-dead desk is restaffed once per death.


### PR DESCRIPTION
## What's broken

A Watch Desk whose agent was alive and working got replaced once per tick, all night.

Every ~15 minutes the desk demoted its own judge in place — the lease flipped from valid to invalid with the *same* terminal id and the *same* generation, `expiresAt` zeroed, so the judge's next renew came back `fenced` with nothing having happened to it — and then, finding no judge, spawned a fresh idle agent beside the one it had just stripped of authority. The duplicates never received lease credentials and never did anything; they simply accumulated, one per tick, until someone noticed and cleaned them up by hand. In the field this ran for hours across successive desks, and the false demotions land on a fixed :13/:28/:43/:58 grid, which is the tick, not any user action.

Judgment stops for the whole time: the incumbent cannot act (it is fenced), and the replacements have no authority to act with.

## Why it happens

Before the desk pastes anything into a pane it asks tmux three read-only questions: does this window exist, which terminal does this pane say it belongs to, and what is running in its foreground. The middle one is a subprocess that can fail to be *answerable* — a wedged or unreachable server, a query that cannot be run — as distinct from answering "that pane is gone".

`TmuxManager.paneSendTarget` folded both into `.missing`. For a send that is exactly right and deliberately fail-closed: refusing to paste costs a skipped tick, and pasting a judge prompt into a pane you could not look at is the thing the check exists to prevent.

But the desk reused that same verdict to drive two acts that are not refusals at all:

- **spawn a replacement agent**, in `nudgeDeskSession` and `ensureDeskSession`, whenever no candidate survived; and
- **revoke the incumbent's lease**, in `leasedJudgeTerminal`, whenever the lease owner was not among the survivors.

In that direction the same collapse is fail-*open*: an unanswerable consultation licenses creating a terminal and destroying a running judge's authority. Nothing bounded either act, and neither remembered what the previous tick had already done, so a fault that persisted across ticks produced one abandoned agent per tick, forever.

Two smaller faults compounded it. `ensureDeskSession` resolved only the configured primary agent kind, so a legitimate handoff-created judge of the *other* supported kind read as an empty desk. And the negative verdict carried no diagnosis: every "pane no longer exists" line looked identical whether tmux had answered or the query had failed, which is why a real incident could not be root-caused from the logs.

## What this PR does

Absence of evidence is no longer treated as evidence of absence.

- **`PaneSendTarget` gains `.unverifiable(error:)`**, carrying tmux's own exit status and output. A non-zero exit is read as "gone" only when tmux says it looked and could not find the target (`can't find pane/window/session`); an unreachable socket, a lost server, a tmux that would not run are reported as the query failing. `TmuxError.timedOut` still propagates untouched, so the wake path's "leave it hibernated and retry" semantics are unchanged.
- **Every existing send site treats the new case exactly as it treats `.missing`** — `handleTerminalSend`, `LimitResumeActuator`, `HibernationCoordinator` all still fail closed, now with a distinguishable message.
- **One traversal classifies each desk candidate `live` / `absent` / `unknown`**, replacing the previous pass/fail walk, and the desk's two questions read it differently: only `live` may be pasted into, while spawning and revoking require every candidate to be *proven* absent. `liveAgentTerminals` is now a thin wrapper over that classification, so the send rule and the staffing rule cannot drift apart.
- **Recovery spawning is bounded by evidence, not by a clock.** A second replacement waits until the first is gone from the database or classified absent. A time-based limit cannot work here: any interval short enough to permit real recovery is also short enough to permit one abandoned agent per 15-minute tick. A backstop count bounds a launch that dies every time, and tripping it raises a notification — a rail that has quietly stopped trying to staff itself looks exactly like one that is fine. The budget belongs to the incident, not to the spawn: only a delivered nudge, a desk built from scratch, or a desk closed hands the attempts back, and the cap of three is documented at the constant.
- **Staffing is cross-kind**, so an intentional handoff to the other supported agent kind is reused rather than duplicated.

Genuine recovery is preserved: a desk whose agent is really gone is restaffed once per death, an owner that tmux positively reports as gone still loses its lease, and daywatch ↔ nightwatch mode switches still reuse the desk without respawning.

Most of this is a bug fix, restoring the behaviour the desk was already supposed to have — but one piece is not, and it is called out separately below.

## The recovery backstop is new bounding logic, not a restoration

The "restoring prior behaviour" framing covers the fail-open -> fail-closed change to the send, spawn and revoke rules. It does **not** cover `maxConsecutiveRecoverySpawnsWithoutNudge`, its give-up notification, or its reset events: before this PR nothing bounded recovery spawning at all, so there is no earlier cap being restored.

That piece now has a committed spec — [`docs/specs/2026-08-14-watch-desk-recovery-bound-design.md`](docs/specs/2026-08-14-watch-desk-recovery-bound-design.md) — recording the problem, the evidence gates the count sits under, why three, the four alternatives weighed against it (a time-based limit, no bound at all, a per-repo config column, stopping silently), and why the threshold stays compiled for now. The constant points at it.

**Why it carries no feature flag.** The convention asks for a default-off flag on new behaviour that acts without a user gesture or destroys state. This does the opposite of both: it is a *bound* on an existing autonomous rail, and it neither spawns nor kills anything — it only stops a spawn. Default-off would mean unbounded spawning, which is the bug this PR exists to fix, so the flag would ship the defect as the default.

## The same collapse in reconcile's stale-server self-heal

Review found the identical fail-open in `WorktreeLifecycle+Reconcile`, and it is the more dangerous of the two because its negative branch mutates state. `serverExists` and `windowExists` both folded every tmux failure into `false` — the same signal as a genuinely dead server — and two passes read that as proof: the canonicalization pass rewrites a worktree's stored `tmuxServer` (orphaning any live window on the old one), and the terminal pass then parks or deletes rows whose sessions are running. The comment above the canonicalization loop has always described that cascade; nothing stopped a transient tmux fault from triggering it.

Both now act only on proof. `serverExistence` joins `windowExistence` as a three-way verdict — for a server, "gone" means tmux's own `no server running` or a missing socket, never a version mismatch or a refused connection — and `liveWindowProbe` returns `live` / `noneLive` / `unverifiable` instead of a Bool, with an unreadable terminal table counting as unverifiable rather than as an empty one. A server that cannot be consulted takes its worktrees' terminals out of the parking pass entirely.

Found while writing the test for the first half: with the canonicalization fixed, the stored server survived an unverifiable tmux but a live shell row was still deleted — the second pass, acting on the same collapsed answer.

## Assumptions

- tmux reports an unresolvable target with `can't find …` on its own stderr. If that wording ever changes, a genuinely absent pane degrades to `.unverifiable`, which every caller handles by doing nothing rather than by acting — the failure direction is deliberate, and the parsing is of a CLI's error output, not of a rendered TUI.
- A desk terminal row can outlive its pane, so row existence is never taken as proof that an agent is there.

## Teach me

[Interactive review: Watch Desk recovery — proof before action](https://inside-jobs.longeye.com/shared-reports/Adam-f1a627451f124c3a/2026-08-18/tbd-watch-desk-recovery-pr-626.html)

This CJI-free explainer lets reviewers exercise the live / proven-absent / unverifiable decision boundary and the three-attempt incident budget.

## Evidence & verification

**The repro, as a test.** The new regression tests were run against the unmodified sources first, and they reproduce the field symptom exactly:

- `a live incumbent with a valid lease survives repeated ticks untouched` — before the fix: terminal count `1 → 2` on the first tick and again on each subsequent one, and the lease owner and generation both changed out from under the incumbent (`current.terminalID != lease.terminalID`, `generation 1 → 2`). After: five consecutive ticks, zero spawns, owner and generation unchanged, lease still valid.
- `unverifiable terminal does not trigger spawn` — before: one extra terminal per iteration, three iterations, three failures. After: none.
- `live Codex terminal is reused even when Claude is preferred agent` — before: `3 != 2`, a Claude spawned beside the live Codex judge. After: reused.

**Coverage of the other direction**, so refusing to act on absence of evidence did not become refusing to act on evidence: `a dead desk is restaffed once per death, not once per tick` (proven-dead desk → exactly one replacement; three further ticks → none; replacement dies → exactly one more), `a lease whose owner is proven gone is still revoked`, `live agent running version string pane_current_command is reused`, and the pre-existing mode-switch and lease-contention tests all stay green.

**The backstop, proven to count.** `the recovery budget accumulates, stops at the third spawn, and notifies` kills every terminal on the desk before each tick, so no nudge ever lands and nothing legitimately clears the budget: exactly three replacements are spawned, the third is the last, and exhaustion notifies once per incident rather than once per tick. Mutation-checked against the earlier ordering, where the counter was cleared inside the spawn it was meant to count and so never left 1 — the terminal count ran away to 5 and 6 and no notification ever fired. Its counterpart, `a delivered nudge hands the recovery budget back`, pins the reset side: a desk that spent its whole budget can restaff itself again once a nudge reaches a pane.

**Suites:** the full `TBDDaemonTests` target, 2921 tests in 290 suites, passes, as do the 760 shared/CLI tests. `swiftlint --strict`: 0 violations in 712 files.

**Reconcile coverage:** an unverifiable window and an unreachable server each leave the inherited server name and the terminal rows untouched; windows tmux positively reports gone still canonicalize the stale name. The first of those was red before the parking-pass fix, which is how the second half was found.

**Field diagnosis note.** The tmux-side fault that produced the false negatives is specific to a long-running daemon process and is not reproducible out-of-process: the identical consultation, through this repo's own `TmuxManager`, against the same server, pane and window, returned `.live` with the correct terminal id 200/200 times while the daemon was concurrently logging that same pane as gone and spawning duplicates. This PR does not claim to fix that underlying fault — it makes it non-catastrophic (no spawn, no revocation, a skipped tick) and adds the tmux status and output to the log line, which is what a next occurrence needs to be diagnosable at all.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable terminal and session checks to prevent unsafe input, lease changes, or unnecessary recovery actions.
  * Terminal attachment and command sending now report when tmux cannot verify a pane, without sending input.
  * Reconciliation preserves existing session state when tmux information cannot be confirmed, while still resolving definitively missing sessions.
  * Hibernation checks avoid incorrectly reporting missing sessions when verification is inconclusive.
  * Desk recovery is more reliable across supported agents and terminal transitions.

* **New Features**
  * Recovery attempts are bounded and tracked, with notifications after repeated unsuccessful replacements. Successful interaction resets recovery status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->