### PR TITLE
fix: preserve Codex activity across goal turns

### DIFF
--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -58,6 +58,8 @@ enum CodexHookOverlay {
     static let sessionStartCommand =
         #"tbd session-event 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
 
+    // Only an active goal can cross a Stop hook into autonomous continuation.
+    // Paused and limited goals have stopped the current run, so they publish idle.
     static let responseCompleteCommand =
         #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null); SESSION_ID_SQL=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g"); GOAL_STATUS=$(sqlite3 -readonly "$CODEX_HOME/goals_1.sqlite" "SELECT status FROM thread_goals WHERE thread_id = '$SESSION_ID_SQL' ORDER BY updated_at_ms DESC, created_at_ms DESC, rowid DESC LIMIT 1;" 2>/dev/null); [ "$GOAL_STATUS" = active ] || tbd terminal-activity idle 2>/dev/null || true"#
 

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -59,7 +59,7 @@ enum CodexHookOverlay {
         #"tbd session-event 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
 
     static let responseCompleteCommand =
-        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
+        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null); SESSION_ID_SQL=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g"); GOAL_STATUS=$(sqlite3 -readonly "$CODEX_HOME/goals_1.sqlite" "SELECT status FROM thread_goals WHERE thread_id = '$SESSION_ID_SQL' LIMIT 1;" 2>/dev/null); [ "$GOAL_STATUS" = active ] || tbd terminal-activity idle 2>/dev/null || true"#
 
     static let stopRenameCheckCommand =
         #"tbd hooks stop-rename-check 2>/dev/null || true"#

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -59,7 +59,7 @@ enum CodexHookOverlay {
         #"tbd session-event 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
 
     static let responseCompleteCommand =
-        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null); SESSION_ID_SQL=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g"); GOAL_STATUS=$(sqlite3 -readonly "$CODEX_HOME/goals_1.sqlite" "SELECT status FROM thread_goals WHERE thread_id = '$SESSION_ID_SQL' ORDER BY updated_at_ms DESC LIMIT 1;" 2>/dev/null); [ "$GOAL_STATUS" = active ] || tbd terminal-activity idle 2>/dev/null || true"#
+        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null); SESSION_ID_SQL=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g"); GOAL_STATUS=$(sqlite3 -readonly "$CODEX_HOME/goals_1.sqlite" "SELECT status FROM thread_goals WHERE thread_id = '$SESSION_ID_SQL' ORDER BY updated_at_ms DESC, created_at_ms DESC, rowid DESC LIMIT 1;" 2>/dev/null); [ "$GOAL_STATUS" = active ] || tbd terminal-activity idle 2>/dev/null || true"#
 
     static let stopRenameCheckCommand =
         #"tbd hooks stop-rename-check 2>/dev/null || true"#

