### PR TITLE
fix: reject invalid Accessibility window geometry

### DIFF
--- a/Sources/TBDApp/Diagnostics/AccessibilityWindowGeometryGuard.swift
+++ b/Sources/TBDApp/Diagnostics/AccessibilityWindowGeometryGuard.swift
@@ -1,0 +1,73 @@
+import AppKit
+import ObjectiveC.runtime
+import os
+
+private let accessibilityGeometryLogger = Logger(
+    subsystem: "com.tbd.app",
+    category: "accessibility-geometry"
+)
+
+private typealias AccessibilityGeometrySetter = @convention(c) (
+    AnyObject,
+    Selector,
+    AnyObject
+) -> Void
+
+/// Prevents malformed geometry from external Accessibility clients from
+/// reaching AppKit's `NSWindow` frame setter, which raises an uncaught
+/// `NSInternalInconsistencyException` for NaN or infinite coordinates.
+@MainActor
+enum AccessibilityWindowGeometryGuard {
+    private static var isInstalled = false
+
+    static func install() {
+        guard !isInstalled else { return }
+        isInstalled = true
+
+        installSetter(
+            selectorName: "accessibilitySetPositionAttribute:",
+            geometryName: "position"
+        ) { value in
+            let point = value.pointValue
+            return point.x.isFinite && point.y.isFinite
+        }
+        installSetter(
+            selectorName: "accessibilitySetSizeAttribute:",
+            geometryName: "size"
+        ) { value in
+            let size = value.sizeValue
+            return size.width.isFinite && size.height.isFinite
+        }
+    }
+
+    private static func installSetter(
+        selectorName: String,
+        geometryName: String,
+        isValid: @escaping (NSValue) -> Bool
+    ) {
+        let selector = NSSelectorFromString(selectorName)
+        guard let method = class_getInstanceMethod(NSWindow.self, selector) else {
+            accessibilityGeometryLogger.fault(
+                "Could not install Accessibility geometry guard; missing selector \(selectorName, privacy: .public)"
+            )
+            return
+        }
+
+        let originalImplementation = method_getImplementation(method)
+        let originalSetter = unsafeBitCast(
+            originalImplementation,
+            to: AccessibilityGeometrySetter.self
+        )
+        let replacement: @convention(block) (AnyObject, AnyObject) -> Void = { window, rawValue in
+            guard let value = rawValue as? NSValue, !isValid(value) else {
+                originalSetter(window, selector, rawValue)
+                return
+            }
+
+            accessibilityGeometryLogger.fault(
+                "Rejected non-finite Accessibility window \(geometryName, privacy: .public) value=\(value.description, privacy: .public) class=\(String(describing: type(of: window)), privacy: .public)"
+            )
+        }
+        method_setImplementation(method, imp_implementationWithBlock(replacement))
+    }
+}

