### PR TITLE
Fix: Say who holds the shared build lock and keep talking while you wait (three agent sessions killed by the silence)

### DIFF
--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -5,6 +5,13 @@ Every TBD worktree shares the same default lock under ``~/tbd/runtime``.  This
 prevents otherwise-independent Claude sessions from each starting a full
 Swift compiler swarm on the same laptop.  The file may remain on disk: flock
 ownership is kernel-managed and is released when this process exits.
+
+Waiting is reported on stderr, never stdout, so a caller parsing SwiftPM's
+output sees nothing from this wrapper.  The holder writes ``pid``/``cwd``/
+``command`` into the lock file after acquiring, and a waiter reads it back to
+say who it is queued behind; a heartbeat then repeats the wait's elapsed time
+so a human can tell a queued build from a hung one and an automated caller's
+stall watchdog sees liveness.
 """
 
 from __future__ import annotations
@@ -20,6 +27,14 @@ import time
 DEFAULT_JOBS = 2
 MAX_JOBS = 4
 DEFAULT_TIMEOUT_SECONDS = 1_800.0
+# Agent harnesses kill a session that emits nothing for 600s, and a queued
+# build used to be silent for the full 30-minute timeout.  One line a minute
+# clears that watchdog by 10x while costing at most 30 lines across the whole
+# timeout, and a typical wait (one sibling build, 1-3 minutes) prints 1-3.
+DEFAULT_HEARTBEAT_SECONDS = 60.0
+# Fields the holder records; anything else in the file is ignored.
+HOLDER_FIELDS = ("pid", "cwd", "command")
+MAX_REPORTED_COMMAND_CHARACTERS = 120
 COMPILE_SUBCOMMANDS = {"build", "run", "test"}
 SUPPORTED_SUBCOMMANDS = COMPILE_SUBCOMMANDS
 RUN_OPTIONS_WITH_VALUES = {
@@ -168,25 +183,109 @@ def _lock_path() -> Path:
     return tbd_home / "runtime" / "swift-build.lock"
 
 
-def _acquire(lock_file, timeout_seconds: float) -> None:
-    deadline = time.monotonic() + timeout_seconds
+def _report(message: str) -> None:
+    """Waiting is diagnostics: stderr only, so stdout stays SwiftPM's alone."""
+    print(message, file=sys.stderr, flush=True)
+
+
+def _holder_fields(lock_path: Path) -> dict[str, str]:
+    """Best-effort read of what the current holder recorded, or ``{}``.
+
+    The holder truncates and rewrites this file after it acquires, so a waiter
+    can catch it empty or half-written.  Only newline-terminated lines are
+    parsed — a trailing fragment such as ``pid=12`` mid-write would otherwise
+    read as a plausible but wrong pid.
+    """
+    try:
+        text = lock_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    fields: dict[str, str] = {}
+    for line in text.split("\n")[:-1]:
+        key, separator, value = line.partition("=")
+        if separator and key in HOLDER_FIELDS and value:
+            fields[key] = value
+    return fields
+
+
+def _process_is_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _holder_description(lock_path: Path) -> str:
+    """Describe the lock holder without ever claiming one we cannot see."""
+    fields = _holder_fields(lock_path)
+    try:
+        pid = int(fields["pid"])
+    except (KeyError, ValueError):
+        return "holder has not recorded its identity yet"
+    if not _process_is_alive(pid):
+        return (
+            f"the lock file names pid {pid}, which is no longer running; "
+            "the current holder is unidentified"
+        )
+
+    parts = [f"pid {pid}"]
+    # The directory basename identifies the worktree; the full path is noise.
+    worktree = Path(fields["cwd"]).name if fields.get("cwd") else ""
+    if worktree:
+        parts.insert(0, f"worktree {worktree}")
+    description = f"held by {', '.join(parts)}"
+    command = fields.get("command")
+    if command:
+        if len(command) > MAX_REPORTED_COMMAND_CHARACTERS:
+            command = command[:MAX_REPORTED_COMMAND_CHARACTERS] + "..."
+        description += f" running: {command}"
+    return description
+
+
+def _acquire(
+    lock_file,
+    lock_path: Path,
+    timeout_seconds: float,
+    heartbeat_seconds: float,
+    *,
+    monotonic=time.monotonic,
+    sleep=time.sleep,
+    report=_report,
+) -> None:
+    start = monotonic()
+    deadline = start + timeout_seconds
     announced = False
+    next_heartbeat = 0.0
     while True:
         try:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             return
         except BlockingIOError:
+            now = monotonic()
             if not announced:
