### PR TITLE
Compound: Teach PR authors to write for cold readers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,11 @@ Summary carrying the motivation. Replace each section's guidance comment with
 prose. Sections whose guidance marks them optional may be deleted outright
 when they don't apply. This repo is public: no org, ticket, or host names —
 see CLAUDE.md.
+
+Write for a cold reader with none of your session's context: establish the
+real-world pathway before the mechanism (who or what triggers this, when, and
+why), and lead with what the diff actually changes — not the investigation
+that motivated it.
 -->
 
 <!-- ═══════════════════════ BUG FIX ═══════════════════════ -->


### PR DESCRIPTION
## Summary

Two recent PRs confused reviewers in mirror-image ways. #621's description led with the profiling investigation ("un-inlined dispatch per character cell"), so a reader expected a render-path diff and instead found a shell script and a warning-banner check. #627 led with the mechanism ("An external Accessibility client can send TBDApp a non-finite window position") without the real-world pathway, drawing a literal "what am I reading here? Why is an external Accessibility client sending TBDApp anything?" from review.

Both are the same failure: the description assumed context that lived only in the author's session. This PR adds one sentence to the PR template's shared preamble telling authors to write for a cold reader — establish who or what triggers the behavior before explaining the mechanism, and lead with what the diff actually changes rather than the investigation that motivated it.

## Why this shape

The template's shared preamble comment is the one spot both variants (bug fix and feature) pass through, so the guidance applies everywhere without duplicating it per section. The existing section comments already push toward plain language ("pragmatics and semantics, minimal syntax and jargon"); what they didn't name was these two ordering failures — pathway before mechanism, change before investigation.

No spec: this is a one-sentence documentation change to an existing template (shipped in #614), not a revision of any system theory.

## What this PR does

- Adds a four-line guidance sentence to the preamble comment of `.github/PULL_REQUEST_TEMPLATE.md`.

## Evidence & verification

Doc-only change; no build or runtime surface. Verified the sentence sits inside the preamble HTML comment, so it renders nowhere — authors see it when editing, readers never do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[🔗 open in tbd](https://cheapsteak.github.io/tbd/open/?worktree=7BC25FA2-5743-41D7-A7A3-38E732E3C211)