### PR TITLE
docs: rewrite draft-safe injection findings around Claude Code's inbox socket

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,11 @@ Summary carrying the motivation. Replace each section's guidance comment with
 prose. Sections whose guidance marks them optional may be deleted outright
 when they don't apply. This repo is public: no org, ticket, or host names —
 see CLAUDE.md.
+
+Write for a cold reader with none of your session's context: establish the
+real-world pathway before the mechanism (who or what triggers this, when, and
+why), and lead with what the diff actually changes — not the investigation
+that motivated it.
 -->
 
 <!-- ═══════════════════════ BUG FIX ═══════════════════════ -->

--- a/docs/research/2026-07-26-claude-code-channels/findings.md
+++ b/docs/research/2026-07-26-claude-code-channels/findings.md
@@ -1,130 +1,322 @@
-# Draft-safe message injection: Claude Code Channels and Codex app-server
+# Draft-safe message injection: the Claude Code inbox socket and Codex app-server
 
 **Status:** Investigated, not implemented
-**Tested:** 2026-07-26 with Claude Code v2.1.220 and Haiku 4.5
+**Claude Code measured:** 2026-08-14 against Claude Code 2.1.233 on macOS 26.1
 **Codex schema inspected:** 2026-07-26 with codex-cli 0.145.0
+
+This directory is named for Claude Code channels; the Claude Code mechanism it
+examines is the per-session inbox socket, which is the surface a script or hook
+posts into.
 
 ## Summary
 
-Claude Code's research-preview Channels interface can deliver an external
-message to a running interactive session without writing into its terminal
-composer. In the interactive test, a channel message started a turn while an
-unsent draft was present, and the draft remained byte-for-byte unchanged after
-the turn.
+Claude Code binds a Unix-domain **inbox socket** for every session with
+cross-session messaging enabled. Anything running as the same OS user can
+connect to it and post a message, and the receiving session enqueues that
+message as a user turn without writing into its terminal composer. It is a
+supported, documented surface: no agent-side MCP server, no startup flag, and
+no per-session consent prompt.
 
-This is a promising mechanism for scheduled TBD messages because it does not
-compete with a person typing in the composer. It is not ready to be treated as a
-general delivery guarantee: custom development channels require startup
-consent, channel notifications have no delivery acknowledgement, and the same
-development-channel mechanism did not work with `claude -p`.
+Draft safety was measured directly. With an unsent draft sitting in the
+composer, an external Python script posted a message to the socket; the message
+was delivered and answered, and the draft was byte-for-byte unchanged
+afterward. This held in both the idle case (the message started a new turn) and
+the mid-turn case (the message was read during a turn already running).
+
+The real constraint is not access, it is the receiver's **inbound gate**. A
+message can be delivered, held for approval, or dropped, depending on the
+receiving session's `crossSessionInbound` setting and — when that is unset — on
+the two sessions' permission-mode classes. A fire-and-exit script on macOS must
+present the session's messaging token, or a bypass-permissions receiver will
+hold its message.
 
 Codex exposes a separate native pathway through its experimental app-server
 protocol. A client can steer an active turn or start a new turn without sending
 terminal input. The protocol shape is documented and present in the installed
 Codex schema, but composer-draft preservation and concurrent-client behavior
-have not yet been tested.
+have not been tested.
 
 Official documentation:
 
