### PR TITLE
fix: prevent queued prompt polling false timeouts

### DIFF
--- a/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
@@ -142,9 +142,6 @@ struct QueuedPromptDeliveryTests {
             if finished.happened { return }
             try? await Task.sleep(for: .milliseconds(5))
         }
-        // The polling task may resume after the deadline even though this
-        // monotone completion became true while it was starved.
-        if finished.happened { return }
         waiter.cancel()
         Issue.record(
             """
@@ -248,9 +245,6 @@ struct QueuedPromptDeliveryTests {
             if await condition() { return }
             try? await Task.sleep(for: .milliseconds(5))
         }
-        // A post-deadline read is authoritative when scheduling overshoots the
-        // bound after this monotone condition has already become true.
-        if await condition() { return }
         Issue.record(
             "timed out after \(seconds)s waiting until \(description)",
             sourceLocation: sourceLocation)

--- a/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
@@ -142,6 +142,9 @@ struct QueuedPromptDeliveryTests {
             if finished.happened { return }
             try? await Task.sleep(for: .milliseconds(5))
         }
+        // The polling task may resume after the deadline even though this
+        // monotone completion became true while it was starved.
+        if finished.happened { return }
         waiter.cancel()
         Issue.record(
             """
@@ -177,6 +180,9 @@ struct QueuedPromptDeliveryTests {
             await clock.advance(by: PendingPromptCoordinator.pendingPromptSettleDelay)
             try? await Task.sleep(for: .milliseconds(2))
         }
+        // The wall deadline bounds a missing condition; it must not veto a
+        // monotone success that completed while this polling task was starved.
+        if await condition() { return }
         Issue.record(
             "timed out after \(seconds)s waiting until \(description)",
             sourceLocation: sourceLocation)
@@ -242,6 +248,9 @@ struct QueuedPromptDeliveryTests {
             if await condition() { return }
             try? await Task.sleep(for: .milliseconds(5))
         }
+        // A post-deadline read is authoritative when scheduling overshoots the
+        // bound after this monotone condition has already become true.
+        if await condition() { return }
         Issue.record(
             "timed out after \(seconds)s waiting until \(description)",
             sourceLocation: sourceLocation)
@@ -414,6 +423,13 @@ struct QueuedPromptDeliveryTests {
         Fix the flake in acme's src/parser.swift.
         It's the "quoted" branch that reds.
         """
+
+    // MARK: - Polling infrastructure
+
+    @Test("the settle poll rechecks completion after the wall deadline")
+    func settlePollRechecksAfterDeadline() async {
+        await advancePastSettle(TestClock<Duration>(), within: 0) { true }
+    }
 
     // MARK: - Flag OFF
 

--- a/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
+++ b/Tests/TBDDaemonTests/QueuedPromptDeliveryTests.swift
@@ -92,10 +92,6 @@ struct QueuedPromptDeliveryTests {
     private final class FirstTime: @unchecked Sendable {
         private let lock = NSLock()
         private var seen = false
-        var happened: Bool {
-            lock.lock(); defer { lock.unlock() }
-            return seen
-        }
         func claim() -> Bool {
             lock.lock(); defer { lock.unlock() }
             if seen { return false }
@@ -123,26 +119,23 @@ struct QueuedPromptDeliveryTests {
         }
     }
 
-    /// Bounded stand-in for `awaitPendingDeliveries()`. A cycle whose
-    /// continuation was orphaned never retires, and the plain await would then
-    /// hang the whole run rather than attribute the defect; this records a
-    /// named failure instead. Tier-2 bounded polling, per `Tests/CLAUDE.md`.
+    /// Bounded stand-in for `awaitPendingDeliveries()`. Poll the coordinator's
+    /// actual in-flight state so a separate wrapper task cannot itself be
+    /// starved after the deliveries finish. A cycle whose continuation was
+    /// orphaned never retires, and the plain await would then hang the whole
+    /// run rather than attribute the defect; this records a named failure
+    /// instead. Tier-2 bounded polling, per `Tests/CLAUDE.md`.
     private func awaitDeliveries(
         _ coordinator: PendingPromptCoordinator,
         within seconds: Double = 20,
         sourceLocation: SourceLocation = #_sourceLocation
     ) async {
-        // Deliberately NOT a task group: the wait it is bounding can be
-        // permanently suspended, and a group awaits every child before it
-        // returns — so the "bound" would be the hang it was meant to report.
-        let finished = FirstTime()
-        let waiter = Task { await coordinator.awaitPendingDeliveries(); _ = finished.claim() }
         let deadline = Date().addingTimeInterval(seconds)
         while Date() < deadline {
-            if finished.happened { return }
+            if await coordinator.inFlightCycleCount == 0 { return }
             try? await Task.sleep(for: .milliseconds(5))
         }
-        waiter.cancel()
+        if await coordinator.inFlightCycleCount == 0 { return }
         Issue.record(
             """
             a delivery cycle never retired within \(seconds)s — a superseded cycle's \
@@ -245,6 +238,7 @@ struct QueuedPromptDeliveryTests {
             if await condition() { return }
             try? await Task.sleep(for: .milliseconds(5))
         }
+        if await condition() { return }
         Issue.record(
             "timed out after \(seconds)s waiting until \(description)",
             sourceLocation: sourceLocation)
@@ -423,6 +417,18 @@ struct QueuedPromptDeliveryTests {
     @Test("the settle poll rechecks completion after the wall deadline")
     func settlePollRechecksAfterDeadline() async {
         await advancePastSettle(TestClock<Duration>(), within: 0) { true }
+    }
+
+    @Test("the delivery poll rechecks completion after the wall deadline")
+    func deliveryPollRechecksAfterDeadline() async throws {
+        let coordinator = PendingPromptCoordinator(db: try TBDDatabase(inMemory: true))
+
+        await awaitDeliveries(coordinator, within: 0)
+    }
+
+    @Test("the condition poll rechecks completion after the wall deadline")
+    func conditionPollRechecksAfterDeadline() async {
+        await waitUntil("an already-complete condition", within: 0) { true }
     }
 
     // MARK: - Flag OFF


### PR DESCRIPTION
## What's broken

The fast parallel `TBDDaemonTests` pass can report queued-prompt delivery timeouts even after delivery completed correctly. In [run 31764111490, job 94656342028](https://github.com/cheapsteak/tbd/actions/runs/31764111490/job/94656342028), eight tests recorded the same 20-second `advancePastSettle` issue, while affected and neighboring tests clustered around 65 seconds. The suite passes in under a second when isolated.

## Why it happens

The suite's bounded polling helpers checked their wall deadline before one final read of their success condition. Under process-wide scheduler saturation, the delivery could complete while the polling test task waited for another turn. If that task resumed after the wall deadline, it exited the loop without observing the now-true monotone condition and recorded a false timeout.

`awaitDeliveries` had a related, stronger version of the problem: it observed a newly spawned wrapper task rather than the coordinator's authoritative in-flight state. The wrapper itself could be starved even after all delivery cycles retired.

The later semantic assertions passed, so the evidence points to the test helpers' verdict ordering rather than `PendingPromptCoordinator` behavior.

## When it broke

The helpers arrived with the queued-prompt delivery suite in #624. Their isolated tests exercised production semantics but did not deterministically cover an already-complete condition at the polling deadline.

## What this PR does

- Rechecks authoritative success state once after each polling deadline and before recording a timeout.
- Makes `awaitDeliveries` poll the coordinator's actual `inFlightCycleCount`, the same state that defines `awaitPendingDeliveries` completion, instead of a starvable wrapper task.
- Adds zero-bound regressions that deterministically exercise the post-deadline branches.
- Leaves the 20-second hang guards, virtual clock, and all production queued-prompt behavior unchanged.

No design spec is required: this is a test-helper bug fix that restores the existing bounded-poll contract and does not revise product or system design.

## Evidence & verification

- RED: before the helper fixes, `scripts/test.sh --filter settlePollRechecksAfterDeadline` failed with `timed out after 0.0s`.
- RED: before the feedback fix, `scripts/test.sh --filter deliveryPollRechecksAfterDeadline` falsely reported an idle coordinator as never retired within 0.0s.
- RED: before the feedback fix, `scripts/test.sh --filter conditionPollRechecksAfterDeadline` falsely timed out an already-true condition at 0.0s.
- GREEN: `scripts/test.sh --filter PollRechecksAfterDeadline` passed all 3 regressions.
- Focused suite: `scripts/test.sh --filter QueuedPromptDeliveryTests` passed all 46 tests in 0.662s; an independent review rerun passed 46/46 in 0.730s.
- Relevant broader path: `scripts/test.sh --parallel -j 2 --filter '^TBDDaemonTests\.'` ran 2,974 tests; the queued-prompt suite passed under load.
- Build: `scripts/swift-safe build` completed successfully.
- Review: an independent review found no issues and confirmed that `inFlightCycleCount == 0` is the correct authoritative equivalent for this bounded test helper.

The broader daemon run still exits 1 because of an unrelated, reproducible failure in `ScratchpadCollectorTests`: `cleanUp refuses to remove the base directory itself for a degenerate empty worktreePath` records three unexpected issues at lines 99–101 (a non-nil `ReapRecord`, the base directory missing, and its marker missing). This PR does not alter that code or hide the failure.
