### PR TITLE
DX: Give poller tests a wait that fails at the missed step instead of hanging

### DIFF
--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -249,13 +249,27 @@ are worth knowing before someone reaches for a raise.**
 guard. Grepping only for the literal `waitForSuspension(` undercounts every
 chain below, which is exactly the miscount a PR #547 reviewer made.
 
-On that basis: the two five-guard poller chains — 225 s of the 240 s ceiling —
-are `GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
-`DaywatchRunnerLoopTests.testSubsequentTicksAtInterval`. Both are on
-`EventDrivenTestClock`'s **strict** waits, so five chained guards on paper are
-one in practice: a missed arming throws before anything advances and the rest of
-the chain never runs (see "The event-driven alternative" below). Suites on the
-predecessor helpers pay the full tally. And counting `waitFor` at 90 s plus
+On that basis, the deepest chains in the tree are the poller tests, and their
+paper tallies do not all fit under the ceiling:
+
+- `GatedIntervalSleepTests.returnsAfterExpectedPollCount` — 3
+  `requireAdvanceWhenArmed` + 2 `requireSleeperArmed` + 1 `FireRecorder.next()`
+  = **6** guards, 270 s, i.e. **over** the 240 s limit.
+- `GatedIntervalSleepTests.boundaryIsExact` (3 + 1 + 1) and
+  `DaywatchRunnerLoopTests.testSubsequentTicksAtInterval` (2 + 3) — **5**
+  guards, 225 s.
+
+Paper is the operative word, and the arithmetic that matters is different:
+**at most one guard can elapse in any single run of these.** All three chains
+are on `EventDrivenTestClock`'s **strict** waits, where a missed arming throws
+before anything advances, so the chain stops at the first bad step and nothing
+after it runs. The one non-throwing guard in each chain — `FireRecorder.next()`,
+which records and continues — sits *last*, with no wait behind it to inherit the
+run. So the real worst case is one 45 s guard, and 270 s describes a run that
+cannot happen. That is a property of these chains' *shape*, not of strictness
+alone: put a `next()` mid-chain and its 45 s becomes payable on top of whatever
+follows. Suites on the predecessor helpers have no such property at all and pay
+the full tally. And counting `waitFor` at 90 s plus
 each clock wait at 45 s, **9 of the 13** `PaneRepairCoordinatorTests` have a
 worst case above 240 s — not just the 6-deep chain (540 s) usually cited. Every one of those is still consistent with
 the invariant, because only an already-failing test walks a full chain of
@@ -719,13 +733,18 @@ a weaker negative.
 **Count each `FireRecorder.next()` in the
 `.clockDriven` tally too**: it carries its own 45 s hang guard, exactly like a
 `waitForSuspension`, so a test with 2 `advanceWhenArmed` + 2 `next()` has a
-180 s worst case against the 240 s limit. Either clock is a legitimate choice
-for a new clock-driven test. Existing `TestClock` suites migrate on field
-evidence, not wholesale — currently `AppearanceDebounceTests` and
-`SearchQueryDebouncerTests`,
+180 s worst case against the 240 s limit. And `next()` is **non-throwing** — it
+records and returns `nil` — so it does not stop a chain the way a strict arming
+wait does: a `next()` that times out mid-chain leaves every guard after it
+payable in the same run. Put it last, which is what makes the poller chains
+above cost one guard in practice rather than their paper tally. Either clock is
+a legitimate choice for a new clock-driven test. Existing `TestClock` suites
+migrate on field evidence, not wholesale — currently `AppearanceDebounceTests`
+and `SearchQueryDebouncerTests`,
 which reproduced the starvation in a full-suite soak, plus the two poller suites
-`GatedIntervalSleepTests` and `DaywatchRunnerLoopTests`, whose five-guard chains
-sat one scheduling excursion from the 240 s limit. Design:
+`GatedIntervalSleepTests` and `DaywatchRunnerLoopTests`, whose chains on the
+predecessor helpers each paid five wall-clock guards — 225 s of the 240 s
+ceiling, one scheduling excursion from tripping it. Design:
 `docs/specs/2026-08-11-event-driven-test-clock-design.md`.
 
 `PollerClock` is **not** this seam and must not be copied as a template — see

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -249,10 +249,13 @@ are worth knowing before someone reaches for a raise.**
 guard. Grepping only for the literal `waitForSuspension(` undercounts every
 chain below, which is exactly the miscount a PR #547 reviewer made.
 
-On that basis: `GatedIntervalSleepTests.returnsAfterExpectedPollCount`
-(3 `advanceWhenSuspended` + 2 `waitForSuspension`) and
-`DaywatchRunnerTests.testSubsequentTicksAtInterval` (2 + 3) each pay **5**
-guards, i.e. 225 s of the 240 s ceiling. And counting `waitFor` at 90 s plus
+On that basis: the two five-guard poller chains — 225 s of the 240 s ceiling —
+are `GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
+`DaywatchRunnerLoopTests.testSubsequentTicksAtInterval`. Both are on
+`EventDrivenTestClock`'s **strict** waits, so five chained guards on paper are
+one in practice: a missed arming throws before anything advances and the rest of
+the chain never runs (see "The event-driven alternative" below). Suites on the
+predecessor helpers pay the full tally. And counting `waitFor` at 90 s plus
 each clock wait at 45 s, **9 of the 13** `PaneRepairCoordinatorTests` have a
 worst case above 240 s — not just the 6-deep chain (540 s) usually cited. Every one of those is still consistent with
 the invariant, because only an already-failing test walks a full chain of
@@ -554,6 +557,18 @@ Permanent desync. The defect is emergent, not a helper bug: one advance has a
 small miss probability, one hundred makes it near-certain. That is a property
 of the *usage*, which is why it is a written rule rather than a helper fix.
 
+**The mechanism is record-and-continue desync**, and naming it says which chains
+are exposed. `EventDrivenTestClock`'s strict waits — `requireSleeperArmed`,
+`requireAdvanceWhenArmed` — do not share it: a missed arming throws *before*
+anything advances, so the chain stops at the first bad step, nothing later runs
+against a desynced clock, and the failure is a named diagnostic rather than a
+hang. **The rule is not lifted for strict callers.** The majority of
+clock-driven suites still use the predecessor helpers, where the warning holds
+in full, and both suites on the strict waits already sit inside single digits —
+so lifting it would buy nothing and cost a rule that currently holds everywhere.
+A future case with a real need can argue it on evidence now that the mechanism
+is written down.
+
 **The counter-rule, because following the above naively degrades coverage.**
 Shortening a chain silently buys a weaker assertion — and it degrades
 invisibly, because the test still passes. One migrated test named for having
@@ -680,8 +695,26 @@ past a deadline that is not in the ledger yet; the re-armed sleep is then
 measured from the new `now` and never fires, and the suite desyncs permanently —
 the same hang described above for `TestClock` under load, except deterministic
 rather than probabilistic. It is the first thing to get right when migrating a
-poller suite (`GatedIntervalSleepTests`, `DaywatchRunnerTests`), where every
-advance past the first is a re-arm.
+poller suite, where every advance past the first is a re-arm.
+
+**Each wait comes in two forms, split like `#expect` / `#require`.**
+`sleeperArmed` / `advanceWhenArmed` record a miss and continue;
+`requireSleeperArmed` / `requireAdvanceWhenArmed` throw the same
+`NoSleeperArmed` diagnostic instead. Prefer the strict pair in anything
+chain-shaped — a poller test, where each step is sound only if the previous one
+landed — and keep the soft pair for a single-shot wait whose next statement is
+an assertion that fails informatively on its own. Both suppress the diagnostic
+on *cancellation*: the wait ends, but attribution belongs to whatever cancelled
+the test. Design:
+`docs/specs/2026-08-13-poller-suite-clock-migration-design.md`.
+
+**And the migration's real work is not the clock swap.** It is replacing
+clock-state inference with the observable the test already holds: a poller suite
+that asked `checkSuspension()` whether its sleep had ended was reading a
+snapshot and relying on that call's internal megaYield to have let the resumed
+task run first. `hasSleeper` has no such nudge, so port those to the positive
+fact — `FireRecorder.next()` on the effect, or joining the task — rather than to
+a weaker negative.
 
 **Count each `FireRecorder.next()` in the
 `.clockDriven` tally too**: it carries its own 45 s hang guard, exactly like a
@@ -690,7 +723,9 @@ advance past the first is a re-arm.
 for a new clock-driven test. Existing `TestClock` suites migrate on field
 evidence, not wholesale — currently `AppearanceDebounceTests` and
 `SearchQueryDebouncerTests`,
-which reproduced the starvation in a full-suite soak. Design:
+which reproduced the starvation in a full-suite soak, plus the two poller suites
+`GatedIntervalSleepTests` and `DaywatchRunnerLoopTests`, whose five-guard chains
+sat one scheduling excursion from the 240 s limit. Design:
 `docs/specs/2026-08-11-event-driven-test-clock-design.md`.
 
 `PollerClock` is **not** this seam and must not be copied as a template — see

--- a/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
+++ b/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
@@ -369,8 +369,11 @@ struct DaywatchRunnerSingleTickTests {
 /// Its `advance` does no yielding of any kind, which is the property to keep in
 /// mind when reading the assertions below: a *positive* fact about a resumed
 /// task is claimed only after an event that happens-after it (the loop's
-/// re-park), and the one *negative* count read pays an explicit `settle()`
-/// where the predecessor leaned on `TestClock.advance`'s incidental megaYield.
+/// re-park), and both *negative* count reads — "no tick a millisecond early"
+/// and "no ticks after `apply(.off)`" — pay an explicit `settle()` where the
+/// predecessor leaned on `TestClock.advance`'s incidental megaYield. The one
+/// negative that pays none is `hasSleeper == false`, which needs no scheduling
+/// turn to become true and justifies itself where it stands.
 @Suite("DaywatchRunner loop", .clockDriven)
 struct DaywatchRunnerLoopTests {
 

--- a/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
+++ b/Tests/TBDDaemonTests/DaywatchRunnerTests.swift
@@ -1,4 +1,3 @@
-import Clocks
 import Foundation
 import TestSupport
 import Testing
@@ -356,16 +355,29 @@ struct DaywatchRunnerSingleTickTests {
 
 // MARK: - Loop tests (virtual time)
 
-/// Tier 1 — the background loop, driven entirely by a `TestClock`. Virtual time
+/// Tier 1 — the background loop, driven entirely by virtual time. Virtual time
 /// makes the *production* interval free, so these run `defaultInterval` rather
 /// than a shrunken test pacing: the timings asserted are the shipped ones.
+///
+/// CLOCK: `EventDrivenTestClock` with its **strict** waits
+/// (`docs/specs/2026-08-13-poller-suite-clock-migration-design.md`). This is a
+/// poller — tick, sleep, tick — so every advance past the first is a re-arm,
+/// and a missed arming that merely recorded an issue would advance virtual time
+/// against an empty ledger and desync the rest of the test into a hang. The
+/// strict waits throw at the first miss, naming the step.
+///
+/// Its `advance` does no yielding of any kind, which is the property to keep in
+/// mind when reading the assertions below: a *positive* fact about a resumed
+/// task is claimed only after an event that happens-after it (the loop's
+/// re-park), and the one *negative* count read pays an explicit `settle()`
+/// where the predecessor leaned on `TestClock.advance`'s incidental megaYield.
 @Suite("DaywatchRunner loop", .clockDriven)
 struct DaywatchRunnerLoopTests {
 
     @Test("loop runs its first tick immediately, before any time passes")
-    func testFirstTickIsImmediate() async {
+    func testFirstTickIsImmediate() async throws {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let clock = TestClock<Duration>()
+        let clock = EventDrivenTestClock()
         let runner = DaywatchRunner(
             executor: executor, interval: DaywatchRunner.defaultInterval, clock: clock)
 
@@ -374,40 +386,49 @@ struct DaywatchRunnerLoopTests {
         // The loop parking on the interval sleep proves — sequentially, since
         // the tick precedes the sleep in runLoop() — that tick 1 completed.
         // Zero advance is the claim: "immediately" means no time passed.
-        await clock.waitForSuspension()
+        try await clock.requireSleeperArmed()
         #expect(await executor.tickCallCount == 1)
     }
 
     @Test("loop ticks again at exactly the production interval")
-    func testSubsequentTicksAtInterval() async {
+    func testSubsequentTicksAtInterval() async throws {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let clock = TestClock<Duration>()
+        let clock = EventDrivenTestClock()
         let runner = DaywatchRunner(
             executor: executor, interval: DaywatchRunner.defaultInterval, clock: clock)
 
         await runner.apply(mode: .daywatch)
-        await clock.waitForSuspension()
+        try await clock.requireSleeperArmed()
         #expect(await executor.tickCallCount == 1)
 
-        // One millisecond short of the interval must not fire.
+        // One millisecond short of the interval must not fire. A **plain**
+        // advance on purpose, and it is sound only because the strict wait
+        // above established that the loop's sleeper is registered — that is
+        // what this step depends on and what the wait above now guarantees.
         await clock.advance(by: .seconds(DaywatchRunner.defaultInterval) - .milliseconds(1))
+        // Negative assertion, so it gets a real settle first: this clock's
+        // advance never runs a resumed task's code for us, and a tick that
+        // fired a millisecond early would otherwise not have had the chance to
+        // show up before the count is read (one-sided as ever — a
+        // pathologically late tick can false-pass, never false-fail).
+        await settle()
         #expect(await executor.tickCallCount == 1)
 
         // The final millisecond does. Wait for the re-park: that is tick 2 done.
-        await clock.advanceWhenSuspended(by: .milliseconds(1))
-        await clock.waitForSuspension()
+        try await clock.requireAdvanceWhenArmed(by: .milliseconds(1))
+        try await clock.requireSleeperArmed()
         #expect(await executor.tickCallCount == 2)
 
         // And it keeps its cadence, not just the one extra tick.
-        await clock.advanceWhenSuspended(by: .seconds(DaywatchRunner.defaultInterval))
-        await clock.waitForSuspension()
+        try await clock.requireAdvanceWhenArmed(by: .seconds(DaywatchRunner.defaultInterval))
+        try await clock.requireSleeperArmed()
         #expect(await executor.tickCallCount == 3)
     }
 
     @Test("duplicate same-mode apply starts exactly one loop")
-    func testDuplicateApplyStartsOneLoop() async {
+    func testDuplicateApplyStartsOneLoop() async throws {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let clock = TestClock<Duration>()
+        let clock = EventDrivenTestClock()
         let runner = DaywatchRunner(
             executor: executor, interval: DaywatchRunner.defaultInterval, clock: clock)
 
@@ -418,49 +439,51 @@ struct DaywatchRunnerLoopTests {
         // but the second loop's first tick is async and a count read can miss it,
         // so the cadence below is the discriminating assertion: over one interval
         // a single loop ticks exactly once more, while two loops would reach 4.
-        await clock.waitForSuspension()
+        try await clock.requireSleeperArmed()
         #expect(await executor.tickCallCount == 1)
 
-        await clock.advanceWhenSuspended(by: .seconds(DaywatchRunner.defaultInterval))
-        await clock.waitForSuspension()
+        try await clock.requireAdvanceWhenArmed(by: .seconds(DaywatchRunner.defaultInterval))
+        try await clock.requireSleeperArmed()
         #expect(await executor.tickCallCount == 2)
     }
 
     @Test("apply(.off) cancels the loop: no sleeper remains, no further ticks")
-    func testApplyOffCancelsLoop() async {
+    func testApplyOffCancelsLoop() async throws {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
-        let clock = TestClock<Duration>()
+        let clock = EventDrivenTestClock()
         let runner = DaywatchRunner(
             executor: executor, interval: DaywatchRunner.defaultInterval, clock: clock)
 
         await runner.apply(mode: .daywatch)
-        await clock.advanceWhenSuspended(by: .seconds(DaywatchRunner.defaultInterval))
-        await clock.waitForSuspension()
+        try await clock.requireAdvanceWhenArmed(by: .seconds(DaywatchRunner.defaultInterval))
+        try await clock.requireSleeperArmed()
         #expect(await executor.tickCallCount == 2)
 
         await runner.apply(mode: .off)
 
-        // `checkSuspension()` throws while a sleeper IS registered, so no error
-        // is the assertion: the loop's timer is gone. Cancelling resumes the
-        // sleeper, which deregisters itself in TestClock.sleep's cancellation
-        // path; checkSuspension's opening megaYield is what gives that
-        // resumption its turn. This stops holding if cancel() ever moves off
-        // the apply() path onto something apply() doesn't await. Recorded via
-        // #expect (not a bare `try`) so a starved megaYield under load cannot
-        // abort the test before the deterministic count assertion below.
-        await #expect(throws: Never.self) { try await clock.checkSuspension() }
+        // The loop's timer is gone, and reading that synchronously is exact
+        // here rather than a snapshot race: `apply(.off)` calls `cancel()`, and
+        // a cancellation handler runs *on the cancelling task* while the loop
+        // sits suspended — this clock's handler removes the ledger entry under
+        // its own lock before `cancel()` returns. No scheduling turn is
+        // involved, so no megaYield is needed to make it true (the predecessor
+        // needed `checkSuspension()`'s for exactly that reason). Nor can a
+        // sleeper reappear later: `sleep` opens with `checkCancellation()`, so
+        // a loop that had not yet reached its sleep registers nothing either.
+        #expect(clock.hasSleeper == false, "apply(.off) must leave no timer armed")
 
-        // Bare advance on purpose: nothing may be sleeping, so
-        // advanceWhenSuspended would wait for a sleeper that must never come.
+        // Bare advance on purpose: nothing may be sleeping, so an arming wait
+        // would wait for a sleeper that must never come.
         await clock.advance(by: .seconds(DaywatchRunner.defaultInterval * 3))
+        await settle()
         #expect(await executor.tickCallCount == 2)
     }
 
     @Test("concurrent same-mode apply: one transition, loop intact")
-    func testConcurrentSameModeApply() async {
+    func testConcurrentSameModeApply() async throws {
         let executor = FakeDaywatchExecutor(tickExitCode: 0)
         let desker = FakeDeskSessionManager()
-        let clock = TestClock<Duration>()
+        let clock = EventDrivenTestClock()
         let runner = DaywatchRunner(
             executor: executor, deskSessionManager: desker,
             interval: DaywatchRunner.defaultInterval, clock: clock)
@@ -480,7 +503,7 @@ struct DaywatchRunnerLoopTests {
         // Pin the loop's first tick (exit 0, no nudge) as *completed* before
         // restubbing the exit code. Otherwise the async first tick can observe
         // exit 10 and nudge, making the count below 2 instead of 1.
-        await clock.waitForSuspension()
+        try await clock.requireSleeperArmed()
 
         // The transition really completed: a tick with exit 10 nudges the desk.
         await executor.setTickExitCode(10)

--- a/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
+++ b/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
@@ -180,6 +180,104 @@ struct EventDrivenTestClockSelfTests {
         _ = await sleeper.value
     }
 
+    // MARK: Strict arming
+
+    /// The strict pair's healthy path must be indistinguishable from the soft
+    /// pair's: a registration releases the wait, whether the waiter parked first
+    /// or the sleeper was already there.
+    @Test("requireSleeperArmed returns for a sleeper that registers after it parks")
+    func requireArmedReturnsOnRegistration() async throws {
+        let clock = EventDrivenTestClock()
+        let recorder = FireRecorder<String>()
+
+        async let armed: Void = clock.requireSleeperArmed()
+        await Self.waitUntil("an arming waiter is parked") { clock.hasParkedArmingWaiter }
+
+        let sleeper = Task { [clock] in
+            try? await clock.sleep(for: .seconds(1))
+            recorder.record("woke")
+        }
+        try await armed
+        #expect(clock.hasSleeper)
+
+        // And the fast path, on a clock that already has one: a 50 ms guard
+        // would fire if this parked instead of returning at once.
+        try await clock.requireSleeperArmed(timeout: .milliseconds(50))
+
+        try await clock.requireAdvanceWhenArmed(by: .seconds(1))
+        #expect(await recorder.next() == "woke")
+        _ = await sleeper.value
+    }
+
+    /// The whole reason the strict pair exists: a chain must **stop** at the
+    /// first missed arming rather than record and walk on. Two claims here, and
+    /// the second is the one that keeps a chain sound — nothing advanced.
+    @Test("requireAdvanceWhenArmed throws the named diagnostic and advances nothing")
+    func requireAdvanceThrowsWithoutAdvancing() async {
+        let clock = EventDrivenTestClock()
+        var thrown: (any Error)?
+        do {
+            // 50 ms rather than the 45 s default, so the proof is cheap.
+            try await clock.requireAdvanceWhenArmed(by: .seconds(1), timeout: .milliseconds(50))
+        } catch {
+            thrown = error
+        }
+
+        let text = thrown.map { String(describing: $0) } ?? "nothing was thrown"
+        #expect(text.contains("no task suspended on the clock within"),
+                "a missed arming must throw the NoSleeperArmed diagnostic — got: \(text)")
+        #expect(text.contains("EventDrivenTestClockSelfTests.swift"),
+                "the thrown diagnostic must name the step that gave up — got: \(text)")
+        #expect(clock.now.offset == .zero,
+                "throwing before the advance is what stops the ledger and now from desyncing")
+    }
+
+    /// Same diagnostic, two delivery mechanisms — so a reader sees identical
+    /// text whether it arrived as a recorded issue or as a thrown error.
+    @Test("the strict and soft waits report the same diagnostic")
+    func strictAndSoftShareOneDiagnostic() async {
+        let clock = EventDrivenTestClock()
+        let recorded = Latch()
+        await withKnownIssue("nothing ever arms, so the soft wait must record") {
+            await clock.sleeperArmed(timeout: .milliseconds(50))
+        } matching: { issue in
+            let text = issue.error.map { String(describing: $0) } ?? ""
+            if text.contains("no task suspended on the clock within") { recorded.latch() }
+            return true
+        }
+        #expect(recorded.isLatched)
+
+        var thrownText = ""
+        do {
+            try await clock.requireSleeperArmed(timeout: .milliseconds(50))
+        } catch {
+            thrownText = String(describing: error)
+        }
+        #expect(thrownText.contains("no task suspended on the clock within"))
+    }
+
+    /// Cancellation is not expiry, and the strict pair keeps that treatment:
+    /// the wait ends, but it neither throws nor records, because the failure
+    /// belongs to whatever cancelled the test.
+    @Test("a cancelled requireSleeperArmed ends without a diagnostic")
+    func requireArmedIsSilentOnCancellation() async {
+        let clock = EventDrivenTestClock()
+        let waiter = Task { [clock] () -> String in
+            do {
+                // Long enough that expiry cannot be what ends this wait.
+                try await clock.requireSleeperArmed(timeout: .seconds(120))
+                return "returned"
+            } catch {
+                return "threw: \(error)"
+            }
+        }
+        await Self.waitUntil("an arming waiter is parked") { clock.hasParkedArmingWaiter }
+
+        waiter.cancel()
+        #expect(await waiter.value == "returned",
+                "attribution belongs to whatever cancelled the test, not to this call site")
+    }
+
     // MARK: Cancellation
 
     /// Pre-cancellation must be invisible to the clock: no ledger entry, and no

--- a/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
+++ b/Tests/TBDDaemonTests/EventDrivenTestClockSelfTests.swift
@@ -55,6 +55,17 @@ struct EventDrivenTestClockSelfTests {
         var isLatched: Bool { lock.withLock { latched } }
     }
 
+    /// The same idea one step further: the matcher hands the *text* out, not
+    /// just the fact that something matched. A test that compares two
+    /// diagnostics has to hold both of them.
+    private final class Captured: @unchecked Sendable {
+        private let lock = NSLock()
+        private var text = ""
+
+        func set(_ value: String) { lock.withLock { text = value } }
+        var value: String { lock.withLock { text } }
+    }
+
     private struct HandshakeTimeout: Error, CustomStringConvertible {
         let what: String
         let timeout: Swift.Duration
@@ -232,28 +243,70 @@ struct EventDrivenTestClockSelfTests {
                 "throwing before the advance is what stops the ledger and now from desyncing")
     }
 
-    /// Same diagnostic, two delivery mechanisms — so a reader sees identical
-    /// text whether it arrived as a recorded issue or as a thrown error.
-    @Test("the strict and soft waits report the same diagnostic")
+    /// One diagnostic, two deliveries — and the difference between them is
+    /// exactly one line, deliberately.
+    ///
+    /// The two texts are **not** identical, so a test that asserted they were
+    /// would be asserting something false, and one that compared a substring
+    /// both happen to contain would pass through any divergence in the rest of
+    /// the message — which is the only thing it could usefully catch. What is
+    /// actually true is prefix-plus-known-suffix: the strict form appends the
+    /// call site, because `Issue.record` already attributes the soft form to the
+    /// caller's line while a thrown error is attributed to the test function.
+    /// Asserting that shape catches a core that drifted *and* a suffix that
+    /// changed.
+    @Test("the strict diagnostic is the soft one verbatim, plus a call-site line")
     func strictAndSoftShareOneDiagnostic() async {
         let clock = EventDrivenTestClock()
-        let recorded = Latch()
+        let recorded = Captured()
         await withKnownIssue("nothing ever arms, so the soft wait must record") {
             await clock.sleeperArmed(timeout: .milliseconds(50))
         } matching: { issue in
-            let text = issue.error.map { String(describing: $0) } ?? ""
-            if text.contains("no task suspended on the clock within") { recorded.latch() }
+            recorded.set(issue.error.map { String(describing: $0) } ?? "")
             return true
         }
-        #expect(recorded.isLatched)
+        let softText = recorded.value
+        #expect(softText.contains("no task suspended on the clock within"),
+                "the soft wait must record the NoSleeperArmed diagnostic — got: \(softText)")
 
+        // Same clock, same timeout, same virtual now: every field the two texts
+        // interpolate is identical, so any difference between them is shape.
         var thrownText = ""
+        let callLine = #line + 2
         do {
             try await clock.requireSleeperArmed(timeout: .milliseconds(50))
         } catch {
             thrownText = String(describing: error)
         }
-        #expect(thrownText.contains("no task suspended on the clock within"))
+
+        #expect(thrownText.hasPrefix(softText),
+                """
+                the strict diagnostic must open with the recorded one verbatim — \
+                recorded: \(softText) / thrown: \(thrownText)
+                """)
+        let addition = String(thrownText.dropFirst(softText.count))
+        #expect(addition == "\nThe wait that gave up: \(#fileID):\(callLine).",
+                "the strict form must add the call site and nothing else — added: \(addition)")
+    }
+
+    /// The strict advance's stated invariant — *nothing is advanced unless a
+    /// sleeper is registered* — has a second way out that is easy to miss: the
+    /// wait ends silently on cancellation, with nothing armed and nothing
+    /// thrown. Advancing there would move virtual time against an empty ledger,
+    /// so it does not.
+    @Test("a cancelled requireAdvanceWhenArmed advances nothing")
+    func requireAdvanceIsInertOnCancellation() async {
+        let clock = EventDrivenTestClock()
+        let waiter = Task { [clock] in
+            // Long enough that expiry cannot be what ends this wait.
+            try? await clock.requireAdvanceWhenArmed(by: .seconds(5), timeout: .seconds(120))
+        }
+        await Self.waitUntil("an arming waiter is parked") { clock.hasParkedArmingWaiter }
+
+        waiter.cancel()
+        _ = await waiter.value
+        #expect(clock.now.offset == .zero,
+                "a wait ended by cancellation must leave virtual time where it found it")
     }
 
     /// Cancellation is not expiry, and the strict pair keeps that treatment:

--- a/Tests/TBDDaemonTests/GatedIntervalSleepTests.swift
+++ b/Tests/TBDDaemonTests/GatedIntervalSleepTests.swift
@@ -1,4 +1,3 @@
-import Clocks
 import Foundation
 import TestSupport
 import Testing
@@ -6,9 +5,23 @@ import Testing
 
 // Tier 1 (docs/specs/2026-07-24-test-hardening-design.md §3): in-process,
 // deterministic, driven entirely by virtual time. The only real sleeping is the
-// scheduling handshake inside `advanceWhenSuspended`/`waitForSuspension`, which
-// `Tests/CLAUDE.md` ("Clock and date seams") explicitly rules not a tier
-// violation.
+// scheduling handshake inside the clock's arming waits, which `Tests/CLAUDE.md`
+// ("Clock and date seams") explicitly rules not a tier violation.
+//
+// CLOCK: `EventDrivenTestClock` with its **strict** waits
+// (`docs/specs/2026-08-13-poller-suite-clock-migration-design.md`). This is a
+// poller test — arm, advance, re-arm, repeated — so a recorded-and-continued
+// missed arming would advance virtual time with nothing registered and desync
+// every later step into a hang. `requireAdvanceWhenArmed` throws at the first
+// miss instead, and the whole chain costs one hang guard rather than one per
+// step.
+//
+// And the fact each assertion rests on is an *observable*, never the clock's
+// own state: `returned.next()` waits for the gated sleep to actually return.
+// The predecessor asked `checkSuspension()` whether a sleeper was still
+// registered and leaned on its internal megaYield to give the resumed task a
+// turn first — a scheduling accident that stops holding under exactly the load
+// these guards exist for.
 //
 // DEFECT UNDER TEST: the gated interval stops being re-evaluated, so a
 // foreground/background transition no longer shortens an in-flight wait.
@@ -22,7 +35,8 @@ import Testing
 // Two failure shapes are covered, because they are distinguishable:
 //   - the closure stops being *called* → the call-count assertions catch it;
 //   - the closure is called but its new value ignored (a cached `due`) → the
-//     "no sleeper remains on the clock" assertions catch it.
+//     "the wait ended" assertions catch it, because a loop honouring a stale
+//     `due` is still parked and never records a return.
 
 /// Records how many times the gated-interval closure was evaluated, and lets a
 /// test change the value it returns mid-wait. An actor because the closure is
@@ -59,33 +73,40 @@ struct GatedIntervalSleepTests {
     private static let tick: Duration = .seconds(10)
 
     @Test("returns after exactly the number of polls the interval implies")
-    func returnsAfterExpectedPollCount() async {
-        let clock = TestClock<Duration>()
+    func returnsAfterExpectedPollCount() async throws {
+        let clock = EventDrivenTestClock()
         let probe = GatedIntervalProbe(interval: .seconds(30))  // 3 ticks
+        let returned = FireRecorder<Int>()
 
         let waiter = Task {
             await Daemon.sleepThroughGatedInterval(
                 { await probe.next() }, tick: Self.tick, clock: clock)
             await probe.markReturned()
+            returned.record(await probe.callCount)
         }
 
         // Tick 1 and 2 re-evaluate and keep waiting; each advance sits next to
-        // the re-park it produces rather than being batched at the top.
-        await clock.advanceWhenSuspended(by: Self.tick)
-        await clock.waitForSuspension()
+        // the re-park it produces rather than being batched at the top. The
+        // re-park is also the happens-before for the count read: the loop
+        // reaches its next `sleep` only after evaluating the interval.
+        try await clock.requireAdvanceWhenArmed(by: Self.tick)
+        try await clock.requireSleeperArmed()
         #expect(await probe.callCount == 1)
 
-        await clock.advanceWhenSuspended(by: Self.tick)
-        await clock.waitForSuspension()
+        try await clock.requireAdvanceWhenArmed(by: Self.tick)
+        try await clock.requireSleeperArmed()
         #expect(await probe.callCount == 2)
 
-        // Tick 3 crosses the threshold.
-        await clock.advanceWhenSuspended(by: Self.tick)
+        // Tick 3 crosses the threshold: 30s waited against a 30s gate.
+        try await clock.requireAdvanceWhenArmed(by: Self.tick)
 
-        // `checkSuspension()` throws while a sleeper IS registered, so "no
-        // error" is the assertion that the wait ended rather than re-parking.
-        // Its opening `megaYield()` is what gives the resumed task its turn.
-        await #expect(throws: Never.self) { try await clock.checkSuspension() }
+        // THE ASSERTION THAT THE WAIT ENDED, and it is the returning itself
+        // that is observed — a loop that re-parked instead records nothing and
+        // this fails with the recorder's named diagnostic. The value carried is
+        // the evaluation count at the moment of return, so "returned" and
+        // "after exactly three polls" are one fact rather than two reads that
+        // could disagree.
+        #expect(await returned.next() == 3)
 
         // Deterministic join. `cancel()` is a no-op on a task that already
         // returned; on a defective loop still parked on the clock it resumes
@@ -93,29 +114,29 @@ struct GatedIntervalSleepTests {
         // the assertions above instead of wedging on `await waiter.value`.
         waiter.cancel()
         await waiter.value
-        let observedCalls = await probe.callCount
-        #expect(observedCalls == 3, "expected 3 interval evaluations, observed \(observedCalls)")
         #expect(await probe.didReturn)
     }
 
     @Test("one tick short of the threshold has not returned; the next tick returns")
-    func boundaryIsExact() async {
-        let clock = TestClock<Duration>()
+    func boundaryIsExact() async throws {
+        let clock = EventDrivenTestClock()
         let probe = GatedIntervalProbe(interval: .seconds(30))  // 3 ticks
+        let returned = FireRecorder<Int>()
 
         let waiter = Task {
             await Daemon.sleepThroughGatedInterval(
                 { await probe.next() }, tick: Self.tick, clock: clock)
             await probe.markReturned()
+            returned.record(await probe.callCount)
         }
 
-        await clock.advanceWhenSuspended(by: Self.tick)
-        await clock.advanceWhenSuspended(by: Self.tick)
+        try await clock.requireAdvanceWhenArmed(by: Self.tick)
+        try await clock.requireAdvanceWhenArmed(by: Self.tick)
 
         // 20s waited against a 30s gate. The re-park is the happens-before for
         // the flag read: reaching a suspension means the loop chose to keep
         // waiting rather than return.
-        await clock.waitForSuspension()
+        try await clock.requireSleeperArmed()
         let returnedEarly = await probe.didReturn
         let callsAtBoundary = await probe.callCount
         #expect(
@@ -126,31 +147,32 @@ struct GatedIntervalSleepTests {
             """
         )
 
-        // The final tick, and only it, ends the wait.
-        await clock.advanceWhenSuspended(by: Self.tick)
-        await #expect(throws: Never.self) { try await clock.checkSuspension() }
+        // The final tick, and only it, ends the wait — proven by the return
+        // itself arriving, after exactly three evaluations.
+        try await clock.requireAdvanceWhenArmed(by: Self.tick)
+        #expect(await returned.next() == 3)
 
         waiter.cancel()
         await waiter.value
         #expect(await probe.didReturn)
-        let observedCalls = await probe.callCount
-        #expect(observedCalls == 3, "expected 3 interval evaluations, observed \(observedCalls)")
     }
 
     @Test("an interval shortened mid-wait shortens the wait")
-    func shortenedIntervalShortensInFlightWait() async {
-        let clock = TestClock<Duration>()
+    func shortenedIntervalShortensInFlightWait() async throws {
+        let clock = EventDrivenTestClock()
         // Background cadence, in miniature: 30 ticks away.
         let probe = GatedIntervalProbe(interval: .seconds(300))
+        let returned = FireRecorder<Int>()
 
         let waiter = Task {
             await Daemon.sleepThroughGatedInterval(
                 { await probe.next() }, tick: Self.tick, clock: clock)
             await probe.markReturned()
+            returned.record(await probe.callCount)
         }
 
-        await clock.advanceWhenSuspended(by: Self.tick)
-        await clock.waitForSuspension()
+        try await clock.requireAdvanceWhenArmed(by: Self.tick)
+        try await clock.requireSleeperArmed()
         let callsBeforeFlip = await probe.callCount
         #expect(callsBeforeFlip == 1, "expected 1 interval evaluation, observed \(callsBeforeFlip)")
         #expect(await probe.didReturn == false)
@@ -158,24 +180,20 @@ struct GatedIntervalSleepTests {
         // The app comes to the foreground mid-wait: the gate drops to 20s,
         // which the 20s already waited after the next tick satisfies.
         await probe.set(interval: .seconds(20))
-        await clock.advanceWhenSuspended(by: Self.tick)
+        try await clock.requireAdvanceWhenArmed(by: Self.tick)
 
         // THE HEADLINE ASSERTION. A loop that sampled the interval once — or
         // cached the first `due` — is still parked here, waiting out the
-        // original 300s, and `checkSuspension()` throws because its sleeper is
-        // registered.
-        await #expect(throws: Never.self) { try await clock.checkSuspension() }
+        // original 300s, so it never returns and never records: this fails with
+        // the recorder's diagnostic instead of passing on a clock snapshot
+        // taken before the resumed task had run.
+        #expect(
+            await returned.next() == 2,
+            "expected the shortened gate to end the wait after 2 evaluations"
+        )
 
         waiter.cancel()
         await waiter.value
         #expect(await probe.didReturn)
-        let observedCalls = await probe.callCount
-        #expect(
-            observedCalls == 2,
-            """
-            expected the shortened gate to end the wait after 2 evaluations, \
-            observed \(observedCalls)
-            """
-        )
     }
 }

--- a/Tests/TBDDaemonTests/GatedIntervalSleepTests.swift
+++ b/Tests/TBDDaemonTests/GatedIntervalSleepTests.swift
@@ -114,7 +114,13 @@ struct GatedIntervalSleepTests {
         // the assertions above instead of wedging on `await waiter.value`.
         waiter.cancel()
         await waiter.value
-        #expect(await probe.didReturn)
+
+        // The join moved nothing, and that is the claim. A loop still parked
+        // when `cancel()` arrived pays one extra `interval()` evaluation on its
+        // way out — `sleepThroughGatedInterval` documents that cost — so an
+        // unmoved count is what distinguishes "the wait ended on its own gate"
+        // from "the join unwedged it".
+        #expect(await probe.callCount == 3)
     }
 
     @Test("one tick short of the threshold has not returned; the next tick returns")
@@ -152,9 +158,11 @@ struct GatedIntervalSleepTests {
         try await clock.requireAdvanceWhenArmed(by: Self.tick)
         #expect(await returned.next() == 3)
 
+        // Same join, same claim as `returnsAfterExpectedPollCount`: a loop the
+        // cancellation had to unwedge would show a fourth evaluation here.
         waiter.cancel()
         await waiter.value
-        #expect(await probe.didReturn)
+        #expect(await probe.callCount == 3)
     }
 
     @Test("an interval shortened mid-wait shortens the wait")
@@ -192,8 +200,11 @@ struct GatedIntervalSleepTests {
             "expected the shortened gate to end the wait after 2 evaluations"
         )
 
+        // As above: the shortened gate, not the cancellation, is what ended the
+        // wait — a loop still parked would evaluate the interval a third time
+        // on its way out of `cancel()`.
         waiter.cancel()
         await waiter.value
-        #expect(await probe.didReturn)
+        #expect(await probe.callCount == 2)
     }
 }

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -72,10 +72,16 @@ public extension Trait where Self == TimeLimitTrait {
     /// Grepping only for the literal `waitForSuspension(` undercounts every
     /// figure below (a PR #547 reviewer did exactly that and read these as
     /// 2 and 3 rather than 5).
-    /// - `GatedIntervalSleepTests.returnsAfterExpectedPollCount`
-    ///   (3 `advanceWhenSuspended` + 2 `waitForSuspension`) and
-    ///   `DaywatchRunnerTests.testSubsequentTicksAtInterval` (2 + 3) each pay
-    ///   **5** guards: 225 s against a 240 s ceiling.
+    /// - `GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
+    ///   `DaywatchRunnerLoopTests.testSubsequentTicksAtInterval` each pay five
+    ///   clock guards, but on `EventDrivenTestClock`'s strict waits
+    ///   (`requireSleeperArmed` / `requireAdvanceWhenArmed`) rather than this
+    ///   type's non-throwing pair: a missed arming throws at the first bad
+    ///   step instead of recording and continuing, so their worst case in
+    ///   practice is one 45 s guard, not the full five-deep chain (see "The
+    ///   event-driven alternative" below). The tightest chains still riding
+    ///   the non-throwing pair — where a miss records and the chain keeps
+    ///   running — are elsewhere in the suite.
     /// - In `PaneRepairCoordinatorTests`, **9 of 13** tests have a worst case
     ///   above 240 s (counting `waitFor` at 90 s and each clock wait at 45 s),
     ///   not just the one 6-deep chain (540 s) usually cited.
@@ -224,10 +230,11 @@ public extension TestClock {
     ///     returns in milliseconds, so the raise costs passing runs nothing.
     ///
     ///     What 45 s does **not** buy is a deep chain: at five of these waits
-    ///     the test is at 225 s of a 240 s limit, and two tests in the fast
-    ///     pass are exactly there — `GatedIntervalSleepTests.returnsAfterExpectedPollCount`
-    ///     and `DaywatchRunnerTests.testSubsequentTicksAtInterval` (both count
-    ///     `advanceWhenSuspended` toward the five; see `.clockDriven` above).
+    ///     a test is at 225 s of a 240 s limit, and this helper's non-throwing
+    ///     shape means a chain that size pays every guard rather than stopping
+    ///     at the first miss (contrast `EventDrivenTestClock`'s strict pair,
+    ///     `requireSleeperArmed` / `requireAdvanceWhenArmed`, under "The
+    ///     event-driven alternative" below, where a miss throws immediately).
     ///     ("Fast pass", not "live": tier-3 `TBDDaemonLiveTests` pins its own
     ///     limit and is unaffected.) That is
     ///     consistent with the invariant — only a failing test walks the whole

--- a/Tests/TestSupport/ClockTestSupport.swift
+++ b/Tests/TestSupport/ClockTestSupport.swift
@@ -68,20 +68,29 @@ public extension Trait where Self == TimeLimitTrait {
     /// past it, all consistent with the invariant (only an already-failing test
     /// ever pays a full chain of timeouts), but with nothing to spare:
     /// Count `advanceWhenSuspended` as a `waitForSuspension` when you tally a
-    /// chain — it *calls* one before advancing, so it pays the full guard.
+    /// chain — it *calls* one before advancing, so it pays the full guard —
+    /// and count each `EventDrivenTestClock.FireRecorder.next()` the same way.
     /// Grepping only for the literal `waitForSuspension(` undercounts every
-    /// figure below (a PR #547 reviewer did exactly that and read these as
-    /// 2 and 3 rather than 5).
-    /// - `GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
-    ///   `DaywatchRunnerLoopTests.testSubsequentTicksAtInterval` each pay five
-    ///   clock guards, but on `EventDrivenTestClock`'s strict waits
-    ///   (`requireSleeperArmed` / `requireAdvanceWhenArmed`) rather than this
-    ///   type's non-throwing pair: a missed arming throws at the first bad
-    ///   step instead of recording and continuing, so their worst case in
-    ///   practice is one 45 s guard, not the full five-deep chain (see "The
-    ///   event-driven alternative" below). The tightest chains still riding
-    ///   the non-throwing pair — where a miss records and the chain keeps
-    ///   running — are elsewhere in the suite.
+    /// figure below, which is how a PR #547 reviewer read two of these chains
+    /// as shallower than they are.
+    /// - `PaneRepairCoordinatorTests.readerWaitEscalatesToTheSlowInterval` is
+    ///   the deepest chain still riding this type's **non-throwing** pair: four
+    ///   `advanceWhenSuspended` plus one `waitForSuspension`, five clock guards
+    ///   for 225 s, and its two `waitFor` calls take the paper worst case to
+    ///   405 s. Every guard there is payable in one run, because a miss records
+    ///   and the chain keeps going.
+    /// - The poller chains are nominally deeper still —
+    ///   `GatedIntervalSleepTests.returnsAfterExpectedPollCount` pays six
+    ///   guards (3 `requireAdvanceWhenArmed` + 2 `requireSleeperArmed` + 1
+    ///   `FireRecorder.next()`) for 270 s, past this limit;
+    ///   `GatedIntervalSleepTests.boundaryIsExact` and
+    ///   `DaywatchRunnerLoopTests.testSubsequentTicksAtInterval` pay five for
+    ///   225 s — but they are on `EventDrivenTestClock`'s strict waits, where a
+    ///   missed arming throws before anything advances, so the chain stops at
+    ///   the first bad step. Their one non-throwing guard, `next()`, sits last
+    ///   with nothing behind it to inherit the run, so at most one 45 s guard
+    ///   elapses in any single run and 270 s describes a run that cannot
+    ///   happen (see "The event-driven alternative" below).
     /// - In `PaneRepairCoordinatorTests`, **9 of 13** tests have a worst case
     ///   above 240 s (counting `waitFor` at 90 s and each clock wait at 45 s),
     ///   not just the one 6-deep chain (540 s) usually cited.

--- a/Tests/TestSupport/EventDrivenTestClock.swift
+++ b/Tests/TestSupport/EventDrivenTestClock.swift
@@ -341,9 +341,14 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     /// ends the test at the first missed arming, so the worst case of a failing
     /// chain is one hang guard rather than one per step.
     ///
-    /// - Throws: the same `NoSleeperArmed` value the non-throwing twin records —
-    ///   one diagnostic, two delivery mechanisms, so a reader sees identical
-    ///   text whichever way it arrived.
+    /// - Throws: the same `NoSleeperArmed` value the non-throwing twin records,
+    ///   carrying the same core text — what arms, what virtual time said, what
+    ///   to suspect — plus one line the recording path has no use for: *"The
+    ///   wait that gave up: file:line."* A recorded issue is already attributed
+    ///   to the caller's line by `Issue.record`; a thrown error is attributed to
+    ///   the test function, so in a chain the message is the only thing that can
+    ///   name the step. One diagnostic, two deliveries, and the strict form
+    ///   spends an extra line to say where.
     /// - Parameters:
     ///   - timeout: hang guard only, exactly as in the non-throwing twin.
     ///     **On task cancellation this returns without throwing and without a
@@ -479,6 +484,14 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     /// so the ledger and `now` cannot desync and every later step of the chain
     /// is skipped rather than run against a broken clock.
     ///
+    /// That invariant has one other way to be reached, and it is closed rather
+    /// than excepted: the wait also ends *silently* on cancellation, with
+    /// nothing armed and nothing thrown (attribution belongs to whatever
+    /// cancelled the test). Advancing there would move virtual time against an
+    /// empty ledger — harmless in the moment, since the test is being torn down,
+    /// but it is the exact shape this method exists to make impossible. So a
+    /// cancelled wait advances nothing and returns.
+    ///
     /// Same convention as its predecessor: **put the advance next to the
     /// assertion it unblocks**, and for a positive assertion follow it with
     /// `await recorder.next()` — advancing still promises only that due
@@ -493,6 +506,10 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
                                         timeout: Swift.Duration = .seconds(45),
                                         sourceLocation: SourceLocation = #_sourceLocation) async throws {
         try await requireSleeperArmed(timeout: timeout, sourceLocation: sourceLocation)
+        // Returning without throwing has two causes, and only one of them means
+        // a sleeper is registered: the other is cancellation, which ends the
+        // wait silently. See the doc above — the invariant is kept in both.
+        guard !Task.isCancelled else { return }
         await advance(by: duration)
     }
 
@@ -522,15 +539,20 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     /// **Re-arming has the same consequence, and it bites harder.** A task that
     /// fires and immediately sleeps again — a poller loop — cannot possibly have
     /// re-registered by the time `advance` returns, because `advance` never
-    /// yields it the chance. So after a fire, the **next** advance must go
-    /// through ``advanceWhenArmed(by:sourceLocation:)``: a bare `advance` moves
-    /// `now` past a deadline that is not in the ledger yet, and the sleep that
-    /// registers afterwards is measured from the new `now` and never fires —
-    /// permanent desync, the hang `Tests/CLAUDE.md` documents for `TestClock`
-    /// under load, except here it is deterministic rather than probabilistic.
-    /// This is the rule to carry into any future poller-suite migration
-    /// (`GatedIntervalSleepTests`, `DaywatchRunnerTests`), where every advance
-    /// after the first is a re-arm.
+    /// yields it the chance. So after a fire, the **next** advance must wait for
+    /// the re-arm — and in a poller chain that means
+    /// ``requireAdvanceWhenArmed(by:timeout:sourceLocation:)``, the strict form:
+    /// a bare `advance` moves `now` past a deadline that is not in the ledger
+    /// yet, and the sleep that registers afterwards is measured from the new
+    /// `now` and never fires — permanent desync, the hang `Tests/CLAUDE.md`
+    /// documents for `TestClock` under load, except here it is deterministic
+    /// rather than probabilistic. The soft
+    /// ``advanceWhenArmed(by:sourceLocation:)`` is not the tool for that
+    /// position: it records a missed re-arm and advances anyway, which is the
+    /// desync itself. This is the rule the poller suites on this clock
+    /// (`GatedIntervalSleepTests`, `DaywatchRunnerLoopTests`) are built around,
+    /// where every advance after the first is a re-arm, and the one to carry
+    /// into any suite that joins them.
     ///
     /// A deadline in the past is a no-op: virtual time never moves backwards.
     public func advance(to deadline: Instant) async {

--- a/Tests/TestSupport/EventDrivenTestClock.swift
+++ b/Tests/TestSupport/EventDrivenTestClock.swift
@@ -51,6 +51,14 @@ import Testing
 ///   ``FireRecorder/next(timeout:sourceLocation:)`` for any *positive*
 ///   assertion about what a resumed task did. See `advance(to:)`.
 ///
+/// Each wait comes in two forms, split like Swift Testing's `#expect` /
+/// `#require`: ``sleeperArmed(timeout:sourceLocation:)`` and
+/// ``advanceWhenArmed(by:sourceLocation:)`` record a miss and continue, while
+/// ``requireSleeperArmed(timeout:sourceLocation:)`` and
+/// ``requireAdvanceWhenArmed(by:sourceLocation:)`` throw. Prefer the strict pair
+/// in anything shaped like a chain — a poller test, where every step's
+/// correctness depends on the previous one having landed.
+///
 /// The correctness property worth stating explicitly, because it is why this is
 /// a clock rather than a wrapper around `TestClock`: the arming signal is
 /// emitted **after** the suspension has been appended to the ledger, under the
@@ -304,9 +312,61 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     /// sites stay free of `try` noise. That is safe only because it returns
     /// nothing — see `Tests/CLAUDE.md` on non-throwing waiters that *do* return
     /// a value.
+    ///
+    /// **This is the legacy shape.** It suits a single-shot test, where the next
+    /// statement is an assertion that fails informatively on its own. A *chain*
+    /// of waits — any poller test — wants
+    /// ``requireSleeperArmed(timeout:sourceLocation:)`` instead, because
+    /// record-and-continue there advances virtual time with nothing registered
+    /// and desyncs every later step. Kept, unchanged, for its settled callers.
     public func sleeperArmed(timeout: Swift.Duration = .seconds(45),
                              sourceLocation: SourceLocation = #_sourceLocation) async {
-        if hasSleeper { return }
+        guard await armingTimedOut(timeout: timeout), !Task.isCancelled else { return }
+        Issue.record(
+            NoSleeperArmed(timeout: timeout, virtualNow: now),
+            sourceLocation: sourceLocation
+        )
+    }
+
+    /// The **strict** twin of ``sleeperArmed(timeout:sourceLocation:)``:
+    /// identical wait, but a miss throws instead of being recorded.
+    ///
+    /// Mirrors Swift Testing's `#expect` / `#require` split, and exists for the
+    /// same reason `#require` does — *the next step depends on this one having
+    /// landed*. In a poller test each `arm → advance → re-arm` step is only
+    /// sound if the previous one succeeded: a recorded-and-continued miss lets
+    /// ``advance(by:)`` move virtual time with no sleeper in the ledger, the
+    /// sleep that registers afterwards is measured from the new `now` and never
+    /// fires, and the test hangs somewhere later with no attribution. Throwing
+    /// ends the test at the first missed arming, so the worst case of a failing
+    /// chain is one hang guard rather than one per step.
+    ///
+    /// - Throws: the same `NoSleeperArmed` value the non-throwing twin records —
+    ///   one diagnostic, two delivery mechanisms, so a reader sees identical
+    ///   text whichever way it arrived.
+    /// - Parameters:
+    ///   - timeout: hang guard only, exactly as in the non-throwing twin.
+    ///     **On task cancellation this returns without throwing and without a
+    ///     diagnostic**: the failure belongs to whatever cancelled the test.
+    ///   - sourceLocation: carried *into the error*, not into an
+    ///     `Issue.record`. A thrown error is attributed to the test function, so
+    ///     in a chain of these the message is the only thing that can say which
+    ///     step gave up.
+    public func requireSleeperArmed(timeout: Swift.Duration = .seconds(45),
+                                    sourceLocation: SourceLocation = #_sourceLocation) async throws {
+        guard await armingTimedOut(timeout: timeout), !Task.isCancelled else { return }
+        throw NoSleeperArmed(timeout: timeout, virtualNow: now, sourceLocation: sourceLocation)
+    }
+
+    /// The wait both arming helpers share, so the soft and strict forms cannot
+    /// drift apart: they differ only in how the verdict is delivered.
+    ///
+    /// - Returns: `true` if the hang guard gave up before any sleeper
+    ///   registered. A `true` under cancellation is not evidence of anything —
+    ///   see the note at the bottom of this method — so both callers check
+    ///   `Task.isCancelled` before reporting.
+    private func armingTimedOut(timeout: Swift.Duration) async -> Bool {
+        if hasSleeper { return false }
 
         let waiterID = UUID()
         let timedOut = await withTaskGroup(of: ArmingRace.self, returning: Bool.self) { group in
@@ -379,22 +439,20 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
         // call leaves an entry behind for the next one to trip over.
         lock.withLock { _ = expiredArmingWaiters.remove(waiterID) }
 
-        // Cancellation is not expiry. A cancelled enclosing task — `.clockDriven`'s
-        // time limit firing, a sibling's `cancelAll()` — cancels the hang guard's
-        // sleep, so the waiter is released early and `timedOut` says `true` for a
-        // timer that may well have been about to arm. Reporting that would put a
-        // fabricated "within 45 s" on an innocent call site and hide the real
-        // cause, so the diagnostic is suppressed and the attribution left to
-        // whatever did the cancelling. The check belongs *here* rather than in
-        // the guard child: cancellation is monotonic, so the enclosing task's
-        // flag is unambiguous, while the child cannot distinguish its parent's
-        // cancellation from the group's own `cancelAll()` on the healthy path.
-        if timedOut && !Task.isCancelled {
-            Issue.record(
-                NoSleeperArmed(timeout: timeout, virtualNow: now),
-                sourceLocation: sourceLocation
-            )
-        }
+        // Cancellation is not expiry, which is why this returns the raw verdict
+        // and leaves the `Task.isCancelled` check to the two callers. A
+        // cancelled enclosing task — `.clockDriven`'s time limit firing, a
+        // sibling's `cancelAll()` — cancels the hang guard's sleep, so the
+        // waiter is released early and `true` comes back for a timer that may
+        // well have been about to arm. Reporting that would put a fabricated
+        // "within 45 s" on an innocent call site and hide the real cause, so
+        // both callers suppress it and leave attribution to whatever did the
+        // cancelling. The check belongs in the *caller* rather than in the
+        // guard child for the same reason it always did: cancellation is
+        // monotonic, so the enclosing task's flag is unambiguous, while the
+        // child cannot distinguish its parent's cancellation from the group's
+        // own `cancelAll()` on the healthy path.
+        return timedOut
     }
 
     /// ``sleeperArmed(timeout:sourceLocation:)`` followed by
@@ -408,6 +466,33 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
     public func advanceWhenArmed(by duration: Swift.Duration,
                                  sourceLocation: SourceLocation = #_sourceLocation) async {
         await sleeperArmed(sourceLocation: sourceLocation)
+        await advance(by: duration)
+    }
+
+    /// ``requireSleeperArmed(timeout:sourceLocation:)`` followed by
+    /// ``advance(by:)`` — the strict form of
+    /// ``advanceWhenArmed(by:sourceLocation:)``, and the one a poller test
+    /// wants for every advance in its chain.
+    ///
+    /// The ordering is the whole point: **nothing is advanced unless a sleeper
+    /// is registered**. A missed arming throws here, before virtual time moves,
+    /// so the ledger and `now` cannot desync and every later step of the chain
+    /// is skipped rather than run against a broken clock.
+    ///
+    /// Same convention as its predecessor: **put the advance next to the
+    /// assertion it unblocks**, and for a positive assertion follow it with
+    /// `await recorder.next()` — advancing still promises only that due
+    /// continuations were resumed, never that the resumed task has run.
+    ///
+    /// `timeout` is the same hang guard, exposed here (where
+    /// ``advanceWhenArmed(by:sourceLocation:)`` does not expose it) for one
+    /// reason: the guard has to be drivable in a self-test, and a proof that
+    /// costs the full 45 s default is a proof nobody keeps. Every production
+    /// call site takes the default.
+    public func requireAdvanceWhenArmed(by duration: Swift.Duration,
+                                        timeout: Swift.Duration = .seconds(45),
+                                        sourceLocation: SourceLocation = #_sourceLocation) async throws {
+        try await requireSleeperArmed(timeout: timeout, sourceLocation: sourceLocation)
         await advance(by: duration)
     }
 
@@ -493,13 +578,20 @@ public final class EventDrivenTestClock: Clock, @unchecked Sendable {
 private struct NoSleeperArmed: Error, CustomStringConvertible {
     let timeout: Swift.Duration
     let virtualNow: EventDrivenTestClock.Instant
+    /// Where the wait was issued, on the **throwing** path only. The recording
+    /// path passes nothing because `Issue.record` already lands the diagnostic
+    /// on the caller's line; a thrown error is attributed to the test function
+    /// instead, so in a chain of these waits the message is the only thing that
+    /// can say which step gave up.
+    var sourceLocation: SourceLocation?
 
     var description: String {
-        """
+        let site = sourceLocation.map { "\nThe wait that gave up: \($0.fileID):\($0.line)." } ?? ""
+        return """
         EventDrivenTestClock: no task suspended on the clock within \(timeout) — observed \
         zero registered sleepers, virtual now = \(virtualNow.offset). The code under test \
         never reached its sleep: did you start the task, cancel it first, or advance past \
-        the point where it would have armed?
+        the point where it would have armed?\(site)
         """
     }
 }

--- a/docs/specs/2026-08-13-poller-suite-clock-migration-design.md
+++ b/docs/specs/2026-08-13-poller-suite-clock-migration-design.md
@@ -1,0 +1,130 @@
+# Poller-suite clock migration, and a strict arming wait
+
+## What this is for
+
+Two clock-driven suites test **poller loops** — code that wakes on an interval, does
+work, and immediately sleeps again. `GatedIntervalSleepTests.returnsAfterExpectedPollCount`
+and `DaywatchRunnerTests.testSubsequentTicksAtInterval` each spend five wall-clock
+handshake guards, 225 seconds against the 240-second `.clockDriven` limit. Neither
+test is failing today. Both are one scheduling excursion away from tripping that
+limit, and a tripped time limit reports "wedged" with no attribution rather than a
+named failure.
+
+`EventDrivenTestClock` (`docs/specs/2026-08-11-event-driven-test-clock-design.md`)
+removed the polled arming handshake for the debounce suites. This applies it to the
+poller shape, and adds the one piece pollers need that debouncers did not: a wait
+that **throws** rather than recording an issue and continuing.
+
+## Why a poller needs a throwing wait
+
+`sleeperArmed` and `advanceWhenArmed` are non-throwing: a timeout records an issue at
+the caller's location and execution continues. That is right for a single-shot
+debounce test, where the next statement is an assertion that will fail informatively.
+
+It is wrong for a chain. A poller test is a sequence of *arm → advance → re-arm*
+steps, and each step's correctness depends on the previous one having landed. When a
+non-throwing wait times out mid-chain, `advance` moves virtual time with no sleeper
+registered; the sleep that arrives afterwards is scheduled against the new `now` and
+never fires. Every later step then runs against a desynced clock, and the failure
+surfaces as a hang rather than as the missed arming that caused it. `Tests/CLAUDE.md`
+records the measurement: a hundred-step chain on the predecessor clock passed in
+0.63 seconds unloaded and hung past ten minutes under load.
+
+A throwing wait ends the test at the first missed arming, with the diagnostic naming
+that step. Nothing afterwards runs against a desynced clock, and the worst-case cost
+of a failing chain becomes one guard rather than one per step.
+
+## Design
+
+### The strict pair
+
+Two additions to `EventDrivenTestClock`, mirroring Swift Testing's `#expect` / `#require`
+split — soft asks, strict requires:
+
+- **`requireSleeperArmed(timeout:sourceLocation:) async throws`** — the throwing twin
+  of `sleeperArmed`. Identical wait; on timeout it throws instead of recording.
+- **`requireAdvanceWhenArmed(by:sourceLocation:) async throws`** — `requireSleeperArmed`
+  followed by `advance(by:)`.
+
+Both throw the existing `NoSleeperArmed` value that the non-throwing pair records, so
+one diagnostic serves both delivery mechanisms and a reader sees the same message
+whether it arrived via `Issue.record` or a thrown error. Cancellation keeps the
+established treatment: the wait ends without a diagnostic, because attribution belongs
+to whatever cancelled the test.
+
+The non-throwing pair stays, unchanged, for its existing callers. New clock-driven
+tests should prefer the strict form; the soft form is documented as the legacy shape
+rather than removed, because a soft wait followed immediately by an assertion is still
+a sound pattern and its callers are settled.
+
+### The two migrations
+
+Both suites already follow the poller idiom by hand: `advanceWhenSuspended(by:)`
+followed by an explicit `waitForSuspension()` to catch the re-park. That maps directly
+onto `requireAdvanceWhenArmed(by:)` followed by `requireSleeperArmed()`.
+
+`DaywatchRunnerTests` additionally uses a plain `advance(by:)` for its
+"one millisecond short of the interval" step, which is sound only because a sleeper is
+already registered at that point. That property must survive the migration: the step
+stays a plain `advance`, and the arming it depends on is established by the preceding
+strict wait.
+
+### Assert the observable, not the clock
+
+`GatedIntervalSleepTests` asserts that its gated sleep *returned* by calling
+`checkSuspension()` and expecting no error — and depends on that call's internal
+`megaYield` to give the resumed task a turn before the flag is read.
+`EventDrivenTestClock.hasSleeper` is a synchronous snapshot with no such nudge, so a
+mechanical port would read the flag before the resumed task has run: it would pass for
+the wrong reason, or fail spuriously under load.
+
+The replacement is not a weaker negative. The test already holds the positive fact —
+the probe records `markReturned()`, and the waiter task can be joined. Asserting on
+that is stronger than any clock-state inference and removes the timing dependency
+entirely.
+
+This is the migration's actual goal. The clock swap is the mechanism; replacing
+clock-state inference with the observable the test already has is the point, and it is
+the same correction applied across the flake cluster these suites belong to: assert the
+event, not a proxy for it.
+
+### The chain-length rule
+
+`Tests/CLAUDE.md` requires advance chains to stay in single digits. That rule is
+retained and gains the mechanism it was missing: the failure it guards against is
+record-and-continue desync, which strict `EventDrivenTestClock` chains do not share,
+because a miss throws at the first bad step.
+
+The rule is **not** lifted for strict callers. Both suites migrated here already sit
+within it, so lifting buys this work nothing, and the majority of clock-driven suites
+still use the predecessor helpers where the warning holds in full. Stating the
+mechanism lets a future reader with an actual need make that case on evidence.
+
+## Rejected alternatives
+
+- **Make the existing waits throw.** Cleanest end state, and it would retire two shapes
+  in favour of one. It also edits suites that are green and settled — including the two
+  debounce suites whose whole value right now is that they stopped flaking — to buy
+  nothing they need.
+- **A `strict:` parameter instead of separate methods.** Swift cannot overload on
+  throwing-ness, so this would force every caller to `try` regardless of the flag,
+  which is worse than two names.
+- **Raise the `.clockDriven` limit so five guards fit comfortably.** Buys headroom only
+  for tests that are already failing, taxes every genuinely wedged test with a longer
+  wait before attribution, and leaves the desync mechanism untouched.
+- **Shorten the chains instead of migrating.** The documented counter-rule applies: a
+  shortened chain silently buys a weaker assertion, and one test migrated that way ran
+  150 milliseconds of virtual time against a docstring claiming a five-second
+  threshold.
+
+## Verification
+
+- Each migrated test still crosses the threshold its name and docstring claim. A
+  shortened or reordered chain that no longer reaches its stated threshold is a
+  regression even while green.
+- A mutation that stops the poller re-arming makes the strict wait throw promptly with
+  its named diagnostic, rather than hanging to the suite time limit.
+- A mutation to each production behaviour under test still reddens the suite, so the
+  migration does not buy stability by weakening what the tests detect.
+- Both suites hold under a loop with machine load induced, since load is the failure
+  condition these guards exist for.

--- a/docs/specs/2026-08-13-poller-suite-clock-migration-design.md
+++ b/docs/specs/2026-08-13-poller-suite-clock-migration-design.md
@@ -3,12 +3,13 @@
 ## What this is for
 
 Two clock-driven suites test **poller loops** — code that wakes on an interval, does
-work, and immediately sleeps again. `GatedIntervalSleepTests.returnsAfterExpectedPollCount`
-and `DaywatchRunnerTests.testSubsequentTicksAtInterval` each spend five wall-clock
-handshake guards, 225 seconds against the 240-second `.clockDriven` limit. Neither
-test is failing today. Both are one scheduling excursion away from tripping that
-limit, and a tripped time limit reports "wedged" with no attribution rather than a
-named failure.
+work, and immediately sleeps again. On `TestClock`'s non-throwing helpers,
+`GatedIntervalSleepTests.returnsAfterExpectedPollCount` and
+`DaywatchRunnerLoopTests.testSubsequentTicksAtInterval` each spend five wall-clock
+handshake guards, 225 seconds against the 240-second `.clockDriven` limit, and every
+one of those guards is payable in a single run. Neither test is failing today. Both
+are one scheduling excursion away from tripping that limit, and a tripped time limit
+reports "wedged" with no attribution rather than a named failure.
 
 `EventDrivenTestClock` (`docs/specs/2026-08-11-event-driven-test-clock-design.md`)
 removed the polled arming handshake for the debounce suites. This applies it to the
@@ -43,8 +44,12 @@ split — soft asks, strict requires:
 
 - **`requireSleeperArmed(timeout:sourceLocation:) async throws`** — the throwing twin
   of `sleeperArmed`. Identical wait; on timeout it throws instead of recording.
-- **`requireAdvanceWhenArmed(by:sourceLocation:) async throws`** — `requireSleeperArmed`
-  followed by `advance(by:)`.
+- **`requireAdvanceWhenArmed(by:timeout:sourceLocation:) async throws`** —
+  `requireSleeperArmed` followed by `advance(by:)`. The hang guard is defaulted to the
+  same 45 seconds, so every production call site passes `by:` alone; it is exposed here
+  (where the soft `advanceWhenArmed` does not expose it) because the clock's self-tests
+  have to drive the guard to its diagnostic, and a proof that costs 45 seconds is a
+  proof nobody keeps.
 
 Both throw the existing `NoSleeperArmed` value that the non-throwing pair records, so
 one diagnostic serves both delivery mechanisms and a reader sees the same message
@@ -63,7 +68,7 @@ Both suites already follow the poller idiom by hand: `advanceWhenSuspended(by:)`
 followed by an explicit `waitForSuspension()` to catch the re-park. That maps directly
 onto `requireAdvanceWhenArmed(by:)` followed by `requireSleeperArmed()`.
 
-`DaywatchRunnerTests` additionally uses a plain `advance(by:)` for its
+`DaywatchRunnerLoopTests` additionally uses a plain `advance(by:)` for its
 "one millisecond short of the interval" step, which is sound only because a sleeper is
 already registered at that point. That property must survive the migration: the step
 stays a plain `advance`, and the arming it depends on is established by the preceding
@@ -78,10 +83,14 @@ strict wait.
 mechanical port would read the flag before the resumed task has run: it would pass for
 the wrong reason, or fail spuriously under load.
 
-The replacement is not a weaker negative. The test already holds the positive fact —
-the probe records `markReturned()`, and the waiter task can be joined. Asserting on
-that is stronger than any clock-state inference and removes the timing dependency
-entirely.
+The replacement is not a weaker negative. The test already holds the positive fact:
+the loop's return records the interval-evaluation count into a `FireRecorder`, so
+"the wait ended" and "after exactly three polls" become one awaited value rather than
+two reads that could disagree. Awaiting that is stronger than any clock-state
+inference and removes the timing dependency entirely. The join that follows carries a
+claim of its own — a loop still parked when `cancel()` arrives pays one extra
+`interval()` evaluation on its way out, so an unmoved count after the join is what
+distinguishes a wait that ended on its own gate from one the join unwedged.
 
 This is the migration's actual goal. The clock swap is the mechanism; replacing
 clock-state inference with the observable the test already has is the point, and it is


### PR DESCRIPTION
## Summary

Two clock-driven suites test **poller loops** — code that wakes on an interval, works, and immediately sleeps again. On the non-throwing waits, `GatedIntervalSleepTests.returnsAfterExpectedPollCount` and `DaywatchRunnerLoopTests.testSubsequentTicksAtInterval` each spent five wall-clock handshake guards, 225 seconds against the 240-second `.clockDriven` limit, every one payable in a single run. Neither was failing. Both were one scheduling excursion from tripping that limit — and a tripped time limit reports "wedged" with no attribution rather than a named failure.

This puts them on `EventDrivenTestClock` (#622) and adds the one thing pollers need that debouncers did not: a wait that **throws** instead of recording an issue and continuing.

Spec: [`docs/specs/2026-08-13-poller-suite-clock-migration-design.md`](docs/specs/2026-08-13-poller-suite-clock-migration-design.md).

## Why this shape

A poller test is a chain of *arm → advance → re-arm*, and each step's correctness depends on the previous one having landed. A non-throwing wait that times out mid-chain lets `advance` move virtual time with no sleeper registered; the sleep that arrives afterwards is scheduled against the new `now` and never fires. Every later step then runs against a desynced clock, and the failure surfaces as a **hang** rather than as the missed arming that caused it — the worst failure shape in this repo's taxonomy, since a truncated run reads as a pass to anything checking exit codes. `Tests/CLAUDE.md` records the measurement: a hundred-step chain on the predecessor clock passed in 0.63 s unloaded and hung past ten minutes under load.

A throwing wait ends the test at the first missed arming, with the diagnostic naming that step, and a failing chain costs one guard instead of one per step.

**The clock swap is the mechanism, not the goal.** The goal is replacing clock-state inference with the observable each test already holds. `GatedIntervalSleepTests` asserted its gated sleep had returned by calling `checkSuspension()` and expecting no error — depending on that call's internal `megaYield` to give the resumed task a turn. The loop's return now records its interval-evaluation count into a `FireRecorder`, so "the wait ended" and "after exactly three polls" are one awaited value rather than two reads that can disagree. That is the same correction applied across the flake cluster these suites belong to (#618, #622, #623): assert the event, not a proxy for it.

## What this PR does

- Adds `requireSleeperArmed` and `requireAdvanceWhenArmed` to `EventDrivenTestClock`, throwing the same `NoSleeperArmed` value the soft pair records. Both go through one private wait so they cannot drift on cancellation, and both keep the established treatment that a cancelled wait ends without a diagnostic — attribution belongs to whatever cancelled the test.
- Migrates `GatedIntervalSleepTests` and `DaywatchRunnerLoopTests`. `DaywatchRunnerLoopTests`' "one millisecond short of the interval" step deliberately stays a plain `advance(by:)`; it is sound only because a sleeper is already registered, and the preceding strict wait is what establishes that.
- Retains the chain-length rule rather than lifting it, and gives it the mechanism it was missing. Both migrated suites already sit inside the rule, so lifting buys this work nothing, and most clock-driven suites still use the predecessor helpers where the warning holds in full.

The non-throwing pair is unchanged and stays for its existing callers; no suite outside the two named here is touched, and no `Sources/` file changes.

## Assumptions

- Assumes the strict form is preferred for **new** clock-driven tests while the soft form remains sound where a wait is followed immediately by an assertion. The settled debounce suites are deliberately left on the soft pair.
- Assumes a chain's *shape* matters as much as its strictness: the "one guard per failing run" property holds because the single non-throwing guard sits **last**, with nothing behind it. A `FireRecorder.next()` placed mid-chain would reopen the multi-guard exposure. This is stated in `Tests/CLAUDE.md` so the next author does not have to rediscover it.

## Evidence & verification

**Thresholds held.** Measured before and after with temporary probes against both trees: `returnsAfterExpectedPollCount` 30.0 s virtual / 3 evaluations, `boundaryIsExact` 30.0 s / 3, `shortenedIntervalShortensInFlightWait` 20.0 s / 2, `testSubsequentTicksAtInterval` 1800.0 s virtual (2 × the production interval) / 3 ticks. Identical in every case — no chain was quietly shortened into a weaker assertion, which is the documented trap here.

**Mutations, each observed red then restored.** Breaking the re-arm (`while` → `if` in `runLoop`) fails three loop tests in 47.9 s with the named diagnostic instead of hanging to the 240 s limit. Breaking the gate comparison (`waited >= due` → `>`) reds all three gated-interval trailing assertions. Breaking the interval (`sleep(interval / 2)`) reds `testSubsequentTicksAtInterval` in 0.046 s. Dropping the call site from the diagnostic, and moving it to the front, each red their respective halves of the tightened self-test. Removing the cancellation guard from `requireAdvanceWhenArmed` reds with `clock.now.offset → 5.0 seconds` where `.zero` was expected.

**Under load.** The migrated suites held 7/7 consecutive runs with load induced (load average 14–25), on top of 10/10 and 5/5 loops during implementation. A local full-suite pass was attempted at a naturally occurring load average above 120 and did **not** produce a result — it timed out waiting for the shared build lock while sibling worktrees held it, which is an infrastructure outcome rather than a test one. CI's full-suite run on a quiet runner is the signal for that, and it is reported on this PR.

**Review found no functional defects and nine precision problems, all fixed.** The one worth naming: `#expect(await probe.didReturn)` was **vacuous** — it ran after `cancel()` and the join, and the production loop always exits and returns on cancellation, so the flag was always true. It was pre-existing, but the first commit of this branch deleted the meaningful assertion beside it, leaving the vacuous one as each test's trailing line. It is now a count check, mutation-proved. Review also caught that both copies of the guard tally were stale: recounted from the code, `returnsAfterExpectedPollCount` pays six guards (270 s, above the ceiling), and the docs now explain why that describes a run which cannot happen rather than quietly restating a smaller number.

## Follow-up, not in scope

`.swiftlint.yml`'s `included:` covers only `Sources`, `Tests/TBDSharedTests` and `Tests/TBDAppTests`, so `Tests/TestSupport`, `Tests/TBDDaemonTests` and `Tests/TBDDaemonLiveTests` receive **no CI lint coverage**. Every "lint clean" claim about files in those directories — including this PR's — is true only in that scope.

Measured, so the decision is concrete rather than a vague warning: linting those three directories file-by-file (a directory argument does *not* work — it re-applies the config's `included:` scope and reports zero) covers **310 files and surfaces 35 violations** across six rules — 23 `optional_data_string_conversion`, 4 `static_over_final_class`, 3 `type_name`, 2 `colon`, 2 `closure_parameter_position`, 1 `inclusive_language`. One of the `closure_parameter_position` hits is in `EventDrivenTestClock.swift`, a file this PR touches. That is a small enough backlog that widening the scope is a realistic follow-up rather than a project, and the `inclusive_language` hit is worth a look on its own given this repo's word ban. Deliberately not bundled here.

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=9EEB84BC-BF9D-408C-ACA1-4543A64AAA7C)
