### PR TITLE
Feat: Make the capacity-facts surface a versioned contract wake programs can depend on

### DIFF
--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -120,6 +120,12 @@ func profileListJSONOutput(_ result: ModelProfileListResult) -> String? {
 /// `--refresh` fails fast exactly as a plain `profile list` would — promising
 /// "listing persisted snapshots" on stderr and then exiting nonzero with empty
 /// stdout would be a lie told one line before it was broken.
+///
+/// One residual imprecision: a truncated response frame also surfaces as a
+/// `DecodingError`, so it is read here as "answered unintelligibly" rather than
+/// as a dead connection. The listing a line later then fails loudly on its own,
+/// which is the same outcome, so telling the two apart would buy nothing for
+/// the cost of reworking `SocketClient`'s error surface.
 func refreshFailureNote(for error: Error) -> String? {
     let detail: String
     switch error {

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -88,20 +88,35 @@ func usageAgeMarker(fetchedAt: Date?, now: Date = Date()) -> String? {
     return "(updated \(hours / 24)d ago)"
 }
 
-/// The one-line stderr note `tbd profile list --refresh` emits when the
-/// refresh RPC refuses (poller not yet constructed during daemon startup, a
-/// mock daemon, a transport failure). The listing continues from persisted
-/// snapshots, so the note names where to read the resulting staleness from.
-/// Ends in a newline; callers write it to stderr verbatim.
-func refreshFailureNote(_ error: Error) -> String {
+/// The exact JSON text `tbd profile list --json` prints: the RPC result inside
+/// the versioned envelope this CLI's contract promises
+/// (`docs/capacity-facts.md`). The wrapping decision and the contract version
+/// live here, in one place, so the command body is a bare print of this and
+/// tests can assert against the real composed bytes.
+func profileListJSONOutput(_ result: ModelProfileListResult) -> String? {
+    jsonString(VersionedJSONEnvelope(
+        schemaVersion: profileListSchemaVersion,
+        payload: result
+    ))
+}
+
+/// Whether a failed usage-refresh may be tolerated, and if so the one-line
+/// note `tbd profile list --refresh` writes to stderr before listing anyway.
+/// Ends in a newline; callers write it verbatim.
+///
+/// Only a `CLIError.rpcError` is tolerable: the daemon answered and refused —
+/// its OAuth usage poller is not constructed yet during the startup window, or
+/// it is a mock daemon. The persisted snapshots are still there to list, and
+/// the note names where their staleness shows.
+///
+/// Every other error means the daemon never answered. Returning nil rethrows
+/// it, so `--refresh` fails fast exactly as a plain `profile list` would —
+/// promising "listing persisted snapshots" on stderr and then exiting nonzero
+/// with empty stdout would be a lie told one line before it was broken.
+func refreshFailureNote(for error: Error) -> String? {
     // CLIError.rpcError already prefixes "Error: "; strip it so the note reads
     // as one sentence rather than two stacked prefixes.
-    let detail: String
-    if case CLIError.rpcError(let message) = error {
-        detail = message
-    } else {
-        detail = "\(error)"
-    }
+    guard case CLIError.rpcError(let detail) = error else { return nil }
     return "warning: usage refresh failed (\(detail)); listing persisted snapshots — "
         + "read each profile's fetchedAt and statusKind for staleness\n"
 }
@@ -220,6 +235,11 @@ struct ProfileList: AsyncParsableCommand {
             // command would hand a scripted caller nothing at all — worse than
             // slightly stale facts. The refusal goes to stderr so stdout stays
             // parseable. Contract: docs/capacity-facts.md.
+            //
+            // Tolerance stops at a refusal the daemon actually sent: an
+            // unreachable daemon rethrows here, because the list call below
+            // would fail anyway and stderr must not promise a listing that
+            // never arrives. `refreshFailureNote(for:)` draws that line.
             do {
                 _ = try client.call(
                     method: RPCMethod.modelProfileUsageRefresh,
@@ -227,7 +247,8 @@ struct ProfileList: AsyncParsableCommand {
                     resultType: ModelProfileUsageRefreshResult.self
                 )
             } catch {
-                FileHandle.standardError.write(Data(refreshFailureNote(error).utf8))
+                guard let note = refreshFailureNote(for: error) else { throw error }
+                FileHandle.standardError.write(Data(note.utf8))
             }
         }
 
@@ -237,11 +258,11 @@ struct ProfileList: AsyncParsableCommand {
         )
 
         if json {
-            // Versioned contract surface — see docs/capacity-facts.md.
-            printJSON(VersionedJSONEnvelope(
-                schemaVersion: profileListSchemaVersion,
-                payload: result
-            ))
+            // Versioned contract surface — composed by profileListJSONOutput,
+            // printed verbatim. See docs/capacity-facts.md.
+            if let output = profileListJSONOutput(result) {
+                print(output)
+            }
             return
         }
         if result.profiles.isEmpty {

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -113,13 +113,17 @@ func profileListJSONOutput(_ result: ModelProfileListResult) -> String? {
 ///   the refresh result's shape did not match, as under daemon/CLI version
 ///   skew. The refresh outcome is unreadable; the listing may still decode.
 ///
-/// Both leave the persisted snapshots there to list, and the note names where
-/// their staleness shows.
+/// Both still produce a listing, but the note must not promise what is in it.
+/// The refusal case in particular arrives when the daemon has no usage poller,
+/// and the listing draws its snapshots from that same poller — so every profile
+/// comes back with `usageSnapshot` absent, which is the "tracked, not yet
+/// fetched" state, not stale numbers. The note therefore points at the absence
+/// rather than at staleness fields that will not be there.
 ///
 /// Anything else means the daemon is unreachable. Returning nil rethrows it, so
-/// `--refresh` fails fast exactly as a plain `profile list` would — promising
-/// "listing persisted snapshots" on stderr and then exiting nonzero with empty
-/// stdout would be a lie told one line before it was broken.
+/// `--refresh` fails fast exactly as a plain `profile list` would — promising a
+/// listing on stderr and then exiting nonzero with empty stdout would be a lie
+/// told one line before it was broken.
 ///
 /// One residual imprecision: a truncated response frame also surfaces as a
 /// `DecodingError`, so it is read here as "answered unintelligibly" rather than
@@ -141,8 +145,9 @@ func refreshFailureNote(for error: Error) -> String? {
     default:
         return nil
     }
-    return "warning: usage refresh failed (\(detail)); listing persisted snapshots — "
-        + "read each profile's fetchedAt and statusKind for staleness\n"
+    return "warning: usage refresh failed (\(detail)); listing anyway, possibly "
+        + "without usage snapshots — an absent usageSnapshot means none fetched "
+        + "yet, not stale numbers\n"
 }
 
 /// Resolve a user-supplied profile reference against the daemon's profile

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -88,6 +88,24 @@ func usageAgeMarker(fetchedAt: Date?, now: Date = Date()) -> String? {
     return "(updated \(hours / 24)d ago)"
 }
 
+/// The one-line stderr note `tbd profile list --refresh` emits when the
+/// refresh RPC refuses (poller not yet constructed during daemon startup, a
+/// mock daemon, a transport failure). The listing continues from persisted
+/// snapshots, so the note names where to read the resulting staleness from.
+/// Ends in a newline; callers write it to stderr verbatim.
+func refreshFailureNote(_ error: Error) -> String {
+    // CLIError.rpcError already prefixes "Error: "; strip it so the note reads
+    // as one sentence rather than two stacked prefixes.
+    let detail: String
+    if case CLIError.rpcError(let message) = error {
+        detail = message
+    } else {
+        detail = "\(error)"
+    }
+    return "warning: usage refresh failed (\(detail)); listing persisted snapshots — "
+        + "read each profile's fetchedAt and statusKind for staleness\n"
+}
+
 /// Resolve a user-supplied profile reference against the daemon's profile
 /// list. Accepts an exact name, a unique case-insensitive name, or a profile
 /// UUID (escape hatch for scripting). Throws a `CLIError` with actionable
@@ -195,11 +213,22 @@ struct ProfileList: AsyncParsableCommand {
         let client = SocketClient()
 
         if refresh {
-            _ = try client.call(
-                method: RPCMethod.modelProfileUsageRefresh,
-                params: ModelProfileUsageRefreshParams(id: nil),
-                resultType: ModelProfileUsageRefreshResult.self
-            )
+            // A refresh is an optimization, never a precondition: the listing
+            // is served from persisted snapshots either way, and each snapshot
+            // carries its own provenance (`fetchedAt`, `statusKind`), so a
+            // consumer can already see that its numbers aged. Failing the whole
+            // command would hand a scripted caller nothing at all — worse than
+            // slightly stale facts. The refusal goes to stderr so stdout stays
+            // parseable. Contract: docs/capacity-facts.md.
+            do {
+                _ = try client.call(
+                    method: RPCMethod.modelProfileUsageRefresh,
+                    params: ModelProfileUsageRefreshParams(id: nil),
+                    resultType: ModelProfileUsageRefreshResult.self
+                )
+            } catch {
+                FileHandle.standardError.write(Data(refreshFailureNote(error).utf8))
+            }
         }
 
         let result = try client.call(

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -208,7 +208,11 @@ struct ProfileList: AsyncParsableCommand {
         )
 
         if json {
-            printJSON(result)
+            // Versioned contract surface — see docs/capacity-facts.md.
+            printJSON(VersionedJSONEnvelope(
+                schemaVersion: profileListSchemaVersion,
+                payload: result
+            ))
             return
         }
         if result.profiles.isEmpty {

--- a/Sources/TBDCLI/Commands/ProfileCommands.swift
+++ b/Sources/TBDCLI/Commands/ProfileCommands.swift
@@ -104,19 +104,37 @@ func profileListJSONOutput(_ result: ModelProfileListResult) -> String? {
 /// note `tbd profile list --refresh` writes to stderr before listing anyway.
 /// Ends in a newline; callers write it verbatim.
 ///
-/// Only a `CLIError.rpcError` is tolerable: the daemon answered and refused —
-/// its OAuth usage poller is not constructed yet during the startup window, or
-/// it is a mock daemon. The persisted snapshots are still there to list, and
-/// the note names where their staleness shows.
+/// The dividing line is **whether the daemon answered the refresh attempt**,
+/// because that is what predicts the list call a line later:
 ///
-/// Every other error means the daemon never answered. Returning nil rethrows
-/// it, so `--refresh` fails fast exactly as a plain `profile list` would —
-/// promising "listing persisted snapshots" on stderr and then exiting nonzero
-/// with empty stdout would be a lie told one line before it was broken.
+/// - **It answered and refused** (`CLIError.rpcError`) — its OAuth usage poller
+///   is not constructed yet during the startup window, or it is a mock daemon.
+/// - **It answered unintelligibly** (`DecodingError`) — the response arrived but
+///   the refresh result's shape did not match, as under daemon/CLI version
+///   skew. The refresh outcome is unreadable; the listing may still decode.
+///
+/// Both leave the persisted snapshots there to list, and the note names where
+/// their staleness shows.
+///
+/// Anything else means the daemon is unreachable. Returning nil rethrows it, so
+/// `--refresh` fails fast exactly as a plain `profile list` would — promising
+/// "listing persisted snapshots" on stderr and then exiting nonzero with empty
+/// stdout would be a lie told one line before it was broken.
 func refreshFailureNote(for error: Error) -> String? {
-    // CLIError.rpcError already prefixes "Error: "; strip it so the note reads
-    // as one sentence rather than two stacked prefixes.
-    guard case CLIError.rpcError(let detail) = error else { return nil }
+    let detail: String
+    switch error {
+    // Bind the associated value rather than rendering the error: CLIError's
+    // `description` prefixes "Error: ", which would stack a second prefix onto
+    // a note that already says "warning:".
+    case CLIError.rpcError(let message):
+        detail = message
+    // DecodingError's own description is long and multi-line; the note is one
+    // line by contract, and the cause is the same whichever key mismatched.
+    case is DecodingError:
+        detail = "daemon answered with an unreadable refresh result (version skew?)"
+    default:
+        return nil
+    }
     return "warning: usage refresh failed (\(detail)); listing persisted snapshots — "
         + "read each profile's fetchedAt and statusKind for staleness\n"
 }
@@ -260,9 +278,20 @@ struct ProfileList: AsyncParsableCommand {
         if json {
             // Versioned contract surface — composed by profileListJSONOutput,
             // printed verbatim. See docs/capacity-facts.md.
-            if let output = profileListJSONOutput(result) {
-                print(output)
+            //
+            // A nil here means the envelope did not encode. Printing nothing
+            // and exiting 0 would tell a scripted consumer "zero profiles",
+            // which is a different fact entirely; fail loudly instead. The
+            // diagnostic is written here rather than carried on a thrown
+            // CLIError because that type's `description` adds its own "Error: "
+            // prefix, which ArgumentParser would then print a second time.
+            guard let output = profileListJSONOutput(result) else {
+                FileHandle.standardError.write(Data(
+                    ("Error: could not encode the profile list as JSON "
+                        + "(schemaVersion \(profileListSchemaVersion))\n").utf8))
+                throw ExitCode.failure
             }
+            print(output)
             return
         }
         if result.profiles.isEmpty {

--- a/Sources/TBDCLI/Commands/TerminalCommands.swift
+++ b/Sources/TBDCLI/Commands/TerminalCommands.swift
@@ -89,7 +89,17 @@ struct TerminalList: AsyncParsableCommand {
         )
 
         if json {
-            printJSON(terminals)
+            // A bare top-level array, unversioned by design — it has nowhere
+            // additive to put a `schemaVersion`. Its `profileID` field is a
+            // documented contract surface (docs/capacity-facts.md), so an
+            // encoding failure must not read as "no terminals": name it on
+            // stderr and exit nonzero instead of printing nothing at exit 0.
+            guard let output = jsonString(terminals) else {
+                FileHandle.standardError.write(Data(
+                    "Error: could not encode the terminal list as JSON\n".utf8))
+                throw ExitCode.failure
+            }
+            print(output)
         } else {
             if terminals.isEmpty {
                 print("No terminals found.")

--- a/Sources/TBDCLI/Utilities.swift
+++ b/Sources/TBDCLI/Utilities.swift
@@ -1,15 +1,52 @@
 import Foundation
 
-/// Print a Codable value as pretty-printed JSON to stdout.
-func printJSON<T: Encodable>(_ value: T) {
+/// Compose a Codable value into the pretty-printed JSON text the CLI prints.
+/// Internal (not private) so TBDCLITests can assert against the same composed
+/// output a command actually emits, rather than a re-encoded lookalike.
+func jsonString<T: Encodable>(_ value: T) -> String? {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     encoder.dateEncodingStrategy = .iso8601
-    if let data = try? encoder.encode(value),
-       let string = String(data: data, encoding: .utf8) {
+    guard let data = try? encoder.encode(value) else { return nil }
+    return String(data: data, encoding: .utf8)
+}
+
+/// Print a Codable value as pretty-printed JSON to stdout.
+func printJSON<T: Encodable>(_ value: T) {
+    if let string = jsonString(value) {
         print(string)
     }
 }
+
+/// Wraps a command's JSON payload with the top-level `schemaVersion` the CLI
+/// contract promises (see `docs/capacity-facts.md`): fields may be added
+/// within a version; a field never changes meaning; removing a field or
+/// changing its meaning requires a version bump.
+///
+/// The payload encodes into the *same* keyed container as `schemaVersion`, so
+/// the envelope is drift-proof: any field the underlying RPC result gains
+/// flows through automatically, with no envelope-side mirror to update.
+/// The payload must therefore encode as a JSON object, not an array.
+struct VersionedJSONEnvelope<Payload: Encodable>: Encodable {
+    let schemaVersion: Int
+    let payload: Payload
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try payload.encode(to: encoder)
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+    }
+}
+
+/// Contract version of `tbd profile list --json` — the machine-readable
+/// capacity surface documented in `docs/capacity-facts.md`. Bump only for a
+/// breaking change (a removed field, or a field whose meaning or units
+/// changed); additions ship within the current version.
+let profileListSchemaVersion = 1
 
 /// Print a dictionary as pretty-printed JSON to stdout.
 func printJSON(_ dict: [String: String]) {

--- a/Sources/TBDCLI/Utilities.swift
+++ b/Sources/TBDCLI/Utilities.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBDShared
 
 /// Compose a Codable value into the pretty-printed JSON text the CLI prints.
 /// Internal (not private) so TBDCLITests can assert against the same composed
@@ -18,6 +19,27 @@ func printJSON<T: Encodable>(_ value: T) {
     }
 }
 
+/// A type whose `Encodable` conformance produces a JSON **object** — not an
+/// array, not a scalar. Conforming is an assertion about encoded shape, and
+/// nothing but the author checks it.
+///
+/// It exists because `VersionedJSONEnvelope` reuses its payload's top-level
+/// container to add one key. A payload that encodes as an array or a scalar has
+/// already claimed the encoder's single top-level container, and asking for a
+/// keyed one afterwards trips `JSONEncoder`'s `preconditionFailure` — a crash,
+/// not a thrown error, so `try?` at the call site would not save it. Most of
+/// this CLI's `--json` output is a bare array (`tbd terminal list --json`,
+/// which stays unversioned for exactly this reason), so the next person to
+/// reach for the envelope is more likely than not holding the wrong shape.
+/// Requiring this conformance turns that into a compile error.
+protocol JSONObjectPayload: Encodable {}
+
+/// The one versioned payload today. Conformance lives in TBDCLI rather than
+/// beside the type in TBDShared: which surfaces carry a printed contract is the
+/// CLI's knowledge, and the daemon's RPC results are an internal seam that
+/// should not grow CLI-shaped marker protocols.
+extension ModelProfileListResult: JSONObjectPayload {}
+
 /// Wraps a command's JSON payload with the top-level `schemaVersion` the CLI
 /// contract promises (see `docs/capacity-facts.md`): fields may be added
 /// within a version; a field never changes meaning; removing a field or
@@ -29,17 +51,12 @@ func printJSON<T: Encodable>(_ value: T) {
 ///
 /// Two consequences of that sharing:
 ///
-/// - **Object-shaped payloads only.** A payload that encodes as an array or a
-///   scalar has already claimed the encoder's single top-level container, and
-///   asking for a keyed one afterwards trips `JSONEncoder`'s
-///   `preconditionFailure` — a crash, not a thrown error, so `try?` will not
-///   save the call site. Bare-array output (`tbd terminal list --json`) must
-///   stay unversioned rather than be wrapped here.
+/// - **Object-shaped payloads only**, enforced by `JSONObjectPayload`.
 /// - **The envelope's `schemaVersion` wins.** It is encoded last, so if a
 ///   payload ever grows a `schemaVersion` key of its own the envelope's value
 ///   overwrites it. That is the intended authority order: the CLI's printed
 ///   contract version is the CLI's to state, not the daemon's.
-struct VersionedJSONEnvelope<Payload: Encodable>: Encodable {
+struct VersionedJSONEnvelope<Payload: JSONObjectPayload>: Encodable {
     let schemaVersion: Int
     let payload: Payload
 

--- a/Sources/TBDCLI/Utilities.swift
+++ b/Sources/TBDCLI/Utilities.swift
@@ -26,7 +26,19 @@ func printJSON<T: Encodable>(_ value: T) {
 /// The payload encodes into the *same* keyed container as `schemaVersion`, so
 /// the envelope is drift-proof: any field the underlying RPC result gains
 /// flows through automatically, with no envelope-side mirror to update.
-/// The payload must therefore encode as a JSON object, not an array.
+///
+/// Two consequences of that sharing:
+///
+/// - **Object-shaped payloads only.** A payload that encodes as an array or a
+///   scalar has already claimed the encoder's single top-level container, and
+///   asking for a keyed one afterwards trips `JSONEncoder`'s
+///   `preconditionFailure` — a crash, not a thrown error, so `try?` will not
+///   save the call site. Bare-array output (`tbd terminal list --json`) must
+///   stay unversioned rather than be wrapped here.
+/// - **The envelope's `schemaVersion` wins.** It is encoded last, so if a
+///   payload ever grows a `schemaVersion` key of its own the envelope's value
+///   overwrites it. That is the intended authority order: the CLI's printed
+///   contract version is the CLI's to state, not the daemon's.
 struct VersionedJSONEnvelope<Payload: Encodable>: Encodable {
     let schemaVersion: Int
     let payload: Payload

--- a/Tests/TBDCLITests/CapacityContractTests.swift
+++ b/Tests/TBDCLITests/CapacityContractTests.swift
@@ -147,7 +147,7 @@ struct CapacityContractTests {
         // The envelope encodes schemaVersion last, so a payload that ever
         // grows a key of that name loses to it. The printed contract version
         // is the CLI's to state.
-        struct PayloadWithItsOwnVersion: Encodable {
+        struct PayloadWithItsOwnVersion: JSONObjectPayload {
             let schemaVersion = 99
             let marker = "payload"
         }
@@ -269,9 +269,12 @@ struct CapacityContractTests {
         #expect(note.hasSuffix("\n"))
         #expect(note.hasPrefix("warning: usage refresh failed ("))
         #expect(note.contains("OAuth usage poller is not running"))
-        #expect(note.contains("listing persisted snapshots"))
-        #expect(note.contains("fetchedAt"))
-        #expect(note.contains("statusKind"))
+        // The note points at ABSENCE, not staleness: this refusal comes from a
+        // daemon with no usage poller, and the listing sources its snapshots
+        // from that same poller, so every profile comes back without one.
+        #expect(note.contains("listing anyway"))
+        #expect(note.contains("an absent usageSnapshot means none fetched yet"))
+        #expect(!note.contains("fetchedAt"))
         // The whole note is one line, so a caller's stderr stays line-oriented.
         #expect(note.filter { $0 == "\n" }.count == 1)
     }
@@ -286,7 +289,7 @@ struct CapacityContractTests {
         let note = try #require(refreshFailureNote(for: DecodingError.dataCorrupted(context)))
         #expect(note.hasPrefix("warning: usage refresh failed ("))
         #expect(note.contains("version skew"))
-        #expect(note.contains("listing persisted snapshots"))
+        #expect(note.contains("listing anyway"))
         #expect(note.filter { $0 == "\n" }.count == 1)
     }
 

--- a/Tests/TBDCLITests/CapacityContractTests.swift
+++ b/Tests/TBDCLITests/CapacityContractTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import Testing
+import TBDShared
+
+@testable import TBDCLI
+
+/// The stated contract of `tbd profile list --json` (schemaVersion 1) and the
+/// `profileID` field of `tbd terminal list --json` — documented in
+/// `docs/capacity-facts.md`. Every assertion here runs the SAME composition
+/// path the commands use (`jsonString`, and the envelope for the versioned
+/// one), then parses the resulting text, so the tests break if the printed
+/// bytes change — not merely if a Swift model changes.
+@Suite("CapacityContract")
+struct CapacityContractTests {
+
+    // MARK: - Fixtures
+
+    /// 2026-07-07T18:00:00Z — the session bucket's reset instant.
+    private static let sessionReset = Date(timeIntervalSince1970: 1_783_447_200)
+    /// 2026-07-07T12:34:56Z — the last successful fetch.
+    private static let fetchedAt = Date(timeIntervalSince1970: 1_783_427_696)
+    /// 2026-07-01T00:00:00Z — profile creation, keeps encoded output stable.
+    private static let createdAt = Date(timeIntervalSince1970: 1_782_864_000)
+
+    private func healthyEntry(id: UUID) -> ModelProfileWithUsage {
+        let snapshot = ProfileUsageSnapshot(
+            buckets: [
+                ClaudeUsageLimitBucket(
+                    kind: "session", group: "session", percent: 42.5,
+                    severity: "normal", resetsAt: Self.sessionReset, isActive: true
+                ),
+                ClaudeUsageLimitBucket(
+                    kind: "weekly_all", group: "weekly", percent: 17,
+                    severity: "normal", resetsAt: nil, isActive: false
+                ),
+                ClaudeUsageLimitBucket(
+                    kind: "weekly_scoped", group: "weekly", percent: 3,
+                    modelDisplayName: "Fable"
+                ),
+            ],
+            fetchedAt: Self.fetchedAt,
+            lastAttemptAt: Self.fetchedAt,
+            status: "ok",
+            statusKind: .ok
+        )
+        return ModelProfileWithUsage(
+            profile: ModelProfile(id: id, name: "primary", kind: .oauth, createdAt: Self.createdAt),
+            loginIdentity: "operator@example.com",
+            usageSnapshot: snapshot
+        )
+    }
+
+    /// A profile whose snapshot EXISTS but whose last fetch failed: no
+    /// `fetchedAt` ever succeeded, and the failure is classified.
+    private func failedFetchEntry(id: UUID) -> ModelProfileWithUsage {
+        let snapshot = ProfileUsageSnapshot(
+            buckets: [],
+            fetchedAt: nil,
+            lastAttemptAt: Self.fetchedAt,
+            status: "fetch failed: HTTP 401",
+            statusKind: .needsLogin
+        )
+        return ModelProfileWithUsage(
+            profile: ModelProfile(id: id, name: "expired", kind: .oauth, createdAt: Self.createdAt),
+            loginIdentity: "stale@example.com",
+            usageSnapshot: snapshot
+        )
+    }
+
+    /// A profile TBD tracks no usage for at all — non-OAuth kind, so the
+    /// poller never even attempts a fetch.
+    private func untrackedEntry(id: UUID) -> ModelProfileWithUsage {
+        ModelProfileWithUsage(
+            profile: ModelProfile(id: id, name: "bedrock-lane", kind: .bedrock, createdAt: Self.createdAt)
+        )
+    }
+
+    // MARK: - Composition helpers (the real command path)
+
+    /// Compose exactly what `ProfileList.run()` prints for `--json`, then
+    /// parse it back into untyped JSON.
+    private func composedProfileListJSON(
+        _ result: ModelProfileListResult
+    ) throws -> [String: Any] {
+        let text = try #require(jsonString(VersionedJSONEnvelope(
+            schemaVersion: profileListSchemaVersion,
+            payload: result
+        )))
+        let data = try #require(text.data(using: .utf8))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    /// Compose exactly what `TerminalList.run()` prints for `--json` (a bare
+    /// top-level array), then parse it back.
+    private func composedTerminalListJSON(_ terminals: [Terminal]) throws -> [[String: Any]] {
+        let text = try #require(jsonString(terminals))
+        let data = try #require(text.data(using: .utf8))
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+    }
+
+    // MARK: - Envelope
+
+    @Test func profileListJSON_stampsSchemaVersionOnTheEnvelope() throws {
+        let defaultID = UUID()
+        let object = try composedProfileListJSON(ModelProfileListResult(
+            profiles: [healthyEntry(id: defaultID)],
+            defaultID: defaultID
+        ))
+
+        #expect(object["schemaVersion"] as? Int == 1)
+        // The payload's own fields survive alongside the stamped key —
+        // the envelope adds, it does not wrap or displace.
+        #expect(object["defaultID"] as? String == defaultID.uuidString)
+        let profiles = try #require(object["profiles"] as? [[String: Any]])
+        #expect(profiles.count == 1)
+        let profile = try #require(profiles[0]["profile"] as? [String: Any])
+        #expect(profile["id"] as? String == defaultID.uuidString)
+        #expect(profile["name"] as? String == "primary")
+        #expect(profile["kind"] as? String == "oauth")
+        #expect(profiles[0]["loginIdentity"] as? String == "operator@example.com")
+    }
+
+    @Test func profileListJSON_carriesUnknownPayloadFieldsThrough() throws {
+        // Fields the capacity contract does not interpret still ship inside the
+        // same versioned object — the envelope mirrors nothing by hand, so a
+        // field added to the RPC result appears without an envelope change.
+        let object = try composedProfileListJSON(ModelProfileListResult(
+            profiles: [],
+            defaultID: nil,
+            primaryAgentPreference: .defaultValue
+        ))
+        #expect(object["schemaVersion"] as? Int == 1)
+        #expect(object["profiles"] as? [Any] != nil)
+        #expect(object["primaryAgentPreference"] != nil)
+        #expect(object["gcEnabled"] as? Bool == true)
+        // `defaultID` is absent (not null) when no global default is configured.
+        #expect(object["defaultID"] == nil)
+    }
+
+    // MARK: - Buckets and units
+
+    @Test func profileListJSON_bucketFieldsCarryValuesAndUnits() throws {
+        let id = UUID()
+        let object = try composedProfileListJSON(ModelProfileListResult(
+            profiles: [healthyEntry(id: id)], defaultID: id
+        ))
+        let profiles = try #require(object["profiles"] as? [[String: Any]])
+        let snapshot = try #require(profiles[0]["usageSnapshot"] as? [String: Any])
+
+        #expect(snapshot["status"] as? String == "ok")
+        #expect(snapshot["statusKind"] as? String == "ok")
+        #expect(snapshot["fetchedAt"] as? String == "2026-07-07T12:34:56Z")
+        #expect(snapshot["lastAttemptAt"] as? String == "2026-07-07T12:34:56Z")
+
+        let buckets = try #require(snapshot["buckets"] as? [[String: Any]])
+        #expect(buckets.count == 3)
+
+        let session = try #require(buckets.first { $0["kind"] as? String == "session" })
+        #expect(session["group"] as? String == "session")
+        // percent is a JSON number on a 0-100 scale, not a formatted string.
+        #expect(session["percent"] as? Double == 42.5)
+        #expect(session["severity"] as? String == "normal")
+        #expect(session["isActive"] as? Bool == true)
+        // resetsAt is ISO 8601 in UTC.
+        #expect(session["resetsAt"] as? String == "2026-07-07T18:00:00Z")
+
+        let weeklyAll = try #require(buckets.first { $0["kind"] as? String == "weekly_all" })
+        #expect(weeklyAll["percent"] as? Double == 17)
+        // The API sent null for this window — the key is omitted, not null.
+        #expect(weeklyAll["resetsAt"] == nil)
+
+        let scoped = try #require(buckets.first { $0["kind"] as? String == "weekly_scoped" })
+        #expect(scoped["modelDisplayName"] as? String == "Fable")
+        #expect(scoped["percent"] as? Double == 3)
+    }
+
+    // MARK: - Absence vs failure
+
+    @Test func profileListJSON_absentSnapshotDiffersFromFailedFetch() throws {
+        let trackedID = UUID()
+        let untrackedID = UUID()
+        let object = try composedProfileListJSON(ModelProfileListResult(
+            profiles: [failedFetchEntry(id: trackedID), untrackedEntry(id: untrackedID)],
+            defaultID: nil
+        ))
+        let profiles = try #require(object["profiles"] as? [[String: Any]])
+        #expect(profiles.count == 2)
+
+        // Untracked: TBD has no usage tracking for this profile at all — the
+        // key is absent entirely.
+        let untracked = try #require(profiles.first {
+            (($0["profile"] as? [String: Any])?["id"] as? String) == untrackedID.uuidString
+        })
+        #expect(untracked["usageSnapshot"] == nil)
+        let untrackedProfile = try #require(untracked["profile"] as? [String: Any])
+        #expect(untrackedProfile["kind"] as? String == "bedrock")
+
+        // Tracked but failing: the snapshot IS present, classified, and says
+        // no fetch has ever succeeded (`fetchedAt` absent).
+        let failing = try #require(profiles.first {
+            (($0["profile"] as? [String: Any])?["id"] as? String) == trackedID.uuidString
+        })
+        let snapshot = try #require(failing["usageSnapshot"] as? [String: Any])
+        #expect(snapshot["statusKind"] as? String == "needsLogin")
+        #expect(snapshot["status"] as? String == "fetch failed: HTTP 401")
+        #expect(snapshot["lastAttemptAt"] as? String == "2026-07-07T12:34:56Z")
+        #expect(snapshot["buckets"] as? [Any] != nil)
+        #expect(snapshot["fetchedAt"] == nil)
+    }
+
+    @Test func profileListJSON_failedFetchCanStillCarryStaleBuckets() throws {
+        // A failure does not empty `buckets`: they are the last SUCCESSFUL
+        // fetch's numbers, and staleness is read off `fetchedAt`.
+        let id = UUID()
+        let snapshot = ProfileUsageSnapshot(
+            buckets: [ClaudeUsageLimitBucket(kind: "session", percent: 99)],
+            fetchedAt: Self.fetchedAt,
+            lastAttemptAt: Self.sessionReset,
+            status: "stale since 2026-07-07T12:34:56Z; fetch failed: offline",
+            statusKind: .networkError
+        )
+        let entry = ModelProfileWithUsage(
+            profile: ModelProfile(id: id, name: "offline", kind: .oauth, createdAt: Self.createdAt),
+            usageSnapshot: snapshot
+        )
+        let object = try composedProfileListJSON(
+            ModelProfileListResult(profiles: [entry], defaultID: nil))
+        let profiles = try #require(object["profiles"] as? [[String: Any]])
+        let composed = try #require(profiles[0]["usageSnapshot"] as? [String: Any])
+
+        #expect(composed["statusKind"] as? String == "networkError")
+        #expect(composed["fetchedAt"] as? String == "2026-07-07T12:34:56Z")
+        #expect(composed["lastAttemptAt"] as? String == "2026-07-07T18:00:00Z")
+        let buckets = try #require(composed["buckets"] as? [[String: Any]])
+        #expect(buckets.count == 1)
+        #expect(buckets[0]["percent"] as? Double == 99)
+    }
+
+    // MARK: - The terminal to profile join
+
+    @Test func terminalListJSON_emitsProfileIDWhenResolved() throws {
+        let profileID = UUID()
+        let terminal = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@1", tmuxPaneID: "%1",
+            createdAt: Self.createdAt, profileID: profileID, kind: .claude
+        )
+        let rows = try composedTerminalListJSON([terminal])
+        #expect(rows.count == 1)
+        #expect(rows[0]["id"] as? String == terminal.id.uuidString)
+        #expect(rows[0]["kind"] as? String == "claude")
+        #expect(rows[0]["profileID"] as? String == profileID.uuidString)
+    }
+
+    @Test func terminalListJSON_omitsProfileIDWhenAmbient() throws {
+        // No profile resolved at spawn time: the session runs on ambient
+        // machine credentials TBD does not track. The key is omitted — a
+        // consumer must read that as "capacity facts unknown", never resolve
+        // it against `defaultID`.
+        let terminal = Terminal(
+            worktreeID: UUID(), tmuxWindowID: "@2", tmuxPaneID: "%2",
+            createdAt: Self.createdAt, kind: .shell
+        )
+        let rows = try composedTerminalListJSON([terminal])
+        #expect(rows.count == 1)
+        #expect(rows[0]["id"] as? String == terminal.id.uuidString)
+        #expect(rows[0]["kind"] as? String == "shell")
+        #expect(rows[0]["worktreeID"] as? String == terminal.worktreeID.uuidString)
+        #expect(rows[0]["profileID"] == nil)
+    }
+}

--- a/Tests/TBDCLITests/CapacityContractTests.swift
+++ b/Tests/TBDCLITests/CapacityContractTests.swift
@@ -6,10 +6,17 @@ import TBDShared
 
 /// The stated contract of `tbd profile list --json` (schemaVersion 1) and the
 /// `profileID` field of `tbd terminal list --json` — documented in
-/// `docs/capacity-facts.md`. Every assertion here runs the SAME composition
-/// path the commands use (`jsonString`, and the envelope for the versioned
-/// one), then parses the resulting text, so the tests break if the printed
-/// bytes change — not merely if a Swift model changes.
+/// `docs/capacity-facts.md`.
+///
+/// What is covered: the composition itself. `profileListJSONOutput` is the
+/// function `ProfileList.run()` calls — it owns the envelope wrapping and the
+/// contract version — and `jsonString` is what `printJSON` composes with, so
+/// these tests parse the same bytes a caller would read on stdout. Drop the
+/// envelope, change the version, or rename a field, and they go red.
+///
+/// What is not: the commands need a live daemon, so the last hop — `run()`
+/// printing this function's output, and `TerminalList.run()` printing
+/// `printJSON(terminals)` — is a one-line print each, verified by reading.
 @Suite("CapacityContract")
 struct CapacityContractTests {
 
@@ -77,15 +84,14 @@ struct CapacityContractTests {
 
     // MARK: - Composition helpers (the real command path)
 
-    /// Compose exactly what `ProfileList.run()` prints for `--json`, then
-    /// parse it back into untyped JSON.
+    /// Run the result through the command's own composition function, then
+    /// parse the text back into untyped JSON. The envelope is NOT built here —
+    /// `profileListJSONOutput` builds it, which is the point: a revert of the
+    /// wrapping reds every assertion below.
     private func composedProfileListJSON(
         _ result: ModelProfileListResult
     ) throws -> [String: Any] {
-        let text = try #require(jsonString(VersionedJSONEnvelope(
-            schemaVersion: profileListSchemaVersion,
-            payload: result
-        )))
+        let text = try #require(profileListJSONOutput(result))
         let data = try #require(text.data(using: .utf8))
         return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
@@ -257,8 +263,9 @@ struct CapacityContractTests {
 
     // MARK: - Refresh is an optimization, not a precondition
 
-    @Test func refreshFailureNote_namesTheCauseAndWhereStalenessShows() {
-        let note = refreshFailureNote(CLIError.rpcError("OAuth usage poller is not running"))
+    @Test func refreshFailureNote_toleratesADaemonRefusalAndNamesTheCause() throws {
+        let note = try #require(
+            refreshFailureNote(for: CLIError.rpcError("OAuth usage poller is not running")))
         #expect(note.hasSuffix("\n"))
         #expect(note.hasPrefix("warning: usage refresh failed ("))
         #expect(note.contains("OAuth usage poller is not running"))
@@ -270,13 +277,17 @@ struct CapacityContractTests {
         #expect(!note.contains("Error: "))
     }
 
-    @Test func refreshFailureNote_carriesANonCLIErrorVerbatim() {
+    @Test func refreshFailureNote_rethrowsWhenTheDaemonNeverAnswered() {
+        // No note means the command rethrows: a transport failure would fail
+        // the list call a line later anyway, so promising a listing on stderr
+        // and then exiting nonzero with empty stdout is the one outcome worse
+        // than failing fast.
         struct Transport: Error, CustomStringConvertible {
             var description: String { "connection refused" }
         }
-        let note = refreshFailureNote(Transport())
-        #expect(note.contains("connection refused"))
-        #expect(note.hasSuffix("\n"))
+        #expect(refreshFailureNote(for: Transport()) == nil)
+        // An argument error is likewise not a daemon refusal.
+        #expect(refreshFailureNote(for: CLIError.invalidArgument("no such profile")) == nil)
     }
 
     // MARK: - The terminal to profile join

--- a/Tests/TBDCLITests/CapacityContractTests.swift
+++ b/Tests/TBDCLITests/CapacityContractTests.swift
@@ -272,9 +272,22 @@ struct CapacityContractTests {
         #expect(note.contains("listing persisted snapshots"))
         #expect(note.contains("fetchedAt"))
         #expect(note.contains("statusKind"))
-        // CLIError.rpcError's own "Error: " prefix is stripped, so the note
-        // reads as one sentence.
-        #expect(!note.contains("Error: "))
+        // The whole note is one line, so a caller's stderr stays line-oriented.
+        #expect(note.filter { $0 == "\n" }.count == 1)
+    }
+
+    @Test func refreshFailureNote_toleratesAnUnreadableRefreshResult() throws {
+        // The daemon answered; only the refresh result's shape did not match
+        // (daemon/CLI version skew). The listing may still decode, so this is
+        // tolerable — and the note stays one line rather than carrying
+        // DecodingError's multi-line description.
+        let context = DecodingError.Context(
+            codingPath: [], debugDescription: "refresh result shape did not match")
+        let note = try #require(refreshFailureNote(for: DecodingError.dataCorrupted(context)))
+        #expect(note.hasPrefix("warning: usage refresh failed ("))
+        #expect(note.contains("version skew"))
+        #expect(note.contains("listing persisted snapshots"))
+        #expect(note.filter { $0 == "\n" }.count == 1)
     }
 
     @Test func refreshFailureNote_rethrowsWhenTheDaemonNeverAnswered() {

--- a/Tests/TBDCLITests/CapacityContractTests.swift
+++ b/Tests/TBDCLITests/CapacityContractTests.swift
@@ -137,6 +137,25 @@ struct CapacityContractTests {
         #expect(object["defaultID"] == nil)
     }
 
+    @Test func envelopeSchemaVersionOverridesAPayloadsOwnKey() throws {
+        // The envelope encodes schemaVersion last, so a payload that ever
+        // grows a key of that name loses to it. The printed contract version
+        // is the CLI's to state.
+        struct PayloadWithItsOwnVersion: Encodable {
+            let schemaVersion = 99
+            let marker = "payload"
+        }
+        let text = try #require(jsonString(VersionedJSONEnvelope(
+            schemaVersion: profileListSchemaVersion,
+            payload: PayloadWithItsOwnVersion()
+        )))
+        let data = try #require(text.data(using: .utf8))
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(object["schemaVersion"] as? Int == 1)
+        #expect(object["marker"] as? String == "payload")
+    }
+
     // MARK: - Buckets and units
 
     @Test func profileListJSON_bucketFieldsCarryValuesAndUnits() throws {
@@ -234,6 +253,30 @@ struct CapacityContractTests {
         let buckets = try #require(composed["buckets"] as? [[String: Any]])
         #expect(buckets.count == 1)
         #expect(buckets[0]["percent"] as? Double == 99)
+    }
+
+    // MARK: - Refresh is an optimization, not a precondition
+
+    @Test func refreshFailureNote_namesTheCauseAndWhereStalenessShows() {
+        let note = refreshFailureNote(CLIError.rpcError("OAuth usage poller is not running"))
+        #expect(note.hasSuffix("\n"))
+        #expect(note.hasPrefix("warning: usage refresh failed ("))
+        #expect(note.contains("OAuth usage poller is not running"))
+        #expect(note.contains("listing persisted snapshots"))
+        #expect(note.contains("fetchedAt"))
+        #expect(note.contains("statusKind"))
+        // CLIError.rpcError's own "Error: " prefix is stripped, so the note
+        // reads as one sentence.
+        #expect(!note.contains("Error: "))
+    }
+
+    @Test func refreshFailureNote_carriesANonCLIErrorVerbatim() {
+        struct Transport: Error, CustomStringConvertible {
+            var description: String { "connection refused" }
+        }
+        let note = refreshFailureNote(Transport())
+        #expect(note.contains("connection refused"))
+        #expect(note.hasSuffix("\n"))
     }
 
     // MARK: - The terminal to profile join

--- a/docs/capacity-facts.md
+++ b/docs/capacity-facts.md
@@ -24,13 +24,16 @@ stable. That is what this document states.
   fetch; it is a way to say "don't hand me numbers that aged out while I
   slept." A refresh failure does not fail the command **when the daemon
   answered the refresh attempt** — it refused, or its answer was unreadable:
-  the cause is noted on stderr, the listing still prints on stdout from
-  persisted snapshots, and the exit code stays 0. Each snapshot's own
-  `fetchedAt` and `statusKind` then say how old its numbers are, so a caller
-  that needs fresh-or-nothing must decide that from those fields rather than
-  from the exit code. An **unreachable** daemon is not tolerated: `--refresh`
-  fails the command like any other invocation would, nonzero and with no
-  listing, rather than promising one it cannot produce.
+  the cause is noted on stderr, the listing still prints on stdout, and the
+  exit code stays 0. The listing may then carry no `usageSnapshot` at all,
+  on any profile: the refusal a daemon sends is that it has no usage poller,
+  and the listing draws its snapshots from that same poller. That is the
+  "tracked, not yet fetched" state below — transient, retry later — and not
+  stale numbers. Where snapshots do come back, `fetchedAt` and `statusKind` say
+  how old they are, so a caller that needs fresh-or-nothing decides from those
+  fields rather than from the exit code. An **unreachable** daemon is not
+  tolerated: `--refresh` fails the command like any other invocation would,
+  nonzero and with no listing, rather than promising one it cannot produce.
 - **`tbd terminal list --json <worktree>`** – per-terminal rows, of which only
   `profileID` participates in this contract: it is the join from a running
   session to the profile whose capacity governs it.
@@ -90,6 +93,16 @@ The envelope also carries app-oriented configuration mirrors —
 similar. They are part of the same versioned output and the additive promise
 covers them too, but the capacity contract only *interprets* the fields
 documented here. Treat the rest as informational.
+
+**Do not log or persist the envelope verbatim.** The env-override fields —
+`globalEnvOverrides` at the top level and `envOverrides` on each profile — are
+exactly the values the daemon routes through tmux's sensitive environment
+channel specifically to keep them out of `ps` output, and they routinely carry
+auth tokens and proxy keys. A capacity consumer needs none of them. Read the
+fields you interpret and drop the rest; if a program keeps the envelope — a
+debug dump, a cached readout, a log line — redact the env-override fields
+first. They stay in the output because removing them would break the additive
+promise, not because they are safe to hold onto.
 
 ## Per profile
 

--- a/docs/capacity-facts.md
+++ b/docs/capacity-facts.md
@@ -22,8 +22,11 @@ stable. That is what this document states.
   to refresh usage for stale logged-in OAuth profiles first. Fresh profiles
   and rate-limited ones are skipped, so `--refresh` is not a way to force a
   fetch; it is a way to say "don't hand me numbers that aged out while I
-  slept." A refresh failure does not fail the command — the snapshot's own
-  `status` fields carry the outcome.
+  slept." A refresh failure does not fail the command: the refusal is noted on
+  stderr, the listing still prints on stdout from persisted snapshots, and the
+  exit code stays 0 — each snapshot's own `fetchedAt` and `statusKind` say how
+  old its numbers are. A caller that needs fresh-or-nothing must decide that
+  from those fields, not from the exit code.
 - **`tbd terminal list --json <worktree>`** – per-terminal rows, of which only
   `profileID` participates in this contract: it is the join from a running
   session to the profile whose capacity governs it.
@@ -48,8 +51,11 @@ nonzero with the refusing condition named on stderr.
   a consumer that branches on `schemaVersion == 1` will not be surprised
   silently.
 
-This is the same convention the rest of TBD's JSON follows (see
-[`cli-supervise.md`](cli-supervise.md)).
+This is the convention newly versioned JSON surfaces in TBD adopt, stated for
+the planned supervision surfaces in [`cli-supervise.md`](cli-supervise.md).
+`tbd profile list --json` is its first shipped instance; TBD's older JSON
+output predates the convention and carries no version, so do not expect a
+`schemaVersion` from a command not documented as having one.
 
 `tbd terminal list --json` is the exception: it prints a **bare JSON array** at
 top level, so it has nowhere additive to put a version. It is unversioned and
@@ -90,20 +96,30 @@ Each element of `profiles`:
 
 ### Absence is not failure
 
-The single most important distinction in this document:
+The single most important distinction in this document. A missing
+`usageSnapshot` and a failing one are different states, and a missing one is
+itself two different states — three in all, each told apart from fields already
+in the payload:
 
-- **`usageSnapshot` ABSENT** – TBD has no usage tracking for this profile at
-  all. Either the kind is not OAuth (API-key and Bedrock profiles have no
-  usage API to poll), or it is an OAuth profile that has never been logged
-  into, or the poller has never attempted a fetch. There are no numbers, stale
-  or otherwise, and none are coming without operator action.
-- **`usageSnapshot` PRESENT with a failing status** – TBD tracks this profile
-  and its last attempt failed. There may still be numbers, from an earlier
-  successful fetch. The failure is classified (`statusKind`) and its recency
-  is knowable (`lastAttemptAt`).
+- **Durably untracked** – `kind` is not `oauth`, or `loginIdentity` is absent.
+  `usageSnapshot` is absent and will stay absent. API-key and Bedrock profiles
+  have no usage API to poll at all, and an OAuth profile nobody has run
+  `/login` into has no credential to poll with. No numbers are coming without
+  operator action — a login, or a different profile.
+- **Tracked, not yet fetched** – `kind` is `oauth`, `loginIdentity` is present,
+  and `usageSnapshot` is still absent. The poller has this profile but no
+  attempt has landed yet: the daemon started moments ago, or the login just
+  completed. This is transient and self-resolving; numbers are coming with no
+  operator action. Retry later rather than concluding anything.
+- **Tracked and failing** – `usageSnapshot` is present with a failing
+  `statusKind`. TBD tracks the profile and its last attempt failed. There may
+  still be numbers, from an earlier successful fetch, and the failure's
+  recency is knowable from `lastAttemptAt`.
 
-A program that collapses these two into "no data" will treat an untracked
-Bedrock lane the same as an account whose token just expired. Keep them apart.
+A program that collapses these into one "no data" bucket will treat an
+untracked Bedrock lane, a daemon that has been up for ten seconds, and an
+account whose token just expired as the same thing — and only the last of the
+three warrants telling an operator anything.
 
 ## The usage snapshot
 
@@ -275,8 +291,9 @@ Read this the way a holding program should:
   `statusKind: needsLogin` says the numbers will not improve on their own.
   A program should hold sessions on this profile and surface the login need,
   not retry into it.
-- **`bedrock-lane`** – no `usageSnapshot` key at all. TBD tracks no capacity
-  for it; sessions joined to it are unknown, not free.
+- **`bedrock-lane`** – no `usageSnapshot` key at all, and `kind` is not
+  `oauth`, so it is durably untracked rather than merely not fetched yet. TBD
+  tracks no capacity for it; sessions joined to it are unknown, not free.
 
 A terminal whose row carries no `profileID` is in that same unknown category,
 regardless of what `defaultID` says.

--- a/docs/capacity-facts.md
+++ b/docs/capacity-facts.md
@@ -206,32 +206,44 @@ Each element of `buckets` is one rate-limit window as the usage API names it:
 `tbd terminal list --json <worktree>` emits a bare array of terminal rows. The
 field that matters here:
 
-- **`profileID` PRESENT** – the UUID of the profile this session is actually
-  running under. It is the **already-resolved** answer: the daemon runs the
-  full precedence chain at spawn time — explicit per-spawn override, then the
-  repo's override, then the scratch override for repo-less spawns, then the
-  global default — and stamps the result. Waking a hibernated session pins to
-  this stamped profile and refuses to wake if it no longer resolves, so the
-  value stays true across a park/wake cycle. (Reviving a *closed* terminal
-  re-runs the chain, so it may come back stamped differently.) Join it to
-  `profiles[].profile.id` to get that session's capacity facts.
-- **`profileID` ABSENT** – the honest reading is **"no capacity facts exist
-  for this terminal."** Either it is not a Claude session at all (shell and
-  codex kinds carry no profile), or resolution produced nothing at spawn — no
-  override and no global default configured — and the session is running on
-  the machine's ambient credentials, an account TBD's usage poller does not
-  track.
+The field has three states, not two — the join can fail as well as be absent:
 
-**A consumer MUST NOT resolve an absent `profileID` against `defaultID`.** The
-default is what the *next* session would get, not what this one got; a session
-spawned before a default was configured, or under credentials TBD never sees,
-would be attributed to an account whose numbers describe a different quota
-entirely. Synthesizing an effective profile also erases the ambient-versus-
-profile distinction that the wake-refusal path depends on.
+- **`profileID` PRESENT and it joins** – the UUID of the profile this session
+  is actually running under. It is the **already-resolved** answer: the daemon
+  runs the full precedence chain at spawn time — explicit per-spawn override,
+  then the repo's override, then the scratch override for repo-less spawns,
+  then the global default — and stamps the result. Waking a hibernated session
+  pins to this stamped profile, and ordinarily refuses to wake at all if it no
+  longer resolves, so the value survives a park/wake cycle. (Reviving a
+  *closed* terminal re-runs the chain, so it may come back stamped
+  differently.) Join it to `profiles[].profile.id` for that session's capacity
+  facts.
+- **`profileID` PRESENT but it joins to nothing** – the pin is dangling: no
+  entry in `profiles[]` carries that id. An operator can delete a profile a
+  parked session was pinned to and then wake it through the explicit
+  fallback that overrides the refusal, which resumes the session on the
+  machine's ambient credentials while the row keeps its original stamp. Read
+  this exactly like the absent case — no capacity facts exist for this
+  terminal — and never as an error or a corrupt payload. It is a normal state
+  with a normal cause.
+- **`profileID` ABSENT** – the honest reading is again **"no capacity facts
+  exist for this terminal."** Either it is not a Claude session at all (shell
+  and codex kinds carry no profile), or resolution produced nothing at spawn —
+  no override and no global default configured — and the session is running on
+  ambient credentials, an account TBD's usage poller does not track.
 
-A holding program should treat an absent `profileID` as **unknown**, which is
-neither "exhausted" nor "free" — and choose which way to fail from its own
-conduct, not from a guess TBD made for it.
+**A consumer MUST NOT resolve an absent or dangling `profileID` against
+`defaultID`.** The default is what the *next* session would get, not what this
+one got; a session spawned before a default was configured, or under
+credentials TBD never sees, would be attributed to an account whose numbers
+describe a different quota entirely. Synthesizing an effective profile also
+erases the ambient-versus-profile distinction that the wake-refusal path
+depends on.
+
+A holding program should treat both as **unknown**, which is neither
+"exhausted" nor "free" — and choose which way to fail from its own conduct,
+not from a guess TBD made for it. Practically: look the id up, and take a
+miss as unknown rather than retrying or reporting a fault.
 
 ## Worked example
 
@@ -315,5 +327,6 @@ Read this the way a holding program should:
   `oauth`, so it is durably untracked rather than merely not fetched yet. TBD
   tracks no capacity for it; sessions joined to it are unknown, not free.
 
-A terminal whose row carries no `profileID` is in that same unknown category,
-regardless of what `defaultID` says.
+A terminal whose row carries no `profileID` — or one that matches none of these
+three ids — is in that same unknown category, regardless of what `defaultID`
+says.

--- a/docs/capacity-facts.md
+++ b/docs/capacity-facts.md
@@ -22,11 +22,15 @@ stable. That is what this document states.
   to refresh usage for stale logged-in OAuth profiles first. Fresh profiles
   and rate-limited ones are skipped, so `--refresh` is not a way to force a
   fetch; it is a way to say "don't hand me numbers that aged out while I
-  slept." A refresh failure does not fail the command: the refusal is noted on
-  stderr, the listing still prints on stdout from persisted snapshots, and the
-  exit code stays 0 — each snapshot's own `fetchedAt` and `statusKind` say how
-  old its numbers are. A caller that needs fresh-or-nothing must decide that
-  from those fields, not from the exit code.
+  slept." A refresh failure does not fail the command **when the daemon
+  answered the refresh attempt** — it refused, or its answer was unreadable:
+  the cause is noted on stderr, the listing still prints on stdout from
+  persisted snapshots, and the exit code stays 0. Each snapshot's own
+  `fetchedAt` and `statusKind` then say how old its numbers are, so a caller
+  that needs fresh-or-nothing must decide that from those fields rather than
+  from the exit code. An **unreachable** daemon is not tolerated: `--refresh`
+  fails the command like any other invocation would, nonzero and with no
+  listing, rather than promising one it cannot produce.
 - **`tbd terminal list --json <worktree>`** – per-terminal rows, of which only
   `profileID` participates in this contract: it is the join from a running
   session to the profile whose capacity governs it.
@@ -203,10 +207,10 @@ Each element of `buckets` is one rate-limit window as the usage API names it:
 
 ## The terminal join
 
-`tbd terminal list --json <worktree>` emits a bare array of terminal rows. The
-field that matters here:
-
-The field has three states, not two — the join can fail as well as be absent:
+`tbd terminal list --json <worktree>` emits a bare array of terminal rows. One
+field on each row participates in this contract: **`profileID`**, the join from
+a session to the profile whose capacity governs it. It has three states, not
+two — the join can fail as well as be absent:
 
 - **`profileID` PRESENT and it joins** – the UUID of the profile this session
   is actually running under. It is the **already-resolved** answer: the daemon
@@ -219,13 +223,17 @@ The field has three states, not two — the join can fail as well as be absent:
   differently.) Join it to `profiles[].profile.id` for that session's capacity
   facts.
 - **`profileID` PRESENT but it joins to nothing** – the pin is dangling: no
-  entry in `profiles[]` carries that id. An operator can delete a profile a
-  parked session was pinned to and then wake it through the explicit
-  fallback that overrides the refusal, which resumes the session on the
-  machine's ambient credentials while the row keeps its original stamp. Read
-  this exactly like the absent case — no capacity facts exist for this
-  terminal — and never as an error or a corrupt payload. It is a normal state
-  with a normal cause.
+  entry in `profiles[]` carries that id. Deleting a profile does exactly this,
+  immediately, to every terminal row that references it — awake, parked, or
+  closed. Nothing rewrites those stamps, deliberately: the stamp records which
+  account a session was started under, and an already-running process keeps
+  using the credentials it was handed, so overwriting the record would
+  misreport what that process is doing. (A parked session pinned to a deleted
+  profile ordinarily refuses to wake at all; the explicit fallback that
+  overrides the refusal resumes it on ambient credentials, still under the old
+  stamp.) Read a dangling pin exactly like the absent case — no capacity facts
+  exist for this terminal — and never as an error or a corrupt payload. It is a
+  normal state with a normal cause.
 - **`profileID` ABSENT** – the honest reading is again **"no capacity facts
   exist for this terminal."** Either it is not a Claude session at all (shell
   and codex kinds carry no profile), or resolution produced nothing at spawn —

--- a/docs/capacity-facts.md
+++ b/docs/capacity-facts.md
@@ -1,0 +1,282 @@
+# Capacity facts
+
+TBD's machine-readable surface for **how much quota an account has left**, and
+for **which account a session is running on**. It exists so a supervision
+program that TBD does not run — a wake program, a sweep program, an operator's
+cron script — can decide for itself whether to hold: not nudging agents that
+are rate-capped, not piling interventions onto a saturated account.
+
+This is the Enabled half of P1-1 in
+[`specs/2026-07-26-fleet-supervision-requirements.md`](specs/2026-07-26-fleet-supervision-requirements.md).
+The daemon enforces nothing here — there is no capacity choke point every wake
+must pass through, deliberately (see
+[`specs/2026-07-26-fleet-supervision-wake-program.md`](specs/2026-07-26-fleet-supervision-wake-program.md)).
+What TBD owes a program author is that the facts are public, documented, and
+stable. That is what this document states.
+
+## The commands
+
+- **`tbd profile list --json`** – the versioned capacity envelope: every model
+  profile, its login identity, and its usage snapshot. This is the contract.
+- **`tbd profile list --json --refresh`** – the same, after asking the daemon
+  to refresh usage for stale logged-in OAuth profiles first. Fresh profiles
+  and rate-limited ones are skipped, so `--refresh` is not a way to force a
+  fetch; it is a way to say "don't hand me numbers that aged out while I
+  slept." A refresh failure does not fail the command — the snapshot's own
+  `status` fields carry the outcome.
+- **`tbd terminal list --json <worktree>`** – per-terminal rows, of which only
+  `profileID` participates in this contract: it is the join from a running
+  session to the profile whose capacity governs it.
+
+Data goes to stdout, messages to stderr; both commands exit 0 on success and
+nonzero with the refusing condition named on stderr.
+
+## The versioning promise
+
+`tbd profile list --json` prints a JSON object carrying a top-level
+`schemaVersion`, currently **1**. Within a version:
+
+- **Fields may be added** – a consumer MUST tolerate keys it does not
+  recognize, at every level: new top-level fields, new per-profile fields, new
+  snapshot fields, and new bucket `kind` values. Unknown bucket kinds flow
+  through from the usage API untouched by design, so new windows appear
+  without a TBD release.
+- **A field never changes meaning or units** – `percent` stays a 0–100
+  utilization number; timestamps stay ISO 8601; an enum value already emitted
+  keeps its sense.
+- **Removing a field, or changing what one means, requires a version bump** –
+  a consumer that branches on `schemaVersion == 1` will not be surprised
+  silently.
+
+This is the same convention the rest of TBD's JSON follows (see
+[`cli-supervise.md`](cli-supervise.md)).
+
+`tbd terminal list --json` is the exception: it prints a **bare JSON array** at
+top level, so it has nowhere additive to put a version. It is unversioned and
+documented as-is; only its `profileID` field is promised here.
+
+## The envelope
+
+Top level of `tbd profile list --json`:
+
+- **`schemaVersion`** – integer, currently `1`.
+- **`profiles`** – array of profile entries, described below.
+- **`defaultID`** – UUID of the globally-configured default profile, or absent
+  when no global default is set. It tells you which profile *new* sessions
+  will be spawned under; it does not tell you what any *existing* session is
+  running on, and it is never a substitute for a missing `profileID` (see
+  "The terminal join").
+
+The envelope also carries app-oriented configuration mirrors —
+`primaryAgentPreference`, `globalEnvOverrides`, merge-automation defaults, and
+similar. They are part of the same versioned output and the additive promise
+covers them too, but the capacity contract only *interprets* the fields
+documented here. Treat the rest as informational.
+
+## Per profile
+
+Each element of `profiles`:
+
+- **`profile`** – the profile itself. `id` (UUID, the value `profileID` on a
+  terminal joins to), `name` (operator-chosen label), `kind` (`oauth`,
+  `apiKey`, or `bedrock`), plus configuration fields outside this contract.
+- **`loginIdentity`** – the account email the profile is logged in as. Absent
+  for non-OAuth kinds, and for an OAuth profile nobody has run `/login` into
+  yet.
+- **`configDirPath`** – absolute path of the profile's isolated Claude config
+  directory. Absent for Bedrock profiles.
+- **`usageSnapshot`** – the capacity facts, or **absent**. Its absence is
+  meaningful; see next.
+
+### Absence is not failure
+
+The single most important distinction in this document:
+
+- **`usageSnapshot` ABSENT** – TBD has no usage tracking for this profile at
+  all. Either the kind is not OAuth (API-key and Bedrock profiles have no
+  usage API to poll), or it is an OAuth profile that has never been logged
+  into, or the poller has never attempted a fetch. There are no numbers, stale
+  or otherwise, and none are coming without operator action.
+- **`usageSnapshot` PRESENT with a failing status** – TBD tracks this profile
+  and its last attempt failed. There may still be numbers, from an earlier
+  successful fetch. The failure is classified (`statusKind`) and its recency
+  is knowable (`lastAttemptAt`).
+
+A program that collapses these two into "no data" will treat an untracked
+Bedrock lane the same as an account whose token just expired. Keep them apart.
+
+## The usage snapshot
+
+Fields of `usageSnapshot`:
+
+- **`buckets`** – the rate-limit windows from the last **successful** fetch.
+  Empty when none has ever succeeded. Described below.
+- **`fetchedAt`** – ISO 8601 instant of the last **successful** fetch.
+  **Absent means no fetch has ever succeeded**, which is exactly when
+  `buckets` is empty or meaningless. This is the field to judge staleness
+  from — TBD persists snapshots across daemon restarts, so an otherwise
+  healthy-looking snapshot can carry hours-old numbers.
+- **`lastAttemptAt`** – ISO 8601 instant of the last attempt, successful or
+  not. Always present. Compare it against `fetchedAt` to see how long the
+  profile has been failing.
+- **`status`** – human-readable outcome of the last attempt: `"ok"`, or a
+  failure description such as
+  `"stale since 2026-07-07T12:34:56Z; fetch failed: HTTP 401"`. Written for
+  people. Do not branch on it — its wording is not a contract.
+- **`statusKind`** – the machine-readable classification to branch on:
+  - **`ok`** – last fetch succeeded; `buckets` are current.
+  - **`rateLimited`** – HTTP 429. The poller is backing off and will retry.
+  - **`needsLogin`** – the credential exists but the server rejected it and
+    automatic token refresh could not recover; the profile needs `/login`.
+  - **`noCredentials`** – no stored credential at all (never logged in, or the
+    keychain item is gone).
+  - **`networkError`** – transport-level failure (DNS, timeout, offline).
+    Transient; retried.
+  - **`decodeError`** – the server replied 200 but the body did not parse.
+    Retried.
+  - **`unknown`** – some other HTTP status, or a snapshot written by an older
+    daemon that did not classify. Treat as a generic retryable failure.
+
+**Buckets and status are independent.** Buckets come from the last successful
+fetch; status describes the last attempt. A snapshot can therefore carry a
+failing `statusKind` *and* a full set of buckets — those numbers are simply
+old. Read truth-of-last-outcome from `statusKind`, and age from `fetchedAt`.
+
+### Buckets
+
+Each element of `buckets` is one rate-limit window as the usage API names it:
+
+- **`kind`** – `session` (the rolling 5-hour window), `weekly_all` (weekly,
+  all models), `weekly_scoped` (weekly, one model family), or a kind TBD has
+  never seen. Unknown kinds are passed through verbatim; do not assume the
+  list is closed.
+- **`modelDisplayName`** – for `weekly_scoped`, the model family the window
+  applies to (e.g. `"Fable"`). Absent when the bucket is not model-scoped.
+- **`group`** – the API's grouping label (`session`, `weekly`). Absent if the
+  API omits it.
+- **`percent`** – utilization of this window, a JSON number on a **0–100**
+  scale. `100` means the window is spent.
+- **`resetsAt`** – ISO 8601 instant when the window resets. **Absent when the
+  API sent null**, which happens for a scoped window that has not been used.
+  Absent is not "resets now."
+- **`severity`** – the API's label: `normal`, `warning`, `critical`. Passed
+  through as sent; absent when the API omits it. It is the provider's
+  judgment, not TBD's threshold.
+- **`isActive`** – whether this is the window currently binding the account.
+  Absent when the API omits it.
+
+## The terminal join
+
+`tbd terminal list --json <worktree>` emits a bare array of terminal rows. The
+field that matters here:
+
+- **`profileID` PRESENT** – the UUID of the profile this session is actually
+  running under. It is the **already-resolved** answer: the daemon runs the
+  full precedence chain at spawn time — explicit per-spawn override, then the
+  repo's override, then the scratch override for repo-less spawns, then the
+  global default — and stamps the result. Waking a hibernated session pins to
+  this stamped profile and refuses to wake if it no longer resolves, so the
+  value stays true across a park/wake cycle. (Reviving a *closed* terminal
+  re-runs the chain, so it may come back stamped differently.) Join it to
+  `profiles[].profile.id` to get that session's capacity facts.
+- **`profileID` ABSENT** – the honest reading is **"no capacity facts exist
+  for this terminal."** Either it is not a Claude session at all (shell and
+  codex kinds carry no profile), or resolution produced nothing at spawn — no
+  override and no global default configured — and the session is running on
+  the machine's ambient credentials, an account TBD's usage poller does not
+  track.
+
+**A consumer MUST NOT resolve an absent `profileID` against `defaultID`.** The
+default is what the *next* session would get, not what this one got; a session
+spawned before a default was configured, or under credentials TBD never sees,
+would be attributed to an account whose numbers describe a different quota
+entirely. Synthesizing an effective profile also erases the ambient-versus-
+profile distinction that the wake-refusal path depends on.
+
+A holding program should treat an absent `profileID` as **unknown**, which is
+neither "exhausted" nor "free" — and choose which way to fail from its own
+conduct, not from a guess TBD made for it.
+
+## Worked example
+
+Abridged output of `tbd profile list --json` — three profiles: one healthy,
+one whose fetch is failing but still holds yesterday's numbers, and one TBD
+tracks no usage for at all.
+
+```json
+{
+  "schemaVersion": 1,
+  "defaultID": "6f1b0e6c-2f8a-4a5e-9c3d-1a2b3c4d5e6f",
+  "profiles": [
+    {
+      "profile": {
+        "id": "6f1b0e6c-2f8a-4a5e-9c3d-1a2b3c4d5e6f",
+        "name": "primary",
+        "kind": "oauth"
+      },
+      "loginIdentity": "operator@example.com",
+      "usageSnapshot": {
+        "status": "ok",
+        "statusKind": "ok",
+        "fetchedAt": "2026-07-07T17:41:03Z",
+        "lastAttemptAt": "2026-07-07T17:41:03Z",
+        "buckets": [
+          {
+            "kind": "session",
+            "group": "session",
+            "percent": 42.5,
+            "severity": "normal",
+            "isActive": true,
+            "resetsAt": "2026-07-07T18:00:00Z"
+          },
+          { "kind": "weekly_all", "group": "weekly", "percent": 17 },
+          {
+            "kind": "weekly_scoped",
+            "group": "weekly",
+            "percent": 3,
+            "modelDisplayName": "Fable"
+          }
+        ]
+      }
+    },
+    {
+      "profile": {
+        "id": "9a7d4c11-55b2-4f0e-8b6a-7c5d3e2f1a0b",
+        "name": "spillover",
+        "kind": "oauth"
+      },
+      "loginIdentity": "spillover@example.com",
+      "usageSnapshot": {
+        "status": "stale since 2026-07-06T22:10:00Z; fetch failed: HTTP 401",
+        "statusKind": "needsLogin",
+        "fetchedAt": "2026-07-06T22:10:00Z",
+        "lastAttemptAt": "2026-07-07T17:41:04Z",
+        "buckets": [
+          { "kind": "session", "group": "session", "percent": 88 }
+        ]
+      }
+    },
+    {
+      "profile": {
+        "id": "1c2d3e4f-6a7b-48c9-90d1-e2f3a4b5c6d7",
+        "name": "bedrock-lane",
+        "kind": "bedrock"
+      }
+    }
+  ]
+}
+```
+
+Read this the way a holding program should:
+
+- **`primary`** – fresh (`fetchedAt` is seconds old), 42.5% through its
+  5-hour window, which resets at 18:00Z. Safe to act on.
+- **`spillover`** – the 88% is from yesterday and the token is rejected now.
+  `statusKind: needsLogin` says the numbers will not improve on their own.
+  A program should hold sessions on this profile and surface the login need,
+  not retry into it.
+- **`bedrock-lane`** – no `usageSnapshot` key at all. TBD tracks no capacity
+  for it; sessions joined to it are unknown, not free.
+
+A terminal whose row carries no `profileID` is in that same unknown category,
+regardless of what `defaultID` says.

--- a/docs/capacity-facts.md
+++ b/docs/capacity-facts.md
@@ -44,9 +44,17 @@ nonzero with the refusing condition named on stderr.
   snapshot fields, and new bucket `kind` values. Unknown bucket kinds flow
   through from the usage API untouched by design, so new windows appear
   without a TBD release.
-- **A field never changes meaning or units** – `percent` stays a 0–100
-  utilization number; timestamps stay ISO 8601; an enum value already emitted
-  keeps its sense.
+- **A field never changes meaning within a version** – timestamps stay ISO
+  8601, an enum value already emitted keeps its sense, and a field TBD computes
+  keeps computing the same thing.
+- **Provider values are passed through as data, not restated as TBD's** –
+  `percent`, `severity`, and bucket `kind` come from the usage API and are
+  emitted verbatim. TBD promises only not to reinterpret or rescale them
+  within a version: the observed scale for `percent` is 0–100 utilization, and
+  if the provider ever changed it, the new scale would surface here as-is
+  rather than being silently converted. Read them as the provider's numbers,
+  and prefer relative judgments (this profile against itself over time) over
+  hard-coded absolute thresholds.
 - **Removing a field, or changing what one means, requires a version bump** –
   a consumer that branches on `schemaVersion == 1` will not be surprised
   silently.
@@ -102,10 +110,9 @@ itself two different states — three in all, each told apart from fields alread
 in the payload:
 
 - **Durably untracked** – `kind` is not `oauth`, or `loginIdentity` is absent.
-  `usageSnapshot` is absent and will stay absent. API-key and Bedrock profiles
-  have no usage API to poll at all, and an OAuth profile nobody has run
-  `/login` into has no credential to poll with. No numbers are coming without
-  operator action — a login, or a different profile.
+  API-key and Bedrock profiles have no usage API to poll at all, and an OAuth
+  profile nobody is logged into has no credential to poll with. No numbers are
+  coming without operator action — a login, or a different profile.
 - **Tracked, not yet fetched** – `kind` is `oauth`, `loginIdentity` is present,
   and `usageSnapshot` is still absent. The poller has this profile but no
   attempt has landed yet: the daemon started moments ago, or the login just
@@ -120,6 +127,17 @@ A program that collapses these into one "no data" bucket will treat an
 untracked Bedrock lane, a daemon that has been up for ten seconds, and an
 account whose token just expired as the same thing — and only the last of the
 three warrants telling an operator anything.
+
+**`loginIdentity` decides "untracked", even against a snapshot that is still
+there.** A profile can briefly show an absent `loginIdentity` alongside a
+present `usageSnapshot` — even one whose `statusKind` is `ok`. The poller
+seeds persisted snapshots when the daemon starts and prunes the ones that are
+no longer eligible on its next full sweep, so after a logout, or a restart
+following one, the old snapshot outlives the credential for up to one sweep
+interval. It is a ghost: the numbers describe an account nothing is running
+under any more, and it disappears on its own. Take the absent `loginIdentity`
+as authoritative and read that profile as durably untracked, whatever the
+lingering snapshot says.
 
 ## The usage snapshot
 
@@ -170,8 +188,10 @@ Each element of `buckets` is one rate-limit window as the usage API names it:
   applies to (e.g. `"Fable"`). Absent when the bucket is not model-scoped.
 - **`group`** – the API's grouping label (`session`, `weekly`). Absent if the
   API omits it.
-- **`percent`** – utilization of this window, a JSON number on a **0–100**
-  scale. `100` means the window is spent.
+- **`percent`** – utilization of this window, a JSON number carrying the
+  provider's own value. On observed responses the scale is 0–100, where `100`
+  means the window is spent. TBD does not rescale it (see "The versioning
+  promise").
 - **`resetsAt`** – ISO 8601 instant when the window resets. **Absent when the
   API sent null**, which happens for a scoped window that has not been used.
   Absent is not "resets now."

--- a/docs/specs/2026-07-26-fleet-supervision-requirements.md
+++ b/docs/specs/2026-07-26-fleet-supervision-requirements.md
@@ -266,8 +266,12 @@ and become a contract that migration and future change must respect.
   *This story splits along the Built/Enabled line. Holding is **Built** for the desks TBD
   runs (design §11). For the wake program it is **Enabled** — the per-profile usage and
   rate-limit facts the daemon already holds must be exposed on a public, machine-readable
-  surface so a program can hold on its own. That surface does not exist today; it is the
-  first concrete API request the Enabled conformance test has produced.*
+  surface so a program can hold on its own. That surface is `tbd profile list --json`: it
+  carries each profile's usage buckets with their provenance — when the numbers were last
+  successfully fetched, and how the last attempt classified — under a top-level
+  `schemaVersion` whose promise is additive-only. Contract in
+  [`../capacity-facts.md`](../capacity-facts.md), which also pins the terminal-to-profile
+  join and what an absent `profileID` may not be resolved against.*
 - **P1-2 [A]** As an operator, I want *whether* to wake a parked session decided from cheap
   facts derived entirely outside it — branch, commits not yet on main, whether a pull request
   exists and its state, whether checks fail — so that the supervisor never has to hold the arc

--- a/docs/specs/2026-07-26-fleet-supervision-wake-program.md
+++ b/docs/specs/2026-07-26-fleet-supervision-wake-program.md
@@ -76,7 +76,8 @@ daemon — and outside the desk — entirely.**
   public, documented, stable surface: parked state and `hibernateReason` in
   the listings; the supervision
   switch readable (`tbd supervise status --json`); per-profile
-  usage facts readable (P1-1 — the one surface that does not exist yet); and
+  usage facts readable (P1-1 — `tbd profile list --json`, contract in
+  [`../capacity-facts.md`](../capacity-facts.md)); and
   `tbd terminal wake --prompt` with its existing race-safety — an
   already-awake session reports `woken:false` and receives nothing, the one
   property that must hold no matter who calls, and it already does. The

--- a/docs/specs/2026-08-14-capacity-facts-contract-design.md
+++ b/docs/specs/2026-08-14-capacity-facts-contract-design.md
@@ -1,0 +1,209 @@
+# Capacity facts as a stated contract — design
+
+Status: **implemented**. The resulting reference document is
+[`../capacity-facts.md`](../capacity-facts.md); this spec records why that
+document says what it says.
+
+## Problem
+
+Story P1-1 of
+[`2026-07-26-fleet-supervision-requirements.md`](2026-07-26-fleet-supervision-requirements.md)
+asks for a capacity-aware supervisor: one that holds interventions when several
+agents are rate-capped at once, and never nudges an individually rate-limited
+agent. The story splits along the Built/Enabled line. Holding is **Built** for
+the desks TBD runs. For a wake program — a script TBD does not run, does not
+schedule, and cannot repair — it is **Enabled**: TBD's obligation is that the
+facts a program needs to hold on its own are public, documented, and stable.
+
+[`2026-07-26-fleet-supervision-wake-program.md`](2026-07-26-fleet-supervision-wake-program.md)
+states the same obligation from the consumer's side, and states its limit: TBD
+guards nothing at actuation. There is no compiled capacity choke point every
+wake must pass through, because such a point would make TBD the guarantor of a
+program it does not own. What TBD owes instead is sufficiency.
+
+The daemon already holds every fact required. It polls per-profile usage, keeps
+buckets with provenance, and stamps each session with the profile it was spawned
+under. `tbd profile list --json` already printed most of it. What did not exist
+was the *promise*: nothing said the shape would hold, nothing defined what a
+missing field meant, and one join a holding program cannot avoid — from a
+session to the account whose quota governs it — was undocumented at exactly the
+point where it is easiest to get wrong.
+
+The gap was therefore never collection. It was that incidental output is not an
+interface. This design closes it with two decisions.
+
+## Decision 1 — the version lives on the envelope
+
+`tbd profile list --json` prints a JSON object carrying a top-level
+`schemaVersion`, stamped by the CLI at print time. Its value is `1`.
+
+Three properties of the surface force that placement:
+
+- **One binary emits one shape.** The CLI that prints a listing prints every
+  entry in it. A version attached to each profile could never legitimately
+  differ between entries, so per-entry versions would be a field that is either
+  always redundant or always a bug.
+- **The contract's join spans the envelope.** Reading capacity for a session
+  needs `profiles[]` and `defaultID` together, and the rule about what a
+  consumer may *not* do with `defaultID` (Decision 2) is a statement about the
+  pair. A version scoped to a snapshot, or to a profile, cannot cover a rule
+  whose subject is the object containing both.
+- **The printed output is the contract surface.** The daemon's RPC result is an
+  internal seam between two binaries shipped together; it carries no promise to
+  anyone outside the process pair, and versioning it would state a commitment at
+  a boundary no external program observes. The CLI stamps the version because
+  the CLI's stdout is what a program reads.
+
+This also matches the convention
+[`../cli-supervise.md`](../cli-supervise.md) states for the planned supervision
+surfaces — JSON output carries a top-level `schemaVersion`, and changes within a
+version are additive only. This command is that convention's first shipped
+instance rather than a second convention.
+
+### What the version promises
+
+- **Additive within a version.** Fields may be added at any level — top level,
+  per profile, per snapshot, and new bucket kinds. A consumer must tolerate keys
+  it does not recognize. Unknown bucket kinds flow through from the usage API by
+  design, so a new rate-limit window appears without a TBD release.
+- **Meanings are fixed within a version.** A field TBD computes keeps computing
+  the same thing; timestamps stay ISO 8601; an enum value already emitted keeps
+  its sense.
+- **Removal or a meaning change requires a bump.** A consumer that branches on
+  `schemaVersion == 1` is never silently surprised.
+- **Provider-originated values are pass-through data.** `percent`, `severity`,
+  and bucket `kind` come from the usage API and are emitted verbatim. TBD
+  promises only not to reinterpret or rescale them. The observed scale for
+  `percent` is 0–100 utilization; an upstream scale change would surface as-is
+  rather than be silently converted, which is why the reference document steers
+  consumers toward relative judgments over hard-coded absolute thresholds.
+
+The envelope is built by encoding the payload into the same keyed container the
+version is then written to, so any field the underlying result gains flows
+through with no envelope-side mirror to maintain. The version is written last
+and therefore wins over a payload key of the same name — deliberate, since the
+printed contract version is the CLI's to state.
+
+### Rejected alternatives
+
+- **A version on each profile entry.** Rejected because entries in one listing
+  cannot legitimately carry different versions, and because the rules being
+  versioned are not per-entry rules.
+- **A version on each usage snapshot.** Rejected for the same reason, plus a
+  sharper one: the absence of a snapshot is itself contractual information
+  (below), and a version living inside the snapshot says nothing in exactly the
+  case that most needs saying.
+- **A version stamped by the daemon into the RPC result.** Rejected because it
+  versions the wrong boundary. It would also make the promise the daemon's to
+  keep while the CLI is what composes and prints the bytes a consumer parses.
+- **Versioning `tbd terminal list --json` too.** Rejected because that command
+  prints a bare JSON array at top level. There is nowhere additive to put a key,
+  and wrapping the array in an object to make room would break every existing
+  consumer — the precise harm versioning exists to prevent. It stays
+  unversioned and documented as-is; only its `profileID` field participates in
+  this contract. To keep that reasoning enforceable rather than advisory, the
+  envelope type accepts only payloads marked as encoding to a JSON object, so
+  wrapping an array is a compile error instead of an encoder crash.
+
+## Decision 2 — a session's profile is documented, never synthesized
+
+`Terminal.profileID` is documented as it is. TBD does not add a computed
+"effective profile" field that fills in a missing value from the global default.
+
+The argument is entirely about what the stored value already means. The daemon
+runs the full precedence chain at spawn time — explicit per-spawn override, then
+the repo's override, then the scratch override for repo-less spawns, then the
+global default — and stamps the result on the terminal row. Waking a hibernated
+session pins to that stamp, and ordinarily refuses to wake at all when the
+pinned profile no longer resolves rather than quietly resuming on some other
+account. Reviving a *closed* terminal re-runs the chain, so it may come back
+stamped differently, which is honest: it is a different spawn.
+
+So a present `profileID` is **already the effective answer**. There is no
+resolution left to perform, and nothing for a synthesized field to add.
+
+Which means an absent one is not an unfinished computation either. It says
+resolution produced nothing — no override and no global default configured — or
+that the session is not a Claude session at all. In the first case the session
+runs on the machine's ambient credentials: a real account, doing real work,
+whose quota TBD's poller does not track and has no way to track.
+
+### Why an effective profileID would be wrong
+
+Synthesizing `defaultID` into the empty slot would produce a number that looks
+like an answer and is not one. `defaultID` is what the *next* session would be
+spawned under. A session started before a default was configured, or under
+ambient credentials TBD never sees, would be reported as running on an account
+whose usage numbers describe a different quota entirely — and a holding program
+would then hold, or decline to hold, on the wrong account's remaining capacity.
+That is the exact mistake P1-1 exists to prevent, dressed as a convenience.
+
+It would also erase a distinction the daemon depends on. Ambient-versus-profile
+is what the wake-refusal path tests: a parked session pinned to a profile that
+no longer resolves is refused precisely because resuming it on ambient
+credentials would be resuming it on the wrong account. A surface that reports
+every session as having a profile makes that distinction unobservable from
+outside.
+
+### The resulting contract reading
+
+`profileID` has three states, and only one of them yields capacity facts:
+
+- **Present and it joins** to an entry in `profiles[]` — that entry's snapshot
+  governs the session.
+- **Present but it joins to nothing.** Deleting a profile dangles the stamp
+  immediately on every terminal row referencing it, awake or parked or closed.
+  Nothing rewrites those stamps, deliberately: the stamp records which account a
+  session was started under, and an already-running process keeps using the
+  credentials it was handed, so overwriting the record would misreport what that
+  process is doing.
+- **Absent** — not a Claude session, or spawned with nothing to resolve.
+
+Both non-joining states mean the same thing to a consumer: **no capacity facts
+exist for this terminal.** Neither is an error or a corrupt payload; both are
+normal states with normal causes. A holding program treats them as *unknown* —
+which is neither "exhausted" nor "free" — and decides which way to fail from its
+own conduct, not from a guess TBD made on its behalf.
+
+## Consequences for the rest of the surface
+
+Three smaller rulings follow from the same principle — say what is true,
+including about what is missing — and are stated in the reference document.
+
+- **Absence is not failure, and it is not one state.** A missing `usageSnapshot`
+  can mean the profile is durably untracked (`kind` is not `oauth`, or
+  `loginIdentity` is absent — nothing to poll), or tracked but not yet fetched
+  (an OAuth profile with a login identity whose first poll has not landed —
+  transient, self-resolving, retry later). A *present* snapshot whose last fetch
+  failed is a third state, carrying possibly-stale buckets from an earlier
+  success. All three are discriminable from fields already in the payload, so
+  the surface owes no new field — only the documentation that makes the
+  discrimination visible. A consumer that collapses them treats an untracked
+  Bedrock lane, a daemon that has been up ten seconds, and an expired token
+  identically, though only the last warrants telling an operator anything.
+- **Refresh tolerance ends where the daemon's answer does.** `--refresh` is an
+  optimization, not a precondition: when the daemon answered and refused, or
+  answered unreadably, the cause goes to stderr, the listing still prints, and
+  the exit code stays 0. An unreachable daemon fails the command like any other
+  invocation, because promising a listing on stderr and then exiting nonzero
+  with empty stdout is worse than failing plainly. The note itself must not
+  overpromise: the refusal a daemon sends is that it has no usage poller, and
+  the listing draws snapshots from that same poller, so in exactly that case the
+  listing carries no snapshots at all — the not-yet-fetched state, not stale
+  numbers.
+- **Secret-bearing fields stay, with a warning.** The envelope's env-override
+  fields are the values the daemon routes through tmux's sensitive environment
+  channel specifically to keep them out of `ps`, and they routinely carry auth
+  tokens and proxy keys. Removing them would break the additive promise, so they
+  remain — but a capacity consumer needs none of them, and the reference
+  document tells programs to drop or redact them before logging or persisting
+  the envelope. A contract that documents a field's presence should also
+  document when holding onto it is a hazard.
+
+## Scope
+
+This design adds no collectors and changes no daemon behavior, no persisted
+state, and no defaults. Everything it promises was already computed; the work is
+stating it, versioning the statement, and making the two rules above impossible
+to misread. Compiled behavior stays where it was — consistent with placing
+capability outside the daemon until field evidence argues it inward.


### PR DESCRIPTION
## Summary

A wake program that decides whether to poke a parked agent needs one thing TBD already knows: how much capacity each account has left, and which account each session draws from. `tbd profile list --json` has carried per-profile usage buckets with provenance for a while — but as incidental CLI output a program could read, not an interface it could depend on. This PR is the fleet-supervision requirements' P1-1 Enabled half: it turns that surface into a stated, versioned contract, documents every field's meaning and units — above all what it means when a field is **absent** — and pins the semantics of a terminal's nil `profileID`, the one genuinely undocumented join a holding program needs.

## Why this shape

Governing spec: `docs/specs/2026-07-26-fleet-supervision-requirements.md` (P1-1) and `docs/specs/2026-07-26-fleet-supervision-wake-program.md` (the consumer). The two decisions this slice makes are specced in `docs/specs/2026-08-14-capacity-facts-contract-design.md` — with the rejected alternatives and the code ground truth each rests on — and summarized here; `docs/capacity-facts.md` is the resulting contract reference a wake-program author reads.

**Decision 1 — `schemaVersion` lives on the envelope** (top level of the command's JSON output), stamped by the CLI at print time, value `1`. Per-profile or per-snapshot versions were rejected: one CLI binary emits one shape, so versions inside the array could never legitimately differ, and the contract's join rule spans the envelope (`profiles[]` *and* `defaultID`), which a snapshot-level version couldn't cover. The CLI stamps it (not the daemon RPC result) because the printed output is the contract surface; the RPC stays an internal seam. This matches the convention `docs/cli-supervise.md` states for the planned supervision surfaces — this command is its first shipped instance. The promise, stated in the doc: within a version fields may be added and consumers must tolerate unknown fields; a field never changes meaning; removal or meaning-change requires a bump. Provider-originated values (`percent`, `severity`, bucket `kind`) are pass-through data — TBD promises not to reinterpret or rescale them.

**Decision 2 — nil `profileID` is documented, not synthesized away.** The slice offered "always emit an effective profileID" as the alternative; code ground truth rules it out. The daemon stamps the **already-resolved** profile at spawn (explicit override → repo override → scratch override → global default), and hibernation wake pins to that stamp — so a present `profileID` is already the effective answer. nil therefore does *not* mean "the default profile": it means resolution produced nothing and the session runs on ambient machine credentials, an account TBD's poller does not track. Resolving nil against `defaultID` would attribute one account's usage numbers to a session running on a different, untracked account — exactly the mistake a holding program must not make. The contract doc states the honest three-state reading (joins / dangling pin / absent), each collapsing to "no capacity facts for this terminal; treat as unknown, never as an error."

## What this PR does

- `Sources/TBDCLI/Utilities.swift` — internal `jsonString(_:)` (extracted from `printJSON` so tests hit the real composition), `VersionedJSONEnvelope` (flattens the payload's keyed container and stamps `schemaVersion` last, envelope authoritative on key conflict), `profileListSchemaVersion = 1`. The envelope's payload is constrained to a `JSONObjectPayload` marker protocol, so wrapping a bare-array payload (most other `--json` output here) is a compile error rather than a `JSONEncoder` precondition crash.
- `Sources/TBDCLI/Commands/ProfileCommands.swift` — the `--json` branch prints through a single internal seam, `profileListJSONOutput(_:)`; an encode failure names itself on stderr and exits nonzero instead of printing nothing at exit 0. `--refresh` no longer fails the whole command when the daemon answered but refused (poller not yet constructed, mock mode) or answered unreadably: one `warning:` line on stderr, persisted snapshots still print, exit 0. An unreachable daemon still fails fast.
- `Sources/TBDCLI/Commands/TerminalCommands.swift` — `terminal list --json` (a bare array, unversioned by design — nowhere additive to put a version) gets the same honest encode-failure guard.
- `docs/capacity-facts.md` — the contract document: versioning promise, every envelope/snapshot/bucket field with units, the absence taxonomy (untracked vs not-yet-fetched vs tracked-and-failing, plus the transient logged-out ghost snapshot), the terminal join's three states, and a do-not-log-verbatim caveat: the envelope's `envOverrides` fields are the values the daemon routes through tmux's sensitive env channel and routinely carry secrets, and a capacity consumer needs none of them.
- Spec corrections: P1-1's Enabled note and the wake-program design now name the shipped surface instead of stating it doesn't exist.
- `Tests/TBDCLITests/CapacityContractTests.swift` — 11 tests (see below).

No daemon changes, no migrations, no flags. All JSON changes are additive.

## Assumptions

- The usage API's `percent` stays on a 0–100 scale; the daemon passes it through verbatim. If upstream changed scale, the value would surface here as-is — the doc tells consumers this, and recommends relative rather than hard-coded thresholds.
- The refresh-tolerance stderr note reads a `DecodingError` as "the daemon answered unintelligibly"; a truncated frame from a daemon dying mid-answer also lands there, but the listing one line later then fails loudly on its own, so the two are not worth telling apart (accepted residual, documented in a code comment).

## Evidence & verification

- 11 `CapacityContract` tests assert against the **real composed output** — the same `profileListJSONOutput`/`jsonString` calls the commands print — parsed back with `JSONSerialization`: `schemaVersion == 1` beside surviving payload fields (additivity); `percent` as a number and `resetsAt` as ISO 8601; a profile with no snapshot omits the key entirely while a failed fetch carries `statusKind` and omits `fetchedAt` (absence ≠ failure, distinguishable); a terminal with an explicit profile emits `profileID`, one without omits it (both branches of the documented rule); envelope-wins on a payload's conflicting `schemaVersion` key; `refreshFailureNote` tolerates a daemon refusal and an unreadable refresh result but rethrows transport errors.
- Five rounds of fresh-context `/code-review high`, fifteen findings addressed across four fix commits (refresh tolerance and its honest wording, test-seam discrimination, dangling-pin state, transport carve-out, encode-failure guards, the secrets caveat, the compile-time envelope constraint); one residual accepted as above.
- `scripts/swift-safe build` clean; `scripts/test.sh` full suite run (only known load-flake suites red, green in isolation); `swiftlint --strict` clean.

[20260811-cultural-toad](https://cheapsteak.github.io/tbd/open/?worktree=5F2D41B3-67E0-4B8F-8AC4-CFE5C56F2F31)