-                print(
+                report(
                     "swift-safe: another TBD worktree is compiling; waiting for "
-                    "the shared build slot",
-                    file=sys.stderr,
-                    flush=True,
+                    f"the shared build slot ({_holder_description(lock_path)})"
                 )
                 announced = True
-            if time.monotonic() >= deadline:
+                next_heartbeat = now + heartbeat_seconds
+            elif now >= next_heartbeat:
+                report(
+                    f"swift-safe: still waiting for the shared build slot after "
+                    f"{now - start:.0f}s of {timeout_seconds:g}s "
+                    f"({_holder_description(lock_path)})"
+                )
+                next_heartbeat = now + heartbeat_seconds
+            if now >= deadline:
                 raise TimeoutError
-            time.sleep(min(0.25, max(0.01, deadline - time.monotonic())))
+            sleep(min(0.25, max(0.01, deadline - now)))
 
 
 def main(arguments: list[str]) -> int:
@@ -210,13 +309,28 @@ def main(arguments: list[str]) -> int:
     timeout = _positive_number(
         "TBD_SWIFT_LOCK_TIMEOUT_SECONDS", DEFAULT_TIMEOUT_SECONDS
     )
+    heartbeat = _positive_number(
+        "TBD_SWIFT_HEARTBEAT_SECONDS", DEFAULT_HEARTBEAT_SECONDS
+    )
+
+    if subcommand == "run":
+        # `run` execs SwiftPM, which stays alive for as long as the program
+        # does, so the slot covers the program's whole lifetime rather than
+        # its compile. Say so rather than letting a machine wedge silently.
+        _report(
+            "swift-safe: `run` holds the machine-global build slot until the "
+            "program exits, not just until it finishes compiling; every other "
+            "TBD worktree waits meanwhile. Prefer `scripts/swift-safe build "
+            "--product <name>` and then executing .build/debug/<name>."
+        )
 
     with path.open("a+", encoding="utf-8") as lock_file:
         try:
-            _acquire(lock_file, timeout)
+            _acquire(lock_file, path, timeout, heartbeat)
         except TimeoutError:
             print(
-                f"swift-safe: timed out after {timeout:g}s waiting for {path}",
+                f"swift-safe: timed out after {timeout:g}s waiting for {path} "
+                f"({_holder_description(path)})",
                 file=sys.stderr,
             )
             return 75

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -17,6 +17,7 @@ stall watchdog sees liveness.
 from __future__ import annotations
 
 import fcntl
+import math
 import os
 from pathlib import Path
 import shutil
@@ -79,6 +80,12 @@ def _positive_number(name: str, default: float) -> float:
         value = float(raw)
     except ValueError:
         raise SystemExit(f"{name} must be a positive number, got {raw!r}")
+    # `float()` accepts "nan" and "inf", and every comparison against nan is
+    # False — an unchecked nan would make the timeout's deadline unreachable
+    # (waiting forever) and the heartbeat's next-beat check never fire
+    # (waiting in silence). Both are the failure this wrapper exists to avoid.
+    if not math.isfinite(value):
+        raise SystemExit(f"{name} must be a finite number, got {raw!r}")
     if value <= 0:
         raise SystemExit(f"{name} must be positive, got {raw!r}")
     return value
@@ -216,7 +223,10 @@ def _process_is_alive(pid: int) -> bool:
         return False
     except PermissionError:
         return True
-    except OSError:
+    # A number too large for the platform's pid_t raises OverflowError, which
+    # is not an OSError — left uncaught it would crash the waiter mid-wait on
+    # a corrupt record. No such process can exist, so it is simply not alive.
+    except (OSError, OverflowError):
         return False
     return True
 
@@ -234,7 +244,7 @@ def _holder_description(lock_path: Path) -> str:
         return "holder has not recorded its identity yet"
     if not _process_is_alive(pid):
         return (
-            f"the lock file names pid {pid}, which is no longer running; "
+            f"the lock file names pid {pid}, which is not running; "
             "the current holder is unidentified"
         )
 

--- a/scripts/swift-safe
+++ b/scripts/swift-safe
@@ -209,8 +209,7 @@ def _holder_fields(lock_path: Path) -> dict[str, str]:
 
 
 def _process_is_alive(pid: int) -> bool:
-    if pid <= 0:
-        return False
+    """Liveness of a single positive pid; callers screen out 0 and negatives."""
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -228,6 +227,10 @@ def _holder_description(lock_path: Path) -> str:
     try:
         pid = int(fields["pid"])
     except (KeyError, ValueError):
+        pid = 0
+    # `os.kill(0, 0)` inspects this process's own group and would report a
+    # holder that is really us, so a non-positive pid counts as unrecorded.
+    if pid <= 0:
         return "holder has not recorded its identity yet"
     if not _process_is_alive(pid):
         return (

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -335,6 +335,16 @@ class WaitReportingTests(unittest.TestCase):
         self.assertNotIn("acme-worktree", description)
         self.assertNotIn("swift test", description)
 
+    def test_non_positive_pids_are_never_probed_or_reported(self):
+        # `os.kill(0, 0)` would signal this process's whole group, and a
+        # negative pid a whole other group: neither is a holder.
+        for recorded in ("0", "-1"):
+            with self.subTest(pid=recorded):
+                self.record(f"pid={recorded}\ncwd=/somewhere/acme-worktree\n")
+                self.assertEqual(
+                    self.description(), "holder has not recorded its identity yet"
+                )
+
     def test_garbage_lock_file_invents_no_holder(self):
         self.record("\x00\x00 not a lock record at all\npid=not-a-number\n")
         self.assertEqual(

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -7,6 +7,7 @@ clock: the shipped heartbeat is a minute apart and no test may spend one.
 
 from __future__ import annotations
 
+import contextlib
 import fcntl
 import importlib.machinery
 import importlib.util
@@ -26,6 +27,7 @@ def _load_runner_module():
     """Import scripts/swift-safe (extensionless) as `swift_safe`."""
     loader = importlib.machinery.SourceFileLoader("swift_safe", str(RUNNER))
     spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None, f"no import spec for {RUNNER}"
     module = importlib.util.module_from_spec(spec)
     loader.exec_module(module)
     return module
@@ -45,6 +47,34 @@ class FakeClock:
 
     def sleep(self, seconds: float) -> None:
         self.now += seconds
+
+
+@contextlib.contextmanager
+def _lock_holder(env: dict[str, str], cwd: str | None = None):
+    """Run a real swift-safe that takes the lock and keeps it until exit.
+
+    Yields once the stub `swift` has printed, which happens only after the
+    lock was taken and the holder record written — so a waiter started inside
+    the block genuinely contends with a genuinely identified holder.
+    """
+    process = subprocess.Popen(
+        [str(RUNNER), "build"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=cwd,
+        env=env,
+    )
+    stdout, stderr = process.stdout, process.stderr
+    assert stdout is not None and stderr is not None
+    try:
+        assert stdout.readline().strip() == "ready"
+        yield process
+    finally:
+        process.terminate()
+        process.wait(timeout=5)
+        stdout.close()
+        stderr.close()
 
 
 def _dead_pid() -> int:
@@ -133,25 +163,12 @@ class SwiftSafeTests(unittest.TestCase):
         )
         env = os.environ.copy()
         env.update({"TBD_HOME": str(self.tbd_home), "TBD_SWIFT_BIN": str(self.fake_swift)})
-        first = subprocess.Popen(
-            [str(RUNNER), "build"],
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env,
-        )
-        try:
-            self.assertEqual(first.stdout.readline().strip(), "ready")
+        with _lock_holder(env):
             result = self.run_runner(
                 "test", TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.05"
             )
             self.assertEqual(result.returncode, 75)
             self.assertIn("timed out", result.stderr)
-        finally:
-            first.terminate()
-            first.wait(timeout=5)
-            first.stdout.close()
-            first.stderr.close()
 
     def test_contended_lock_times_out_without_spawning_swift(self):
         lock_path = self.tbd_home / "runtime" / "swift-build.lock"
@@ -180,16 +197,7 @@ class SwiftSafeTests(unittest.TestCase):
                 "TBD_SWIFT_BIN": str(self.fake_swift),
             }
         )
-        holder = subprocess.Popen(
-            [str(RUNNER), "build"],
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=str(holder_directory),
-            env=env,
-        )
-        try:
-            self.assertEqual(holder.stdout.readline().strip(), "ready")
+        with _lock_holder(env, cwd=str(holder_directory)) as holder:
             result = self.run_runner(
                 "test",
                 TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.4",
@@ -203,11 +211,6 @@ class SwiftSafeTests(unittest.TestCase):
             self.assertNotIn(str(holder_directory), result.stderr)
             # Nothing the waiter says may reach a caller parsing SwiftPM output.
             self.assertEqual(result.stdout, "")
-        finally:
-            holder.terminate()
-            holder.wait(timeout=5)
-            holder.stdout.close()
-            holder.stderr.close()
 
     def test_run_warns_that_the_slot_covers_the_whole_program(self):
         result = self.run_runner("run", "TBDApp")

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -1,8 +1,15 @@
-"""Black-box tests for scripts/swift-safe (stdlib only)."""
+"""Tests for scripts/swift-safe (stdlib only).
+
+Mostly black-box, through the real script.  The wait-reporting tests import
+the script as a module instead, so they can drive `_acquire` with a fake
+clock: the shipped heartbeat is a minute apart and no test may spend one.
+"""
 
 from __future__ import annotations
 
 import fcntl
+import importlib.machinery
+import importlib.util
 import os
 from pathlib import Path
 import subprocess
@@ -13,6 +20,38 @@ import unittest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RUNNER = REPO_ROOT / "scripts" / "swift-safe"
+
+
+def _load_runner_module():
+    """Import scripts/swift-safe (extensionless) as `swift_safe`."""
+    loader = importlib.machinery.SourceFileLoader("swift_safe", str(RUNNER))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+swift_safe = _load_runner_module()
+
+
+class FakeClock:
+    """Virtual monotonic time that only advances when the code sleeps."""
+
+    def __init__(self):
+        self.now = 1_000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _dead_pid() -> int:
+    """A pid that has certainly exited and been reaped."""
+    finished = subprocess.Popen(["/bin/sh", "-c", "exit 0"])
+    finished.wait(timeout=5)
+    return finished.pid
 
 
 class SwiftSafeTests(unittest.TestCase):
@@ -125,6 +164,207 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 75)
         self.assertIn("timed out", result.stderr)
         self.assertEqual(result.stdout, "")
+
+    def test_waiting_reports_the_holder_and_heartbeats_on_stderr(self):
+        """End to end: a real waiter behind a real holder, compressed cadence."""
+        holder_directory = Path(self.temp.name) / "acme-worktree"
+        holder_directory.mkdir()
+        self.fake_swift.write_text(
+            "#!/bin/sh\nprintf 'ready\\n'\nsleep 30\n",
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env.update(
+            {
+                "TBD_HOME": str(self.tbd_home),
+                "TBD_SWIFT_BIN": str(self.fake_swift),
+            }
+        )
+        holder = subprocess.Popen(
+            [str(RUNNER), "build"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=str(holder_directory),
+            env=env,
+        )
+        try:
+            self.assertEqual(holder.stdout.readline().strip(), "ready")
+            result = self.run_runner(
+                "test",
+                TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.4",
+                TBD_SWIFT_HEARTBEAT_SECONDS="0.05",
+            )
+            self.assertEqual(result.returncode, 75)
+            self.assertIn("worktree acme-worktree", result.stderr)
+            self.assertIn(f"pid {holder.pid}", result.stderr)
+            self.assertIn("still waiting for the shared build slot after", result.stderr)
+            # The worktree is named by its basename; the path is not disclosed.
+            self.assertNotIn(str(holder_directory), result.stderr)
+            # Nothing the waiter says may reach a caller parsing SwiftPM output.
+            self.assertEqual(result.stdout, "")
+        finally:
+            holder.terminate()
+            holder.wait(timeout=5)
+            holder.stdout.close()
+            holder.stderr.close()
+
+    def test_run_warns_that_the_slot_covers_the_whole_program(self):
+        result = self.run_runner("run", "TBDApp")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("until the program exits", result.stderr)
+        self.assertEqual(result.stdout.strip(), "run --jobs 2 TBDApp")
+
+    def test_build_does_not_warn_about_the_program_lifetime(self):
+        result = self.run_runner("build")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("until the program exits", result.stderr)
+
+
+class WaitReportingTests(unittest.TestCase):
+    """Drive `_acquire` against a real contended flock with a fake clock."""
+
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.lock_path = Path(self.temp.name) / "swift-build.lock"
+        # A second open file description in this same process genuinely
+        # conflicts under flock, so the waiter below really does block.
+        self.holder = self.lock_path.open("a+", encoding="utf-8")
+        fcntl.flock(self.holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    def tearDown(self):
+        self.holder.close()
+        self.temp.cleanup()
+
+    def record(self, text: str) -> None:
+        self.holder.seek(0)
+        self.holder.truncate()
+        self.holder.write(text)
+        self.holder.flush()
+
+    def wait_messages(self, timeout=125.0, heartbeat=60.0, on_report=None):
+        clock = FakeClock()
+        messages: list[str] = []
+
+        def report(message: str) -> None:
+            messages.append(message)
+            if on_report is not None:
+                on_report(len(messages))
+
+        with self.lock_path.open("a+", encoding="utf-8") as waiter:
+            with self.assertRaises(TimeoutError):
+                swift_safe._acquire(
+                    waiter,
+                    self.lock_path,
+                    timeout,
+                    heartbeat,
+                    monotonic=clock.monotonic,
+                    sleep=clock.sleep,
+                    report=report,
+                )
+        return messages
+
+    def test_first_line_names_the_holder_worktree_pid_and_command(self):
+        self.record(
+            f"pid={os.getpid()}\ncwd=/somewhere/acme-worktree\n"
+            "command=swift build --jobs 2\n"
+        )
+        first = self.wait_messages()[0]
+        self.assertIn("waiting for the shared build slot", first)
+        self.assertIn("worktree acme-worktree", first)
+        self.assertIn(f"pid {os.getpid()}", first)
+        self.assertIn("running: swift build --jobs 2", first)
+        self.assertNotIn("/somewhere/", first)
+
+    def test_heartbeat_repeats_with_elapsed_time_on_the_configured_cadence(self):
+        self.record(f"pid={os.getpid()}\ncwd=/somewhere/acme-worktree\n")
+        messages = self.wait_messages(timeout=125.0, heartbeat=60.0)
+        heartbeats = [m for m in messages if "still waiting" in m]
+        self.assertEqual(len(messages), 3)
+        self.assertEqual(len(heartbeats), 2)
+        self.assertIn("after 60s of 125s", heartbeats[0])
+        self.assertIn("after 120s of 125s", heartbeats[1])
+        self.assertTrue(all("worktree acme-worktree" in m for m in heartbeats))
+
+    def test_a_faster_cadence_produces_more_heartbeats(self):
+        self.record(f"pid={os.getpid()}\n")
+        heartbeats = [
+            message
+            for message in self.wait_messages(timeout=125.0, heartbeat=30.0)
+            if "still waiting" in message
+        ]
+        self.assertEqual(len(heartbeats), 4)
+        self.assertIn("after 30s of 125s", heartbeats[0])
+        self.assertIn("after 120s of 125s", heartbeats[3])
+
+    def test_shipped_cadence_clears_a_stall_watchdog_with_margin(self):
+        self.assertLessEqual(swift_safe.DEFAULT_HEARTBEAT_SECONDS * 5, 600)
+
+    def description(self) -> str:
+        """The holder clause on its own, free of the surrounding wait line."""
+        return swift_safe._holder_description(self.lock_path)
+
+    def test_empty_lock_file_invents_no_holder(self):
+        self.assertEqual(
+            self.description(), "holder has not recorded its identity yet"
+        )
+
+    def test_missing_lock_file_invents_no_holder(self):
+        self.lock_path.unlink()
+        self.assertEqual(
+            self.description(), "holder has not recorded its identity yet"
+        )
+
+    def test_partially_written_pid_line_is_not_trusted(self):
+        self.record(f"pid={os.getpid()}")  # no terminating newline yet
+        description = self.description()
+        self.assertEqual(description, "holder has not recorded its identity yet")
+        self.assertNotIn(str(os.getpid()), description)
+
+    def test_partially_written_cwd_line_is_not_trusted(self):
+        self.record(f"pid={os.getpid()}\ncwd=/somewhere/acme-work")
+        description = self.description()
+        self.assertEqual(description, f"held by pid {os.getpid()}")
+
+    def test_stale_holder_identity_is_reported_as_gone(self):
+        stale = _dead_pid()
+        self.record(f"pid={stale}\ncwd=/somewhere/acme-worktree\ncommand=swift test\n")
+        description = self.description()
+        self.assertIn(f"names pid {stale}, which is no longer running", description)
+        self.assertIn("unidentified", description)
+        self.assertNotIn("acme-worktree", description)
+        self.assertNotIn("swift test", description)
+
+    def test_garbage_lock_file_invents_no_holder(self):
+        self.record("\x00\x00 not a lock record at all\npid=not-a-number\n")
+        self.assertEqual(
+            self.description(), "holder has not recorded its identity yet"
+        )
+
+    def test_a_stale_description_still_reaches_the_wait_line(self):
+        stale = _dead_pid()
+        self.record(f"pid={stale}\ncwd=/somewhere/acme-worktree\n")
+        first = self.wait_messages()[0]
+        self.assertIn("waiting for the shared build slot", first)
+        self.assertIn("no longer running", first)
+        self.assertNotIn("acme-worktree", first)
+
+    def test_heartbeat_rereads_a_holder_that_identifies_itself_late(self):
+        """The holder records its identity only after acquiring, so re-read."""
+
+        def populate(message_count: int) -> None:
+            if message_count == 1:
+                self.record(f"pid={os.getpid()}\ncwd=/somewhere/acme-worktree\n")
+
+        messages = self.wait_messages(on_report=populate)
+        self.assertIn("holder has not recorded its identity yet", messages[0])
+        self.assertIn("worktree acme-worktree", messages[1])
+
+    def test_an_over_long_command_is_truncated(self):
+        self.record(f"pid={os.getpid()}\ncommand=swift build {'x' * 400}\n")
+        first = self.wait_messages()[0]
+        self.assertIn("...", first)
+        self.assertLess(len(first), 400)
 
 
 if __name__ == "__main__":

--- a/scripts/test-swift-safe.py
+++ b/scripts/test-swift-safe.py
@@ -182,6 +182,36 @@ class SwiftSafeTests(unittest.TestCase):
         self.assertIn("timed out", result.stderr)
         self.assertEqual(result.stdout, "")
 
+    def test_a_corrupt_holder_record_does_not_crash_the_waiter(self):
+        """An unusable pid must degrade to "unidentified", never a traceback."""
+        lock_path = self.tbd_home / "runtime" / "swift-build.lock"
+        lock_path.parent.mkdir(parents=True)
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            # Well-formed and numeric, but far past the platform's pid_t.
+            lock_file.write("pid=99999999999\ncwd=/somewhere/acme-worktree\n")
+            lock_file.flush()
+            result = self.run_runner("build", TBD_SWIFT_LOCK_TIMEOUT_SECONDS="0.05")
+        self.assertEqual(result.returncode, 75)
+        self.assertNotIn("Traceback", result.stderr)
+        self.assertIn("is not running", result.stderr)
+        self.assertNotIn("acme-worktree", result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_non_finite_wait_settings_are_rejected(self):
+        """nan/inf survive float() and would silently disable the wait's limits."""
+        for variable in (
+            "TBD_SWIFT_LOCK_TIMEOUT_SECONDS",
+            "TBD_SWIFT_HEARTBEAT_SECONDS",
+        ):
+            for value in ("nan", "inf", "-inf", "NaN", "Infinity"):
+                with self.subTest(variable=variable, value=value):
+                    result = self.run_runner("build", **{variable: value})
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(variable, result.stderr)
+                    # Rejected before SwiftPM is exec'd, not after.
+                    self.assertEqual(result.stdout, "")
+
     def test_waiting_reports_the_holder_and_heartbeats_on_stderr(self):
         """End to end: a real waiter behind a real holder, compressed cadence."""
         holder_directory = Path(self.temp.name) / "acme-worktree"
@@ -333,7 +363,7 @@ class WaitReportingTests(unittest.TestCase):
         stale = _dead_pid()
         self.record(f"pid={stale}\ncwd=/somewhere/acme-worktree\ncommand=swift test\n")
         description = self.description()
-        self.assertIn(f"names pid {stale}, which is no longer running", description)
+        self.assertIn(f"names pid {stale}, which is not running", description)
         self.assertIn("unidentified", description)
         self.assertNotIn("acme-worktree", description)
         self.assertNotIn("swift test", description)
@@ -348,6 +378,13 @@ class WaitReportingTests(unittest.TestCase):
                     self.description(), "holder has not recorded its identity yet"
                 )
 
+    def test_a_pid_too_large_for_the_platform_is_not_alive(self):
+        # `os.kill` raises OverflowError — not an OSError — past pid_t's range.
+        self.record(f"pid={2**31}\ncwd=/somewhere/acme-worktree\n")
+        description = self.description()
+        self.assertIn(f"names pid {2**31}, which is not running", description)
+        self.assertNotIn("acme-worktree", description)
+
     def test_garbage_lock_file_invents_no_holder(self):
         self.record("\x00\x00 not a lock record at all\npid=not-a-number\n")
         self.assertEqual(
@@ -359,7 +396,7 @@ class WaitReportingTests(unittest.TestCase):
         self.record(f"pid={stale}\ncwd=/somewhere/acme-worktree\n")
         first = self.wait_messages()[0]
         self.assertIn("waiting for the shared build slot", first)
-        self.assertIn("no longer running", first)
+        self.assertIn("is not running", first)
         self.assertNotIn("acme-worktree", first)
 
     def test_heartbeat_rereads_a_holder_that_identifies_itself_late(self):


### PR DESCRIPTION
## What's broken

`scripts/swift-safe` serializes every Swift compile on the machine behind one
lock, so on a box with several active worktrees, waiting for the build slot is
routine. The wait is silent. The waiter prints one line — "another TBD worktree
is compiling; waiting for the shared build slot" — and then says nothing at all
for up to its 30-minute timeout.

Two costs, both observed on a five-worktree machine:

- **A human cannot tell a queued build from a hung one.** No indication of who
  holds the slot, and no indication that time is passing. The only way to tell a
  healthy queue from a wedged compiler was to go digging in `ps`.
- **Automated callers get killed mid-work.** An agent session that emits nothing
  for 600s is terminated by its harness's stall watchdog. Three sessions died
  that way in one afternoon, each losing its in-progress work; the build
  underneath was healthy every time. The silence is what killed them.

That second cost is the motivating one, and it generalizes: any wait longer than
a watchdog window destroys in-progress work, and this lock is the largest single
source of long waits in the repo. A wait that reports itself is not just nicer to
read — it is the difference between queuing and losing the session.

## Why it happens

The information needed was already on disk and simply never read. Before exec'ing
SwiftPM, the lock holder writes its `pid`, `cwd` and `command` into the lock file.
A waiter opens that exact file to take the lock — and never looks at its contents.
`_acquire` set an `announced` flag on the first blocked attempt and used it only to
suppress every subsequent line, so the spin loop ran mute until it either won the
lock or timed out.

## What this PR does

The waiter now reads the record it was already holding open:

- **Names the holder on first blocking** — the worktree by its directory
  basename, the pid, and the command. The basename is what identifies a worktree
  to a person; the full path is noise, and in a public multi-tenant repo it is
  unnecessary detail.
- **Heartbeats every 60s** with elapsed time and a re-read of the holder, so both
  a human and a watchdog see liveness, and a slot that changed hands is reported
  as it now stands rather than as it was.
- **Stays entirely on stderr**, so a caller parsing SwiftPM's stdout sees nothing
  from the wrapper.
- **Never claims a holder it cannot see.** Only newline-terminated lines are
  parsed, so a record caught mid-write (`pid=12` of an eventual `pid=12345`) is
  ignored rather than read as a plausible wrong pid. A recorded pid is reported
  only while that process is alive; a stale record is reported as stale, and a
  non-positive pid is treated as unrecorded rather than probed — `os.kill(0, 0)`
  inspects the waiter's own process group and would always "succeed" — and a pid
  past the platform's `pid_t` is reported as not running rather than crashing the
  waiter, since `os.kill` raises `OverflowError` there and that is not an
  `OSError`. The holder writes its identity *after* acquiring, so "someone holds
  this, and has not said who yet" is a real state and gets its own honest wording.
- **Rejects a wait setting that would disable the wait's own limits.** `float()`
  accepts `"nan"` and `"inf"`, and every comparison against nan is False, so the
  old positivity check passed them through: a nan heartbeat never fires (silent
  wait again) and a nan timeout makes the deadline unreachable, so the wait never
  ends at all. Both settings now require a finite number, checked before the
  positivity test since nan defeats that test. The unbounded-timeout half of this
  predates the PR; it shares the one guard.

The timeout line now carries the holder too, since that is the moment a reader
most wants it.

**Why 60s for the heartbeat.** The floor is the 600s stall watchdog that has been
killing sessions; the ceiling is not wanting to spam a 30-minute wait. 60s clears
the watchdog by 10x — enough margin that several delayed beats on a loaded machine
still cannot trip it — and costs at most 30 lines across the entire timeout. A
typical wait behind one sibling build (1-3 minutes) prints one to three lines.

**The `execv` is untouched.** The lock still rides the process that becomes the
compiler, so a killed wrapper cannot release the slot while leaving an orphaned
compiler alive for the next worktree to overlap.

## Findings for follow-up PRs

**`run` holds the slot for the running program's whole lifetime — latent, not
live.** `COMPILE_SUBCOMMANDS` includes `run`, and because of the `execv`,
`scripts/swift-safe run TBDApp` would hold the machine-global lock until TBDApp
*exits*, blocking every other worktree indefinitely. I verified it is unexercised
rather than merely believed to be: no script, workflow or doc in the repo invokes
`swift-safe run`. `restart.sh` and `mock.sh` build and then launch the built
binary; `test.sh` and the nightly stress harness pass `test`/`build` (its
`run_governed_swift` pass-through has exactly one call site, and it passes
`build --build-tests`). The path is reachable by instruction, though — the
guardrail that blocks raw SwiftPM tells users to run
`scripts/swift-safe <build|test|run> ...` — so this PR adds a stderr warning on
that path rather than leaving the trap unmarked.

I did not fix it here, deliberately. The obvious fix — build, release, then run
the built product — needs the build to happen in a child process so the wrapper
survives to release the lock, and that is precisely the structure the `execv`
exists to avoid. There is a version that preserves the property (fork, let the
child inherit the lock fd so the open file description outlives a killed parent,
then release and exec the product), but it also needs product-path derivation and
`swift run` argument semantics, which is real restructuring of the load-bearing
exec path for a path with no callers today. Worth its own PR with that sketch as
the starting point.

**Lock fairness.** The acquire loop is a 0.25s `LOCK_NB` spin with no queue, so
wake order is arbitrary and a worktree can be starved indefinitely while others
cycle through. Real, and now more visible — the heartbeat will show it happening.
A fix is a behavior change that needs its own design.

**An unrelated test is racy and flaked on this PR's first CI run.**
`theFallbackRemovalArmsItsOwnRaisedTimeout()` in
`Tests/TBDDaemonTests/WorktreeArchiveDeletionQueueTests.swift:118` was the single
real failure in a run reporting 71 issues (70 known). Its control step removes a
throwaway worktree through a `GitManager(subprocessTimeout: .milliseconds(1))`,
expects `GitTimeoutError`, and then asserts the directory **still exists** — on
the reasoning that a killed `git worktree remove` cannot have completed. That
last step is a race rather than a deduction: if git finishes the unlink inside
the 1 ms window before the kill lands, the directory is legitimately gone and the
assertion fails. It fails on a **fast** machine, not a slow one. The test's own
comment says `runBoundedProcess` "makes that discriminating rather than racy",
which holds for *reporting* `.timedOut` (the `#expect(throws:)` above it) but not
for *whether the directory survives* — two different claims. Fixing it means
making the survival assertion deterministic instead of dependent on winning a
race; that belongs in its own change rather than in a build-wrapper PR. The test
dates from #604 and has no quarantine entry, so this looks like its first
recorded flake. It passed on re-run here with no code change.

**The job budget may be obsolete.** `DEFAULT_JOBS = 2` machine-wide dates from
Swift 6.2, whose WMO debug builds hit 6-9 GB RSS per frontend. `Package.swift`
documents that Swift 6.3 fixed this (measured peak 1.35 GB), so the machine may
be sitting idle while everyone queues. That needs measurement, not a guess, and
an evidence-driven PR of its own.

## Assumptions

- A recorded pid that is alive is the holder. A pid recycled between the holder's
  write and the waiter's read would be misreported; the window is small and the
  consequence is a wrong name in a diagnostic line, not a wrong locking decision.
- 600s is the stall-watchdog window worth designing against. If a harness uses a
  materially shorter one, the 10x margin absorbs it down to about 300s; below
  that, `TBD_SWIFT_HEARTBEAT_SECONDS` overrides the cadence.

## Evidence & verification

Repro before the fix: hold the lock from one worktree and start a build in
another — one line, then nothing, for as long as you care to watch.

After, against a real holder in a directory named `acme-worktree`:

```
swift-safe: another TBD worktree is compiling; waiting for the shared build slot (held by worktree acme-worktree, pid 85653 running: swift build --jobs 2)
swift-safe: still waiting for the shared build slot after 60s of 1800s (held by worktree acme-worktree, pid 85653 running: swift build --jobs 2)
```

`scripts/test-swift-safe.py` grows from 12 to 29 tests (5s, no build), covering
the holder being reported when the record is populated, nothing fabricated when
it is empty/missing/truncated/garbage/stale/impossible, the heartbeat cadence,
non-finite settings being rejected before SwiftPM is exec'd, and stdout staying
clean. Cadence is driven by a fake clock that advances only when the code
sleeps, and the end-to-end test compresses the interval via
`TBD_SWIFT_HEARTBEAT_SECONDS`, so no test spends real time waiting. It already
runs in the `plans-guard` CI job, so the new coverage is gated without a workflow
change.

Discriminating evidence — every guard was broken, watched red, and restored:

- Parse half-written lines → the two "partially written" tests fail.
- Report a non-positive recorded pid as a holder → seven tests fail, including
  the empty-file and garbage-file cases, which start claiming "held by pid 0".
- Treat a dead pid as alive → the stale-holder tests fail.
- Print the holder's full `cwd` instead of the basename → four tests fail,
  including the end-to-end path-disclosure assertion.
- Announce once and never heartbeat → the cadence tests and the end-to-end
  heartbeat assertion fail.
- Send the reports to stdout → five tests fail on stdout no longer being
  SwiftPM's alone.
- Cache the holder description instead of re-reading it → the late-identification
  test fails.
- Drop the `run` warning → the two `run` tests fail.
- Fabricate a holder when none is recorded → seven tests fail.
- Never truncate an over-long command → the truncation test fails.
- Let `OverflowError` escape again → the impossible-pid test errors and the
  end-to-end no-traceback test fails.
- Drop the finite check → the non-finite settings test fails on nan and inf for
  both variables.
- Order the finite check after the positivity check → nan is caught by the
  `!= nan` fallback but `inf` still slips through, so the test fails on inf.

Both review findings were reproduced against the real script before being fixed
(traceback and exit 1 for the oversized pid; a nan-timeout waiter still spinning
after 4s when a 0.5s timeout exits at 75), and re-run green after.

Pyright is clean on both files.