--- a/Sources/TBDDaemon/Codex/CodexHomeManager.swift
+++ b/Sources/TBDDaemon/Codex/CodexHomeManager.swift
@@ -59,7 +59,7 @@ enum CodexHookOverlay {
         #"tbd session-event 2>/dev/null || true; tbd terminal-activity idle 2>/dev/null || true"#
 
     static let responseCompleteCommand =
-        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null); SESSION_ID_SQL=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g"); GOAL_STATUS=$(sqlite3 -readonly "$CODEX_HOME/goals_1.sqlite" "SELECT status FROM thread_goals WHERE thread_id = '$SESSION_ID_SQL' LIMIT 1;" 2>/dev/null); [ "$GOAL_STATUS" = active ] || tbd terminal-activity idle 2>/dev/null || true"#
+        #"MSG=$(printf '%s' "$PAYLOAD" | jq -r '.last_assistant_message // empty' 2>/dev/null); tbd notify --type response_complete --message "$MSG" 2>/dev/null || true; SESSION_ID=$(printf '%s' "$PAYLOAD" | jq -r '.session_id // empty' 2>/dev/null); SESSION_ID_SQL=$(printf '%s' "$SESSION_ID" | sed "s/'/''/g"); GOAL_STATUS=$(sqlite3 -readonly "$CODEX_HOME/goals_1.sqlite" "SELECT status FROM thread_goals WHERE thread_id = '$SESSION_ID_SQL' ORDER BY updated_at_ms DESC LIMIT 1;" 2>/dev/null); [ "$GOAL_STATUS" = active ] || tbd terminal-activity idle 2>/dev/null || true"#
 
     static let stopRenameCheckCommand =
         #"tbd hooks stop-rename-check 2>/dev/null || true"#

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -5,7 +5,10 @@ import TBDShared
 
 @Suite struct CodexHookOverlayTests {
 
-    private func runStopHook(goalStatus: String) throws -> [String] {
+    private func runStopHook(
+        goalStatus: String,
+        sessionID: String = "a1b2c3d4-e5f6-4789-abcd-0123456789ab"
+    ) throws -> [String] {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-stop-hook-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -22,26 +25,29 @@ import TBDShared
             ofItemAtPath: tbdPath.path
         )
 
-        let jqPath = directory.appendingPathComponent("jq")
-        try """
-        #!/bin/sh
-        case "$*" in
-          *session_id*) printf '%s\\n' 'a1b2c3d4-e5f6-4789-abcd-0123456789ab' ;;
-          *) printf '%s\\n' 'done' ;;
-        esac
-        """.write(to: jqPath, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755],
-            ofItemAtPath: jqPath.path
-        )
-
         let databaseProcess = Process()
         databaseProcess.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
         databaseProcess.arguments = [
             directory.appendingPathComponent("goals_1.sqlite").path,
             """
-            CREATE TABLE thread_goals (thread_id TEXT PRIMARY KEY, status TEXT NOT NULL);
-            INSERT INTO thread_goals VALUES ('a1b2c3d4-e5f6-4789-abcd-0123456789ab', '\(goalStatus)');
+            CREATE TABLE thread_goals (
+                thread_id TEXT PRIMARY KEY NOT NULL,
+                goal_id TEXT NOT NULL,
+                objective TEXT NOT NULL,
+                status TEXT NOT NULL CHECK(status IN (
+                    'active', 'paused', 'blocked', 'usage_limited', 'budget_limited', 'complete'
+                )),
+                token_budget INTEGER,
+                tokens_used INTEGER NOT NULL DEFAULT 0,
+                time_used_seconds INTEGER NOT NULL DEFAULT 0,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL
+            );
+            INSERT INTO thread_goals (
+                thread_id, goal_id, objective, status, created_at_ms, updated_at_ms
+            ) VALUES (
+                '\(sessionID)', 'goal-id', 'Test objective', '\(goalStatus)', 1, 1
+            );
             """
         ]
         databaseProcess.standardOutput = Pipe()
@@ -64,7 +70,9 @@ import TBDShared
         process.standardOutput = Pipe()
         process.standardError = Pipe()
         try process.run()
-        let payload = #"{"session_id":"a1b2c3d4-e5f6-4789-abcd-0123456789ab","hook_event_name":"Stop","last_assistant_message":"done"}"#
+        let payload = """
+        {"session_id":"\(sessionID)","hook_event_name":"Stop","last_assistant_message":"done"}
+        """
         input.fileHandleForWriting.write(Data(payload.utf8))
         try input.fileHandleForWriting.close()
         process.waitUntilExit()
@@ -136,6 +144,15 @@ import TBDShared
         let invocations = try runStopHook(goalStatus: "active")
 
         #expect(invocations.contains { $0.hasPrefix("notify --type response_complete") })
+        #expect(!invocations.contains("terminal-activity idle"))
+    }
+
+    @Test func stopHookReadsSessionIDFromPayloadJSON() throws {
+        let invocations = try runStopHook(
+            goalStatus: "active",
+            sessionID: "b2c3d4e5-f607-489a-bcde-1234567890ab"
+        )
+
         #expect(!invocations.contains("terminal-activity idle"))
     }
 

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -8,7 +8,9 @@ import TBDShared
     private func runStopHook(
         goalStatus: String,
         sessionID: String = "a1b2c3d4-e5f6-4789-abcd-0123456789ab",
-        priorGoalStatus: String? = nil
+        priorGoalStatus: String? = nil,
+        assistantMessage: String = "done",
+        goalTimestampsTie: Bool = false
     ) throws -> [String] {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-stop-hook-\(UUID().uuidString)", isDirectory: true)
@@ -20,6 +22,9 @@ import TBDShared
         try """
         #!/bin/sh
         printf '%s\\n' "$*" >> "$TBD_HOOK_TEST_LOG"
+        if [ "$1" = notify ]; then
+          printf 'notify-message=%s\\n' "$5" >> "$TBD_HOOK_TEST_LOG"
+        fi
         """.write(to: tbdPath, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o755],
@@ -31,6 +36,7 @@ import TBDShared
         // Codex 0.147 keys this table by thread_id. Only the history test
         // relaxes that constraint to exercise a possible future schema shape.
         let threadIDConstraint = priorGoalStatus == nil ? "PRIMARY KEY NOT NULL" : "NOT NULL"
+        let currentTimestamp = goalTimestampsTie ? 1 : 2
         let priorGoalInsert = priorGoalStatus.map { status in
             """
             INSERT INTO thread_goals (
@@ -60,7 +66,8 @@ import TBDShared
             INSERT INTO thread_goals (
                 thread_id, goal_id, objective, status, created_at_ms, updated_at_ms
             ) VALUES (
-                '\(sessionID)', 'goal-id', 'Test objective', '\(goalStatus)', 2, 2
+                '\(sessionID)', 'goal-id', 'Test objective', '\(goalStatus)',
+                \(currentTimestamp), \(currentTimestamp)
             );
             """
         ]
@@ -85,7 +92,7 @@ import TBDShared
         process.standardError = Pipe()
         try process.run()
         let payload = """
-        {"session_id":"\(sessionID)","hook_event_name":"Stop","last_assistant_message":"done"}
+        {"session_id":"\(sessionID)","hook_event_name":"Stop","last_assistant_message":"\(assistantMessage)"}
         """
         input.fileHandleForWriting.write(Data(payload.utf8))
         try input.fileHandleForWriting.close()
@@ -170,6 +177,15 @@ import TBDShared
         #expect(!invocations.contains("terminal-activity idle"))
     }
 