--- a/Sources/TBDApp/Diagnostics/AccessibilityWindowGeometryGuard.swift
+++ b/Sources/TBDApp/Diagnostics/AccessibilityWindowGeometryGuard.swift
@@ -26,14 +26,16 @@ enum AccessibilityWindowGeometryGuard {
 
         installSetter(
             selectorName: "accessibilitySetPositionAttribute:",
-            geometryName: "position"
+            geometryName: "position",
+            expectedObjCType: String(cString: NSValue(point: .zero).objCType)
         ) { value in
             let point = value.pointValue
             return point.x.isFinite && point.y.isFinite
         }
         installSetter(
             selectorName: "accessibilitySetSizeAttribute:",
-            geometryName: "size"
+            geometryName: "size",
+            expectedObjCType: String(cString: NSValue(size: .zero).objCType)
         ) { value in
             let size = value.sizeValue
             return size.width.isFinite && size.height.isFinite
@@ -43,6 +45,7 @@ enum AccessibilityWindowGeometryGuard {
     private static func installSetter(
         selectorName: String,
         geometryName: String,
+        expectedObjCType: String,
         isValid: @escaping (NSValue) -> Bool
     ) {
         let selector = NSSelectorFromString(selectorName)
@@ -59,14 +62,18 @@ enum AccessibilityWindowGeometryGuard {
             to: AccessibilityGeometrySetter.self
         )
         let replacement: @convention(block) (AnyObject, AnyObject) -> Void = { window, rawValue in
-            guard let value = rawValue as? NSValue, !isValid(value) else {
+            guard let value = rawValue as? NSValue else {
                 originalSetter(window, selector, rawValue)
                 return
             }
+            guard String(cString: value.objCType) == expectedObjCType, isValid(value) else {
+                accessibilityGeometryLogger.fault(
+                    "Rejected invalid Accessibility window \(geometryName, privacy: .public) value=\(value.description, privacy: .public) class=\(String(describing: type(of: window)), privacy: .public)"
+                )
+                return
+            }
 
-            accessibilityGeometryLogger.fault(
-                "Rejected non-finite Accessibility window \(geometryName, privacy: .public) value=\(value.description, privacy: .public) class=\(String(describing: type(of: window)), privacy: .public)"
-            )
+            originalSetter(window, selector, rawValue)
         }
         method_setImplementation(method, imp_implementationWithBlock(replacement))
     }

--- a/Sources/TBDApp/TBDApp.swift
+++ b/Sources/TBDApp/TBDApp.swift
@@ -194,6 +194,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // persists into the real plist, per repo UserDefaults rules.
         UserDefaults.standard.register(defaults: ["NSTableViewCanEstimateRowHeights": false])
 
+        // External Accessibility clients can send malformed window geometry.
+        // AppKit raises an uncaught exception if NaN or infinity reaches its
+        // frame setter, so reject only those values at the Accessibility edge.
+        AccessibilityWindowGeometryGuard.install()
+
         // Install crash handlers before any AppKit/SwiftUI code can throw or trap.
         // The Obj-C exception preprocessor must come first — it's our only chance
         // to capture the reason for exceptions that AppKit converts to SIGTRAP via

--- a/Tests/TBDAppTests/AccessibilityWindowGeometryGuardTests.swift
+++ b/Tests/TBDAppTests/AccessibilityWindowGeometryGuardTests.swift
@@ -1,0 +1,86 @@
+import AppKit
+import Testing
+@testable import TBDApp
+
+@Suite("Accessibility window geometry guard", .serialized)
+@MainActor
+struct AccessibilityWindowGeometryGuardTests {
+    @Test("rejects a non-finite Accessibility position")
+    func rejectsNonFinitePosition() {
+        AccessibilityWindowGeometryGuard.install()
+        let window = makeWindow()
+        let originalFrame = window.frame
+
+        setAccessibilityValue(
+            NSValue(point: NSPoint(x: -556, y: CGFloat.nan)),
+            selectorName: "accessibilitySetPositionAttribute:",
+            on: window
+        )
+
+        #expect(window.frame == originalFrame)
+    }
+
+    @Test("forwards a finite Accessibility position")
+    func forwardsFinitePosition() {
+        AccessibilityWindowGeometryGuard.install()
+        let window = makeWindow()
+
+        setAccessibilityValue(
+            NSValue(point: NSPoint(x: 40, y: 50)),
+            selectorName: "accessibilitySetPositionAttribute:",
+            on: window
+        )
+
+        #expect(window.frame.origin == NSPoint(x: 40, y: 50))
+    }
+
+    @Test("rejects a non-finite Accessibility size")
+    func rejectsNonFiniteSize() {
+        AccessibilityWindowGeometryGuard.install()
+        let window = makeWindow()
+        let originalFrame = window.frame
+
+        setAccessibilityValue(
+            NSValue(size: NSSize(width: CGFloat.infinity, height: 240)),
+            selectorName: "accessibilitySetSizeAttribute:",
+            on: window
+        )
+
+        #expect(window.frame == originalFrame)
+    }
+
+    @Test("forwards a finite Accessibility size")
+    func forwardsFiniteSize() {
+        AccessibilityWindowGeometryGuard.install()
+        let window = makeWindow()
+        let originalSize = window.frame.size
+
+        setAccessibilityValue(
+            NSValue(size: NSSize(width: 420, height: 310)),
+            selectorName: "accessibilitySetSizeAttribute:",
+            on: window
+        )
+
+        #expect(window.frame.size != originalSize)
+        #expect(window.frame.width == 420)
+    }
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 10, y: 20, width: 320, height: 240),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    private func setAccessibilityValue(
+        _ value: NSValue,
+        selectorName: String,
+        on window: NSWindow
+    ) {
+        let selector = NSSelectorFromString(selectorName)
+        #expect(window.responds(to: selector))
+        _ = window.perform(selector, with: value)
+    }
+}

--- a/Tests/TBDAppTests/AccessibilityWindowGeometryGuardTests.swift
+++ b/Tests/TBDAppTests/AccessibilityWindowGeometryGuardTests.swift
@@ -34,6 +34,21 @@ struct AccessibilityWindowGeometryGuardTests {
         #expect(window.frame.origin == NSPoint(x: 40, y: 50))
     }
 
+    @Test("rejects a type-mismatched Accessibility position")
+    func rejectsMismatchedPositionValueType() {
+        AccessibilityWindowGeometryGuard.install()
+        let window = makeWindow()
+        let originalFrame = window.frame
+
+        setAccessibilityValue(
+            NSValue(rect: NSRect(x: 1, y: 2, width: 3, height: 4)),
+            selectorName: "accessibilitySetPositionAttribute:",
+            on: window
+        )
+
+        #expect(window.frame == originalFrame)
+    }
+
     @Test("rejects a non-finite Accessibility size")
     func rejectsNonFiniteSize() {
         AccessibilityWindowGeometryGuard.install()
@@ -63,6 +78,21 @@ struct AccessibilityWindowGeometryGuardTests {
 
         #expect(window.frame.size != originalSize)
         #expect(window.frame.width == 420)
+    }
+
+    @Test("rejects a type-mismatched Accessibility size")
+    func rejectsMismatchedSizeValueType() {
+        AccessibilityWindowGeometryGuard.install()
+        let window = makeWindow()
+        let originalFrame = window.frame
+
+        setAccessibilityValue(
+            NSValue(rect: NSRect(x: 1, y: 2, width: 3, height: 4)),
+            selectorName: "accessibilitySetSizeAttribute:",
+            on: window
+        )
+
+        #expect(window.frame == originalFrame)
     }
 
     private func makeWindow() -> NSWindow {


### PR DESCRIPTION
## What's broken

An external Accessibility client can send TBDApp a non-finite window position or size. AppKit accepts the Accessibility request far enough to construct an invalid `NSWindow` frame, then raises an uncaught `NSInternalInconsistencyException` and terminates TBDApp. The observed crash attempted to apply a frame whose vertical origin was `NaN`.

## Why it happens

TBDApp relies on AppKit's default Accessibility window setters. Those setters forward position and size values into AppKit's frame machinery without rejecting `NaN` or infinite components, and AppKit treats the resulting frame as an internal-consistency violation rather than returning an Accessibility error.

## What this PR does

- Installs a one-time guard on `NSWindow`'s Accessibility position and size setters before SwiftUI creates application windows.
- Rejects geometry containing non-finite components or an unexpected Objective-C payload encoding, and records a fault-level diagnostic.
- Forwards finite and unexpected values through the original AppKit implementations unchanged.
- Adds real-AppKit regression coverage for non-finite and type-mismatched position/size values plus valid forwarding.

The interception stays at the Accessibility boundary implicated by the crash instead of changing general `NSWindow` frame behavior.

## Evidence & verification

- Standalone reproduction: sending `(-556, NaN)` through AppKit's Accessibility position setter reproduced the same invalid-frame exception outside TBDApp.
- RED: `scripts/test.sh --filter AccessibilityWindowGeometryGuardTests` failed because the guard did not exist before production code was added.
- Claude review follow-up RED: passing `NSValue(rect:)` to the position setter reproduced the uncaught Objective-C accessor exception.
- GREEN on the current PR head: the focused command passes all 6 tests, including the observed `(-556, NaN)` position, an infinite size, and mismatched Objective-C value encodings.
- `scripts/swift-safe build` passes.
- `swiftlint --strict` reports 0 violations across 721 files.
- A full `scripts/test.sh` run executed 5,865 tests. The new Accessibility suite passed; the run had one unexpected failure in the unrelated transcript row-height estimator suite. Rerunning that suite alone, without installing or executing this guard, reproduces the same existing failure.
- Independent pre-merge review found no blocking correctness, ABI, lifecycle, or isolation issues after direct IMP-level verification of the reviewer's initial `nil` concern.