-- [Channels](https://code.claude.com/docs/en/channels)
-- [Channels reference](https://code.claude.com/docs/en/channels-reference)
+- [Cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging)
+- [Channels](https://code.claude.com/docs/en/channels) — the separate shipped
+  feature for pushing external events (CI results, chat) into a session
+- [Settings](https://code.claude.com/docs/en/settings) — `crossSessionInbound`,
+  `dialogExpiry`, `isolatePeerMachines`
 - [Codex app-server](https://learn.chatgpt.com/docs/app-server.md)
 - [Codex scheduled tasks](https://learn.chatgpt.com/docs/automations.md)
 
-## Observed facts
+A broader external message-injection API is an open upstream feature request:
+[anthropics/claude-code#53049](https://github.com/anthropics/claude-code/issues/53049).
 
-The test MCP server advertised the experimental channel capability in its
-initialize result:
+## How these findings were established
+
+Three kinds of evidence appear below, and each claim says which one backs it:
+
+- **Measured** — reproduced live against Claude Code 2.1.233 on macOS 26.1, by
+  running a session and probing it.
+- **Read from the 2.1.233 binary** — recovered by inspecting the installed
+  executable. These are implementation details of one version, not a stable
+  contract, and should be rechecked on upgrade.
+- **Documented** — stated by upstream documentation and not independently
+  reproduced here.
+
+## The session registry
+
+**Measured.** Every session writes a `<pid>.json` row under
+`$CLAUDE_CONFIG_DIR/sessions`, defaulting to `~/.claude/sessions`. Across the
+61 rows present on the probe machine, every row carried `pid`, `sessionId`,
+`cwd`, `startedAt`, `procStart`, `version`, `peerProtocol`, `kind`,
+`entrypoint`, `name`, `status`, `statusUpdatedAt` and `updatedAt`; most also
+carried `tmux` (a target pane), `messagingSocketPath` and `nameSource`. Rows
+that carry `bridgeSessionId` are the link to cloud and Remote Control sessions.
+`status` is coarse — `idle`, `busy`, `waiting`, `shell`. **No transcript
+content appears in the registry.**
+
+The registry lives under the config directory, so it **fragments per config
+directory**. Sessions started with different `CLAUDE_CONFIG_DIR` values cannot
+see each other's rows. The socket directory does not fragment; it is per OS
+user.
+
+## The socket
+
+**Read from the 2.1.233 binary.** The socket path is
+`$XDG_RUNTIME_DIR/cc-socks/<pid>.sock`. When `XDG_RUNTIME_DIR` is unset the
+base is `$CLAUDE_CODE_TMPDIR`, falling back to `/tmp`, which is what makes the
+macOS path `/tmp/cc-socks/<pid>.sock`. If that path would exceed 103 bytes —
+the `sun_path` limit — the fallback is `<tmp>/cc-socks-<uid>/<pid>.sock`.
+
+The socket file is created mode 0600, so it is reachable only by the OS user
+that owns the session. The peer key file described below is written mode 0600
+into a mode 0700 directory.
+
+## Environment variables
+
+**Documented, and measured for an interactive session.** Claude Code exports
+two variables into hooks — including `SessionStart` — and into every Bash tool
+call:
+
+- **`CLAUDE_CODE_MESSAGING_SOCKET`** — this session's own socket path.
+- **`CLAUDE_CODE_MESSAGING_TOKEN`** — this session's **child** token.
+
+Each session exports its own pair, never one inherited from a parent. When a
+session starts before the feature flag that turns messaging on has resolved,
+both are exported once the fetch completes, so processes started earlier keep
+seeing them unset. `/status` shows the same path in its `Peer address` row,
+prefixed `uds:`.
+
+## Wire protocol
+
+**Read from the 2.1.233 binary.** The socket speaks newline-delimited JSON. The
+receiver drops the connection if its read buffer passes 1 MiB without a
+newline.
+
+An auth frame, when sent, must be the first line:
 
 ```json
-{
-  "capabilities": {
-    "experimental": {
-      "claude/channel": {}
-    }
-  }
-}
+{"type":"auth","token":"<32 hex characters>"}
 ```
 
-It later emitted this MCP notification:
+A user message:
 
 ```json
-{
-  "jsonrpc": "2.0",
-  "method": "notifications/claude/channel",
-  "params": {
-    "content": "Reply with exactly: CHANNEL_RECEIVED_7c92",
-    "meta": {
-      "kind": "scheduled-test"
-    }
-  }
-}
+{"type":"user","from":"ci","priority":"next",
+ "message":{"role":"user","content":"…"}}
 ```
 
-Claude Code represented the delivered notification to the conversation in a
-channel envelope of this form:
+`message.content` must be a non-empty string; anything else is ignored with a
+warning. Optional fields on the user frame:
 
-```xml
-<channel source="tbd-channel-test" kind="scheduled-test">
-Reply with exactly: CHANNEL_RECEIVED_7c92
-</channel>
+- **`session_id`** — if present and it does not match the receiving session's
+  ID, the message is dropped. This is the guard against a reused pid.
+- **`priority`** — `now`, `next`, or `later`; anything else falls back to
+  `next`.
+- **`msg_id`** — correlates the sender-side delivery receipt described below.
+- **`uuid`** — the queue entry's identifier; one is generated if omitted.
+- **`file_attachments`** — materialized locally before the message is enqueued.
+
+Control frames carry an `action`:
+
+```json
+{"type":"control","action":"rename","name":"…"}
+{"type":"control","action":"peer_message_status",
+ "status":"held|denied|expired|delivered","orig_msg_id":"…"}
 ```
 
-With `/path/to/mcp.json` registering the test server as
-`tbd-channel-test`, the interactive session was started with the development
-channel explicitly enabled:
+`rename` changes the name the session answers to in `ListAgents`.
+`peer_message_status` is the sender-side delivery receipt; a status naming an
+`orig_msg_id` with no outstanding send is discarded.
+
+An injected user message is enqueued with `isMeta: true` and
+`skipSlashCommands: true`, so **a slash command inside an injected message is
+inert** — it arrives as plain text and is never executed. That is a meaningful
+safety property for anything built on this surface.
+
+The CLI logs its own injection recipe at bind time, which is the most direct
+citation for the format:
 
 ```sh
-claude --model haiku \
-  --mcp-config /path/to/mcp.json \
-  --dangerously-load-development-channels server:tbd-channel-test
+[uds-messaging] Inject messages (auth line optional here):
+{ echo '{"type":"auth","token":"'"$CLAUDE_CODE_MESSAGING_TOKEN"'"}';
+  echo '{"type":"user","message":{"role":"user","content":"hello"}}'; } |
+socat - UNIX-CONNECT:/tmp/cc-socks/<pid>.sock
 ```
 
-Development channels prompt for per-session startup consent. After consent,
-Claude Code registered the server's channel handler.
+## Trust classes, and why auth is not a gate
 
-Two interactive cases were exercised:
+**Read from the 2.1.233 binary.** Two 16-byte random tokens exist per session,
+rendered as 32 hex characters:
 
-| Composer state | Result |
-| --- | --- |
-| Empty | The notification immediately started a Haiku 4.5 turn, which returned the requested response. |
-| Unsent draft present | The notification immediately started its own turn. The pre-existing draft remained byte-for-byte unchanged in the composer afterward. |
+- **`peerToken`** — published in
+  `$CLAUDE_CONFIG_DIR/sessions/<pid>.<sha256-of-socket-path>.key`, mode 0600,
+  readable by the OS user. Authenticates as trust class **peer**.
+- **`childToken`** — the `CLAUDE_CODE_MESSAGING_TOKEN` environment variable.
+  Authenticates as trust class **child**.
 
-No terminal input or textbox submission was used to trigger either channel
-turn.
+Whether an auth frame is required at all resolves as `requireAuth ??
+isWindows()`, and cross-session messaging is not offered on native Windows.
+**In practice the auth frame is therefore never mandatory**: it does not gate
+entry to the socket. What it does is establish the sender's trust class, which
+is what the inbound gate then judges.
 
-The custom development channel was also tested in noninteractive print mode:
+## The inbound gate
 
-```sh
-claude -p --model haiku \
-  --mcp-config /path/to/mcp.json \
-  --dangerously-load-development-channels server:tbd-channel-test \
-  "Use Bash to run sleep 7, then finish the original request."
-```
+**Read from the 2.1.233 binary, and consistent with the documentation.**
+Delivery runs through the `crossSessionInbound` setting:
 
-The forced sleep kept the original turn active while the MCP server emitted its
-notification. The server initialized and successfully emitted the notification,
-but Claude Code did not register or consume it. The notification was silently
-dropped, and only the original print-mode turn completed.
+- **`accept`** — deliver the message.
+- **`hold`** — set it aside undelivered, show a notice, and release it only if
+  an `accept` later applies.
+- **`refuse`** — drop it, with no notice to the sender.
 
-## Installed-binary inspection
+When no value applies, Claude Code decides per message from the two sessions'
+permission-mode classes. It groups sessions that bypass permission prompts into
+one class and every other session into the other:
 
-Inspection of the installed Claude Code v2.1.220 executable showed that
-development-channel CLI entries are not applied in noninteractive mode. This
-matches the observed `claude -p` result.
+- **A receiver that prompts for permissions** delivers each message, holding
+  one only when the sender identifies itself as bypassing.
+- **A receiver that bypasses permission prompts** holds each message for
+  approval, delivering one only when the sender also identifies as bypassing.
 
-The ordinary `--channels` parsing path remains present in noninteractive mode.
-That does not establish that an approved plugin channel works with `claude -p`;
-that combination was not tested.
+The gate fails closed: an unrecognized or unreadable permission mode holds.
 
-This section describes v2.1.220 implementation details, not a stable public
-contract. It should be rechecked when upgrading Claude Code.
+Other limits:
+
+- **Held-message expiry** — a held message expires at `dialogExpiry`, one of
+  `60s`, `5m`, `10m` or `never`, defaulting to `5m`. A message held by an
+  explicit `hold` setting does not expire; it waits for an `accept` to apply.
+- **Hold buffer** — at most 100 held messages; past that the oldest is evicted
+  and reported to its sender as expired.
+- **Accepted queue and loop throttling** — *documented, not verified here*:
+  Claude Code rate-limits repeated messages per sender, drops identical repeats
+  arriving within a short window, and caps accepted messages waiting to be read
+  at 50 per session, so a message loop between two sessions stops on its own.
+
+For an unattended `claude -p` worker, set `crossSessionInbound: accept` in its
+`--settings` value.
+
+## Own-child messages and the macOS seam
+
+This is the single most important operational detail for anything TBD would
+build here.
+
+**Documented, and confirmed in the 2.1.233 binary.** When no
+`crossSessionInbound` value applies, a message Claude Code verifies came from
+its own child process — a hook or a Bash command posting back to its own
+session's socket — is delivered. Verification has a platform seam:
+
+- **On Linux, including WSL 2**, process evidence survives the poster exiting,
+  so a fire-and-exit script still verifies.
+- **On macOS**, process evidence holds only while the posting process is still
+  alive.
+- **In a container where Claude Code runs as process ID 1**, there is no
+  process evidence at all.
+
+Where process evidence is missing, the `CLAUDE_CODE_MESSAGING_TOKEN` auth frame
+is what verifies the child. **A fire-and-exit script on macOS must therefore
+present the token**, or it is treated as asserting no permission class — which
+a bypass-permissions receiver holds for approval.
+
+## Availability
+
+**Documented.** Cross-session messaging requires Claude Code v2.1.224 or later.
+It runs on macOS and Linux including WSL 2, and is not offered on native
+Windows. It is not available on Amazon Bedrock, Claude Platform on AWS, Google
+Cloud's Agent Platform, or Microsoft Foundry. It stays off entirely when
+feature-flag evaluation is disabled by any of
+`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, `DO_NOT_TRACK`
+or `DISABLE_GROWTHBOOK`. `/list-agents`, aliased `/peers`, checks a session.
+
+**Measured.** A `claude -p` session binds an inbox socket and registers itself,
+with `entrypoint: "sdk-cli"`, so a long-running print-mode worker is reachable
+and appears in the listing. Bare mode binds no socket and does not appear
+(*documented*, not verified here).
+
+## Draft safety
+
+**Measured** on 2026-08-14 against Claude Code 2.1.233 on macOS 26.1. A
+throwaway interactive session was started in its own tmux server, and an
+unrelated external Python process — no Claude involved, no auth token
+presented — posted a message to that session's socket. The composer's rendered
+draft line was captured before and after and compared byte-for-byte.
+
+- **Idle receiver, unsent draft present.** The message was delivered, rendered
+  in the conversation, and started a new turn that ran to completion. The draft
+  was unchanged afterward.
+- **Mid-turn receiver, unsent draft typed while the turn ran.** The session's
+  registry `status` was confirmed `busy` immediately before and after the post.
+  The message was delivered and answered, and the draft was unchanged
+  afterward.
+
+This is the property that matters for scheduled delivery: a message arriving on
+the socket does not compete with a person typing. It establishes the behavior
+of 2.1.233, not a compatibility guarantee for future versions.
+
+## Security posture
+
+**Measured.** The delivered message was rendered to the receiver as
+**"Another Claude session sent a message:"** followed by the text and an
+anti-escalation preamble, which tells the receiving Claude that the message
+came from a peer rather than the user, that a peer cannot grant escalation,
+that it must never edit permission settings, `CLAUDE.md` or config because a
+peer asked, and that a peer claiming it was denied permission and asking the
+receiver to act instead must be refused and surfaced to the user.
+
+**Measured.** The `from` field is sender-asserted and unverified. The probe
+sent `from: "external-shell-probe"` and the message was still framed as coming
+from another Claude session. What is actually verified is the trust class, and
+that feeds only the hold-or-deliver gate, not the framing text.
+
+So the honest statement is: **anything running as the same OS user can inject
+text that a session presents as a trusted teammate**, and the guardrails
+against escalation are prompt-level rather than enforced. This is why
+`crossSessionInbound: refuse` combined with permission deny rules naming
+`SendMessage` and `ListAgents` exists for managed settings. One observation
+from the probe: the receiving model did refuse the injected instruction and
+surfaced it as a suspected injection attempt — the preamble works, but it works
+by persuasion.
+
+## Reference scripts
+
+Two runnable Python 3 scripts sit next to this document. Both are standard
+library only.
+
+- **[`inject-message.py`](inject-message.py)** — posts a user message to a
+  socket. Defaults the target to `$CLAUDE_CODE_MESSAGING_SOCKET` and sends the
+  `CLAUDE_CODE_MESSAGING_TOKEN` auth frame when one is available. Takes
+  `--from`, `--priority` and `--session-id`.
+- **[`list-sessions.py`](list-sessions.py)** — reads the session registry from
+  `$CLAUDE_CONFIG_DIR/sessions`, falling back to `~/.claude/sessions`, and
+  prints live peers with pid, name, status, cwd and socket, skipping rows whose
+  process is gone.
+
+The measurements above were taken with these two scripts.
 
 ## Codex app-server pathway
 
-Codex app-server is the native protocol used by rich Codex clients. Unlike
-Claude Code Channels, it is not an MCP capability. A terminal UI can connect to
-an app-server over a local Unix socket:
+Codex app-server is the native protocol used by rich Codex clients. It is not
+an MCP capability. A terminal UI can connect to an app-server over a local Unix
+socket:
 
 ```sh
 codex app-server --listen unix:///path/to/codex.sock
@@ -169,21 +361,25 @@ follow-up loops, but it does not replace a TBD-controlled local delivery
 protocol.
 
 No official Codex documentation describes an MCP server pushing unsolicited
-channel messages into a Codex conversation. App-server is therefore the
-narrowest documented integration point for TBD.
+messages into a Codex conversation. App-server is therefore the narrowest
+documented integration point for TBD.
 
 ## Unknowns and limitations
 
-- Channels are a research-preview Claude Code feature.
-- Custom development channels need explicit consent each time the session
-  starts.
-- A channel notification has no delivery acknowledgement. Successful emission
-  by the MCP server does not prove that Claude Code consumed it.
-- Approved plugin channels with `claude -p --channels ...` remain unverified.
-- Reconnect, session restart, burst ordering, backpressure, and failure recovery
-  were not tested.
-- The interactive tests establish composer preservation for v2.1.220; they do
-  not establish a compatibility guarantee for future versions.
+- Draft preservation is established for Claude Code 2.1.233 on macOS. It is not
+  a compatibility guarantee for future versions, and it was not re-measured on
+  Linux.
+- The own-child macOS seam — that a fire-and-exit poster needs the token — was
+  not reproduced against a bypass-permissions receiver; it rests on the
+  documentation and on the binary's verification logic.
+- The documented loop throttles (per-sender rate limiting, identical-repeat
+  suppression, the 50-message accepted queue cap) were not reproduced.
+- Reconnect, session restart, burst ordering, backpressure, and failure
+  recovery were not tested.
+- The registry's `status` field is coarse and its freshness was not
+  characterized; it is not a substitute for a liveness signal TBD owns.
+- Everything read from the 2.1.233 binary describes one version's
+  implementation, not a stable public contract.
 - Codex app-server is experimental.
 - The Codex pathway has not been exercised with an unsent terminal composer
   draft. Because it bypasses terminal input, draft preservation is plausible,
@@ -193,28 +389,41 @@ narrowest documented integration point for TBD.
 
 ## Implication for TBD
 
-If TBD pursues scheduled, draft-safe messages, the narrowest design is a small
-MCP channel adapter associated with each Claude session:
+If TBD pursues scheduled, draft-safe messages to Claude Code sessions, the
+narrowest design needs nothing inside the agent at all:
 
 ```text
 TBD scheduler
     -> tbdd
-    -> terminal-specific local socket
-    -> MCP channel adapter launched with Claude
-    -> notifications/claude/channel
+    -> read $CLAUDE_CONFIG_DIR/sessions/<pid>.json for the session
+    -> connect to /tmp/cc-socks/<pid>.sock
+    -> {"type":"auth",…} then {"type":"user",…}
     -> Claude Code conversation queue
 ```
 
-TBD already supplies `TBD_TERMINAL_ID` to spawned sessions. The adapter can use
-that value to bind its MCP process to the correct daemon socket and terminal,
-without inferring identity from terminal content. `terminal.send` should remain
-the mechanism for intentional terminal input; Channels would be a distinct
-out-of-band path for messages that must not disturb the composer.
+Three consequences follow for TBD specifically:
 
-Because notifications are not acknowledged, TBD should not report delivery
-merely because it wrote the MCP notification. A first implementation should
-either describe delivery as best-effort or add a separate acknowledgement
-protocol, with bounded retention and deduplication in the daemon.
+- **Session identification is a lookup, not an inference.** The registry row
+  carries `sessionId`, `cwd` and the tmux target pane, so TBD can match a
+  session to a worktree without reading terminal content. Sending `session_id`
+  on the user frame makes a reused pid a dropped message rather than a
+  misdelivered one.
+- **The registry fragments per profile.** TBD gives each model profile its own
+  `CLAUDE_CONFIG_DIR`, so the daemon must look under the profile the session
+  was spawned with, not under `~/.claude`. The socket directory is per OS user
+  and does not fragment.
+- **Delivery is gated at the receiver, so it must be arranged at spawn.** A
+  fleet session running in bypass-permissions mode holds an unauthenticated
+  message. TBD would need to pass `crossSessionInbound: accept` in the
+  session's settings, present the child token, or accept that delivery depends
+  on the receiver's mode. Writing the frames is not evidence of delivery;
+  `peer_message_status` is the receipt, and a first implementation should
+  describe delivery as best-effort with bounded retention and deduplication in
+  the daemon until it consumes that receipt.
+
+`terminal.send` should remain the mechanism for intentional terminal input; the
+inbox socket would be a distinct out-of-band path for messages that must not
+disturb the composer.
 
 For Codex, the corresponding candidate path is:
 
@@ -226,36 +435,57 @@ TBD scheduler
     -> Codex conversation
 ```
 
-This path has stronger protocol feedback than Claude Code Channels:
-`turn/steer` returns the accepted turn ID, rejects a stale `expectedTurnId`, and
-the server reports turn completion. TBD would still need bounded retention,
+This path has stronger protocol feedback than a single socket write:
+`turn/steer` returns the accepted turn ID, rejects a stale `expectedTurnId`,
+and the server reports turn completion. TBD would still need bounded retention,
 deduplication, and a policy for non-steerable turns.
 
 ## Constraint tension
 
-This design is in tension with
-[`recipe/constraints/no-agent-cooperation.md`](../../../recipe/constraints/no-agent-cooperation.md),
-which says TBD should not require agent-side integrations or changes to agent
-configuration. A development Channel requires both an MCP integration and a
-Claude startup flag/consent flow.
+[`recipe/constraints/no-agent-cooperation.md`](../../../recipe/constraints/no-agent-cooperation.md)
+says TBD should not require agent-side integrations or changes to agent
+configuration: agents are unmodified Claude Code sessions.
 
-There is no decision yet about changing that constraint. Plausible boundaries
-for later design work include making Channels an optional capability, limiting
-them to user-configured scheduled messaging, or packaging an approved plugin
-channel if its noninteractive and consent behavior is acceptable. Any of these
-would need an explicit product decision before implementation.
+The Claude Code inbox socket sits almost entirely inside that constraint. Every
+eligible session binds it automatically and registers itself on disk; there is
+no MCP server to install, no startup flag, and no consent prompt. Reading the
+registry and writing to the socket are host-side actions against a session that
+knows nothing about TBD.
+
+What remains is narrower, and it is a capability question rather than a
+cooperation one:
+
+- **Reliable delivery to a bypass-permissions session needs a settings value.**
+  Setting `crossSessionInbound: accept` at spawn is a change to the session's
+  configuration, even though TBD makes it through a launch flag it already
+  controls rather than through anything the user installs.
+- **The capability must be detected, not assumed.** Version, platform,
+  provider, and the telemetry environment variables all decide whether a
+  session binds a socket at all, so TBD has to treat reachability as a
+  per-session fact with a fallback, not as a property of Claude Code.
+
+The Codex app-server path carries the heavier tension: it is a host integration
+rather than an agent-side plugin, but adopting it would change how TBD launches
+and owns Codex sessions.
 
 ## Recommendation
 
-Treat Channels as a validated interactive prototype, not yet as core
-infrastructure. The next investigation should verify an approved Claude plugin
-channel and run the same empty-composer and dirty-composer tests against a
-remote Codex TUI plus app-server client. It should also test multiple clients,
-reconnect behavior, and non-steerable-turn recovery before either pathway is
-used for delivery.
+The Claude Code inbox socket is ready to be designed against as the draft-safe
+delivery path, with reachability treated as a per-session fact and delivery
+reported as best-effort until the `peer_message_status` receipt is consumed.
 
-Decide separately whether an optional Claude agent integration is compatible
-with TBD's no-cooperation constraint. Codex app-server is a host integration
-rather than an agent-side MCP plugin, but it would change how TBD launches and
-owns Codex sessions. Keep scheduled delivery out of `terminal.send`: terminal
-input cannot provide the draft-preservation property demonstrated here.
+The next investigations, in order of value:
+
+1. Reproduce the own-child macOS seam against a bypass-permissions receiver,
+   with and without the token, so the spawn-time requirement is measured rather
+   than inferred.
+2. Re-measure draft safety on Linux and on the next Claude Code minor version,
+   to learn how stable the property is.
+3. Exercise the documented loop throttles, and burst and reconnect behavior,
+   before anything unattended writes to a socket on a schedule.
+4. Run the same empty-composer and dirty-composer tests against a remote Codex
+   TUI plus app-server client, and test multiple clients, reconnect behavior,
+   and non-steerable-turn recovery.
+
+Keep scheduled delivery out of `terminal.send`: terminal input cannot provide
+the draft-preservation property demonstrated here.

--- a/docs/research/2026-07-26-claude-code-channels/findings.md
+++ b/docs/research/2026-07-26-claude-code-channels/findings.md
@@ -12,8 +12,8 @@ posts into.
 
 Claude Code binds a Unix-domain **inbox socket** for every session with
 cross-session messaging enabled. Anything running as the same OS user can
-connect to it and post a message, and the receiving session enqueues that
-message as a user turn without writing into its terminal composer. It is a
+connect to it and post a message, and a message the receiving session accepts
+is enqueued as a user turn without writing into its terminal composer. It is a
 supported, documented surface: no agent-side MCP server, no startup flag, and
 no per-session consent prompt.
 
@@ -26,9 +26,10 @@ the mid-turn case (the message was read during a turn already running).
 The real constraint is not access, it is the receiver's **inbound gate**. A
 message can be delivered, held for approval, or dropped, depending on the
 receiving session's `crossSessionInbound` setting and — when that is unset — on
-the two sessions' permission-mode classes. A fire-and-exit script on macOS must
-present the session's messaging token, or a bypass-permissions receiver will
-hold its message.
+the two sessions' permission-mode classes. Upstream documents one consequence
+that matters most here: a fire-and-exit script on macOS must present the
+session's messaging token, or a bypass-permissions receiver will hold its
+message.
 
 Codex exposes a separate native pathway through its experimental app-server
 protocol. A client can steer an active turn or start a new turn without sending
@@ -51,7 +52,8 @@ A broader external message-injection API is an open upstream feature request:
 
 ## How these findings were established
 
-Three kinds of evidence appear below, and each claim says which one backs it:
+Three kinds of evidence back the Claude Code sections, and each section says
+which ones it rests on. A section citing two has both:
 
 - **Measured** — reproduced live against Claude Code 2.1.233 on macOS 26.1, by
   running a session and probing it.
@@ -61,10 +63,16 @@ Three kinds of evidence appear below, and each claim says which one backs it:
 - **Documented** — stated by upstream documentation and not independently
   reproduced here.
 
+The Codex app-server section rests on a different and older basis: the
+generated experimental schema shipped with codex-cli 0.145.0, read on
+2026-07-26, plus upstream Codex documentation. Nothing in it was measured
+against a running Codex session.
+
 ## The session registry
 
-**Measured.** Every session writes a `<pid>.json` row under
-`$CLAUDE_CONFIG_DIR/sessions`, defaulting to `~/.claude/sessions`. Across the
+**Measured.** Every session that binds an inbox socket also writes a
+`<pid>.json` row under `$CLAUDE_CONFIG_DIR/sessions`, defaulting to
+`~/.claude/sessions`. Across the
 61 rows present on the probe machine, every row carried `pid`, `sessionId`,
 `cwd`, `startedAt`, `procStart`, `version`, `peerProtocol`, `kind`,
 `entrypoint`, `name`, `status`, `statusUpdatedAt` and `updatedAt`; most also
@@ -220,7 +228,7 @@ For an unattended `claude -p` worker, set `crossSessionInbound: accept` in its
 This is the single most important operational detail for anything TBD would
 build here.
 
-**Documented, and confirmed in the 2.1.233 binary.** When no
+**Documented, and matched by the 2.1.233 binary's verification logic.** When no
 `crossSessionInbound` value applies, a message Claude Code verifies came from
 its own child process — a hook or a Bash command posting back to its own
 session's socket — is delivered. Verification has a platform seam:
@@ -236,6 +244,12 @@ Where process evidence is missing, the `CLAUDE_CODE_MESSAGING_TOKEN` auth frame
 is what verifies the child. **A fire-and-exit script on macOS must therefore
 present the token**, or it is treated as asserting no permission class — which
 a bypass-permissions receiver holds for approval.
+
+*Documented.* One prerequisite sits underneath all of this: a Bash command
+running inside Claude Code's sandbox reaches the socket only if the sandbox's
+Unix-socket settings, `sandbox.network.allowAllUnixSockets` and
+`sandbox.network.allowUnixSockets`, permit it. That constrains the hook and
+Bash-command path, not a host-side process posting from outside the session.
 
 ## Availability
 

--- a/docs/research/2026-07-26-claude-code-channels/inject-message.py
+++ b/docs/research/2026-07-26-claude-code-channels/inject-message.py
@@ -83,7 +83,14 @@ def main() -> int:
             "inside a session with cross-session messaging)."
         )
 
-    text = sys.stdin.read() if args.message == "-" else args.message
+    if args.message == "-":
+        # Drop one trailing newline so `echo text | …` and `printf text | …`
+        # put the same content on the wire.
+        text = sys.stdin.read()
+        if text.endswith("\n"):
+            text = text[:-1]
+    else:
+        text = args.message
     if not text:
         fail("empty message; the receiver ignores a message with no content.")
 

--- a/docs/research/2026-07-26-claude-code-channels/inject-message.py
+++ b/docs/research/2026-07-26-claude-code-channels/inject-message.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Post a user message into a running Claude Code session's inbox socket.
+
+Usage:
+    inject-message.py "text"                          # post to this session
+    inject-message.py --socket /tmp/cc-socks/PID.sock "text"
+    printf 'text' | inject-message.py --socket /tmp/cc-socks/PID.sock -
+
+The target socket defaults to $CLAUDE_CODE_MESSAGING_SOCKET and the auth frame
+to $CLAUDE_CODE_MESSAGING_TOKEN. Both are exported into hooks and Bash tool
+calls by the session that owns them. The auth frame is sent only when a token
+is available; it does not gate entry to the socket, it establishes the sender's
+trust class, which is what the receiver's inbound gate judges. A script that
+posts to its own session's socket and then exits should present the token on
+macOS, where process evidence of the sender disappears with the process.
+
+Whether the receiving session delivers, holds, or drops the message is decided
+there, by its `crossSessionInbound` setting or, when that is unset, by the two
+sessions' permission-mode classes. A zero exit means the frames were written,
+not that Claude read them.
+
+Python 3 standard library only.
+"""
+
+import argparse
+import json
+import os
+import socket
+import sys
+from typing import NoReturn
+
+MAX_FRAME_BYTES = 1024 * 1024  # the receiver drops the connection past this
+
+
+def fail(message: str, code: int = 2) -> NoReturn:
+    print(f"inject-message: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Post a user message into a Claude Code session's inbox socket.",
+        epilog="Pass - as the message to read it from stdin.",
+    )
+    parser.add_argument("message", help="message text, or - to read stdin")
+    parser.add_argument(
+        "--socket",
+        default=os.environ.get("CLAUDE_CODE_MESSAGING_SOCKET"),
+        help="target socket path (default: $CLAUDE_CODE_MESSAGING_SOCKET)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("CLAUDE_CODE_MESSAGING_TOKEN"),
+        help="auth token (default: $CLAUDE_CODE_MESSAGING_TOKEN)",
+    )
+    parser.add_argument(
+        "--from",
+        dest="sender",
+        default="script",
+        help="sender label shown to the receiver; asserted, not verified",
+    )
+    parser.add_argument(
+        "--priority",
+        choices=("now", "next", "later"),
+        default="next",
+        help="queue priority (default: next)",
+    )
+    parser.add_argument(
+        "--session-id",
+        help="drop the message unless the receiver has this session ID; "
+        "guards against a reused pid",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.socket:
+        fail(
+            "no target socket. Pass --socket, or run where "
+            "CLAUDE_CODE_MESSAGING_SOCKET is set (a hook or a Bash tool call "
+            "inside a session with cross-session messaging)."
+        )
+
+    text = sys.stdin.read() if args.message == "-" else args.message
+    if not text:
+        fail("empty message; the receiver ignores a message with no content.")
+
+    frames = []
+    if args.token:
+        frames.append({"type": "auth", "token": args.token})
+    user_frame = {
+        "type": "user",
+        "from": args.sender,
+        "priority": args.priority,
+        "message": {"role": "user", "content": text},
+    }
+    if args.session_id:
+        user_frame["session_id"] = args.session_id
+    frames.append(user_frame)
+
+    payload = b"".join(
+        json.dumps(frame).encode("utf-8") + b"\n" for frame in frames
+    )
+    for line in payload.split(b"\n"):
+        if len(line) + 1 > MAX_FRAME_BYTES:
+            fail(
+                f"frame is {len(line)} bytes; the receiver drops any connection "
+                f"whose line exceeds {MAX_FRAME_BYTES} bytes."
+            )
+
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.connect(args.socket)
+            sock.sendall(payload)
+    except FileNotFoundError:
+        fail(
+            f"no socket at {args.socket}. The session may have exited, or it "
+            "may be one that binds no socket (bare mode)."
+        )
+    except ConnectionRefusedError:
+        fail(
+            f"connection refused at {args.socket}. The socket file is stale — "
+            "its session is gone."
+        )
+    except PermissionError:
+        fail(
+            f"permission denied on {args.socket}. Sockets are mode 0600 and "
+            "restricted to the OS user that owns the session."
+        )
+    except OSError as error:
+        fail(f"could not write to {args.socket}: {error}")
+
+    print(f"posted {len(payload)} bytes to {args.socket}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/research/2026-07-26-claude-code-channels/list-sessions.py
+++ b/docs/research/2026-07-26-claude-code-channels/list-sessions.py
@@ -16,6 +16,13 @@ directory: a session started with a different `CLAUDE_CONFIG_DIR` writes its
 row somewhere this script will not look unless you point `--registry` there.
 The socket directory does not fragment — it is per OS user.
 
+Liveness here is only "a process with that pid exists". A row whose session
+died can be resurrected by an unrelated process inheriting its pid, so treat a
+listed socket as a candidate rather than a confirmed target. The row's
+`procStart` is the discriminator if you need to be sure, and posting a message
+with the row's `sessionId` as the frame's `session_id` makes the receiver drop
+a misaddressed message rather than act on it.
+
 Python 3 standard library only.
 """
 
@@ -36,6 +43,10 @@ def registry_dir(override: Optional[str]) -> Path:
 
 
 def process_alive(pid: int) -> bool:
+    # pid 0 would signal the caller's whole process group, and bool is an int
+    # subclass, so both are rejected before os.kill sees them.
+    if isinstance(pid, bool) or pid <= 0:
+        return False
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -51,8 +62,10 @@ def read_rows(directory: Path) -> list:
     rows = []
     for path in sorted(directory.glob("*.json")):
         try:
-            row = json.loads(path.read_text())
+            row = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
+            continue
+        if not isinstance(row, dict):
             continue
         pid = row.get("pid")
         if not isinstance(pid, int) or not process_alive(pid):

--- a/docs/research/2026-07-26-claude-code-channels/list-sessions.py
+++ b/docs/research/2026-07-26-claude-code-channels/list-sessions.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""List live Claude Code sessions from the on-disk session registry.
+
+Usage:
+    list-sessions.py
+    list-sessions.py --json
+    list-sessions.py --registry /path/to/config/sessions
+
+Each session writes a `<pid>.json` row under `$CLAUDE_CONFIG_DIR/sessions`
+(`~/.claude/sessions` when that variable is unset) describing itself: pid,
+session ID, cwd, version, name, coarse status, and the path of its inbox
+socket. Rows whose process is gone are stale; this script skips them.
+
+The registry lives under the config directory, so it fragments per config
+directory: a session started with a different `CLAUDE_CONFIG_DIR` writes its
+row somewhere this script will not look unless you point `--registry` there.
+The socket directory does not fragment — it is per OS user.
+
+Python 3 standard library only.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def registry_dir(override: Optional[str]) -> Path:
+    if override:
+        return Path(override).expanduser()
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    base = Path(config_dir).expanduser() if config_dir else Path.home() / ".claude"
+    return base / "sessions"
+
+
+def process_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by another user
+    except OSError:
+        return False
+    return True
+
+
+def read_rows(directory: Path) -> list:
+    rows = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            row = json.loads(path.read_text())
+        except (OSError, ValueError):
+            continue
+        pid = row.get("pid")
+        if not isinstance(pid, int) or not process_alive(pid):
+            continue
+        rows.append(row)
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="List live Claude Code sessions and their inbox sockets."
+    )
+    parser.add_argument(
+        "--registry",
+        help="registry directory (default: $CLAUDE_CONFIG_DIR/sessions, "
+        "else ~/.claude/sessions)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit the raw rows as a JSON array"
+    )
+    args = parser.parse_args()
+
+    directory = registry_dir(args.registry)
+    if not directory.is_dir():
+        print(
+            f"list-sessions: no registry at {directory}. Set CLAUDE_CONFIG_DIR "
+            "or pass --registry.",
+            file=sys.stderr,
+        )
+        return 2
+
+    rows = read_rows(directory)
+
+    if args.json:
+        json.dump(rows, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+
+    if not rows:
+        print(f"No live sessions in {directory}.")
+        return 0
+
+    for row in sorted(rows, key=lambda r: r["pid"]):
+        socket_path = row.get("messagingSocketPath") or "(no socket)"
+        print(f'{row["pid"]}  {row.get("name", "?")}  [{row.get("status", "?")}]')
+        print(f'    cwd:    {row.get("cwd", "?")}')
+        print(f"    socket: {socket_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/research/2026-07-31-codex-session-import/findings.md
+++ b/docs/research/2026-07-31-codex-session-import/findings.md
@@ -27,7 +27,7 @@ entire client path landed upstream between plugin 1.0.4 and 1.0.6.
 
 Bare `codex app-server` speaks newline-delimited JSON-RPC on stdio. (A socket form,
 `codex app-server --listen unix://…`, is documented in
-[the channels findings](../2026-07-26-claude-code-channels/findings.md).)
+[the message-injection findings](../2026-07-26-claude-code-channels/findings.md).)
 
 ```jsonc
 >> {"jsonrpc":"2.0","id":1,"method":"initialize",

--- a/docs/specs/2026-07-26-fleet-supervision-design.md
+++ b/docs/specs/2026-07-26-fleet-supervision-design.md
@@ -2680,12 +2680,15 @@ the same source-and-freshness treatment as any other fact.
 today.** This is the parity choice, and for much of the fleet it is
 permanent: older agent versions and future agent kinds may never offer a
 message channel, so typing is the floor that delivery stands on when nothing
-better exists. Claude Code's research-preview Channels interface was
-validated as a prototype
+better exists. Claude Code's per-session inbox socket was validated as a
+draft-safe path
 (`docs/research/2026-07-26-claude-code-channels/findings.md`, landed on
-`main` separately): it delivers a message without touching the composer, but
-it needs agent-side setup and an interactive consent prompt at session
-start, so it cannot be assumed for fleet sessions.
+`main` separately): it delivers a message without touching the composer and
+needs no agent-side setup, but it exists only on recent Claude Code versions
+on supported platforms, and whether a message is delivered or held is decided
+by the receiving session's inbound settings. Reachability is therefore a
+per-session fact to be measured, not something fleet sessions can be assumed
+to have.
 
 Typing carries one known risk, and this design names it rather than waving
 it off. If a human has typed something into an agent's composer and not yet

--- a/docs/submit-reliability.md
+++ b/docs/submit-reliability.md
@@ -30,8 +30,9 @@ multi-line messages. Optionally layer a verify-and-retry step so the unattended
 
 For messages that must arrive without touching a user's in-progress composer,
 `terminal.send` is the wrong abstraction even when submission is reliable.
-Interactive Claude Code Channels preserved an unsent draft during testing; see
-[Claude Code Channels: draft-safe message injection](research/2026-07-26-claude-code-channels/findings.md).
+A message posted to a Claude Code session's inbox socket preserved an unsent
+draft byte-for-byte in testing; see
+[draft-safe message injection: the Claude Code inbox socket and Codex app-server](research/2026-07-26-claude-code-channels/findings.md).
 
 ## The mechanism (current code)
 


### PR DESCRIPTION
## Summary

TBD sometimes needs to get a message into a running agent session — a scheduled
nudge, a supervision message, a "the thing you were blocked on just landed".
Today the only mechanism is `terminal.send`, which types into the agent's
terminal. That carries a real hazard: if a human has typed something into the
composer and not yet pressed enter, a paste-and-submit delivery ships the
human's unsent words along with ours, as one message apparently from them.

`docs/research/2026-07-26-claude-code-channels/findings.md` is the document
that exists to answer whether a draft-safe alternative is available. Claude
Code now binds a per-session Unix-domain inbox socket that any process running
as the same OS user can post to, and upstream documents posting to it from a
script or hook. This PR rewrites the Claude Code half of that document around
that socket, measured against Claude Code 2.1.233 on macOS 26.1, and adds two
runnable reference scripts so the next person can reproduce the measurements
in a minute rather than a morning.

The headline result: **draft safety is measured, not assumed.** With an unsent
draft sitting in the composer, an unrelated external process posted a message
to the session's socket. The message was delivered and answered, and the draft
was byte-for-byte unchanged — in both the idle case (the message started a new
turn) and the mid-turn case (it was read during a turn already running).

## Why this shape

This is a documentation change to a research findings document, so it needs no
design spec and did not run `/tbd-brainstorming`. It records what a mechanism
does; it does not revise TBD's theory of anything or add behavior. Any TBD
feature built on these findings would need its own spec.

Two shaping decisions worth naming:

- **Every claim is labeled by evidence class** — "Measured", "Read from the
  2.1.233 binary", or "Documented". The three are not equally durable: a
  measurement is a fact about this version, a binary reading is an
  implementation detail that can change on upgrade, and a documented claim is
  upstream's word that we did not independently reproduce. Collapsing them
  would make the document read more confidently than the evidence supports,
  which is the failure mode a findings doc most needs to avoid.
- **The file and directory keep their existing paths.** Several documents link
  to `docs/research/2026-07-26-claude-code-channels/findings.md`, including a
  permalink in the fleet-supervision requirements pinned to a specific commit
  SHA that is deliberately immutable. Renaming for tidiness would break live
  links for no benefit, so the directory name stays and one short orientation
  sentence covers the mismatch.

## What this PR does

- Rewrites `docs/research/2026-07-26-claude-code-channels/findings.md` around
  the inbox socket: session registry layout and its per-config-directory
  fragmentation, socket path and fallback, the two exported environment
  variables, the newline-delimited JSON wire protocol, the two trust classes
  and why the auth frame is not an access gate, the receiver-side inbound gate,
  the macOS own-child seam, availability, draft safety, and security posture.
- Replaces the old prose table with lists, per the repo's no-prose-tables rule.
- Adds `inject-message.py` and `list-sessions.py` next to the findings —
  Python 3 standard library only, executable, with usage comments and readable
  failure messages instead of tracebacks.
- Re-evaluates the "Constraint tension" section against
  `recipe/constraints/no-agent-cooperation.md`. The socket needs no agent-side
  MCP server, no startup flag, and no consent prompt, so most of the tension
  the Claude Code path used to carry is gone; what remains is narrower and is
  stated as such. The Codex app-server tension does remain and is kept.
- Keeps the Codex app-server section intact — `turn/steer` / `turn/start` /
  `turn/completed`, the `activeTurnNotSteerable` caveat, and the Codex unknowns
  are all still accurate.
- Corrects three inbound references whose link text or surrounding sentence
  described the older mechanism: `docs/submit-reliability.md`,
  `docs/research/2026-07-31-codex-session-import/findings.md`, and the delivery
  adapters section of `docs/specs/2026-07-26-fleet-supervision-design.md`,
  which claimed the Claude Code path needs agent-side setup and a startup
  consent prompt. The pinned permalink in
  `docs/specs/2026-07-26-fleet-supervision-requirements.md` is untouched.

## Follow-up this PR deliberately does not do

The "Desks alone: channel-first" subsection of
`docs/specs/2026-07-26-fleet-supervision-design.md` still designs desk delivery
around the superseded development-channels mechanism — a channel-envelope
handshake, a consent-prompt problem, and a list of options for working around
that prompt. The socket has no consent prompt, so that subsection needs
rethinking rather than a find-and-replace, and choosing the new desk handshake
is a design call for a human. Left standing and named here rather than changed
quietly.

For the same reason, `docs/specs/2026-07-26-fleet-supervision-requirements.md`
around line 538 is untouched: its description of the old mechanism is attached
to a permalink pinned to commit `b0e3ab35`, and the pin exists so the prose and
the cited content agree. Rewriting one without the other would break that.

## Assumptions

- The socket, wire protocol, and gate internals were read out of the Claude
  Code 2.1.233 executable. They are one version's implementation, not a
  published contract, and the document says so. If Claude Code changes them,
  the sections labeled "Read from the 2.1.233 binary" go stale first.
- Draft preservation was measured on macOS only. The document does not claim it
  for Linux.

## Evidence & verification

Measured live against Claude Code 2.1.233 on macOS 26.1, using the two scripts
this PR adds:

- **Draft safety, idle receiver.** A throwaway interactive session was started
  in its own tmux server with an unsent draft in the composer. An external
  Python process — no Claude involved, no auth token — posted a message to its
  socket. The message was delivered, rendered in the conversation, and started
  a turn that ran to completion. The composer's draft line was captured before
  and after and compared: identical.
- **Draft safety, mid-turn receiver.** The same, with the draft typed while a
  turn was already running. The session's registry `status` was confirmed
  `busy` immediately before and after the post. The message was delivered and
  answered, and the draft line was again identical.
- **`from` is unverified.** The probe sent `from: "external-shell-probe"` and
  the receiver still framed the message as coming from another Claude session,
  with the anti-escalation preamble. This is the main security fact in the
  document and it is a direct observation, not an inference.
- **`claude -p` binds a socket.** A print-mode session registered itself with
  `entrypoint: "sdk-cli"` and a live socket file.
- **Registry shape.** Field names and their frequency were taken from the 61
  session rows present on the probe machine, confirming no transcript content
  is stored there.
- **Both scripts were run**, including their failure paths — missing socket
  file, missing environment variable, missing registry directory — each of
  which prints a one-line explanation and exits non-zero rather than raising.

What is *not* verified, and is listed as such in the document's "Unknowns and
limitations": the macOS own-child seam against a bypass-permissions receiver,
the documented loop throttles, burst and reconnect behavior, and anything on
Linux. The next-investigations list is ordered accordingly.

No Swift changed, so no build or test run applies.

[update-injection-findings](https://cheapsteak.github.io/tbd/open/?worktree=008EF686-3118-43F2-AC77-39E7B72D2823)
