### PR TITLE
Fix file panel toolbar toggle state synchronization

### DIFF
--- a/Sources/TBDApp/ContentView.swift
+++ b/Sources/TBDApp/ContentView.swift
@@ -2,11 +2,16 @@ import AppKit
 import SwiftUI
 import TBDShared
 
+private enum FilePanelStorageKey {
+    static let isVisible = "filePanel.isVisible"
+    static let width = "filePanel.width"
+}
+
 struct ContentView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
-    @AppStorage("filePanel.isVisible") private var showFilePanel = true
-    @AppStorage("filePanel.width") private var filePanelWidth: Double = 280
+    @AppStorage(FilePanelStorageKey.isVisible) private var showFilePanel = true
+    @AppStorage(FilePanelStorageKey.width) private var filePanelWidth: Double = 280
     @AppStorage(AppState.nightwatchExperimentalKey) private var nightwatchExperimental: Bool = false
     // Part of the PR split button's .id key: the baked (non-template) icon
     // colors depend on the appearance, and the materialized-once toolbar item
@@ -56,7 +61,7 @@ struct ContentView: View {
                 SidebarView()
                     .navigationSplitViewColumnWidth(min: 220, ideal: 260, max: 400)
             } detail: {
-                DetailSectionHostPager(showFilePanel: $showFilePanel, filePanelWidth: $filePanelWidth)
+                DetailSectionHostPager()
             }
             .toolbar(removing: .sidebarToggle)
             .toolbar {
@@ -518,7 +523,7 @@ struct ContentView: View {
 /// the `tv.window != nil` guards in `TerminalPanelView`).
 ///
 /// Each tab's content is a small internally-reactive wrapper — it reads
-/// `@EnvironmentObject`/`@Binding` state itself rather than being handed a
+/// `@EnvironmentObject`/`@AppStorage` state itself rather than being handed a
 /// fresh value on every `updateNSViewController` — so its
 /// `NSHostingController` is created exactly once and its `rootView` is
 /// never reassigned: the same "stable identity, reactive interior" shape
@@ -530,9 +535,6 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
         case providerDesk
         case other
     }
-
-    @Binding var showFilePanel: Bool
-    @Binding var filePanelWidth: Double
 
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var appearance: AppearanceSettings
@@ -576,7 +578,7 @@ struct DetailSectionHostPager: NSViewControllerRepresentable {
 
         if !currentIDs.contains(Self.otherTabID) {
             let host = NSHostingController(
-                rootView: OtherSectionContent(showFilePanel: $showFilePanel, filePanelWidth: $filePanelWidth)
+                rootView: OtherSectionContent()
                     .environmentObject(appState)
                     .environmentObject(overlayCoordinator)
             )
@@ -666,8 +668,8 @@ private struct ProviderDeskHostSlot: View {
 /// remote-session branch (now `RemoteSessionHostSlot`'s job) — same
 /// conditions, same order, same views.
 private struct OtherSectionContent: View {
-    @Binding var showFilePanel: Bool
-    @Binding var filePanelWidth: Double
+    @AppStorage(FilePanelStorageKey.isVisible) private var showFilePanel = true
+    @AppStorage(FilePanelStorageKey.width) private var filePanelWidth: Double = 280
 
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var overlayCoordinator: TranscriptOverlayCoordinator
@@ -768,11 +770,10 @@ private struct OtherSectionContent: View {
 /// + the optional file panel, the overlay coordinator's transcript overlay,
 /// and the window-wide click-outside catcher.
 ///
-/// `showFilePanel`/`filePanelWidth` stay `@Binding` (not independent
-/// `@AppStorage` re-declarations of the same keys) — `ContentView`'s
-/// toolbar toggle button needs the SAME state, and threading one `Binding`
-/// through (via `DetailSectionHostPager` → `OtherSectionContent`) avoids two
-/// literal copies of the UserDefaults key strings ever drifting apart.
+/// `showFilePanel`/`filePanelWidth` stay `@Binding`: the stable
+/// `OtherSectionContent` host owns the corresponding `@AppStorage` values and
+/// passes live bindings into this branch. `ContentView` independently observes
+/// the same centralized visibility key for its toolbar action.
 /// `contentAreaHeight` moves in as this view's own `@State` instead: nothing
 /// outside this branch ever read it in `ContentView`.
 private struct WorktreeDetailAreaView: View {


### PR DESCRIPTION
## What's broken

The top-right Changes-panel toolbar button can appear to do nothing even though Command-Shift-E still closes the panel. A pointer click should toggle the same panel state as the keyboard shortcut.

## Why it happens

`DetailSectionHostPager` creates the non-remote detail `NSHostingController` once so terminal views survive navigation. That stable host was initialized with `Binding` values from the surrounding representable, but its root view was intentionally never refreshed. The hosted panel could therefore keep rendering an old visibility value while the toolbar observed and changed the current `@AppStorage` value.

In the failing app, a physical click hit the expected SwiftUI toolbar button and ran its action, changing the current visibility value from `false` to `true`, while the hosted panel was already visibly open. The matching stale value made the click appear ineffective.

## When it broke

Commit `5997faa9` introduced the stable detail-section host while preserving the panel preferences as bindings across that hosting boundary. The recent PR-toolbar restructuring in `fef21eb1` did not change the file-panel button or cause the state divergence.

## What this PR does

- Makes the stable non-remote hosted view observe the file-panel `@AppStorage` preferences directly.
- Keeps the toolbar and hosted panel on independent reactive observers of the same centralized preference keys.
- Preserves the one-time `NSHostingController` creation that keeps terminal views alive.

## Evidence & verification

- Before the fix, live AppKit tracing showed a physical click hitting `SwiftUIAppKitButton` and running the toggle from `false` to `true` while the panel was already visibly open and remained open.
- After the fix, clicking the same top-right toolbar button closed the open Changes panel.
- `scripts/test.sh --filter DetailSectionHostPagerTests` — 8 tests passed in 1 suite.
- `scripts/swift-safe build` — passed (`Build complete!`).