+    @Test func stopHookReadsAssistantMessageFromPayloadJSON() throws {
+        let invocations = try runStopHook(
+            goalStatus: "complete",
+            assistantMessage: "goal work finished"
+        )
+
+        #expect(invocations.contains("notify-message=goal work finished"))
+    }
+
     @Test func stopHookUsesMostRecentlyUpdatedGoalStateIfSchemaAllowsHistory() throws {
         let invocations = try runStopHook(
             goalStatus: "active",
@@ -177,6 +193,35 @@ import TBDShared
         )
 
         #expect(!invocations.contains("terminal-activity idle"))
+    }
+
+    @Test func stopHookIgnoresStaleActiveGoalIfLatestStateIsComplete() throws {
+        let invocations = try runStopHook(
+            goalStatus: "complete",
+            priorGoalStatus: "active"
+        )
+
+        #expect(invocations.contains("terminal-activity idle"))
+    }
+
+    @Test func stopHookUsesLatestActiveStateWhenGoalTimestampsTie() throws {
+        let invocations = try runStopHook(
+            goalStatus: "active",
+            priorGoalStatus: "complete",
+            goalTimestampsTie: true
+        )
+
+        #expect(!invocations.contains("terminal-activity idle"))
+    }
+
+    @Test func stopHookUsesLatestCompleteStateWhenGoalTimestampsTie() throws {
+        let invocations = try runStopHook(
+            goalStatus: "complete",
+            priorGoalStatus: "active",
+            goalTimestampsTie: true
+        )
+
+        #expect(invocations.contains("terminal-activity idle"))
     }
 
     @Test func stopHookPublishesIdleWhenCodexGoalIsComplete() throws {

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -10,7 +10,8 @@ import TBDShared
         sessionID: String = "a1b2c3d4-e5f6-4789-abcd-0123456789ab",
         priorGoalStatus: String? = nil,
         assistantMessage: String = "done",
-        goalTimestampsTie: Bool = false
+        goalTimestampsTie: Bool = false,
+        createdAtBreaksUpdateTie: Bool = false
     ) throws -> [String] {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-stop-hook-\(UUID().uuidString)", isDirectory: true)
@@ -37,6 +38,8 @@ import TBDShared
         // relaxes that constraint to exercise a possible future schema shape.
         let threadIDConstraint = priorGoalStatus == nil ? "PRIMARY KEY NOT NULL" : "NOT NULL"
         let currentTimestamp = goalTimestampsTie ? 1 : 2
+        let currentCreatedAt = createdAtBreaksUpdateTie ? 2 : currentTimestamp
+        let currentUpdatedAt = createdAtBreaksUpdateTie ? 1 : currentTimestamp
         let priorGoalInsert = priorGoalStatus.map { status in
             """
             INSERT INTO thread_goals (
@@ -46,6 +49,17 @@ import TBDShared
             );
             """
         } ?? ""
+        let currentGoalInsert = """
+            INSERT INTO thread_goals (
+                thread_id, goal_id, objective, status, created_at_ms, updated_at_ms
+            ) VALUES (
+                '\(sessionID)', 'goal-id', 'Test objective', '\(goalStatus)',
+                \(currentCreatedAt), \(currentUpdatedAt)
+            );
+            """
+        let goalInserts = createdAtBreaksUpdateTie
+            ? "\(currentGoalInsert)\n\(priorGoalInsert)"
+            : "\(priorGoalInsert)\n\(currentGoalInsert)"
         databaseProcess.arguments = [
             directory.appendingPathComponent("goals_1.sqlite").path,
             """
@@ -62,13 +76,7 @@ import TBDShared
                 created_at_ms INTEGER NOT NULL,
                 updated_at_ms INTEGER NOT NULL
             );
-            \(priorGoalInsert)
-            INSERT INTO thread_goals (
-                thread_id, goal_id, objective, status, created_at_ms, updated_at_ms
-            ) VALUES (
-                '\(sessionID)', 'goal-id', 'Test objective', '\(goalStatus)',
-                \(currentTimestamp), \(currentTimestamp)
-            );
+            \(goalInserts)
             """
         ]
         databaseProcess.standardOutput = Pipe()
@@ -81,7 +89,14 @@ import TBDShared
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
         process.arguments = ["-c", CodexHookOverlay.stopCommand]
         var environment = ProcessInfo.processInfo.environment
-        environment["PATH"] = "\(directory.path):/usr/bin:/bin"
+        let inheritedPath = environment["PATH"] ?? ""
+        environment["PATH"] = ([
+            directory.path,
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+        ] + inheritedPath.split(separator: ":").map(String.init)).joined(separator: ":")
         environment["CODEX_HOME"] = directory.path
         environment["TBD_HOOK_TEST_LOG"] = logPath.path
         process.environment = environment
@@ -224,6 +239,16 @@ import TBDShared
         #expect(invocations.contains("terminal-activity idle"))
     }
 
+    @Test func stopHookUsesCreatedAtWhenUpdatedTimesTieBeforeInsertionOrder() throws {
+        let invocations = try runStopHook(
+            goalStatus: "active",
+            priorGoalStatus: "complete",
+            createdAtBreaksUpdateTie: true
+        )
+
+        #expect(!invocations.contains("terminal-activity idle"))
+    }
+
     @Test func stopHookPublishesIdleWhenCodexGoalIsComplete() throws {
         let invocations = try runStopHook(goalStatus: "complete")
 
@@ -233,6 +258,13 @@ import TBDShared
 
     @Test func stopHookPublishesIdleWhenCodexGoalIsBlocked() throws {
         let invocations = try runStopHook(goalStatus: "blocked")
+
+        #expect(invocations.contains("terminal-activity idle"))
+    }
+
+    @Test(arguments: ["paused", "usage_limited", "budget_limited"])
+    func stopHookPublishesIdleWhenCodexGoalCannotContinue(status: String) throws {
+        let invocations = try runStopHook(goalStatus: status)
 
         #expect(invocations.contains("terminal-activity idle"))
     }

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -7,7 +7,8 @@ import TBDShared
 
     private func runStopHook(
         goalStatus: String,
-        sessionID: String = "a1b2c3d4-e5f6-4789-abcd-0123456789ab"
+        sessionID: String = "a1b2c3d4-e5f6-4789-abcd-0123456789ab",
+        priorGoalStatus: String? = nil
     ) throws -> [String] {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("tbd-codex-stop-hook-\(UUID().uuidString)", isDirectory: true)
@@ -27,11 +28,23 @@ import TBDShared
 
         let databaseProcess = Process()
         databaseProcess.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+        // Codex 0.147 keys this table by thread_id. Only the history test
+        // relaxes that constraint to exercise a possible future schema shape.
+        let threadIDConstraint = priorGoalStatus == nil ? "PRIMARY KEY NOT NULL" : "NOT NULL"
+        let priorGoalInsert = priorGoalStatus.map { status in
+            """
+            INSERT INTO thread_goals (
+                thread_id, goal_id, objective, status, created_at_ms, updated_at_ms
+            ) VALUES (
+                '\(sessionID)', 'prior-goal-id', 'Prior objective', '\(status)', 1, 1
+            );
+            """
+        } ?? ""
         databaseProcess.arguments = [
             directory.appendingPathComponent("goals_1.sqlite").path,
             """
             CREATE TABLE thread_goals (
-                thread_id TEXT PRIMARY KEY NOT NULL,
+                thread_id TEXT \(threadIDConstraint),
                 goal_id TEXT NOT NULL,
                 objective TEXT NOT NULL,
                 status TEXT NOT NULL CHECK(status IN (
@@ -43,10 +56,11 @@ import TBDShared
                 created_at_ms INTEGER NOT NULL,
                 updated_at_ms INTEGER NOT NULL
             );
+            \(priorGoalInsert)
             INSERT INTO thread_goals (
                 thread_id, goal_id, objective, status, created_at_ms, updated_at_ms
             ) VALUES (
-                '\(sessionID)', 'goal-id', 'Test objective', '\(goalStatus)', 1, 1
+                '\(sessionID)', 'goal-id', 'Test objective', '\(goalStatus)', 2, 2
             );
             """
         ]
@@ -151,6 +165,15 @@ import TBDShared
         let invocations = try runStopHook(
             goalStatus: "active",
             sessionID: "b2c3d4e5-f607-489a-bcde-1234567890ab"
+        )
+
+        #expect(!invocations.contains("terminal-activity idle"))
+    }
+
+    @Test func stopHookUsesMostRecentlyUpdatedGoalStateIfSchemaAllowsHistory() throws {
+        let invocations = try runStopHook(
+            goalStatus: "active",
+            priorGoalStatus: "complete"
         )
 
         #expect(!invocations.contains("terminal-activity idle"))

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -5,6 +5,75 @@ import TBDShared
 
 @Suite struct CodexHookOverlayTests {
 
+    private func runStopHook(goalStatus: String) throws -> [String] {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tbd-codex-stop-hook-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let logPath = directory.appendingPathComponent("tbd-invocations.log")
+        let tbdPath = directory.appendingPathComponent("tbd")
+        try """
+        #!/bin/sh
+        printf '%s\\n' "$*" >> "$TBD_HOOK_TEST_LOG"
+        """.write(to: tbdPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: tbdPath.path
+        )
+
+        let jqPath = directory.appendingPathComponent("jq")
+        try """
+        #!/bin/sh
+        case "$*" in
+          *session_id*) printf '%s\\n' 'a1b2c3d4-e5f6-4789-abcd-0123456789ab' ;;
+          *) printf '%s\\n' 'done' ;;
+        esac
+        """.write(to: jqPath, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: jqPath.path
+        )
+
+        let databaseProcess = Process()
+        databaseProcess.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+        databaseProcess.arguments = [
+            directory.appendingPathComponent("goals_1.sqlite").path,
+            """
+            CREATE TABLE thread_goals (thread_id TEXT PRIMARY KEY, status TEXT NOT NULL);
+            INSERT INTO thread_goals VALUES ('a1b2c3d4-e5f6-4789-abcd-0123456789ab', '\(goalStatus)');
+            """
+        ]
+        databaseProcess.standardOutput = Pipe()
+        databaseProcess.standardError = Pipe()
+        try databaseProcess.run()
+        databaseProcess.waitUntilExit()
+        #expect(databaseProcess.terminationStatus == 0)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", CodexHookOverlay.stopCommand]
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(directory.path):/usr/bin:/bin"
+        environment["CODEX_HOME"] = directory.path
+        environment["TBD_HOOK_TEST_LOG"] = logPath.path
+        process.environment = environment
+
+        let input = Pipe()
+        process.standardInput = input
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        let payload = #"{"session_id":"a1b2c3d4-e5f6-4789-abcd-0123456789ab","hook_event_name":"Stop","last_assistant_message":"done"}"#
+        input.fileHandleForWriting.write(Data(payload.utf8))
+        try input.fileHandleForWriting.close()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+
+        let log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
+        return log.split(separator: "\n").map(String.init)
+    }
+
     @Test func generateBodyHasExpectedShape() throws {
         let data = try CodexHookOverlay.generateBody()
         let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -61,6 +130,26 @@ import TBDShared
         #expect(stopCommand?.contains("printf '%s\\n' \"$RENAME_RESULT\"") == true)
         #expect(stopCommand?.contains("tbd notify --type response_complete") == true)
         #expect(stopCommand?.contains("tbd terminal-activity idle") == true)
+    }
+
+    @Test func stopHookKeepsWorkingWhileCodexGoalIsActive() throws {
+        let invocations = try runStopHook(goalStatus: "active")
+
+        #expect(invocations.contains { $0.hasPrefix("notify --type response_complete") })
+        #expect(!invocations.contains("terminal-activity idle"))
+    }
+
+    @Test func stopHookPublishesIdleWhenCodexGoalIsComplete() throws {
+        let invocations = try runStopHook(goalStatus: "complete")
+
+        #expect(invocations.contains { $0.hasPrefix("notify --type response_complete") })
+        #expect(invocations.contains("terminal-activity idle"))
+    }
+
+    @Test func stopHookPublishesIdleWhenCodexGoalIsBlocked() throws {
+        let invocations = try runStopHook(goalStatus: "blocked")
+
+        #expect(invocations.contains("terminal-activity idle"))
     }
 
     @Test func roundtripsAsValidJSON() throws {

--- a/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
+++ b/Tests/TBDDaemonTests/CodexHookOverlayTests.swift
@@ -39,13 +39,15 @@ import TBDShared
         let threadIDConstraint = priorGoalStatus == nil ? "PRIMARY KEY NOT NULL" : "NOT NULL"
         let currentTimestamp = goalTimestampsTie ? 1 : 2
         let currentCreatedAt = createdAtBreaksUpdateTie ? 2 : currentTimestamp
-        let currentUpdatedAt = createdAtBreaksUpdateTie ? 1 : currentTimestamp
+        let currentUpdatedAt = createdAtBreaksUpdateTie ? 3 : currentTimestamp
+        let priorUpdatedAt = createdAtBreaksUpdateTie ? 3 : 1
         let priorGoalInsert = priorGoalStatus.map { status in
             """
             INSERT INTO thread_goals (
                 thread_id, goal_id, objective, status, created_at_ms, updated_at_ms
             ) VALUES (
-                '\(sessionID)', 'prior-goal-id', 'Prior objective', '\(status)', 1, 1
+                '\(sessionID)', 'prior-goal-id', 'Prior objective', '\(status)',
+                1, \(priorUpdatedAt)
             );
             """
         } ?? ""


### PR DESCRIPTION
## What's broken

A Codex worktree starts showing its working indicator when `/goal` begins, but the indicator disappears after the first autonomous turn even though goal work continues.

## Why it happens

TBD marks Codex as working only when Codex emits `UserPromptSubmit`, then marks it idle on every `Stop`. Goal execution crosses intermediate turn boundaries automatically: Codex completes one turn and starts the next without another user submission, so the Stop hook clears the only working signal.

Persisted Codex events confirm consecutive `task_complete` and `task_started` events milliseconds apart during goal execution, with no user-submission event between them.

## What this PR does

The generated Codex Stop hook now reads the hook payload's session ID and queries Codex's goal store in read-only mode. It suppresses the idle activity update only while that session's latest goal status is `active`.

Goal rows are selected by semantic recency using `updated_at_ms`, then `created_at_ms`, with SQLite insertion order as the final tie-breaker. Complete, blocked, paused, usage-limited, and budget-limited goals publish idle because the current run cannot continue autonomously; only `active` can cross a Stop boundary into another autonomous turn.

Missing-row, unavailable-database, and query-failure paths retain the existing idle behavior.

The regression harness sends real JSON through the generated shell command and `jq`, asserting extraction of both the session ID and exact assistant message. Its PATH keeps the fake `tbd` first, includes Apple Silicon and Intel Homebrew locations plus system paths, then preserves the inherited PATH.

## Why no design spec

This is a bug fix, which the project workflow explicitly exempts from the design-spec requirement. It restores the existing activity-indicator theory—working only while execution can continue autonomously—and does not introduce a new product mode, autonomous action, or destructive behavior.

## Assumptions

This relies on Codex storing goal state in `$CODEX_HOME/goals_1.sqlite`, in `thread_goals`, keyed by the hook payload's `session_id`. The fixture mirrors the verified Codex 0.147 schema: `thread_id` is the primary key and the table carries `created_at_ms` and `updated_at_ms`. A separate drift fixture relaxes uniqueness to verify deterministic behavior if Codex later retains multiple goal attempts for one thread.

If Codex versions or removes that store or schema, the query fails closed to the previous idle behavior, but active-goal status persistence would stop working.

## Evidence & verification

- Original regression test failed before the fix because an active goal emitted `terminal-activity idle`.
- Real-JSON regression failed with the prior fake `jq` because it returned a hard-coded session ID.
- Unordered-query mutation failed in both directions: stale complete caused idle, while stale active suppressed idle.
- Timestamp-only ordering failed both equal-timestamp direction tests; the final insertion-order tie-breaker made both deterministic.
- Removing `created_at_ms DESC` failed the direct middle-key regression, whose valid timestamp rows deliberately oppose semantic creation time and insertion order.
- Wrong-message-filter mutation failed the exact assistant-message assertion.
- `scripts/test.sh --filter CodexHookOverlayTests`: 26 tests passed.
- `scripts/swift-safe build`: passed.
- The macOS-26 CI test job passed the real-`jq` harness before the PATH portability expansion; the expanded PATH also covers both standard Homebrew locations.
- Independent review found no High, Important, or Minor issues in the final diff.
- Full GitHub `test`, `Lint`, `Review scripts tests`, and `No committed implementation plans` checks passed on commit `d65e5f9c`; the next push reruns them for the review follow-up commits.
- Live app verification has not been performed yet.
